### PR TITLE
fix(boot): retry OIDC auth on cold boot instead of crashing ROS nodes

### DIFF
--- a/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
+++ b/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
@@ -41,6 +41,28 @@ class AuthError(Exception):
         super().__init__(message)
 
 
+def _is_transient_auth_error(exc: "AuthError") -> bool:
+    """Return True when ``exc`` represents a retryable condition.
+
+    Treated as transient:
+      * no HTTP status (``URLError``: DNS not ready, TLS handshake,
+        connection reset, timeout before any response),
+      * 408 Request Timeout,
+      * 429 Too Many Requests,
+      * any 5xx server error.
+
+    Everything else — notably 400/401/403/404 — is a permanent config or
+    credential issue and should fail fast so the caller (systemd unit,
+    init script, ...) can surface it rather than spin forever.
+    """
+    status = exc.status_code
+    if status is None:
+        return True
+    if status in (408, 429):
+        return True
+    return 500 <= status < 600
+
+
 def _decode_jwt_payload(token: str) -> dict[str, object]:
     """Decode the payload of a JWT *without* signature verification.
 
@@ -135,9 +157,20 @@ class AuthProvider:
         surface as :class:`AuthError` from
         :meth:`_discover_token_endpoint`.
 
-        Uses exponential backoff between attempts.  Non-:class:`AuthError`
-        exceptions (e.g. malformed JWT) propagate immediately — only
-        transient conditions are retried.
+        Uses exponential backoff between attempts.  Only *transient*
+        :class:`AuthError` conditions are retried — permanent HTTP 4xx
+        responses (wrong service key → 401, wrong issuer URL → 404,
+        etc.) re-raise immediately so systemd can observe a clean
+        failure and restart / report the misconfiguration instead of
+        spinning forever.  Non-:class:`AuthError` exceptions also
+        propagate immediately.
+
+        Retried status codes:
+
+        * ``None`` — no HTTP response (DNS, TLS, connection reset).
+        * ``408`` Request Timeout.
+        * ``429`` Too Many Requests.
+        * ``5xx`` Server Error.
 
         Args:
             timeout: Max seconds to wait.  ``None`` means wait forever.
@@ -152,7 +185,8 @@ class AuthProvider:
             A valid JWT string.
 
         Raises:
-            AuthError: If ``timeout`` elapses without success.
+            AuthError: If a permanent failure is seen, or if ``timeout``
+                elapses without success.
         """
         deadline = time.monotonic() + timeout if timeout is not None else None
         delay = initial_delay
@@ -162,6 +196,8 @@ class AuthProvider:
             try:
                 return self.token
             except AuthError as exc:
+                if not _is_transient_auth_error(exc):
+                    raise
                 now = time.monotonic()
                 if deadline is not None and now >= deadline:
                     raise
@@ -303,6 +339,11 @@ class AuthProvider:
             )
             with urllib.request.urlopen(disco_req, timeout=10) as resp:
                 discovery: dict[str, object] = json.loads(resp.read())
+        except urllib.error.HTTPError as exc:
+            raise AuthError(
+                f"OIDC discovery failed at {url}: HTTP {exc.code}",
+                status_code=exc.code,
+            ) from exc
         except urllib.error.URLError as exc:
             raise AuthError(f"OIDC discovery failed at {url}: {exc}") from exc
 

--- a/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
+++ b/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
@@ -198,11 +198,14 @@ class AuthProvider:
             except AuthError as exc:
                 if not _is_transient_auth_error(exc):
                     raise
-                now = time.monotonic()
-                if deadline is not None and now >= deadline:
-                    raise
+                # If there's no budget left for another sleep, raise now
+                # instead of firing the callback with a meaningless
+                # "retrying in 0s" and an immediate retry.
                 if deadline is not None:
-                    next_delay = min(delay, max(0.0, deadline - now))
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise
+                    next_delay = min(delay, remaining)
                 else:
                     next_delay = delay
                 if on_retry is not None:

