### PR TITLE
version missmatch on ssh connection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -361,6 +361,7 @@ download_release() {
                 git remote add origin "https://github.com/$GITHUB_REPO.git"
             fi
             git fetch --tags -q 2>/dev/null || true
+            git fetch origin main -q 2>/dev/null || true
             git checkout -b main -q 2>/dev/null || true
             git reset --soft "$LATEST_TAG" 2>/dev/null || true
         fi

--- a/scripts/update/innate-update
+++ b/scripts/update/innate-update
@@ -368,6 +368,11 @@ class GitRepo:
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip().split("\n")[0]
+        # Fallback: origin/<branch> may not exist (e.g. partial clone from install.sh).
+        # List all version-sorted tags instead.
+        result = self._run(["tag", "--sort=-v:refname"], check=False)
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip().split("\n")[0]
         return ""
 
     def get_current_tag(self) -> str:
@@ -823,16 +828,15 @@ class UpdateManager:
             except OSError:
                 pass
 
-        # Fetch silently
-        if not self.git.fetch():
-            return 0
+        # Fetch silently (best-effort; even on failure we check local tags)
+        self.git.fetch()
 
         current = self.git.current_commit()
         latest_tag = self.git.get_latest_tag()
 
         if not latest_tag:
-            self._write_cache("0")
-            return 0
+            # No tags at all -- can't determine status; don't cache a false "0"
+            return 2
 
         latest_tag_commit = self.git.resolve_ref(latest_tag)
 


### PR DESCRIPTION
Previously we got this when connecting on shh

```**Current:** 0.4.2

**Latest:**  0.4.5

[OK] You are on the latest Innate OS release.
