### PR TITLE
feat: claude-mem integration for skill execution monitoring

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py
@@ -61,6 +61,7 @@ from brain_messages.srv import ReloadSkillsAgents
 from std_srvs.srv import SetBool, Trigger
 
 from brain_client.ws_bridge import WSBridge
+from brain_client.claude_mem_observer import ClaudeMemObserver
 from brain_client.initializers import initialize_agents
 from brain_client.tts_handler import TTSHandler
 from brain_client.hot_reload_watcher import HotReloadWatcher
@@ -205,6 +206,9 @@ class BrainClientNode(Node):
         self.get_logger().info(
             f"BrainClient running in {'simulator' if self.simulator_mode else 'real robot'} mode"
         )
+
+        # Claude-Mem: observe agent decisions for persistent memory
+        self._claude_mem = ClaudeMemObserver(self.get_logger())
 
         self.ws_uri = (
             self.get_parameter("websocket_uri").get_parameter_value().string_value
@@ -1674,6 +1678,10 @@ class BrainClientNode(Node):
                 )
 
         if payload.thoughts:
+            # Claude-Mem: record agent thought
+            directive_id = getattr(self.current_directive, 'id', None) if hasattr(self, 'current_directive') and self.current_directive else None
+            self._claude_mem.on_agent_thought(payload.thoughts, agent_id=directive_id)
+
             chat_entry = MessageOut(
                 type=MessageOutType.CHAT_OUT,
                 payload={"text": payload.thoughts},
@@ -2364,6 +2372,9 @@ class BrainClientNode(Node):
         if directive_name in self.directives:
             self.current_directive = self.directives[directive_name]
             self.get_logger().info(f"Activated directive: {directive_name}")
+
+            # Claude-Mem: record directive change
+            self._claude_mem.on_directive_change(directive_name, directive_name)
 
             # Clear local chat history when changing agent
             self.chat_history = []

--- a/ros2_ws/src/brain/brain_client/brain_client/claude_mem_observer.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/claude_mem_observer.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Claude-Mem integration for innate-os.
+
+Captures skill executions and agent decisions, posting them as observations
+to the claude-mem worker API for persistent cross-session memory.
+
+The observer is fire-and-forget: it never blocks skill execution, and
+silently degrades if the claude-mem worker is unavailable.
+
+Configuration via environment variables:
+  CLAUDE_MEM_ENABLED=true|false   (default: true)
+  CLAUDE_MEM_HOST=127.0.0.1      (default: 127.0.0.1)
+  CLAUDE_MEM_PORT=37777           (default: 37777)
+"""
+
+import json
+import os
+import threading
+import urllib.request
+import urllib.error
+import uuid
+from typing import Optional
+
+
+class ClaudeMemObserver:
+    """Posts skill executions to claude-mem's worker API as observations."""
+
+    def __init__(self, logger):
+        self._logger = logger
+        self._enabled = os.environ.get("CLAUDE_MEM_ENABLED", "true").lower() == "true"
+
+        if not self._enabled:
+            self._logger.info("[claude-mem] Observer disabled via CLAUDE_MEM_ENABLED=false")
+            return
+
+        host = os.environ.get("CLAUDE_MEM_HOST", "127.0.0.1")
+        port = os.environ.get("CLAUDE_MEM_PORT", "37777")
+        self._worker_url = f"http://{host}:{port}/api/sessions/observations"
+        self._session_id = f"innate-os-{uuid.uuid4().hex[:12]}"
+        self._cwd = os.environ.get("INNATE_OS_ROOT", os.path.expanduser("~/innate-os"))
+
+        # Track consecutive failures to avoid log spam
+        self._consecutive_failures = 0
+        self._max_logged_failures = 3
+
+        self._logger.info(
+            f"[claude-mem] Observer active — session={self._session_id}, "
+            f"worker={self._worker_url}"
+        )
+
+    def on_skill_start(self, skill_type: str, inputs: dict):
+        """Record the start of a skill execution. Non-blocking."""
+        if not self._enabled:
+            return
+        self._post_async(
+            tool_name=f"skill:{skill_type}",
+            tool_input=inputs,
+            tool_response={"status": "started"},
+        )
+
+    def on_skill_result(
+        self,
+        skill_type: str,
+        inputs: dict,
+        result_message: str,
+        result_status: str,
+        duration_seconds: float,
+    ):
+        """Record a completed skill execution with its result. Non-blocking."""
+        if not self._enabled:
+            return
+        self._post_async(
+            tool_name=f"skill:{skill_type}",
+            tool_input=inputs,
+            tool_response={
+                "message": result_message,
+                "status": result_status,
+                "duration_seconds": round(duration_seconds, 3),
+            },
+        )
+
+    def on_agent_thought(self, thought_text: str, agent_id: Optional[str] = None):
+        """Record an agent's reasoning/thought. Non-blocking."""
+        if not self._enabled:
+            return
+        self._post_async(
+            tool_name="agent:thought",
+            tool_input={"agent_id": agent_id or "unknown"},
+            tool_response={"thought": thought_text},
+        )
+
+    def on_directive_change(self, directive_id: str, directive_name: str):
+        """Record an agent directive change. Non-blocking."""
+        if not self._enabled:
+            return
+        self._post_async(
+            tool_name="agent:directive_change",
+            tool_input={"directive_id": directive_id, "directive_name": directive_name},
+            tool_response={"status": "activated"},
+        )
+
+    def _post_async(self, tool_name: str, tool_input: dict, tool_response: dict):
+        """Fire-and-forget POST to claude-mem worker."""
+        thread = threading.Thread(
+            target=self._post,
+            args=(tool_name, tool_input, tool_response),
+            daemon=True,
+        )
+        thread.start()
+
+    def _post(self, tool_name: str, tool_input: dict, tool_response: dict):
+        try:
+            body = json.dumps({
+                "contentSessionId": self._session_id,
+                "tool_name": tool_name,
+                "tool_input": json.dumps(tool_input, default=str),
+                "tool_response": json.dumps(tool_response, default=str),
+                "cwd": self._cwd,
+            }).encode("utf-8")
+
+            req = urllib.request.Request(
+                self._worker_url,
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                self._consecutive_failures = 0
+                self._logger.debug(f"[claude-mem] Observation posted: {tool_name}")
+
+        except Exception as e:
+            self._consecutive_failures += 1
+            if self._consecutive_failures <= self._max_logged_failures:
+                self._logger.debug(f"[claude-mem] Post failed (non-critical): {e}")
+            elif self._consecutive_failures == self._max_logged_failures + 1:
+                self._logger.debug(
+                    "[claude-mem] Suppressing further failure logs until next success"
+                )

--- a/ros2_ws/src/brain/brain_client/brain_client/skills_action_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills_action_server.py
@@ -13,6 +13,7 @@ import json
 import math  # For yaw calculation
 import os
 import threading
+import time
 import types
 from pathlib import Path
 
@@ -46,6 +47,7 @@ from brain_client.skill_types import (
     Skill,
     SkillResult,
 )
+from brain_client.claude_mem_observer import ClaudeMemObserver
 
 
 class SkillsActionServer(Node):
@@ -191,6 +193,9 @@ class SkillsActionServer(Node):
             debounce_seconds=1.0,
         )
         self._hot_reload_watcher.start()
+
+        # Claude-Mem: observe skill executions for persistent memory
+        self._claude_mem = ClaudeMemObserver(self.get_logger())
 
     def _on_skills_file_changed(self, skill_names: list, _agent_names: list):
         """Called by HotReloadWatcher when skill files change.
@@ -727,6 +732,10 @@ class SkillsActionServer(Node):
 
         skill_type = goal_handle.request.skill_type
 
+        # Claude-Mem: record skill start
+        self._claude_mem.on_skill_start(skill_type, inputs)
+        _skill_start_time = time.monotonic()
+
         # Snapshot the skill entry under lock so check-then-access is atomic.
         with self._skills_lock:
             code_entry = self._code_skills.get(skill_type)
@@ -734,11 +743,10 @@ class SkillsActionServer(Node):
 
         # Check if it's a code skill
         if code_entry is not None:
-            return self._execute_code_skill(goal_handle, skill_type, inputs)
-
+            result = self._execute_code_skill(goal_handle, skill_type, inputs)
         # Check if it's a physical skill
         elif physical_entry is not None:
-            return self._execute_physical_skill(goal_handle, skill_type, inputs)
+            result = self._execute_physical_skill(goal_handle, skill_type, inputs)
 
         # Skill not found
         else:
@@ -747,12 +755,23 @@ class SkillsActionServer(Node):
             self.get_logger().error(f"Skill '{skill_type}' not available")
             self.get_logger().error(f"Available skills: {all_skills}")
             goal_handle.abort()
-            return ExecuteSkill.Result(
+            result = ExecuteSkill.Result(
                 success=False,
                 message="Skill not available",
                 skill_type=skill_type,
                 success_type=SkillResult.FAILURE.value,
             )
+
+        # Claude-Mem: record skill result
+        _skill_duration = time.monotonic() - _skill_start_time
+        self._claude_mem.on_skill_result(
+            skill_type=skill_type,
+            inputs=inputs,
+            result_message=result.message,
+            result_status=result.success_type,
+            duration_seconds=_skill_duration,
+        )
+        return result
 
     def _update_skill_robot_state(self, skill):
         """Helper to update a skill's robot state from current sensor data."""


### PR DESCRIPTION
## Summary
- Adds `ClaudeMemObserver` — a non-blocking, fire-and-forget observer that posts skill executions and agent decisions to the claude-mem worker API
- Hooks into `SkillsActionServer.execute_callback()` to capture every skill invocation with timing data (start, result, duration)
- Hooks into `BrainClientNode` to capture agent thoughts and directive changes
- Gives innate-os persistent cross-session memory of all tool uses via claude-mem

## How it works
The observer POSTs to `http://{CLAUDE_MEM_HOST}:{CLAUDE_MEM_PORT}/api/sessions/observations` using background threads. If the claude-mem worker isn't running, it silently degrades — never blocks skill execution.

Each innate-os boot generates a unique session ID so claude-mem can correlate all skill executions from a single run.

## What gets captured
| Event | Tool Name | Data |
|-------|-----------|------|
| Skill start | `skill:{skill_id}` | inputs |
| Skill result | `skill:{skill_id}` | message, status, duration_seconds |
| Agent thought | `agent:thought` | thought text, agent_id |
| Directive change | `agent:directive_change` | directive_id, directive_name |

## Configuration
```bash
export CLAUDE_MEM_ENABLED=true    # default: true
export CLAUDE_MEM_HOST=127.0.0.1  # default: 127.0.0.1
export CLAUDE_MEM_PORT=37777      # default: 37777
```

## Test plan
- [ ] Verify innate-os boots normally with claude-mem worker not running (graceful degradation)
- [ ] Verify skill executions are captured when claude-mem worker is running
- [ ] Verify agent thoughts appear as observations in claude-mem
- [ ] Verify `CLAUDE_MEM_ENABLED=false` disables all observation posting
- [ ] Verify no latency impact on skill execution (all POSTs are fire-and-forget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)