### PR TITLE
Improve OS connection error logging

### DIFF
--- a/dev/launcher/stack.py
+++ b/dev/launcher/stack.py
@@ -465,6 +465,7 @@ def run_logged_with_heartbeat(
     failure_message: str,
     progress_message: str,
     heartbeat_seconds: float = 10.0,
+    include_recent_log_on_failure: bool = True,
 ) -> None:
     ensure_state_dir()
     with log_path.open("a", encoding="utf-8") as log_file:
@@ -493,6 +494,8 @@ def run_logged_with_heartbeat(
             time.sleep(0.5)
 
     if return_code != 0:
+        if not include_recent_log_on_failure:
+            raise StackError(f"{failure_message}\nFull log: {log_path}")
         raise StackError(
             f"{failure_message}\nRecent log output:\n{tail_file(log_path, limit=60)}"
         )
@@ -926,8 +929,22 @@ def docker_compose_env(base_env: dict[str, str] | None = None) -> dict[str, str]
     return env
 
 
+def shorten_docker_image_ref(image: str) -> str:
+    if ":" not in image:
+        return image
+    repo, tag = image.rsplit(":", 1)
+    if tag.startswith("inputs-") and len(tag) > 22:
+        tag = f"{tag[:19]}..."
+    return f"{repo}:{tag}"
+
+
 def ensure_os_image_available(
-    image: str, *, cwd: Path, env: dict[str, str], pull_if_missing: bool
+    image: str,
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    pull_if_missing: bool,
+    include_pull_log_on_failure: bool = True,
 ) -> None:
     if command_succeeds(["docker", "image", "inspect", image], cwd=cwd, env=env):
         return
@@ -936,14 +953,18 @@ def ensure_os_image_available(
             f"Innate OS image is not available locally: {image}\n"
             "Pull or build it, or unset sim/config.toml os.image to use the local Docker build."
         )
-    log(f"Pulling Innate OS image {image}...")
+    log(f"Pulling Innate OS image {shorten_docker_image_ref(image)}...")
     run_logged_with_heartbeat(
         ["docker", "pull", image],
         cwd=cwd,
         env=env,
         log_path=COMPOSE_LOG_PATH,
-        failure_message=f"Failed to pull Innate OS image: {image}",
+        failure_message=(
+            "Could not pull the prebuilt Innate OS image: "
+            f"{shorten_docker_image_ref(image)}"
+        ),
         progress_message="Docker is still pulling the Innate OS image.",
+        include_recent_log_on_failure=include_pull_log_on_failure,
     )
 
 
@@ -963,14 +984,15 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
                     cwd=os_repo,
                     env=docker_compose_env(),
                     pull_if_missing=bool(config["os_pull_image"]),
+                    include_pull_log_on_failure=not os_image_auto,
                 )
-            except StackError as exc:
+            except StackError:
                 if not os_image_auto:
                     raise
                 warn(
-                    "Matching prebuilt Innate OS image is not available; "
-                    "falling back to the local Docker build.\n"
-                    f"{exc}"
+                    "No matching prebuilt Innate OS image is available for this checkout "
+                    f"({shorten_docker_image_ref(os_image)}). Building it locally instead. "
+                    f"Pull details are in {COMPOSE_LOG_PATH}."
                 )
                 os_image = ""
             else:
@@ -2297,6 +2319,42 @@ def fetch_simulator_metrics(port: str) -> dict[str, object]:
         return {}
 
 
+def fetch_brain_backend_status(port: str) -> dict[str, object]:
+    try:
+        with urlopen(f"http://localhost:{port}/get_available_agents", timeout=2) as response:
+            if response.status != 200:
+                return {}
+            payload = json.loads(response.read().decode("utf-8"))
+            status = payload.get("brain_backend_status")
+            return status if isinstance(status, dict) else {}
+    except (URLError, TimeoutError, json.JSONDecodeError):
+        return {}
+
+
+def health_from_brain_backend(
+    status: dict[str, object], mode: str
+) -> tuple[str, str]:
+    if not status:
+        return ("warn", "unknown") if mode == HOSTED_MODE else ("warn", "not reported")
+
+    connected = bool(status.get("connected", False))
+    state = str(status.get("state", "unknown") or "unknown")
+    message = str(status.get("message", "") or "")
+    label = state.replace("_", " ")
+
+    if connected:
+        return "healthy", "connected"
+    if state == "invalid_config" and "KEY" in message.upper():
+        return "error", "missing key"
+    if state == "invalid_config":
+        return "error", "invalid config"
+    if state in {"connection_error", "backend_error", "disconnected", "stopped"}:
+        return "error", label
+    if state in {"unknown", "starting", "configured", "connecting", "authenticating"}:
+        return "warn", label
+    return "warn", label
+
+
 def set_simulator_log_mode(port: str, mode: str) -> bool:
     payload = json.dumps({"mode": mode}).encode("utf-8")
     request = Request(
@@ -2340,6 +2398,10 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
         and tcp_port_open(rosbridge_port)
     )
     metrics = fetch_simulator_metrics(simulator_port) if sim_running else {}
+    backend_status = fetch_brain_backend_status(simulator_port) if sim_running else {}
+    backend_level, backend_label = health_from_brain_backend(
+        backend_status, str(config["mode"])
+    )
     queue_sizes = metrics.get("queue_sizes", {}) if isinstance(metrics, dict) else {}
     sim_log_mode = (
         str(metrics.get("sim_log_mode", config.get("sim_log_mode", "quiet")))
@@ -2366,7 +2428,7 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
         brain_label = "brain booting"
     elif rosbridge_live:
         brain_level = "healthy"
-        brain_label = "connected"
+        brain_label = "ros ready"
     else:
         brain_level = "warn"
         brain_label = "booting"
@@ -2377,9 +2439,9 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
     )
     agent_label = "hosted" if config["mode"] == HOSTED_MODE else ("online" if agent_running else "offline")
 
