### PR TITLE
Expose n_action_steps + pydantic-validate behavior_config

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/skills_action_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills_action_server.py
@@ -479,7 +479,20 @@ class SkillsActionServer(Node):
                 "guidelines": "",
                 "guidelines_when_running": "",
                 "inputs": {},
-                "execution": {},
+                # Optional execution overrides; null = use manipulation_server default.
+                # `checkpoint` / `stats_file` are filled in by the run-activation flow.
+                #   duration            - seconds; default 120.0
+                #   progress_threshold  - early-term threshold on progress head; default 2.0
+                #   start_pose          - list of joint targets, or null to skip
+                #   end_pose            - list of joint targets, or null to skip
+                #   n_action_steps      - ACT replanning horizon; default min(40, chunk_size)
+                "execution": {
+                    "duration": None,
+                    "progress_threshold": None,
+                    "start_pose": None,
+                    "end_pose": None,
+                    "n_action_steps": None,
+                },
             }
             metadata_path = os.path.join(skill_dir, "metadata.json")
             with open(metadata_path, "w") as f:

--- a/ros2_ws/src/brain/manipulation/manipulation/config_validation.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/config_validation.py
@@ -37,6 +37,7 @@ from pydantic import (
     Field,
     ValidationError,
     field_validator,
+    model_validator,
 )
 
 
@@ -101,6 +102,28 @@ class _BaseExecCfg(BaseModel):
     # ``extra='ignore'`` keeps existing metadata files (e.g. wave's
     # ``model_type`` / ``downloads`` keys) compatible.
     model_config = ConfigDict(extra="ignore", strict=False)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _null_means_default(cls, data: Any) -> Any:
+        """Treat JSON ``null`` the same as a missing key.
+
+        The canonical skill-creation template emits ``null`` placeholders
+        for every optional override (``duration``, ``progress_threshold``,
+        ``start_pose``, ...) so the file self-documents which knobs exist
+        without baking in default values that could drift from the ones
+        baked into ``manipulation_server``. Without this pre-hook, pydantic
+        would reject ``"duration": null`` because ``None`` isn't a
+        ``float`` - here we strip null entries so each field falls back to
+        its declared default instead.
+
+        For required fields (``checkpoint``, ``replay_file``, ``poses``),
+        an explicit null still fails validation - but with a clearer
+        ``Field required`` message instead of a type-mismatch one.
+        """
+        if isinstance(data, dict):
+            return {k: v for k, v in data.items() if v is not None}
+        return data
 
 
 class LearnedExecCfg(_BaseExecCfg):

