### PR TITLE
Remove startup directive behavior

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py
@@ -55,7 +55,6 @@ from brain_messages.srv import GetChatHistory
 from brain_messages.action import ExecuteSkill
 from brain_messages.srv import GetAvailableDirectives
 from brain_messages.srv import ResetBrain
-from brain_messages.srv import SetDirectiveOnStartup
 from brain_messages.msg import AvailableSkills
 from brain_messages.srv import ReloadSkillsAgents
 from std_srvs.srv import SetBool, Trigger
@@ -328,12 +327,6 @@ class BrainClientNode(Node):
         self.get_logger().info("testing update")
         self.get_logger().info(f"Log everything mode: {self.log_everything}")
 
-        # Directive on startup persistence file
-        maurice_root = os.environ.get(
-            "INNATE_OS_ROOT", os.path.join(os.path.expanduser("~"), "innate-os")
-        )
-        self.directive_file = os.path.join(maurice_root, ".directive_on_startup")
-
         # Initialize TF2 buffer and listener
         self.tf_buffer = Buffer()
         self.tf_listener = TransformListener(self.tf_buffer, self)
@@ -430,13 +423,6 @@ class BrainClientNode(Node):
         # --- New: Service for activating/deactivating the brain ---
         self.set_brain_active_srv = self.create_service(
             SetBool, "/brain/set_brain_active", self.handle_set_brain_active
-        )
-
-        # --- Service for setting directive on startup ---
-        self.set_directive_on_startup_srv = self.create_service(
-            SetDirectiveOnStartup,
-            "/brain/set_directive_on_startup",
-            self.handle_set_directive_on_startup,
         )
 
         # --- Helper node for making synchronous service calls from callbacks ---
@@ -559,24 +545,6 @@ class BrainClientNode(Node):
         self.directives, self.current_directive = initialize_agents(
             self.get_logger(), self.primitives_dict
         )
-
-        # Load startup directive from file
-        startup_directive = self.load_startup_directive()
-        if startup_directive and startup_directive in self.directives:
-            self.current_directive = self.directives[startup_directive]
-            self.get_logger().info(f"Applied startup directive: {startup_directive}")
-            # Auto-activate brain if a startup directive is configured
-            if not self.is_brain_active:
-                self.is_brain_active = True
-                self._start_brain_subscriptions()
-                self.get_logger().info(
-                    "\033[1;92m[BrainClient] Auto-activating brain because startup directive is configured\033[0m"
-                )
-        elif startup_directive:
-            self.get_logger().warn(
-                f"Startup directive '{startup_directive}' not found in available directives. "
-                f"Available: {list(self.directives.keys())}. Using default."
-            )
 
         # Activate input devices required by the current directive
         if self.current_directive:
@@ -2426,10 +2394,6 @@ class BrainClientNode(Node):
         response.directives = [json.dumps(directive_details)]
         response.current_directive = self.current_directive.id
 
-        # Get startup directive from file
-        startup_directive = self.load_startup_directive()
-        response.startup_directive = startup_directive if startup_directive else ""
-
         return response
 
     def _unregister_primitives(self):
@@ -2850,8 +2814,6 @@ class BrainClientNode(Node):
         self.is_brain_active = True
         self._start_brain_subscriptions()
 
-        # NOTE: We do NOT apply directive_on_startup here - that's only for initial startup
-        # On reactivation, we keep whatever directive was active before
         self.get_logger().info(
             f"\033[1;92m[BrainClient] Continuing with current directive: {self.current_directive.id}\033[0m"
         )
@@ -2913,120 +2875,6 @@ class BrainClientNode(Node):
                 response.success = True
                 response.message = "Brain deactivated."
         return response
