### PR TITLE
Fix arm part alignment in MARS/Maurice MJCF model

### DIFF
--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -71,7 +71,7 @@
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                 <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>
                 
-                <body name="link3" pos="-0.02825 0 -0.12125">
+                <body name="link3" pos="0.12125 0 -0.02825" euler="0 -1.5708 0">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>
                   <joint name="joint3" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -69,7 +69,7 @@
               <body name="link2" pos="0 0 0.04225">
                 <inertial pos="0 0 0" mass="0.080" diaginertia="0.0001 0.0001 0.0001"/>
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
-                <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 0 1.5708"/>
+                <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 1.5708 1.5708"/>
                 
                 <body name="link3" pos="0.02825 0 0.12125">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -61,10 +61,10 @@
             <camera name="camera_base" pos="0.0197 0 0.19663" 
                     quat="0.5416752 0.4545195 -0.4545195 -0.5416752" mode="fixed" fovy="80"/>
             
-            <body name="link1" pos="0.086 -0.05285 0.04025">
+            <body name="link1" pos="-0.05285 -0.086 0.04025" euler="0 0 3.1416">
               <inertial pos="0 0 0" mass="0.065" diaginertia="0.0001 0.0001 0.0001"/>
               <joint name="joint1" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
-              <geom name="link1_geom" type="mesh" mesh="link1_mesh" material="bright_orange" euler="0 0 1.5708"/>
+              <geom name="link1_geom" type="mesh" mesh="link1_mesh" material="bright_orange" euler="0 0 3.1416"/>
               
               <body name="link2" pos="0 0 0.04225">
                 <inertial pos="0 0 0" mass="0.080" diaginertia="0.0001 0.0001 0.0001"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -92,7 +92,7 @@
                   <joint name="joint3" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>
 
-                  <body name="link4" pos="0 0.1375 0.0045" euler="6.2832 0 0">
+                  <body name="link4" pos="0.0045 0.1375 0" euler="6.2832 0 0">
                     <inertial pos="0 0 0" mass="0.022" diaginertia="0.00005 0.00005 0.00005"/>
                     <joint name="joint4" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                     <geom name="link4_geom" type="mesh" mesh="link4_mesh" material="matt_black" euler="1.5708 0 1.5708"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -1,5 +1,5 @@
 <mujoco model="maurice_bot">
-  <compiler angle="radian" coordinate="local" meshdir="/home/vignesh/maurice-prod/ros2_ws/src/maurice_bot/maurice_sim/meshes" eulerseq="zyx"/>
+  <compiler angle="radian" coordinate="local" meshdir="../meshes" eulerseq="zyx"/>
   <!-- COLLISION DISABLED: Testing external collision checker -->
   <option gravity="0 0 -9.81" />
   

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -76,7 +76,7 @@
                   <joint name="joint3" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>
                   
-                  <body name="link4" pos="0.1375 0 -0.0045">
+                  <body name="link4" pos="0 0.1375 0.0045" euler="1.5708 0 0">
                     <inertial pos="0 0 0" mass="0.022" diaginertia="0.00005 0.00005 0.00005"/>
                     <joint name="joint4" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                     <geom name="link4_geom" type="mesh" mesh="link4_mesh" material="matt_black" euler="1.5708 0 1.5708"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -78,7 +78,7 @@
                   
                   <body name="link4" pos="0 0.1375 0.0045" euler="1.5708 0 0">
                     <inertial pos="0 0 0" mass="0.022" diaginertia="0.00005 0.00005 0.00005"/>
-                    <joint name="joint4" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
+                    <joint name="joint4" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                     <geom name="link4_geom" type="mesh" mesh="link4_mesh" material="matt_black" euler="1.5708 0 1.5708"/>
                     
                     <body name="link5" pos="0.019 0 0">

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -87,7 +87,7 @@
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                 <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>
 
-                <body name="link3" pos="0.12125 0 0.02825" euler="0 -3.1452 -1.5708">
+                <body name="link3" pos="0.12125 0 0.02825" euler="0 -3.1416 -1.5708">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>
                   <joint name="joint3" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>
@@ -115,7 +115,7 @@
                       </body>
 
                       <!-- Add End Effector -->
