### PR TITLE
Optimize simulator startup path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep the local Docker build context tiny and stable. Runtime source is
+# bind-mounted by docker-compose.dev.yml; the image only needs dependency
+# manifests during build.
+**
+
+!Dockerfile
+!ros2_ws/
+!ros2_ws/apt-dependencies.common.txt
+!ros2_ws/apt-dependencies.hardware.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 !ros2_ws/
 !ros2_ws/apt-dependencies.common.txt
 !ros2_ws/apt-dependencies.hardware.txt
+!ros2_ws/apt-dependencies.simulation.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,119 +1,132 @@
+# syntax=docker/dockerfile:1.7
 #
-# Dockerfile for Maurice Robot (ROS 2 Humble) with zsh + oh-my-zsh
+# Dockerfile for Maurice Robot (ROS 2 Humble) with zsh + oh-my-zsh.
 #
+# Keep this image focused on OS/runtime dependencies. The ROS workspace source
+# is bind-mounted by docker-compose.dev.yml and built into persistent named
+# volumes at runtime, so source edits do not require rebuilding the image.
 
-# Start with a minimal ROS 2 Humble base
-FROM ros:humble-ros-base
+ARG ROS_BASE_IMAGE=ros:humble-ros-base
+FROM ${ROS_BASE_IMAGE} AS os-deps
 
-# Build argument to choose between simulation and hardware mode
+# Build argument to choose between simulation and hardware dependency sets.
 # Usage: docker build --build-arg MODE=simulation .
 #        docker build --build-arg MODE=hardware .
 ARG MODE=simulation
 
-# 1. Install base packages needed before apt-dependencies.txt
-RUN apt-get update && apt-get install -y \
-    curl \
-    iputils-ping \
-    gnupg \
-    lsb-release \
-    htop \
-    btop
+ENV DEBIAN_FRONTEND=noninteractive \
+    UV_SYSTEM_PYTHON=1 \
+    UV_LINK_MODE=copy \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# 2. Add Innate packages repository (for ros-humble-innate-rws, etc.)
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# 1. Install base packages needed before apt-dependencies.txt.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        iputils-ping \
+        gnupg \
+        lsb-release \
+        ca-certificates \
+        htop \
+        btop
+
+# 2. Add Innate packages repository (for ros-humble-innate-rws, etc.).
 RUN curl -fsSL https://innate-inc.github.io/innate-packages/pubkey.gpg | \
         gpg --dearmor -o /usr/share/keyrings/innate-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/innate-archive-keyring.gpg] https://innate-inc.github.io/innate-packages/ $(lsb_release -cs) main" | \
         tee /etc/apt/sources.list.d/innate.list > /dev/null
 
-# 3. Copy and install common apt dependencies
+# 3. Copy and install common apt dependencies.
 COPY ros2_ws/apt-dependencies.common.txt /tmp/apt-dependencies.common.txt
-RUN apt-get update && \
-    grep -v '^#' /tmp/apt-dependencies.common.txt | grep -v '^$' | xargs apt-get install -y && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    grep -v '^#' /tmp/apt-dependencies.common.txt | grep -v '^$' | xargs apt-get install -y --no-install-recommends && \
     rm /tmp/apt-dependencies.common.txt
 
-# 4. Install hardware-specific dependencies if in hardware mode
+# 4. Install hardware-specific dependencies only in hardware mode.
 COPY ros2_ws/apt-dependencies.hardware.txt /tmp/apt-dependencies.hardware.txt
-RUN if [ "$MODE" = "hardware" ]; then \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    if [ "$MODE" = "hardware" ]; then \
         apt-get update && \
-        grep -v '^#' /tmp/apt-dependencies.hardware.txt | grep -v '^$' | xargs apt-get install -y; \
+        grep -v '^#' /tmp/apt-dependencies.hardware.txt | grep -v '^$' | xargs apt-get install -y --no-install-recommends; \
     fi && \
     rm /tmp/apt-dependencies.hardware.txt
 
-# 5. Install pip packages
-RUN pip install --upgrade \
-    websockets \
-    pydantic \
-    'numpy<2' \
-    'opencv-python<4.10' \
-    h5py \
-    cartesia \
-    torch \
-    torchvision \
-    einops \
-    python-dotenv \
-    websocket-client
+# 5. Install uv for fast, cached Python package installation.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    ln -sf /root/.local/bin/uv /usr/local/bin/uv
 
-# 5. Install oh-my-zsh (for root, since containers typically run as root unless changed)
-#    The official install script tries to prompt, so we run it in a way that doesn't hang.
+# 6. Install Python runtime packages with uv.
+# Simulation images use CPU PyTorch wheels to avoid pulling multi-GB CUDA/NVIDIA
+# packages into local Apple Silicon Docker builds. Hardware images keep using
+# the normal torch packages so Jetson-specific indexes/tooling can provide CUDA.
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    uv pip install --system \
+        websockets \
+        pydantic \
+        'numpy<2' \
+        'opencv-python<4.10' \
+        h5py \
+        cartesia \
+        einops \
+        python-dotenv \
+        websocket-client && \
+    if [ "$MODE" = "simulation" ]; then \
+        uv pip install --system \
+            --index-url https://download.pytorch.org/whl/cpu \
+            --extra-index-url https://pypi.org/simple \
+            --index-strategy unsafe-best-match \
+            'torch==2.11.0+cpu' \
+            'torchvision==0.26.0+cpu'; \
+    else \
+        uv pip install --system \
+            --extra-index-url https://pypi.jetson-ai-lab.io/jp6/cu126 \
+            --index-strategy unsafe-best-match \
+            torch \
+            torchvision; \
+    fi
+
+# 7. Install oh-my-zsh (for root, since containers typically run as root unless changed).
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \
     || true
 
-# 6. Make zsh the default shell for root inside the container
-SHELL ["/usr/bin/zsh", "-c"]
-RUN chsh -s /usr/bin/zsh root
+# 8. Make zsh the default shell for root inside the container and use a compact theme.
+RUN chsh -s /usr/bin/zsh root && \
+    sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="agnoster"/' /root/.zshrc
 
