### PR TITLE
Enhance episode management in training client and node

### DIFF
--- a/ros2_ws/src/brain/manipulation/manipulation/policy.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/policy.py
@@ -253,7 +253,7 @@ class InferenceNode(Node):
                 self.get_logger().warn(
                     f"Invalid inference duration {inference_duration}s requested, using default 20s."
                 )
-                inference_duration = 20.0 # Default if not specified or invalid
+                inference_duration = 120.0 # Default if not specified or invalid
 
             # Step 1: Move arm to start position
             self.get_logger().info("Moving arm to start position...")

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/episode_converter.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/episode_converter.py
@@ -242,11 +242,16 @@ def _encode_camera_to_mp4(
                 if not np.isfortran(frames):
                     frames = np.ascontiguousarray(frames)
                 proc.stdin.write(frames.tobytes())
-            proc.stdin.close()
         except BrokenPipeError:
             pass
+        finally:
+            try:
+                proc.stdin.close()
+            except (BrokenPipeError, OSError, ValueError):
+                pass
 
-        _, stderr_bytes = proc.communicate()
+        stderr_bytes = proc.stderr.read()
+        proc.wait()
 
         if proc.returncode != 0:
             stderr = stderr_bytes.decode(errors="replace")

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/skill_manager.py
@@ -144,6 +144,43 @@ def write_skill_id(skill_dir: str | Path, skill_id: str) -> None:
         logger.info("Wrote training_skill_id %s to %s", skill_id, meta_path)
 
 
+def read_local_episode_count(skill_dir: str | Path) -> int:
+    """Read ``number_of_episodes`` from ``data/dataset_metadata.json``.
+
+    This file is written by the C++ TaskManager when episodes are recorded.
+    Returns 0 if the file is missing or the key is absent.
+    """
+    meta_path = Path(skill_dir) / "data" / "dataset_metadata.json"
+    if not meta_path.is_file():
+        return 0
+    try:
+        data = json.loads(meta_path.read_text())
+        return int(data.get("number_of_episodes", 0))
+    except (json.JSONDecodeError, OSError, ValueError, TypeError):
+        return 0
+
+
+def read_uploaded_episode_count(skill_dir: str | Path) -> int:
+    """Read ``uploaded_episode_count`` from ``metadata.json``.
+
+    Returns -1 if the key is absent (meaning never uploaded).
+    Plain JSON read without file locking since it's read-only.
+    """
+    meta_path = Path(skill_dir) / METADATA_JSON
+    data = _read_meta(meta_path)
+    return int(data.get("uploaded_episode_count", -1))
+
+
+def write_uploaded_episode_count(skill_dir: str | Path, count: int) -> None:
+    """Persist ``uploaded_episode_count`` into ``metadata.json`` under the file lock."""
+    skill_dir = Path(skill_dir)
+    with _locked_metadata(skill_dir) as meta_path:
+        meta = _read_meta(meta_path)
+        meta["uploaded_episode_count"] = count
+        _write_meta(meta_path, meta)
+        logger.info("Wrote uploaded_episode_count=%d to %s", count, meta_path)
+
+
 class SkillManager:
     """
     High-level API for the training client.

--- a/ros2_ws/src/cloud/innate_cloud_msgs/msg/TrainingSkillStatus.msg
+++ b/ros2_ws/src/cloud/innate_cloud_msgs/msg/TrainingSkillStatus.msg
@@ -9,4 +9,6 @@ bool has_active_transfer
 bool transfer_done           # true once an upload finished (persists for node lifetime)
 innate_cloud_msgs/TransferProgress active_transfer
 
+int32 uploaded_episode_count  # episode count at last successful upload (-1 = never uploaded)
+
 innate_cloud_msgs/TrainingRunStatus[] runs

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/job_store.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/job_store.py
@@ -75,6 +75,7 @@ class JobStore:
         self._completed_transfers: set[tuple[int, str, int]] = set()
         self._download_initiated: set[tuple[str, int]] = set()
         self._dir_map: dict[str, str] = {}  # skill_id → skill_dir
+        self._uploaded_ep_counts: dict[str, int] = {}  # skill_id → uploaded episode count
 
     # ── Jobs ────────────────────────────────────────────────────────
 
@@ -126,6 +127,16 @@ class JobStore:
         with self._lock:
             return self._dir_map.get(skill_id)
 
+    # ── Uploaded episode counts ────────────────────────────────────
+
+    def set_uploaded_ep_count(self, skill_id: str, count: int) -> None:
+        with self._lock:
+            self._uploaded_ep_counts[skill_id] = count
+
+    def get_uploaded_ep_count(self, skill_id: str) -> int:
+        with self._lock:
+            return self._uploaded_ep_counts.get(skill_id, -1)
+
     # ── Transfers ───────────────────────────────────────────────────
 
     def update_transfer(
@@ -170,6 +181,7 @@ class JobStore:
         dict[tuple[int, str, int], TransferProgress],
         set[tuple[int, str, int]],
         dict[str, str],
+        dict[str, int],
     ]:
         """Atomically grab everything needed for one publish cycle."""
         with self._lock:
@@ -179,6 +191,7 @@ class JobStore:
                 dict(self._transfers),
                 set(self._completed_transfers),
                 dict(self._dir_map),
+                dict(self._uploaded_ep_counts),
             )
 
 
@@ -215,6 +228,7 @@ def build_skill_status(
     download_transfers: dict[int, TransferProgress],
     downloads_done: set[int],
     skill_dir: str = "",
+    uploaded_episode_count: int = -1,
 ) -> TrainingSkillStatus:
     """Build a ``TrainingSkillStatus`` msg (skill + nested runs)."""
     s = TrainingSkillStatus()
@@ -222,6 +236,7 @@ def build_skill_status(
     s.skill_name = skill.name if skill else ""
     s.skill_dir = skill_dir
     s.transfer_done = upload_done
+    s.uploaded_episode_count = uploaded_episode_count
     if upload_transfer is not None:
         s.has_active_transfer = True
         s.active_transfer = upload_transfer

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
@@ -262,10 +262,11 @@ class TrainingNode(Node):
             lookup_skill_id = read_skill_id(req.skill_dir)
             if lookup_skill_id:
                 self._store.register_dir(lookup_skill_id, req.skill_dir)
-                self._store.set_uploaded_ep_count(
-                    lookup_skill_id,
-                    _read_ep_count_from_disk(req.skill_dir),
-                )
+                if self._store.get_uploaded_ep_count(lookup_skill_id) < 0:
+                    self._store.set_uploaded_ep_count(
+                        lookup_skill_id,
+                        _read_ep_count_from_disk(req.skill_dir),
+                    )
 
         res.found = False
         for skill in self._build_skill_statuses():

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
@@ -71,7 +71,13 @@ def _build_training_params(
     if msg.preset:
         params["preset"] = msg.preset
     if msg.env:
-        params["env"] = list(msg.env)
+        env_dict: dict[str, str] = {}
+        for entry in msg.env:
+            key, _, value = entry.partition("=")
+            if key:
+                env_dict[key] = value
+        if env_dict:
+            params["env"] = env_dict
     return (params or None), None
 
 

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
@@ -27,7 +27,11 @@ from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from innate_cloud_msgs.msg import TrainingJobList, TrainingParams, TransferProgress
 from innate_cloud_msgs.srv import CreateRun, DownloadResults, GetTrainingStatus, SubmitSkill
 
-from training_client.src.skill_manager import SkillManager, read_skill_id
+from training_client.src.skill_manager import (
+    SkillManager,
+    read_skill_id,
+    read_uploaded_episode_count as _read_ep_count_from_disk,
+)
 from training_client.src.types import (
     ClientConfig,
     DEFAULT_AUTH_ISSUER_URL,
@@ -191,7 +195,7 @@ class TrainingNode(Node):
 
     def _build_skill_statuses(self) -> list:
         """Build the current list of TrainingSkillStatus from the store."""
-        jobs, skills, transfers, completed, dir_map = self._store.snapshot()
+        jobs, skills, transfers, completed, dir_map, ep_counts = self._store.snapshot()
 
         runs_by_skill: dict[str, list] = defaultdict(list)
         for run in jobs:
@@ -202,7 +206,11 @@ class TrainingNode(Node):
 
         for sid in sorted(all_skill_ids):
             upload_xfer = transfers.get((TransferProgress.UPLOAD, sid, -1))
-            upload_done = (TransferProgress.UPLOAD, sid, -1) in completed
+            # upload_done: in-memory completed set OR persisted ep count exists
+            upload_done = (
+                (TransferProgress.UPLOAD, sid, -1) in completed
+                or ep_counts.get(sid, -1) >= 0
+            )
 
             dl_xfers: dict[int, TransferProgress] = {}
             dl_done: set[int] = set()
@@ -224,6 +232,7 @@ class TrainingNode(Node):
                     dl_xfers,
                     dl_done,
                     skill_dir=dir_map.get(sid, ""),
+                    uploaded_episode_count=ep_counts.get(sid, -1),
                 )
             )
         return result
@@ -247,6 +256,10 @@ class TrainingNode(Node):
             lookup_skill_id = read_skill_id(req.skill_dir)
             if lookup_skill_id:
                 self._store.register_dir(lookup_skill_id, req.skill_dir)
+                self._store.set_uploaded_ep_count(
+                    lookup_skill_id,
+                    _read_ep_count_from_disk(req.skill_dir),
+                )
 
         res.found = False
         for skill in self._build_skill_statuses():

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/workers.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/workers.py
@@ -16,7 +16,11 @@ import time
 import rclpy.logging
 from innate_cloud_msgs.msg import TransferProgress
 
-from training_client.src.skill_manager import SkillManager
+from training_client.src.skill_manager import (
+    SkillManager,
+    read_local_episode_count,
+    write_uploaded_episode_count,
+)
 from training_client.src.types import ProgressStage, ProgressUpdate
 
 from .job_store import JobStore
@@ -185,6 +189,15 @@ def do_upload(
             ),
         )
         return
+
+    # Persist the episode count at the time of this successful upload.
+    try:
+        ep_count = read_local_episode_count(skill_dir)
+        write_uploaded_episode_count(skill_dir, ep_count)
+        store.set_uploaded_ep_count(skill_id, ep_count)
+        _ros.info(f"Persisted uploaded_episode_count={ep_count} for {sid}")
+    except Exception as e:
+        _ros.warning(f"Failed to persist uploaded_episode_count for {sid}: {e}")
 
     store.update_transfer(
         TransferProgress.UPLOAD,

--- a/ros2_ws/src/maurice_bot/maurice_control/launch/app.launch.py
+++ b/ros2_ws/src/maurice_bot/maurice_control/launch/app.launch.py
@@ -3,20 +3,29 @@ from launch_ros.actions import Node
 import os
 
 def generate_launch_description():
-    # Use environment variable if set, otherwise construct from HOME
     maurice_root = os.environ.get('INNATE_OS_ROOT', os.path.join(os.path.expanduser('~'), 'innate-os'))
     data_directory = os.path.join(maurice_root, 'data')
-    
-    # Default hardware revision for new robots
+
     default_hardware_revision = 'R6'
-    
-    # Create rosbridge websocket node
+
     rosbridge_node = Node(
         package='rws',
         executable='rws_server',
         name='ros_websocket_server',
         parameters=[{}],
-        output='screen'
+        output='screen',
+        respawn=True,
+        respawn_delay=2.0,
+        # Disable Zenoh SHM for rws_server to prevent __pthread_tpp_change_priority
+        # crash from priority-inheritance mutex contention between websocketpp threads
+        # and Zenoh SHM watchdog threads. rws_server is a JSON bridge — no SHM needed.
+        additional_env={
+            'ZENOH_SESSION_CONFIG_OVERRIDE': (
+                'transport/shared_memory/enabled=false'
+                ';transport/link/tx/queue/congestion_control/drop/wait_before_drop=900000'
+                ';transport/link/tx/queue/congestion_control/drop/max_wait_before_drop_fragments=900000'
+            ),
+        },
     )
 
     app_node = Node(
@@ -26,11 +35,10 @@ def generate_launch_description():
         output='screen',
         parameters=[{
             'data_directory': data_directory,
-            'default_hardware_revision': default_hardware_revision
-        }]
+            'default_hardware_revision': default_hardware_revision,
+        }],
     )
 
-    # Return LaunchDescription with all nodes
     return LaunchDescription([
         rosbridge_node,
         app_node,

--- a/skills/retrieve_emails_template.py
+++ b/skills/retrieve_emails_template.py
@@ -31,3 +31,6 @@ class RetrieveEmails(Skill):
             )
         except Exception as e:
             return f"Failed to retrieve emails: {str(e)}", SkillResult.FAILURE
+
+    def cancel(self):
+        return "Email retrieval cannot be canceled once started"


### PR DESCRIPTION
- Refactor episode encoding to ensure proper closure of subprocess stdin.
- Introduce functions to read and write episode counts in skill_manager.
- Update TrainingSkillStatus message to include uploaded_episode_count.
- Implement methods in JobStore for managing uploaded episode counts.
- Modify TrainingNode to utilize uploaded episode counts during skill status building.
- Persist uploaded episode count upon successful upload in workers.

These changes improve the handling of episode data and enhance the robustness of the training client.