### PR TITLE
fix: fix ros topic list so that is shows on first try

### DIFF
--- a/zshrcs/.zshrc
+++ b/zshrcs/.zshrc
@@ -113,3 +113,5 @@ if [ -f '/home/jetson1/google-cloud-sdk/path.zsh.inc' ]; then . '/home/jetson1/g
 
 # The next line enables shell command completion for gcloud.
 if [ -f '/home/jetson1/google-cloud-sdk/completion.zsh.inc' ]; then . '/home/jetson1/google-cloud-sdk/completion.zsh.inc'; fi
+
+(ros2 daemon start &) >/dev/null 2>&1


### PR DESCRIPTION
It silently starts the ROS 2 daemon in the background without showing any output or error messages. This is commonly done at startup to ensure the daemon is running before you start using ROS 2 commands, improving their performance.