### PR TITLE
fix(cam): remove redundant disable_auto_exposure parameter

### DIFF
--- a/ros2_ws/src/maurice_bot/maurice_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/maurice_bot/maurice_cam/config/stereo_depth_estimator.yaml
@@ -19,7 +19,7 @@ main_camera_driver:
     exposure: -1
     gain: -1
     default_gain: 110
-    enable_auto_exposure: false
+    auto_exposure_mode: 0
     target_brightness: 128.0
     ae_kp: 0.8
     auto_exposure_update_interval: 3

--- a/ros2_ws/src/maurice_bot/maurice_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/maurice_bot/maurice_cam/config/stereo_depth_estimator.yaml
@@ -18,7 +18,6 @@ main_camera_driver:
     publish_stereo: false
     exposure: -1
     gain: -1
-    disable_auto_exposure: false
     default_gain: 110
     enable_auto_exposure: false
     target_brightness: 128.0

--- a/ros2_ws/src/maurice_bot/maurice_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/maurice_bot/maurice_cam/config/stereo_depth_estimator.yaml
@@ -19,7 +19,7 @@ main_camera_driver:
     exposure: -1
     gain: -1
     default_gain: 110
-    auto_exposure_mode: 0
+    auto_exposure_mode: 0  # 0=hardware AE (camera built-in), 1=custom PID AE, 2=manual (no AE)
     target_brightness: 128.0
     ae_kp: 0.8
     auto_exposure_update_interval: 3

--- a/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/main_camera_driver.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/main_camera_driver.hpp
@@ -298,7 +298,6 @@ private:
   bool v4l2_controls_initialized_{false};
   int exposure_setting_{-1};
   int gain_setting_{-1};
-  bool disable_auto_exposure_{false};
   int default_gain_param_{110};
 
   // Auto exposure control

--- a/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/main_camera_driver.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/main_camera_driver.hpp
@@ -166,6 +166,15 @@ class MainCameraDriver : public rclcpp::Node
 {
 public:
   /**
+   * @brief Auto exposure mode selection
+   */
+  enum class AutoExposureMode : int {
+    HARDWARE = 0,   // Camera built-in AE (aperture priority)
+    CUSTOM_PID = 1, // Custom PID controller (manual V4L2 mode)
+    MANUAL = 2,     // Pure manual, no AE
+  };
+
+  /**
    * @brief Constructor
    * @param options Node options for component composition
    */
@@ -302,7 +311,7 @@ private:
 
   // Auto exposure control
   AutoExposureController auto_exposure_controller_;
-  bool enable_auto_exposure_{true};
+  AutoExposureMode auto_exposure_mode_{AutoExposureMode::HARDWARE};
   double target_brightness_{128.0};
   double ae_kp_{0.8};
   int auto_exposure_update_interval_{3};  // Update every N frames (10Hz for 30Hz camera)

--- a/ros2_ws/src/maurice_bot/maurice_cam/launch/main_camera_driver.launch.py
+++ b/ros2_ws/src/maurice_bot/maurice_cam/launch/main_camera_driver.launch.py
@@ -102,10 +102,10 @@ def generate_launch_description():
     )
     
     # Auto exposure parameters
