### PR TITLE
feat(training-client): add fetch-data command to download skill input data

### DIFF
--- a/ros2_ws/src/cloud/clients/training-client/training_client/cli.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/cli.py
@@ -301,6 +301,23 @@ def download(ctx: click.Context, skill_dir: str, run_id: int, dest: str | None) 
     _print_progress(gen)
 
 
+# ── Fetch Input Data ────────────────────────────────────────────────
+
+
+@cli.command("fetch-data")
+@click.argument("skill_dir", type=click.Path(exists=True, file_okay=False), default=".")
+@click.option("--dest", type=click.Path(), default=None,
+              help="Destination dir (default: SKILL_DIR/data)")
+@click.pass_context
+def fetch_data(ctx: click.Context, skill_dir: str, dest: str | None) -> None:
+    """Download the input training data files for a skill."""
+    manager = _make_manager(ctx)
+    skill_id = _resolve_skill_id(skill_dir)
+    dest = dest or str(Path(skill_dir) / "data")
+    gen = manager.fetch_data(skill_id, dest)
+    _print_progress(gen)
+
+
 # ── List Skills ─────────────────────────────────────────────────────
 
 

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
@@ -164,6 +164,8 @@ def download_skill_data(
     dest_dir: Path,
 ) -> Generator[ProgressUpdate, None, None]:
     """List and download all input data files for a skill into *dest_dir*."""
