### PR TITLE
Do easy extlinux & systemd stuff to make boot faster

### DIFF
--- a/scripts/monitor_ros_status.sh
+++ b/scripts/monitor_ros_status.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Monitor ROS nodes, topics, and services startup status
+# Logs output to /tmp/ros_monitor.log
+
+LOG_FILE="/tmp/ros_monitor.log"
+ROS_WS_PATH="${INNATE_OS_ROOT:-$HOME/innate-os}/ros2_ws"
+DDS_SETUP_SCRIPT="${INNATE_OS_ROOT:-$HOME/innate-os}/dds/setup_dds.zsh"
+
+# Source environment
+source "$DDS_SETUP_SCRIPT" || { echo "ERROR: Failed to source DDS setup." >&2; exit 1; }
+if [ -f "$ROS_WS_PATH/install/setup.bash" ]; then
+    source "$ROS_WS_PATH/install/setup.bash" || { echo "ERROR: Failed to source ROS workspace." >&2; exit 1; }
+else
+    echo "ERROR: ROS workspace setup not found at $ROS_WS_PATH/install/setup.bash" >&2
+    exit 1
+fi
+
+# Clear previous log
+> "$LOG_FILE"
+
+for i in {1..100}; do
+    {
+        # ros2 node list > /tmp/ros_nodes 2>&1 & 
+        echo nah > /tmp/ros_nodes 2>&1 & 
+        ros2 topic list > /tmp/ros_topics 2>&1 & 
+        # ros2 service list > /tmp/ros_services 2>&1 & 
+        echo nah > /tmp/ros_services 2>&1 & 
+
+        wait
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] === Iteration $i ===" 
+        
+        echo '--- System Status ---'
+        echo "SSHD: $(systemctl is-active sshd)"
+        echo "zenoh-router: $(systemctl is-active zenoh-router.service)"
+        echo "ros-app: $(systemctl is-active ros-app.service)"
+        echo "ble-provisioner: $(systemctl is-active ble-provisioner.service)"
+        WIFI_IP=$(ip addr show wlP1p1s0 2>/dev/null | grep "inet " | awk '{print $2}')
+        if [ -n "$WIFI_IP" ]; then
+            echo "WiFi IP: $WIFI_IP"
+        else
+            echo "WiFi IP: NOT CONFIGURED"
+        fi
+        echo ''
+        
+        
+        
+        echo '--- Nodes ---' 
+        nl /tmp/ros_nodes 
+        echo ''
+        
+        echo '--- Topics ---' 
+        nl /tmp/ros_topics 
+        echo ''
+        
+        echo '--- Services ---' 
+        nl /tmp/ros_services 
+        echo ''
+        
+        rm -f /tmp/ros_nodes /tmp/ros_topics /tmp/ros_services
+        sleep 1
+    } >> "$LOG_FILE"
+done
+
+echo "Monitor complete. Full log saved to: $LOG_FILE"

