### PR TITLE
Validate behavior_config in manipulation_server with pydantic

### DIFF
--- a/ros2_ws/src/brain/manipulation/manipulation/config_validation.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/config_validation.py
@@ -1,0 +1,329 @@
+"""Validation for per-behavior execution configs stored in a skill's metadata.json.
+
+Parses and validates the ``behavior_config`` payload that
+``manipulation_server`` receives on every ``/behavior/execute`` goal. The
+single source of truth for defaults lives here, so the rest of
+``manipulation_server`` can operate on typed, already-validated config
+objects instead of scattering ``dict.get(key, default)`` calls and ad hoc
+type checks through every execution path.
+
+Contract:
+
+- Happy path: ``validate_behavior_config`` returns a :class:`ValidatedBehavior`
+  whose ``params`` is one of :class:`LearnedExecCfg` / :class:`PosesExecCfg`
+  / :class:`ReplayExecCfg`, and whose ``resolved_path`` (for learned /
+  replay skills) is the absolute path to the file referenced by
+  ``execution.checkpoint`` / ``execution.replay_file``.
+- Any failure (bad JSON, unknown type, missing/wrong-type/out-of-bounds
+  field, missing file on disk) raises :class:`BehaviorConfigError` with a
+  human-readable message prefixed by ``execution.<field>`` where
+  applicable.
+
+This module is deliberately ROS-free so it can be unit-tested without a
+ROS environment.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from typing import Annotated, Any, Optional, Union
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
+
+class BehaviorConfigError(ValueError):
+    """Raised when a behavior_config payload cannot be validated."""
+
+
+# ---------------------------------------------------------------------------
+# Shared primitives
+# ---------------------------------------------------------------------------
+
+ARM_DOF = 6  # Length expected for every pose (joint-space target).
+
+KNOWN_BEHAVIOR_TYPES = ("learned", "poses", "replay")
+
+
+def _reject_bool_and_str(value: Any) -> Any:
+    """Reject bool and str inputs on numeric fields.
+
+    pydantic in non-strict mode happily coerces ``True`` to ``1`` (bool is
+    an int subclass in Python) and ``"120"`` to ``120``; both are almost
+    always bugs in a JSON-backed config, so we reject them up front with a
+    clear message.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"expected a number, got bool ({value!r})")
+    if isinstance(value, str):
+        raise ValueError(f"expected a number, got string ({value!r})")
+    return value
+
+
+def _finite_number(value: Any) -> Any:
+    """Reject non-finite floats (NaN / +-inf) after the bool/str guard."""
+    value = _reject_bool_and_str(value)
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"expected a finite number, got {value!r}")
+    return value
+
+
+def _empty_pose_to_none(value: Any) -> Any:
+    """Coerce an empty list to ``None`` so the existing ``[] means skip``
+    semantics keep working without sprinkling the check in every caller.
+    """
+    if isinstance(value, list) and len(value) == 0:
+        return None
+    return value
+
+
+# Length-constrained pose vector. Applied after _empty_pose_to_none via the
+# field validator on each pose field below.
+Pose6 = Annotated[list[float], Field(min_length=ARM_DOF, max_length=ARM_DOF)]
+
+
+# ---------------------------------------------------------------------------
+# Per-type execution configs
+# ---------------------------------------------------------------------------
+
+
+class _BaseExecCfg(BaseModel):
+    """Shared pydantic configuration for every execution schema."""
+
+    # ``extra='ignore'`` keeps existing metadata files (e.g. wave's
+    # ``model_type`` / ``downloads`` keys) compatible.
+    model_config = ConfigDict(extra="ignore", strict=False)
+
+
+class LearnedExecCfg(_BaseExecCfg):
+    """``execution`` block for ``type: learned`` skills."""
+
+    checkpoint: str = Field(..., min_length=1)
+    action_dim: int = Field(10, ge=1, le=64)
+    duration: float = Field(120.0, gt=0)
+    progress_threshold: float = Field(2.0, ge=0)
+    start_pose: Optional[Pose6] = None
+    end_pose: Optional[Pose6] = None
+    start_pose_time: float = Field(1.0, gt=0)
+    end_pose_time: float = Field(1.0, gt=0)
+    # chunk_size-aware clamping happens inside create_act_config once the
+    # checkpoint is loaded; the schema only enforces ``>= 1``.
+    n_action_steps: Optional[int] = Field(None, ge=1)
+
+    @field_validator("start_pose", "end_pose", mode="before")
+    @classmethod
+    def _coerce_empty_pose(cls, value: Any) -> Any:
+        return _empty_pose_to_none(value)
+
+    @field_validator(
+        "action_dim",
+        "duration",
+        "progress_threshold",
+        "start_pose_time",
+        "end_pose_time",
+        "n_action_steps",
+        mode="before",
+    )
+    @classmethod
+    def _guard_numeric(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return _finite_number(value)
+
+
+class PosesExecCfg(_BaseExecCfg):
+    """``execution`` block for ``type: poses`` skills."""
+
+    poses: list[Pose6] = Field(..., min_length=1)
+    # ``steps`` is the per-pose duration in seconds that the task manager
+    # holds between waypoints. ``None`` => defer to ``len(poses)`` in the
+    # caller (preserves the legacy default).
+    steps: Optional[float] = Field(None, gt=0)
+
+    @field_validator("steps", mode="before")
+    @classmethod
+    def _guard_steps(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return _finite_number(value)
+
+
+class ReplayExecCfg(_BaseExecCfg):
+    """``execution`` block for ``type: replay`` skills."""
+
+    replay_file: str = Field(..., min_length=1)
+    start_pose: Optional[Pose6] = None
+    end_pose: Optional[Pose6] = None
+    start_pose_time: float = Field(1.0, gt=0)
+    end_pose_time: float = Field(1.0, gt=0)
+    replay_frequency: float = Field(12.0, gt=0)
+
+    @field_validator("start_pose", "end_pose", mode="before")
+    @classmethod
+    def _coerce_empty_pose(cls, value: Any) -> Any:
+        return _empty_pose_to_none(value)
+
+    @field_validator(
+        "start_pose_time",
+        "end_pose_time",
+        "replay_frequency",
+        mode="before",
+    )
+    @classmethod
+    def _guard_numeric(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return _finite_number(value)
+
+
+ExecCfg = Union[LearnedExecCfg, PosesExecCfg, ReplayExecCfg]
+
+
+_MODEL_FOR_TYPE: dict[str, type[_BaseExecCfg]] = {
+    "learned": LearnedExecCfg,
+    "poses": PosesExecCfg,
+    "replay": ReplayExecCfg,
+}
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidatedBehavior:
+    """Result of successfully validating a behavior_config payload."""
+
+    behavior_type: str
+    params: ExecCfg
+    # Absolute path to the on-disk asset referenced by the config
+    # (``checkpoint`` for learned, ``replay_file`` for replay). ``None`` for
+    # poses skills, which don't reference any file.
+    resolved_path: Optional[str] = None
+
+
+def _format_validation_error(exc: ValidationError, prefix: str = "execution") -> str:
+    """Turn a pydantic ValidationError into a one-line message.
+
+    Each error is rendered as ``{prefix}.{field}: {msg} (got {input!r})`` so
+    whoever reads the log / action-result message can immediately see what
+    was wrong in metadata.json.
+    """
+    parts: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err.get("loc", ()))
+        full = f"{prefix}.{loc}" if loc else prefix
+        msg = err.get("msg", "invalid value")
+        input_val = err.get("input", "<missing>")
+        parts.append(f"{full}: {msg} (got {input_val!r})")
+    return "; ".join(parts) if parts else str(exc)
+
+
+def validate_behavior_config(
+    behavior_config: Union[str, dict],
+    skill_dir: str,
+    *,
+    check_files_exist: bool = True,
+) -> ValidatedBehavior:
+    """Parse + validate a behavior_config payload.
+
+    Parameters
+    ----------
+    behavior_config:
+        Either the raw JSON string (as received over the
+        ``ExecuteBehavior`` action request) or an already-decoded ``dict``.
+    skill_dir:
+        Absolute path to the skill directory. Used to resolve
+        ``checkpoint`` / ``replay_file`` to absolute paths.
+    check_files_exist:
+        When ``True`` (default), also assert that the referenced checkpoint
+        / replay file is present on disk. Pass ``False`` for pure schema
+        tests.
+
+    Returns
+    -------
+    ValidatedBehavior
+        Behavior type, typed params, and resolved absolute asset path.
+
+    Raises
+    ------
+    BehaviorConfigError
+        On any parse, schema, bounds, or file-existence failure.
+    """
+    # 1. JSON decode if needed.
+    if isinstance(behavior_config, str):
+        try:
+            payload = json.loads(behavior_config)
+        except json.JSONDecodeError as exc:
+            raise BehaviorConfigError(
+                f"behavior_config is not valid JSON: {exc}"
+            ) from exc
+    elif isinstance(behavior_config, dict):
+        payload = behavior_config
+    else:
+        raise BehaviorConfigError(
+            f"behavior_config must be a JSON string or dict, got "
+            f"{type(behavior_config).__name__}"
+        )
+
+    if not isinstance(payload, dict):
+        raise BehaviorConfigError(
+            f"behavior_config must decode to a JSON object, got "
+            f"{type(payload).__name__}"
+        )
+
+    # 2. Top-level shape.
+    behavior_type = payload.get("type")
+    if behavior_type not in KNOWN_BEHAVIOR_TYPES:
+        raise BehaviorConfigError(
+            f"type: must be one of {list(KNOWN_BEHAVIOR_TYPES)}, got "
+            f"{behavior_type!r}"
+        )
+
+    exec_dict = payload.get("execution")
+    if not isinstance(exec_dict, dict):
+        raise BehaviorConfigError(
+            f"execution: must be a JSON object, got "
+            f"{type(exec_dict).__name__}"
+        )
+
+    # 3. Per-type schema validation.
+    model_cls = _MODEL_FOR_TYPE[behavior_type]
+    try:
+        params = model_cls.model_validate(exec_dict)
+    except ValidationError as exc:
+        raise BehaviorConfigError(_format_validation_error(exc)) from exc
+
+    # 4. Asset existence checks.
+    resolved_path: Optional[str] = None
+    if behavior_type == "learned":
+        assert isinstance(params, LearnedExecCfg)  # for type checkers
+        resolved_path = os.path.join(skill_dir, params.checkpoint)
+        if check_files_exist and not os.path.isfile(resolved_path):
+            raise BehaviorConfigError(
+                f"execution.checkpoint: file does not exist at "
+                f"{resolved_path!r}"
+            )
+    elif behavior_type == "replay":
+        assert isinstance(params, ReplayExecCfg)
+        resolved_path = os.path.join(skill_dir, params.replay_file)
+        if check_files_exist and not os.path.isfile(resolved_path):
+            raise BehaviorConfigError(
+                f"execution.replay_file: file does not exist at "
+                f"{resolved_path!r}"
+            )
+
+    return ValidatedBehavior(
+        behavior_type=behavior_type,
+        params=params,
+        resolved_path=resolved_path,
+    )

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -9,7 +9,7 @@ from std_msgs.msg import Float64MultiArray
 from std_srvs.srv import Trigger
 from maurice_msgs.srv import GotoJS
 from brain_messages.action import ExecuteBehavior
-from rclpy.action import ActionServer, CancelResponse
+from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from cv_bridge import CvBridge
 import numpy as np
 import torch
@@ -27,6 +27,14 @@ torch.backends.cudnn.benchmark = True
 
 # Import your policy class and trajectory generator
 from manipulation.ACT import ACTPolicy, ACTConfig
+from manipulation.config_validation import (
+    BehaviorConfigError,
+    LearnedExecCfg,
+    PosesExecCfg,
+    ReplayExecCfg,
+    ValidatedBehavior,
+    validate_behavior_config,
+)
 
 def create_act_config(action_dim=10, chunk_size=30):
     """Create ACT configuration matching the training setup."""
@@ -141,12 +149,38 @@ class ManipulationServer(Node):
             self,
             ExecuteBehavior,
             '/behavior/execute',
+            goal_callback=self.goal_callback,
             execute_callback=self.execute_behavior_callback,
             cancel_callback=self.cancel_behavior_callback
         )
         
         self.get_logger().info("Behavior server ready - pure execution engine using absolute skill directories")
-    
+
+    def goal_callback(self, goal_request):
+        """Accept-time validation of behavior_config.
+
+        Rejects malformed goals with ``GoalResponse.REJECT`` so the action
+        client gets immediate feedback instead of the server accepting and
+        then aborting. ``execute_behavior_callback`` revalidates as a
+        belt-and-braces check against the file being deleted between accept
+        and execute.
+        """
+        skill_dir = getattr(goal_request, 'skill_dir', '')
+        payload = getattr(goal_request, 'behavior_config', '')
+        if not payload:
+            self.get_logger().error(
+                f"Rejecting behavior goal for {skill_dir}: behavior_config is empty"
+            )
+            return GoalResponse.REJECT
+        try:
+            validate_behavior_config(payload, skill_dir, check_files_exist=True)
+        except BehaviorConfigError as exc:
+            self.get_logger().error(
+                f"Rejecting behavior goal for {skill_dir}: {exc}"
+            )
+            return GoalResponse.REJECT
+        return GoalResponse.ACCEPT
+
     def cancel_behavior_callback(self, goal_handle_to_cancel):
         """Handle action cancel requests."""
         self.get_logger().info("Received cancel request...")
@@ -170,32 +204,33 @@ class ManipulationServer(Node):
             self.get_logger().warn(f"Behavior {skill_dir} requested but already running")
             goal_handle.abort()
             return result
-        
-        # Get config from goal (from primitive_execution_action_server)
-        if not hasattr(goal_handle.request, 'behavior_config') or not goal_handle.request.behavior_config:
-            result = ExecuteBehavior.Result()
-            result.success = False
-            result.message = f"No behavior_config provided for skill_dir: {skill_dir}"
-            self.get_logger().error(f"No behavior_config provided for skill_dir: {skill_dir}")
-            goal_handle.abort()
-            return result
-        
+
+        # Re-validate at execute-time. goal_callback already ran the same
+        # check at accept-time, but files can disappear between accept and
+        # execute, and defense in depth is cheap (pydantic parse is us-scale).
         try:
-            behavior_config = json.loads(goal_handle.request.behavior_config)
-            self.get_logger().info(f"Executing behavior at skill_dir: {skill_dir}")
-        except json.JSONDecodeError as e:
-            self.get_logger().error(f"Failed to parse behavior_config JSON: {e}")
+            validated = validate_behavior_config(
+                goal_handle.request.behavior_config,
+                skill_dir,
+                check_files_exist=True,
+            )
+        except BehaviorConfigError as exc:
             result = ExecuteBehavior.Result()
             result.success = False
-            result.message = f"Invalid behavior_config JSON: {e}"
+            result.message = f"Invalid behavior_config for {skill_dir}: {exc}"
+            self.get_logger().error(result.message)
             goal_handle.abort()
             return result
-        
+
+        self.get_logger().info(
+            f"Executing {validated.behavior_type} behavior at skill_dir: {skill_dir}"
+        )
+
         # Reset cancel flag
         self._cancel_requested.clear()
         
         # Execute the behavior
-        outcome, reason = self._execute_behavior(goal_handle, skill_dir, behavior_config)
+        outcome, reason = self._execute_behavior(goal_handle, skill_dir, validated)
         
         # Set result based on outcome
         result = ExecuteBehavior.Result()
@@ -223,26 +258,45 @@ class ManipulationServer(Node):
         
         return result
     
-    def _execute_behavior(self, goal_handle, skill_dir, behavior_config):
-        """Execute a behavior based on its configuration."""
+    def _execute_behavior(self, goal_handle, skill_dir, validated: ValidatedBehavior):
+        """Execute a behavior based on its validated configuration."""
         try:
             self.current_goal_handle = goal_handle
             self.execution_running = True
             self._start_sensor_subscriptions()
-            
-            behavior_type = behavior_config.get('type', 'unknown')
+
+            behavior_type = validated.behavior_type
             self.get_logger().info(f"Executing {behavior_type} behavior at: {skill_dir}")
-            
+
             if behavior_type == 'learned':
-                return self._execute_learned_behavior(goal_handle, skill_dir, behavior_config)
+                assert isinstance(validated.params, LearnedExecCfg)
+                assert validated.resolved_path is not None
+                return self._execute_learned_behavior(
+                    goal_handle,
+                    skill_dir,
+                    validated.params,
+                    checkpoint_path=validated.resolved_path,
+                )
             elif behavior_type == 'poses':
-                return self._execute_poses_behavior(goal_handle, skill_dir, behavior_config)
+                assert isinstance(validated.params, PosesExecCfg)
+                return self._execute_poses_behavior(
+                    goal_handle, skill_dir, validated.params
+                )
             elif behavior_type == 'replay':
-                return self._execute_replay_behavior(goal_handle, skill_dir, behavior_config)
+                assert isinstance(validated.params, ReplayExecCfg)
+                assert validated.resolved_path is not None
+                return self._execute_replay_behavior(
+                    goal_handle,
+                    skill_dir,
+                    validated.params,
+                    replay_path=validated.resolved_path,
+                )
             else:
+                # Unreachable: validator restricts behavior_type to the three
+                # branches above. Kept as defense in depth.
                 self.get_logger().error(f"Unknown behavior type: {behavior_type}")
                 return "FAILURE", f"Unknown behavior type: {behavior_type}"
-                
+
         except Exception as e:
             self.get_logger().error(f"Error executing behavior {skill_dir}: {e}")
             return "FAILURE", f"Exception during execution: {str(e)}"
@@ -268,30 +322,22 @@ class ManipulationServer(Node):
             self.get_logger().warn(f"Error releasing policy: {e}")
             self.current_policy = None
     
-    def _execute_learned_behavior(self, goal_handle, skill_dir, behavior_config):
-        """Execute a learned behavior using ACT policy."""
+    def _execute_learned_behavior(self, goal_handle, skill_dir, params: LearnedExecCfg, checkpoint_path: str):
+        """Execute a learned behavior using ACT policy.
+
+        Config has already been validated by ``validate_behavior_config``;
+        this method trusts types, bounds, and file existence.
+        """
         try:
             behavior_name = os.path.basename(skill_dir.rstrip('/'))
-            checkpoint_file = behavior_config['execution'].get('checkpoint')
-            checkpoint_path = os.path.join(skill_dir, checkpoint_file)
-            action_dim = behavior_config['execution'].get('action_dim', 10)
-            duration = behavior_config['execution'].get('duration', 120.0)
-            progress_threshold = behavior_config['execution'].get('progress_threshold', 2.0)
-            start_pose = behavior_config['execution'].get('start_pose')
-            end_pose = behavior_config['execution'].get('end_pose')
-            start_pose_time = behavior_config['execution'].get('start_pose_time', 1)
-            end_pose_time = behavior_config['execution'].get('end_pose_time', 1)
-            
-            # Treat empty lists as None
-            if start_pose is not None and len(start_pose) == 0:
-                start_pose = None
-            if end_pose is not None and len(end_pose) == 0:
-                end_pose = None
-            
-            if not checkpoint_path or not os.path.exists(checkpoint_path):
-                self.get_logger().error(f"Checkpoint not found: {checkpoint_path}")
-                return "FAILURE", f"Checkpoint file not found: {checkpoint_path}"
-            
+            action_dim = params.action_dim
+            duration = params.duration
+            progress_threshold = params.progress_threshold
+            start_pose = params.start_pose
+            end_pose = params.end_pose
+            start_pose_time = params.start_pose_time
+            end_pose_time = params.end_pose_time
+
             # Load policy
             if not self._load_policy_for_behavior(checkpoint_path, action_dim):
                 return "FAILURE", f"Failed to load policy from {checkpoint_path}"
@@ -499,14 +545,16 @@ class ManipulationServer(Node):
             self._stop_robot()
             return "FAILURE", f"Exception during execution: {str(e)}"
     
-    def _execute_poses_behavior(self, goal_handle, skill_dir, behavior_config):
+    def _execute_poses_behavior(self, goal_handle, skill_dir, params: PosesExecCfg):
         """Execute a poses-based behavior."""
         behavior_name = os.path.basename(skill_dir.rstrip('/'))
         self.get_logger().info(f"Executing poses behavior: {behavior_name}")
-        
-        poses = behavior_config['execution'].get('poses', [])
-        steps = int(behavior_config['execution'].get('steps', len(poses)))
-        
+
+        poses = params.poses
+        # ``steps`` is the per-pose duration in seconds. Preserve legacy
+        # fallback: if omitted, use ``len(poses)``.
+        steps = params.steps if params.steps is not None else float(len(poses))
+
         try:
             for i, pose in enumerate(poses):
                 # Check for cancellation
@@ -536,37 +584,26 @@ class ManipulationServer(Node):
             self.get_logger().error(f"Error in poses behavior execution: {e}")
             return "FAILURE", f"Exception during poses execution: {str(e)}"
     
-    def _execute_replay_behavior(self, goal_handle, skill_dir, behavior_config):
+    def _execute_replay_behavior(self, goal_handle, skill_dir, params: ReplayExecCfg, replay_path: str):
         """Execute a replay-based behavior from H5 file."""
         behavior_name = os.path.basename(skill_dir.rstrip('/'))
         self.get_logger().info(f"Executing replay behavior: {behavior_name}")
-        
-        replay_file = behavior_config['execution'].get('replay_file')
-        if not replay_file:
-            self.get_logger().error("Missing replay_file in behavior execution config")
-            return "FAILURE", "Missing replay_file in behavior execution config"
-        file_path = os.path.join(skill_dir, replay_file)
-        start_pose = behavior_config['execution'].get('start_pose')
-        end_pose = behavior_config['execution'].get('end_pose')
-        start_pose_time = behavior_config['execution'].get('start_pose_time', 1)
-        end_pose_time = behavior_config['execution'].get('end_pose_time', 1)
-        
-        if not file_path or not os.path.exists(file_path):
-            self.get_logger().error(f"Replay file not found: {file_path}")
-            return "FAILURE", f"Replay file not found: {file_path}"
-        
+
+        start_pose = params.start_pose
+        end_pose = params.end_pose
+        start_pose_time = params.start_pose_time
+        end_pose_time = params.end_pose_time
+        replay_hz = params.replay_frequency
+
         try:
-            # Get replay frequency from config (default to 12.0 Hz)
-            replay_hz = behavior_config['execution'].get('replay_frequency', 12.0)
-            
             # Load H5 file and extract actions
-            with h5py.File(file_path, 'r') as h5file:
+            with h5py.File(replay_path, 'r') as h5file:
                 if 'action' not in h5file:
                     self.get_logger().error("No 'action' dataset found in H5 file")
                     return "FAILURE", "No 'action' dataset found in H5 file"
                 
                 actions = h5file['action'][:]  # Shape: (n_steps, action_dim)
-                self.get_logger().info(f"Loaded {actions.shape[0]} action steps from {file_path}")
+                self.get_logger().info(f"Loaded {actions.shape[0]} action steps from {replay_path}")
             
             if actions.shape[0] == 0:
                 self.get_logger().error("No actions found in replay file")

--- a/ros2_ws/src/brain/manipulation/test/test_config_validation.py
+++ b/ros2_ws/src/brain/manipulation/test/test_config_validation.py
@@ -1,0 +1,444 @@
+"""Unit tests for manipulation.config_validation.
+
+These tests are ROS-free and can be run with ``pytest`` directly::
+
+    cd ros2_ws/src/brain/manipulation
+    python -m pytest test/ -q
+
+They cover schema happy paths, every numeric/string/pose edge case the
+goal_callback is expected to reject, and a regression check that a real
+``metadata.json`` from the ``wave`` skill still parses cleanly with
+``extra='ignore'``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the in-tree package importable without rebuilding the colcon workspace.
+_MANIPULATION_PKG_ROOT = Path(__file__).resolve().parents[1]
+if str(_MANIPULATION_PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(_MANIPULATION_PKG_ROOT))
+
+from manipulation.config_validation import (  # noqa: E402
+    BehaviorConfigError,
+    LearnedExecCfg,
+    PosesExecCfg,
+    ReplayExecCfg,
+    validate_behavior_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate(cfg, tmp_path, *, check_files=False):
+    return validate_behavior_config(cfg, str(tmp_path), check_files_exist=check_files)
+
+
+def _touch(dir_path: Path, name: str) -> str:
+    """Create an empty file so check_files_exist=True can succeed."""
+    path = dir_path / name
+    path.write_bytes(b"")
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Top-level shape
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelShape:
+    def test_raw_json_string_decodes(self, tmp_path):
+        cfg = json.dumps(
+            {"type": "learned", "execution": {"checkpoint": "a.pth"}}
+        )
+        result = _validate(cfg, tmp_path)
+        assert result.behavior_type == "learned"
+
+    def test_malformed_json_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="not valid JSON"):
+            _validate("{not json", tmp_path)
+
+    def test_unknown_type_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="type: must be one of"):
+            _validate({"type": "bogus", "execution": {}}, tmp_path)
+
+    def test_missing_execution_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="execution"):
+            _validate({"type": "learned"}, tmp_path)
+
+    def test_execution_not_object_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="execution"):
+            _validate(
+                {"type": "learned", "execution": "not a dict"}, tmp_path
+            )
+
+    def test_non_string_non_dict_payload_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="must be a JSON"):
+            _validate(12345, tmp_path)
+
+    def test_json_array_payload_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="decode to a JSON object"):
+            _validate("[1, 2, 3]", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Learned config
+# ---------------------------------------------------------------------------
+
+
+class TestLearnedExecCfg:
+    def test_minimal_happy_path(self, tmp_path):
+        result = _validate(
+            {"type": "learned", "execution": {"checkpoint": "ckpt.pth"}},
+            tmp_path,
+        )
+        assert isinstance(result.params, LearnedExecCfg)
+        assert result.params.checkpoint == "ckpt.pth"
+        assert result.params.duration == 120.0
+        assert result.params.action_dim == 10
+        assert result.params.progress_threshold == 2.0
+        assert result.params.start_pose is None
+        assert result.params.n_action_steps is None
+        assert result.resolved_path == os.path.join(str(tmp_path), "ckpt.pth")
+
+    def test_full_happy_path(self, tmp_path):
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {
+                    "checkpoint": "ckpt.pth",
+                    "action_dim": 8,
+                    "duration": 30.0,
+                    "progress_threshold": 1.5,
+                    "start_pose": [0.0] * 6,
+                    "end_pose": [1.0] * 6,
+                    "start_pose_time": 2.0,
+                    "end_pose_time": 2.0,
+                    "n_action_steps": 40,
+                },
+            },
+            tmp_path,
+        )
+        params = result.params
+        assert isinstance(params, LearnedExecCfg)
+        assert params.action_dim == 8
+        assert params.duration == 30.0
+        assert params.start_pose == [0.0] * 6
+        assert params.n_action_steps == 40
+
+    def test_missing_checkpoint_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="checkpoint"):
+            _validate({"type": "learned", "execution": {}}, tmp_path)
+
+    def test_empty_checkpoint_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="checkpoint"):
+            _validate(
+                {"type": "learned", "execution": {"checkpoint": ""}}, tmp_path
+            )
+
+    def test_null_checkpoint_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="checkpoint"):
+            _validate(
+                {"type": "learned", "execution": {"checkpoint": None}}, tmp_path
+            )
+
+    def test_checkpoint_file_missing_on_disk(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="does not exist"):
+            validate_behavior_config(
+                {"type": "learned", "execution": {"checkpoint": "nope.pth"}},
+                str(tmp_path),
+                check_files_exist=True,
+            )
+
+    def test_checkpoint_file_exists_on_disk(self, tmp_path):
+        _touch(tmp_path, "ckpt.pth")
+        result = validate_behavior_config(
+            {"type": "learned", "execution": {"checkpoint": "ckpt.pth"}},
+            str(tmp_path),
+            check_files_exist=True,
+        )
+        assert result.resolved_path == str(tmp_path / "ckpt.pth")
+
+    @pytest.mark.parametrize(
+        "bad",
+        [0, -1, -0.5, float("nan"), float("inf"), "120", True, "abc"],
+    )
+    def test_duration_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="duration"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {"checkpoint": "ckpt.pth", "duration": bad},
+                },
+                tmp_path,
+            )
+
+    @pytest.mark.parametrize("bad", [0, -1, 100, True, "10"])
+    def test_action_dim_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="action_dim"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {
+                        "checkpoint": "ckpt.pth",
+                        "action_dim": bad,
+                    },
+                },
+                tmp_path,
+            )
+
+    def test_negative_progress_threshold_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="progress_threshold"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {
+                        "checkpoint": "ckpt.pth",
+                        "progress_threshold": -0.1,
+                    },
+                },
+                tmp_path,
+            )
+
+    @pytest.mark.parametrize(
+        "bad_pose",
+        [[0.0, 0.0, 0.0], [0.0] * 7, "not-a-list", [0.0, 0.0, 0.0, 0.0, 0.0, "x"]],
+    )
+    def test_bad_start_pose_rejected(self, tmp_path, bad_pose):
+        with pytest.raises(BehaviorConfigError, match="start_pose"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {
+                        "checkpoint": "ckpt.pth",
+                        "start_pose": bad_pose,
+                    },
+                },
+                tmp_path,
+            )
+
+    def test_empty_start_pose_coerced_to_none(self, tmp_path):
+        # Preserve legacy "empty list means skip this pose" semantics.
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {"checkpoint": "ckpt.pth", "start_pose": []},
+            },
+            tmp_path,
+        )
+        assert result.params.start_pose is None
+
+    def test_null_start_pose_accepted(self, tmp_path):
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {"checkpoint": "ckpt.pth", "start_pose": None},
+            },
+            tmp_path,
+        )
+        assert result.params.start_pose is None
+
+    @pytest.mark.parametrize("bad", [0, -1, True, "42"])
+    def test_n_action_steps_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="n_action_steps"):
+            _validate(
+                {
+                    "type": "learned",
+                    "execution": {
+                        "checkpoint": "ckpt.pth",
+                        "n_action_steps": bad,
+                    },
+                },
+                tmp_path,
+            )
+
+    def test_n_action_steps_null_accepted(self, tmp_path):
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {
+                    "checkpoint": "ckpt.pth",
+                    "n_action_steps": None,
+                },
+            },
+            tmp_path,
+        )
+        assert result.params.n_action_steps is None
+
+    def test_extra_keys_ignored(self, tmp_path):
+        # extra='ignore' keeps metadata like 'stats_file', 'downloads',
+        # 'model_type' from erroring out.
+        result = _validate(
+            {
+                "type": "learned",
+                "execution": {
+                    "checkpoint": "ckpt.pth",
+                    "stats_file": "stats.pt",
+                    "downloads": {"foo": "bar"},
+                },
+            },
+            tmp_path,
+        )
+        assert result.params.checkpoint == "ckpt.pth"
+
+
+# ---------------------------------------------------------------------------
+# Poses config
+# ---------------------------------------------------------------------------
+
+
+class TestPosesExecCfg:
+    def test_happy_path(self, tmp_path):
+        result = _validate(
+            {
+                "type": "poses",
+                "execution": {
+                    "poses": [[0.0] * 6, [1.0] * 6],
+                    "steps": 2.0,
+                },
+            },
+            tmp_path,
+        )
+        assert isinstance(result.params, PosesExecCfg)
+        assert len(result.params.poses) == 2
+        assert result.params.steps == 2.0
+        assert result.resolved_path is None
+
+    def test_missing_poses_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="poses"):
+            _validate({"type": "poses", "execution": {}}, tmp_path)
+
+    def test_empty_poses_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="poses"):
+            _validate(
+                {"type": "poses", "execution": {"poses": []}}, tmp_path
+            )
+
+    def test_inner_pose_wrong_length_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match=r"poses\.0"):
+            _validate(
+                {"type": "poses", "execution": {"poses": [[0, 0, 0]]}}, tmp_path
+            )
+
+    def test_steps_optional(self, tmp_path):
+        result = _validate(
+            {"type": "poses", "execution": {"poses": [[0.0] * 6]}}, tmp_path
+        )
+        assert result.params.steps is None
+
+    @pytest.mark.parametrize("bad", [0, -1, True, "2"])
+    def test_bad_steps_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="steps"):
+            _validate(
+                {
+                    "type": "poses",
+                    "execution": {"poses": [[0.0] * 6], "steps": bad},
+                },
+                tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Replay config
+# ---------------------------------------------------------------------------
+
+
+class TestReplayExecCfg:
+    def test_happy_path(self, tmp_path):
+        result = _validate(
+            {
+                "type": "replay",
+                "execution": {
+                    "replay_file": "ep.h5",
+                    "replay_frequency": 20.0,
+                },
+            },
+            tmp_path,
+        )
+        assert isinstance(result.params, ReplayExecCfg)
+        assert result.params.replay_file == "ep.h5"
+        assert result.params.replay_frequency == 20.0
+        assert result.resolved_path == os.path.join(str(tmp_path), "ep.h5")
+
+    def test_missing_replay_file_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="replay_file"):
+            _validate({"type": "replay", "execution": {}}, tmp_path)
+
+    def test_replay_file_missing_on_disk(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="does not exist"):
+            validate_behavior_config(
+                {"type": "replay", "execution": {"replay_file": "nope.h5"}},
+                str(tmp_path),
+                check_files_exist=True,
+            )
+
+    def test_replay_file_exists_on_disk(self, tmp_path):
+        _touch(tmp_path, "ep.h5")
+        result = validate_behavior_config(
+            {"type": "replay", "execution": {"replay_file": "ep.h5"}},
+            str(tmp_path),
+            check_files_exist=True,
+        )
+        assert result.resolved_path == str(tmp_path / "ep.h5")
+
+    @pytest.mark.parametrize("bad", [0, -1.0, float("nan"), True, "20"])
+    def test_bad_replay_frequency_rejected(self, tmp_path, bad):
+        with pytest.raises(BehaviorConfigError, match="replay_frequency"):
+            _validate(
+                {
+                    "type": "replay",
+                    "execution": {
+                        "replay_file": "ep.h5",
+                        "replay_frequency": bad,
+                    },
+                },
+                tmp_path,
+            )
+
+    def test_start_pose_wrong_length_rejected(self, tmp_path):
+        with pytest.raises(BehaviorConfigError, match="start_pose"):
+            _validate(
+                {
+                    "type": "replay",
+                    "execution": {
+                        "replay_file": "ep.h5",
+                        "start_pose": [0, 0, 0],
+                    },
+                },
+                tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Regression: real skill metadata files must keep parsing.
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_WAVE_METADATA = _REPO_ROOT / "skills" / "wave" / "metadata.json"
+
+
+@pytest.mark.skipif(
+    not _WAVE_METADATA.exists(),
+    reason="wave skill metadata.json not present in this checkout",
+)
+def test_wave_metadata_parses(tmp_path):
+    """Regression check: the hand-authored wave skill (replay type, with
+    legacy extra keys like ``duration`` / ``model_type``) must keep parsing
+    under ``extra='ignore'``.
+    """
+    payload = json.loads(_WAVE_METADATA.read_text())
+    result = _validate(payload, _WAVE_METADATA.parent)
+    assert result.behavior_type == "replay"
+    assert isinstance(result.params, ReplayExecCfg)
+    assert math.isclose(result.params.replay_frequency, 50.0)


### PR DESCRIPTION
## Summary

- New `manipulation/config_validation.py` module with pydantic v2 schemas (`LearnedExecCfg` / `PosesExecCfg` / `ReplayExecCfg`) + a top-level `validate_behavior_config()` that returns a typed, already-parsed behavior config plus the resolved absolute path to the referenced checkpoint / replay file. `BehaviorConfigError` carries a human-readable `execution.<field>: <reason>` message.
- `manipulation_server` now validates twice:
  - **accept-time** in a new `goal_callback` -> `GoalResponse.REJECT` so clients get immediate feedback instead of "accepted, then aborted".
  - **execute-time** in `execute_behavior_callback` as belt-and-braces against a file being deleted between accept and execute.
- `_execute_learned_behavior` / `_execute_poses_behavior` / `_execute_replay_behavior` now consume the typed config objects plus pre-resolved file paths. Drops the per-site `.get(...)` calls, the empty-list-as-None coercion, and the redundant `os.path.exists` guards (all moved into the validator).
- New `test/test_config_validation.py` pytest suite with 60 cases covering each schema's happy path and every edge case that motivated this change (bool-as-int, NaN/inf, string-as-number, empty-list-as-None, wrong-length poses, missing files), plus a regression check on the real `skills/wave/metadata.json`.

Net effect: a malformed `metadata.json` now surfaces as `execution.duration: Input should be greater than 0 (got 0)` at goal-accept time, instead of a bare `TypeError` deep inside a running policy loop.

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest ros2_ws/src/brain/manipulation/test/ -q` -> 60 passed
- [x] `python3 -m py_compile ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py`
- [x] Compat sweep: parsed every `metadata.json` under `skills/` and `~/skills/` with the new validator. The three hand-authored / activated skills (`tape-test`, `pick_socks`, `wave`) parse cleanly; the remaining six are untrained placeholders with `execution: {}`, which are correctly rejected with `execution.checkpoint: Field required` (these were already broken under old code, just with a worse error message).
- [ ] End-to-end smoke test on the Jetson: activate a run, execute the skill, confirm the action succeeds (QA once the PR is reviewed).
- [ ] Submit a malformed metadata (e.g. `"duration": "120"`, `"start_pose": [0, 0, 0]`) via the action client and confirm `goal_callback` rejects with a clean message.

## Out of scope (tracked as follow-ups)

- Moving validation into `brain_client` so it can reject at skill-loading time.
- Adding `code`-type skill validation (different story: Python modules, not metadata-driven).
- Wiring the validated `n_action_steps` through to `create_act_config` (lands with `vig/policy_params_metadata`; trivial rebase once both merge).

Made with [Cursor](https://cursor.com)