-
-    def handle_set_directive_on_startup(self, request, response):
-        """
-        Service handler for setting the directive on startup.
-        Accepts directive name or empty string to clear.
-        Note: This only affects the NEXT startup, not reactivation.
-        """
-        directive_name = request.directive_name.strip()
-
-        if not directive_name:  # Empty string means clear the saved directive
-            # Remove the directive file
-            try:
-                if os.path.exists(self.directive_file):
-                    os.remove(self.directive_file)
-                self.get_logger().info(
-                    "\033[1;92m[BrainClient] Startup directive cleared. "
-                    "Will use default from initialize_agents() on next startup.\033[0m"
-                )
-            except Exception as e:
-                self.get_logger().error(f"Error clearing directive file: {e}")
-
-            # Publish confirmation
-            chat_entry = {
-                "sender": "system",
-                "text": "Startup directive cleared. Default will be used on next startup.",
-                "timestamp": time.time(),
-            }
-            self.chat_history.append(chat_entry)
-            out_msg = String(data=json.dumps(chat_entry))
-            self.chat_out_pub.publish(out_msg)
-
-            response.success = True
-            response.message = (
-                "Startup directive cleared. Will use default on next startup."
-            )
-
-        elif directive_name in self.directives:
-            # Save directive to file
-            self.save_startup_directive(directive_name)
-
-            # Also immediately switch to it if brain is active
-            self.current_directive = self.directives[directive_name]
-            self.get_logger().info(
-                f"\033[1;92m[BrainClient] Startup directive set to: {directive_name}\033[0m"
-            )
-
-            # Re-register primitives and directive with the server to update immediately
-            if self.is_brain_active and self.primitives_registered:
-                self.register_primitives_and_directive()
-
-            # Activate input devices required by this directive
-            self.activate_directive_inputs()
-
-            # Publish confirmation
-            chat_entry = {
-                "sender": "system",
-                "text": f"Startup directive set to: {directive_name}. Active now and will be used on next startup.",
-                "timestamp": time.time(),
-            }
-            self.chat_history.append(chat_entry)
-            out_msg = String(data=json.dumps(chat_entry))
-            self.chat_out_pub.publish(out_msg)
-
-            response.success = True
-            response.message = f"Startup directive set to: {directive_name}. Active now and will be used on next startup."
-
-        else:
-            self.get_logger().error(
-                f"\033[91m[BrainClient] Unknown directive: {directive_name}\033[0m"
-            )
-            available_directives = list(self.directives.keys())
-            error_msg = {
-                "sender": "system",
-                "text": f"Error: Unknown directive '{directive_name}'. Available directives: {available_directives}",
-                "timestamp": time.time(),
-            }
-            self.chat_history.append(error_msg)
-            out_msg = String(data=json.dumps(error_msg))
-            self.chat_out_pub.publish(out_msg)
-
-            response.success = False
-            response.message = f"Unknown directive '{directive_name}'. Available directives: {available_directives}"
-
-        return response
-
-    def load_startup_directive(self):
-        """Load the startup directive from file, returns None if not configured"""
-        try:
-            if os.path.exists(self.directive_file):
-                with open(self.directive_file, "r") as f:
-                    saved_directive = f.read().strip()
-                    if saved_directive:
-                        self.get_logger().info(
-                            f"Loaded startup directive: {saved_directive}"
-                        )
-                        return saved_directive
-            self.get_logger().info(
-                "No startup directive configured, using default from initialize_agents()"
-            )
-            return None
-        except Exception as e:
-            self.get_logger().error(f"Error loading startup directive: {e}")
-            return None
-
-    def save_startup_directive(self, directive_name):
-        """Save the directive to load on startup"""
-        try:
-            # Ensure directory exists
-            os.makedirs(os.path.dirname(self.directive_file), exist_ok=True)
-            with open(self.directive_file, "w") as f:
-                f.write(directive_name)
-            self.get_logger().debug(f"Saved startup directive: {directive_name}")
-        except Exception as e:
-            self.get_logger().error(f"Error saving startup directive: {e}")
 
     def _speak(self, text: str):
         """Speak text if TTS is available."""

--- a/ros2_ws/src/brain/brain_messages/CMakeLists.txt
+++ b/ros2_ws/src/brain/brain_messages/CMakeLists.txt
@@ -25,7 +25,6 @@ set(srv_files
   "srv/SaveMap.srv"
   "srv/DeleteMap.srv"
   "srv/GetDatasetInfo.srv"
-  "srv/SetDirectiveOnStartup.srv"
   "srv/LoadEpisode.srv"
   "srv/ReloadSkillsAgents.srv"
   "srv/CreatePhysicalSkill.srv"

--- a/ros2_ws/src/brain/brain_messages/srv/GetAvailableDirectives.srv
+++ b/ros2_ws/src/brain/brain_messages/srv/GetAvailableDirectives.srv
@@ -3,4 +3,3 @@
 # Response
 string[] directives      # List of available directive names
 string current_directive # Currently active directive name
-string startup_directive # Directive that will be loaded on next startup (empty if none saved)

--- a/ros2_ws/src/brain/brain_messages/srv/SetDirectiveOnStartup.srv
+++ b/ros2_ws/src/brain/brain_messages/srv/SetDirectiveOnStartup.srv
@@ -1,9 +1,0 @@
-# brain_messages/srv/SetDirectiveOnStartup.srv
-
-# Request
-string directive_name  # Directive name to set for startup, or empty string to clear
----
-# Response
-bool success
-string message
-


### PR DESCRIPTION
## Summary
- remove the saved startup directive service and persistence path
- stop applying or auto-activating a directive on robot boot
- remove startup_directive from GetAvailableDirectives

## Verification
- rebuilt brain_messages and brain_client on mars-the-44th.local
- rebooted mars-the-44th.local successfully
- verified /brain/get_available_directives responds without startup_directive
- verified SetDirectiveOnStartup is no longer generated

Linear: INN-147