### PR TITLE
Refactor data recording to use primitives directory structure with da…

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/primitive_execution_action_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/primitive_execution_action_server.py
@@ -168,13 +168,14 @@ class PrimitiveExecutionActionServer(Node):
                         primitive_name = metadata.get('name', item)
                         
                         # Validate primitive before loading
-                        is_valid, is_in_training = self.primitive_loader.validate_physical_primitive(item_path, metadata)
+                        is_valid, is_in_training, episode_count = self.primitive_loader.validate_physical_primitive(item_path, metadata)
                         
                         if is_valid:
                             primitive_data = {
                                 'metadata': metadata,
                                 'directory': item_path,
-                                'in_training': is_in_training
+                                'in_training': is_in_training,
+                                'episode_count': episode_count
                             }
                             
                             if is_in_training:
@@ -245,9 +246,10 @@ class PrimitiveExecutionActionServer(Node):
                 "guidelines": metadata.get('guidelines', ''),
                 "guidelines_when_running": metadata.get('guidelines_when_running', ''),
                 "inputs": metadata.get('inputs', {}),
-                "in_training": False
+                "in_training": False,
+                "episode_count": physical_data.get('episode_count', 0)
             }
-            self.get_logger().info(f"Physical primitive '{name}' has inputs: {metadata.get('inputs', {})}")
+            self.get_logger().info(f"Physical primitive '{name}' has inputs: {metadata.get('inputs', {})}, episodes: {physical_data.get('episode_count', 0)}")
             all_primitives.append(primitive_info)
         
         # Add in-training primitives if requested
@@ -260,9 +262,10 @@ class PrimitiveExecutionActionServer(Node):
                     "guidelines": metadata.get('guidelines', ''),
                     "guidelines_when_running": metadata.get('guidelines_when_running', ''),
                     "inputs": metadata.get('inputs', {}),
-                    "in_training": True
+                    "in_training": True,
+                    "episode_count": physical_data.get('episode_count', 0)
                 }
-                self.get_logger().info(f"In-training primitive '{name}' has inputs: {metadata.get('inputs', {})}")
+                self.get_logger().info(f"In-training primitive '{name}' has inputs: {metadata.get('inputs', {})}, episodes: {physical_data.get('episode_count', 0)}")
                 all_primitives.append(primitive_info)
         
         response.primitives_json = json.dumps(all_primitives)

--- a/ros2_ws/src/brain/brain_client/brain_client/primitive_execution_action_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/primitive_execution_action_server.py
@@ -121,8 +121,9 @@ class PrimitiveExecutionActionServer(Node):
         self.get_logger().info(f"Successfully loaded {len(self._code_primitives)} code primitives")
         
         # Load physical primitives from metadata.json files
-        self._physical_primitives = self._load_physical_primitives(primitives_directory)
+        self._physical_primitives, self._in_training_primitives = self._load_physical_primitives(primitives_directory)
         self.get_logger().info(f"Successfully loaded {len(self._physical_primitives)} physical primitives")
+        self.get_logger().info(f"Found {len(self._in_training_primitives)} in-training primitives")
         
         # Create action client to delegate physical primitives to behavior_server
         self._behavior_client = ActionClient(self, ExecuteBehavior, '/behavior/execute')
@@ -147,7 +148,13 @@ class PrimitiveExecutionActionServer(Node):
         self.get_logger().info(f"Total primitives available: {len(self._code_primitives) + len(self._physical_primitives)}")
 
     def _load_physical_primitives(self, primitives_directory):
+        """Load physical primitives from metadata.json files.
+        
+        Returns:
+            tuple: (physical_primitives dict, in_training_primitives dict)
+        """
         physical_primitives = {}
+        in_training_primitives = {}
         
         for item in os.listdir(primitives_directory):
             item_path = os.path.join(primitives_directory, item)
@@ -161,19 +168,29 @@ class PrimitiveExecutionActionServer(Node):
                         primitive_name = metadata.get('name', item)
                         
                         # Validate primitive before loading
-                        if self.primitive_loader.validate_physical_primitive(item_path, metadata):
-                            physical_primitives[primitive_name] = {
+                        is_valid, is_in_training = self.primitive_loader.validate_physical_primitive(item_path, metadata)
+                        
+                        if is_valid:
+                            primitive_data = {
                                 'metadata': metadata,
-                                'directory': item_path
+                                'directory': item_path,
+                                'in_training': is_in_training
                             }
-                            self.get_logger().info(f"Loaded physical primitive: {primitive_name} (type: {metadata.get('type', 'unknown')})")
+                            
+                            if is_in_training:
+                                in_training_primitives[primitive_name] = primitive_data
+                                self.get_logger().info(f"Loaded in-training primitive: {primitive_name} (type: {metadata.get('type', 'unknown')})")
+                            else:
+                                physical_primitives[primitive_name] = primitive_data
+                                self.get_logger().info(f"Loaded physical primitive: {primitive_name} (type: {metadata.get('type', 'unknown')})")
                         else:
                             self.get_logger().warn(f"Skipped invalid physical primitive: {primitive_name}")
         
-        return physical_primitives
+        return physical_primitives, in_training_primitives
 
     def _handle_get_available_primitives(self, request, response):
         all_primitives = []
+        include_in_training = request.include_in_training
         
         # Add code primitives
         for name, primitive_instance in self._code_primitives.items():
@@ -227,10 +244,26 @@ class PrimitiveExecutionActionServer(Node):
                 "type": metadata.get('type', 'physical'),
                 "guidelines": metadata.get('guidelines', ''),
                 "guidelines_when_running": metadata.get('guidelines_when_running', ''),
-                "inputs": metadata.get('inputs', {})
+                "inputs": metadata.get('inputs', {}),
+                "in_training": False
             }
             self.get_logger().info(f"Physical primitive '{name}' has inputs: {metadata.get('inputs', {})}")
             all_primitives.append(primitive_info)
+        
+        # Add in-training primitives if requested
+        if include_in_training:
+            for name, physical_data in self._in_training_primitives.items():
+                metadata = physical_data['metadata']
+                primitive_info = {
+                    "name": metadata.get('name', name),
+                    "type": metadata.get('type', 'physical'),
+                    "guidelines": metadata.get('guidelines', ''),
+                    "guidelines_when_running": metadata.get('guidelines_when_running', ''),
+                    "inputs": metadata.get('inputs', {}),
+                    "in_training": True
+                }
+                self.get_logger().info(f"In-training primitive '{name}' has inputs: {metadata.get('inputs', {})}")
+                all_primitives.append(primitive_info)
         
         response.primitives_json = json.dumps(all_primitives)
         self.get_logger().info(f"Returned {len(all_primitives)} primitives to service caller")

--- a/ros2_ws/src/brain/brain_client/brain_client/primitive_execution_action_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/primitive_execution_action_server.py
@@ -240,6 +240,8 @@ class PrimitiveExecutionActionServer(Node):
         # Add physical primitives
         for name, physical_data in self._physical_primitives.items():
             metadata = physical_data['metadata']
+            # Fetch episode count dynamically (not cached)
+            episode_count = self.primitive_loader._get_episode_count(physical_data['directory'])
             primitive_info = {
                 "name": metadata.get('name', name),
                 "type": metadata.get('type', 'physical'),
@@ -247,15 +249,17 @@ class PrimitiveExecutionActionServer(Node):
                 "guidelines_when_running": metadata.get('guidelines_when_running', ''),
                 "inputs": metadata.get('inputs', {}),
                 "in_training": False,
-                "episode_count": physical_data.get('episode_count', 0)
+                "episode_count": episode_count
             }