--- a/scripts/monitor_ros_status.sh
+++ b/scripts/monitor_ros_status.sh
@@ -22,7 +22,7 @@ for i in {1..100}; do
     {
         # ros2 node list > /tmp/ros_nodes 2>&1 & 
         echo nah > /tmp/ros_nodes 2>&1 & 
-        ros2 topic list > /tmp/ros_topics 2>&1 & 
+        timeout 2 ros2 topic list > /tmp/ros_topics 2>&1 & 
         # ros2 service list > /tmp/ros_services 2>&1 & 
         echo nah > /tmp/ros_services 2>&1 & 
 

--- a/scripts/monitor_ros_status_analyzer.py
+++ b/scripts/monitor_ros_status_analyzer.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Parse ROS monitor log file and create a table with one row per iteration.
+Columns: Timestamp, SSHD, discovery-server, ros-app, ble-provisioner, WiFi IP,
+         Nodes (count), Topics (count), Services (count)
+"""
+
+import re
+from tabulate import tabulate
+
+
+def parse_log_file(filepath):
+    """Parse the log file and extract data for each iteration."""
+    
+    iterations = []
+    current_iteration = {}
+    current_section = None
+    section_line_count = 0
+    
+    with open(filepath, 'r') as f:
+        for line in f:
+            line_stripped = line.strip()
+            
+            # Check for iteration marker with timestamp
+            if '=== Iteration' in line_stripped:
+                # Save previous iteration if exists (with final Services count)
+                if current_iteration:
+                    if current_section == 'Services':
+                        current_iteration['Services'] = section_line_count
+                    iterations.append(current_iteration)
+                
+                # Extract timestamp from line like: [1969-12-31 16:00:46] === Iteration 1 ===
+                timestamp_match = re.search(r'\[(.*?)\]', line_stripped)
+                iteration_match = re.search(r'Iteration (\d+)', line_stripped)
+                
+                current_iteration = {
+                    'timestamp': timestamp_match.group(1) if timestamp_match else 'N/A',
+                    'iteration': int(iteration_match.group(1)) if iteration_match else 0,
+                    'SSHD': '',
+                    'zenoh-router': '',
+                    'ros-app': '',
+                    'ble-provisioner': '',
+                    'WiFi IP': '',
+                    'Nodes': 0,
+                    'Topics': 0,
+                    'Services': 0
+                }
+                current_section = None
+                section_line_count = 0
+                continue
+            
+            # Check for section headers
+            if line_stripped.startswith('--- System Status ---'):
+                current_section = 'System Status'
+                section_line_count = 0
+                continue
+            elif line_stripped.startswith('--- Nodes ---'):
+                current_section = 'Nodes'
+                section_line_count = 0
+                continue
+            elif line_stripped.startswith('--- Topics ---'):
+                # Save Nodes count before switching sections
+                if current_iteration and current_section == 'Nodes':
+                    current_iteration['Nodes'] = section_line_count
+                current_section = 'Topics'
+                section_line_count = 0
+                continue
+            elif line_stripped.startswith('--- Services ---'):
+                # Save Topics count before switching sections
+                if current_iteration and current_section == 'Topics':
+                    current_iteration['Topics'] = section_line_count
+                current_section = 'Services'
+                section_line_count = 0
+                continue
+            
+            # Count lines in current section (lines that start with numbers)
+            if current_section in ['Nodes', 'Topics', 'Services']:
+                # Check if line starts with whitespace then a number (the item number)
+                if re.match(r'^\s*\d+\s', line):
+                    section_line_count += 1
+            
+            # Parse system status lines
+            if current_section == 'System Status' and line_stripped and ':' in line_stripped:
+                parts = line_stripped.split(':', 1)
+                if len(parts) == 2:
+                    service = parts[0].strip()
+                    status = parts[1].strip()
+                    
+                    if service in current_iteration:
+                        current_iteration[service] = status
+        
+        # Don't forget the last iteration and its final Services count
+        if current_iteration:
+            if current_section == 'Services':
+                current_iteration['Services'] = section_line_count
+            iterations.append(current_iteration)
+    
+    return iterations
+
+
+def create_table(iterations):
+    """Create formatted table from the parsed data."""
+    
+    # Prepare table data
+    table_data = []
+    found_steady = False
+    for it in iterations:
+        row = [
+            it['iteration'],
+            it['timestamp'],
+            it['SSHD'],
+            it['zenoh-router'],
+            it['ros-app'],
+            it['ble-provisioner'],
+            it['WiFi IP'],
+            it['Nodes'],
+            it['Topics'],
+            it['Services']
+        ]
+        if '1969' not in it['timestamp'] and (iterations[-1]['Nodes'], iterations[-1]['Topics'], iterations[-1]['Services']) == (it['Nodes'], it['Topics'], it['Services']):
+            if found_steady:
+                break
+            found_steady = True
+        table_data.append(row)
+    
+    headers = [
+        'Iter',
+        'Timestamp',
+        'SSHD',
+        'zenoh-router',
+        'ros-app',
+        'ble-provisioner',
+        'WiFi IP',
+        'Nodes',
+        'Topics',
+        'Services'
+    ]
+    
+    print(tabulate(table_data, headers=headers, tablefmt='grid'))
+    print(f"\nTotal iterations: {len(iterations)}")
+
+
+def main():
+    import sys
+    
+    if len(sys.argv) < 2:
+        print("Usage: python analyze_ros_log.py <log_file>")
+        sys.exit(1)
+    
+    filepath = sys.argv[1]
+    
+    print(f"\nAnalyzing {filepath}...\n")
+    
+    iterations = parse_log_file(filepath)
+    create_table(iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update/configure_hardware.sh
+++ b/scripts/update/configure_hardware.sh
@@ -128,6 +128,112 @@ fi
 # Note: Not restarting NetworkManager here to avoid SSH disconnection.
 # The config will be applied on next reboot or manual NetworkManager restart.
 
+# -----------------------------------------------------------------------------
+# 5. Boot Timeout Configuration
+# -----------------------------------------------------------------------------
+log "Checking boot timeout configuration..."
+
+EXTLINUX_CONF="/boot/extlinux/extlinux.conf"
+if [ -f "$EXTLINUX_CONF" ]; then
+    # Check if there's a TIMEOUT line that is not already "TIMEOUT 0"
+    if grep -q "TIMEOUT" "$EXTLINUX_CONF" && ! grep -q "TIMEOUT 0" "$EXTLINUX_CONF"; then
+        log "  Modifying boot timeout to 0..."
+        # Create a backup
+        cp "$EXTLINUX_CONF" "${EXTLINUX_CONF}.bak.$(date +%Y%m%d%H%M%S)"
+        
+        # Replace TIMEOUT <number> with TIMEOUT 0
+        sed -i 's/TIMEOUT [0-9]\+/TIMEOUT 0/' "$EXTLINUX_CONF"
+        
+        log "  Boot timeout set to 0"
+        REBOOT_REQUIRED=true
+    elif grep -q "TIMEOUT 0" "$EXTLINUX_CONF"; then
+        log "  Boot timeout already set to 0"
+    else
+        log "  No TIMEOUT line found in extlinux.conf"
+    fi
+else
+    log "  Skipping boot timeout config - $EXTLINUX_CONF not found"
+fi
+
+# -----------------------------------------------------------------------------
+# 6. Disable Unnecessary Services
+# -----------------------------------------------------------------------------
+log "Configuring system services..."
+
+# Mask services that are not needed or slow down boot
+SERVICES_TO_MASK=(
+    "lvm2-monitor.service"
+    "lvm2-monitor-early.service"
+    "snapd.service"
+)
+
+for service in "${SERVICES_TO_MASK[@]}"; do
+    if systemctl list-unit-files "$service" &>/dev/null; then
+        if ! systemctl is-masked "$service" &>/dev/null; then
+            log "  Masking $service"
+            systemctl mask "$service" 2>/dev/null || log "    WARNING: Failed to mask $service"
+        else
+            log "  $service already masked"
+        fi
+    else
+        log "  $service not found, skipping"
+    fi
+done
+
+# Create systemd-update-utmp.service override to change dependency
+UTMP_SOURCE="/lib/systemd/system/systemd-update-utmp.service"
+UTMP_OVERRIDE="/etc/systemd/system/systemd-update-utmp.service"
+
+if [ -f "$UTMP_SOURCE" ]; then
+    # Check if override already exists with the correct content
+    if [ -f "$UTMP_OVERRIDE" ] && grep -q "multi-user.target" "$UTMP_OVERRIDE"; then
+        log "  systemd-update-utmp.service override already configured"
+    else
+        log "  Creating systemd-update-utmp.service override"
+        sed 's/sysinit\.target/multi-user.target/g' "$UTMP_SOURCE" > "$UTMP_OVERRIDE"
+        systemctl daemon-reload
+        log "  systemd-update-utmp.service override created"
+    fi
+else
+    log "  systemd-update-utmp.service not found, skipping"
+fi
+
+# -----------------------------------------------------------------------------
+# 7. Delay Anacron and Cron Services
+# -----------------------------------------------------------------------------
+log "Configuring anacron and cron service delays..."
+
+# TODO: DOUBLE CHECK THIS ACTUALLY DOES STUFF
+
+# Services to delay
+SERVICES_TO_DELAY=("anacron.service" "cron.service")
+
+for service in "${SERVICES_TO_DELAY[@]}"; do
+    if systemctl list-unit-files "$service" &>/dev/null; then
+        SERVICE_NAME="${service%%.*}"
+        OVERRIDE_DIR="/etc/systemd/system/$service.d"
+        OVERRIDE_FILE="$OVERRIDE_DIR/override.conf"
+        
+        mkdir -p "$OVERRIDE_DIR"
+        
+        if [ -f "$OVERRIDE_FILE" ] && grep -q "ExecStartPre=/bin/sleep 40" "$OVERRIDE_FILE"; then
+            log "  $service delay already configured"
+        else
+            log "  Adding 40s delay to $service"
+            cat > "$OVERRIDE_FILE" << 'EOF'
+[Service]
+ExecStartPre=/bin/sleep 40
+EOF
+            systemctl daemon-reload
+            log "  $service delay configured"
+        fi
+    else
+        log "  $service not found, skipping"
+    fi
+done
+
+
+
 log "Hardware configuration completed"
 
 # Exit with code 2 if reboot is required (allows caller to detect this)

--- a/systemd/ros-monitor.service
+++ b/systemd/ros-monitor.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=ROS Application Launcher in Tmux
+# Only depends on /tmp existing
+#After=tmp.mount
+
+[Service]
+# Run service manager as root, but execute script as jetson1 via sudo
+# User=jetson1 # Removed
+# Group=jetson1 # Removed
+
+# The launch script handles sourcing, tmux management, and running ros2 launch
+# Ensure this script is executable (chmod +x)
+# Preserve common/ROS environment variables including INNATE_OS_ROOT
+Environment="INNATE_OS_ROOT=/home/jetson1/innate-os"
+ExecStart=/usr/bin/sudo -u jetson1 --preserve-env=PATH,ROS_DISTRO,AMENT_PREFIX_PATH,PYTHONPATH,LD_LIBRARY_PATH,INNATE_OS_ROOT -- /bin/bash -c '${INNATE_OS_ROOT}/scripts/monitor_ros_status.sh'
+
+# Ensure the service runs only once and does not restart
+Type=simple
+RemainAfterExit=true
+
+# Disable automatic restarts
+Restart=no
+
+# Log output of the launch script to journald
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+# Enable this service to start on boot
+WantedBy=multi-user.target


### PR DESCRIPTION
- Remove timeout from extlinux bootloader (which allows selecting between multiple kernel versions/configs)
- Disable some disk encryption services (we don't use disk encryption) and disable snapd from starting on boot (can still run when triggered by the socket) (mainly used by firefox in this version of ubuntu)
- Move some boot logging services to happen before multi-user instead of sysinit, so instead of blocking ROS they happen in parallel (systemd-update-utmp.service)
- Add fixed 40s delay to cron and anacron starting. For some reason they use a ton of CPU and they don't necessarily need to start before ROS nodes are set up.

I have made linear issues for other boot improvements that are more time consuming to implement (See INN-206 and INN-207).


TODO:
- [ ] test on a freshly flashed robot and get numbers for this PR
Before: 1:15 to service stable (45 + 30)
After: 1:12 to service stable (39 + 33)
(there's some variability as you can see the second number shouldn't have changed very much but it does)
1:11 with only extlinux wtf

1:13 w/ only extlinux and hard reset
1:14 w/ everything and hard reset huh
This closes INN-45.