-    if all(level == "healthy" for level in (video_level, transport_level, brain_level, agent_level)):
+    if all(level == "healthy" for level in (video_level, transport_level, brain_level, backend_level, agent_level)):
         stack_mood = ("healthy", "LIVE")
-    elif any(level == "error" for level in (video_level, transport_level, brain_level)):
+    elif any(level == "error" for level in (video_level, transport_level, brain_level, backend_level)):
         stack_mood = ("error", "DEGRADED")
     else:
         stack_mood = ("warn", "WARMING")
@@ -2403,7 +2465,8 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
     system_summary = (
         f"os {'up' if os_running else 'down'} | "
         f"sim {'up' if sim_running else 'down'} | "
-        f"brain {'ok' if brain_level == 'healthy' else brain_label}"
+        f"brain {'ok' if brain_level == 'healthy' else brain_label} | "
+        f"backend {'ok' if backend_level == 'healthy' else backend_label}"
     )
 
     return {
@@ -2427,6 +2490,9 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
         "queue_load_score": queue_load_score(transport_level, queue_peak),
         "brain_level": brain_level,
         "brain_label": brain_label,
+        "backend_status": backend_status,
+        "backend_level": backend_level,
+        "backend_label": backend_label,
         "agent_level": agent_level,
         "agent_label": agent_label,
         "stack_level": stack_mood[0],
@@ -2481,6 +2547,7 @@ def render_status(
                 f"{BOLD}Video:{NC} {format_level(str(snapshot['video_level']), str(snapshot['video_label']))}",
                 f"{BOLD}Transport:{NC} {format_level(str(snapshot['transport_level']), str(snapshot['transport_label']))}",
                 f"{BOLD}Brain:{NC} {format_level(str(snapshot['brain_level']), str(snapshot['brain_label']))}",
+                f"{BOLD}Backend:{NC} {format_level(str(snapshot['backend_level']), str(snapshot['backend_label']))}",
                 f"{BOLD}Agent:{NC} {format_level(str(snapshot['agent_level']), str(snapshot['agent_label']))}",
             ]
         ),

--- a/ros2_ws/src/brain/brain_client/brain_client/message_types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/message_types.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from typing import Dict, Optional, List, Any
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, field_serializer, field_validator
 
 
 class NavigationToPosition(BaseModel):
@@ -53,6 +53,15 @@ class MessageIn(BaseModel):
 class MessageOut(BaseModel):
     type: MessageOutType
     payload: Dict[str, Any]
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def normalize_message_out_type(cls, value):
+        if isinstance(value, str) and "/" in value:
+            suffix = value.rsplit("/", 1)[-1]
+            if suffix in MessageOutType._value2member_map_:
+                return suffix
+        return value
 
     @field_serializer("type")
     def serialize_message_out_type(self, value: MessageOutType) -> str:

--- a/ros2_ws/src/brain/brain_client/brain_client/ws_bridge.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/ws_bridge.py
@@ -6,6 +6,16 @@ from std_msgs.msg import String
 from brain_client.message_types import MessageOut, MessageOutType
 
 