-            self.get_logger().info(f"Physical primitive '{name}' has inputs: {metadata.get('inputs', {})}, episodes: {physical_data.get('episode_count', 0)}")
+            self.get_logger().info(f"Physical primitive '{name}' has inputs: {metadata.get('inputs', {})}, episodes: {episode_count}")
             all_primitives.append(primitive_info)
         
         # Add in-training primitives if requested
         if include_in_training:
             for name, physical_data in self._in_training_primitives.items():
                 metadata = physical_data['metadata']
+                # Fetch episode count dynamically (not cached)
+                episode_count = self.primitive_loader._get_episode_count(physical_data['directory'])
                 primitive_info = {
                     "name": metadata.get('name', name),
                     "type": metadata.get('type', 'physical'),
@@ -263,9 +267,9 @@ class PrimitiveExecutionActionServer(Node):
                     "guidelines_when_running": metadata.get('guidelines_when_running', ''),
                     "inputs": metadata.get('inputs', {}),
                     "in_training": True,
-                    "episode_count": physical_data.get('episode_count', 0)
+                    "episode_count": episode_count
                 }
-                self.get_logger().info(f"In-training primitive '{name}' has inputs: {metadata.get('inputs', {})}, episodes: {physical_data.get('episode_count', 0)}")
+                self.get_logger().info(f"In-training primitive '{name}' has inputs: {metadata.get('inputs', {})}, episodes: {episode_count}")
                 all_primitives.append(primitive_info)
         
         response.primitives_json = json.dumps(all_primitives)

--- a/ros2_ws/src/brain/brain_client/brain_client/primitive_loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/primitive_loader.py
@@ -155,28 +155,43 @@ class PrimitiveLoader:
                 
         return all_primitives
 
-    def validate_physical_primitive(self, primitive_dir: str, metadata: dict) -> bool:
+    def validate_physical_primitive(self, primitive_dir: str, metadata: dict) -> tuple:
+        """Validate a physical primitive.
+        
+        Returns:
+            tuple: (is_valid: bool, is_in_training: bool)
+                - is_valid: True if the primitive can be loaded (either ready or in training)
+                - is_in_training: True if the primitive is a learned type missing its checkpoint
+        """
         primitive_type = metadata.get('type', '').lower()
         execution = metadata.get('execution', {})
         
         if primitive_type == 'learned':
             return self._validate_learned_primitive(primitive_dir, execution)
         elif primitive_type == 'replay':
-            return self._validate_replay_primitive(primitive_dir, execution)
+            is_valid = self._validate_replay_primitive(primitive_dir, execution)
+            return (is_valid, False)  # Replay primitives are never "in training"
         else:
             self.logger.warning(f"Unknown primitive type '{primitive_type}' in {primitive_dir}")
-            return True  # Allow unknown types but log warning
+            return (True, False)  # Allow unknown types but log warning
     
-    def _validate_learned_primitive(self, primitive_dir: str, execution: dict) -> bool:
+    def _validate_learned_primitive(self, primitive_dir: str, execution: dict) -> tuple:
+        """Validate a learned primitive.
+        
+        Returns:
+            tuple: (is_valid: bool, is_in_training: bool)
+        """
         checkpoint_file = execution.get('checkpoint')
+        
+        # If no checkpoint specified, it's in training
         if not checkpoint_file:
-            self.logger.error(f"Learned primitive in {primitive_dir} missing checkpoint file in execution config")
-            return False
+            self.logger.info(f"Learned primitive in {primitive_dir} has no checkpoint - marked as in_training")
+            return (True, True)  # Valid but in training
         
         checkpoint_path = os.path.join(primitive_dir, checkpoint_file)
         if not os.path.exists(checkpoint_path):
-            self.logger.error(f"Learned primitive checkpoint not found: {checkpoint_path}")
-            return False
+            self.logger.info(f"Learned primitive checkpoint not found: {checkpoint_path} - marked as in_training")
+            return (True, True)  # Valid but in training
         
         # Check for stats file (optional but commonly needed)
         stats_file = execution.get('stats_file', 'dataset_stats.pt')
@@ -185,9 +200,10 @@ class PrimitiveLoader:
             self.logger.warning(f"Learned primitive stats file not found: {stats_path} (optional)")
         
         self.logger.info(f"Learned primitive validation passed: {primitive_dir}")
-        return True
+        return (True, False)  # Valid and ready
     
-    def _validate_replay_primitive(self, primitive_dir: str, execution: dict) -> bool:
+    def _validate_replay_primitive_internal(self, primitive_dir: str, execution: dict) -> bool:
+        """Internal validation for replay primitives. Returns bool for validity."""
         replay_file = execution.get('replay_file')
         if not replay_file:
             self.logger.error(f"Replay primitive in {primitive_dir} missing replay_file in execution config")
@@ -216,4 +232,8 @@ class PrimitiveLoader:
         
         self.logger.info(f"Replay primitive validation passed: {primitive_dir}")
         return True
+
+    def _validate_replay_primitive(self, primitive_dir: str, execution: dict) -> bool:
+        """Validate a replay primitive. Returns bool for backwards compatibility."""
+        return self._validate_replay_primitive_internal(primitive_dir, execution)
 

--- a/ros2_ws/src/brain/brain_client/brain_client/primitive_loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/primitive_loader.py
@@ -159,21 +159,24 @@ class PrimitiveLoader:
         """Validate a physical primitive.
         
         Returns:
-            tuple: (is_valid: bool, is_in_training: bool)
+            tuple: (is_valid: bool, is_in_training: bool, episode_count: int)
                 - is_valid: True if the primitive can be loaded (either ready or in training)
                 - is_in_training: True if the primitive is a learned type missing its checkpoint
+                - episode_count: Number of recorded episodes (0 if not applicable or not found)
         """
         primitive_type = metadata.get('type', '').lower()
         execution = metadata.get('execution', {})
         
         if primitive_type == 'learned':
-            return self._validate_learned_primitive(primitive_dir, execution)
+            is_valid, is_in_training = self._validate_learned_primitive(primitive_dir, execution)
+            episode_count = self._get_episode_count(primitive_dir)
+            return (is_valid, is_in_training, episode_count)
         elif primitive_type == 'replay':
             is_valid = self._validate_replay_primitive(primitive_dir, execution)
-            return (is_valid, False)  # Replay primitives are never "in training"
+            return (is_valid, False, 0)  # Replay primitives are never "in training", no episodes
         else:
             self.logger.warning(f"Unknown primitive type '{primitive_type}' in {primitive_dir}")
-            return (True, False)  # Allow unknown types but log warning
+            return (True, False, 0)  # Allow unknown types but log warning
     
     def _validate_learned_primitive(self, primitive_dir: str, execution: dict) -> tuple:
         """Validate a learned primitive.
@@ -182,7 +185,6 @@ class PrimitiveLoader:
             tuple: (is_valid: bool, is_in_training: bool)
         """
         checkpoint_file = execution.get('checkpoint')
-        
         # If no checkpoint specified, it's in training
         if not checkpoint_file:
             self.logger.info(f"Learned primitive in {primitive_dir} has no checkpoint - marked as in_training")
@@ -201,6 +203,30 @@ class PrimitiveLoader:
         
         self.logger.info(f"Learned primitive validation passed: {primitive_dir}")
         return (True, False)  # Valid and ready