--- a/ros2_ws/src/brain/manipulation/manipulation/config_validation.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/config_validation.py
@@ -1,0 +1,329 @@
+"""Validation for per-behavior execution configs stored in a skill's metadata.json.
+
+Parses and validates the ``behavior_config`` payload that
+``manipulation_server`` receives on every ``/behavior/execute`` goal. The
+single source of truth for defaults lives here, so the rest of
+``manipulation_server`` can operate on typed, already-validated config
+objects instead of scattering ``dict.get(key, default)`` calls and ad hoc
+type checks through every execution path.
+
+Contract:
+
+- Happy path: ``validate_behavior_config`` returns a :class:`ValidatedBehavior`
+  whose ``params`` is one of :class:`LearnedExecCfg` / :class:`PosesExecCfg`
+  / :class:`ReplayExecCfg`, and whose ``resolved_path`` (for learned /
+  replay skills) is the absolute path to the file referenced by
+  ``execution.checkpoint`` / ``execution.replay_file``.
+- Any failure (bad JSON, unknown type, missing/wrong-type/out-of-bounds
+  field, missing file on disk) raises :class:`BehaviorConfigError` with a
+  human-readable message prefixed by ``execution.<field>`` where
+  applicable.
+
+This module is deliberately ROS-free so it can be unit-tested without a
+ROS environment.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from typing import Annotated, Any, Optional, Union
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
+
+class BehaviorConfigError(ValueError):
+    """Raised when a behavior_config payload cannot be validated."""
+
+
+# ---------------------------------------------------------------------------
+# Shared primitives
+# ---------------------------------------------------------------------------
+
+ARM_DOF = 6  # Length expected for every pose (joint-space target).
+
+KNOWN_BEHAVIOR_TYPES = ("learned", "poses", "replay")
+
+
+def _reject_bool_and_str(value: Any) -> Any:
+    """Reject bool and str inputs on numeric fields.
+
+    pydantic in non-strict mode happily coerces ``True`` to ``1`` (bool is
+    an int subclass in Python) and ``"120"`` to ``120``; both are almost
+    always bugs in a JSON-backed config, so we reject them up front with a
+    clear message.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"expected a number, got bool ({value!r})")
+    if isinstance(value, str):
+        raise ValueError(f"expected a number, got string ({value!r})")
+    return value
+
+
+def _finite_number(value: Any) -> Any:
+    """Reject non-finite floats (NaN / +-inf) after the bool/str guard."""
+    value = _reject_bool_and_str(value)
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"expected a finite number, got {value!r}")
+    return value
+
+
+def _empty_pose_to_none(value: Any) -> Any:
+    """Coerce an empty list to ``None`` so the existing ``[] means skip``
+    semantics keep working without sprinkling the check in every caller.
+    """
+    if isinstance(value, list) and len(value) == 0:
+        return None
+    return value
+
+
+# Length-constrained pose vector. Applied after _empty_pose_to_none via the
+# field validator on each pose field below.
+Pose6 = Annotated[list[float], Field(min_length=ARM_DOF, max_length=ARM_DOF)]
+
+
+# ---------------------------------------------------------------------------
+# Per-type execution configs
+# ---------------------------------------------------------------------------
+
+
+class _BaseExecCfg(BaseModel):
+    """Shared pydantic configuration for every execution schema."""
+
+    # ``extra='ignore'`` keeps existing metadata files (e.g. wave's
+    # ``model_type`` / ``downloads`` keys) compatible.
+    model_config = ConfigDict(extra="ignore", strict=False)
+
+
+class LearnedExecCfg(_BaseExecCfg):
+    """``execution`` block for ``type: learned`` skills."""
+
+    checkpoint: str = Field(..., min_length=1)
+    action_dim: int = Field(10, ge=1, le=64)
+    duration: float = Field(120.0, gt=0)
+    progress_threshold: float = Field(2.0, ge=0)
+    start_pose: Optional[Pose6] = None
+    end_pose: Optional[Pose6] = None
+    start_pose_time: float = Field(1.0, gt=0)
+    end_pose_time: float = Field(1.0, gt=0)
+    # chunk_size-aware clamping happens inside create_act_config once the
+    # checkpoint is loaded; the schema only enforces ``>= 1``.
+    n_action_steps: Optional[int] = Field(None, ge=1)
+
+    @field_validator("start_pose", "end_pose", mode="before")
+    @classmethod
+    def _coerce_empty_pose(cls, value: Any) -> Any:
+        return _empty_pose_to_none(value)
+
+    @field_validator(
+        "action_dim",
+        "duration",
+        "progress_threshold",
+        "start_pose_time",
+        "end_pose_time",
+        "n_action_steps",
+        mode="before",
+    )
+    @classmethod
+    def _guard_numeric(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return _finite_number(value)
+
+
+class PosesExecCfg(_BaseExecCfg):
+    """``execution`` block for ``type: poses`` skills."""
+
+    poses: list[Pose6] = Field(..., min_length=1)
+    # ``steps`` is the per-pose duration in seconds that the task manager
+    # holds between waypoints. ``None`` => defer to ``len(poses)`` in the
+    # caller (preserves the legacy default).
+    steps: Optional[float] = Field(None, gt=0)
+
+    @field_validator("steps", mode="before")
+    @classmethod
+    def _guard_steps(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return _finite_number(value)
+
+
+class ReplayExecCfg(_BaseExecCfg):
+    """``execution`` block for ``type: replay`` skills."""
+
+    replay_file: str = Field(..., min_length=1)
+    start_pose: Optional[Pose6] = None
+    end_pose: Optional[Pose6] = None
+    start_pose_time: float = Field(1.0, gt=0)
+    end_pose_time: float = Field(1.0, gt=0)
+    replay_frequency: float = Field(12.0, gt=0)
+
+    @field_validator("start_pose", "end_pose", mode="before")
+    @classmethod
+    def _coerce_empty_pose(cls, value: Any) -> Any:
+        return _empty_pose_to_none(value)
+
+    @field_validator(
+        "start_pose_time",
+        "end_pose_time",
+        "replay_frequency",
+        mode="before",
+    )
+    @classmethod
+    def _guard_numeric(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return _finite_number(value)
+
+
+ExecCfg = Union[LearnedExecCfg, PosesExecCfg, ReplayExecCfg]
+
+
+_MODEL_FOR_TYPE: dict[str, type[_BaseExecCfg]] = {
+    "learned": LearnedExecCfg,
+    "poses": PosesExecCfg,
+    "replay": ReplayExecCfg,
+}
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidatedBehavior:
+    """Result of successfully validating a behavior_config payload."""
+
+    behavior_type: str
+    params: ExecCfg
+    # Absolute path to the on-disk asset referenced by the config
+    # (``checkpoint`` for learned, ``replay_file`` for replay). ``None`` for
+    # poses skills, which don't reference any file.
+    resolved_path: Optional[str] = None
+
+
+def _format_validation_error(exc: ValidationError, prefix: str = "execution") -> str:
+    """Turn a pydantic ValidationError into a one-line message.
+
+    Each error is rendered as ``{prefix}.{field}: {msg} (got {input!r})`` so
+    whoever reads the log / action-result message can immediately see what
+    was wrong in metadata.json.
+    """
+    parts: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err.get("loc", ()))
+        full = f"{prefix}.{loc}" if loc else prefix
+        msg = err.get("msg", "invalid value")
+        input_val = err.get("input", "<missing>")
+        parts.append(f"{full}: {msg} (got {input_val!r})")
+    return "; ".join(parts) if parts else str(exc)
+
+
+def validate_behavior_config(
+    behavior_config: Union[str, dict],
+    skill_dir: str,
+    *,
+    check_files_exist: bool = True,
+) -> ValidatedBehavior:
+    """Parse + validate a behavior_config payload.
+
+    Parameters
+    ----------
+    behavior_config:
+        Either the raw JSON string (as received over the
+        ``ExecuteBehavior`` action request) or an already-decoded ``dict``.
+    skill_dir:
+        Absolute path to the skill directory. Used to resolve
+        ``checkpoint`` / ``replay_file`` to absolute paths.
+    check_files_exist:
+        When ``True`` (default), also assert that the referenced checkpoint
+        / replay file is present on disk. Pass ``False`` for pure schema
+        tests.
+
+    Returns
+    -------
+    ValidatedBehavior
+        Behavior type, typed params, and resolved absolute asset path.
+
+    Raises
+    ------
+    BehaviorConfigError
+        On any parse, schema, bounds, or file-existence failure.
+    """
+    # 1. JSON decode if needed.
+    if isinstance(behavior_config, str):
+        try:
+            payload = json.loads(behavior_config)
+        except json.JSONDecodeError as exc:
+            raise BehaviorConfigError(
+                f"behavior_config is not valid JSON: {exc}"
+            ) from exc
+    elif isinstance(behavior_config, dict):
+        payload = behavior_config
+    else:
+        raise BehaviorConfigError(
+            f"behavior_config must be a JSON string or dict, got "
+            f"{type(behavior_config).__name__}"
+        )
+
+    if not isinstance(payload, dict):
+        raise BehaviorConfigError(
+            f"behavior_config must decode to a JSON object, got "
+            f"{type(payload).__name__}"
+        )
+
+    # 2. Top-level shape.
+    behavior_type = payload.get("type")
+    if behavior_type not in KNOWN_BEHAVIOR_TYPES:
+        raise BehaviorConfigError(
+            f"type: must be one of {list(KNOWN_BEHAVIOR_TYPES)}, got "
+            f"{behavior_type!r}"
+        )
+
+    exec_dict = payload.get("execution")
+    if not isinstance(exec_dict, dict):
+        raise BehaviorConfigError(
+            f"execution: must be a JSON object, got "
+            f"{type(exec_dict).__name__}"
+        )
+
+    # 3. Per-type schema validation.
+    model_cls = _MODEL_FOR_TYPE[behavior_type]
+    try:
+        params = model_cls.model_validate(exec_dict)
+    except ValidationError as exc:
+        raise BehaviorConfigError(_format_validation_error(exc)) from exc
+
+    # 4. Asset existence checks.
+    resolved_path: Optional[str] = None
+    if behavior_type == "learned":
+        assert isinstance(params, LearnedExecCfg)  # for type checkers
+        resolved_path = os.path.join(skill_dir, params.checkpoint)
+        if check_files_exist and not os.path.isfile(resolved_path):
+            raise BehaviorConfigError(
+                f"execution.checkpoint: file does not exist at "
+                f"{resolved_path!r}"
+            )
+    elif behavior_type == "replay":
+        assert isinstance(params, ReplayExecCfg)
+        resolved_path = os.path.join(skill_dir, params.replay_file)
+        if check_files_exist and not os.path.isfile(resolved_path):
+            raise BehaviorConfigError(
+                f"execution.replay_file: file does not exist at "
+                f"{resolved_path!r}"
+            )
+
+    return ValidatedBehavior(
+        behavior_type=behavior_type,
+        params=params,
+        resolved_path=resolved_path,
+    )

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -9,7 +9,7 @@ from std_msgs.msg import Float64MultiArray
 from std_srvs.srv import Trigger
 from maurice_msgs.srv import GotoJS
 from brain_messages.action import ExecuteBehavior
-from rclpy.action import ActionServer, CancelResponse
+from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from cv_bridge import CvBridge
 import numpy as np
 import torch
@@ -27,6 +27,14 @@ torch.backends.cudnn.benchmark = True
 
 # Import your policy class and trajectory generator
 from manipulation.ACT import ACTPolicy, ACTConfig
+from manipulation.config_validation import (
+    BehaviorConfigError,
+    LearnedExecCfg,
+    PosesExecCfg,
+    ReplayExecCfg,
+    ValidatedBehavior,
+    validate_behavior_config,
+)
 
 def create_act_config(action_dim=10, chunk_size=30, n_action_steps=None):
     """Create ACT configuration matching the training setup.
@@ -183,12 +191,38 @@ class ManipulationServer(Node):
             self,
             ExecuteBehavior,
             '/behavior/execute',
+            goal_callback=self.goal_callback,
             execute_callback=self.execute_behavior_callback,
             cancel_callback=self.cancel_behavior_callback
         )
         
         self.get_logger().info("Behavior server ready - pure execution engine using absolute skill directories")
-    
+
+    def goal_callback(self, goal_request):
+        """Accept-time validation of behavior_config.
+
+        Rejects malformed goals with ``GoalResponse.REJECT`` so the action
+        client gets immediate feedback instead of the server accepting and
+        then aborting. ``execute_behavior_callback`` revalidates as a
+        belt-and-braces check against the file being deleted between accept
+        and execute.
+        """
+        skill_dir = getattr(goal_request, 'skill_dir', '')
+        payload = getattr(goal_request, 'behavior_config', '')
+        if not payload:
+            self.get_logger().error(
+                f"Rejecting behavior goal for {skill_dir}: behavior_config is empty"
+            )
+            return GoalResponse.REJECT
+        try:
+            validate_behavior_config(payload, skill_dir, check_files_exist=True)
+        except BehaviorConfigError as exc:
+            self.get_logger().error(
+                f"Rejecting behavior goal for {skill_dir}: {exc}"
+            )
+            return GoalResponse.REJECT
+        return GoalResponse.ACCEPT
+
     def cancel_behavior_callback(self, goal_handle_to_cancel):
         """Handle action cancel requests."""
         self.get_logger().info("Received cancel request...")
@@ -212,32 +246,33 @@ class ManipulationServer(Node):
             self.get_logger().warn(f"Behavior {skill_dir} requested but already running")
             goal_handle.abort()
             return result
-        
-        # Get config from goal (from primitive_execution_action_server)
-        if not hasattr(goal_handle.request, 'behavior_config') or not goal_handle.request.behavior_config:
-            result = ExecuteBehavior.Result()
-            result.success = False
-            result.message = f"No behavior_config provided for skill_dir: {skill_dir}"
-            self.get_logger().error(f"No behavior_config provided for skill_dir: {skill_dir}")
-            goal_handle.abort()
-            return result
-        
+
+        # Re-validate at execute-time. goal_callback already ran the same
+        # check at accept-time, but files can disappear between accept and
+        # execute, and defense in depth is cheap (pydantic parse is us-scale).
         try:
-            behavior_config = json.loads(goal_handle.request.behavior_config)
-            self.get_logger().info(f"Executing behavior at skill_dir: {skill_dir}")
-        except json.JSONDecodeError as e:
-            self.get_logger().error(f"Failed to parse behavior_config JSON: {e}")
+            validated = validate_behavior_config(
+                goal_handle.request.behavior_config,
+                skill_dir,
+                check_files_exist=True,
+            )
+        except BehaviorConfigError as exc:
             result = ExecuteBehavior.Result()
             result.success = False
-            result.message = f"Invalid behavior_config JSON: {e}"
+            result.message = f"Invalid behavior_config for {skill_dir}: {exc}"
+            self.get_logger().error(result.message)
             goal_handle.abort()
             return result
-        
+
+        self.get_logger().info(
+            f"Executing {validated.behavior_type} behavior at skill_dir: {skill_dir}"
+        )
+
         # Reset cancel flag
         self._cancel_requested.clear()
         
         # Execute the behavior
-        outcome, reason = self._execute_behavior(goal_handle, skill_dir, behavior_config)
+        outcome, reason = self._execute_behavior(goal_handle, skill_dir, validated)
         
         # Set result based on outcome
         result = ExecuteBehavior.Result()
@@ -265,26 +300,45 @@ class ManipulationServer(Node):
         
         return result
     
-    def _execute_behavior(self, goal_handle, skill_dir, behavior_config):
-        """Execute a behavior based on its configuration."""
+    def _execute_behavior(self, goal_handle, skill_dir, validated: ValidatedBehavior):
+        """Execute a behavior based on its validated configuration."""
         try:
             self.current_goal_handle = goal_handle
             self.execution_running = True
             self._start_sensor_subscriptions()
-            
-            behavior_type = behavior_config.get('type', 'unknown')
+
+            behavior_type = validated.behavior_type
             self.get_logger().info(f"Executing {behavior_type} behavior at: {skill_dir}")
-            
+
             if behavior_type == 'learned':
-                return self._execute_learned_behavior(goal_handle, skill_dir, behavior_config)
+                assert isinstance(validated.params, LearnedExecCfg)
+                assert validated.resolved_path is not None
+                return self._execute_learned_behavior(
+                    goal_handle,
+                    skill_dir,
+                    validated.params,
+                    checkpoint_path=validated.resolved_path,
+                )
             elif behavior_type == 'poses':
-                return self._execute_poses_behavior(goal_handle, skill_dir, behavior_config)
+                assert isinstance(validated.params, PosesExecCfg)
+                return self._execute_poses_behavior(
+                    goal_handle, skill_dir, validated.params
+                )
             elif behavior_type == 'replay':
-                return self._execute_replay_behavior(goal_handle, skill_dir, behavior_config)
+                assert isinstance(validated.params, ReplayExecCfg)
+                assert validated.resolved_path is not None
+                return self._execute_replay_behavior(
+                    goal_handle,
+                    skill_dir,
+                    validated.params,
+                    replay_path=validated.resolved_path,
+                )
             else:
+                # Unreachable: validator restricts behavior_type to the three
+                # branches above. Kept as defense in depth.
                 self.get_logger().error(f"Unknown behavior type: {behavior_type}")
                 return "FAILURE", f"Unknown behavior type: {behavior_type}"
-                
+
         except Exception as e:
             self.get_logger().error(f"Error executing behavior {skill_dir}: {e}")
             return "FAILURE", f"Exception during execution: {str(e)}"
@@ -310,50 +364,23 @@ class ManipulationServer(Node):
             self.get_logger().warn(f"Error releasing policy: {e}")
             self.current_policy = None
     
-    def _execute_learned_behavior(self, goal_handle, skill_dir, behavior_config):
-        """Execute a learned behavior using ACT policy."""
+    def _execute_learned_behavior(self, goal_handle, skill_dir, params: LearnedExecCfg, checkpoint_path: str):
+        """Execute a learned behavior using ACT policy.
+
+        Config has already been validated by ``validate_behavior_config``;
+        this method trusts types, bounds, and file existence.
+        """
         try:
             behavior_name = os.path.basename(skill_dir.rstrip('/'))
-            exec_cfg = behavior_config['execution']
+            action_dim = params.action_dim
+            duration = params.duration
+            progress_threshold = params.progress_threshold
+            start_pose = params.start_pose
+            end_pose = params.end_pose
+            start_pose_time = params.start_pose_time
+            end_pose_time = params.end_pose_time
+            n_action_steps_override = params.n_action_steps
 
-            # For optional numeric overrides, a null / missing value means
-            # "use the server default", keeping manipulation_server as the
-            # single source of truth for defaults.
-            def _get_or(key, default):
-                val = exec_cfg.get(key)
-                return default if val is None else val
-
-            checkpoint_file = exec_cfg.get('checkpoint')
-            if not isinstance(checkpoint_file, str) or not checkpoint_file:
-                self.get_logger().error(
-                    f"Missing or invalid 'checkpoint' in metadata.json for "
-                    f"{behavior_name}: {checkpoint_file!r}"
-                )
-                return (
-                    "FAILURE",
-                    "metadata.json execution.checkpoint is missing or not a string. "
-                    "Activate a trained run before executing this skill.",
-                )
-            checkpoint_path = os.path.join(skill_dir, checkpoint_file)
-            action_dim = _get_or('action_dim', 10)
-            duration = _get_or('duration', 120.0)
-            progress_threshold = _get_or('progress_threshold', 2.0)
-            start_pose = exec_cfg.get('start_pose')
-            end_pose = exec_cfg.get('end_pose')
-            start_pose_time = _get_or('start_pose_time', 1)
-            end_pose_time = _get_or('end_pose_time', 1)
-            n_action_steps_override = exec_cfg.get('n_action_steps')
-
-            # Treat empty lists as None
-            if start_pose is not None and len(start_pose) == 0:
-                start_pose = None
-            if end_pose is not None and len(end_pose) == 0:
-                end_pose = None
-            
-            if not checkpoint_path or not os.path.exists(checkpoint_path):
-                self.get_logger().error(f"Checkpoint not found: {checkpoint_path}")
-                return "FAILURE", f"Checkpoint file not found: {checkpoint_path}"
-            
             # Load policy
             if not self._load_policy_for_behavior(
                 checkpoint_path,
@@ -565,14 +592,16 @@ class ManipulationServer(Node):
             self._stop_robot()
             return "FAILURE", f"Exception during execution: {str(e)}"
     
-    def _execute_poses_behavior(self, goal_handle, skill_dir, behavior_config):
+    def _execute_poses_behavior(self, goal_handle, skill_dir, params: PosesExecCfg):
         """Execute a poses-based behavior."""
         behavior_name = os.path.basename(skill_dir.rstrip('/'))
         self.get_logger().info(f"Executing poses behavior: {behavior_name}")
-        
-        poses = behavior_config['execution'].get('poses', [])
-        steps = int(behavior_config['execution'].get('steps', len(poses)))
-        
+
+        poses = params.poses
+        # ``steps`` is the per-pose duration in seconds. Preserve legacy
+        # fallback: if omitted, use ``len(poses)``.
+        steps = params.steps if params.steps is not None else float(len(poses))
+
         try:
             for i, pose in enumerate(poses):
                 # Check for cancellation
@@ -602,37 +631,26 @@ class ManipulationServer(Node):
             self.get_logger().error(f"Error in poses behavior execution: {e}")
             return "FAILURE", f"Exception during poses execution: {str(e)}"
     
-    def _execute_replay_behavior(self, goal_handle, skill_dir, behavior_config):
+    def _execute_replay_behavior(self, goal_handle, skill_dir, params: ReplayExecCfg, replay_path: str):
         """Execute a replay-based behavior from H5 file."""
         behavior_name = os.path.basename(skill_dir.rstrip('/'))
         self.get_logger().info(f"Executing replay behavior: {behavior_name}")
-        
-        replay_file = behavior_config['execution'].get('replay_file')
-        if not replay_file:
-            self.get_logger().error("Missing replay_file in behavior execution config")
-            return "FAILURE", "Missing replay_file in behavior execution config"
-        file_path = os.path.join(skill_dir, replay_file)
-        start_pose = behavior_config['execution'].get('start_pose')
-        end_pose = behavior_config['execution'].get('end_pose')
-        start_pose_time = behavior_config['execution'].get('start_pose_time', 1)
-        end_pose_time = behavior_config['execution'].get('end_pose_time', 1)
-        
-        if not file_path or not os.path.exists(file_path):
-            self.get_logger().error(f"Replay file not found: {file_path}")
-            return "FAILURE", f"Replay file not found: {file_path}"
-        
+
+        start_pose = params.start_pose
+        end_pose = params.end_pose
+        start_pose_time = params.start_pose_time
+        end_pose_time = params.end_pose_time
+        replay_hz = params.replay_frequency
+
         try:
-            # Get replay frequency from config (default to 12.0 Hz)
-            replay_hz = behavior_config['execution'].get('replay_frequency', 12.0)
-            
             # Load H5 file and extract actions
-            with h5py.File(file_path, 'r') as h5file:
+            with h5py.File(replay_path, 'r') as h5file:
                 if 'action' not in h5file:
                     self.get_logger().error("No 'action' dataset found in H5 file")
                     return "FAILURE", "No 'action' dataset found in H5 file"
                 
                 actions = h5file['action'][:]  # Shape: (n_steps, action_dim)
-                self.get_logger().info(f"Loaded {actions.shape[0]} action steps from {file_path}")
+                self.get_logger().info(f"Loaded {actions.shape[0]} action steps from {replay_path}")
             
             if actions.shape[0] == 0:
                 self.get_logger().error("No actions found in replay file")

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -28,8 +28,13 @@ torch.backends.cudnn.benchmark = True
 # Import your policy class and trajectory generator
 from manipulation.ACT import ACTPolicy, ACTConfig
 
-def create_act_config(action_dim=10, chunk_size=30):
-    """Create ACT configuration matching the training setup."""
+def create_act_config(action_dim=10, chunk_size=30, n_action_steps=None):
+    """Create ACT configuration matching the training setup.
+
+    n_action_steps: optional override for the ACT replanning horizon.
+    When None, falls back to min(40, chunk_size). Values exceeding chunk_size
+    are clamped with a warning (ACTConfig would otherwise raise ValueError).
+    """
     input_shapes = {
         "observation.image_camera_1": [3, 224, 224],  # [C, H, W]
         "observation.image_camera_2": [3, 224, 224],  # [C, H, W]
@@ -39,11 +44,28 @@ def create_act_config(action_dim=10, chunk_size=30):
     output_shapes = {
         "action": [action_dim]  # action_dim - now configurable
     }
-    
+
+    if n_action_steps is None:
+        effective_n_action_steps = min(40, chunk_size)
+    else:
+        effective_n_action_steps = int(n_action_steps)
+        if effective_n_action_steps > chunk_size:
+            print(
+                f"[create_act_config] n_action_steps={effective_n_action_steps} "
+                f"exceeds chunk_size={chunk_size}; clamping to chunk_size."
+            )
+            effective_n_action_steps = chunk_size
+        if effective_n_action_steps < 1:
+            print(
+                f"[create_act_config] n_action_steps={effective_n_action_steps} "
+                f"is < 1; clamping to 1."
+            )
+            effective_n_action_steps = 1
+
     return ACTConfig(
         n_obs_steps=1,
         chunk_size=chunk_size,
-        n_action_steps=min(40, chunk_size),
+        n_action_steps=effective_n_action_steps,
         speed=1.5,
         input_shapes=input_shapes,
         output_shapes=output_shapes,
@@ -272,16 +294,26 @@ class ManipulationServer(Node):
         """Execute a learned behavior using ACT policy."""
         try:
             behavior_name = os.path.basename(skill_dir.rstrip('/'))
-            checkpoint_file = behavior_config['execution'].get('checkpoint')
+            exec_cfg = behavior_config['execution']
+
+            # For optional numeric overrides, a null / missing value means
+            # "use the server default", keeping manipulation_server as the
+            # single source of truth for defaults.
+            def _get_or(key, default):
+                val = exec_cfg.get(key)
+                return default if val is None else val
+
+            checkpoint_file = exec_cfg.get('checkpoint')
             checkpoint_path = os.path.join(skill_dir, checkpoint_file)
-            action_dim = behavior_config['execution'].get('action_dim', 10)
-            duration = behavior_config['execution'].get('duration', 120.0)
-            progress_threshold = behavior_config['execution'].get('progress_threshold', 2.0)
-            start_pose = behavior_config['execution'].get('start_pose')
-            end_pose = behavior_config['execution'].get('end_pose')
-            start_pose_time = behavior_config['execution'].get('start_pose_time', 1)
-            end_pose_time = behavior_config['execution'].get('end_pose_time', 1)
-            
+            action_dim = _get_or('action_dim', 10)
+            duration = _get_or('duration', 120.0)
+            progress_threshold = _get_or('progress_threshold', 2.0)
+            start_pose = exec_cfg.get('start_pose')
+            end_pose = exec_cfg.get('end_pose')
+            start_pose_time = _get_or('start_pose_time', 1)
+            end_pose_time = _get_or('end_pose_time', 1)
+            n_action_steps_override = exec_cfg.get('n_action_steps')
+
             # Treat empty lists as None
             if start_pose is not None and len(start_pose) == 0:
                 start_pose = None
@@ -293,7 +325,11 @@ class ManipulationServer(Node):
                 return "FAILURE", f"Checkpoint file not found: {checkpoint_path}"
             
             # Load policy
-            if not self._load_policy_for_behavior(checkpoint_path, action_dim):
+            if not self._load_policy_for_behavior(
+                checkpoint_path,
+                action_dim,
+                n_action_steps_override=n_action_steps_override,
+            ):
                 return "FAILURE", f"Failed to load policy from {checkpoint_path}"
             
             # Check sensor availability before starting
@@ -664,8 +700,12 @@ class ManipulationServer(Node):
             self._stop_robot()
             return "FAILURE", f"Exception during replay execution: {str(e)}"
     
-    def _load_policy_for_behavior(self, checkpoint_path, action_dim=8):
-        """Load ACT policy for a specific behavior."""
+    def _load_policy_for_behavior(self, checkpoint_path, action_dim=8, n_action_steps_override=None):
+        """Load ACT policy for a specific behavior.
+
+        n_action_steps_override: optional override for the ACT replanning horizon.
+        When None, create_act_config falls back to min(40, chunk_size).
+        """
         try:
             load_start = time.time()
             
@@ -723,8 +763,18 @@ class ManipulationServer(Node):
                 chunk_size = state_dict[pos_embed_key].shape[0]
                 self.get_logger().info(f"Inferred chunk_size={chunk_size} from checkpoint")
             
-            self.get_logger().info(f"Creating ACTPolicy with action_dim={action_dim}, chunk_size={chunk_size} on device={self.device}")
-            policy_config = create_act_config(action_dim=action_dim, chunk_size=chunk_size)
+            self.get_logger().info(
+                f"Creating ACTPolicy with action_dim={action_dim}, chunk_size={chunk_size}, "
+                f"n_action_steps_override={n_action_steps_override} on device={self.device}"
+            )
+            policy_config = create_act_config(
+                action_dim=action_dim,
+                chunk_size=chunk_size,
+                n_action_steps=n_action_steps_override,
+            )
+            self.get_logger().info(
+                f"Resolved n_action_steps={policy_config.n_action_steps} (chunk_size={chunk_size})"
+            )
             self.current_policy = ACTPolicy(config=policy_config, dataset_stats=dataset_stats).to(self.device)
             
             # Load state dict with strict=False to handle potential mismatches gracefully

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -45,22 +45,42 @@ def create_act_config(action_dim=10, chunk_size=30, n_action_steps=None):
         "action": [action_dim]  # action_dim - now configurable
     }
 
+    default_n_action_steps = min(40, chunk_size)
     if n_action_steps is None:
-        effective_n_action_steps = min(40, chunk_size)
+        effective_n_action_steps = default_n_action_steps
     else:
-        effective_n_action_steps = int(n_action_steps)
-        if effective_n_action_steps > chunk_size:
+        try:
+            # Reject bools (bool is an int subclass in Python) and anything
+            # that isn't a numeric type outright, so malformed metadata
+            # (e.g. a string or NaN) doesn't crash policy loading.
+            if isinstance(n_action_steps, bool) or not isinstance(
+                n_action_steps, (int, float)
+            ):
+                raise TypeError(
+                    f"expected int or float, got {type(n_action_steps).__name__}"
+                )
+            # int() on NaN -> ValueError, on inf -> OverflowError, both caught below.
+            effective_n_action_steps = int(n_action_steps)
+        except (TypeError, ValueError, OverflowError) as exc:
             print(
-                f"[create_act_config] n_action_steps={effective_n_action_steps} "
-                f"exceeds chunk_size={chunk_size}; clamping to chunk_size."
+                f"[create_act_config] Invalid n_action_steps={n_action_steps!r} "
+                f"({exc}); falling back to default "
+                f"min(40, chunk_size)={default_n_action_steps}."
             )
-            effective_n_action_steps = chunk_size
-        if effective_n_action_steps < 1:
-            print(
-                f"[create_act_config] n_action_steps={effective_n_action_steps} "
-                f"is < 1; clamping to 1."
-            )
-            effective_n_action_steps = 1
+            effective_n_action_steps = default_n_action_steps
+        else:
+            if effective_n_action_steps > chunk_size:
+                print(
+                    f"[create_act_config] n_action_steps={effective_n_action_steps} "
+                    f"exceeds chunk_size={chunk_size}; clamping to chunk_size."
+                )
+                effective_n_action_steps = chunk_size
+            if effective_n_action_steps < 1:
+                print(
+                    f"[create_act_config] n_action_steps={effective_n_action_steps} "
+                    f"is < 1; clamping to 1."
+                )
+                effective_n_action_steps = 1
 
     return ACTConfig(
         n_obs_steps=1,
@@ -304,6 +324,16 @@ class ManipulationServer(Node):
                 return default if val is None else val
 
             checkpoint_file = exec_cfg.get('checkpoint')
+            if not isinstance(checkpoint_file, str) or not checkpoint_file:
+                self.get_logger().error(
+                    f"Missing or invalid 'checkpoint' in metadata.json for "
+                    f"{behavior_name}: {checkpoint_file!r}"
+                )
+                return (
+                    "FAILURE",
+                    "metadata.json execution.checkpoint is missing or not a string. "
+                    "Activate a trained run before executing this skill.",
+                )
             checkpoint_path = os.path.join(skill_dir, checkpoint_file)
             action_dim = _get_or('action_dim', 10)
             duration = _get_or('duration', 120.0)

--- a/ros2_ws/src/brain/manipulation/test/test_config_validation.py
+++ b/ros2_ws/src/brain/manipulation/test/test_config_validation.py
@@ -1,0 +1,444 @@
+"""Unit tests for manipulation.config_validation.
+
+These tests are ROS-free and can be run with ``pytest`` directly::
+
+    cd ros2_ws/src/brain/manipulation
+    python -m pytest test/ -q
+
+They cover schema happy paths, every numeric/string/pose edge case the
+goal_callback is expected to reject, and a regression check that a real
+``metadata.json`` from the ``wave`` skill still parses cleanly with
+``extra='ignore'``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the in-tree package importable without rebuilding the colcon workspace.
+_MANIPULATION_PKG_ROOT = Path(__file__).resolve().parents[1]
+if str(_MANIPULATION_PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(_MANIPULATION_PKG_ROOT))
+
+from manipulation.config_validation import (  # noqa: E402
+    BehaviorConfigError,
+    LearnedExecCfg,
+    PosesExecCfg,
+    ReplayExecCfg,
+    validate_behavior_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate(cfg, tmp_path, *, check_files=False):
+    return validate_behavior_config(cfg, str(tmp_path), check_files_exist=check_files)
+
+
+def _touch(dir_path: Path, name: str) -> str:
+    """Create an empty file so check_files_exist=True can succeed."""
+    path = dir_path / name
+    path.write_bytes(b"")
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Top-level shape
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelShape:
+    def test_raw_json_string_decodes(self, tmp_path):
+        cfg = json.dumps(
+            {"type": "learned", "execution": {"checkpoint": "a.pth"}}
+        )
+        result = _validate(cfg, tmp_path)
+        assert result.behavior_type == "learned"
+
+    def test_malformed_json_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="not valid JSON"):
+            _validate("{not json", tmp_path)
+
+    def test_unknown_type_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="type: must be one of"):
+            _validate({"type": "bogus", "execution": {}}, tmp_path)
+
+    def test_missing_execution_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="execution"):
+            _validate({"type": "learned"}, tmp_path)
+
+    def test_execution_not_object_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="execution"):
+            _validate(
+                {"type": "learned", "execution": "not a dict"}, tmp_path
+            )
+
+    def test_non_string_non_dict_payload_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="must be a JSON"):
+            _validate(12345, tmp_path)
+
+    def test_json_array_payload_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="decode to a JSON object"):
+            _validate("[1, 2, 3]", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Learned config
+# ---------------------------------------------------------------------------
+
+
+class TestLearnedExecCfg:
+    def test_minimal_happy_path(self, tmp_path):
+        result = _validate(
+            {"type": "learned", "execution": {"checkpoint": "ckpt.pth"}},
+            tmp_path,
+        )
+        assert isinstance(result.params, LearnedExecCfg)
+        assert result.params.checkpoint == "ckpt.pth"
+        assert result.params.duration == 120.0
+        assert result.params.action_dim == 10
+        assert result.params.progress_threshold == 2.0
+        assert result.params.start_pose is None
+        assert result.params.n_action_steps is None
+        assert result.resolved_path == os.path.join(str(tmp_path), "ckpt.pth")
+
+    def test_full_happy_path(self, tmp_path):
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {
+                    "checkpoint": "ckpt.pth",
+                    "action_dim": 8,
+                    "duration": 30.0,
+                    "progress_threshold": 1.5,
+                    "start_pose": [0.0] * 6,
+                    "end_pose": [1.0] * 6,
+                    "start_pose_time": 2.0,
+                    "end_pose_time": 2.0,
+                    "n_action_steps": 40,
+                },
+            },
+            tmp_path,
+        )
+        params = result.params
+        assert isinstance(params, LearnedExecCfg)
+        assert params.action_dim == 8
+        assert params.duration == 30.0
+        assert params.start_pose == [0.0] * 6
+        assert params.n_action_steps == 40
+
+    def test_missing_checkpoint_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="checkpoint"):
+            _validate({"type": "learned", "execution": {}}, tmp_path)
+
+    def test_empty_checkpoint_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="checkpoint"):
+            _validate(
+                {"type": "learned", "execution": {"checkpoint": ""}}, tmp_path
+            )
+
+    def test_null_checkpoint_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="checkpoint"):
+            _validate(
+                {"type": "learned", "execution": {"checkpoint": None}}, tmp_path
+            )
+
+    def test_checkpoint_file_missing_on_disk(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="does not exist"):
+            validate_behavior_config(
+                {"type": "learned", "execution": {"checkpoint": "nope.pth"}},
+                str(tmp_path),
+                check_files_exist=True,
+            )
+
+    def test_checkpoint_file_exists_on_disk(self, tmp_path):
+        _touch(tmp_path, "ckpt.pth")
+        result = validate_behavior_config(
+            {"type": "learned", "execution": {"checkpoint": "ckpt.pth"}},
+            str(tmp_path),
+            check_files_exist=True,
+        )
+        assert result.resolved_path == str(tmp_path / "ckpt.pth")
+
+    @pytest.mark.parametrize(
+        "bad",
+        [0, -1, -0.5, float("nan"), float("inf"), "120", True, "abc"],
+    )
+    def test_duration_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="duration"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {"checkpoint": "ckpt.pth", "duration": bad},
+                },
+                tmp_path,
+            )
+
+    @pytest.mark.parametrize("bad", [0, -1, 100, True, "10"])
+    def test_action_dim_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="action_dim"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {
+                        "checkpoint": "ckpt.pth",
+                        "action_dim": bad,
+                    },
+                },
+                tmp_path,
+            )
+
+    def test_negative_progress_threshold_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="progress_threshold"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {
+                        "checkpoint": "ckpt.pth",
+                        "progress_threshold": -0.1,
+                    },
+                },
+                tmp_path,
+            )
+
+    @pytest.mark.parametrize(
+        "bad_pose",
+        [[0.0, 0.0, 0.0], [0.0] * 7, "not-a-list", [0.0, 0.0, 0.0, 0.0, 0.0, "x"]],
+    )
+    def test_bad_start_pose_rejected(self, tmp_path, bad_pose):
+        with pytest.raises(BehaviorConfigError, match="start_pose"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {
+                        "checkpoint": "ckpt.pth",
+                        "start_pose": bad_pose,
+                    },
+                },
+                tmp_path,
+            )
+
+    def test_empty_start_pose_coerced_to_none(self, tmp_path):
+        # Preserve legacy "empty list means skip this pose" semantics.
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {"checkpoint": "ckpt.pth", "start_pose": []},
+            },
+            tmp_path,
+        )
+        assert result.params.start_pose is None
+
+    def test_null_start_pose_accepted(self, tmp_path):
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {"checkpoint": "ckpt.pth", "start_pose": None},
+            },
+            tmp_path,
+        )
+        assert result.params.start_pose is None
+
+    @pytest.mark.parametrize("bad", [0, -1, True, "42"])
+    def test_n_action_steps_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="n_action_steps"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {
+                        "checkpoint": "ckpt.pth",
+                        "n_action_steps": bad,
+                    },
+                },
+                tmp_path,
+            )
+
+    def test_n_action_steps_null_accepted(self, tmp_path):
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {
+                    "checkpoint": "ckpt.pth",
+                    "n_action_steps": None,
+                },
+            },
+            tmp_path,
+        )
+        assert result.params.n_action_steps is None
+
+    def test_extra_keys_ignored(self, tmp_path):
+        # extra='ignore' keeps metadata like 'stats_file', 'downloads',
+        # 'model_type' from erroring out.
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {
+                    "checkpoint": "ckpt.pth",
+                    "stats_file": "stats.pt",
+                    "downloads": {"foo": "bar"},
+                },
+            },
+            tmp_path,
+        )
+        assert result.params.checkpoint == "ckpt.pth"
+
+
+# ---------------------------------------------------------------------------
+# Poses config
+# ---------------------------------------------------------------------------
+
+
+class TestPosesExecCfg:
+    def test_happy_path(self, tmp_path):
+        result = _validate(
+            {
+                "type": "poses",
+                "execution": {
+                    "poses": [[0.0] * 6, [1.0] * 6],
+                    "steps": 2.0,
+                },
+            },
+            tmp_path,
+        )
+        assert isinstance(result.params, PosesExecCfg)
+        assert len(result.params.poses) == 2
+        assert result.params.steps == 2.0
+        assert result.resolved_path is None
+
+    def test_missing_poses_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="poses"):
+            _validate({"type": "poses", "execution": {}}, tmp_path)
+
+    def test_empty_poses_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="poses"):
+            _validate(
+                {"type": "poses", "execution": {"poses": []}}, tmp_path
+            )
+
+    def test_inner_pose_wrong_length_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match=r"poses\.0"):
+            _validate(
+                {"type": "poses", "execution": {"poses": [[0, 0, 0]]}}, tmp_path
+            )
+
+    def test_steps_optional(self, tmp_path):
+        result = _validate(
+            {"type": "poses", "execution": {"poses": [[0.0] * 6]}}, tmp_path
+        )
+        assert result.params.steps is None
+
+    @pytest.mark.parametrize("bad", [0, -1, True, "2"])
+    def test_bad_steps_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="steps"):
+            _validate(
+                {
+                    "type": "poses",
+                    "execution": {"poses": [[0.0] * 6], "steps": bad},
+                },
+                tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Replay config
+# ---------------------------------------------------------------------------
+
+
+class TestReplayExecCfg:
+    def test_happy_path(self, tmp_path):
+        result = _validate(
+            {
+                "type": "replay",
+                "execution": {
+                    "replay_file": "ep.h5",
+                    "replay_frequency": 20.0,
+                },
+            },
+            tmp_path,
+        )
+        assert isinstance(result.params, ReplayExecCfg)
+        assert result.params.replay_file == "ep.h5"
+        assert result.params.replay_frequency == 20.0
+        assert result.resolved_path == os.path.join(str(tmp_path), "ep.h5")
+
+    def test_missing_replay_file_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="replay_file"):
+            _validate({"type": "replay", "execution": {}}, tmp_path)
+
+    def test_replay_file_missing_on_disk(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="does not exist"):
+            validate_behavior_config(
+                {"type": "replay", "execution": {"replay_file": "nope.h5"}},
+                str(tmp_path),
+                check_files_exist=True,
+            )
+
+    def test_replay_file_exists_on_disk(self, tmp_path):
+        _touch(tmp_path, "ep.h5")
+        result = validate_behavior_config(
+            {"type": "replay", "execution": {"replay_file": "ep.h5"}},
+            str(tmp_path),
+            check_files_exist=True,
+        )
+        assert result.resolved_path == str(tmp_path / "ep.h5")
+
+    @pytest.mark.parametrize("bad", [0, -1.0, float("nan"), True, "20"])
+    def test_bad_replay_frequency_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="replay_frequency"):
+            _validate(
+                {
+                    "type": "replay",
+                    "execution": {
+                        "replay_file": "ep.h5",
+                        "replay_frequency": bad,
+                    },
+                },
+                tmp_path,
+            )
+
+    def test_start_pose_wrong_length_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="start_pose"):
+            _validate(
+                {
+                    "type": "replay",
+                    "execution": {
+                        "replay_file": "ep.h5",
+                        "start_pose": [0, 0, 0],
+                    },
+                },
+                tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Regression: real skill metadata files must keep parsing.
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_WAVE_METADATA = _REPO_ROOT / "skills" / "wave" / "metadata.json"
+
+
+@pytest.mark.skipif(
+    not _WAVE_METADATA.exists(),
+    reason="wave skill metadata.json not present in this checkout",
+)
+def test_wave_metadata_parses(tmp_path):
+    """Regression check: the hand-authored wave skill (replay type, with
+    legacy extra keys like ``duration`` / ``model_type``) must keep parsing
+    under ``extra='ignore'``.
+    """
+    payload = json.loads(_WAVE_METADATA.read_text())
+    result = _validate(payload, _WAVE_METADATA.parent)
+    assert result.behavior_type == "replay"
+    assert isinstance(result.params, ReplayExecCfg)
+    assert math.isclose(result.params.replay_frequency, 50.0)

--- a/ros2_ws/src/brain/manipulation/test/test_config_validation.py
+++ b/ros2_ws/src/brain/manipulation/test/test_config_validation.py
@@ -275,6 +275,38 @@ class TestLearnedExecCfg:
         )
         assert result.params.n_action_steps is None
 