+def _payload_summary(data):
+    payload = data.get("payload")
+    if isinstance(payload, dict):
+        keys = ", ".join(sorted(str(key) for key in payload.keys())[:8])
+        return f" payload keys=[{keys}]"
+    if payload is None:
+        return " payload=<missing>"
+    return f" payload_type={type(payload).__name__}"
+
+
 class WSBridge:
     """
     WSBridge subscribes to a ROS topic (default "ws_messages") where the WSClient node publishes
@@ -60,7 +70,11 @@ class WSBridge:
         try:
             ws_msg = MessageOut.model_validate(data)
         except Exception as e:
-            self.node.get_logger().error(f"WSBridge: Message validation error: {e}")
+            first_line = str(e).splitlines()[0]
+            self.node.get_logger().error(
+                "WSBridge: Incoming backend message is not supported "
+                f"(type={msg_type_str!r},{_payload_summary(data)}): {first_line}"
+            )
             return
 
         # Dispatch to the registered handler for this message type.

--- a/ros2_ws/src/brain/brain_client/brain_client/ws_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/ws_client_node.py
@@ -20,6 +20,19 @@ from brain_client.message_types import (
 )
 
 
+PLACEHOLDER_SERVICE_KEYS = {
+    "my_hardcoded_token",
+    "your_service_key_here",
+    "your-service-key-here",
+    "replace_me",
+    "changeme",
+    "change_me",
+    "todo",
+}
+
+CONNECTED_GRACE_SECONDS = 2.0
+
+
 ###############################################################################
 # WSClient class – largely unchanged, but now it relies on its node to publish.
 ###############################################################################
@@ -42,7 +55,12 @@ class WSClient:
         max_reconnect_delay = 30  # Max 30 seconds between retries
         
         while rclpy.ok() and not self.node.exit_event.is_set():
+            disconnect_reason = "Connection lost."
+            status_reported = False
             self.node.get_logger().info(f"[WSClient] Connecting to {self.uri} ...")
+            self.node.set_ws_status(
+                "connecting", False, f"Connecting to {self.uri}"
+            )
             try:
                 # Set a longer timeout that works for all operations
                 async with websockets.connect(
@@ -51,7 +69,11 @@ class WSClient:
                     ping_timeout=60,  # Wait up to 60 seconds for a pong response
                 ) as websocket:
                     self.websocket = websocket
-                    self.node.get_logger().info(f"[WSClient] Connected to {self.uri}")
+                    self.node.set_ws_status(
+                        "authenticating",
+                        False,
+                        f"Socket opened to {self.uri}; authenticating.",
+                    )
                     reconnect_delay = 1  # Reset delay on successful connection
 
                     # Send auth message upon connection.
@@ -64,10 +86,17 @@ class WSClient:
                     )
                     await self.send(auth_msg)
                     self.node.get_logger().debug(f"[WSClient] Auth message sent with version: {self.robot_version}")
+                    self.node.set_ws_status(
+                        "authenticating",
+                        False,
+                        "Auth message sent; waiting for backend confirmation.",
+                    )
 
-                    await self.listen()
+                    disconnect_reason = await self.listen()
             except Exception as e:
-                self.node.get_logger().error(f"[WSClient] Connection error: {e}")
+                disconnect_reason = f"Connection error: {e}"
+                self.node.set_ws_status("connection_error", False, disconnect_reason)
+                status_reported = True
             
             self.websocket = None
             
@@ -75,29 +104,64 @@ class WSClient:
             if self.node.exit_event.is_set() or not rclpy.ok():
                 break
                 
-            self.node.get_logger().warn(f"[WSClient] Connection lost. Reconnecting in {reconnect_delay}s...")
+            self.node.get_logger().warn(
+                f"[WSClient] {disconnect_reason} Reconnecting in {reconnect_delay}s..."
+            )
+            if not status_reported:
+                self.node.set_ws_status(
+                    "disconnected",
+                    False,
+                    f"{disconnect_reason} Reconnecting in {reconnect_delay}s.",
+                )
             await asyncio.sleep(reconnect_delay)
             reconnect_delay = min(reconnect_delay * 2, max_reconnect_delay)  # Exponential backoff
 
         self.node.get_logger().info("[WSClient] Stopping WSClient.")
         self.websocket = None
+        self.node.set_ws_status("stopped", False, "WebSocket client stopped.")
 
     async def listen(self):
+        connected_started_at = time.time()
+        connected_reported = False
+
         while rclpy.ok() and not self.node.exit_event.is_set():
             try:
                 # Use longer timeout to reduce CPU spin; we'll wake immediately on message
                 incoming = await asyncio.wait_for(self.websocket.recv(), timeout=1.0)
             except asyncio.TimeoutError:
+                if (
+                    not connected_reported
+                    and time.time() - connected_started_at >= CONNECTED_GRACE_SECONDS
+                ):
+                    self.node.get_logger().info(f"[WSClient] Connected to {self.uri}")
+                    self.node.set_ws_status(
+                        "connected", True, f"Connected to {self.uri}"
+                    )
+                    connected_reported = True
                 # No message received, just continue the loop (no extra sleep needed)
                 continue
-            except websockets.exceptions.ConnectionClosed:
-                self.node.get_logger().warn("WebSocket connection closed by server.")
-                break
+            except websockets.exceptions.ConnectionClosed as e:
+                reason = e.reason or "no reason"
+                message = (
+                    f"WebSocket connection closed by server "
+                    f"(code={e.code}, reason={reason})."
+                )
+                if (
+                    reason == "no reason"
+                    and self.node._last_ws_error_message
+                    and time.time() - self.node._last_ws_error_at < 60.0
+                ):
+                    message = f"{message} Last backend error: {self.node._last_ws_error_message}"
+                return message
 
             # Check for error messages (especially version_mismatch)
             try:
                 data = json.loads(incoming)
-                if data.get("type") == "error":
+                msg_type = data.get("type")
+                normalized_type = (
+                    msg_type.rsplit("/", 1)[-1] if isinstance(msg_type, str) else msg_type
+                )
+                if normalized_type == "error":
                     payload = data.get("payload", {})
                     error_type = payload.get("error", "unknown")
                     message = payload.get("message", "Unknown error")
@@ -105,11 +169,21 @@ class WSClient:
             except json.JSONDecodeError:
                 pass  # Not valid JSON, just forward it
 
+            if (
+                not connected_reported
+                and time.time() - connected_started_at >= CONNECTED_GRACE_SECONDS
+            ):
+                self.node.get_logger().info(f"[WSClient] Connected to {self.uri}")
+                self.node.set_ws_status("connected", True, f"Connected to {self.uri}")
+                connected_reported = True
+
             # Forward the raw JSON string from the WS server by publishing it.
             self.node.get_logger().debug(f"Forwarding incoming message: {incoming}")
             ros_msg = String()
             ros_msg.data = incoming
             self.node.ws_pub.publish(ros_msg)
+
+        return "WebSocket listener stopped."
 
     async def send(self, msg):
         if self.websocket is not None:
@@ -130,17 +204,57 @@ class WSClientNode(Node):
             self.get_parameter("websocket_uri").get_parameter_value().string_value
         )
         self.token = self.get_parameter("token").get_parameter_value().string_value
+        self.exit_event = threading.Event()
+
+        self._ws_status_pub = self.create_publisher(
+            String, "/brain/websocket_status", 10
+        )
+        self._ws_status = {
+            "state": "starting",
+            "connected": False,
+            "message": "WebSocket client starting.",
+            "uri": self.ws_uri,
+            "hosted": False,
+            "timestamp": time.time(),
+        }
+        self._ws_status_timer = self.create_timer(2.0, self._publish_ws_status)
+        self._last_backend_unavailable_log_key = None
+        self._last_backend_unavailable_log_at = 0.0
+        self._last_invalid_config_log_at = 0.0
+        self._last_ws_error_message = ""
+        self._last_ws_error_at = 0.0
 
         # Validate websocket URI early
         self._ws_configured = self._validate_ws_uri(self.ws_uri)
         if not self._ws_configured:
-            self.get_logger().error("❌ WebSocket URI not configured or invalid. Set 'websocket_uri' parameter (must start with ws:// or wss://).")
+            self._log_invalid_config_once(
+                "❌ WebSocket URI not configured or invalid. Set 'websocket_uri' "
+                "parameter (must start with ws:// or wss://)."
+            )
         self._hosted_innate_uri = self._is_hosted_innate_uri(self.ws_uri)
         self._token_configured = self._validate_token_for_uri(self.ws_uri, self.token)
         if not self._token_configured:
-            self.get_logger().error(
-                "❌ Missing INNATE_SERVICE_KEY for hosted Innate agent. "
-                "This client cannot authenticate to the hosted agent without a token."
+            self._log_invalid_config_once(
+                "❌ Missing or placeholder INNATE_SERVICE_KEY for hosted Innate agent. "
+                "Set a real service key before connecting to the hosted agent."
+            )
+        if not self._ws_configured:
+            self.set_ws_status(
+                "invalid_config",
+                False,
+                "WebSocket URI is not configured or invalid.",
+            )
+        elif not self._token_configured:
+            self.set_ws_status(
+                "invalid_config",
+                False,
+                "Missing or placeholder INNATE_SERVICE_KEY for hosted Innate agent.",
+            )
+        else:
+            self.set_ws_status(
+                "configured",
+                False,
+                "WebSocket configured; waiting for connection request.",
             )
 
         # Robot version from /robot/info
@@ -160,8 +274,6 @@ class WSClientNode(Node):
             String, "ws_outgoing", self.ws_outgoing_callback, 10
         )
 
-        self.exit_event = threading.Event()
-
         # Set up the WSClient (only if configured).
         if self._ws_configured and self._token_configured:
             self.ws_client = WSClient(self.ws_uri, self.token, self, self._robot_version)
@@ -171,6 +283,55 @@ class WSClientNode(Node):
         # Start the websocket event loop in a separate thread.
         self.ws_thread = None
         self.get_logger().info("WSClientNode initialized.")
+
+    def set_ws_status(self, state: str, connected: bool, message: str):
+        """Update and publish cloud/local-agent websocket status."""
+        self._ws_status = {
+            "state": state,
+            "connected": connected,
+            "message": message,
+            "uri": self.ws_uri,
+            "hosted": self._hosted_innate_uri,
+            "timestamp": time.time(),
+        }
+        self._publish_ws_status()
+        self._log_backend_unavailable_once(state, connected, message)
+
+    def _log_backend_unavailable_once(
+        self, state: str, connected: bool, message: str
+    ):
+        if connected or state in {"starting", "configured", "connecting", "authenticating"}:
+            return
+
+        now = time.time()
+        key = (state, message)
+        if (
+            key == self._last_backend_unavailable_log_key
+            and now - self._last_backend_unavailable_log_at < 30.0
+        ):
+            return
+
+        self._last_backend_unavailable_log_key = key
+        self._last_backend_unavailable_log_at = now
+        self.get_logger().error(
+            "[WSClient] Brain backend unavailable "
+            f"(state={state}, uri={self.ws_uri}): {message}"
+        )
+
+    def _log_invalid_config_once(self, message: str):
+        now = time.time()
+        if now - self._last_invalid_config_log_at < 30.0:
+            return
+        self._last_invalid_config_log_at = now
+        self.get_logger().error(message)
+
+    def _publish_ws_status(self):
+        try:
+            msg = String()
+            msg.data = json.dumps(self._ws_status)
+            self._ws_status_pub.publish(msg)
+        except Exception as e:
+            self.get_logger().debug(f"Failed to publish websocket status: {e}")
 
     def _robot_info_callback(self, msg: String):
         """Callback to extract robot version from /robot/info."""
@@ -198,11 +359,17 @@ class WSClientNode(Node):
 
     def _handle_ws_error(self, error_type: str, message: str):
         """Handle WebSocket error messages."""
+        self._last_ws_error_message = f"{error_type}: {message}"
+        self._last_ws_error_at = time.time()
         if error_type == "version_mismatch":
             self._speak_error(message)
             self.get_logger().error(f"Version mismatch: {message}")
+            self.set_ws_status("backend_error", False, f"Version mismatch: {message}")
         else:
-            self.get_logger().warn(f"WebSocket error: {error_type} - {message}")
+            self.get_logger().error(f"WebSocket error: {error_type} - {message}")
+            self.set_ws_status(
+                "backend_error", False, f"Backend error ({error_type}): {message}"
+            )
 
     def _validate_ws_uri(self, uri: str) -> bool:
         """Check if the websocket URI is valid."""
@@ -218,7 +385,10 @@ class WSClientNode(Node):
     def _validate_token_for_uri(self, uri: str, token: str) -> bool:
         if not self._is_hosted_innate_uri(uri):
             return True
-        return bool(token and token.strip())
+        normalized = (token or "").strip()
+        if not normalized:
+            return False
+        return normalized.lower() not in PLACEHOLDER_SERVICE_KEYS
 
     def ws_outgoing_callback(self, msg: String):
         """
