### PR TITLE
Add right compressed main camera topic

### DIFF
--- a/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/main_camera_driver.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/main_camera_driver.hpp
@@ -254,7 +254,8 @@ private:
   // ROS 2 publishers
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_pub_;   // Left camera raw
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_pub_;  // Right camera raw
-  rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressed_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr left_compressed_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr right_compressed_pub_;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr stereo_pub_;
 
   // Camera info publishers + calibration
@@ -333,4 +334,3 @@ private:
 };
 
 } // namespace maurice_cam
-

--- a/ros2_ws/src/maurice_bot/maurice_cam/launch/main_camera_driver.launch.py
+++ b/ros2_ws/src/maurice_bot/maurice_cam/launch/main_camera_driver.launch.py
@@ -63,6 +63,12 @@ def generate_launch_description():
         default_value='camera_optical_frame',
         description='Camera frame ID'
     )
+
+    right_frame_id_arg = DeclareLaunchArgument(
+        'right_frame_id',
+        default_value='right_camera_optical_frame',
+        description='Right camera frame ID'
+    )
     
     jpeg_quality_arg = DeclareLaunchArgument(
         'jpeg_quality',
@@ -149,6 +155,7 @@ def generate_launch_description():
                 'publish_stereo_height': LaunchConfiguration('publish_stereo_height'),
                 'fps': LaunchConfiguration('fps'),
                 'frame_id': LaunchConfiguration('frame_id'),
+                'right_frame_id': LaunchConfiguration('right_frame_id'),
                 'jpeg_quality': LaunchConfiguration('jpeg_quality'),
                 'publish_compressed': LaunchConfiguration('publish_compressed'),
                 'compressed_frame_interval': LaunchConfiguration('compressed_frame_interval'),
@@ -177,6 +184,7 @@ def generate_launch_description():
         publish_stereo_height_arg,
         fps_arg,
         frame_id_arg,
+        right_frame_id_arg,
         jpeg_quality_arg,
         publish_compressed_arg,
         compressed_frame_interval_arg,
@@ -190,4 +198,3 @@ def generate_launch_description():
         use_sim_time_arg,
         main_camera_driver_node
     ])
-

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/main_camera_driver.cpp
@@ -134,6 +134,7 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(this->get_logger(), "Publish left: %dx%d (natural split: %dx%d)", publish_left_width_, publish_left_height_, left_width_, left_height_);
   RCLCPP_INFO(this->get_logger(), "FPS: %.1f", fps_);
   RCLCPP_INFO(this->get_logger(), "Frame ID: %s", frame_id_.c_str());
+  RCLCPP_INFO(this->get_logger(), "Right Frame ID: %s", right_frame_id_.c_str());
   RCLCPP_INFO(this->get_logger(), "JPEG Quality: %d", jpeg_quality_);
 
   // Initialize publishers
@@ -148,8 +149,12 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions & options)
   );
 
   if (publish_compressed_) {
-    compressed_pub_ = this->create_publisher<sensor_msgs::msg::CompressedImage>(
+    left_compressed_pub_ = this->create_publisher<sensor_msgs::msg::CompressedImage>(
       "/mars/main_camera/left/image_raw/compressed",
+      rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort)
+    );
+    right_compressed_pub_ = this->create_publisher<sensor_msgs::msg::CompressedImage>(
+      "/mars/main_camera/right/image_raw/compressed",
       rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort)
     );
   }
@@ -166,6 +171,7 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/right/image_raw (%dx%d)", left_width_, left_height_);
   if (publish_compressed_) {
     RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/left/image_raw/compressed (%dx%d)", left_width_, left_height_);
+    RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/right/image_raw/compressed (%dx%d)", left_width_, left_height_);
   }
   if (publish_stereo_) {
     RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/stereo (%dx%d)", publish_stereo_width_, publish_stereo_height_);
@@ -644,23 +650,32 @@ void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame)
       compressed_frame_counter_ = 0;
       
       auto left_compressed_msg = std::make_unique<sensor_msgs::msg::CompressedImage>();
+      auto right_compressed_msg = std::make_unique<sensor_msgs::msg::CompressedImage>();
       left_compressed_msg->header.stamp = current_time;
       left_compressed_msg->header.frame_id = frame_id_;
       left_compressed_msg->format = "jpeg";
+      right_compressed_msg->header.stamp = current_time;
+      right_compressed_msg->header.frame_id = right_frame_id_;
+      right_compressed_msg->format = "jpeg";
       
-      // Encode from the left view using TurboJPEG
+      // Encode and publish both views using TurboJPEG so both stereo channels
+      // have symmetric compressed topic availability.
       try {
-        if (left_view.type() == CV_8UC3 && left_view.channels() == 3) {
+        if (left_view.type() == CV_8UC3 && left_view.channels() == 3 &&
+            right_view.type() == CV_8UC3 && right_view.channels() == 3) {
           jpeg_encoder_->encodeBGR(left_view, jpeg_quality_, left_compressed_msg->data);
-          compressed_pub_->publish(std::move(left_compressed_msg));
+          jpeg_encoder_->encodeBGR(right_view, jpeg_quality_, right_compressed_msg->data);
+          left_compressed_pub_->publish(std::move(left_compressed_msg));
+          right_compressed_pub_->publish(std::move(right_compressed_msg));
         } else {
           RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-                               "Left image format invalid for JPEG encoding: type=%d, channels=%d",
-                               left_view.type(), left_view.channels());
+                               "Image format invalid for JPEG encoding: left(type=%d, channels=%d) right(type=%d, channels=%d)",
+                               left_view.type(), left_view.channels(),
+                               right_view.type(), right_view.channels());
         }
       } catch (const std::exception& e) {
         RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-                             "JPEG turbo encode failed: %s", e.what());
+                             "JPEG turbo encode failed for stereo pair: %s", e.what());
       }
     }
   }
@@ -897,4 +912,3 @@ int main(int argc, char** argv)
   return 0;
 }
 #endif
-


### PR DESCRIPTION
Add `/mars/main_camera/right/image_raw/compressed` to the main camera driver so compressed stereo topics are published symmetrically.

The driver published:
  - `/mars/main_camera/left/image_raw`
  - `/mars/main_camera/right/image_raw`
  - `/mars/main_camera/left/image_raw/compressed`

  But it did not publish:
  - `/mars/main_camera/right/image_raw/compressed`

  That made the right camera unavailable to consumers expecting compressed transport parity
  with the left camera. This change fixes this.

