### PR TITLE
Fix Training Manager creating metadata in __pycache__

### DIFF
--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
@@ -26,16 +26,14 @@ from training_client.src.skill_manager import (
 )
 from training_client.src.types import ClientConfig, ProgressUpdate
 
+from training_manager.api.skill_paths import iter_skill_dirs, skills_dir
+
 logger = logging.getLogger("training_manager.api.datasets")
 
 router = APIRouter(tags=["datasets"])
 
 _submit_jobs: dict[str, dict[str, Any]] = {}
 _submit_lock = threading.Lock()
-
-
-def _skills_dir(request: Request) -> Path:
-    return Path(request.app.state.skills_dir)
 
 
 def _replace_stem(video_filename: str, old_stem: str, new_stem: str) -> str:
@@ -75,20 +73,8 @@ def _dataset_status(skill_path: Path) -> str:
 @router.get("")
 async def list_datasets(request: Request) -> list[dict[str, Any]]:
     """List all skills with their dataset info."""
-    root = _skills_dir(request)
-    if not root.is_dir():
-        return []
-
     datasets: list[dict[str, Any]] = []
-    for child in sorted(root.iterdir()):
-        if (
-            not child.is_dir()
-            or child.name.startswith(".")
-            or child.name == "__pycache__"
-            or not (child / "metadata.json").is_file()
-        ):
-            continue
-
+    for child in iter_skill_dirs(skills_dir(request)):
         with _locked_metadata(child) as meta_path:
             meta = _read_meta(meta_path)
         if not meta:
@@ -114,7 +100,7 @@ async def list_datasets(request: Request) -> list[dict[str, Any]]:
 @router.get("/{skill_name}")
 async def get_dataset(request: Request, skill_name: str) -> dict[str, Any]:
     """Full dataset details including per-episode info."""
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     if not skill_path.is_dir():
         raise HTTPException(404, f"Skill not found: {skill_name}")
 
@@ -146,7 +132,7 @@ async def get_episode_video(
     request: Request, skill_name: str, episode_id: int, camera: int = 0
 ) -> FileResponse:
     """Stream an episode MP4 file."""
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     ds_meta = _read_dataset_metadata(skill_path)
     if ds_meta is None:
         raise HTTPException(404, "No dataset metadata")