@@ -240,12 +410,24 @@ class WSClientNode(Node):
                 self.get_logger().info(f"Internal message: {internal_message}")
                 if internal_message.type == InternalMessageType.READY_FOR_CONNECTION:
                     if not self._ws_configured:
-                        self.get_logger().error("WebSocket not configured, ignoring connection request.")
+                        self._log_invalid_config_once(
+                            "WebSocket not configured, ignoring connection request."
+                        )
+                        self.set_ws_status(
+                            "invalid_config",
+                            False,
+                            "WebSocket URI is not configured or invalid.",
+                        )
                         return
                     if not self._token_configured:
-                        self.get_logger().error(
-                            "Hosted Innate agent selected but INNATE_SERVICE_KEY is missing. "
+                        self._log_invalid_config_once(
+                            "Hosted Innate agent selected but INNATE_SERVICE_KEY is missing or a placeholder. "
                             "Skipping websocket connection."
+                        )
+                        self.set_ws_status(
+                            "invalid_config",
+                            False,
+                            "Missing or placeholder INNATE_SERVICE_KEY for hosted Innate agent.",
                         )
                         return
                     self.get_logger().debug("Received ready for connection message.")
@@ -260,7 +442,12 @@ class WSClientNode(Node):
                 self.get_logger().debug(f"Outgoing message: {outgoing_message.type}")
 
                 # Check if the loop exists and is running before trying to send
-                if self.ws_client and self.ws_client.loop and self.ws_client.loop.is_running():
+                if not self.ws_client:
+                    self._log_invalid_config_once(
+                        "Cannot send websocket message: hosted Innate agent is not configured "
+                        "(missing or placeholder INNATE_SERVICE_KEY)."
+                    )
+                elif self.ws_client.loop and self.ws_client.loop.is_running():
                     try:
                         asyncio.run_coroutine_threadsafe(
                             self.ws_client.send(outgoing_message), self.ws_client.loop

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import gc
+import sys
 import time
 import threading
+from pathlib import Path
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import Image, JointState
@@ -20,6 +22,13 @@ import json
 from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
 from rclpy.executors import MultiThreadedExecutor
 import h5py
+
+_script_dir = Path(__file__).resolve().parent
+_package_parent = (
+    _script_dir if (_script_dir / "manipulation").is_dir() else _script_dir.parent
+)
+if str(_package_parent) not in sys.path:
+    sys.path.insert(0, str(_package_parent))
 
 # Enable CUDNN for better performance
 torch.backends.cudnn.enabled = True

--- a/sim/frontend/src/App.tsx
+++ b/sim/frontend/src/App.tsx
@@ -6,12 +6,56 @@ import { ImageDisplay } from "./components/ImageDisplay";
 import { Chat } from "./components/Chat";
 import {
   AvailableAgentsResponse,
+  BrainBackendStatus,
   RobotAgent,
   getAvailableAgentsDirect,
   resetBrainDirect,
   setBrainActiveDirect,
   setDirectiveDirect,
 } from "./services/rosbridgeService";
+
+const AGENT_BACKEND_WARNING_DELAY_MS = 15_000;
+const BACKEND_CONNECTED_STABLE_MS = 3_000;
+const BACKEND_WARMUP_STATES = new Set([
+  "unknown",
+  "starting",
+  "configured",
+  "connecting",
+  "authenticating",
+]);
+
+function formatBackendState(state?: string | null) {
+  return (state || "unknown").replace(/_/g, " ");
+}
+
+function isBackendWarningStatus(
+  status: BrainBackendStatus | null,
+  timedOut: boolean,
+) {
+  if (!status) {
+    return false;
+  }
+
+  if (status.connected) {
+    return timedOut && !isBackendConnectedStable(status);
+  }
+
+  const state = status.state || "unknown";
+  return timedOut || !BACKEND_WARMUP_STATES.has(state);
+}
+
+function isBackendConnectedStable(status: BrainBackendStatus | null) {
+  if (!status?.connected) {
+    return false;
+  }
+
+  const timestamp = status.timestamp ?? status.updated_at;
+  if (typeof timestamp !== "number") {
+    return true;
+  }
+
+  return Date.now() - timestamp * 1000 >= BACKEND_CONNECTED_STABLE_MS;
+}
 
 // Main App Container
 const AppContainer = styled.div`
@@ -66,9 +110,10 @@ const Logo = styled.div`
   }
 `;
 
-const StatusBadge = styled.div`
+const StatusBadge = styled.div<{ $isWarning?: boolean }>`
   margin-right: 16px;
-  background: ${({ theme }) => theme.colors.primary};
+  background: ${({ $isWarning, theme }) =>
+    $isWarning ? theme.colors.error : theme.colors.primary};
   color: white;
   padding: 6px 16px;
   border-radius: 20px;
@@ -237,9 +282,41 @@ const AgentItem = styled.div<{ $isActive: boolean }>`
   }
 `;
 
+const AgentStatusItem = styled.div`
+  padding: 12px 16px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.foreground};
+  font-size: 13px;
+  font-weight: 500;
+  opacity: 0.65;
+`;
+
 const AgentName = styled.span`
   font-size: 13px;
   font-weight: 500;
