### PR TITLE
Download skill assets from metadata.json during post_update

### DIFF
--- a/ros2_ws/apt-dependencies.common.txt
+++ b/ros2_ws/apt-dependencies.common.txt
@@ -15,6 +15,7 @@ zsh
 tmux
 
 # System libraries
+jq
 zstd
 libudev-dev
 libusb-1.0-0-dev

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -674,6 +674,21 @@ if [ -d "$DIRECTIVES_DIR" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# 11b. Download skill assets from metadata.json
+# -----------------------------------------------------------------------------
+for meta_file in "$REPO_DIR"/skills/*/metadata.json; do
+    [ -f "$meta_file" ] || continue
+    jq -r '.downloads // {} | to_entries[] | "\(.key)\t\(.value)"' "$meta_file" 2>/dev/null | \
+    while IFS=$'\t' read -r fname url; do
+        dest="$(dirname "$meta_file")/$fname"
+        [ -f "$dest" ] && continue
+        log "  Downloading $dest"
+        sudo -u "$ACTUAL_USER" curl -fsSL -o "$dest.tmp" "$url"
+        mv "$dest.tmp" "$dest"
+    done
+done
+
+# -----------------------------------------------------------------------------
 # 12. Enable and restart services
 # -----------------------------------------------------------------------------
 log "Enabling and starting services..."

--- a/skills/wave/metadata.json
+++ b/skills/wave/metadata.json
@@ -4,6 +4,9 @@
     "guidelines": "",
     "guidelines_when_running": "",
     "inputs": {},
+    "downloads": {
+        "episode_0.h5": "https://storage.googleapis.com/karmanyaah-public/arm_wave/episode_0.h5"
+    },
     "execution": {
         "model_type": "replay",
         "replay_file": "episode_0.h5",


### PR DESCRIPTION
## Summary
- post_update.sh now iterates `skills/*/metadata.json`, reads the `downloads` map (`{filename: url}`), and fetches any missing files
- Skips files that already exist on disk
- Adds `episode_0.h5` download URL to wave skill metadata

## Test plan
- [ ] Fresh robot: wave/episode_0.h5 gets downloaded during post_update
- [ ] Second run: skips download since file exists
- [ ] Skills without `downloads` key are unaffected