--- a/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
+++ b/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
@@ -45,22 +45,31 @@ def _is_transient_auth_error(exc: "AuthError") -> bool:
     """Return True when ``exc`` represents a retryable condition.
 
     Treated as transient:
-      * no HTTP status (``URLError``: DNS not ready, TLS handshake,
-        connection reset, timeout before any response),
-      * 408 Request Timeout,
-      * 429 Too Many Requests,
-      * any 5xx server error.
+      * HTTP 408 Request Timeout,
+      * HTTP 429 Too Many Requests,
+      * any HTTP 5xx server error,
+      * no HTTP status *and* the AuthError was chained from a
+        ``urllib.error.URLError`` (DNS not ready, TLS handshake,
+        connection reset, timeout before any response).
 
-    Everything else — notably 400/401/403/404 — is a permanent config or
-    credential issue and should fail fast so the caller (systemd unit,
-    init script, ...) can surface it rather than spin forever.
+    Everything else — notably 400/401/403/404, and semantic errors like
+    "discovery response missing token_endpoint" or "auth response missing
+    token" which raise ``AuthError`` with no ``status_code`` *and* no
+    ``__cause__`` — is a permanent config/credential/server-contract
+    issue and should fail fast so the caller (systemd unit, init
+    script, ...) can surface it rather than spin forever.
     """
     status = exc.status_code
-    if status is None:
-        return True
-    if status in (408, 429):
-        return True
-    return 500 <= status < 600
+    if status is not None:
+        if status in (408, 429):
+            return True
+        return 500 <= status < 600
+    cause = exc.__cause__
+    while cause is not None:
+        if isinstance(cause, urllib.error.URLError):
+            return True
+        cause = cause.__cause__
+    return False
 
 
 def _decode_jwt_payload(token: str) -> dict[str, object]:

--- a/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
+++ b/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
@@ -24,9 +24,11 @@ import base64
 import json
 import logging
 import threading
+import time
 import urllib.request
 import urllib.error
 from datetime import datetime, timezone
+from typing import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +116,70 @@ class AuthProvider:
             "User-Agent": "innate-robot",
             "Authorization": f"Bearer {self.token}",
         }