+    
+    def _get_episode_count(self, primitive_dir: str) -> int:
+        """Get the number of recorded episodes for a learned primitive.
+        
+        Looks for data/dataset_metadata.json and reads the number_of_episodes field.
+        
+        Args:
+            primitive_dir: Path to the primitive directory.
+            
+        Returns:
+            int: Number of episodes, or 0 if not found.
+        """
+        dataset_metadata_path = os.path.join(primitive_dir, 'data', 'dataset_metadata.json')
+        
+        if not os.path.exists(dataset_metadata_path):
+            return 0
+        
+        try:
+            with open(dataset_metadata_path, 'r') as f:
+                dataset_metadata = json.load(f)
+                return dataset_metadata.get('number_of_episodes', 0)
+        except Exception as e:
+            self.logger.warning(f"Error reading dataset metadata from {dataset_metadata_path}: {e}")
+            return 0
     
     def _validate_replay_primitive_internal(self, primitive_dir: str, execution: dict) -> bool:
         """Internal validation for replay primitives. Returns bool for validity."""

--- a/ros2_ws/src/brain/brain_messages/srv/GetAvailablePrimitives.srv
+++ b/ros2_ws/src/brain/brain_messages/srv/GetAvailablePrimitives.srv
@@ -1,5 +1,6 @@
 # Service to get all available primitives (code and physical)
-# Request is empty
+# Request
+bool include_in_training false  # If true, include learned primitives that are still in training (missing checkpoint)
 ---
 # Response contains JSON-encoded list of primitive metadata
 string primitives_json