+    def test_null_optional_numeric_falls_back_to_default(self, tmp_path):
+        """The canonical new-skill template emits null placeholders for
+        every optional override. Those must be treated as "field missing
+        -> use server default", not as type errors.
+        """
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {
+                    "checkpoint": "ckpt.pth",
+                    "duration": None,
+                    "progress_threshold": None,
+                    "start_pose": None,
+                    "end_pose": None,
+                    "start_pose_time": None,
+                    "end_pose_time": None,
+                    "action_dim": None,
+                    "n_action_steps": None,
+                },
+            },
+            tmp_path,
+        )
+        params = result.params
+        assert params.duration == 120.0
+        assert params.progress_threshold == 2.0
+        assert params.action_dim == 10
+        assert params.start_pose_time == 1.0
+        assert params.end_pose_time == 1.0
+        assert params.start_pose is None
+        assert params.end_pose is None
+        assert params.n_action_steps is None
+
     def test_extra_keys_ignored(self, tmp_path):
         # extra='ignore' keeps metadata like 'stats_file', 'downloads',
         # 'model_type' from erroring out.

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
@@ -422,10 +422,20 @@ async def merge_datasets(request: Request, body: MergeRequest) -> dict[str, str]
     data_dest = dest / "data"
     data_dest.mkdir()
 
