### PR TITLE
feat(gaze): add vision event system for proactive agent behavior

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py
@@ -953,7 +953,10 @@ class BrainClientNode(Node):
         if wants_gaze and self._gaze_tracker is None:
             try:
                 TrackerClass = _get_gaze_tracker_class()
-                self._gaze_tracker = TrackerClass(self)
+                self._gaze_tracker = TrackerClass(
+                    self,
+                    on_vision_event=self._handle_vision_event,
+                )
                 self._gaze_tracker.start()
                 self.get_logger().info(
                     f"👁️ Gaze tracker started for directive '{self.current_directive.id}'"
@@ -963,6 +966,45 @@ class BrainClientNode(Node):
                 self._gaze_tracker = None
         elif not wants_gaze and self._gaze_tracker is not None:
             self._stop_gaze_tracker()
+
+    def _handle_vision_event(self, event_type: str, event_data: dict):
+        """
+        Handle vision events from gaze tracker and forward to BASIC.
+
+        This enables agents to react to visual events like people approaching.
+
+        Currently supports face.* events. Future versions may support:
+        - object.detected / object.left (general object detection)
+        - motion.detected (scene change detection)
+        """
+        if not self.is_brain_active:
+            return
+
+        # Format message for BASIC based on event type
+        if event_type == "face.detected":
+            count = event_data.get("count", 1)
+            if count == 1:
+                text = "[Vision] I see a person in front of me."
+            else:
+                text = f"[Vision] I see {count} people in front of me."
+        elif event_type == "face.approaching":
+            text = "[Vision] The person is getting closer to me."
+        elif event_type == "face.left":
+            text = "[Vision] The person has left my field of view."
+        else:
+            # Unknown event type - log but don't send
+            self.get_logger().debug(f"👁️ Unhandled vision event: {event_type}")
+            return
+
+        self.get_logger().info(f"👁️ Vision event: {event_type} -> {text}")
+
+        # Send as chat_in message to BASIC
+        payload = {"text": text}
+        if image_b64 := self._encode_current_image():
+            payload["image_b64"] = image_b64
+
+        outgoing_msg = MessageIn(type=MessageInType.CHAT_IN, payload=payload)
+        self.ws_bridge.send_message(outgoing_msg)
 
     def _stop_gaze_tracker(self):
         """Stop and clean up gaze tracker."""

--- a/ros2_ws/src/brain/brain_client/brain_client/gaze.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/gaze.py
@@ -163,10 +163,35 @@ class GazeController:
 class ROSPersonTracker:
     """ROS2 person tracker - simple interface for agents."""
 
-    def __init__(self, node, camera_topic: str = "/mars/main_camera/image"):
+    # Face event cooldowns (seconds)
+    FACE_EVENT_COOLDOWN = 10.0  # Min time between "person detected" events
+    APPROACH_COOLDOWN = 15.0    # Min time between "person approaching" events
+    APPROACH_THRESHOLD = 1.5    # Face must grow by 50% to trigger approach event
+
+    def __init__(
+        self,
+        node,
+        camera_topic: str = "/mars/main_camera/image",
+        on_vision_event: Optional[Callable[[str, dict], None]] = None,
+    ):
+        """
+        Initialize person tracker.
+
+        Args:
+            node: ROS2 node
+            camera_topic: Camera topic to subscribe to
+            on_vision_event: Optional callback for vision events. Called with:
+                - event_type: "face.detected", "face.approaching", "face.left"
+                - event_data: dict with detection info (size, position, etc.)
+
+                Future event types may include:
+                - "object.detected", "object.left" (general object detection)
+                - "motion.detected" (scene change detection)
+        """
         self._node = node
         self._frame = None
         self._frame_lock = threading.Lock()
+        self._on_vision_event = on_vision_event
 
         # Hardware interfaces
         self._head = HeadInterface(node, node.get_logger())
@@ -185,6 +210,12 @@ class ROSPersonTracker:
         # Face tracking state
         self._last_face_time = 0.0
         self._face_timeout = 5.0
+
+        # Face event state
+        self._had_face = False
+        self._last_face_size = 0.0
+        self._last_person_detected_event = 0.0
+        self._last_approach_event = 0.0
 
         qos = QoSProfile(
             reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -254,17 +285,58 @@ class ROSPersonTracker:
             if frame is not None:
                 shape = (frame.shape[0], frame.shape[1])
                 faces = self._detector.detect(frame)
+                now = time.time()
 
                 if faces:
                     # Track largest face
                     best = max(faces, key=lambda f: f["width"] * f["height"])
                     self._gaze.track_face(best, shape)
-                    self._last_face_time = time.time()
-                elif time.time() - self._last_face_time > self._face_timeout:
-                    # Return to neutral after timeout
-                    with self._gaze._lock:
-                        self._gaze._target_tilt = 0.0
-                    self._last_face_time = time.time()
+                    self._last_face_time = now
+
+                    # Calculate face size (area as fraction of frame)
+                    face_size = best["width"] * best["height"]
+
+                    # Emit vision events
+                    if self._on_vision_event:
+                        # New person detected (no face -> face)
+                        if not self._had_face:
+                            if now - self._last_person_detected_event > self.FACE_EVENT_COOLDOWN:
+                                self._on_vision_event("face.detected", {
+                                    "count": len(faces),
+                                    "size": face_size,
+                                    "position": (best["center_x"], best["center_y"]),
+                                })
+                                self._last_person_detected_event = now
+                                self._last_face_size = face_size
+
+                        # Person approaching (face getting significantly larger)
+                        elif self._last_face_size > 0:
+                            size_ratio = face_size / self._last_face_size
+                            if size_ratio > self.APPROACH_THRESHOLD:
+                                if now - self._last_approach_event > self.APPROACH_COOLDOWN:
+                                    self._on_vision_event("face.approaching", {
+                                        "count": len(faces),
+                                        "size": face_size,
+                                        "previous_size": self._last_face_size,
+                                        "growth_ratio": size_ratio,
+                                    })
+                                    self._last_approach_event = now
+                                    self._last_face_size = face_size
+
+                    self._had_face = True
+
+                else:
+                    # No faces detected
+                    if self._had_face and now - self._last_face_time > self._face_timeout:
+                        # Person left
+                        if self._on_vision_event:
+                            self._on_vision_event("face.left", {})
+                        self._had_face = False
+                        self._last_face_size = 0.0
+
+                        # Return to neutral
+                        with self._gaze._lock:
+                            self._gaze._target_tilt = 0.0
 
             elapsed = time.time() - loop_start
             if elapsed < dt:


### PR DESCRIPTION
## Summary

- Adds a vision event callback system to `ROSPersonTracker` that forwards detection events to BASIC
- Enables agents to react to visual stimuli without custom input devices
- Uses extensible API designed for future object detection support

## What this enables

Agent prompts can now include instructions like:
- "When you see someone approaching, greet them"
- "If a person leaves, say goodbye"

BASIC receives events as `chat_in` messages:
- `[Vision] I see a person in front of me.`
- `[Vision] The person is getting closer to me.`
- `[Vision] The person has left my field of view.`

## API Design

The callback uses a general `on_vision_event(event_type, data)` pattern designed for future extensibility:

**Current events (face detection):**
- `face.detected` - New face appears
- `face.approaching` - Face size increases significantly  
- `face.left` - Face gone for >5 seconds

**Future events (not yet implemented):**
- `object.detected` / `object.left` - General object detection
- `motion.detected` - Scene change detection

## Why faces only (for now)

Face detection runs "for free" since InspireFace is already loaded for gaze tracking. General object detection would require:
- Additional model (YOLO, etc.)
- More GPU/CPU overhead
- Careful tuning to avoid event spam

The extensible API means object detection can be added later without breaking changes.

## Implementation details

- **Debouncing:** 10s cooldown for detection, 15s for approach events
- **Automatic image attachment** to vision messages
- **Clean separation** between detection (`gaze.py`) and messaging (`brain_client_node.py`)

## Test plan

- [ ] Deploy to robot with gaze-enabled agent
- [ ] Verify `face.detected` fires when person enters view
- [ ] Verify `face.approaching` fires when person walks toward robot
- [ ] Verify `face.left` fires after person leaves for >5s
- [ ] Verify BASIC receives messages and can act on them
- [ ] Verify debouncing prevents event spam

🤖 Generated with [Claude Code](https://claude.ai/code)