-    enable_auto_exposure_arg = DeclareLaunchArgument(
-        'enable_auto_exposure',
-        default_value='false',
-        description='Enable custom auto exposure algorithm (true/false)'
+    auto_exposure_mode_arg = DeclareLaunchArgument(
+        'auto_exposure_mode',
+        default_value='0',
+        description='Auto exposure mode: 0=hardware AE, 1=custom PID AE, 2=manual'
     )
     
     target_brightness_arg = DeclareLaunchArgument(
@@ -155,7 +155,7 @@ def generate_launch_description():
                 'exposure': LaunchConfiguration('exposure'),
                 'gain': LaunchConfiguration('gain'),
                 'default_gain': LaunchConfiguration('default_gain'),
-                'enable_auto_exposure': LaunchConfiguration('enable_auto_exposure'),
+                'auto_exposure_mode': LaunchConfiguration('auto_exposure_mode'),
                 'target_brightness': LaunchConfiguration('target_brightness'),
                 'ae_kp': LaunchConfiguration('ae_kp'),
                 'auto_exposure_update_interval': LaunchConfiguration('auto_exposure_update_interval'),
@@ -183,7 +183,7 @@ def generate_launch_description():
         exposure_arg,
         gain_arg,
         default_gain_arg,
-        enable_auto_exposure_arg,
+        auto_exposure_mode_arg,
         target_brightness_arg,
         ae_kp_arg,
         auto_exposure_update_interval_arg,

--- a/ros2_ws/src/maurice_bot/maurice_cam/launch/main_camera_driver.launch.py
+++ b/ros2_ws/src/maurice_bot/maurice_cam/launch/main_camera_driver.launch.py
@@ -95,12 +95,6 @@ def generate_launch_description():
         description='Manual gain value (-1 = use current value, 0-255)'
     )
     
-    disable_auto_exposure_arg = DeclareLaunchArgument(
-        'disable_auto_exposure',
-        default_value='false',
-        description='Disable automatic exposure (true/false)'
-    )
-    
     default_gain_arg = DeclareLaunchArgument(
         'default_gain',
         default_value='110',
@@ -160,7 +154,6 @@ def generate_launch_description():
                 'compressed_frame_interval': LaunchConfiguration('compressed_frame_interval'),
                 'exposure': LaunchConfiguration('exposure'),
                 'gain': LaunchConfiguration('gain'),
-                'disable_auto_exposure': LaunchConfiguration('disable_auto_exposure'),
                 'default_gain': LaunchConfiguration('default_gain'),
                 'enable_auto_exposure': LaunchConfiguration('enable_auto_exposure'),
                 'target_brightness': LaunchConfiguration('target_brightness'),
@@ -189,7 +182,6 @@ def generate_launch_description():
         compressed_frame_interval_arg,
         exposure_arg,
         gain_arg,
-        disable_auto_exposure_arg,
         default_gain_arg,
         enable_auto_exposure_arg,
         target_brightness_arg,

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/main_camera_driver.cpp
@@ -30,7 +30,7 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions & options)
   this->declare_parameter<int>("default_gain", 110);  // Default gain for auto-exposure mode
   
   // Auto exposure parameters
-  this->declare_parameter<bool>("enable_auto_exposure", true);
+  this->declare_parameter<int>("auto_exposure_mode", 0);
   this->declare_parameter<double>("target_brightness", 128.0);
   this->declare_parameter<double>("ae_kp", 0.8);
   this->declare_parameter<int>("auto_exposure_update_interval", 3);
@@ -58,7 +58,7 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions & options)
   default_gain_param_ = this->get_parameter("default_gain").as_int();
   
   // Get auto exposure parameter values
-  enable_auto_exposure_ = this->get_parameter("enable_auto_exposure").as_bool();
+  auto_exposure_mode_ = static_cast<AutoExposureMode>(this->get_parameter("auto_exposure_mode").as_int());
   target_brightness_ = this->get_parameter("target_brightness").as_double();
   ae_kp_ = this->get_parameter("ae_kp").as_double();
   auto_exposure_update_interval_ = this->get_parameter("auto_exposure_update_interval").as_int();