-# 7. (Optional) Change oh-my-zsh theme for root
-#    RobbyRussell is default; here we switch to `agnoster`, or pick another if you like
-RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="agnoster"/' /root/.zshrc
-
-# 7b. Pre-approve GitHub SSH host key to avoid prompts
+# 9. Pre-approve GitHub SSH host key to avoid prompts.
 RUN mkdir -p /root/.ssh && \
     ssh-keyscan -t ed25519 github.com >> /root/.ssh/known_hosts 2>/dev/null
 
-# 8. Copy your entire innate-os directory (including dds, ros2_ws, .git for version info)
-COPY ros2_ws /root/innate-os/ros2_ws
-COPY dds /root/innate-os/dds
-COPY scripts /root/innate-os/scripts
-COPY config /root/innate-os/config
+FROM os-deps AS dev-runtime
 
-# For version tracking, git needs to be present
-COPY .git /root/innate-os/.git
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# 9. Build your ROS 2 workspace.
-#    We have to source the system setup.zsh for colcon to find ROS packages.
-WORKDIR /root/innate-os/ros2_ws
-RUN source /opt/ros/humble/setup.zsh && colcon build
+# docker-compose.dev.yml bind-mounts the real source tree here. Creating the
+# mount points keeps the image usable even before the bind mounts are attached.
+RUN mkdir -p \
+        /root/innate-os/ros2_ws \
+        /root/innate-os/dds \
+        /root/innate-os/scripts \
+        /root/innate-os/config \
+        /root/innate-os/agents \
+        /root/innate-os/skills
 
-#
-# 10. Patch the root .zshrc to set up your environment the same way
-#    "setup_dds.zsh" does. This means:
-#      - Source ROS 2
-#      - Source your workspace
-#      - Export environment variables for RMW + discovery
-#      - Dynamically generate the super_client_configuration.xml
-#
-#    We inject shell code at the end of /root/.zshrc so that
-#    whenever you start a new zsh inside the container (interactive or not),
-#    these environment vars are set and the file is created.
-#
-#    If you prefer, you can copy a local .zshrc instead.
-#
-RUN echo '\
-# ----- Innate OS custom environment -----\n\
-# Source the ROS 2 setup\n\
-source /opt/ros/humble/setup.zsh\n\
-\n\
-# Source the workspace setup\n\
-source /root/innate-os/ros2_ws/install/setup.zsh\n\
-\n\
-# Source the DDS setup\n\
-source /root/innate-os/dds/setup_dds.zsh\n\
-\n\
-# Set INNATE_OS_ROOT environment variable\n\
-export INNATE_OS_ROOT=/root/innate-os\n\
-' >> /root/.zshrc
+# Patch root .zshrc to source ROS, the workspace, and DDS only when present.
+RUN cat >> /root/.zshrc <<'EOF'
 
