### PR TITLE
Add simulator image publishing workflow

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,24 @@
+# Keep Cloud Build source uploads small and deterministic for simulator images.
+# The dependency image only needs Dockerfile + apt manifests; the ROS-prebuilt
+# image only needs ros2_ws/src.
+
+.git/
+.venv/
+build/
+install/
+log/
+dev/launcher/.state/
+sim/.venv/
+
+**
+!Dockerfile
+!Dockerfile.ros-prebuilt
+!.dockerignore
+!Dockerfile.ros-prebuilt.dockerignore
+!cloudbuild.sim-images.yaml
+!ros2_ws/
+!ros2_ws/apt-dependencies.common.txt
+!ros2_ws/apt-dependencies.hardware.txt
+!ros2_ws/apt-dependencies.simulation.txt
+!ros2_ws/src/
+!ros2_ws/src/**

--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -1,0 +1,118 @@
+name: Cleanup Simulator Images
+
+on:
+  schedule:
+    - cron: "17 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print what would be deleted without deleting package versions"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  packages: write
+
+concurrency:
+  group: cleanup-sim-images
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    env:
+      ORG: innate-inc
+      KEEP_SHA_TAGS: "20"
+      KEEP_INPUTS_TAGS: "20"
+      KEEP_MANUAL_TAGS: "5"
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - innate-os-sim-deps
+          - innate-os-sim-ros
+
+    steps:
+      - name: Cleanup old GHCR versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          package="${{ matrix.package }}"
+          keep_file="$(mktemp)"
+          versions_file="$(mktemp)"
+
+          gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"
+
+          jq -r '
+            .[]
+            | select((.metadata.container.tags // []) | any(. == "main" or . == "buildcache"))
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
+
+          jq -r --argjson keep "${KEEP_SHA_TAGS}" '
+            [
+              .[]
+              | select((.metadata.container.tags // []) | any(startswith("sha-")))
+              | {id, updated_at}
+            ]
+            | sort_by(.updated_at)
+            | reverse
+            | .[:$keep][]
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
+
+          jq -r --argjson keep "${KEEP_INPUTS_TAGS}" '
+            [
+              .[]
+              | select((.metadata.container.tags // []) | any(startswith("inputs-")))
+              | {id, updated_at}
+            ]
+            | sort_by(.updated_at)
+            | reverse
+            | .[:$keep][]
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
+
+          jq -r --argjson keep "${KEEP_MANUAL_TAGS}" '
+            [
+              .[]
+              | select((.metadata.container.tags // []) | any(startswith("manual-")))
+              | {id, updated_at}
+            ]
+            | sort_by(.updated_at)
+            | reverse
+            | .[:$keep][]
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
+
+          sort -u -o "${keep_file}" "${keep_file}"
+
+          delete_file="$(mktemp)"
+          jq -r '.[] | .id' "${versions_file}" \
+            | grep -Fvx -f "${keep_file}" \
+            > "${delete_file}" || true
+
+          echo "Package: ${package}"
+          echo "Keeping $(wc -l < "${keep_file}" | xargs) package versions."
+          echo "Deleting $(wc -l < "${delete_file}" | xargs) package versions."
+
+          while IFS= read -r version_id; do
+            [ -n "${version_id}" ] || continue
+            tags="$(jq -r --argjson id "${version_id}" '
+              .[] | select(.id == $id) | (.metadata.container.tags // []) | join(",")
+            ' "${versions_file}")"
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "dry-run delete ${package} version ${version_id}: ${tags}"
+            else
+              echo "delete ${package} version ${version_id}: ${tags}"
+              gh api --method DELETE "/orgs/${ORG}/packages/container/${package}/versions/${version_id}"
+            fi
+          done < "${delete_file}"

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -45,6 +45,40 @@ jobs:
         run: |
           set -euo pipefail
 
+          image_inputs_hash="$(python3 - <<'PY'
+          import hashlib
+          from pathlib import Path
+
+          root = Path(".")
+          static_paths = (
+              ".dockerignore",
+              "Dockerfile",
+              "Dockerfile.ros-prebuilt",
+              "Dockerfile.ros-prebuilt.dockerignore",
+              "ros2_ws/apt-dependencies.common.txt",
+              "ros2_ws/apt-dependencies.hardware.txt",
+              "ros2_ws/apt-dependencies.simulation.txt",
+          )
+          paths = [Path(path) for path in static_paths if (root / path).is_file()]
+          src_root = root / "ros2_ws" / "src"
+          if src_root.exists():
+              for path in sorted(src_root.rglob("*")):
+                  if not path.is_file():
+                      continue
+                  relative_path = path.relative_to(root)
+                  if "__pycache__" in relative_path.parts or relative_path.suffix == ".pyc":
+                      continue
+                  paths.append(relative_path)
+
+          digest = hashlib.sha256()
+          for path in sorted(paths, key=lambda item: item.as_posix()):
+              digest.update(path.as_posix().encode("utf-8"))
+              digest.update(b"\0")
+              digest.update((root / path).read_bytes())
+              digest.update(b"\0")
+          print(digest.hexdigest())
+          PY
+          )"
           short_sha="${GITHUB_SHA::12}"
           push_main_tags="false"
 
@@ -56,6 +90,7 @@ jobs:
           fi
 
           echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
+          echo "image_inputs_hash=${image_inputs_hash}" >> "$GITHUB_OUTPUT"
           echo "push_main_tags=${push_main_tags}" >> "$GITHUB_OUTPUT"
 
       - name: Submit Cloud Build
@@ -69,9 +104,11 @@ jobs:
             --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \
             --service-account="projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_CLOUD_BUILD_SERVICE_ACCOUNT }}" \
             --config=cloudbuild.sim-images.yaml \
-            --substitutions="_IMAGE_PREFIX=${{ vars.SIM_IMAGE_PREFIX }},_IMAGE_TAG=${{ steps.image_tags.outputs.image_tag }},_PUSH_MAIN_TAGS=${{ steps.image_tags.outputs.push_main_tags }},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }},_COMMIT_SHA=${GITHUB_SHA},_SHORT_SHA=${GITHUB_SHA::12}"
+            --substitutions="_IMAGE_PREFIX=${{ vars.SIM_IMAGE_PREFIX }},_IMAGE_TAG=${{ steps.image_tags.outputs.image_tag }},_IMAGE_INPUTS_HASH=${{ steps.image_tags.outputs.image_inputs_hash }},_PUSH_MAIN_TAGS=${{ steps.image_tags.outputs.push_main_tags }},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }},_COMMIT_SHA=${GITHUB_SHA},_SHORT_SHA=${GITHUB_SHA::12}"
 
       - name: Published image tags
         run: |
           echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-deps:${{ steps.image_tags.outputs.image_tag }}"
+          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-deps:inputs-${{ steps.image_tags.outputs.image_inputs_hash }}"
           echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-ros:${{ steps.image_tags.outputs.image_tag }}"
+          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-ros:inputs-${{ steps.image_tags.outputs.image_inputs_hash }}"

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -12,19 +12,6 @@ on:
       - Dockerfile.ros-prebuilt.dockerignore
       - ros2_ws/apt-dependencies*.txt
       - ros2_ws/src/**
-  pull_request:
-    branches:
-      - main
-      - codex/innate-os-sim-monorepo-stack-clean
-    paths:
-      - .github/workflows/publish-sim-images.yml
-      - .gcloudignore
-      - cloudbuild.sim-images.yaml
-      - Dockerfile
-      - Dockerfile.ros-prebuilt
-      - Dockerfile.ros-prebuilt.dockerignore
-      - ros2_ws/apt-dependencies*.txt
-      - ros2_ws/src/**
   workflow_dispatch:
 
 permissions:
@@ -37,7 +24,6 @@ concurrency:
 
 jobs:
   publish:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -62,9 +48,7 @@ jobs:
           short_sha="${GITHUB_SHA::12}"
           push_main_tags="false"
 
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            image_tag="pr-${{ github.event.pull_request.number }}-${short_sha}"
-          elif [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             image_tag="sha-${short_sha}"
             push_main_tags="true"
           else

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -1,0 +1,93 @@
+name: Publish Simulator Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/publish-sim-images.yml
+      - .gcloudignore
+      - cloudbuild.sim-images.yaml
+      - Dockerfile
+      - Dockerfile.ros-prebuilt
+      - Dockerfile.ros-prebuilt.dockerignore
+      - ros2_ws/apt-dependencies*.txt
+      - ros2_ws/src/**
+  pull_request:
+    branches:
+      - main
+      - codex/innate-os-sim-monorepo-stack-clean
+    paths:
+      - .github/workflows/publish-sim-images.yml
+      - .gcloudignore
+      - cloudbuild.sim-images.yaml
+      - Dockerfile
+      - Dockerfile.ros-prebuilt
+      - Dockerfile.ros-prebuilt.dockerignore
+      - ros2_ws/apt-dependencies*.txt
+      - ros2_ws/src/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-sim-images-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Compute image tags
+        id: image_tags
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          short_sha="${GITHUB_SHA::12}"
+          push_main_tags="false"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            image_tag="pr-${{ github.event.pull_request.number }}-${short_sha}"
+          elif [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            image_tag="sha-${short_sha}"
+            push_main_tags="true"
+          else
+            image_tag="manual-${short_sha}"
+          fi
+
+          echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
+          echo "push_main_tags=${push_main_tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Submit Cloud Build
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gcloud builds submit \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \
+            --service-account="projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_CLOUD_BUILD_SERVICE_ACCOUNT }}" \
+            --config=cloudbuild.sim-images.yaml \
+            --substitutions="_IMAGE_PREFIX=${{ vars.SIM_IMAGE_PREFIX }},_IMAGE_TAG=${{ steps.image_tags.outputs.image_tag }},_PUSH_MAIN_TAGS=${{ steps.image_tags.outputs.push_main_tags }},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }},_COMMIT_SHA=${GITHUB_SHA},_SHORT_SHA=${GITHUB_SHA::12}"
+
+      - name: Published image tags
+        run: |
+          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-deps:${{ steps.image_tags.outputs.image_tag }}"
+          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-ros:${{ steps.image_tags.outputs.image_tag }}"

--- a/cloudbuild.sim-images.yaml
+++ b/cloudbuild.sim-images.yaml
@@ -1,0 +1,103 @@
+timeout: 7200s
+
+substitutions:
+  _DEPS_IMAGE_NAME: innate-os-sim-deps
+  _GHCR_TOKEN_SECRET: innate-os-sim-ghcr-token
+  _GHCR_USERNAME_SECRET: innate-os-sim-ghcr-username
+  _COMMIT_SHA: manual
+  _IMAGE_PREFIX: ghcr.io/innate-inc
+  _IMAGE_TAG: manual
+  _PUSH_MAIN_TAGS: "false"
+  _ROS_IMAGE_NAME: innate-os-sim-ros
+  _SHORT_SHA: manual
+
+steps:
+  - id: build-and-push-simulator-images
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    secretEnv:
+      - GHCR_TOKEN
+      - GHCR_USERNAME
+    env:
+      - DOCKER_BUILDKIT=1
+    args:
+      - -ceu
+      - |
+        docker_login() {
+          echo "$$GHCR_TOKEN" | docker login ghcr.io -u "$$GHCR_USERNAME" --password-stdin
+        }
+
+        push_tags() {
+          local image="$1"
+          local source_tag="$2"
+          shift 2
+
+          local pushed=""
+          for tag in "$@"; do
+            if [[ -z "$tag" || "$pushed" == *"|$tag|"* ]]; then
+              continue
+            fi
+
+            if [[ "$tag" != "$source_tag" ]]; then
+              docker tag "$image:$source_tag" "$image:$tag"
+            fi
+
+            docker push "$image:$tag"
+            pushed="$pushed|$tag|"
+          done
+        }
+
+        deps_image="${_IMAGE_PREFIX}/${_DEPS_IMAGE_NAME}"
+        ros_image="${_IMAGE_PREFIX}/${_ROS_IMAGE_NAME}"
+        sha_tag="sha-${_SHORT_SHA}"
+
+        docker_login
+
+        docker pull "$deps_image:buildcache" || true
+        docker build \
+          --progress=plain \
+          --build-arg MODE=simulation \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          --cache-from "$deps_image:buildcache" \
+          --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
+          --label "org.opencontainers.image.revision=${_COMMIT_SHA}" \
+          --tag "$deps_image:${_IMAGE_TAG}" \
+          --file Dockerfile \
+          .
+
+        deps_tags=("${_IMAGE_TAG}" "$sha_tag" "buildcache")
+        if [[ "${_PUSH_MAIN_TAGS}" == "true" ]]; then
+          deps_tags+=("main")
+        fi
+        push_tags "$deps_image" "${_IMAGE_TAG}" "${deps_tags[@]}"
+
+        deps_ros_base="$deps_image:buildcache"
+        docker pull "$ros_image:buildcache" || true
+        docker build \
+          --progress=plain \
+          --build-arg "BASE_IMAGE=$deps_ros_base" \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          --cache-from "$ros_image:buildcache" \
+          --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
+          --label "org.opencontainers.image.revision=${_COMMIT_SHA}" \
+          --tag "$ros_image:${_IMAGE_TAG}" \
+          --file Dockerfile.ros-prebuilt \
+          .
+
+        ros_tags=("${_IMAGE_TAG}" "$sha_tag" "buildcache")
+        if [[ "${_PUSH_MAIN_TAGS}" == "true" ]]; then
+          ros_tags+=("main")
+        fi
+        push_tags "$ros_image" "${_IMAGE_TAG}" "${ros_tags[@]}"
+
+availableSecrets:
+  secretManager:
+    - env: GHCR_USERNAME
+      versionName: projects/$PROJECT_ID/secrets/${_GHCR_USERNAME_SECRET}/versions/latest
+    - env: GHCR_TOKEN
+      versionName: projects/$PROJECT_ID/secrets/${_GHCR_TOKEN_SECRET}/versions/latest
+
+options:
+  diskSizeGb: "200"
+  logging: CLOUD_LOGGING_ONLY
+  machineType: E2_HIGHCPU_8

--- a/cloudbuild.sim-images.yaml
+++ b/cloudbuild.sim-images.yaml
@@ -5,6 +5,7 @@ substitutions:
   _GHCR_TOKEN_SECRET: innate-os-sim-ghcr-token
   _GHCR_USERNAME_SECRET: innate-os-sim-ghcr-username
   _COMMIT_SHA: manual
+  _IMAGE_INPUTS_HASH: manual
   _IMAGE_PREFIX: ghcr.io/innate-inc
   _IMAGE_TAG: manual
   _PUSH_MAIN_TAGS: "false"
@@ -50,6 +51,10 @@ steps:
         deps_image="${_IMAGE_PREFIX}/${_DEPS_IMAGE_NAME}"
         ros_image="${_IMAGE_PREFIX}/${_ROS_IMAGE_NAME}"
         sha_tag="sha-${_SHORT_SHA}"
+        inputs_tag=""
+        if [[ -n "${_IMAGE_INPUTS_HASH}" && "${_IMAGE_INPUTS_HASH}" != "manual" ]]; then
+          inputs_tag="inputs-${_IMAGE_INPUTS_HASH}"
+        fi
 
         docker_login
 
@@ -65,7 +70,7 @@ steps:
           --file Dockerfile \
           .
 
-        deps_tags=("${_IMAGE_TAG}" "$sha_tag" "buildcache")
+        deps_tags=("${_IMAGE_TAG}" "$sha_tag" "$inputs_tag" "buildcache")
         if [[ "${_PUSH_MAIN_TAGS}" == "true" ]]; then
           deps_tags+=("main")
         fi
@@ -84,7 +89,7 @@ steps:
           --file Dockerfile.ros-prebuilt \
           .
 
-        ros_tags=("${_IMAGE_TAG}" "$sha_tag" "buildcache")
+        ros_tags=("${_IMAGE_TAG}" "$sha_tag" "$inputs_tag" "buildcache")
         if [[ "${_PUSH_MAIN_TAGS}" == "true" ]]; then
           ros_tags+=("main")
         fi

--- a/dev/launcher/stack.py
+++ b/dev/launcher/stack.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import io
 import json
 import os
@@ -67,6 +68,18 @@ HOSTED_MODE = "hosted"
 LOCAL_IMAGE_MODE = "local-image"
 LOCAL_SOURCE_MODE = "local-source"
 LOCAL_MODES = {LOCAL_IMAGE_MODE, LOCAL_SOURCE_MODE}
+AUTO_OS_IMAGE = "auto"
+LOCAL_OS_IMAGE = "local"
+DEFAULT_SIM_OS_IMAGE = "ghcr.io/innate-inc/innate-os-sim-ros"
+SIM_IMAGE_INPUT_FILES = (
+    ".dockerignore",
+    "Dockerfile",
+    "Dockerfile.ros-prebuilt",
+    "Dockerfile.ros-prebuilt.dockerignore",
+    "ros2_ws/apt-dependencies.common.txt",
+    "ros2_ws/apt-dependencies.hardware.txt",
+    "ros2_ws/apt-dependencies.simulation.txt",
+)
 OS_CONTAINER_SERVICE = "innate"
 OS_CONTAINER_TMUX_CMD = "./scripts/launch_sim_in_tmux.zsh --detach"
 ENV_KEYS_MOVED_TO_OS_CONFIG = {
@@ -653,6 +666,48 @@ def require_path(path: Path, label: str) -> Path:
     return path
 
 
+def iter_sim_image_input_files(repo_root: Path) -> list[Path]:
+    relative_paths: list[Path] = []
+    for raw_path in SIM_IMAGE_INPUT_FILES:
+        relative_path = Path(raw_path)
+        if (repo_root / relative_path).is_file():
+            relative_paths.append(relative_path)
+
+    src_root = repo_root / "ros2_ws" / "src"
+    if src_root.exists():
+        for path in sorted(src_root.rglob("*")):
+            if not path.is_file():
+                continue
+            relative_path = path.relative_to(repo_root)
+            if "__pycache__" in relative_path.parts or relative_path.suffix == ".pyc":
+                continue
+            relative_paths.append(relative_path)
+
+    return sorted(relative_paths, key=lambda path: path.as_posix())
+
+
+def compute_sim_image_inputs_hash(repo_root: Path) -> str:
+    digest = hashlib.sha256()
+    for relative_path in iter_sim_image_input_files(repo_root):
+        digest.update(relative_path.as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update((repo_root / relative_path).read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def resolve_auto_os_image(repo_root: Path) -> str:
+    return f"{DEFAULT_SIM_OS_IMAGE}:inputs-{compute_sim_image_inputs_hash(repo_root)}"
+
+
+def resolve_os_image_setting(value: str | None, repo_root: Path) -> tuple[str, bool]:
+    if value is None or value == AUTO_OS_IMAGE:
+        return resolve_auto_os_image(repo_root), True
+    if value == LOCAL_OS_IMAGE:
+        return "", False
+    return value, False
+
+
 def get_config() -> dict[str, object]:
     ensure_env_file()
     ensure_config_file(OS_CONFIG_PATH, OS_CONFIG_TEMPLATE_PATH)
@@ -699,6 +754,12 @@ def get_config() -> dict[str, object]:
 
     os_always_build = get_nested_bool(sim_config, "os", "always_build")
     os_pull_image = get_nested_bool(sim_config, "os", "pull_image")
+    configured_os_image = get_nested_str(sim_config, "os", "image")
+    env_os_image = os.environ.get("INNATE_OS_IMAGE", "").strip() or None
+    os_image, os_image_auto = resolve_os_image_setting(
+        configured_os_image or env_os_image,
+        os_repo,
+    )
 
     return {
         "raw_env": merged_env,
@@ -718,8 +779,8 @@ def get_config() -> dict[str, object]:
         else False,
         "sim_log_mode": "quiet",
         "sim_args": "--log-everything",
-        "os_image": get_nested_str(sim_config, "os", "image")
-        or os.environ.get("INNATE_OS_IMAGE", ""),
+        "os_image": os_image,
+        "os_image_auto": os_image_auto,
         "os_pull_image": os_pull_image if os_pull_image is not None else True,
         "os_always_build": os_always_build if os_always_build is not None else False,
         "skip_local_cloud_auth": True,
@@ -889,23 +950,36 @@ def ensure_os_image_available(
 def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
     os_repo: Path = config["os_repo"]  # type: ignore[assignment]
     os_image = str(config["os_image"]).strip()
-    compose_values = {"INNATE_OS_ENV_FILE": str(os_env_file)}
-    if os_image:
-        compose_values["INNATE_OS_IMAGE"] = os_image
-    compose_env = docker_compose_env(compose_values)
+    os_image_auto = bool(config["os_image_auto"])
 
     if container_running("innate-dev"):
         log("Innate OS dev container already running.")
     else:
         up_cmd = ["docker", "compose", "-f", "docker-compose.dev.yml", "up", "-d"]
         if os_image:
-            ensure_os_image_available(
-                os_image,
-                cwd=os_repo,
-                env=compose_env,
-                pull_if_missing=bool(config["os_pull_image"]),
-            )
-            up_cmd.append("--no-build")
+            try:
+                ensure_os_image_available(
+                    os_image,
+                    cwd=os_repo,
+                    env=docker_compose_env(),
+                    pull_if_missing=bool(config["os_pull_image"]),
+                )
+            except StackError as exc:
+                if not os_image_auto:
+                    raise
+                warn(
+                    "Matching prebuilt Innate OS image is not available; "
+                    "falling back to the local Docker build.\n"
+                    f"{exc}"
+                )
+                os_image = ""
+            else:
+                up_cmd.append("--no-build")
+
+        compose_values = {"INNATE_OS_ENV_FILE": str(os_env_file)}
+        if os_image:
+            compose_values["INNATE_OS_IMAGE"] = os_image
+        compose_env = docker_compose_env(compose_values)
         log("Starting Innate OS dev container...")
         run_logged_with_heartbeat(
             up_cmd,
@@ -918,6 +992,10 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
                 "First boot or an image rebuild can take a minute."
             ),
         )
+    compose_values = {"INNATE_OS_ENV_FILE": str(os_env_file)}
+    if os_image:
+        compose_values["INNATE_OS_IMAGE"] = os_image
+    compose_env = docker_compose_env(compose_values)
 
     colcon_build_cmd = (
         "colcon build --symlink-install "

--- a/sim/config.toml.template
+++ b/sim/config.toml.template
@@ -6,9 +6,13 @@
 # visualization = true
 
 [os]
-# Optional prebuilt Innate OS image. If set, the launcher pulls/uses this image
-# instead of building the local Dockerfile. Images built from Dockerfile.ros-prebuilt
-# can seed ros2_ws/install and skip the first local colcon build when source matches.
+# Optional prebuilt Innate OS image. By default, the launcher tries a
+# content-addressed prebuilt image matching this checkout, then falls back to
+# the local Docker build if no matching image is available.
+# image = "auto"
+#
+# Other options:
+# image = "local"
 # image = "ghcr.io/innate-inc/innate-os-sim-ros:main"
 # pull_image = true
 


### PR DESCRIPTION
## Summary
- add a Cloud Build config that builds and pushes the simulator dependency and ROS-prebuilt images to GHCR
- add a GitHub Actions workflow that authenticates to GCP with Workload Identity and submits Cloud Build
- keep Cloud Build source uploads small with a dedicated .gcloudignore
- publish `manual` / `sha` / `buildcache` tags for test builds; publish `main` too only from pushes to `main`

## Publish behavior
This workflow does not run automatically on PR commits. It auto-builds only after image-relevant changes land on `main`, plus explicit manual runs via `workflow_dispatch`.

Automatic trigger:
- `push` to `main`, path-filtered to simulator image inputs.

Manual trigger:
- `workflow_dispatch`, for one-off smoke tests or cache refreshes.

Path filter:
- `.github/workflows/publish-sim-images.yml`
- `.gcloudignore`
- `cloudbuild.sim-images.yaml`
- `Dockerfile`
- `Dockerfile.ros-prebuilt`
- `Dockerfile.ros-prebuilt.dockerignore`
- `ros2_ws/apt-dependencies*.txt`
- `ros2_ws/src/**`

Tags produced per image family:
- Push to `main`: `sha-<short-sha>`, `inputs-<image-inputs-hash>`, `buildcache`, `main`
- Manual run: `manual-<short-sha>`, `sha-<short-sha>`, `inputs-<image-inputs-hash>`, `buildcache`

Images:
- `ghcr.io/innate-inc/innate-os-sim-deps`
- `ghcr.io/innate-inc/innate-os-sim-ros`

The launcher defaults to `image = "auto"`. In auto mode, it computes the same image-inputs hash from the local checkout and tries to pull `ghcr.io/innate-inc/innate-os-sim-ros:inputs-<hash>`. If that exact image exists, it uses the prebuilt ROS install. If not, it falls back to the local Docker build.

This avoids asking developers to copy a commit SHA while also avoiding a moving `:main` image mismatch. Normal pulls of `main` should keep using a matching prebuilt image as long as the CD build has completed for the relevant image inputs.

Image cleanup:
- Added `.github/workflows/cleanup-sim-images.yml`.
- Runs weekly and can be run manually.
- Keeps `main` and `buildcache`.
- Keeps latest 20 `sha-*` versions per image family.
- Keeps latest 20 `inputs-*` versions per image family.
- Keeps latest 5 `manual-*` versions per image family.
- Deletes older GHCR package versions.
- Manual dispatch defaults to `dry_run=true`.

This requires the workflow token to be allowed to delete GitHub Packages versions. If the default `GITHUB_TOKEN` is too restricted in org settings, we will need to add a package-management token secret or loosen package workflow permissions for this repo.

## Cost Estimate
Current pricing inputs:
- Cloud Build `e2-highcpu-8` in `us-central1`: $0.0156/build-minute.
- Cloud Build queued time is not billed.
- The config requests 200 GB disk; the first 100 GB is free, so the extra 100 GB adds about $0.00023/GB-hour, which is under a quarter cent for these builds.
- GitHub Actions `ubuntu-latest` uses the standard Linux 2-core hosted runner: $0.006/minute beyond included plan minutes, rounded up per job.
- GHCR Container Registry storage and bandwidth are currently free for container images. If GitHub changes that policy later, they say they will give at least one month of notice.

Approximate all-in cost per workflow run, assuming we are past any included GitHub Actions minutes:
- Warm-cache build: about $0.03 total.
- Typical cached PR/main build from the smoke tests: about $0.08-$0.09 total.
- Cold/no-cache build: about $0.13 total.

GCP-only Cloud Build cost from measured runs:
- Warm-cache 1m12s: about $0.019.
- PR workflow Cloud Build 3m40s: about $0.059.
- Cold/no-cache 5m45s: about $0.092.

Monthly examples:
- 10 relevant image builds/month: roughly $0.30 warm-cache, $0.80-$0.90 typical, $1.30 cold worst-case.
- 50 relevant image builds/month: roughly $1.50 warm-cache, $4-$5 typical, $6-$7 cold worst-case.
- 100 relevant image builds/month: roughly $3 warm-cache, $8-$9 typical, $13 cold worst-case.

Other tiny costs:
- Cloud Build source upload is about 15 MB per run. Even if retained, this is pennies/month at normal volumes; we can add a lifecycle rule later if the staging bucket starts accumulating.
- Old `pr-*` and `sha-*` GHCR tags will accumulate, but current GHCR container-image storage cost is $0. We should still add cleanup later to keep the package list sane.

## Timing From Smoke Tests
Fresh/no-cache Cloud Build:
- Build `6343098f-5f4b-4fe1-8c34-9f2555508212`
- Duration: 5m45s
- Pushed both image families to GHCR

Patched build after fixing the ROS cache key:
- Build `88b1db1f-7356-45eb-9bed-2f8a59a7dc65`
- Duration: 3m19s
- Refreshed stable cache tags

PR workflow build:
- GitHub Actions run `25814285804`
- Cloud Build `58173ffb-728b-49fb-b9ef-31b96a9b8437`
- Duration: 3m40s
- Published:
  - `ghcr.io/innate-inc/innate-os-sim-deps:pr-391-f04feffeb2a5`
  - `ghcr.io/innate-inc/innate-os-sim-ros:pr-391-f04feffeb2a5`

Warm-cache Cloud Build:
- Build `a99334b2-00de-4c03-b5a6-e2112f6caca3`
- Duration: 1m12s
- Deps Dockerfile steps cached
- ROS Dockerfile steps cached, including the `colcon build` layer

## Local Fresh Setup Smoke Test
Using the PR image explicitly:

```bash
INNATE_OS_IMAGE=ghcr.io/innate-inc/innate-os-sim-ros:pr-391-f04feffeb2a5 ./innate sim up
```

Measured locally after deleting generated sim env/frontend/data, simulator containers/volumes, and local simulator images:
- `./innate sim setup`: 32.33s
- First `sim up` with prebuilt PR image: 129.31s
- Total setup + first launch: 161.64s, about 2m42s
- Subsequent start after `sim down`: 37.00s

Runtime verification:
- `http://localhost:8000/video_feeds_ready` returned `200 {"ready":true,"message":"Simulation is running"}`
- Dashboard showed video smooth around 10-15 FPS

## Test plan
- Cleanup workflow added: keeps `main`/`buildcache`, latest 20 `sha-*`, latest 20 `inputs-*`, latest 5 `manual-*`; manual dry-run is supported.
- Content-addressed image tag smoke test succeeded: `767f73ba-708c-4f54-8380-9162f1846044`, 1m17s, published `inputs-b25a52bedaaa559280ffb95c80c1010d7cbe986b7bde663ec24c5ea12c4bd994` for both image families
- YAML parsed locally
- Cloud Build source upload checked locally: 443 files, about 15 MB
- Manual Cloud Build smoke test succeeded: `6343098f-5f4b-4fe1-8c34-9f2555508212`, 5m45s, pushed both image families to GHCR
- Fixed ROS cache key after a cache-test run showed the ROS image still rebuilding because its base image tag changed per run
- Patched Cloud Build succeeded: `88b1db1f-7356-45eb-9bed-2f8a59a7dc65`, 3m19s, refreshed stable cache tags
- PR workflow check succeeded: GitHub Actions run `25814285804`, Cloud Build `58173ffb-728b-49fb-b9ef-31b96a9b8437`, 3m40s, published `ghcr.io/innate-inc/innate-os-sim-deps:pr-391-f04feffeb2a5` and `ghcr.io/innate-inc/innate-os-sim-ros:pr-391-f04feffeb2a5`
- Warm Cloud Build succeeded: `a99334b2-00de-4c03-b5a6-e2112f6caca3`, 1m12s, with deps and ROS build steps cached, including the `colcon build` layer