+
+    def wait_for_token(
+        self,
+        *,
+        timeout: float | None = None,
+        initial_delay: float = 2.0,
+        max_delay: float = 30.0,
+        on_retry: Callable[[int, "AuthError", float], None] | None = None,
+    ) -> str:
+        """Block until a JWT can be obtained, retrying transient failures.
+
+        Intended for startup on systems where networking may not be
+        immediately usable — e.g. cold boots where DNS hasn't come up
+        yet (``URLError`` / ``EAI_AGAIN``) or boards without an RTC
+        where TLS rejects the server cert as "not yet valid" until
+        ``systemd-timesyncd`` has completed its first sync.  Both
+        surface as :class:`AuthError` from
+        :meth:`_discover_token_endpoint`.
+
+        Uses exponential backoff between attempts.  Non-:class:`AuthError`
+        exceptions (e.g. malformed JWT) propagate immediately — only
+        transient conditions are retried.
+
+        Args:
+            timeout: Max seconds to wait.  ``None`` means wait forever.
+            initial_delay: First backoff delay in seconds.
+            max_delay: Cap on the backoff delay.
+            on_retry: Optional callback ``(attempt, error, next_delay_s)``
+                invoked after each failure.  Useful to route progress
+                messages to a non-stdlib logger (e.g. a ROS logger).
+                When ``None``, warnings are emitted on the module logger.
+
+        Returns:
+            A valid JWT string.
+
+        Raises:
+            AuthError: If ``timeout`` elapses without success.
+        """
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        delay = initial_delay
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                return self.token
+            except AuthError as exc:
+                now = time.monotonic()
+                if deadline is not None and now >= deadline:
+                    raise
+                if deadline is not None:
+                    next_delay = min(delay, max(0.0, deadline - now))
+                else:
+                    next_delay = delay
+                if on_retry is not None:
+                    on_retry(attempt, exc, next_delay)
+                else:
+                    logger.warning(
+                        "Auth not ready (attempt %d): %s — retrying in %.0fs",
+                        attempt,
+                        exc,
+                        next_delay,
+                    )
+                time.sleep(next_delay)
+                delay = min(delay * 2, max_delay)
 
     async def ws_connect(self, url: str, extra_headers: dict[str, str] | None = None, **ws_kwargs):
         """Open an async WebSocket with Bearer auth and one 401 retry.

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/client.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/client.py
@@ -49,6 +49,11 @@ class OrchestratorClient:
                 issuer_url=config.auth_issuer_url,
                 service_key=config.auth_token,
             )
+            # Cold boots can fail auth for several minutes (DNS not ready, or
+            # no RTC so the system clock hasn't caught up to the server cert's
+            # notBefore).  wait_for_token() retries these transient conditions
+            # with exponential backoff instead of crashing the caller.
+            self._auth.wait_for_token()
             self._update_auth_header()
         else:
             self._auth = None

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import time
 from typing import Optional
 
 import psutil
@@ -68,14 +67,11 @@ class LoggerNode(Node):
 
         # ── Auth + telemetry client ─────────────────────────────────
         auth = AuthProvider(issuer_url=auth_issuer, service_key=service_key)
-        # Cold boots on this Jetson can fail to auth for several minutes:
-        #   • DNS isn't ready yet (URLError / EAI_AGAIN), or
-        #   • the carrier board has no RTC so TLS sees "certificate not
-        #     yet valid" until systemd-timesyncd completes its first sync.
-        # Both surface as AuthError from _discover_token_endpoint. Prime the
-        # JWT up-front with exponential backoff so our periodic telemetry
-        # timer doesn't spam transient errors during that window.
-        self._prime_auth_with_retry(auth)
+        # Cold boots can fail auth for several minutes (DNS not ready, or no
+        # RTC so TLS sees the server cert as "not yet valid").  Prime the JWT
+        # up-front with AuthProvider's retry helper so the periodic telemetry
+        # timer doesn't silently paper over those errors.
+        auth.wait_for_token(on_retry=self._log_auth_retry)
         self._client = TelemetryClient(url=telemetry_url, auth=auth)
 
         # Git commit at startup
@@ -101,33 +97,13 @@ class LoggerNode(Node):
 
     # ── Helpers ─────────────────────────────────────────────────────
 
-    def _prime_auth_with_retry(self, auth: AuthProvider) -> None:
-        """Fetch the first JWT, retrying on transient OIDC failures.
-
-        OIDC discovery can fail for a few minutes after a cold boot until
-        DNS resolves and the system clock is within the server cert's
-        validity window.  Keep retrying rather than letting the periodic
-        telemetry timer paper over those errors as generic failures.
-        """
-        delay = 2.0
-        max_delay = 30.0
-        attempt = 0
-        while True:
-            attempt += 1
-            try:
-                _ = auth.token
-                if attempt > 1:
-                    self.get_logger().info(
-                        f"Auth succeeded on attempt {attempt}"
-                    )
-                return
-            except AuthError as e:
-                self.get_logger().warning(
-                    f"Auth not ready yet (attempt {attempt}): {e} — "
-                    f"retrying in {delay:.0f}s"
-                )
-            time.sleep(delay)
-            delay = min(delay * 2, max_delay)
+    def _log_auth_retry(
+        self, attempt: int, error: AuthError, next_delay: float
+    ) -> None:
+        self.get_logger().warning(
+            f"Auth not ready yet (attempt {attempt}): {error} — "
+            f"retrying in {next_delay:.0f}s"
+        )
 
     @staticmethod
     def _get_git_commit() -> str:

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 from typing import Optional
 
 import psutil
@@ -16,7 +17,7 @@ from sensor_msgs.msg import BatteryState
 from diagnostic_msgs.msg import DiagnosticArray
 from std_msgs.msg import String
 
-from auth_client import AuthProvider
+from auth_client import AuthError, AuthProvider
 
 from innate_logger.client import TelemetryClient
 
@@ -67,6 +68,14 @@ class LoggerNode(Node):
 
         # ── Auth + telemetry client ─────────────────────────────────
         auth = AuthProvider(issuer_url=auth_issuer, service_key=service_key)
+        # Cold boots on this Jetson can fail to auth for several minutes:
+        #   • DNS isn't ready yet (URLError / EAI_AGAIN), or
+        #   • the carrier board has no RTC so TLS sees "certificate not
+        #     yet valid" until systemd-timesyncd completes its first sync.
+        # Both surface as AuthError from _discover_token_endpoint. Prime the
+        # JWT up-front with exponential backoff so our periodic telemetry
+        # timer doesn't spam transient errors during that window.
+        self._prime_auth_with_retry(auth)
         self._client = TelemetryClient(url=telemetry_url, auth=auth)
 
         # Git commit at startup
@@ -91,6 +100,34 @@ class LoggerNode(Node):
         self.create_timer(self.LOG_INTERVAL, self._log_vitals)
 
     # ── Helpers ─────────────────────────────────────────────────────
+
+    def _prime_auth_with_retry(self, auth: AuthProvider) -> None:
+        """Fetch the first JWT, retrying on transient OIDC failures.
+
+        OIDC discovery can fail for a few minutes after a cold boot until
+        DNS resolves and the system clock is within the server cert's
+        validity window.  Keep retrying rather than letting the periodic
+        telemetry timer paper over those errors as generic failures.
+        """
+        delay = 2.0
+        max_delay = 30.0
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                _ = auth.token
+                if attempt > 1:
+                    self.get_logger().info(
+                        f"Auth succeeded on attempt {attempt}"
+                    )
+                return
+            except AuthError as e:
+                self.get_logger().warning(
+                    f"Auth not ready yet (attempt {attempt}): {e} — "
+                    f"retrying in {delay:.0f}s"
+                )
+            time.sleep(delay)
+            delay = min(delay * 2, max_delay)
 
     @staticmethod
     def _get_git_commit() -> str:

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
@@ -129,9 +129,15 @@ class TrainingNode(Node):
 
         # Bridge stdlib logs from training_client + auth_client → ROS logger.
         # auth_client emits its cold-boot retry progress here via wait_for_token.
+        # Python's stdlib loggers are module-global singletons, so if
+        # TrainingNode is constructed more than once in the same process
+        # (tests, composable-node containers) we must evict any handlers
+        # installed by a prior instance to avoid duplicate emission.
         _ros_handler = _RosHandler(self.get_logger())
         for _name in ("training_client", "auth_client"):
             _lib_logger = logging.getLogger(_name)
+            for _stale in [h for h in _lib_logger.handlers if isinstance(h, _RosHandler)]:
+                _lib_logger.removeHandler(_stale)
             _lib_logger.setLevel(logging.DEBUG)
             _lib_logger.addHandler(_ros_handler)
 

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import threading
+import time
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,8 @@ from typing import Any
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+
+from auth_client import AuthError
 
 from innate_cloud_msgs.msg import TrainingJobList, TrainingParams, TransferProgress
 from innate_cloud_msgs.srv import CreateRun, DownloadResults, GetTrainingStatus, SubmitSkill
@@ -165,7 +168,13 @@ class TrainingNode(Node):
             auth_issuer_url=auth_issuer,
             poll_interval_seconds=poll_sec,
         )
-        self._mgr: SkillManager = SkillManager(config)
+        # Cold boots on this Jetson can fail to auth for several minutes:
+        #   • DNS isn't ready yet (URLError / EAI_AGAIN), or
+        #   • the carrier board has no RTC so TLS sees "certificate not
+        #     yet valid" until systemd-timesyncd completes its first sync.
+        # Both surface as AuthError from _discover_token_endpoint, so we
+        # retry with exponential backoff instead of crashing the node.
+        self._mgr: SkillManager = self._build_skill_manager_with_retry(config)
         self._store: JobStore = JobStore()
 
         # ── Publisher ───────────────────────────────────────────────
@@ -196,6 +205,37 @@ class TrainingNode(Node):
     def destroy_node(self) -> None:
         self._poller.stop()
         super().destroy_node()
+
+    def _build_skill_manager_with_retry(
+        self, config: ClientConfig
+    ) -> SkillManager:
+        """Construct a ``SkillManager``, retrying on transient auth failures.
+
+        ``SkillManager.__init__`` eagerly runs OIDC discovery to populate the
+        session's bearer header; on a cold boot this can fail until DNS is
+        usable and the system clock has advanced past the cert's ``notBefore``.
+        We back off and keep trying so the node comes up as soon as the
+        environment is ready, rather than crashing the whole ros-app unit.
+        """
+        delay = 2.0
+        max_delay = 30.0
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                mgr = SkillManager(config)
+                if attempt > 1:
+                    self.get_logger().info(
+                        f"Auth succeeded on attempt {attempt}"
+                    )
+                return mgr
+            except AuthError as e:
+                self.get_logger().warning(
+                    f"Auth not ready yet (attempt {attempt}): {e} — "
+                    f"retrying in {delay:.0f}s"
+                )
+            time.sleep(delay)
+            delay = min(delay * 2, max_delay)
 
     # ── Periodic publish ────────────────────────────────────────────
 

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
@@ -16,7 +16,6 @@ import json
 import logging
 import os
 import threading
-import time
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -24,8 +23,6 @@ from typing import Any
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
-
-from auth_client import AuthError
 
 from innate_cloud_msgs.msg import TrainingJobList, TrainingParams, TransferProgress
 from innate_cloud_msgs.srv import CreateRun, DownloadResults, GetTrainingStatus, SubmitSkill
@@ -123,10 +120,13 @@ class TrainingNode(Node):
     def __init__(self) -> None:
         super().__init__("innate_training")
 
-        # Bridge stdlib logs from training_client → ROS logger
-        _lib_logger = logging.getLogger("training_client")
-        _lib_logger.setLevel(logging.DEBUG)
-        _lib_logger.addHandler(_RosHandler(self.get_logger()))
+        # Bridge stdlib logs from training_client + auth_client → ROS logger.
+        # auth_client emits its cold-boot retry progress here via wait_for_token.
+        _ros_handler = _RosHandler(self.get_logger())
+        for _name in ("training_client", "auth_client"):
+            _lib_logger = logging.getLogger(_name)
+            _lib_logger.setLevel(logging.DEBUG)
+            _lib_logger.addHandler(_ros_handler)
 
         env_path = find_dotenv(usecwd=True)
         if env_path:
@@ -168,13 +168,10 @@ class TrainingNode(Node):
             auth_issuer_url=auth_issuer,
             poll_interval_seconds=poll_sec,
         )
-        # Cold boots on this Jetson can fail to auth for several minutes:
-        #   • DNS isn't ready yet (URLError / EAI_AGAIN), or
-        #   • the carrier board has no RTC so TLS sees "certificate not
-        #     yet valid" until systemd-timesyncd completes its first sync.
-        # Both surface as AuthError from _discover_token_endpoint, so we
-        # retry with exponential backoff instead of crashing the node.
-        self._mgr: SkillManager = self._build_skill_manager_with_retry(config)
+        # OrchestratorClient uses AuthProvider.wait_for_token() internally
+        # so cold-boot auth failures (DNS not ready, no RTC → TLS notBefore)
+        # are retried with exponential backoff instead of crashing init.
+        self._mgr: SkillManager = SkillManager(config)
         self._store: JobStore = JobStore()
 
         # ── Publisher ───────────────────────────────────────────────
@@ -205,37 +202,6 @@ class TrainingNode(Node):
     def destroy_node(self) -> None:
         self._poller.stop()
         super().destroy_node()
-
-    def _build_skill_manager_with_retry(
-        self, config: ClientConfig
-    ) -> SkillManager:
-        """Construct a ``SkillManager``, retrying on transient auth failures.
-
-        ``SkillManager.__init__`` eagerly runs OIDC discovery to populate the
-        session's bearer header; on a cold boot this can fail until DNS is
-        usable and the system clock has advanced past the cert's ``notBefore``.
-        We back off and keep trying so the node comes up as soon as the
-        environment is ready, rather than crashing the whole ros-app unit.
-        """
-        delay = 2.0
-        max_delay = 30.0
-        attempt = 0
-        while True:
-            attempt += 1
-            try:
-                mgr = SkillManager(config)
-                if attempt > 1:
-                    self.get_logger().info(
-                        f"Auth succeeded on attempt {attempt}"
-                    )
-                return mgr
-            except AuthError as e:
-                self.get_logger().warning(
-                    f"Auth not ready yet (attempt {attempt}): {e} — "
-                    f"retrying in {delay:.0f}s"
-                )
-            time.sleep(delay)
-            delay = min(delay * 2, max_delay)
 
     # ── Periodic publish ────────────────────────────────────────────
 

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/node.py
@@ -94,15 +94,13 @@ def _require_absolute(skill_dir: str) -> str | None:
 
 
 class _RosHandler(logging.Handler):
-    """Forward stdlib log records to a ROS logger."""
+    """Forward stdlib log records to a ROS logger.
 
