### PR TITLE
Fix completions dir permission error in post_update

### DIFF
--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -262,9 +262,11 @@ if [ -d "$REPO_DIR/scripts" ]; then
     # Regenerate zsh completions from the Click command tree
     if [ -f "$REPO_DIR/scripts/innate" ]; then
         log "  Generating zsh completions"
+        # Clean up stale completions from old path (was root-owned, blocks colcon rebuild)
+        rm -rf "$REPO_DIR/ros2_ws/build/completions"
         mkdir -p "$REPO_DIR/scripts/build/completions"
+        chown -R "$ACTUAL_USER:$ACTUAL_USER" "$REPO_DIR/scripts/build"
         sudo -u "$ACTUAL_USER" "$REPO_DIR/scripts/innate" completions > "$REPO_DIR/scripts/build/completions/_innate"
-        chown "$ACTUAL_USER:$ACTUAL_USER" "$REPO_DIR/scripts/build/completions/_innate"
     fi
 
     # Symlink restart script if it exists


### PR DESCRIPTION
The completions `mkdir -p` ran as root, so `ros2_ws/build/completions` was root-owned. Colcon rebuild does `rm -rf build/` as the user and fails with permission denied.

- `chown -R` the `scripts/build` directory after creating it
- Remove stale `ros2_ws/build/completions` from the old path