### PR TITLE
infra: add chess runtime Python dependencies

### DIFF
--- a/ros2_ws/pip-requirements.txt
+++ b/ros2_ws/pip-requirements.txt
@@ -37,6 +37,8 @@ websocket-client
 
 # Other AI
 inspireface
+google-genai
+python-chess
 
 # Input handling
 pygame
@@ -47,4 +49,3 @@ watchdog
 
 # Cupy
 cupy-cuda12x
-


### PR DESCRIPTION
## Summary
- add `google-genai` runtime dependency
- add `python-chess` runtime dependency

## Notes
- stacked PR 1/4
- base branch: `main`