+`;
+
+const AgentNotice = styled.div`
+  margin: 12px 16px;
+  padding: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.error};
+  background: rgba(255, 59, 59, 0.12);
+  color: ${({ theme }) => theme.colors.foreground};
+`;
+
+const AgentNoticeTitle = styled.div`
+  color: ${({ theme }) => theme.colors.error};
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.3;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+`;
+
+const AgentNoticeDetail = styled.div`
+  font-size: 12px;
+  line-height: 1.45;
+  opacity: 0.85;
+  word-break: break-word;
 `;
 
 const AgentCheck = styled.div<{ $isActive: boolean }>`
@@ -476,9 +553,17 @@ export default function App() {
   const [activeAgent, setActiveAgent] = useState<string | null>(null);
   const [agents, setAgents] = useState<RobotAgent[]>([]);
   const [isLoadingAgents, setIsLoadingAgents] = useState(true);
+  const [agentAvailabilityWarning, setAgentAvailabilityWarning] = useState<
+    string | null
+  >(null);
+  const [brainBackendStatus, setBrainBackendStatus] =
+    useState<BrainBackendStatus | null>(null);
+  const [agentLoadTimedOut, setAgentLoadTimedOut] = useState(false);
+  const [backendWarmupTimedOut, setBackendWarmupTimedOut] = useState(false);
   const hasAgentsRef = useRef(false);
   const isFetchingAgentsRef = useRef(false);
   const blockedAgentsFetchUntilRef = useRef(0);
+  const agentsLoadStartedAtRef = useRef(Date.now());
   const useDirectRobot = import.meta.env.VITE_DIRECT_ROBOT === "true";
   const robotWsUrl = import.meta.env.VITE_ROBOT_WS_URL ?? "ws://localhost:9090";
   const [viewMode, setViewMode] = useState<"frontFocus" | "map">("frontFocus");
@@ -591,18 +676,50 @@ export default function App() {
           const baseUrl =
             import.meta.env.VITE_SIM_BASE_URL ?? "http://localhost:8000";
           const response = await fetch(`${baseUrl}/get_available_agents`);
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
           data = (await response.json()) as AvailableAgentsResponse;
         }
+
+        if (data.brain_backend_status) {
+          setBrainBackendStatus(data.brain_backend_status);
+        }
+        const warningDelayElapsed =
+          Date.now() - agentsLoadStartedAtRef.current >=
+          AGENT_BACKEND_WARNING_DELAY_MS;
+        setBackendWarmupTimedOut(warningDelayElapsed);
+        const backendWarnsNow = isBackendWarningStatus(
+          data.brain_backend_status ?? null,
+          warningDelayElapsed,
+        );
 
         if (data.agents && data.agents.length > 0) {
           setAgents(data.agents);
           hasAgentsRef.current = true;
+          setAgentAvailabilityWarning(null);
+          setAgentLoadTimedOut(false);
+          setIsLoadingAgents(false);
           setActiveAgent((previousAgentId) =>
             previousAgentId &&
             data.agents.some((agent) => agent.id === previousAgentId)
               ? previousAgentId
               : null,
           );
+        } else {
+          const timedOut = warningDelayElapsed;
+          setAgentLoadTimedOut(timedOut);
+          if (timedOut || backendWarnsNow) {
+            setIsLoadingAgents(false);
+          }
+          if (timedOut) {
+            setAgentAvailabilityWarning(
+              data.error ||
+                "The brain has not reported any available behavior agents yet.",
+            );
+          } else {
+            setAgentAvailabilityWarning(null);
+          }
         }
       } catch (error) {
         const errorMessage =
@@ -613,18 +730,29 @@ export default function App() {
             "[Agents] /brain/get_available_directives timed out. Pausing retries for 60s.",
           );
         }
