### PR TITLE
Point uninavid at nav-v1.innate.bot

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -20,6 +20,6 @@ TELEMETRY_URL=https://logs.innate.bot
 # INNATE_PROXY_URL=https://proxy-v1.innate.bot
 # INNATE_AUTH_URL=https://auth-v1.innate.bot
 # INNATE_TRAINING_URL=https://training-v1.innate.bot
-# UNINAVID_WS_URL=wss://office.servers.innatebotstatus.com:9000
+# UNINAVID_WS_URL=wss://nav-v1.innate.bot
 
 # test training node to CI able

--- a/ros2_ws/src/cloud/.env.template
+++ b/ros2_ws/src/cloud/.env.template
@@ -16,4 +16,4 @@ INNATE_PROXY_URL=http://localhost:8083
 # Production (defaults if unset):
 # INNATE_AUTH_URL=https://auth-v1.innate.bot
 # TRAINING_SERVER_URL=https://training-v1.innate.bot
-# UNINAVID_WS_URL=wss://office.servers.innatebotstatus.com:9000
+# UNINAVID_WS_URL=wss://nav-v1.innate.bot

--- a/ros2_ws/src/cloud/innate_uninavid/PROTOCOL.md
+++ b/ros2_ws/src/cloud/innate_uninavid/PROTOCOL.md
@@ -27,7 +27,7 @@ config file at `config/params.yaml` or overridden on the command line.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `ws_url` | string | env `UNINAVID_WS_URL` or `wss://office.servers.innatebotstatus.com:9000` | WebSocket server URL |
+| `ws_url` | string | env `UNINAVID_WS_URL` or `wss://nav-v1.innate.bot` | WebSocket server URL |
 | `service_key` | string | env `INNATE_SERVICE_KEY` | Service key for auth token acquisition |
 | `auth_issuer_url` | string | env `INNATE_AUTH_URL` or `https://auth-v1.innate.bot` | Auth token issuer |
 | `cmd_duration_sec` | float | 0.1 | How long each action command is published |

--- a/ros2_ws/src/cloud/innate_uninavid/config/params.yaml
+++ b/ros2_ws/src/cloud/innate_uninavid/config/params.yaml
@@ -3,7 +3,7 @@ uninavid_node:
     # ── Connection ────────────────────────────────────────────────────────
     # ws_url, service_key, and auth_issuer_url default from env vars;
     # override here if needed.
-    # ws_url: "wss://office.servers.innatebotstatus.com:9000"
+    # ws_url: "wss://nav-v1.innate.bot"
     # service_key: ""
     # auth_issuer_url: "https://auth-v1.innate.bot"
 

--- a/ros2_ws/src/cloud/innate_uninavid/innate_uninavid/node.py
+++ b/ros2_ws/src/cloud/innate_uninavid/innate_uninavid/node.py
@@ -38,7 +38,7 @@ from innate_cloud_msgs.action import NavigateInstruction
 
 from .ws_client import Action, ClientState, UninavidWsClient
 
-DEFAULT_WS_URL = "wss://office.servers.innatebotstatus.com:9000"
+DEFAULT_WS_URL = "wss://nav-v1.innate.bot"
 DEFAULT_AUTH_ISSUER_URL = "https://auth-v1.innate.bot"
 
 _CMD_VEL: dict[int, tuple[float, float]] = {


### PR DESCRIPTION
## Summary
- Switch default `UNINAVID_WS_URL` from `wss://office.servers.innatebotstatus.com:9000` to `wss://nav-v1.innate.bot`
- Updated in env templates (root + `ros2_ws/src/cloud/`), `node.py` `DEFAULT_WS_URL`, `params.yaml` example, and `PROTOCOL.md`

## Test plan
- [ ] Launch uninavid on robot with no `UNINAVID_WS_URL` override and confirm it connects to `nav-v1.innate.bot`
- [ ] Run a navigate-with-vision skill end-to-end against the new endpoint