+    # Per-checkpoint keys that get filled in at run-activation; never
+    # propagate them as null into a fresh merged skill, even if a source
+    # happens to have them.
+    _NON_INHERITABLE_EXECUTION_KEYS = frozenset({"checkpoint", "stats_file"})
+
     try:
         merged_episodes: list[dict[str, Any]] = []
         data_frequency: int | None = None
         dataset_type: str = "h5"
+        # Union of execution-block keys observed across all source skills.
+        # Whatever knobs upstream skills exposed will be exposed (as null) in
+        # the merged skill, so this code stays in sync with the canonical
+        # create-skill template without duplicating its schema.
+        inherited_exec_keys: set[str] = set()
         new_idx = 0
 
         for src in body.sources:
@@ -444,6 +454,11 @@ async def merge_datasets(request: Request, body: MergeRequest) -> dict[str, str]
                     f"Source {src.skill_name} has dataset_type '{src_type}'; "
                     "only h264 datasets can be merged",
                 )
+
+            src_meta = _read_meta(src_path) or {}
+            src_exec = src_meta.get("execution") or {}
+            if isinstance(src_exec, dict):
+                inherited_exec_keys.update(src_exec.keys())
 
             if data_frequency is None:
                 data_frequency = src_ds.get("data_frequency", 10)