-# 11. When the container starts with no command, we just run zsh (login shell).
-#    You'll drop into an interactive oh-my-zsh environment with everything set up.
+# ----- Innate OS custom environment -----
+[ -f /opt/ros/humble/setup.zsh ] && source /opt/ros/humble/setup.zsh
+[ -f /root/innate-os/ros2_ws/install/setup.zsh ] && source /root/innate-os/ros2_ws/install/setup.zsh
+[ -f /root/innate-os/dds/setup_dds.zsh ] && source /root/innate-os/dds/setup_dds.zsh
+export INNATE_OS_ROOT=/root/innate-os
+export CCACHE_DIR=/root/.cache/ccache
+EOF
+
 WORKDIR /root/innate-os
 CMD ["zsh", "-l"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     uv pip install --system \
         websockets \
         pydantic \
+        'packaging>=24' \
+        'setuptools==59.6.0' \
         'numpy<2' \
         'opencv-python<4.10' \
         h5py \
@@ -89,7 +91,10 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
             --index-strategy unsafe-best-match \
             torch \
             torchvision; \
-    fi
+    fi && \
+    uv pip install --system \
+        'packaging>=24' \
+        'setuptools==59.6.0'
 
 # 7. Install oh-my-zsh (for root, since containers typically run as root unless changed).
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,19 @@ RUN curl -fsSL https://innate-inc.github.io/innate-packages/pubkey.gpg | \
     echo "deb [signed-by=/usr/share/keyrings/innate-archive-keyring.gpg] https://innate-inc.github.io/innate-packages/ $(lsb_release -cs) main" | \
         tee /etc/apt/sources.list.d/innate.list > /dev/null
 
-# 3. Copy and install common apt dependencies.
+# 3. Copy and install mode-specific apt dependencies.
 COPY ros2_ws/apt-dependencies.common.txt /tmp/apt-dependencies.common.txt
+COPY ros2_ws/apt-dependencies.simulation.txt /tmp/apt-dependencies.simulation.txt
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update && \
-    grep -v '^#' /tmp/apt-dependencies.common.txt | grep -v '^$' | xargs apt-get install -y --no-install-recommends && \
-    rm /tmp/apt-dependencies.common.txt
+    if [ "$MODE" = "simulation" ]; then \
+        deps_file=/tmp/apt-dependencies.simulation.txt; \
+    else \
+        deps_file=/tmp/apt-dependencies.common.txt; \
+    fi && \
+    grep -v '^#' "$deps_file" | grep -v '^$' | xargs apt-get install -y --no-install-recommends && \
+    rm /tmp/apt-dependencies.common.txt /tmp/apt-dependencies.simulation.txt
 
 # 4. Install hardware-specific dependencies only in hardware mode.
 COPY ros2_ws/apt-dependencies.hardware.txt /tmp/apt-dependencies.hardware.txt
@@ -72,7 +78,6 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
         'packaging>=24' \
         'setuptools==59.6.0' \
         'numpy<2' \
-        'opencv-python<4.10' \
         h5py \
         cartesia \
         einops \

--- a/Dockerfile.ros-prebuilt
+++ b/Dockerfile.ros-prebuilt
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7
+#
+# Optional ROS-prebuilt image.
+#
+# Build this on top of the dependency-only dev image to bake a matching
+# ros2_ws/install into the image. The launcher can seed its persistent install
+# volume from /opt/innate-os-prebuilt when the mounted local source matches.
+
+ARG BASE_IMAGE=innate-os-sim-clean-innate:latest
+FROM ${BASE_IMAGE} AS ros-prebuilt
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV INNATE_OS_PREBUILT_ROS_ROOT=/opt/innate-os-prebuilt/ros2_ws
+
+RUN mkdir -p "${INNATE_OS_PREBUILT_ROS_ROOT}"
+
+COPY ros2_ws/src "${INNATE_OS_PREBUILT_ROS_ROOT}/src"
+
+WORKDIR ${INNATE_OS_PREBUILT_ROS_ROOT}
+
+RUN --mount=type=cache,target=/root/.cache/ccache,sharing=locked \
+    source /opt/ros/humble/setup.bash && \
+    export CCACHE_DIR=/root/.cache/ccache && \
+    colcon build --symlink-install \
+        --cmake-args \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache && \
+    find src -type f \
+        ! -path '*/__pycache__/*' \
+        ! -name '*.pyc' \
+        -print0 | sort -z | xargs -0 -r sha256sum | sha256sum | awk '{print $1}' > source.sha256
+
+WORKDIR /root/innate-os
+CMD ["zsh", "-l"]

--- a/Dockerfile.ros-prebuilt.dockerignore
+++ b/Dockerfile.ros-prebuilt.dockerignore
@@ -1,0 +1,6 @@
+# Keep the ROS-prebuilt image context scoped to workspace source only.
+**
+
+!ros2_ws/
+!ros2_ws/src/
+!ros2_ws/src/**

--- a/dev/launcher/stack.py
+++ b/dev/launcher/stack.py
@@ -57,6 +57,10 @@ OS_BUILD_LOG_PATH = LOG_DIR / "os-build.log"
 OS_SESSION_LOG_PATH = LOG_DIR / "os-session.log"
 DOWN_LOG_PATH = LOG_DIR / "down.log"
 SIM_PID_PATH = STATE_DIR / "simulator.pid"
+SIM_STARTUP_CHECK_DELAY_SECONDS = 0.25
+SIM_HTTP_POLL_SECONDS = 0.25
+SIM_HTTP_REQUEST_TIMEOUT_SECONDS = 0.5
+OS_SESSION_READY_POLL_SECONDS = 0.25
 GENERATED_OS_ENV_PATH = STATE_DIR / "innate-os.env"
 GENERATED_CLOUD_ENV_PATH = STATE_DIR / "cloud-agent.env"
 HOSTED_MODE = "hosted"
@@ -932,6 +936,10 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
         "prebuilt_root=${INNATE_OS_PREBUILT_ROS_ROOT:-/opt/innate-os-prebuilt/ros2_ws}; "
         "[ -f \"$prebuilt_root/install/setup.zsh\" ] || return 1; "
         "[ -f \"$prebuilt_root/source.sha256\" ] || return 1; "
+        "if find \"$prebuilt_root/install\" -xtype l -print -quit | grep -q .; then "
+        "echo 'Prebuilt ROS workspace install has dangling symlinks; running colcon build.'; "
+        "return 1; "
+        "fi; "
         "prebuilt_hash=$(cat \"$prebuilt_root/source.sha256\"); "
         "current_hash=$(current_source_hash); "
         "if [ \"$current_hash\" != \"$prebuilt_hash\" ]; then "
@@ -963,7 +971,12 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
             "if seed_prebuilt_install; then "
             ":; "
             "elif [ ! -f install/setup.zsh ] || "
+            "find install -xtype l -print -quit | grep -q . || "
             "find src -type f -newer install/setup.zsh -print -quit | grep -q .; then "
+            "if [ -d install ] && find install -xtype l -print -quit | grep -q .; then "
+            "echo 'Removing unusable ROS install before rebuild.'; "
+            "rm -rf build install log; "
+            "fi; "
             f"{colcon_build_cmd}; "
             "else "
             "echo 'ROS workspace install is current; skipping rebuild.'; "
@@ -1214,15 +1227,15 @@ def start_simulator(config: dict[str, object], sim_python: Path) -> None:
             start_new_session=True,
         )
 
-    time.sleep(2)
+    SIM_PID_PATH.write_text(f"{proc.pid}\n")
+    time.sleep(SIM_STARTUP_CHECK_DELAY_SECONDS)
     if proc.poll() is not None:
+        SIM_PID_PATH.unlink(missing_ok=True)
         tail = tail_file(SIM_LOG_PATH)
         raise StackError(
             "Simulator backend exited immediately.\n"
             f"Recent log output:\n{tail}"
         )
-
-    SIM_PID_PATH.write_text(f"{proc.pid}\n")
 
 
 def tail_file(path: Path, limit: int = 40) -> str:
@@ -1311,18 +1324,38 @@ def os_process_running(config: dict[str, object], pattern: str) -> bool:
     )
 
 
+def os_session_ready(config: dict[str, object]) -> bool:
+    if not container_running("innate-dev"):
+        return False
+    os_repo: Path = config["os_repo"]  # type: ignore[assignment]
+    compose_env = docker_compose_env({"INNATE_OS_ENV_FILE": str(GENERATED_OS_ENV_PATH)})
+    ready_cmd = (
+        f"tmux has-session -t {shlex.quote(TMUX_SESSION_NAME)} && "
+        "pgrep -f rws_server >/dev/null && "
+        "pgrep -f brain_client_node.py >/dev/null"
+    )
+    return command_succeeds(
+        docker_compose_cmd(
+            "exec",
+            "-T",
+            OS_CONTAINER_SERVICE,
+            "zsh",
+            "-lc",
+            ready_cmd,
+        ),
+        cwd=os_repo,
+        env=compose_env,
+    )
+
+
 def wait_for_os_session_ready(
     config: dict[str, object], *, timeout_seconds: float = 20.0
 ) -> bool:
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
-        if (
-            os_tmux_session_running(config)
-            and os_process_running(config, "rws_server")
-            and os_process_running(config, "brain_client_node.py")
-        ):
+        if os_session_ready(config):
             return True
-        time.sleep(1.0)
+        time.sleep(OS_SESSION_READY_POLL_SECONDS)
     return False
 
 
@@ -2143,17 +2176,17 @@ def wait_for_simulator_http(port: str, timeout_seconds: float = 90.0) -> None:
                 f"Recent log output:\n{tail}{hint}"
             )
         try:
-            with urlopen(url, timeout=2) as response:
+            with urlopen(url, timeout=SIM_HTTP_REQUEST_TIMEOUT_SECONDS) as response:
                 if response.status != 200:
-                    time.sleep(2)
+                    time.sleep(SIM_HTTP_POLL_SECONDS)
                     continue
                 payload = json.loads(response.read().decode("utf-8"))
                 if payload.get("ready"):
                     return
         except URLError:
-            time.sleep(2)
+            time.sleep(SIM_HTTP_POLL_SECONDS)
         except (TimeoutError, json.JSONDecodeError):
-            time.sleep(2)
+            time.sleep(SIM_HTTP_POLL_SECONDS)
     tail = tail_file(SIM_LOG_PATH, limit=80)
     raise StackError(
         "Timed out waiting for the simulator HTTP endpoint.\n"

--- a/dev/launcher/stack.py
+++ b/dev/launcher/stack.py
@@ -693,6 +693,8 @@ def get_config() -> dict[str, object]:
     elif (WORKSPACE_ROOT / "innate-cloud-agent").exists():
         cloud_repo = (WORKSPACE_ROOT / "innate-cloud-agent").resolve()
 
+    os_always_build = get_nested_bool(sim_config, "os", "always_build")
+
     return {
         "raw_env": merged_env,
         "user_env": user_env,
@@ -711,7 +713,7 @@ def get_config() -> dict[str, object]:
         else False,
         "sim_log_mode": "quiet",
         "sim_args": "--log-everything",
-        "os_always_build": True,
+        "os_always_build": os_always_build if os_always_build is not None else False,
         "skip_local_cloud_auth": True,
     }
 
@@ -875,14 +877,20 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
             ),
         )
 
+    colcon_build_cmd = (
+        "colcon build --symlink-install "
+        "--cmake-args "
+        "-DCMAKE_C_COMPILER_LAUNCHER=ccache "
+        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+    )
     build_cmd = "source /opt/ros/humble/setup.zsh && cd ~/innate-os/ros2_ws && "
     if config["os_always_build"]:
-        build_cmd += "colcon build"
+        build_cmd += colcon_build_cmd
     else:
         build_cmd += (
             "if [ ! -f install/setup.zsh ] || "
             "find src -type f -newer install/setup.zsh -print -quit | grep -q .; then "
-            "colcon build; "
+            f"{colcon_build_cmd}; "
             "else "
             "echo 'ROS workspace install is current; skipping rebuild.'; "
             "fi"

--- a/dev/launcher/stack.py
+++ b/dev/launcher/stack.py
@@ -694,6 +694,7 @@ def get_config() -> dict[str, object]:
         cloud_repo = (WORKSPACE_ROOT / "innate-cloud-agent").resolve()
 
     os_always_build = get_nested_bool(sim_config, "os", "always_build")
+    os_pull_image = get_nested_bool(sim_config, "os", "pull_image")
 
     return {
         "raw_env": merged_env,
@@ -713,6 +714,9 @@ def get_config() -> dict[str, object]:
         else False,
         "sim_log_mode": "quiet",
         "sim_args": "--log-everything",
+        "os_image": get_nested_str(sim_config, "os", "image")
+        or os.environ.get("INNATE_OS_IMAGE", ""),
+        "os_pull_image": os_pull_image if os_pull_image is not None else True,
         "os_always_build": os_always_build if os_always_build is not None else False,
         "skip_local_cloud_auth": True,
     }
@@ -857,16 +861,50 @@ def docker_compose_env(base_env: dict[str, str] | None = None) -> dict[str, str]
     return env
 
 
+def ensure_os_image_available(
+    image: str, *, cwd: Path, env: dict[str, str], pull_if_missing: bool
+) -> None:
+    if command_succeeds(["docker", "image", "inspect", image], cwd=cwd, env=env):
+        return
+    if not pull_if_missing:
+        raise StackError(
+            f"Innate OS image is not available locally: {image}\n"
+            "Pull or build it, or unset sim/config.toml os.image to use the local Docker build."
+        )
+    log(f"Pulling Innate OS image {image}...")
+    run_logged_with_heartbeat(
+        ["docker", "pull", image],
+        cwd=cwd,
+        env=env,
+        log_path=COMPOSE_LOG_PATH,
+        failure_message=f"Failed to pull Innate OS image: {image}",
+        progress_message="Docker is still pulling the Innate OS image.",
+    )
+
+
 def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
     os_repo: Path = config["os_repo"]  # type: ignore[assignment]
-    compose_env = docker_compose_env({"INNATE_OS_ENV_FILE": str(os_env_file)})
+    os_image = str(config["os_image"]).strip()
+    compose_values = {"INNATE_OS_ENV_FILE": str(os_env_file)}
+    if os_image:
+        compose_values["INNATE_OS_IMAGE"] = os_image
+    compose_env = docker_compose_env(compose_values)
 
     if container_running("innate-dev"):
         log("Innate OS dev container already running.")
     else:
+        up_cmd = ["docker", "compose", "-f", "docker-compose.dev.yml", "up", "-d"]
+        if os_image:
+            ensure_os_image_available(
+                os_image,
+                cwd=os_repo,
+                env=compose_env,
+                pull_if_missing=bool(config["os_pull_image"]),
+            )
+            up_cmd.append("--no-build")
         log("Starting Innate OS dev container...")
         run_logged_with_heartbeat(
-            ["docker", "compose", "-f", "docker-compose.dev.yml", "up", "-d"],
+            up_cmd,
             cwd=os_repo,
             env=compose_env,
             log_path=COMPOSE_LOG_PATH,
@@ -883,12 +921,48 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
         "-DCMAKE_C_COMPILER_LAUNCHER=ccache "
         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
     )
-    build_cmd = "source /opt/ros/humble/setup.zsh && cd ~/innate-os/ros2_ws && "
+    prebuilt_seed_cmd = (
+        "current_source_hash() { "
+        "find src -type f "
+        "! -path '*/__pycache__/*' "
+        "! -name '*.pyc' "
+        "-print0 | sort -z | xargs -0 -r sha256sum | sha256sum | awk '{print $1}'; "
+        "}; "
+        "seed_prebuilt_install() { "
+        "prebuilt_root=${INNATE_OS_PREBUILT_ROS_ROOT:-/opt/innate-os-prebuilt/ros2_ws}; "
+        "[ -f \"$prebuilt_root/install/setup.zsh\" ] || return 1; "
+        "[ -f \"$prebuilt_root/source.sha256\" ] || return 1; "
+        "prebuilt_hash=$(cat \"$prebuilt_root/source.sha256\"); "
+        "current_hash=$(current_source_hash); "
+        "if [ \"$current_hash\" != \"$prebuilt_hash\" ]; then "
+        "echo 'Local ROS source differs from the prebuilt image; running colcon build.'; "
+        "return 1; "
+        "fi; "
+        "if [ ! -f install/setup.zsh ] || "
+        "[ \"$(cat install/.innate-prebuilt-source.sha256 2>/dev/null)\" != \"$prebuilt_hash\" ]; then "
+        "echo 'Using prebuilt ROS workspace install from image.'; "
+        "mkdir -p install; "
+        "find install -mindepth 1 -maxdepth 1 -exec rm -rf {} +; "
+        "cp -a \"$prebuilt_root/install/.\" install/; "
+        "echo \"$prebuilt_hash\" > install/.innate-prebuilt-source.sha256; "
+        "else "
+        "echo 'Prebuilt ROS workspace install is current.'; "
+        "fi; "
+        "echo 'ROS workspace install is current; skipping rebuild.'; "
+        "return 0; "
+        "}; "
+    )
+    build_cmd = (
+        "source /opt/ros/humble/setup.zsh && cd ~/innate-os/ros2_ws && "
+        f"{prebuilt_seed_cmd}"
+    )
     if config["os_always_build"]:
         build_cmd += colcon_build_cmd
     else:
         build_cmd += (
-            "if [ ! -f install/setup.zsh ] || "
+            "if seed_prebuilt_install; then "
+            ":; "
+            "elif [ ! -f install/setup.zsh ] || "
             "find src -type f -newer install/setup.zsh -print -quit | grep -q .; then "
             f"{colcon_build_cmd}; "
             "else "

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,6 +15,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: dev-runtime
       args:
         MODE: simulation # Change to 'simulation' or 'hardware'
     container_name: innate-dev
@@ -25,12 +26,14 @@ services:
       - DISPLAY=novnc:0.0
       - INNATE_OS_ROOT=/root/innate-os
       - SKIP_UPDATE_CHECK=1 # Skip git update checks in simulation mode
+      - CCACHE_DIR=/root/.cache/ccache
     ports:
       - "9090:9090"
 
     volumes:
       # 1) Mount your local code
       - ./ros2_ws:/root/innate-os/ros2_ws:rw
+      - ./dds:/root/innate-os/dds:ro
       - ./scripts:/root/innate-os/scripts:rw
       - ./config:/root/innate-os/config:ro
       - ./agents:/root/innate-os/agents:rw
@@ -41,6 +44,7 @@ services:
       - ros2_ws_build:/root/innate-os/ros2_ws/build
       - ros2_ws_install:/root/innate-os/ros2_ws/install
       - ros2_ws_log:/root/innate-os/ros2_ws/log
+      - ccache:/root/.cache/ccache
 
       # 3) Mount git credentials from host (read-only for security)
       - ~/.ssh:/root/.ssh:ro
@@ -62,6 +66,7 @@ volumes:
   ros2_ws_build:
   ros2_ws_install:
   ros2_ws_log:
+  ccache:
 
 networks:
   x11:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
       - x11
 
   innate:
+    image: ${INNATE_OS_IMAGE:-innate-os-sim-clean-innate:latest}
     build:
       context: .
       dockerfile: Dockerfile

--- a/ros2_ws/apt-dependencies.simulation.txt
+++ b/ros2_ws/apt-dependencies.simulation.txt
@@ -1,0 +1,106 @@
+# Simulation-focused system dependencies for the Innate OS container.
+#
+# This intentionally avoids hardware/debug/meta packages from
+# apt-dependencies.common.txt so the published simulation image stays smaller.
+# Hardware builds still use apt-dependencies.common.txt plus
+# apt-dependencies.hardware.txt.
+
+# Build/runtime tools used by the local sim launcher
+ccache
+openssh-client
+zsh
+tmux
+jq
+zstd
+pkg-config
+
+# C++ libraries used by workspace packages
+libeigen3-dev
+libfcl-dev
+libhdf5-dev
+libopenmpi-dev
+libopencv-dev
+libturbojpeg0-dev
+libyaml-cpp-dev
+nlohmann-json3-dev
+
+# WebRTC streaming runtime/build dependencies
+gstreamer1.0-tools
+gstreamer1.0-plugins-base
+gstreamer1.0-plugins-good
+gstreamer1.0-plugins-bad
+gstreamer1.0-libav
+gstreamer1.0-nice
+libgstreamer1.0-dev
+libgstreamer-plugins-base1.0-dev
+libgstreamer-plugins-bad1.0-dev
+
+# ROS 2 build/runtime basics
+ros-humble-ament-cmake
+ros-humble-ament-cmake-python
+ros-humble-ament-index-python
+ros-humble-launch-xml
+ros-humble-rclcpp
+ros-humble-rclcpp-components
+ros-humble-rclcpp-lifecycle
+ros-humble-rclpy
+ros-humble-rmw-zenoh-cpp
+
+# ROS 2 messages and transforms used by the sim stack
+ros-humble-action-msgs
+ros-humble-diagnostic-msgs
+ros-humble-geometry-msgs
+ros-humble-lifecycle-msgs
+ros-humble-nav-msgs
+ros-humble-rcl-interfaces
+ros-humble-rosgraph-msgs
+ros-humble-sensor-msgs
+ros-humble-std-msgs
+ros-humble-std-srvs
+ros-humble-stereo-msgs
+ros-humble-tf2
+ros-humble-tf2-geometry-msgs
+ros-humble-tf2-msgs
+ros-humble-tf2-ros
+ros-humble-tf-transformations
+ros-humble-trajectory-msgs
+ros-humble-unique-identifier-msgs
+ros-humble-visualization-msgs
+
+# Default simulation navigation path
+ros-humble-behaviortree-cpp-v3
+ros-humble-dwb-core
+ros-humble-dwb-critics
+ros-humble-dwb-plugins
+ros-humble-nav2-behavior-tree
+ros-humble-nav2-behaviors
+ros-humble-nav2-bt-navigator
+ros-humble-nav2-controller
+ros-humble-nav2-core
+ros-humble-nav2-costmap-2d
+ros-humble-nav2-dwb-controller
+ros-humble-nav2-lifecycle-manager
+ros-humble-nav2-msgs
+ros-humble-nav2-navfn-planner
+ros-humble-nav2-planner
+ros-humble-nav2-simple-commander
+ros-humble-nav2-util
+ros-humble-nav2-voxel-grid
+
+# Camera, image, and bridge packages required by built packages
+ros-humble-camera-info-manager
+ros-humble-compressed-image-transport
+ros-humble-cv-bridge
+ros-humble-image-transport
+ros-humble-message-filters
+
+# Arm, behavior, and support packages used by loaded skills and nodes
+ros-humble-dynamixel-sdk
+ros-humble-innate-rws
+ros-humble-moveit-msgs
+ros-humble-robot-state-publisher
+ros-humble-rosidl-default-generators
+ros-humble-rosidl-default-runtime
+ros-humble-shape-msgs
+ros-humble-topic-tools
+ros-humble-xacro

--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -12,9 +12,18 @@ fi
 SESSION_NAME="${INNATE_SIM_TMUX_SESSION:-innate}"
 # Use braces in tmux targets so zsh does not interpret ":foo" as a parameter modifier.
 TMUX_TARGET_PREFIX="${SESSION_NAME}"
+STARTUP_SETTLE_SECONDS="${INNATE_SIM_TMUX_SETTLE_SECONDS:-0.5}"
+TMUX_CLEANUP_SETTLE_SECONDS="${INNATE_SIM_TMUX_CLEANUP_SETTLE_SECONDS:-0.25}"
+
+settle_after_launch() {
+  if [[ "$STARTUP_SETTLE_SECONDS" != "0" && "$STARTUP_SETTLE_SECONDS" != "0.0" ]]; then
+    sleep "$STARTUP_SETTLE_SECONDS"
+  fi
+}
 
 # First, ensure we have a clean tmux environment
 tmux kill-session -t "$SESSION_NAME" 2>/dev/null
+sleep "$TMUX_CLEANUP_SETTLE_SECONDS"
 
 # Create a new tmux session for the local Innate runtime
 tmux new-session -d -x 240 -y 72 -s "$SESSION_NAME" -n zenoh
@@ -22,13 +31,13 @@ tmux new-session -d -x 240 -y 72 -s "$SESSION_NAME" -n zenoh
 # === Window 0: Zenoh Router ===
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:zenoh" "ros2 run rmw_zenoh_cpp rmw_zenohd" C-m
 echo "Started Zenoh router..."
-sleep 2  # Give Zenoh router time to start up
+settle_after_launch
 
 # === Window 1: Rosbridge + App ===
 tmux new-window -t "$SESSION_NAME" -n rosbridge-app
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:rosbridge-app" "ros2 launch maurice_sim_bringup sim_rosbridge.launch.py" C-m
 echo "Started rosbridge..."
-sleep 2
+settle_after_launch
 # Split and run app
 tmux split-window -t "${TMUX_TARGET_PREFIX}:rosbridge-app" -h
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:rosbridge-app.1" "ros2 launch maurice_control app.sim.launch.py" C-m
@@ -42,7 +51,7 @@ echo "Started webrtc streamer (sim mode with compressed images)..."
 tmux new-window -t "$SESSION_NAME" -n nav-brain
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:nav-brain" "ros2 launch maurice_nav navigation_sim.launch.py" C-m
 echo "Started navigation system..."
-sleep 2
+settle_after_launch
 # Split and run brain client
 tmux split-window -t "${TMUX_TARGET_PREFIX}:nav-brain" -h
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:nav-brain.1" "ros2 launch brain_client brain_client.sim.launch.py" C-m

--- a/sim/config.toml.template
+++ b/sim/config.toml.template
@@ -5,6 +5,11 @@
 [display]
 # visualization = true
 
+[os]
+# Run `colcon build` on every startup. Leave false for incremental startup:
+# the launcher rebuilds only when ros2_ws/src is newer than install/setup.zsh.
+# always_build = false
+
 [cloud_agent]
 # mode = "hosted"
 # image = "ghcr.io/your-org/innate-cloud-agent:latest"

--- a/sim/config.toml.template
+++ b/sim/config.toml.template
@@ -6,6 +6,12 @@
 # visualization = true
 
 [os]
+# Optional prebuilt Innate OS image. If set, the launcher pulls/uses this image
+# instead of building the local Dockerfile. Images built from Dockerfile.ros-prebuilt
+# can seed ros2_ws/install and skip the first local colcon build when source matches.
+# image = "ghcr.io/innate-inc/innate-os-sim-ros:main"
+# pull_image = true
+
 # Run `colcon build` on every startup. Leave false for incremental startup:
 # the launcher rebuilds only when ros2_ws/src is newer than install/setup.zsh.
 # always_build = false

--- a/sim/main.py
+++ b/sim/main.py
@@ -33,6 +33,14 @@ load_dotenv()
 ROSBRIDGE_URI = os.getenv("ROSBRIDGE_URI", "ws://localhost:9090")
 SIMULATOR_PORT = int(os.getenv("SIMULATOR_PORT", "8000"))
 
+
+def env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 app = FastAPI()
 
 # Enable CORS
@@ -150,11 +158,19 @@ def main():
         default=None,
         help="Path to initial environment JSON (absolute or workspace-relative)",
     )
-    parser.add_argument(
+    robot_collision_group = parser.add_mutually_exclusive_group()
+    robot_collision_group.add_argument(
         "--disable-robot-collision",
         action="store_true",
-        default=False,
+        dest="disable_robot_collision",
+        default=not env_bool("SIM_ENABLE_COLLISION", True),
         help="Disable robot collisions with scene geometry (temporary debug mode).",
+    )
+    robot_collision_group.add_argument(
+        "--enable-robot-collision",
+        action="store_false",
+        dest="disable_robot_collision",
+        help="Enable robot collisions with scene geometry.",
     )
     parser.add_argument(
         "--sim-log-mode",

--- a/sim/requirements.macos.txt
+++ b/sim/requirements.macos.txt
@@ -39,7 +39,7 @@ fonttools==4.61.1
 fqdn==1.5.1
 freetype-py==2.5.1
 fsspec==2025.12.0
-genesis-world==0.4.3
+genesis-world==0.4.6
 glfw==2.10.0
 google-auth==2.49.1
 google-genai==1.66.0

--- a/sim/requirements.ubuntu.txt
+++ b/sim/requirements.ubuntu.txt
@@ -75,7 +75,7 @@ fsspec==2025.7.0
 future==1.0.0
 gast==0.6.0
 gdown==5.2.0
-genesis-world==0.4.3
+genesis-world==0.4.6
 glfw==2.9.0
 google-auth==2.49.1
 google-auth-oauthlib==1.2.2

--- a/sim/ros2_env.yaml
+++ b/sim/ros2_env.yaml
@@ -623,7 +623,7 @@ dependencies:
   - zstd=1.5.6=hb46c0d2_0
   - zziplib=0.13.69=he1e0b03_1
   - pip:
-    - genesis-world==0.4.3
+    - genesis-world==0.4.6
     - open3d==0.18.0
     - torch==2.5.1
 

--- a/sim/src/simulation/simulation_node.py
+++ b/sim/src/simulation/simulation_node.py
@@ -50,6 +50,24 @@ class EnvironmentRebuildRequired(Exception):
     """Raised when applying an environment requires rebuilding the Genesis scene."""
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        print(f"[SimulationNode] Invalid {name}={value!r}; using {default}.")
+        return default
+
+
 def xyzw_to_wxyz(xyzw):
     return (xyzw[3], xyzw[0], xyzw[1], xyzw[2])
 
@@ -151,20 +169,37 @@ class SimulationNode:
             2 * atan(tan(radians(self.robot_camera_vfov) / 2) * 640 / 480)
         )
         self.robot_camera_res = (640, 480)
+        self.physics_collision_enabled = _env_bool("SIM_ENABLE_COLLISION", True)
+        self.camera_mode = os.getenv("SIM_CAMERA_MODE", "all").strip().lower()
+        self.cameras_enabled = self.camera_mode != "none"
+        self.robot_camera = None
+        self.arm_wrist_camera = None
+        self.chase_camera = None
+        self.startup_timings_enabled = _env_bool("SIM_STARTUP_TIMINGS")
+        self._startup_t0 = time.perf_counter()
+        self._startup_last = self._startup_t0
 
         print(
             f"Robot camera FOV (vfov, hfov, res): {self.robot_camera_vfov}, {self.robot_camera_hfov}, {self.robot_camera_res}"
         )
+        self._startup_mark("initial state")
 
         # Initialize core components
         self._init_genesis()
+        self._startup_mark("gs.init")
         self._init_scene()
+        self._startup_mark("scene options/entities")
         self._init_environment()
+        self._startup_mark("static environment")
         self._init_robot()
+        self._startup_mark("robot entity")
         self._init_camera()
+        self._startup_mark("cameras")
         self._init_map_params()
+        self._startup_mark("map params")
 
         self.scene.build()
+        self._startup_mark("scene.build")
         self._init_robot_base_pose_control()
         self._set_robot_base_pose(ROBOT_INIT_POS, xyzw_to_wxyz(ROBOT_INIT_QUAT))
         self.scene_built = True
@@ -184,15 +219,58 @@ class SimulationNode:
             self.current_entity_asset_signature = tuple()
 
         print("SimulationNode initialized.")
+        self._startup_mark("post-build init")
+
+    def _startup_mark(self, label: str):
+        if not self.startup_timings_enabled:
+            return
+        now = time.perf_counter()
+        print(
+            f"[StartupTiming] {label}: +{now - self._startup_last:.3f}s "
+            f"(total {now - self._startup_t0:.3f}s)"
+        )
+        self._startup_last = now
 
     def _init_genesis(self):
         """Initialize Genesis backend"""
-        gs.init(backend=gs.cpu)
+        backend_name = os.getenv("SIM_GENESIS_BACKEND", "cpu").strip().lower()
+        backend = getattr(gs, backend_name, None)
+        if backend is None:
+            print(
+                f"[SimulationNode] Unknown SIM_GENESIS_BACKEND={backend_name!r}; using cpu."
+            )
+            backend = gs.cpu
+
+        log_level = os.getenv("SIM_GENESIS_LOG_LEVEL", "").strip()
+        init_kwargs = {"backend": backend}
+        if log_level:
+            init_kwargs["logging_level"] = log_level
+        print(f"[SimulationNode] Genesis backend: {backend_name}")
+        gs.init(**init_kwargs)
 
     def _init_scene(self):
         """Initialize the main simulation scene"""
+        substeps = _env_int("SIM_SCENE_SUBSTEPS", 4)
+        scene_kwargs = {}
+        if not self.physics_collision_enabled:
+            print("[SimulationNode] Physics collisions disabled.")
+            scene_kwargs["rigid_options"] = gs.options.RigidOptions(
+                enable_collision=False,
+                enable_self_collision=False,
+                max_collision_pairs=8,
+                iterations=5,
+                ls_iterations=1,
+            )
+        elif _env_bool("SIM_LIGHT_RIGID_OPTIONS", True):
+            print("[SimulationNode] Using light rigid solver options.")
+            scene_kwargs["rigid_options"] = gs.options.RigidOptions(
+                enable_self_collision=False,
+                max_collision_pairs=64,
+                iterations=20,
+                ls_iterations=10,
+            )
         self.scene = gs.Scene(
-            sim_options=gs.options.SimOptions(dt=0.05, substeps=4),
+            sim_options=gs.options.SimOptions(dt=0.05, substeps=substeps),
             viewer_options=gs.options.ViewerOptions(
                 camera_pos=(3.5, 0.0, 2.5),
                 camera_lookat=(0.0, 0.0, 0.5),
@@ -204,9 +282,17 @@ class SimulationNode:
             ),
             show_FPS=False,
             show_viewer=self.enable_vis,
+            **scene_kwargs,
         )
         # Add ground plane
-        self.scene.add_entity(gs.morphs.Plane(pos=(0, 0.05, 0)))
+        ground_collision = _env_bool(
+            "SIM_GROUND_COLLISION", self.physics_collision_enabled
+        )
+        self.scene.add_entity(
+            gs.morphs.Plane(pos=(0, 0.05, 0), collision=ground_collision)
+        )
+        if not ground_collision:
+            print("[SimulationNode] Ground plane collision disabled.")
 
     def _resolve_project_path(self, path: str) -> str:
         """Resolve relative paths from project root while preserving absolute paths."""
@@ -281,7 +367,12 @@ class SimulationNode:
 
         # Add separate collision geometry when a stage config is available.
         collision_stage_config = scene_config.get("collision_stage_config")
-        if collision_stage_config:
+        if _env_bool("SIM_SKIP_STATIC_COLLISION", not self.physics_collision_enabled):
+            print(
+                "[SimulationNode] SIM_SKIP_STATIC_COLLISION enabled; "
+                "skipping static collision mesh import."
+            )
+        elif collision_stage_config:
             # ReplicaCAD stage metadata remains in the original Y-up-authored frame
             # even though Genesis 0.4.x now auto-converts the visible GLB to Z-up.
             self._add_collision_from_stage_config(
@@ -800,6 +891,16 @@ class SimulationNode:
 
     def _init_camera(self):
         """Initialize robot camera, arm wrist camera, and chase camera"""
+        if not self.cameras_enabled:
+            print("[SimulationNode] SIM_CAMERA_MODE=none; skipping Genesis cameras.")
+            self.width = 640
+            self.height = 480
+            self.fx = 554.256
+            self.fy = 554.256
+            self.cx = 320.0
+            self.cy = 240.0
+            return
+
         # Main robot camera (will be positioned at arm_camera_link)
         self.robot_camera = self.scene.add_camera(
             res=self.robot_camera_res,
@@ -807,6 +908,21 @@ class SimulationNode:
             lookat=(1, 0, 0),
             fov=self.robot_camera_vfov,
         )
+
+        if self.camera_mode in {"first-person", "first_person", "primary"}:
+            print(
+                "[SimulationNode] SIM_CAMERA_MODE=first-person; "
+                "skipping arm and chase cameras."
+            )
+            self.arm_wrist_camera = None
+            self.chase_camera = None
+            self.width = 640
+            self.height = 480
+            self.fx = 554.256
+            self.fy = 554.256
+            self.cx = 320.0
+            self.cy = 240.0
+            return
 
         # Arm wrist camera (mounted on link5, looking forward along the arm)
         self.arm_wrist_camera = self.scene.add_camera(
@@ -1842,38 +1958,55 @@ class SimulationNode:
                 pass
 
             # Check if enough time has passed since last render
-            if sim_time - self.last_render_time >= self.render_interval:
+            if (
+                self.cameras_enabled
+                and sim_time - self.last_render_time >= self.render_interval
+            ):
                 camera_link = self.robot.get_link("head_camera_link")
                 camera_pos = camera_link.get_pos()
                 camera_quat = camera_link.get_quat()
                 look_dir = rotate_vector(local_forward, camera_quat)
                 lookat = camera_pos.cpu().numpy() + look_dir
-                self.robot_camera.set_pose(pos=camera_pos.cpu().numpy(), lookat=lookat)
+                if self.robot_camera is not None:
+                    self.robot_camera.set_pose(
+                        pos=camera_pos.cpu().numpy(), lookat=lookat
+                    )
 
                 # Update arm wrist camera (mounted on link5, looking forward along the arm)
-                link5 = self.robot.get_link("link5")
-                link5_pos = link5.get_pos()
-                link5_quat = link5.get_quat()
-                arm_forward = np.array([1.0, 0.0, 0.0])  # Arm points along X axis
-                arm_look_dir = rotate_vector(arm_forward, link5_quat)
-                arm_lookat = link5_pos.cpu().numpy() + arm_look_dir
-                self.arm_wrist_camera.set_pose(
-                    pos=link5_pos.cpu().numpy(), lookat=arm_lookat
-                )
+                if self.arm_wrist_camera is not None:
+                    link5 = self.robot.get_link("link5")
+                    link5_pos = link5.get_pos()
+                    link5_quat = link5.get_quat()
+                    arm_forward = np.array([1.0, 0.0, 0.0])  # Arm points along X axis
+                    arm_look_dir = rotate_vector(arm_forward, link5_quat)
+                    arm_lookat = link5_pos.cpu().numpy() + arm_look_dir
+                    self.arm_wrist_camera.set_pose(
+                        pos=link5_pos.cpu().numpy(), lookat=arm_lookat
+                    )
 
                 # Update chase camera to follow robot
-                robot_pos, robot_quat = self._get_robot_base_pose()
-                offset = np.array([-2.0, 0.0, 2.0])  # 2m behind, 2m up
-                rotated_offset = rotate_vector(offset, robot_quat)
-                chase_pos = robot_pos + rotated_offset
-                self.chase_camera.set_pose(
-                    pos=chase_pos, lookat=robot_pos, up=(0, 0, 1)
-                )
+                if self.chase_camera is not None:
+                    robot_pos, robot_quat = self._get_robot_base_pose()
+                    offset = np.array([-2.0, 0.0, 2.0])  # 2m behind, 2m up
+                    rotated_offset = rotate_vector(offset, robot_quat)
+                    chase_pos = robot_pos + rotated_offset
+                    self.chase_camera.set_pose(
+                        pos=chase_pos, lookat=robot_pos, up=(0, 0, 1)
+                    )
 
                 # Render all cameras
-                rgb, depth, seg, normal = self.robot_camera.render(depth=True)
-                arm_rgb, _, _, _ = self.arm_wrist_camera.render()
-                chase_rgb, _, _, _ = self.chase_camera.render()
+                if self.robot_camera is not None:
+                    rgb, depth, seg, normal = self.robot_camera.render(depth=True)
+                else:
+                    rgb, depth = None, None
+                if self.arm_wrist_camera is not None:
+                    arm_rgb, _, _, _ = self.arm_wrist_camera.render()
+                else:
+                    arm_rgb = None
+                if self.chase_camera is not None:
+                    chase_rgb, _, _, _ = self.chase_camera.render()
+                else:
+                    chase_rgb = None
 
                 # Convert RGB to BGR format if needed (or BGR to RGB)
                 if rgb is not None:


### PR DESCRIPTION
## Summary
- add prebuilt/cached ROS and simulator dependency startup optimizations
- bump Genesis to 0.4.6 and tighten launcher startup waits
- default simulator physics to lighter collision-enabled rigid options for faster dev startup
- keep explicit env/CLI switches for full collision/debug modes and camera minimization

## Measurements
- real `./innate sim up` after changes: ~30.24s to runtime up on this machine
- simulator node init with collision-enabled light physics: ~9.21s
- `scene.build` in that path: ~3.95s

## Verification
- `sim/.venv/bin/python -m py_compile sim/main.py sim/src/simulation/simulation_node.py`
- `./innate sim up` reached ready HTTP endpoint
- `./innate sim down` stopped runtime

Stacked on #323 (`codex/innate-os-sim-monorepo-stack-clean`).