-                      <body name="ee_link" pos="0.09285 0 0">
+                      <body name="ee_link" pos="-0.0188 0.03 0">
                         <inertial pos="0 0 0" mass="0.001" diaginertia="0.00001 0.00001 0.00001"/>
                         <geom name="ee_geom" type="sphere" size="0.005" material="bright_orange"/>
                       </body>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -61,7 +61,7 @@
             <camera name="camera_base" pos="0.0197 0 0.19663" 
                     quat="0.5416752 0.4545195 -0.4545195 -0.5416752" mode="fixed" fovy="80"/>
             
-            <body name="link1" pos="-0.05285 -0.086 0.04025" euler="0 0 3.1416">
+            <body name="link1" pos="-0.05285 -0.086 0.04025" euler="-1.5708 0 3.1416">
               <inertial pos="0 0 0" mass="0.065" diaginertia="0.0001 0.0001 0.0001"/>
               <joint name="joint1" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
               <geom name="link1_geom" type="mesh" mesh="link1_mesh" material="bright_orange" euler="0 0 3.1416"/>
@@ -71,7 +71,7 @@
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                 <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>
                 
-                <body name="link3" pos="0.12125 0 -0.02825" euler="0 -1.5708 0">
+                <body name="link3" pos="0.12125 -0.02825 0" euler="0 -1.5708 -1.5708">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>
                   <joint name="joint3" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -2,7 +2,7 @@
   <compiler angle="radian" coordinate="local" meshdir="../meshes" eulerseq="zyx"/>
   <!-- COLLISION DISABLED: Testing external collision checker -->
   <option gravity="0 0 -9.81" />
-  
+
   <!-- Disable all collisions globally -->
   <default>
     <geom contype="0" conaffinity="0"/>
@@ -17,11 +17,12 @@
     <mesh name="link5_mesh" file="link5.STL" scale="0.001 0.001 0.001"/>
     <mesh name="link61_mesh" file="link61.STL" scale="0.001 0.001 0.001"/>
     <mesh name="link62_mesh" file="link62.STL" scale="0.001 0.001 0.001"/>
-    
+    <mesh name="head_mesh" file="head.STL" scale="1 1 1"/>
+
     <!-- Add grid texture and material -->
     <texture type="2d" name="grid" builtin="checker" rgb1=".1 .2 .3" rgb2=".2 .3 .4" width="512" height="512" mark="edge" markrgb=".8 .8 .8"/>
     <material name="grid_material" texture="grid" texrepeat="5 5" texuniform="true" reflectance=".0"/>
-    
+
     <!-- New materials -->
     <material name="matt_black" rgba="0.05 0.05 0.05 1"/>
     <material name="bright_orange" rgba="1.0 0.5 0.0 1"/>
@@ -40,70 +41,85 @@
     <!-- Reordering: x and y translations before yaw rotation -->
     <body name="base_root" pos="0 0 0">
       <inertial pos="0 0 0" mass="0.01" diaginertia="0.1 0.1 0.1"/>
-      
+
       <!-- First, translation along the x-axis -->
       <joint name="base_x" type="slide" axis="1 0 0" damping="5"/>
-      
+
       <body name="base_x" pos="0 0 0">
         <inertial pos="0 0 0" mass="0.01" diaginertia="0.1 0.1 0.1"/>
         <!-- Then, translation along the y-axis -->
         <joint name="base_y" type="slide" axis="0 1 0" damping="5"/>
-        
+
         <body name="base_y" pos="0 0 0">
           <inertial pos="0 0 0" mass="0.01" diaginertia="0.1 0.1 0.1"/>
           <!-- Finally, apply yaw rotation -->
           <joint name="base_yaw" type="hinge" axis="0 0 1" damping="5"/>
-          
+
           <!-- Base link and the rest of the arm -->
           <body name="base_link" pos="0 0 0">
             <inertial pos="0 0 0" mass="0.89" diaginertia="0.001 0.001 0.001"/>
             <geom name="base_geom" type="mesh" mesh="base_mesh" material="matt_black" euler="-1.5708 0 0"/>
-            <camera name="camera_base" pos="0.0197 0 0.19663" 
+            <camera name="camera_base" pos="0.0197 0 0.19663"
                     quat="0.5416752 0.4545195 -0.4545195 -0.5416752" mode="fixed" fovy="80"/>
