### PR TITLE
fix: add retry loop for sensor availability check before policy execution

### DIFF
--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -281,10 +281,14 @@ class ManipulationServer(Node):
             if not self._load_policy_for_behavior(checkpoint_path, action_dim):
                 return "FAILURE", f"Failed to load policy from {checkpoint_path}"
             
-            # Check sensor availability before starting
-            if not self._check_sensor_availability():
-                self.get_logger().error("Required sensors not available. Cannot execute learned behavior.")
-                return "FAILURE", "Required sensors not available (cameras or joint state)"
+            # Wait for sensor data to arrive after subscription creation
+            sensor_wait_deadline = time.time() + 5.0
+            while not self._check_sensor_availability():
+                if time.time() > sensor_wait_deadline:
+                    self.get_logger().error("Required sensors not available after 5s. Cannot execute learned behavior.")
+                    return "FAILURE", "Required sensors not available (cameras or joint state)"
+                time.sleep(0.1)
+            self.get_logger().info("All sensors available")
             
             # Set head to AI position for optimal camera angle
             self.get_logger().info("Setting head to AI position for optimal camera angle")


### PR DESCRIPTION
## Summary

We participated in RoboHacks and discovered that when the same learned policy is run twice consecutively without performing an `innate restart` in between, the second execution fails immediately with a "Required sensors not available" error. This happens because the previous policy execution's cleanup invalidates cached sensor data (camera frames and joint states), and the node's ROS2 subscriptions need a brief moment to re-receive fresh messages on the topics. The original code performed a single, instantaneous check — so if sensor data hadn't arrived yet at that exact moment, it would immediately return `FAILURE`.

## Changes

- Replaced the one-shot `_check_sensor_availability()` guard with a polling loop that retries for up to 5 seconds (at 100ms intervals), giving ROS2 subscriptions time to deliver fresh sensor data before giving up.
- Added an explicit log message confirming all sensors are available once the check passes.