### PR TITLE
Provisioner service starting fixed

### DIFF
--- a/ros2_ws/src/maurice_bot/maurice_bt_provisioner/maurice_bt_provisioner/simple_bt_service.py
+++ b/ros2_ws/src/maurice_bot/maurice_bt_provisioner/maurice_bt_provisioner/simple_bt_service.py
@@ -359,9 +359,30 @@ class BleProvisionerServer:
 
         adapter_address = self.adapter.address
         logger.info(f"Using adapter at address: {adapter_address}")
-        logger.info(f"Adapter properties: Discoverable={self.adapter.discoverable}, Powered={self.adapter.powered}, Pairable={self.adapter.pairable}")
+        
+        # Set adapter alias to match robot name
+        try:
+            self.adapter.alias = ROBOT_NAME
+            logger.info(f"Set adapter alias to '{ROBOT_NAME}'")
+        except Exception as e:
+            logger.warning(f"Failed to set adapter alias: {e}")
+        
+        # Check current discoverable state
+        is_discoverable = self.adapter.discoverable
+        logger.info(f"Adapter properties: Discoverable={is_discoverable}, Powered={self.adapter.powered}, Pairable={self.adapter.pairable}")
+        
+        # If already discoverable, temporarily disable to avoid Busy error when AdvertisingManager tries to set it
+        if is_discoverable:
+            logger.info("Adapter is already discoverable, temporarily disabling to avoid conflict...")
+            try:
+                self.adapter.discoverable = False
+                time.sleep(0.5)  # Brief pause to let the state change
+                logger.info("Temporarily disabled discoverable state")
+            except Exception as e:
+                logger.warning(f"Could not disable discoverable state: {e}")
 
         try:
+            # Create Peripheral - AdvertisingManager will set discoverable=True internally
             self.peripheral = peripheral.Peripheral(adapter_address,
                                                  local_name=ROBOT_NAME,
                                                  appearance=192) # 192: Generic Computer
@@ -402,7 +423,8 @@ class BleProvisionerServer:
             # Start advertising
             logger.info("Starting BLE advertisement...")
             self.peripheral.publish()
-            self.adapter.discoverable = True
+            # Note: discoverable is already set to True by AdvertisingManager inside Peripheral
+            # No need to set it again here (removed redundant line)
             logger.info("BLE Server is running. Press Ctrl+C to stop.")
         
         except Exception as e:


### PR DESCRIPTION
Problem
The BLE provisioner service failed to start with org.bluez.Error.Busy when the Bluetooth adapter was already discoverable. The AdvertisingManager in bluezero attempts to set discoverable=True during Peripheral initialization, which fails if the adapter is already discoverable, causing the service to crash before advertising begins.
Solution
Set adapter alias to match robot name from robot_info.json before creating the Peripheral (was loading in old version (?) investigate more as I thought some other piece of code was loading this in)
Check discoverable state before creating Peripheral; if already discoverable, temporarily disable it to avoid the conflict
Remove redundant discoverable=True assignment after publish() (already handled by AdvertisingManager)
The service now handles the discoverable state correctly and starts successfully, making the device visible in BLE scans as expected.