-            
+
+            <body name="head" pos="-0.040751 -0.0002 0.25882">
+              <inertial pos="0 0 0" mass="0.148" diaginertia="0.0002 0.0001 0.0002"/>
+              <geom name="head_geom" type="mesh" mesh="head_mesh" material="matt_black" pos="0.04 0 0" euler="-1.5708 0 0"/>
+
+              <body name="head_camera_left" pos="0.04327 0.0297 -0.000275">
+                <inertial pos="0 0 0" mass="0.01" diaginertia="0.00001 0.00001 0.00001"/>
+                <geom name="head_camera_left_geom" type="sphere" size="0.005" material="matt_black"/>
+              </body>
+
+              <body name="head_camera_right" pos="0.04327 -0.0303 -0.000275">
+                <inertial pos="0 0 0" mass="0.01" diaginertia="0.00001 0.00001 0.00001"/>
+                <geom name="head_camera_right_geom" type="sphere" size="0.005" material="matt_black"/>
+              </body>
+            </body>
+
             <body name="link1" pos="-0.05285 -0.086 0.04025" euler="-1.5708 0 3.1416">
               <inertial pos="0 0 0" mass="0.065" diaginertia="0.0001 0.0001 0.0001"/>
               <joint name="joint1" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
               <geom name="link1_geom" type="mesh" mesh="link1_mesh" material="bright_orange" euler="0 0 3.1416"/>
-              
+
               <body name="link2" pos="0 0 -0.04225">
                 <inertial pos="0 0 0" mass="0.080" diaginertia="0.0001 0.0001 0.0001"/>
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                 <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>
-                
+
                 <body name="link3" pos="0.12125 0 0.02825" euler="0 -1.5708 -1.5708">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>
                   <joint name="joint3" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>
-                  
+
                   <body name="link4" pos="0 0.1375 0.0045" euler="6.2832 0 0">
                     <inertial pos="0 0 0" mass="0.022" diaginertia="0.00005 0.00005 0.00005"/>
                     <joint name="joint4" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                     <geom name="link4_geom" type="mesh" mesh="link4_mesh" material="matt_black" euler="1.5708 0 1.5708"/>
-                    
+
                     <body name="link5" pos="0.019 0 0">
                       <inertial pos="0 0 0" mass="0.050" diaginertia="0.00005 0.00005 0.00005"/>
                       <joint name="joint5" type="hinge" axis="1 0 0" limited="true" range="-3.14 3.14" damping="5"/>
                       <geom name="link5_geom" type="mesh" mesh="link5_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>
-                      
+
                       <body name="link61" pos="0.044 -0.0091 0">
                         <inertial pos="0 0 0" mass="0.012" diaginertia="0.00002 0.00002 0.00002"/>
                         <joint name="joint6" type="hinge" axis="0 0 -1" limited="true" range="-1.57 1.57" damping="5"/>
                         <geom name="link61_geom" type="mesh" mesh="link61_mesh" material="matt_black" euler="1.5708 0 1.5708"/>
                       </body>
-                      
+
                       <body name="link62" pos="0.044 0.0091 0">
                         <inertial pos="0 0 0" mass="0.012" diaginertia="0.00002 0.00002 0.00002"/>
                         <joint name="joint6M" type="hinge" axis="0 0 1" limited="true" range="-1.57 1.57" damping="5"/>
                         <geom name="link62_geom" type="mesh" mesh="link62_mesh" material="matt_black" euler="1.5708 0 1.5708"/>
                       </body>
-                      
+
                       <!-- Add End Effector -->
                       <body name="ee_link" pos="0.09285 0 0">
                         <inertial pos="0 0 0" mass="0.001" diaginertia="0.00001 0.00001 0.00001"/>
                         <geom name="ee_geom" type="sphere" size="0.005" material="bright_orange"/>
                       </body>
-                      
+
                       <body name="arm_camera_link" pos="0.00454 0 0.05448">
                         <inertial pos="0 0 0" mass="0.01" diaginertia="1e-4 1e-4 1e-4"/>
                         <camera name="camera_arm" mode="fixed" fovy="80" quat="0.6532815 0.2705981 -0.2705981 -0.6532815"/>
@@ -132,7 +148,7 @@
     <exclude name="ex_link5_link61" body1="link5" body2="link61"/>
     <exclude name="ex_link5_link62" body1="link5" body2="link62"/>
   </contact>
-  
+
   <!-- Geared gripper constraint: joint6M mimics joint6 with 1:1 ratio -->
   <equality>
     <joint name="gripper_gear" joint1="joint6" joint2="joint6M" polycoef="0 1 0 0 0" solref="0.001 1" solimp="0.99 0.999 0.001"/>