+        const timedOut =
+          Date.now() - agentsLoadStartedAtRef.current >=
+            AGENT_BACKEND_WARNING_DELAY_MS ||
+          errorMessage.includes("timed out");
+        setAgentLoadTimedOut(timedOut);
+        if (timedOut) {
+          setIsLoadingAgents(false);
+          setAgentAvailabilityWarning(
+            `Unable to load behavior agents: ${errorMessage}`,
+          );
+        }
         console.error("Error fetching agents:", error);
       } finally {
         isFetchingAgentsRef.current = false;
-        setIsLoadingAgents(false);
       }
     };
 
     fetchAgents();
 
-    // Poll for agents every 5 seconds until we have some
+    // Poll until agents are loaded, and keep polling the sim backend so
+    // brain/cloud-agent connection warnings can recover without a refresh.
     const intervalId = setInterval(async () => {
-      if (!hasAgentsRef.current) {
+      if (!useDirectRobot || !hasAgentsRef.current) {
         await fetchAgents();
       }
     }, 5000);
@@ -958,6 +1086,29 @@ export default function App() {
     }
   }
 
+  const backendStatusIsWarning = isBackendWarningStatus(
+    brainBackendStatus,
+    backendWarmupTimedOut || agentLoadTimedOut,
+  );
+  const backendIsBrieflyConnected =
+    brainBackendStatus?.connected && !isBackendConnectedStable(brainBackendStatus);
+  const agentWarning = backendStatusIsWarning
+    ? {
+        title: backendIsBrieflyConnected
+          ? "Brain backend connecting"
+          : "Brain backend disconnected",
+        detail: backendIsBrieflyConnected
+          ? "The websocket opened briefly; waiting for the backend to stay connected."
+          : brainBackendStatus?.message ||
+            `Status: ${formatBackendState(brainBackendStatus?.state)}`,
+      }
+    : agentAvailabilityWarning
+      ? {
+          title: "Behavior agents unavailable",
+          detail: agentAvailabilityWarning,
+        }
+      : null;
+
   return (
     <AppContainer>
       <Header>
@@ -981,9 +1132,9 @@ export default function App() {
           <Logo>INNATE SIM</Logo>
         </div>
         <div></div>
-        <StatusBadge>
+        <StatusBadge $isWarning={Boolean(agentWarning)}>
           <StatusDot />
-          System Active
+          {agentWarning ? "Agent Offline" : "System Active"}
         </StatusBadge>
       </Header>
 
@@ -1029,14 +1180,18 @@ export default function App() {
           <PanelSection style={{ flex: 1 }}>
             <PanelHeader>Behavior Agents</PanelHeader>
             <div>
-              {isLoadingAgents ? (
-                <AgentItem $isActive={false}>
-                  <AgentName>Loading agents...</AgentName>
-                </AgentItem>
-              ) : agents.length === 0 ? (
-                <AgentItem $isActive={false}>
-                  <AgentName>Waiting for robot connection</AgentName>
-                </AgentItem>
+              {agentWarning && (
+                <AgentNotice role="alert">
+                  <AgentNoticeTitle>{agentWarning.title}</AgentNoticeTitle>
+                  <AgentNoticeDetail>{agentWarning.detail}</AgentNoticeDetail>
+                </AgentNotice>
+              )}
+              {agents.length === 0 ? (
+                isLoadingAgents ? (
+                  <AgentStatusItem>Loading agents...</AgentStatusItem>
+                ) : agentWarning ? null : (
+                  <AgentStatusItem>Waiting for robot connection</AgentStatusItem>
+                )
               ) : (
                 agents.map((agent) => (
                   <AgentItem

--- a/sim/frontend/src/services/rosbridgeService.ts
+++ b/sim/frontend/src/services/rosbridgeService.ts
@@ -6,10 +6,21 @@ export interface RobotAgent {
   skills: string[];
 }
 
+export interface BrainBackendStatus {
+  state: string;
+  connected: boolean;
+  message?: string | null;
+  updated_at?: number | null;
+  timestamp?: number | null;
+  uri?: string | null;
+  hosted?: boolean | null;
+}
+
 export interface AvailableAgentsResponse {
   agents: RobotAgent[];
   current_agent_id: string | null;
   startup_agent_id: string | null;
+  brain_backend_status?: BrainBackendStatus;
   error?: string;
 }
 

--- a/sim/src/agent/agent_websocket_bridge.py
+++ b/sim/src/agent/agent_websocket_bridge.py
@@ -33,6 +33,16 @@ from src.shared_queues import ChatMessage, ChatSignal, AgentInfo
 from src.agent.navigation_controller import NavigationController
 
 
+BACKEND_WARMUP_STATES = {
+    "unknown",
+    "starting",
+    "configured",
+    "connecting",
+    "authenticating",
+}
+BACKEND_STATUS_LOG_INTERVAL_SEC = 30.0
+
+
 def np_encoder(obj):
     """JSON serializer that converts numpy.* types to native Python types."""
     if isinstance(obj, np.generic):
@@ -40,6 +50,39 @@ def np_encoder(obj):
     if isinstance(obj, np.ndarray):
         return obj.tolist()
     raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+
+
+def log_brain_backend_status(shared_queues, status: dict):
+    """Emit low-noise logs matching the frontend brain backend warning state."""
+    state = str(status.get("state", "unknown") or "unknown")
+    connected = bool(status.get("connected", False))
+    message = status.get("message") or ""
+    uri = status.get("uri") or "unknown"
+    now = time.time()
+
+    if connected:
+        key = ("connected", uri)
+        if getattr(shared_queues, "_last_brain_backend_log_key", None) != key:
+            print(f"[ROSBridge] Brain backend connected (uri={uri}).")
+            shared_queues._last_brain_backend_log_key = key
+            shared_queues._last_brain_backend_log_at = now
+        return
+
+    if state in BACKEND_WARMUP_STATES:
+        return
+
+    key = (state, message, uri)
+    last_key = getattr(shared_queues, "_last_brain_backend_log_key", None)
+    last_at = getattr(shared_queues, "_last_brain_backend_log_at", 0.0)
+    if key == last_key and now - last_at < BACKEND_STATUS_LOG_INTERVAL_SEC:
+        return
+
+    print(
+        "[ROSBridge] ERROR: Brain backend unavailable "
+        f"(state={state}, uri={uri}): {message}"
+    )
+    shared_queues._last_brain_backend_log_key = key
+    shared_queues._last_brain_backend_log_at = now
 
 
 #
@@ -145,6 +188,18 @@ async def inbound_data_loop(ws, shared_queues):
                     )
                     # Forward to sim
                     shared_queues.chat_from_bridge.put_nowait(chat_msg)
+
+            elif topic == "/brain/websocket_status":
+                raw_status = msg_data.get("data", "{}")
+                try:
+                    status = json.loads(raw_status)
+                    if isinstance(status, dict):
+                        shared_queues.update_brain_backend_status(status)
+                        log_brain_backend_status(shared_queues, status)
+                except json.JSONDecodeError:
+                    print(
+                        f"[ROSBridge] Failed to parse /brain/websocket_status JSON: {raw_status}"
+                    )
 
             # 3) /sim_navigation/global_plan
             elif topic == "/sim_navigation/global_plan":
@@ -460,6 +515,9 @@ async def outbound_data_loop(ws, shared_queues, service_call_queue):
     # Also subscribe to /cmd_vel, /chat_out, and navigation topics
     sub_cmd_vel = rosbridge_subscribe("/cmd_vel", "geometry_msgs/msg/Twist")
     sub_chat_out = rosbridge_subscribe("/brain/chat_out", "std_msgs/msg/String")
+    sub_brain_ws_status = rosbridge_subscribe(
+        "/brain/websocket_status", "std_msgs/msg/String"
+    )
     sub_nav_path = rosbridge_subscribe(
         "/sim_navigation/global_plan", "nav_msgs/msg/Path"
     )
@@ -469,11 +527,12 @@ async def outbound_data_loop(ws, shared_queues, service_call_queue):
     )
     await ws.send(json.dumps(sub_cmd_vel))
     await ws.send(json.dumps(sub_chat_out))
+    await ws.send(json.dumps(sub_brain_ws_status))
     await ws.send(json.dumps(sub_nav_path))
     await ws.send(json.dumps(sub_nav_cancel))
     await ws.send(json.dumps(sub_arm_cmd))
     print(
-        "[ROSBridge] Subscribed to /cmd_vel, /brain/chat_out, /mars/arm/commands, and navigation topics"
+        "[ROSBridge] Subscribed to /cmd_vel, /brain/chat_out, /brain/websocket_status, /mars/arm/commands, and navigation topics"
     )
 
     # Initialize navigation controller
@@ -653,6 +712,8 @@ async def outbound_service_loop(ws, shared_queues, service_call_queue):
     )
     await ws.send(json.dumps(srv_get_agents))
     print("[ROSBridge] [service] Called /brain/get_available_directives")
+    last_agents_refresh_at = time.time()
+    agents_retry_interval = 5.0
 
     # Process queued service calls from the data loop
     while not shared_queues.exit_event.is_set():
@@ -662,6 +723,16 @@ async def outbound_service_loop(ws, shared_queues, service_call_queue):
             service_name = srv_msg.get("service", "unknown")
             print(f"[ROSBridge] [service] Forwarded call_service: {service_name}")
         except asyncio.TimeoutError:
+            agents, _, _ = shared_queues.get_available_agents()
+            now = time.time()
+            if not agents and now - last_agents_refresh_at >= agents_retry_interval:
+                retry_get_agents = rosbridge_call_service(
+                    "/brain/get_available_directives",
+                    "brain_messages/srv/GetAvailableDirectives",
+                )
+                await ws.send(json.dumps(retry_get_agents))
+                last_agents_refresh_at = now
+                print("[ROSBridge] [service] Retrying /brain/get_available_directives")
             continue
         except websockets.exceptions.ConnectionClosed:
             print("[ROSBridge] Service connection closed in outbound_service_loop.")

--- a/sim/src/routes/video_api.py
+++ b/sim/src/routes/video_api.py
@@ -202,11 +202,20 @@ def get_available_agents(request: Request):
                 "current_agent_id": None,
                 "startup_agent_id": None,
                 "error": "Simulation not initialized",
+                "brain_backend_status": {
+                    "state": "sim_not_initialized",
+                    "connected": False,
+                    "message": "Simulation not initialized",
+                    "updated_at": time.time(),
+                    "uri": None,
+                    "hosted": None,
+                },
             },
             status_code=200,
         )
 
     agents, current_agent_id, startup_agent_id = shared_queues.get_available_agents()
+    brain_backend_status = shared_queues.get_brain_backend_status()
 
     # Convert AgentInfo namedtuples to dicts for JSON serialization
     agents_data = [
@@ -225,5 +234,6 @@ def get_available_agents(request: Request):
             "agents": agents_data,
             "current_agent_id": current_agent_id,
             "startup_agent_id": startup_agent_id,
+            "brain_backend_status": brain_backend_status,
         }
     )

--- a/sim/src/shared_queues.py
+++ b/sim/src/shared_queues.py
@@ -75,6 +75,17 @@ class SharedQueues:
         self.startup_agent_id: Optional[str] = None
         self.agents_lock = threading.Lock()  # For thread-safe updates
 
+        # Store the brain client's cloud/local-agent websocket state for the UI.
+        self.brain_backend_status: Dict[str, Any] = {
+            "state": "unknown",
+            "connected": False,
+            "message": "Waiting for brain backend status",
+            "updated_at": None,
+            "uri": None,
+            "hosted": None,
+        }
+        self.brain_backend_status_lock = threading.Lock()
+
         # One-shot status map for /set_environment request/response.
         # Key: request_id, Value: {"success": bool, "error": Optional[str]}
         self.environment_apply_results: Dict[str, Dict[str, Any]] = {}
@@ -164,6 +175,27 @@ class SharedQueues:
                 self.current_agent_id,
                 self.startup_agent_id,
             )
+
+    def update_brain_backend_status(self, status: Dict[str, Any]):
+        """Thread-safe method to update brain/cloud backend connection status."""
+        now = time.time()
+        with self.brain_backend_status_lock:
+            self.brain_backend_status.update(
+                {
+                    "state": str(status.get("state", "unknown") or "unknown"),
+                    "connected": bool(status.get("connected", False)),
+                    "message": status.get("message") or "",
+                    "updated_at": now,
+                    "uri": status.get("uri"),
+                    "hosted": status.get("hosted"),
+                    "timestamp": status.get("timestamp"),
+                }
+            )
+
+    def get_brain_backend_status(self) -> Dict[str, Any]:
+        """Thread-safe method to get brain/cloud backend connection status."""
+        with self.brain_backend_status_lock:
+            return dict(self.brain_backend_status)
 
     def set_environment_apply_result(
         self, request_id: Optional[str], success: bool, error: Optional[str] = None


### PR DESCRIPTION
## Summary
- surface hosted brain websocket status through the sim API, frontend, and launcher dashboard
- treat missing/placeholder INNATE_SERVICE_KEY as invalid config instead of a vague websocket close
- accept namespaced hosted-agent message types like brain/chat_out and make backend validation logs concise
- fix the manipulation server import path so the behavior server boots in the sim container

## Verification
- python3 -m py_compile on changed Python files
- npx eslint src/App.tsx src/services/rosbridgeService.ts
- npm run build in sim/frontend
- launched ./innate sim up --once and verified CLI + frontend show missing-key backend status