@@ -491,26 +506,24 @@ async def merge_datasets(request: Request, body: MergeRequest) -> dict[str, str]
             json.dumps(new_ds_meta, indent=4) + "\n"
         )
 
+        # Inherit execution-block knob keys from the source skills (union)
+        # so the merged skill exposes the same set of optional overrides as
+        # whatever was upstream. Per-checkpoint keys are stripped because
+        # they're populated by run-activation, not by skill creation.
+        # Values are always null -> manipulation_server falls back to its
+        # built-in defaults at execution time.
+        exec_block: dict[str, Any] = {
+            k: None
+            for k in sorted(inherited_exec_keys - _NON_INHERITABLE_EXECUTION_KEYS)
+        }
+
         meta: dict[str, Any] = {
             "name": body.new_name,
             "type": "learned",
             "guidelines": "",
             "guidelines_when_running": "",
             "inputs": {},
-            # Optional execution overrides; null = use manipulation_server default.
-            # `checkpoint` / `stats_file` are filled in by the run-activation flow.
-            #   duration            - seconds; default 120.0
-            #   progress_threshold  - early-term threshold on progress head; default 2.0
-            #   start_pose          - list of joint targets, or null to skip
-            #   end_pose            - list of joint targets, or null to skip
-            #   n_action_steps      - ACT replanning horizon; default min(40, chunk_size)
-            "execution": {
-                "duration": None,
-                "progress_threshold": None,
-                "start_pose": None,
-                "end_pose": None,
-                "n_action_steps": None,
-            },
+            "execution": exec_block,
         }
         _write_meta(dest / "metadata.json", meta)
     except Exception:

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
@@ -455,7 +455,8 @@ async def merge_datasets(request: Request, body: MergeRequest) -> dict[str, str]
                     "only h264 datasets can be merged",
                 )
 