@@ -143,7 +159,7 @@
     <velocity joint="base_x" kv="100"/>
     <velocity joint="base_y" kv="100"/>
     <velocity joint="base_yaw" kv="100"/>
-    
+
     <!-- Position control actuators for the arm joints -->
     <position joint="joint1" kp="1000"/>
     <position joint="joint2" kp="1000"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -71,9 +71,9 @@
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                 <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>
                 
-                <body name="link3" pos="0.12125 -0.02825 0" euler="0 -1.5708 -1.5708">
+                <body name="link3" pos="0.12125 0 0.02825" euler="0 -1.5708 -1.5708">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>
-                  <joint name="joint3" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
+                  <joint name="joint3" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>
                   
                   <body name="link4" pos="0.1375 0 -0.0045">

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -82,7 +82,7 @@
               <joint name="joint1" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
               <geom name="link1_geom" type="mesh" mesh="link1_mesh" material="bright_orange" euler="0 0 3.1416"/>
 
-              <body name="link2" pos="0 0 -0.04225">
+              <body name="link2" pos="0 0 -0.04225" euler="0 1.5708 0">
                 <inertial pos="0 0 0" mass="0.080" diaginertia="0.0001 0.0001 0.0001"/>
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                 <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -76,7 +76,7 @@
                   <joint name="joint3" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>
                   
-                  <body name="link4" pos="0 0.1375 0.0045" euler="1.5708 0 0">
+                  <body name="link4" pos="0 0.1375 0.0045" euler="6.2832 0 0">
                     <inertial pos="0 0 0" mass="0.022" diaginertia="0.00005 0.00005 0.00005"/>
                     <joint name="joint4" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                     <geom name="link4_geom" type="mesh" mesh="link4_mesh" material="matt_black" euler="1.5708 0 1.5708"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -87,7 +87,7 @@
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                 <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>
 
-                <body name="link3" pos="0.12125 0 0.02825" euler="0 -1.5708 -1.5708">
+                <body name="link3" pos="0.12125 0 0.02825" euler="0 -3.1452 -1.5708">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>
                   <joint name="joint3" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -66,10 +66,10 @@
               <joint name="joint1" type="hinge" axis="0 0 1" limited="true" range="-3.14 3.14" damping="5"/>
               <geom name="link1_geom" type="mesh" mesh="link1_mesh" material="bright_orange" euler="0 0 3.1416"/>
               
-              <body name="link2" pos="0 0 0.04225">
+              <body name="link2" pos="0 0 -0.04225">
                 <inertial pos="0 0 0" mass="0.080" diaginertia="0.0001 0.0001 0.0001"/>
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
-                <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 1.5708 1.5708"/>
+                <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>
                 
                 <body name="link3" pos="0.02825 0 0.12125">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>

--- a/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
+++ b/ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf
@@ -71,7 +71,7 @@
                 <joint name="joint2" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                 <geom name="link2_geom" type="mesh" mesh="link2_mesh" material="matt_black" euler="1.5708 -1.5708 1.5708"/>
                 
-                <body name="link3" pos="0.02825 0 0.12125">
+                <body name="link3" pos="-0.02825 0 -0.12125">
                   <inertial pos="0 0 0" mass="0.055" diaginertia="0.0001 0.0001 0.0001"/>
                   <joint name="joint3" type="hinge" axis="0 1 0" limited="true" range="-3.14 3.14" damping="5"/>
                   <geom name="link3_geom" type="mesh" mesh="link3_mesh" material="bright_orange" euler="1.5708 0 1.5708"/>


### PR DESCRIPTION
The alignment of arm in existing MJCF model (`ros2_ws/src/maurice_bot/maurice_sim/mjcf/maurice.mjcf`) doesn't seem to be correct—maybe it was introduced during URDF to MJCF conversion. This PR does a best-effort fix, just going off of the visuals and the joint limits of servos by inspection, and may not be entirely accurate. 

Before fix:
<img width="2528" height="1768" alt="image" src="https://github.com/user-attachments/assets/56130268-b11a-4afe-8069-462b6264d839" />

After fix:
<img width="1264" height="884" alt="_ 2026-04-11 at 5 55 02 PM" src="https://github.com/user-attachments/assets/1c3d109a-2c41-427b-ba16-e153236caacf" />
