### PR TITLE
Leave sim agent unselected on load

### DIFF
--- a/sim/frontend/src/App.tsx
+++ b/sim/frontend/src/App.tsx
@@ -597,12 +597,12 @@ export default function App() {
         if (data.agents && data.agents.length > 0) {
           setAgents(data.agents);
           hasAgentsRef.current = true;
-          // Set active agent to current agent from robot, or first agent
-          if (data.current_agent_id) {
-            setActiveAgent(data.current_agent_id);
-          } else if (data.agents.length > 0) {
-            setActiveAgent(data.agents[0].id);
-          }
+          setActiveAgent((previousAgentId) =>
+            previousAgentId &&
+            data.agents.some((agent) => agent.id === previousAgentId)
+              ? previousAgentId
+              : null,
+          );
         }
       } catch (error) {
         const errorMessage =


### PR DESCRIPTION
## Summary
- keep the simulator frontend with no active agent selected on initial load
- preserve a user-selected agent only while it still exists in the available agent list

## Verification
- npm run build
- npx eslint src/App.tsx
- verified in the local frontend that no agent card is selected on initial load