-    _LEVEL_MAP = {
-        logging.DEBUG: "debug",
-        logging.INFO: "info",
-        logging.WARNING: "warn",
-        logging.ERROR: "error",
-        logging.CRITICAL: "fatal",
-    }
+    rclpy (Humble) caches severity per call-site ``(file, line, function)``
+    and rejects changes with ``"Logger severity cannot be changed between
+    calls"``.  Dispatch each severity from its own source line so the
+    caller_id differs per level.
+    """
 
     def __init__(self, ros_logger) -> None:
         super().__init__()
@@ -110,8 +108,17 @@ class _RosHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         msg = self.format(record)
-        fn = self._LEVEL_MAP.get(record.levelno, "info")
-        getattr(self._ros, fn)(msg)
+        level = record.levelno
+        if level >= logging.CRITICAL:
+            self._ros.fatal(msg)
+        elif level >= logging.ERROR:
+            self._ros.error(msg)
+        elif level >= logging.WARNING:
+            self._ros.warn(msg)
+        elif level >= logging.INFO:
+            self._ros.info(msg)
+        else:
+            self._ros.debug(msg)
 
 
 class TrainingNode(Node):

--- a/systemd/ros-app.service
+++ b/systemd/ros-app.service
@@ -10,13 +10,6 @@ After=zenoh-router.service network-online.target
 # Ensure this script is executable (chmod +x)
 # Preserve common/ROS environment variables including INNATE_OS_ROOT
 Environment="INNATE_OS_ROOT=/home/jetson1/innate-os" "XDG_RUNTIME_DIR=/run/user/1000"
-# Wait until the system clock is NTP-synchronized (up to ~4 min) so TLS
-# cert validation doesn't fail with "certificate is not yet valid" on boots
-# that start at epoch (no RTC battery on this Jetson).
-ExecStartPre=/bin/bash -c 'for i in $(seq 1 120); do if [ "$(timedatectl show -p NTPSynchronized --value)" = "yes" ]; then echo "clock synced after $((i*2))s"; exit 0; fi; sleep 2; done; echo "WARNING: clock not synced after 240s, starting anyway"; exit 0'
-# Wait until DNS can resolve the auth host (up to ~2 min) so the first
-# OIDC discovery call doesn't fail with EAI_AGAIN on early boot.
-ExecStartPre=/bin/bash -c 'for i in $(seq 1 60); do if getent hosts auth-v1.innate.bot >/dev/null 2>&1; then echo "DNS ready after $((i*2))s"; exit 0; fi; sleep 2; done; echo "WARNING: DNS still failing after 120s, starting anyway"; exit 0'
 ExecStart=/usr/bin/sudo -u jetson1 --preserve-env=PATH,ROS_DISTRO,XDG_RUNTIME_DIR,AMENT_PREFIX_PATH,PYTHONPATH,LD_LIBRARY_PATH,INNATE_OS_ROOT -- /bin/bash -c '${INNATE_OS_ROOT}/scripts/launch_ros_in_tmux.sh'
 # Stop the tmux session (kills all ROS processes in it)
 ExecStop=/usr/bin/sudo -u jetson1 -- /bin/bash -c 'tmux kill-session -t ros_nodes 2>/dev/null || true'
@@ -24,8 +17,6 @@ ExecStop=/usr/bin/sudo -u jetson1 -- /bin/bash -c 'tmux kill-session -t ros_node
 # Type=simple should work if the script exits after starting tmux detached.
 # If the script waits for tmux, Type=forking might be needed, but usually not.
 Type=simple
-# Give the ExecStartPre waits room to run (clock up to 240s + DNS up to 120s).
-TimeoutStartSec=600
 # Reduce timeout for shutdown to 15 seconds
 TimeoutStopSec=15
 # Kill main process with SIGTERM, then SIGKILL remaining children

--- a/systemd/ros-app.service
+++ b/systemd/ros-app.service
@@ -10,6 +10,13 @@ After=zenoh-router.service network-online.target
 # Ensure this script is executable (chmod +x)
 # Preserve common/ROS environment variables including INNATE_OS_ROOT
 Environment="INNATE_OS_ROOT=/home/jetson1/innate-os" "XDG_RUNTIME_DIR=/run/user/1000"
+# Wait until the system clock is NTP-synchronized (up to ~4 min) so TLS
+# cert validation doesn't fail with "certificate is not yet valid" on boots
+# that start at epoch (no RTC battery on this Jetson).
+ExecStartPre=/bin/bash -c 'for i in $(seq 1 120); do if [ "$(timedatectl show -p NTPSynchronized --value)" = "yes" ]; then echo "clock synced after $((i*2))s"; exit 0; fi; sleep 2; done; echo "WARNING: clock not synced after 240s, starting anyway"; exit 0'
+# Wait until DNS can resolve the auth host (up to ~2 min) so the first
+# OIDC discovery call doesn't fail with EAI_AGAIN on early boot.
+ExecStartPre=/bin/bash -c 'for i in $(seq 1 60); do if getent hosts auth-v1.innate.bot >/dev/null 2>&1; then echo "DNS ready after $((i*2))s"; exit 0; fi; sleep 2; done; echo "WARNING: DNS still failing after 120s, starting anyway"; exit 0'
 ExecStart=/usr/bin/sudo -u jetson1 --preserve-env=PATH,ROS_DISTRO,XDG_RUNTIME_DIR,AMENT_PREFIX_PATH,PYTHONPATH,LD_LIBRARY_PATH,INNATE_OS_ROOT -- /bin/bash -c '${INNATE_OS_ROOT}/scripts/launch_ros_in_tmux.sh'
 # Stop the tmux session (kills all ROS processes in it)
 ExecStop=/usr/bin/sudo -u jetson1 -- /bin/bash -c 'tmux kill-session -t ros_nodes 2>/dev/null || true'
@@ -17,6 +24,8 @@ ExecStop=/usr/bin/sudo -u jetson1 -- /bin/bash -c 'tmux kill-session -t ros_node
 # Type=simple should work if the script exits after starting tmux detached.
 # If the script waits for tmux, Type=forking might be needed, but usually not.
 Type=simple
+# Give the ExecStartPre waits room to run (clock up to 240s + DNS up to 120s).
+TimeoutStartSec=600
 # Reduce timeout for shutdown to 15 seconds
 TimeoutStopSec=15
 # Kill main process with SIGTERM, then SIGKILL remaining children


### PR DESCRIPTION
## Summary

On cold boots the Jetson carrier board launches the ROS stack before DNS is usable and, because the board has no RTC coin cell, before `systemd-timesyncd` has advanced the clock past the server cert's `notBefore` (~3m24s observed). Both conditions surface as `AuthError` inside `auth_client.provider._discover_token_endpoint` and were hard-crashing `TrainingNode.__init__`.

Instead of adding a systemd ordering dependency, the retry lives in the library so every OIDC consumer benefits.

## Changes

- **`auth_client.AuthProvider.wait_for_token(...)`** — new helper: blocks until a JWT is obtained, retrying only on `AuthError` (DNS `URLError` / EAI_AGAIN, TLS "certificate not yet valid") with 2s → 30s exponential backoff. Supports `timeout` and `on_retry(attempt, err, next_delay)` so callers can route progress to a non-stdlib logger (e.g. a ROS logger). Non-auth exceptions propagate immediately so real misconfiguration isn't masked.
- **`training-client` `OrchestratorClient.__init__`** — now primes auth via `self._auth.wait_for_token()` before the initial header set, so `SkillManager(config)` no longer crashes `TrainingNode.__init__` on cold boots.
- **`innate_training_node`** — bridges both `training_client` and `auth_client` stdlib loggers into the ROS logger so retry progress is visible.
- **`innate_training_node` `_RosHandler.emit`** — dispatches each severity from its own source line to work around rclpy Humble's "Logger severity cannot be changed between calls" (caller_id keyed on `(file, line, function)` would otherwise reject the WARN → INFO flip when auth finally succeeds).
- **`innate_logger`** — uses `auth.wait_for_token(on_retry=self._log_auth_retry)` to prime the JWT at startup so the periodic telemetry timer no longer silently papers over transient auth failures.

## Test plan

- [x] `wait_for_token` smoke test with an unreachable issuer: returns on timeout, invokes `on_retry` with the expected cadence, last sleep is clamped to remaining budget.
- [x] Logger node cold-boot launch: three retry warnings during the DNS + clock-sync window, then attempt 4 succeeds silently and the battery/cpu timer resumes cleanly once the clock jumps to 2026.
- [x] Training node cold boot survives the WARN → WARN → WARN → INFO transition without raising "Logger severity cannot be changed between calls".
- [x] Normal (warm) boot still authenticates on the first attempt without regression.

Made with [Cursor](https://cursor.com)