--- a/ros2_ws/src/brain/manipulation/config/recorder.yaml
+++ b/ros2_ws/src/brain/manipulation/config/recorder.yaml
@@ -1,17 +1,14 @@
 # File: brain/manipulation/config/recorder.yaml
 /**:
   ros__parameters:
-    data_directory: "~/innate-os/data"       # Fallback directory (overridden by INNATE_OS_ROOT env var in code)
+    data_directory: "~/innate-os/primitives"  # Base directory for primitives (each task stores episodes in {task}/data/)
     data_frequency: 20                    # Frequency (e.g., Hz) at which data is recorded
-    # Action-only recording configuration
-    action_only_enabled: true            # Enable high-frequency action-only recording mode
-    action_only_frequency: 100            # Frequency in Hz for action-only recording
-    action_only_subdirectory: "action_only"  # Subfolder name inside each task directory
     image_topics:                         # List of image topic names
       - "/mars/main_camera/image"
       - "/mars/arm/image_raw"
     arm_state_topic: "/mars/arm/state"          # Topic for the arm state
     leader_command_topic: "/mars/arm/commands"  # Single leader command topic
     velocity_topic: "/cmd_vel"             # Topic for velocity data
+    odom_topic: "/odom"                    # Topic for odometry data (used to verify robot is alive)
     image_size: [640, 480]
     head_ai_position_topic: "/mars/head/set_ai_position"     # Topic to set head to AI position for recording

--- a/ros2_ws/src/brain/manipulation/manipulation/DataUtils.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/DataUtils.py
@@ -188,27 +188,29 @@ class TaskManager:
         self.metadata = None  # Will hold the task metadata
         self.episodes = []    # List of EpisodeData objects
 
-    def start_new_task(self, task_name, data_frequency):
+    def start_new_task(self, task_name, data_frequency, primitive_type='learned'):
         """
         Start a new task by creating the data directory and initializing dataset metadata.
         If dataset_metadata.json already exists, the task will be resumed instead.
+        Also creates the primitive metadata.json file for the primitive server.
 
         Args:
             task_name (str): The name for the new task (primitive name).
             data_frequency (float): The frequency at which data is collected (in Hz).
+            primitive_type (str): The type of primitive being created (default: 'learned').
         """
         self.current_task_name = task_name
         self.current_task_dir = os.path.join(self.base_data_directory, task_name)
         data_dir = os.path.join(self.current_task_dir, "data")
-        metadata_path = os.path.join(data_dir, "dataset_metadata.json")
+        dataset_metadata_path = os.path.join(data_dir, "dataset_metadata.json")
 
-        if os.path.exists(metadata_path):
+        if os.path.exists(dataset_metadata_path):
             # Dataset already exists; resume it.
             print(f"Dataset for '{task_name}' already exists. Resuming.")
             self.resume_task(task_name)
             return
 
-        # Create data directory and initialize metadata.
+        # Create data directory and initialize dataset metadata.
         os.makedirs(data_dir, exist_ok=True)
         self.metadata = {
             "data_frequency": data_frequency,
@@ -217,6 +219,9 @@ class TaskManager:
         }
         self._save_metadata()
         self.episodes = []  # Reset the episodes list.
+        
+        # Create the primitive metadata.json file for the primitive server
+        self._create_primitive_metadata(task_name, primitive_type)
 
     def resume_task(self, task_name):
         """
@@ -295,6 +300,43 @@ class TaskManager:
         metadata_path = os.path.join(data_dir, "dataset_metadata.json")
         with open(metadata_path, 'w') as f:
             json.dump(self.metadata, f, indent=4)
+
+    def _create_primitive_metadata(self, task_name, primitive_type):
+        """
+        Create the metadata.json file for the primitive server.
+        This file is placed in the root of the primitive directory (not in data/).
+        
+        Args:
+            task_name (str): The name of the primitive.
+            primitive_type (str): The type of primitive ('learned', 'replay', etc.).
+        """
+        if self.current_task_dir is None:
+            raise RuntimeError("No active task directory to create primitive metadata.")
+        
+        primitive_metadata_path = os.path.join(self.current_task_dir, "metadata.json")
+        
+        # Only create if it doesn't already exist
+        if os.path.exists(primitive_metadata_path):
+            print(f"Primitive metadata.json already exists for '{task_name}'. Skipping creation.")
+            return
+        
+        primitive_metadata = {
+            "name": task_name,
+            "type": primitive_type,
+            "guidelines": "",
+            "guidelines_when_running": "",
+            "inputs": {},
+            "execution": {
+                # Checkpoint will be filled in after training
+                # "checkpoint": "best_model.pt",
+                # "stats_file": "dataset_stats.pt"
+            }
+        }
+        
+        with open(primitive_metadata_path, 'w') as f:
+            json.dump(primitive_metadata, f, indent=4)
+        
+        print(f"Created primitive metadata.json for '{task_name}' (type: {primitive_type})")
 
     def load_metadata(self):
         """

--- a/ros2_ws/src/brain/manipulation/manipulation/DataUtils.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/DataUtils.py
@@ -188,68 +188,52 @@ class TaskManager:
         self.metadata = None  # Will hold the task metadata
         self.episodes = []    # List of EpisodeData objects
 
-    def start_new_task(self, task_name, task_description, mobile_flag, data_frequency, action_only_frequency=None):
+    def start_new_task(self, task_name, data_frequency):
         """
-        Start a new task by creating a task directory and initializing metadata.
-        If a task with the given name already exists (i.e., a metadata file is found),
-        the task will be resumed instead.
+        Start a new task by creating the data directory and initializing dataset metadata.
+        If dataset_metadata.json already exists, the task will be resumed instead.
 
         Args:
-            task_name (str): The name for the new task.
-            task_description (str): A description for the task.
-            mobile_flag (bool): Indicates if the task involves mobile data.
+            task_name (str): The name for the new task (primitive name).
             data_frequency (float): The frequency at which data is collected (in Hz).
         """
         self.current_task_name = task_name
         self.current_task_dir = os.path.join(self.base_data_directory, task_name)
-        metadata_path = os.path.join(self.current_task_dir, "metadata.json")
+        data_dir = os.path.join(self.current_task_dir, "data")
+        metadata_path = os.path.join(data_dir, "dataset_metadata.json")
 
         if os.path.exists(metadata_path):
-            # Task already exists; resume it.
-            print(f"Task '{task_name}' already exists. Resuming task.")
+            # Dataset already exists; resume it.
+            print(f"Dataset for '{task_name}' already exists. Resuming.")
             self.resume_task(task_name)
-            # Optionally update AO frequency on resume if provided
-            if action_only_frequency is not None:
-                if self.metadata is None:
-                    self.load_metadata()
-                self.metadata["action_only_frequency"] = action_only_frequency
-                self._save_metadata()
             return
 
-        # Task does not exist; create a new one.
-        os.makedirs(self.current_task_dir, exist_ok=True)
+        # Create data directory and initialize metadata.
+        os.makedirs(data_dir, exist_ok=True)
         self.metadata = {
-            "task_name": task_name,
-            "task_description": task_description,
-            "mobile_task": mobile_flag,
             "data_frequency": data_frequency,
             "number_of_episodes": 0,
-            "episodes": [],  # Will contain details for each saved episode.
-            # Track action-only episodes separately
-            "number_of_ao_episodes": 0,
-            "ao_episodes": []
+            "episodes": []  # Will contain details for each saved episode.
         }
-        # Record the action-only frequency if provided
-        if action_only_frequency is not None:
-            self.metadata["action_only_frequency"] = action_only_frequency
         self._save_metadata()
         self.episodes = []  # Reset the episodes list.
 
     def resume_task(self, task_name):
         """
-        Resume a previously started task by loading its metadata and setting the current task context.
+        Resume a previously started task by loading its dataset metadata.
         
         Args:
             task_name (str): The name of the task to resume.
         
         Raises:
-            FileNotFoundError: If the task directory or metadata file does not exist.
+            FileNotFoundError: If the data directory or dataset_metadata.json does not exist.
         """
         self.current_task_name = task_name
         self.current_task_dir = os.path.join(self.base_data_directory, task_name)
-        metadata_path = os.path.join(self.current_task_dir, "metadata.json")
+        data_dir = os.path.join(self.current_task_dir, "data")
+        metadata_path = os.path.join(data_dir, "dataset_metadata.json")
         if not os.path.exists(metadata_path):
-            raise FileNotFoundError(f"Metadata file not found for task '{task_name}' at {self.current_task_dir}")
+            raise FileNotFoundError(f"Dataset metadata not found for task '{task_name}' at {metadata_path}")
         self.load_metadata()
         # Optionally, the episodes list can be updated if needed by reading from the HDF5 files.
         # For now, we leave self.episodes as an empty list.
@@ -257,16 +241,21 @@ class TaskManager:
     def add_episode(self, episode_data, start_timestamp, end_timestamp):
         """
         Save an episode's data to an HDF5 file and update the task's metadata.
+        Episodes are stored in the 'data/' subdirectory of the task.
 
         Args:
             episode_data (EpisodeData): The EpisodeData object containing buffered data.
             start_timestamp (str): Start timestamp of the episode (e.g., ISO format).
             end_timestamp (str): End timestamp of the episode.
         """
+        # Ensure data subdirectory exists
+        data_dir = os.path.join(self.current_task_dir, "data")
+        os.makedirs(data_dir, exist_ok=True)
+        
         # Determine new episode ID and filename.
         episode_id = self.metadata["number_of_episodes"]
         file_name = f"episode_{episode_id}.h5"
-        file_path = os.path.join(self.current_task_dir, file_name)
+        file_path = os.path.join(data_dir, file_name)
         
         # Save the episode HDF5 file.
         episode_data.save_file(file_path)
@@ -274,7 +263,7 @@ class TaskManager:
         # Update metadata with new episode info.
         episode_info = {
             "episode_id": episode_id,
-            "file_name": file_name,
+            "file_name": file_name,  # Just the filename since metadata is in data/ directory
             "start_timestamp": start_timestamp,
             "end_timestamp": end_timestamp
         }
@@ -284,44 +273,6 @@ class TaskManager:
         
         # Optionally, store the episode_data object.
         #self.episodes.append(episode_data)
-
-    def add_action_only_episode(self, episode_data, start_timestamp, end_timestamp, subdirectory_name: str = "action_only"):
-        """
-        Save an action-only episode under a dedicated subdirectory and update metadata.
-
-        Args:
-            episode_data (EpisodeData): Contains only actions.
-            start_timestamp (str): Start timestamp.
-            end_timestamp (str): End timestamp.
-            subdirectory_name (str): Subfolder name inside the task directory.
-        """
-        # Ensure subdirectory exists
-        target_dir = os.path.join(self.current_task_dir, subdirectory_name)
-        os.makedirs(target_dir, exist_ok=True)
-
-        # Determine new ID and path
-        ao_id = self.metadata.get("number_of_ao_episodes", 0)
-        file_name = f"episode_{ao_id}.h5"
-        file_path = os.path.join(target_dir, file_name)
-
-        # Save file (will include only /action if no observations)
-        episode_data.save_file(file_path)
-
-        # Update metadata
-        ao_info = {
-            "episode_id": ao_id,
-            "file_name": file_name,
-            "subdirectory": subdirectory_name,
-            "start_timestamp": start_timestamp,
-            "end_timestamp": end_timestamp
-        }
-        if "ao_episodes" not in self.metadata:
-            self.metadata["ao_episodes"] = []
-        if "number_of_ao_episodes" not in self.metadata:
-            self.metadata["number_of_ao_episodes"] = 0
-        self.metadata["ao_episodes"].append(ao_info)
-        self.metadata["number_of_ao_episodes"] += 1
-        self._save_metadata()
 
     def end_task(self):
         """
@@ -335,21 +286,23 @@ class TaskManager:
 
     def _save_metadata(self):
         """
-        Save the current metadata to a JSON file in the task directory.
+        Save the current metadata to dataset_metadata.json in the data directory.
         """
         if self.current_task_dir is None:
             raise RuntimeError("No active task directory to save metadata.")
-        metadata_path = os.path.join(self.current_task_dir, "metadata.json")
+        data_dir = os.path.join(self.current_task_dir, "data")
+        os.makedirs(data_dir, exist_ok=True)
+        metadata_path = os.path.join(data_dir, "dataset_metadata.json")
         with open(metadata_path, 'w') as f:
             json.dump(self.metadata, f, indent=4)
 
     def load_metadata(self):
         """
-        Load the metadata from the JSON file in the current task directory.
+        Load the metadata from dataset_metadata.json in the data directory.
         """
         if self.current_task_dir is None:
             raise RuntimeError("No active task directory to load metadata from.")
-        metadata_path = os.path.join(self.current_task_dir, "metadata.json")
+        metadata_path = os.path.join(self.current_task_dir, "data", "dataset_metadata.json")
         with open(metadata_path, 'r') as f:
             self.metadata = json.load(f)
 
@@ -373,7 +326,7 @@ class TaskManager:
 
     def _get_enriched_metadata_for_task(self, task_directory):
         """
-        Loads, enriches (with episode num_timesteps), and returns metadata for a single task
+        Loads, enriches (with episode num_timesteps), and returns dataset metadata for a single task
         using its absolute directory path.
 
         Args:
@@ -381,33 +334,34 @@ class TaskManager:
 
         Returns:
             tuple: (dict_or_None, error_message_or_None)
-                   - dict_or_None: The enriched task metadata.
+                   - dict_or_None: The enriched dataset metadata.
                    - error_message_or_None: Description of error if any.
         """
-        metadata_file_path = os.path.join(task_directory, "metadata.json")
-        # Extract task name from directory path for fallback if not in metadata
-        task_name_for_fallback = os.path.basename(task_directory) 
+        data_dir = os.path.join(task_directory, "data")
+        metadata_file_path = os.path.join(data_dir, "dataset_metadata.json")
+        task_name = os.path.basename(task_directory)
 
         if not os.path.exists(task_directory) or not os.path.isdir(task_directory):
             return None, f"Task directory {task_directory} not found or is not a directory."
         
         if not os.path.exists(metadata_file_path):
-            return None, f"Metadata.json not found in {task_directory}."
+            return None, f"dataset_metadata.json not found in {data_dir}."
 
         try:
             with open(metadata_file_path, 'r') as f:
-                task_metadata = json.load(f)
+                dataset_metadata = json.load(f)
         except json.JSONDecodeError as e:
-            return None, f"Error decoding metadata.json in {task_directory}: {e}"
+            return None, f"Error decoding dataset_metadata.json in {data_dir}: {e}"
         except Exception as e:
-            return None, f"Error reading metadata.json in {task_directory}: {e}"
+            return None, f"Error reading dataset_metadata.json in {data_dir}: {e}"
 
         processed_episodes = []
-        if "episodes" in task_metadata and isinstance(task_metadata["episodes"], list):
-            for episode_info in task_metadata["episodes"]:
+        if "episodes" in dataset_metadata and isinstance(dataset_metadata["episodes"], list):
+            for episode_info in dataset_metadata["episodes"]:
                 num_timesteps = 0
                 episode_file_name = episode_info.get("file_name", "")
-                episode_file_path = os.path.join(task_directory, episode_file_name)
+                # Episodes are in data/ directory alongside dataset_metadata.json
+                episode_file_path = os.path.join(data_dir, episode_file_name)
                 
                 if episode_file_name and os.path.exists(episode_file_path):
                     try:
@@ -422,45 +376,16 @@ class TaskManager:
                     "start_time": episode_info.get("start_timestamp", "N/A"),
                     "end_time": episode_info.get("end_timestamp", "N/A"),
                     "num_timesteps": num_timesteps,
-                    "data_file_name": episode_file_name
+                    "file_name": episode_file_name
                 })
         
         enriched_metadata = {
-            "task_name": task_metadata.get("task_name", task_name_for_fallback),
-            "task_description": task_metadata.get("task_description", "N/A"),
-            "mobile_task": task_metadata.get("mobile_task", False),
-            "data_frequency": task_metadata.get("data_frequency", 0),
-            "task_directory": task_directory, 
-            "episodes": processed_episodes,
-            **{k: v for k, v in task_metadata.items() if k not in ["task_name", "task_description", "mobile_task", "data_frequency", "task_directory", "episodes"]}
+            "task_name": task_name,
+            "task_directory": task_directory,
+            "data_frequency": dataset_metadata.get("data_frequency", 0),
+            "number_of_episodes": dataset_metadata.get("number_of_episodes", 0),
+            "episodes": processed_episodes
         }
-
-        # Also attach processed action-only episodes if present
-        processed_ao_episodes = []
-        if "ao_episodes" in task_metadata and isinstance(task_metadata["ao_episodes"], list):
-            for ao_info in task_metadata["ao_episodes"]:
-                num_timesteps = 0
-                subdir = ao_info.get("subdirectory", "action_only")
-                ao_file = ao_info.get("file_name", "")
-                ao_path = os.path.join(task_directory, subdir, ao_file)
-                if ao_file and os.path.exists(ao_path):
-                    try:
-                        with h5py.File(ao_path, 'r') as hf:
-                            if '/action' in hf:
-                                num_timesteps = len(hf['/action'])
-                    except Exception as e:
-                        print(f"Error reading HDF5 file {ao_path} for timesteps: {e}")
-                processed_ao_episodes.append({
-                    "episode_id": f"episode_{ao_info.get('episode_id', 'N/A')}",
-                    "start_time": ao_info.get("start_timestamp", "N/A"),
-                    "end_time": ao_info.get("end_timestamp", "N/A"),
-                    "num_timesteps": num_timesteps,
-                    "data_file_name": ao_file,
-                    "subdirectory": subdir
-                })
-
-        if processed_ao_episodes:
-            enriched_metadata["ao_episodes"] = processed_ao_episodes
         
         return enriched_metadata, None
 

--- a/ros2_ws/src/brain/manipulation/manipulation/recorder.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/recorder.py
@@ -111,7 +111,7 @@ class RecorderNode(Node):
         self.head_ai_position_pub = self.create_publisher(Empty, self.head_ai_position_topic, 10)
         
         # Create service servers with updated names prefixed with "recorder/"
-        self.new_task_srv = self.create_service(ManipulationTask, 'brain/recorder/new_task', self.handle_new_task)
+        self.new_physical_primitive_srv = self.create_service(ManipulationTask, 'brain/recorder/new_physical_primitive', self.handle_new_physical_primitive)
         self.new_episode_srv = self.create_service(Trigger, 'brain/recorder/new_episode', self.handle_new_episode)
         self.save_episode_srv = self.create_service(Trigger, 'brain/recorder/save_episode', self.handle_save_episode)
         self.cancel_episode_srv = self.create_service(Trigger, 'brain/recorder/cancel_episode', self.handle_cancel_episode)
@@ -123,7 +123,7 @@ class RecorderNode(Node):
         
         # Log the services it is hosting
         self.get_logger().info("Hosting services:")
-        self.get_logger().info("  brain/recorder/new_task")
+        self.get_logger().info("  brain/recorder/new_physical_primitive")
         self.get_logger().info("  brain/recorder/new_episode")
         self.get_logger().info("  brain/recorder/save_episode")
         self.get_logger().info("  brain/recorder/cancel_episode")
@@ -247,24 +247,27 @@ class RecorderNode(Node):
             self.get_logger().error(f"Error setting AI position: {e}")
 
     # Service handlers.
-    def handle_new_task(self, request, response):
+    def handle_new_physical_primitive(self, request, response):
+        """Handle request to create a new physical primitive (type: learned)."""
         if self.state in ["EPISODE_ACTIVE", "EPISODE_STOPPED"]:
-            self.get_logger().warn(f"New task requested during an {self.state.lower()} episode; canceling current episode.")
+            self.get_logger().warn(f"New physical primitive requested during an {self.state.lower()} episode; canceling current episode.")
             # Publish status update for cancelled episode
             self.publish_status(status="cancelled", episode_number=str(self.episode_count), current_task_name=self.current_task_name)
             if self.current_episode:
                 self.current_episode.clear()
             self.current_episode = None
             # self.state will be set to TASK_ACTIVE by the rest of the method.
-            # Episode count for the new task will effectively start fresh.
+            # Episode count for the new primitive will effectively start fresh.
         
         # Set head to AI position for optimal camera angle during recording
-        self.get_logger().info("Setting head to AI position for new task setup")
+        self.get_logger().info("Setting head to AI position for new physical primitive setup")
         self._set_head_ai_position()
         
+        # Start new task with type set to 'learned'
         self.task_manager.start_new_task(
             request.task_name,
-            self.data_frequency
+            self.data_frequency,
+            primitive_type='learned'  # Physical primitives are of type 'learned'
         )
         if self.task_manager.metadata:
             self.episode_count = self.task_manager.metadata["number_of_episodes"]
@@ -272,8 +275,8 @@ class RecorderNode(Node):
             self.episode_count = 0
         self.current_task_name = request.task_name
         self.state = "TASK_ACTIVE"
-        self.get_logger().info(f"New task '{request.task_name}' started.")
-        # Publish status update for new task
+        self.get_logger().info(f"New physical primitive '{request.task_name}' (type: learned) started.")
+        # Publish status update for new primitive
         self.publish_status(status="active", episode_number="", current_task_name=self.current_task_name)
         response.success = True
         return response

--- a/ros2_ws/src/brain/manipulation/manipulation/recorder.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/recorder.py
@@ -35,7 +35,7 @@ class RecorderNode(Node):
         self.declare_parameter('velocity_topic', '/cmd_vel')
         self.declare_parameter('odom_topic', '/odom')
         self.declare_parameter('image_size', [640, 480])
-        self.declare_parameter('head_ai_position_topic', '/head/set_ai_position')
+        self.declare_parameter('head_ai_position_topic', '/mars/head/set_ai_position')
         
         # Get parameter values
         data_directory = os.path.expanduser(self.get_parameter('data_directory').value)

--- a/ros2_ws/src/brain/manipulation/manipulation/recorder.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/recorder.py
@@ -10,6 +10,7 @@ from manipulation.DataUtils import EpisodeData, TaskManager
 from sensor_msgs.msg import Image, JointState
 from std_msgs.msg import Float64MultiArray, Empty
 from geometry_msgs.msg import Twist
+from nav_msgs.msg import Odometry
 from cv_bridge import CvBridge  # For image conversion
 import cv2
 # Import RecorderStatus message
@@ -28,28 +29,22 @@ class RecorderNode(Node):
         # Load parameters (can be set via a YAML file or launch file)
         self.declare_parameter('data_directory', '/path/to/data')
         self.declare_parameter('data_frequency', 10)
-        # Action-only mode parameters
-        self.declare_parameter('action_only_enabled', False)
-        self.declare_parameter('action_only_frequency', 100)
-        self.declare_parameter('action_only_subdirectory', 'action_only')
         self.declare_parameter('image_topics', ['/camera/image_raw', '/camera/image_processed'])
         self.declare_parameter('arm_state_topic', '/arm/state')
         self.declare_parameter('leader_command_topic', '/leader/command')
         self.declare_parameter('velocity_topic', '/cmd_vel')
+        self.declare_parameter('odom_topic', '/odom')
         self.declare_parameter('image_size', [640, 480])
         self.declare_parameter('head_ai_position_topic', '/head/set_ai_position')
         
         # Get parameter values
         data_directory = os.path.expanduser(self.get_parameter('data_directory').value)
         self.data_frequency = self.get_parameter('data_frequency').value
-        # Action-only config
-        self.action_only_enabled = bool(self.get_parameter('action_only_enabled').value)
-        self.action_only_frequency = self.get_parameter('action_only_frequency').value
-        self.action_only_subdirectory = self.get_parameter('action_only_subdirectory').value
         self.image_topics = self.get_parameter('image_topics').value
         self.arm_state_topic = self.get_parameter('arm_state_topic').value
         self.leader_command_topic = self.get_parameter('leader_command_topic').value
         self.velocity_topic = self.get_parameter('velocity_topic').value
+        self.odom_topic = self.get_parameter('odom_topic').value
         self.image_size = self.get_parameter('image_size').value
         self.head_ai_position_topic = self.get_parameter('head_ai_position_topic').value
         # Initialize TaskManager and internal state
@@ -57,15 +52,10 @@ class RecorderNode(Node):
         self.current_episode = None  # Holds an EpisodeData instance when an episode is active
         self.state = "IDLE"          # Possible states: "IDLE", "TASK_ACTIVE", "EPISODE_ACTIVE", "EPISODE_STOPPED"
         self.episode_start_time = None
-        # Action-only episode state
-        self.current_ao_episode = None
-        self.ao_state = "AO_IDLE"    # "AO_IDLE", "AO_EPISODE_ACTIVE", "AO_EPISODE_STOPPED"
-        self.ao_episode_start_time = None
         
         # Internal variables to track current task and episode number
         self.current_task_name = ""
         self.episode_count = 0
-        self.ao_episode_count = 0
         
         # Initialize CvBridge for image conversion
         self.bridge = CvBridge()
@@ -76,6 +66,7 @@ class RecorderNode(Node):
         self.latest_arm_state = None
         self.latest_leader_command = None
         self.latest_cmd_vel = None
+        self.latest_odom = None
         
         # Tracking message reception for each topic.
         # Initialize booleans for image topics and the other topics.
@@ -107,12 +98,14 @@ class RecorderNode(Node):
         self.create_subscription(JointState, self.arm_state_topic, self.arm_state_callback, 10)
         self.create_subscription(Float64MultiArray, self.leader_command_topic, self.leader_command_callback, 10)
         self.create_subscription(Twist, self.velocity_topic, self.cmd_vel_callback, 10)
+        self.create_subscription(Odometry, self.odom_topic, self.odom_callback, 10)
         
         # Log the topics it is subscribing to
         self.get_logger().info(f"Subscribing to image topics: {self.image_topics}")
         self.get_logger().info(f"Subscribing to arm state topic: {self.arm_state_topic}")
         self.get_logger().info(f"Subscribing to leader command topic: {self.leader_command_topic}")
         self.get_logger().info(f"Subscribing to velocity topic: {self.velocity_topic}")
+        self.get_logger().info(f"Subscribing to odom topic: {self.odom_topic}")
         
         # Create publishers
         self.head_ai_position_pub = self.create_publisher(Empty, self.head_ai_position_topic, 10)
@@ -123,11 +116,6 @@ class RecorderNode(Node):
         self.save_episode_srv = self.create_service(Trigger, 'brain/recorder/save_episode', self.handle_save_episode)
         self.cancel_episode_srv = self.create_service(Trigger, 'brain/recorder/cancel_episode', self.handle_cancel_episode)
         self.stop_episode_srv = self.create_service(Trigger, 'brain/recorder/stop_episode', self.handle_stop_episode)
-        # Action-only services (Trigger)
-        self.ao_new_episode_srv = self.create_service(Trigger, 'brain/recorder/ao_new_episode', self.handle_ao_new_episode)
-        self.ao_save_episode_srv = self.create_service(Trigger, 'brain/recorder/ao_save_episode', self.handle_ao_save_episode)
-        self.ao_cancel_episode_srv = self.create_service(Trigger, 'brain/recorder/ao_cancel_episode', self.handle_ao_cancel_episode)
-        self.ao_stop_episode_srv = self.create_service(Trigger, 'brain/recorder/ao_stop_episode', self.handle_ao_stop_episode)
         self.end_task_srv = self.create_service(Trigger, 'brain/recorder/end_task', self.handle_end_task)
         self.get_task_metadata_list_srv = self.create_service(GetTaskMetadataList, 'brain/recorder/get_task_metadata_list', self.handle_get_task_metadata_list)
         self.update_task_metadata_srv = self.create_service(UpdateTaskMetadata, 'brain/recorder/update_task_metadata', self.handle_update_task_metadata)
@@ -140,10 +128,6 @@ class RecorderNode(Node):
         self.get_logger().info("  brain/recorder/save_episode")
         self.get_logger().info("  brain/recorder/cancel_episode")
         self.get_logger().info("  brain/recorder/stop_episode")
-        self.get_logger().info("  brain/recorder/ao_new_episode")
-        self.get_logger().info("  brain/recorder/ao_save_episode")
-        self.get_logger().info("  brain/recorder/ao_cancel_episode")
-        self.get_logger().info("  brain/recorder/ao_stop_episode")
         self.get_logger().info("  brain/recorder/end_task")
         self.get_logger().info("  brain/recorder/get_task_metadata_list")
         self.get_logger().info("  brain/recorder/update_task_metadata")
@@ -154,13 +138,6 @@ class RecorderNode(Node):
         
         # Create a timer that will attempt to add sensor data as a new timestep at the specified frequency.
         self.timer = self.create_timer(1.0 / self.data_frequency, self.timer_callback)
-
-        # Create action-only timer if enabled
-        if self.action_only_enabled:
-            self.ao_timer = self.create_timer(1.0 / float(self.action_only_frequency), self.ao_timer_callback)
-            self.get_logger().info(f"Action-only mode enabled at {self.action_only_frequency} Hz, subdir '{self.action_only_subdirectory}'")
-        else:
-            self.ao_timer = None
         
         self.get_logger().info("Recorder Node initialized in IDLE state.")
     
@@ -199,27 +176,40 @@ class RecorderNode(Node):
             self.get_logger().info(f"First message received on velocity topic: {self.velocity_topic}")
             self.check_all_topics_received()
 
+    def odom_callback(self, msg):
+        self.latest_odom = msg
+
     # Timer callback to record sensor data as a timestep.
     def timer_callback(self):
         # Only record data if an episode is active.
         if self.state != "EPISODE_ACTIVE" or self.current_episode is None:
             return
         
-        # Ensure all sensor data are available.
+        # Ensure required sensor data are available (images, arm_state, odom)
         for topic in self.image_topics:
             if self.latest_images[topic] is None:
                 self.get_logger().warn(f"Incomplete sensor data; missing image from topic {topic}. Skipping timestep.")
                 return
         
-        if self.latest_arm_state is None or self.latest_leader_command is None or self.latest_cmd_vel is None:
-            self.get_logger().warn("Incomplete sensor data; skipping timestep.")
+        if self.latest_arm_state is None:
+            self.get_logger().warn("Incomplete sensor data; missing arm state. Skipping timestep.")
             return
         
-        # Build action data starting with leader command
-        action_data = list(self.latest_leader_command.data)  # leader_command is a list of floats
-        # Add only forward speed and yaw rate from cmd_vel
-        twist = self.latest_cmd_vel
-        action_data.extend([twist.linear.x, twist.angular.z])
+        if self.latest_odom is None:
+            self.get_logger().warn("Incomplete sensor data; missing odom. Skipping timestep.")
+            return
+        
+        # Build action data starting with leader command (use zeros if not available)
+        if self.latest_leader_command is not None:
+            action_data = list(self.latest_leader_command.data)
+        else:
+            action_data = [0.0] * 10  # Default to 10 zeros for arm commands
+        
+        # Add forward speed and yaw rate from cmd_vel (use zeros if not available)
+        if self.latest_cmd_vel is not None:
+            action_data.extend([self.latest_cmd_vel.linear.x, self.latest_cmd_vel.angular.z])
+        else:
+            action_data.extend([0.0, 0.0])
         
         # Get joint positions and velocities from the arm state message.
         qpos = list(self.latest_arm_state.position)
@@ -238,7 +228,11 @@ class RecorderNode(Node):
         
         try:
             self.current_episode.add_timestep(action_data, qpos, qvel, images_converted)
-            self.get_logger().debug("Added timestep to current episode.")
+            timestep_count = self.current_episode.get_episode_length()
+            # Log progress every 20 timesteps (roughly every second at 20Hz)
+            if timestep_count % 20 == 0:
+                elapsed = time.time() - self.episode_start_time
+                self.get_logger().info(f"Recording... {timestep_count} timesteps ({elapsed:.1f}s)")
         except ValueError as e:
             self.get_logger().error(f"Error adding timestep: {e}")
 
@@ -270,138 +264,18 @@ class RecorderNode(Node):
         
         self.task_manager.start_new_task(
             request.task_name,
-            request.task_description,
-            request.mobile_task,
-            self.data_frequency,
-            action_only_frequency=self.action_only_frequency if self.action_only_enabled else None
+            self.data_frequency
         )
         if self.task_manager.metadata:
             self.episode_count = self.task_manager.metadata["number_of_episodes"]
-            self.ao_episode_count = self.task_manager.metadata.get("number_of_ao_episodes", 0)
         else:
             self.episode_count = 0
-            self.ao_episode_count = 0
         self.current_task_name = request.task_name
         self.state = "TASK_ACTIVE"
         self.get_logger().info(f"New task '{request.task_name}' started.")
         # Publish status update for new task
         self.publish_status(status="active", episode_number="", current_task_name=self.current_task_name)
         response.success = True
-        return response
-
-    # ----------------------------
-    # Action-only service handlers
-    # ----------------------------
-    def handle_ao_new_episode(self, request, response):
-        if self.state == "IDLE":
-            self.get_logger().error("Cannot start a new action-only episode unless a task is active.")
-            self.publish_status(status="ao_failed - no active task", episode_number="", current_task_name="")
-            response.success = False
-            response.message = "No active task. Please start a task first."
-            return response
-        elif self.ao_state in ["AO_EPISODE_ACTIVE", "AO_EPISODE_STOPPED"]:
-            self.get_logger().error("Cannot start a new action-only episode while one is already active or stopped.")
-            self.publish_status(status="ao_failed - episode in progress", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-            response.success = False
-            response.message = "An action-only episode is already active or stopped."
-            return response
-        
-        # Check if required topics have received data for action-only recording
-        if self.latest_leader_command is None or self.latest_cmd_vel is None:
-            missing_topics = []
-            if self.latest_leader_command is None:
-                missing_topics.append(self.leader_command_topic)
-            if self.latest_cmd_vel is None:
-                missing_topics.append(self.velocity_topic)
-            
-            error_msg = f"Cannot start action-only episode: Required topics have not received data yet: {missing_topics}"
-            self.get_logger().error(error_msg)
-            self.publish_status(status="ao_failed - topics not ready", episode_number="", current_task_name=self.current_task_name)
-            response.success = False
-            response.message = error_msg
-            return response
-
-        self.current_ao_episode = EpisodeData()
-        self.ao_episode_start_time = time.time()
-        self.ao_state = "AO_EPISODE_ACTIVE"
-        self.ao_episode_count += 1
-        self.get_logger().info("Action-only episode started.")
-        self.publish_status(status="ao_active", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-        response.success = True
-        response.message = "Action-only episode started."
-        return response
-
-    def handle_ao_save_episode(self, request, response):
-        if self.ao_state not in ["AO_EPISODE_ACTIVE", "AO_EPISODE_STOPPED"] or self.current_ao_episode is None:
-            self.get_logger().error("No active or stopped action-only episode to save.")
-            self.publish_status(status="ao_failed - no active/stopped episode to save", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-            response.success = False
-            response.message = "No action-only episode to save."
-            return response
-
-        if self.current_ao_episode.get_episode_length() == 0:
-            self.get_logger().error("Cannot save empty action-only episode.")
-            self.publish_status(status="ao_failed - empty episode", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-            response.success = False
-            response.message = "Cannot save empty action-only episode."
-            return response
-
-        end_time = time.time()
-        self.task_manager.add_action_only_episode(
-            self.current_ao_episode,
-            time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime(self.ao_episode_start_time)),
-            time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime(end_time)),
-            subdirectory_name=self.action_only_subdirectory
-        )
-        self.get_logger().info("Action-only episode saved successfully.")
-        self.publish_status(status="ao_saved", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-        self.current_ao_episode = None
-        self.ao_state = "AO_IDLE"
-        response.success = True
-        response.message = "Action-only episode saved."
-        return response
-
-    def handle_ao_cancel_episode(self, request, response):
-        if self.ao_state not in ["AO_EPISODE_ACTIVE", "AO_EPISODE_STOPPED"] or self.current_ao_episode is None:
-            self.get_logger().error("No active or stopped action-only episode to cancel.")
-            self.publish_status(status="ao_failed - no active/stopped episode to cancel", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-            response.success = False
-            response.message = "No action-only episode to cancel."
-            return response
-
-        self.current_ao_episode.clear()
-        if self.ao_episode_count > 0:
-            self.ao_episode_count -= 1
-        self.get_logger().info("Action-only episode canceled; buffered data discarded.")
-        self.publish_status(status="ao_cancelled", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-        self.current_ao_episode = None
-        self.ao_state = "AO_IDLE"
-        response.success = True
-        response.message = "Action-only episode canceled."
-        return response
-
-    def handle_ao_stop_episode(self, request, response):
-        if self.ao_state == "AO_EPISODE_ACTIVE":
-            self.ao_state = "AO_EPISODE_STOPPED"
-            self.get_logger().info("Action-only episode recording stopped. Waiting for save or cancel command.")
-            self.publish_status(status="ao_stopped", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-            response.success = True
-            response.message = "Action-only episode stopped."
-        elif self.ao_state == "AO_EPISODE_STOPPED":
-            self.get_logger().warn("Stop action-only episode requested, but episode is already stopped.")
-            self.publish_status(status="ao_failed - episode already stopped", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-            response.success = False
-            response.message = "Action-only episode is already stopped."
-        elif self.state == "TASK_ACTIVE":
-            self.get_logger().error("Stop action-only episode requested, but no action-only episode is active.")
-            self.publish_status(status="ao_failed - no active episode", episode_number=str(self.ao_episode_count), current_task_name=self.current_task_name)
-            response.success = False
-            response.message = "No active action-only episode to stop."
-        else:  # IDLE
-            self.get_logger().error("Stop action-only episode requested, but no task is active.")
-            self.publish_status(status="ao_failed - no active task", episode_number="", current_task_name="")
-            response.success = False
-            response.message = "No active task or episode to stop."
         return response
 
     def handle_new_episode(self, request, response):
@@ -418,22 +292,15 @@ class RecorderNode(Node):
             response.message = f"An episode is already {self.state.lower()}. Please save or cancel the current episode first."
             return response
         
-        # Check if all required topics have received data
-        if not self.all_topics_received:
-            missing_topics = [topic for topic, received in self.topics_received.items() if not received]
-            error_msg = f"Cannot start episode: Not all topics have received data yet. Missing: {missing_topics}"
-            self.get_logger().error(error_msg)
-            self.publish_status(status="failed - topics not ready", episode_number="", current_task_name=self.current_task_name)
-            response.success = False
-            response.message = error_msg
-            return response
-        
         self.current_episode = EpisodeData()
         self.episode_start_time = time.time()
         self.state = "EPISODE_ACTIVE"
         self.episode_count += 1
         episode_str = str(self.episode_count)
-        self.get_logger().info("Episode started; now recording data.")
+        self.get_logger().info(f"=== RECORDING STARTED ===")
+        self.get_logger().info(f"Task: {self.current_task_name}, Episode: {episode_str}")
+        self.get_logger().info(f"Recording at {self.data_frequency} Hz")
+        self.get_logger().info(f"Image topics: {self.image_topics}")
         self.publish_status(status="active", episode_number=episode_str, current_task_name=self.current_task_name)
         response.success = True
         response.message = "Episode started."
@@ -460,12 +327,16 @@ class RecorderNode(Node):
             return response
 
         end_time = time.time()
+        duration = end_time - self.episode_start_time
+        timesteps = self.current_episode.get_episode_length()
         self.task_manager.add_episode(
             self.current_episode,
             time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime(self.episode_start_time)),
             time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime(end_time))
         )
-        self.get_logger().info("Episode saved successfully.")
+        self.get_logger().info(f"=== EPISODE SAVED ===")
+        self.get_logger().info(f"Task: {self.current_task_name}, Episode: {self.episode_count}")
+        self.get_logger().info(f"Duration: {duration:.1f}s, Timesteps: {timesteps}")
         # Publish status update for saved episode
         episode_str = str(self.episode_count)
         self.publish_status(status="saved", episode_number=episode_str, current_task_name=self.current_task_name)
@@ -536,10 +407,6 @@ class RecorderNode(Node):
             self.current_episode = None
         self.task_manager.end_task()
         self.state = "IDLE"
-        # Reset action-only state as well
-        self.current_ao_episode = None
-        self.ao_state = "AO_IDLE"
-        self.ao_episode_count = 0
         self.get_logger().info("Task ended; recorder state set to IDLE.")
         # Publish status update for ending task
         self.publish_status(status="idle", episode_number="", current_task_name="")
@@ -549,32 +416,6 @@ class RecorderNode(Node):
         response.success = True
         response.message = "Task ended."
         return response
-
-    # ----------------------------
-    # Action-only timer callback
-    # ----------------------------
-    def ao_timer_callback(self):
-        # Record action-only timesteps at high frequency
-        if self.ao_state != "AO_EPISODE_ACTIVE" or self.current_ao_episode is None:
-            return
-        # Require leader command and velocity only
-        if self.latest_leader_command is None or self.latest_cmd_vel is None:
-            return
-
-        # Build action data: leader command + [vx, wz]
-        try:
-            action_data = list(self.latest_leader_command.data)
-        except Exception:
-            # Fallback if Float64MultiArray-like but no .data list
-            action_data = []
-        twist = self.latest_cmd_vel
-        action_data.extend([twist.linear.x, twist.angular.z])
-
-        try:
-            # No observations for action-only episodes
-            self.current_ao_episode.add_timestep(action_data, [], [], [])
-        except ValueError as e:
-            self.get_logger().error(f"Error adding action-only timestep: {e}")
 
     def handle_get_task_metadata_list(self, request, response):
         self.get_logger().info("Received request to get task metadata list.")

--- a/ros2_ws/src/maurice_bot/maurice_arm/config/arm_config.yaml
+++ b/ros2_ws/src/maurice_bot/maurice_arm/config/arm_config.yaml
@@ -94,7 +94,7 @@ maurice_arm:
               "servo_id": 7,
               "position_limits": {
                   "min": -0.4363,
-                  "max": 0.2618
+                  "max": 0.4363
               },
               "pwm_limits": 885,
               "current_limit": 500,

--- a/ros2_ws/src/maurice_bot/maurice_control/maurice_control/app.py
+++ b/ros2_ws/src/maurice_bot/maurice_control/maurice_control/app.py
@@ -235,10 +235,6 @@ class AppControl(Node):
         cmd_msg.data = positions_rad.tolist()
         self.cmd_pub.publish(cmd_msg)
         
-        self.get_logger().info(
-            f"Leader positions: {msg.data} -> Transformed (rad): {cmd_msg.data}"
-        )
-
     def publish_robot_info_callback(self):
         """
         Reads robot_info.json and os_config.json, extracts specified keys, and publishes them as a JSON string.


### PR DESCRIPTION
…taset_metadata.json

- Change base directory from ~/innate-os/data to ~/innate-os/primitives
- Store episodes in {task}/data/ subdirectory instead of task root
- Rename metadata.json to dataset_metadata.json
- Remove action-only recording mode (services, timers, and configuration)
- Remove task_description and mobile_flag from task metadata
- Make leader_command and cmd_vel optional (use zeros if unavailable)
- Add odom topic subscription