-            src_meta = _read_meta(src_path) or {}
+            with _locked_metadata(src_path) as src_meta_path:
+                src_meta = _read_meta(src_meta_path) or {}
             src_exec = src_meta.get("execution") or {}
             if isinstance(src_exec, dict):
                 inherited_exec_keys.update(src_exec.keys())

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
@@ -497,7 +497,20 @@ async def merge_datasets(request: Request, body: MergeRequest) -> dict[str, str]
             "guidelines": "",
             "guidelines_when_running": "",
             "inputs": {},
-            "execution": {},
+            # Optional execution overrides; null = use manipulation_server default.
+            # `checkpoint` / `stats_file` are filled in by the run-activation flow.
+            #   duration            - seconds; default 120.0
+            #   progress_threshold  - early-term threshold on progress head; default 2.0
+            #   start_pose          - list of joint targets, or null to skip
+            #   end_pose            - list of joint targets, or null to skip
+            #   n_action_steps      - ACT replanning horizon; default min(40, chunk_size)
+            "execution": {
+                "duration": None,
+                "progress_threshold": None,
+                "start_pose": None,
+                "end_pose": None,
+                "n_action_steps": None,
+            },
         }
         _write_meta(dest / "metadata.json", meta)
     except Exception:


### PR DESCRIPTION
Supersedes #381 (closed; its single commit was cherry-picked onto this branch).