@@ -183,7 +169,7 @@ async def submit_skill(
     training client, which handles H.264 conversion, signed-URL uploads,
     verification, and metadata updates.
     """
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     if not skill_path.is_dir():
         raise HTTPException(404, f"Skill not found: {skill_name}")
 
@@ -313,7 +299,7 @@ async def copy_dataset(
     Clears training_skill_id, checkpoint, stats_file, and removes run
     directories from the copy.
     """
-    root = _skills_dir(request)
+    root = skills_dir(request)
     source = root / skill_name
     if not source.is_dir():
         raise HTTPException(404, f"Skill not found: {skill_name}")
@@ -412,7 +398,7 @@ async def merge_datasets(request: Request, body: MergeRequest) -> dict[str, str]
     Uses the training client's locked metadata for safe reads from source
     skills.  The new skill gets a fresh metadata.json with empty execution.
     """
-    root = _skills_dir(request)
+    root = skills_dir(request)
     dest_dir_name = body.new_name.replace(" ", "-").lower()
     dest = root / dest_dir_name
     if dest.exists():

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
@@ -17,7 +17,6 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
-
 from training_client.src.skill_manager import (
     SkillManager,
     _locked_metadata,
@@ -82,7 +81,12 @@ async def list_datasets(request: Request) -> list[dict[str, Any]]:
 
     datasets: list[dict[str, Any]] = []
     for child in sorted(root.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
+        if (
+            not child.is_dir()
+            or child.name.startswith(".")
+            or child.name == "__pycache__"
+            or not (child / "metadata.json").is_file()
+        ):
             continue
 
         with _locked_metadata(child) as meta_path:
@@ -235,10 +239,8 @@ def _run_submit(
         job["message"] = "Submitting skill..."
         logger.info("[%s] Submitting skill...", skill_name)
 
-        skill_info = None
         for update in manager.submit(skill_dir):
             _apply_progress(job, update, skill_name)
-            skill_info = update
 
         skill_id = read_skill_id(skill_dir)
         if not skill_id:

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skill_paths.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skill_paths.py
@@ -1,0 +1,30 @@
+"""Shared helpers for locating skill directories."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from fastapi import Request
+
+
+def skills_dir(request: Request) -> Path:
+    return Path(request.app.state.skills_dir)
+
+
+def is_skill_dir(path: Path) -> bool:
+    return (
+        path.is_dir()
+        and not path.name.startswith(".")
+        and path.name != "__pycache__"
+        and (path / "metadata.json").is_file()
+    )
+
+
+def iter_skill_dirs(root: Path) -> Iterator[Path]:
+    if not root.is_dir():
+        return
+
+    for child in sorted(root.iterdir()):
+        if is_skill_dir(child):
+            yield child

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skills.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skills.py
@@ -14,13 +14,11 @@ from training_client.src.skill_manager import (
     _write_meta,
 )
 
+from training_manager.api.skill_paths import iter_skill_dirs, skills_dir
+
 logger = logging.getLogger("training_manager.api.skills")
 
 router = APIRouter(tags=["skills"])
-
-
-def _skills_dir(request: Request) -> Path:
-    return Path(request.app.state.skills_dir)
 
 
 def _read_dataset_metadata(skill_path: Path) -> dict[str, Any] | None:
@@ -59,19 +57,8 @@ def _skill_summary(skill_path: Path) -> dict[str, Any] | None:
 @router.get("")
 async def list_skills(request: Request) -> list[dict[str, Any]]:
     """List all skills found in the skills directory."""
-    root = _skills_dir(request)
-    if not root.is_dir():
-        return []
-
     skills: list[dict[str, Any]] = []
-    for child in sorted(root.iterdir()):
-        if (
-            not child.is_dir()
-            or child.name.startswith(".")
-            or child.name == "__pycache__"
-            or not (child / "metadata.json").is_file()
-        ):
-            continue
+    for child in iter_skill_dirs(skills_dir(request)):
         summary = _skill_summary(child)
         if summary is not None:
             skills.append(summary)
@@ -82,7 +69,7 @@ async def list_skills(request: Request) -> list[dict[str, Any]]:
 @router.get("/{skill_name}")
 async def get_skill(request: Request, skill_name: str) -> dict[str, Any]:
     """Return the full metadata.json for a skill."""
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     if not skill_path.is_dir():
         raise HTTPException(404, f"Skill directory not found: {skill_name}")
 
@@ -117,7 +104,7 @@ async def update_skill(
     Uses the training client's locked metadata pattern for safe
     concurrent access.
     """
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     if not skill_path.is_dir():
         raise HTTPException(404, f"Skill directory not found: {skill_name}")
 

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skills.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skills.py
@@ -8,12 +8,10 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
-
 from training_client.src.skill_manager import (
     _locked_metadata,
     _read_meta,
     _write_meta,
-    read_skill_id,
 )
 
 logger = logging.getLogger("training_manager.api.skills")
@@ -67,7 +65,12 @@ async def list_skills(request: Request) -> list[dict[str, Any]]:
 
     skills: list[dict[str, Any]] = []
     for child in sorted(root.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
+        if (
+            not child.is_dir()
+            or child.name.startswith(".")
+            or child.name == "__pycache__"
+            or not (child / "metadata.json").is_file()
+        ):
             continue
         summary = _skill_summary(child)
         if summary is not None:

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/training.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/training.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 import threading
-from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -24,6 +23,8 @@ from training_client.src.skill_manager import (
     read_skill_id,
 )
 from training_client.src.types import ClientConfig, ProgressUpdate, RunInfo
+
+from training_manager.api.skill_paths import iter_skill_dirs, skills_dir
 
 logger = logging.getLogger("training_manager.api.training")
 
@@ -65,10 +66,6 @@ INFRASTRUCTURE_DEFAULTS: dict[str, Any] = {
     "hours": 5,
     "budget": 200,
 }
-
-
-def _skills_dir(request: Request) -> Path:
-    return Path(request.app.state.skills_dir)
 
 
 def _make_manager() -> SkillManager:
@@ -117,22 +114,10 @@ async def list_all_runs(request: Request) -> list[dict[str, Any]]:
     Uses SkillManager.list_runs() for each skill that has a
     training_skill_id.
     """
-    root = _skills_dir(request)
-    if not root.is_dir():
-        return []
-
     manager = _make_manager()
     all_runs: list[dict[str, Any]] = []
 
-    for child in sorted(root.iterdir()):
-        if (
-            not child.is_dir()
-            or child.name.startswith(".")
-            or child.name == "__pycache__"
-            or not (child / "metadata.json").is_file()
-        ):
-            continue
-
+    for child in iter_skill_dirs(skills_dir(request)):
         skill_id = read_skill_id(child)
         if not skill_id:
             continue
@@ -157,7 +142,7 @@ async def list_all_runs(request: Request) -> list[dict[str, Any]]:
 @router.get("/runs/{skill_name}/{run_id}")
 async def get_run(request: Request, skill_name: str, run_id: int) -> dict[str, Any]:
     """Get details for a specific training run via SkillManager.run_status()."""
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     skill_id = read_skill_id(skill_path)
     if not skill_id:
         raise HTTPException(404, f"No training_skill_id for {skill_name}")
@@ -180,7 +165,7 @@ async def watch_run(
     request: Request, skill_name: str, run_id: int
 ) -> StreamingResponse:
     """SSE endpoint that polls run status using SkillManager.run_status()."""
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     skill_id = read_skill_id(skill_path)
     if not skill_id:
         raise HTTPException(404, f"No training_skill_id for {skill_name}")
@@ -230,7 +215,7 @@ async def create_run(
     Builds the training_params dict in the same format as the training
     CLI's `run` command, including source_dir for result download.
     """
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     skill_id = read_skill_id(skill_path)
     if not skill_id:
         raise HTTPException(404, f"No training_skill_id for {skill_name}")
@@ -330,7 +315,7 @@ async def download_run(
     Uses SkillManager.download() which writes into the run's
     ``source_dir/{run_id}/`` and marks the run ``downloaded`` on success.
     """
-    skill_path = _skills_dir(request) / skill_name
+    skill_path = skills_dir(request) / skill_name
     skill_id = read_skill_id(skill_path)
     if not skill_id:
         raise HTTPException(404, f"No training_skill_id for {skill_name}")

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/training.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/training.py
@@ -11,14 +11,12 @@ import json
 import logging
 import os
 import threading
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from starlette.responses import StreamingResponse
-
 from training_client.src.skill_manager import (
     SkillManager,
     _locked_metadata,
@@ -127,7 +125,12 @@ async def list_all_runs(request: Request) -> list[dict[str, Any]]:
     all_runs: list[dict[str, Any]] = []
 
     for child in sorted(root.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
+        if (
+            not child.is_dir()
+            or child.name.startswith(".")
+            or child.name == "__pycache__"
+            or not (child / "metadata.json").is_file()
+        ):
             continue
 
         skill_id = read_skill_id(child)
@@ -167,7 +170,7 @@ async def get_run(request: Request, skill_name: str, run_id: int) -> dict[str, A
     try:
         r = manager.run_status(skill_id, run_id)
     except Exception as e:
-        raise HTTPException(502, f"Failed to get run status: {e}")
+        raise HTTPException(502, f"Failed to get run status: {e}") from e
 
     return _run_to_dict(r, skill_name, skill_display_name)
 
@@ -257,7 +260,7 @@ async def create_run(
     try:
         result = manager.client.create_run(skill_id, training_params=params)
     except Exception as e:
-        raise HTTPException(502, f"Failed to create run: {e}")
+        raise HTTPException(502, f"Failed to create run: {e}") from e
 
     logger.info(
         "Created run %s/%s for skill %s", skill_id, result.get("run_id"), skill_name


### PR DESCRIPTION
## Summary
- skip __pycache__ and non-skill directories when Training Manager lists skills, datasets, and runs
- require an existing metadata.json before list endpoints call the locked metadata helper
- clean up Ruff issues in the touched Training Manager files

## Verification
- ruff check ros2_ws/src/cloud/clients/training-manager/training_manager/api/skills.py ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py ros2_ws/src/cloud/clients/training-manager/training_manager/api/training.py
- temp skills-dir repro: list_skills/list_datasets/list_all_runs return the real skill and do not create __pycache__/metadata.json

Fixes INN-489