+    dest_dir = dest_dir.resolve()
+
     yield ProgressUpdate(
         stage=ProgressStage.DOWNLOADING,
         message=f"Listing input data files for skill {skill_id}…",
@@ -190,5 +192,11 @@ def download_skill_data(
         client=client,
         files=files,
         dest_dir=dest_dir,
+        skill_id=skill_id,
+    )
+
+    yield ProgressUpdate(
+        stage=ProgressStage.DONE,
+        message=f"Skill {skill_id} input data downloaded to {dest_dir}",
         skill_id=skill_id,
     )

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
@@ -156,3 +156,40 @@ def download_results(
         skill_id=skill_id,
         run_id=run_id,
     )
+
+
+def download_skill_data(
+    *,
+    client: OrchestratorClient,
+    skill_id: str,
+    dest_dir: Path,
+) -> Generator[ProgressUpdate, None, None]:
+    """List and download all input data files for a skill into *dest_dir*."""
+    yield ProgressUpdate(
+        stage=ProgressStage.DOWNLOADING,
+        message=f"Listing input data files for skill {skill_id}…",
+        skill_id=skill_id,
+    )
+
+    files = client.list_skill_files(skill_id)
+
+    if not files:
+        yield ProgressUpdate(
+            stage=ProgressStage.DOWNLOADING,
+            message="No input data files found for this skill.",
+            skill_id=skill_id,
+        )
+        return
+
+    yield ProgressUpdate(
+        stage=ProgressStage.DOWNLOADING,
+        message=f"Found {len(files)} input data file(s) to download",
+        skill_id=skill_id,
+    )
+
+    yield from _download_files(
+        client=client,
+        files=files,
+        dest_dir=dest_dir,
+        skill_id=skill_id,
+    )

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
@@ -20,7 +20,7 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
-def _download_files(
+def download_files(
     *,
     client: OrchestratorClient,
     files: dict[str, str],
@@ -118,7 +118,6 @@ def _download_files(
 def download_results(
     *,
     client: OrchestratorClient,
-    config: ClientConfig,
     skill_id: str,
     run_id: int,
     dest_dir: Path,
@@ -149,7 +148,7 @@ def download_results(
         run_id=run_id,
     )
 
-    yield from _download_files(
+    yield from download_files(
         client=client,
         files=files,
         dest_dir=dest_dir,
@@ -187,7 +186,7 @@ def download_skill_data(
         skill_id=skill_id,
     )
 
-    yield from _download_files(
+    yield from download_files(
         client=client,
         files=files,
         dest_dir=dest_dir,

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
@@ -11,7 +11,6 @@ from typing import Generator
 from .client import OrchestratorClient
 from .compression import decompress_file
 from .types import (
-    ClientConfig,
     FileProgress,
     ProgressStage,
     ProgressUpdate,
@@ -178,6 +177,11 @@ def download_skill_data(
         yield ProgressUpdate(
             stage=ProgressStage.DOWNLOADING,
             message="No input data files found for this skill.",
+            skill_id=skill_id,
+        )
+        yield ProgressUpdate(
+            stage=ProgressStage.DONE,
+            message=f"Skill {skill_id} input data downloaded to {dest_dir}",
             skill_id=skill_id,
         )
         return

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/downloader.py
@@ -1,5 +1,5 @@
 """
-Download run results (outputs/checkpoints).
+Download run results (outputs/checkpoints) and skill input data.
 """
 
 from __future__ import annotations
@@ -20,47 +20,20 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
-def download_results(
+def _download_files(
     *,
     client: OrchestratorClient,
-    config: ClientConfig,
-    skill_id: str,
-    run_id: int,
+    files: dict[str, str],
     dest_dir: Path,
+    skill_id: str | None = None,
+    run_id: int | None = None,
 ) -> Generator[ProgressUpdate, None, None]:
+    """Download a ``{filename: signed_url}`` mapping into *dest_dir*.
+
+    Shared by :func:`download_results` (run outputs) and skill input data.
+    ``.zst`` files are auto-decompressed after download.
     """
-    List and download all output files for a run.
-
-    Files are saved into *dest_dir*.  ``.zst`` files are auto-decompressed.
-
-    Yields :class:`ProgressUpdate` for each file downloaded.
-    """
-    yield ProgressUpdate(
-        stage=ProgressStage.DOWNLOADING,
-        message=f"Listing result files for run {skill_id}/{run_id}…",
-        skill_id=skill_id,
-        run_id=run_id,
-    )
-
-    files = client.list_run_files(skill_id, run_id)
-
-    if not files:
-        yield ProgressUpdate(
-            stage=ProgressStage.DOWNLOADING,
-            message="No result files found",
-            skill_id=skill_id,
-            run_id=run_id,
-        )
-        return
-
     total = len(files)
-    yield ProgressUpdate(
-        stage=ProgressStage.DOWNLOADING,
-        message=f"Found {total} result file(s) to download",
-        skill_id=skill_id,
-        run_id=run_id,
-    )
-
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     for idx, (filename, signed_url) in enumerate(files.items(), start=1):
@@ -136,7 +109,50 @@ def download_results(
 
     yield ProgressUpdate(
         stage=ProgressStage.DOWNLOADING,
-        message=f"All {total} result file(s) downloaded to {dest_dir}",
+        message=f"All {total} file(s) downloaded to {dest_dir}",
+        skill_id=skill_id,
+        run_id=run_id,
+    )
+
+
+def download_results(
+    *,
+    client: OrchestratorClient,
+    config: ClientConfig,
+    skill_id: str,
+    run_id: int,
+    dest_dir: Path,
+) -> Generator[ProgressUpdate, None, None]:
+    """List and download all output files for a run into *dest_dir*."""
+    yield ProgressUpdate(
+        stage=ProgressStage.DOWNLOADING,
+        message=f"Listing result files for run {skill_id}/{run_id}…",
+        skill_id=skill_id,
+        run_id=run_id,
+    )
+
+    files = client.list_run_files(skill_id, run_id)
+
+    if not files:
+        yield ProgressUpdate(
+            stage=ProgressStage.DOWNLOADING,
+            message="No result files found",
+            skill_id=skill_id,
+            run_id=run_id,
+        )
+        return
+
+    yield ProgressUpdate(
+        stage=ProgressStage.DOWNLOADING,
+        message=f"Found {len(files)} result file(s) to download",
+        skill_id=skill_id,
+        run_id=run_id,
+    )
+
+    yield from _download_files(
+        client=client,
+        files=files,
+        dest_dir=dest_dir,
         skill_id=skill_id,
         run_id=run_id,
     )

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
@@ -19,7 +19,7 @@ from typing import Any, Generator
 
 from .client import APIError, OrchestratorClient
 from .compression import cleanup_compressed
-from .downloader import download_results, _download_files
+from .downloader import download_results, download_skill_data, _download_files
 from .types import (
     ClientConfig,
     RunInfo,
@@ -463,27 +463,10 @@ class SkillManager:
         Files are saved into *dest_dir*.  ``.zst`` files are auto-decompressed.
         Yields :class:`ProgressUpdate` for each file downloaded.
         """
-        yield ProgressUpdate(
-            stage=ProgressStage.DOWNLOADING,
-            message=f"Listing input data files for skill {skill_id}…",
-            skill_id=skill_id,
-        )
-
-        files = self.client.list_skill_files(skill_id)
-
-        if not files:
-            yield ProgressUpdate(
-                stage=ProgressStage.DOWNLOADING,
-                message="No input data files found for this skill.",
-                skill_id=skill_id,
-            )
-            return
-
-        yield from _download_files(
+        yield from download_skill_data(
             client=self.client,
-            files=files,
-            dest_dir=Path(dest_dir),
             skill_id=skill_id,
+            dest_dir=Path(dest_dir),
         )
 
     # ── Cleanup ─────────────────────────────────────────────────────

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
@@ -19,7 +19,7 @@ from typing import Any, Generator
 
 from .client import APIError, OrchestratorClient
 from .compression import cleanup_compressed
-from .downloader import download_results, download_skill_data, download_files, _download_files
+from .downloader import download_results, download_skill_data, download_files
 from .types import (
     ClientConfig,
     RunInfo,

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
@@ -19,7 +19,7 @@ from typing import Any, Generator
 
 from .client import APIError, OrchestratorClient
 from .compression import cleanup_compressed
-from .downloader import download_results
+from .downloader import download_results, _download_files
 from .types import (
     ClientConfig,
     RunInfo,
@@ -450,6 +450,41 @@ class SkillManager:
         )
 
         return {"checkpoint": checkpoint, "stats_file": stats_file}
+
+    # ── Fetch input data ────────────────────────────────────────────
+
+    def fetch_data(
+        self,
+        skill_id: str,
+        dest_dir: str | Path,
+    ) -> Generator[ProgressUpdate, None, None]:
+        """Download the input training data files for a skill.
+
+        Files are saved into *dest_dir*.  ``.zst`` files are auto-decompressed.
+        Yields :class:`ProgressUpdate` for each file downloaded.
+        """
+        yield ProgressUpdate(
+            stage=ProgressStage.DOWNLOADING,
+            message=f"Listing input data files for skill {skill_id}…",
+            skill_id=skill_id,
+        )
+
+        files = self.client.list_skill_files(skill_id)
+
+        if not files:
+            yield ProgressUpdate(
+                stage=ProgressStage.DOWNLOADING,
+                message="No input data files found for this skill.",
+                skill_id=skill_id,
+            )
+            return
+
+        yield from _download_files(
+            client=self.client,
+            files=files,
+            dest_dir=Path(dest_dir),
+            skill_id=skill_id,
+        )
 
     # ── Cleanup ─────────────────────────────────────────────────────
 

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
@@ -19,7 +19,7 @@ from typing import Any, Generator
 
 from .client import APIError, OrchestratorClient
 from .compression import cleanup_compressed
-from .downloader import download_results, download_skill_data, _download_files
+from .downloader import download_results, download_skill_data, download_files, _download_files
 from .types import (
     ClientConfig,
     RunInfo,
@@ -367,7 +367,6 @@ class SkillManager:
 
         yield from download_results(
             client=self.client,
-            config=self.config,
             skill_id=skill_id,
             run_id=run_id,
             dest_dir=dest,


### PR DESCRIPTION
Adds `fetch-data` CLI command — the missing counterpart to `upload`.

## What
- New `fetch-data` command downloads input training data (h5 episodes, metadata) for a skill
- Extracts `_download_files` helper from `download_results` to avoid duplicating the per-file download/decompress loop
- Adds `SkillManager.fetch_data()` using `list_skill_files` + shared helper

## Usage
```bash
python -m training_client.cli fetch-data ./skill
python -m training_client.cli fetch-data ./skill --dest /tmp/training-data
```

## Tested
Verified live against the Socks1a skill — downloaded 37 files (h5 episodes + metadata) successfully.