## Summary

This PR makes `manipulation_server`'s `behavior_config` parsing strict and self-documenting, exposes a new per-skill `n_action_steps` knob, and keeps the skill-creation paths consistent with what the server actually accepts. Six commits, grouped here by what they do rather than chronologically.

### 1. New per-skill knob: `n_action_steps`

`manipulation_server` now reads `n_action_steps` from a learned skill's `execution` block and threads it through `create_act_config`, clamping to `chunk_size` to avoid `ACTConfig`'s `ValueError`. This lets us tune the ACT replanning horizon per-skill without touching server code or rebuilding.

Commits: `7a99e4c4` (initial), `d29f0f1c` (input hardening — rejects bools/non-numeric up front, catches `TypeError` / `ValueError` / `OverflowError` on `int()` conversion, falls back to default with a clear warning rather than crashing).

### 2. Pydantic validation framework for `behavior_config`

New `manipulation/config_validation.py` module (ROS-free, unit-testable) with pydantic v2 schemas for all three metadata-driven behavior types: `LearnedExecCfg`, `PosesExecCfg`, `ReplayExecCfg`.

- **Two-stage validation in `manipulation_server`.** A new `goal_callback` validates at **accept-time** and returns `GoalResponse.REJECT` on failure so clients get immediate feedback. `execute_behavior_callback` re-validates at **execute-time** as defense in depth (e.g., a checkpoint file deleted between accept and execute).
- **Typed handoff to executors.** `_execute_learned_behavior` / `_execute_poses_behavior` / `_execute_replay_behavior` each consume the typed pydantic model plus a pre-resolved absolute path, removing scattered `.get()` calls and per-site existence checks. `_get_or` from the n_action_steps work is subsumed by the validator.
- **`null` means "use server default."** A `_null_means_default` model_validator on the shared `_BaseExecCfg` strips `None` values from the input dict before field validation, so explicit JSON `null` for an optional knob (`duration`, `progress_threshold`, `n_action_steps`, `*_pose_time`, `action_dim`) cleanly resolves to the server default. This keeps `manipulation_server` as the single source of truth for defaults and lets new-skill `metadata.json` files ship with self-documenting `null` placeholders.
- **Clear error messages.** A bad metadata surfaces as e.g. `execution.duration: Input should be greater than 0 (got 0)` at goal-accept time, instead of a bare `TypeError` deep inside a running policy loop.