@@ -273,32 +273,39 @@ bool MainCameraDriver::initializeCamera()
   if (!initializeV4L2Controls()) {
     RCLCPP_WARN(this->get_logger(), "Failed to initialize V4L2 controls, using default settings");
   } else {
-    // Initialize auto exposure controller if enabled
-    if (enable_auto_exposure_) {
-      auto_exposure_controller_.initialize(exposure_min_, exposure_max_, 
-                                         target_brightness_, ae_kp_);
-      RCLCPP_DEBUG(this->get_logger(), "Auto exposure controller initialized:");
-      RCLCPP_DEBUG(this->get_logger(), "  Target brightness: %.1f", target_brightness_);
-      RCLCPP_DEBUG(this->get_logger(), "  Proportional gain: Kp=%.2f", ae_kp_);
-      RCLCPP_DEBUG(this->get_logger(), "  Update interval: every %d frames (%.1f Hz)", 
-                  auto_exposure_update_interval_, fps_ / auto_exposure_update_interval_);
-    }
-    // Apply parameter settings if specified
-    if (enable_auto_exposure_) {
-      // Use manual mode for custom auto exposure (we control exposure via PID)
-      if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL)) {
-        RCLCPP_DEBUG(this->get_logger(), "Disabled camera auto exposure (Manual Mode for custom AE)");
-      }
-    } else {
-      // Use camera's built-in auto exposure
-      if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_APERTURE_PRIORITY)) {
-        RCLCPP_DEBUG(this->get_logger(), "Enabled camera auto exposure (Aperture Priority Mode)");
-        // Reset gain to default when switching to auto-exposure
-        if (setV4L2Control(V4L2_CID_GAIN, default_gain_param_)) {
-          current_gain_ = default_gain_param_;
-          RCLCPP_DEBUG(this->get_logger(), "Reset gain to default: %d", default_gain_param_);
+    // Configure V4L2 and initialize AE controller based on mode
+    switch (auto_exposure_mode_) {
+      case AutoExposureMode::HARDWARE:
+        // Camera built-in AE (aperture priority) — no PID, reset gain to default
+        if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_APERTURE_PRIORITY)) {
+          RCLCPP_DEBUG(this->get_logger(), "AE mode: HARDWARE (aperture priority)");
+          if (setV4L2Control(V4L2_CID_GAIN, default_gain_param_)) {
+            current_gain_ = default_gain_param_;
+            RCLCPP_DEBUG(this->get_logger(), "Reset gain to default: %d", default_gain_param_);
+          }
         }
-      }
+        break;
+
+      case AutoExposureMode::CUSTOM_PID:
+        // Custom PID AE — set V4L2 manual mode, initialize and run PID controller
+        if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL)) {
+          RCLCPP_DEBUG(this->get_logger(), "AE mode: CUSTOM_PID (manual V4L2 + PID controller)");
+        }
+        auto_exposure_controller_.initialize(exposure_min_, exposure_max_,
+                                             target_brightness_, ae_kp_);
+        RCLCPP_DEBUG(this->get_logger(), "Auto exposure controller initialized:");
+        RCLCPP_DEBUG(this->get_logger(), "  Target brightness: %.1f", target_brightness_);
+        RCLCPP_DEBUG(this->get_logger(), "  Proportional gain: Kp=%.2f", ae_kp_);
+        RCLCPP_DEBUG(this->get_logger(), "  Update interval: every %d frames (%.1f Hz)",
+                    auto_exposure_update_interval_, fps_ / auto_exposure_update_interval_);
+        break;
+
+      case AutoExposureMode::MANUAL:
+        // Pure manual — set V4L2 manual mode, no PID controller
+        if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL)) {
+          RCLCPP_DEBUG(this->get_logger(), "AE mode: MANUAL (pure manual, no PID)");
+        }
+        break;
     }
     
     if (exposure_setting_ >= 0) {
@@ -503,7 +510,7 @@ void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame)
   }
   
   // Apply auto exposure control (frame is already rotated and downscaled)
