### PR TITLE
Disable shared memory on Zenoh Router

### DIFF
--- a/dds/setup_dds.zsh
+++ b/dds/setup_dds.zsh
@@ -9,7 +9,7 @@ export ZENOH_ROUTER_CHECK_ATTEMPTS=0 # wait forever for router start
 # TODO: once we move nodes to be individually launchable, this value 
 # should be set on a per-node basis to avoid wasting 12MiB per node 
 # (or potentially bottlenecking the camera nodes)
-export ZENOH_SESSION_CONFIG_OVERRIDE='transport/shared_memory/enabled=true;transport/shared_memory/transport_optimization/pool_size=12582912;transport/link/tx/queue/congestion_control/drop/wait_before_drop=4000000;transport/link/tx/queue/congestion_control/drop/max_wait_before_drop_fragments=5000000'
-export ZENOH_ROUTER_CONFIG_OVERRIDE='transport/shared_memory/enabled=false;transport/shared_memory/transport_optimization/pool_size=12582912;transport/link/tx/queue/congestion_control/drop/wait_before_drop=4000000;transport/link/tx/queue/congestion_control/drop/max_wait_before_drop_fragments=5000000'
+export ZENOH_SESSION_CONFIG_OVERRIDE='transport/shared_memory/enabled=true;transport/shared_memory/transport_optimization/pool_size=12582912;transport/link/tx/queue/congestion_control/drop/wait_before_drop=200000;transport/link/tx/queue/congestion_control/drop/max_wait_before_drop_fragments=300000'
+export ZENOH_ROUTER_CONFIG_OVERRIDE='transport/shared_memory/enabled=false;transport/shared_memory/transport_optimization/pool_size=12582912;transport/link/tx/queue/congestion_control/drop/wait_before_drop=200000;transport/link/tx/queue/congestion_control/drop/max_wait_before_drop_fragments=300000'
 export ZENOH_CONFIG_OVERRIDE="$ZENOH_SESSION_CONFIG_OVERRIDE"
 # export RUST_LOG=debug

--- a/dds/setup_dds.zsh
+++ b/dds/setup_dds.zsh
@@ -9,4 +9,7 @@ export ZENOH_ROUTER_CHECK_ATTEMPTS=0 # wait forever for router start
 # TODO: once we move nodes to be individually launchable, this value 
 # should be set on a per-node basis to avoid wasting 12MiB per node 
 # (or potentially bottlenecking the camera nodes)
-export ZENOH_CONFIG_OVERRIDE='transport/shared_memory/enabled=true;transport/shared_memory/transport_optimization/pool_size=12582912'
+export ZENOH_SESSION_CONFIG_OVERRIDE='transport/shared_memory/enabled=true;transport/shared_memory/transport_optimization/pool_size=12582912;transport/link/tx/queue/congestion_control/drop/wait_before_drop=4000000;transport/link/tx/queue/congestion_control/drop/max_wait_before_drop_fragments=5000000'
+export ZENOH_ROUTER_CONFIG_OVERRIDE='transport/shared_memory/enabled=false;transport/shared_memory/transport_optimization/pool_size=12582912;transport/link/tx/queue/congestion_control/drop/wait_before_drop=4000000;transport/link/tx/queue/congestion_control/drop/max_wait_before_drop_fragments=5000000'
+export ZENOH_CONFIG_OVERRIDE="$ZENOH_SESSION_CONFIG_OVERRIDE"
+# export RUST_LOG=debug

--- a/dds/start_zenoh_router.zsh
+++ b/dds/start_zenoh_router.zsh
@@ -34,4 +34,6 @@ else
   echo "Running Zenoh in default router mode"
 fi
 
+export ZENOH_CONFIG_OVERRIDE="$ZENOH_ROUTER_CONFIG_OVERRIDE"
+
 exec ros2 run rmw_zenoh_cpp rmw_zenohd

--- a/dds/start_zenoh_router.zsh
+++ b/dds/start_zenoh_router.zsh
@@ -13,6 +13,8 @@ else
 fi
 source "$(dirname "$0")/setup_dds.zsh"
 
+export ZENOH_CONFIG_OVERRIDE="$ZENOH_ROUTER_CONFIG_OVERRIDE"
+
 # Check if an argument is provided
 if [ -n "$1" ]; then
   # echo "Initiating a satellite zenoh router for debugging"
@@ -33,7 +35,5 @@ if [ -n "$1" ]; then
 else
   echo "Running Zenoh in default router mode"
 fi
-
-export ZENOH_CONFIG_OVERRIDE="$ZENOH_ROUTER_CONFIG_OVERRIDE"
 
 exec ros2 run rmw_zenoh_cpp rmw_zenohd


### PR DESCRIPTION
Remote Zenoh Routers were unable to communicate with the main one because of this.

Disabling SHM for router still allows the local nodes to talk to each other using SHM, but when something goes to the router (i.e. when a remote node is subscribed to a topic) it gets sent over the network, instead of using SHM.

From testing: as soon as a remote node subscribes to the image topic, it goes down to 12fps or so for ALL subscribes (even local ones). As soon as it unsubscribes, it goes back up to 30fps. So any transport selection is per-message, which is the best we can get I guess without a lossy zenoh serializing proxy

Closes INN-230