Commits: `f1e8be33` (validator + server integration), `6a8e4e19` (`_null_means_default` + regression test).

### 3. Skill-creation paths kept in sync with the server

Both paths that create a fresh `metadata.json` now emit an `execution` block whose keys match what the validated schema accepts.

- **`brain_client/skills_action_server.py` (create_physical_skill service).** Hardcoded template now includes null placeholders for `duration`, `progress_threshold`, `start_pose`, `end_pose`, and `n_action_steps` alongside `checkpoint` / `stats_file`.
- **`training-manager/api/datasets.py` (merge_datasets endpoint).** Rather than hardcoding a parallel template, the merge endpoint now **inherits the union of `execution`-block keys from its source skills** (excluding `checkpoint` / `stats_file`, which are populated at run-activation). This means `merge` automatically picks up any new knob a source skill exposes, with no template drift between this code and the create path.

Commits: `7a99e4c4` (create_physical_skill template), `abb88c63` (key-inheritance redesign for merge), `c37c3a4d` (bug fix: merge was calling `_read_meta(src_path)` on a directory, which silently returned `{}` and left the inherited key set empty; now wraps in `_locked_metadata(src_path)` matching the convention used elsewhere in the file).

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest ros2_ws/src/brain/manipulation/test/ -q` — **61 passed** (every schema's happy path, every rejection class, regression check against `skills/wave/metadata.json`, and `_null_means_default` regression).
- [x] `python3 -m py_compile ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py`.
- [x] Compat sweep: every real `metadata.json` on disk under `skills/` and `~/skills/` either parses cleanly (`tape-test`, `pick_socks`, `wave`) or is correctly rejected with `execution.checkpoint: Field required` (untrained placeholders that couldn't execute under old code either — strict improvement since the message is now actionable).
- [x] `~/skills/tape-test/metadata.json` updated with the new optional `null` placeholders and re-validated cleanly: `duration` and `progress_threshold` resolve to server defaults (120.0 and 2.0), `start_pose` / `end_pose` / `n_action_steps` stay `None`.
- [x] End-to-end smoke test on the Jetson: activate a run, execute a learned skill, confirm the action succeeds.
- [x] Submit a malformed metadata (e.g. `"duration": "120"`, `"start_pose": [0, 0, 0]`) via the action client and confirm `goal_callback` rejects with a clean message (no execute-time crash).
- [x] Set `n_action_steps` in a real skill's `metadata.json` and confirm the ACT policy uses the override (and logs the clamp warning when it exceeds `chunk_size`).
- [x] Trigger `/datasets/merge` with two source skills whose `execution` blocks expose different knob sets, confirm the merged `metadata.json` carries the union (minus `checkpoint` / `stats_file`).

## Out of scope (follow-ups)

- Path-injection hardening for `execution.checkpoint` / `execution.replay_file` (Copilot review comment): `os.path.join(skill_dir, params.checkpoint)` accepts absolute paths and `..` traversal. Not exploitable today (payload comes from on-disk `metadata.json` cached by `skills_action_server`), but worth tightening with realpath-confinement so paths must resolve inside `skill_dir`.
- Moving validation into `brain_client` so it can reject at skill-loading time, not just at goal-send time.
- Adding `code`-type skill validation (Python modules, not metadata-driven).