-  if (enable_auto_exposure_ && v4l2_controls_initialized_) {
+  if (auto_exposure_mode_ == AutoExposureMode::CUSTOM_PID && v4l2_controls_initialized_) {
     frame_counter_++;
     if (frame_counter_ >= auto_exposure_update_interval_) {
       // Use left half of the already-downscaled frame

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/main_camera_driver.cpp
@@ -27,7 +27,6 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions & options)
   this->declare_parameter<bool>("publish_stereo", false);  // Combined stereo image for legacy compatibility
   this->declare_parameter<int>("exposure", -1);  // -1 means use current value
   this->declare_parameter<int>("gain", -1);      // -1 means use current value
-  this->declare_parameter<bool>("disable_auto_exposure", false);
   this->declare_parameter<int>("default_gain", 110);  // Default gain for auto-exposure mode
   
   // Auto exposure parameters
@@ -56,7 +55,6 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions & options)
   // Get V4L2 control parameters
   exposure_setting_ = this->get_parameter("exposure").as_int();
   gain_setting_ = this->get_parameter("gain").as_int();
-  disable_auto_exposure_ = this->get_parameter("disable_auto_exposure").as_bool();
   default_gain_param_ = this->get_parameter("default_gain").as_int();
   
   // Get auto exposure parameter values
@@ -276,7 +274,7 @@ bool MainCameraDriver::initializeCamera()
     RCLCPP_WARN(this->get_logger(), "Failed to initialize V4L2 controls, using default settings");
   } else {
     // Initialize auto exposure controller if enabled
-    if (enable_auto_exposure_ && !disable_auto_exposure_) {
+    if (enable_auto_exposure_) {
       auto_exposure_controller_.initialize(exposure_min_, exposure_max_, 
                                          target_brightness_, ae_kp_);
       RCLCPP_DEBUG(this->get_logger(), "Auto exposure controller initialized:");
@@ -286,14 +284,10 @@ bool MainCameraDriver::initializeCamera()
                   auto_exposure_update_interval_, fps_ / auto_exposure_update_interval_);
     }
     // Apply parameter settings if specified
-    if (disable_auto_exposure_ || enable_auto_exposure_) {
-      // Use manual mode for either manual control or custom auto exposure
+    if (enable_auto_exposure_) {
+      // Use manual mode for custom auto exposure (we control exposure via PID)
       if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL)) {
-        if (enable_auto_exposure_) {
-          RCLCPP_DEBUG(this->get_logger(), "Disabled camera auto exposure (Manual Mode for custom AE)");
-        } else {
-          RCLCPP_DEBUG(this->get_logger(), "Disabled auto exposure (Manual Mode)");
-        }
+        RCLCPP_DEBUG(this->get_logger(), "Disabled camera auto exposure (Manual Mode for custom AE)");
       }
     } else {
       // Use camera's built-in auto exposure
@@ -509,7 +503,7 @@ void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame)
   }
   
   // Apply auto exposure control (frame is already rotated and downscaled)
-  if (enable_auto_exposure_ && !disable_auto_exposure_ && v4l2_controls_initialized_) {
+  if (enable_auto_exposure_ && v4l2_controls_initialized_) {
     frame_counter_++;
     if (frame_counter_ >= auto_exposure_update_interval_) {
       // Use left half of the already-downscaled frame


### PR DESCRIPTION
## Summary

Removes the `disable_auto_exposure` parameter from the main camera driver. It was never set to `true` in any config or launch file, and created a confusing 3-state model using two booleans.

## Analysis

The camera driver had two boolean params controlling auto exposure:
- `enable_auto_exposure` — enables custom PID-based auto exposure
- `disable_auto_exposure` — was intended to force pure manual mode (no AE at all)

This created 4 possible combinations but only 2 were ever used:
| enable | disable | Behavior | Ever used? |
|--------|---------|----------|------------|
| false | false | Camera hardware AE (aperture priority) | ✅ Default in all configs |
| true | false | Custom PID AE (manual V4L2 mode) | ✅ When enabled |
| false | true | Pure manual (no AE) | ❌ Never |
| true | true | Contradictory → same as false/true | ❌ Never |

`disable_auto_exposure` defaulted to `false` in the C++ code, launch file, and YAML config. No config ever set it to `true`.

## Changes

Simplified to single boolean `enable_auto_exposure`:
- `true` → custom PID-based AE (V4L2 manual mode, software controls exposure)
- `false` → camera hardware AE (aperture priority mode)

Removed from:
- Parameter declaration and reading (`main_camera_driver.cpp`)
- Member variable (`main_camera_driver.hpp`)
- Launch arguments (`main_camera_driver.launch.py`)
- YAML config (`stereo_depth_estimator.yaml`)
- All conditional checks that used it as an override

## Testing

No behavioral change — `disable_auto_exposure` was always `false`, so the `!disable_auto_exposure_` guards were always `true`. The simplified conditionals produce identical behavior for all existing configurations.