### PR TITLE
Prompt for hosted service key during sim setup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,7 @@
 # Keep non-secret runtime settings in config/os.toml
 # and simulator settings in sim/config.toml.
 
+# Filled by `./innate setup` / `./innate sim setup` when you use hosted brain mode.
 INNATE_SERVICE_KEY=your_service_key_here
 
 # Explore other voices at https://play.cartesia.ai

--- a/dev/launcher/README.md
+++ b/dev/launcher/README.md
@@ -31,12 +31,12 @@ innate-os/
 
 ```bash
 cd innate-os
-./innate sim setup
+./innate setup
 ./innate sim up
 ```
 
 If any local config file does not exist yet, the CLI creates it from its template automatically.
-`./innate sim setup` prepares the Python environment, builds the simulator frontend, and downloads the required ReplicaCAD scene datasets into `sim/data/` when needed. This requires Git LFS (`brew install git-lfs && git lfs install` on macOS).
+`./innate setup` prepares the Python environment, builds the simulator frontend, and downloads the required ReplicaCAD scene datasets into `sim/data/` when needed. In hosted brain mode, it also asks for an Innate service key and stores it in `.env`. This requires Git LFS (`brew install git-lfs && git lfs install` on macOS).
 On interactive terminals, `./innate sim up` drops into a live dashboard after startup. It keeps the simulator, agent, and brain logs visible together and adds a `btop`-style metrics band at the top. Use `d` to toggle the simulator's real runtime log mode between `quiet` and `debug` without restarting, `q` to leave the dashboard while keeping the runtime running, and `Ctrl+C` to stop the full runtime.
 
 If you want the native simulator viewer window for a run:
@@ -97,7 +97,7 @@ visible URL after applying them.
 ## Notes
 
 - The CLI uses the `sim/` frontend build instead of a separate Vite dev server so the runtime stays self-contained.
-- `./innate sim setup` always bootstraps the simulator environment, frontend build, and required scene data when needed.
+- `./innate setup` and `./innate sim setup` both bootstrap the simulator environment, frontend build, required scene data, and hosted brain credentials when needed.
 - `sim/config.toml` can make the simulator start with its native viewer window by default, while `./innate sim up --vis` is the one-run override.
 - The simulator starts in quiet log mode by default. Press `d` in the dashboard to switch between `quiet` and `debug` live.
 - `status` opens as a dashboard panel with simulator logs, local agent logs, and the OS brain pane side by side when your terminal is wide enough.

--- a/dev/launcher/config.py
+++ b/dev/launcher/config.py
@@ -74,6 +74,9 @@ ENV_KEYS_MOVED_TO_OS_CONFIG = {
     "TELEMETRY_URL",
     "CARTESIA_VOICE_ID",
 }
+SECRET_ENV_KEYS = (
+    "INNATE_SERVICE_KEY",
+)
 LOG_TARGETS = {
     "bootstrap": BOOTSTRAP_LOG_PATH,
     "frontend": FRONTEND_LOG_PATH,
@@ -128,7 +131,7 @@ def ensure_env_file() -> None:
     if ENV_PATH.exists():
         return
     shutil.copyfile(ENV_TEMPLATE_PATH, ENV_PATH)
-    warn(f"Created {ENV_PATH} from template. Add your Innate service key there if needed.")
+    warn(f"Created {ENV_PATH} from template.")
 
 
 def ensure_config_file(path: Path, template_path: Path) -> None:
@@ -408,6 +411,9 @@ def get_config() -> dict[str, object]:
         for key, value in user_env.items()
         if key not in ENV_KEYS_MOVED_TO_OS_CONFIG
     }
+    for key in SECRET_ENV_KEYS:
+        if value := os.environ.get(key, "").strip():
+            raw_env[key] = value
     if ignored_os_env_keys:
         warn(
             f"Ignoring deprecated OS config keys in {ENV_PATH.name}: "

--- a/dev/launcher/config.py
+++ b/dev/launcher/config.py
@@ -77,6 +77,17 @@ ENV_KEYS_MOVED_TO_OS_CONFIG = {
 SECRET_ENV_KEYS = (
     "INNATE_SERVICE_KEY",
 )
+SECRET_ENV_PLACEHOLDERS = {
+    "INNATE_SERVICE_KEY": {
+        "",
+        "your_service_key_here",
+        "your-innate-service-key",
+        "your-generated-token-here",
+    },
+}
+SECRET_ENV_MIN_LENGTHS = {
+    "INNATE_SERVICE_KEY": 16,
+}
 LOG_TARGETS = {
     "bootstrap": BOOTSTRAP_LOG_PATH,
     "frontend": FRONTEND_LOG_PATH,
@@ -159,6 +170,16 @@ def parse_env_file(path: Path) -> dict[str, str]:
             value = value[1:-1]
         env[key.strip()] = value
     return env
+
+
+def is_configured_secret_value(key: str, value: str | None) -> bool:
+    if value is None:
+        return False
+    stripped = value.strip()
+    if stripped in SECRET_ENV_PLACEHOLDERS.get(key, {""}):
+        return False
+    minimum_length = SECRET_ENV_MIN_LENGTHS.get(key, 1)
+    return len(stripped) >= minimum_length
 
 
 def parse_toml_file(path: Path) -> dict[str, object]:
@@ -412,7 +433,8 @@ def get_config() -> dict[str, object]:
         if key not in ENV_KEYS_MOVED_TO_OS_CONFIG
     }
     for key in SECRET_ENV_KEYS:
-        if value := os.environ.get(key, "").strip():
+        value = os.environ.get(key, "").strip()
+        if is_configured_secret_value(key, value):
             raw_env[key] = value
     if ignored_os_env_keys:
         warn(

--- a/dev/launcher/main.py
+++ b/dev/launcher/main.py
@@ -63,6 +63,7 @@ from runtime import (
     wait_for_os_runtime_ready,
     wait_for_simulator_http,
 )
+from setup_wizard import configure_hosted_service_key
 
 DASHBOARD_OPTIONS = DashboardOptions(
     hosted_mode=HOSTED_MODE,
@@ -197,6 +198,7 @@ def cmd_logs(target: str) -> None:
 
 def cmd_setup(config: dict[str, object]) -> None:
     print_banner()
+    configure_hosted_service_key(config)
     sim_python = ensure_sim_setup(config, allow_setup=True)
     ensure_sim_data(config, allow_fetch=True)
     success("Simulator setup is ready.")
@@ -212,6 +214,11 @@ def build_parser() -> argparse.ArgumentParser:
         description="Innate local development CLI."
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser(
+        "setup",
+        prog=f"{CLI_ROOT} setup",
+        help="Prepare the simulator environment and first-run credentials",
+    )
     sim_parser = subparsers.add_parser(
         "sim",
         prog=f"{CLI_ROOT} sim",
@@ -221,7 +228,7 @@ def build_parser() -> argparse.ArgumentParser:
     sim_subparsers.add_parser(
         "setup",
         prog=f"{CLI_SIM} setup",
-        help="Prepare the simulator environment, frontend build, and required scene data",
+        help="Prepare the simulator environment, frontend build, scene data, and credentials",
     )
     up_parser = sim_subparsers.add_parser(
         "up",
@@ -276,6 +283,10 @@ def main() -> int:
 
     try:
         config = get_config()
+
+        if args.command == "setup":
+            cmd_setup(config)
+            return 0
 
         if args.command != "sim":
             parser.error(f"Unknown command group: {args.command}")

--- a/dev/launcher/setup_wizard.py
+++ b/dev/launcher/setup_wizard.py
@@ -9,6 +9,7 @@ from config import ENV_PATH, HOSTED_MODE, warn, success
 from dashboard import BOLD, CYAN, DIM, GREEN, NC, YELLOW
 
 INNATE_SERVICE_KEY = "INNATE_SERVICE_KEY"
+MIN_SERVICE_KEY_LENGTH = 16
 SERVICE_KEY_PLACEHOLDERS = {
     "",
     "your_service_key_here",
@@ -28,7 +29,18 @@ def is_configured_secret(value: str | None) -> bool:
     if value is None:
         return False
     stripped = value.strip()
-    return stripped not in SERVICE_KEY_PLACEHOLDERS
+    return (
+        stripped not in SERVICE_KEY_PLACEHOLDERS
+        and len(stripped) >= MIN_SERVICE_KEY_LENGTH
+    )
+
+
+def _is_active_env_assignment(line: str, key: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return False
+    assignment_key, _ = stripped.split("=", 1)
+    return assignment_key.strip() == key
 
 
 def _prompt_yes_no(question: str, *, default: bool = False) -> bool:
@@ -66,14 +78,10 @@ def write_env_value(path: Path, key: str, value: str) -> None:
     output: list[str] = []
 
     for line in lines:
-        stripped = line.strip()
-        uncommented = stripped[1:].strip() if stripped.startswith("#") else stripped
-        if uncommented.startswith(f"{key}="):
+        if _is_active_env_assignment(line, key):
             if not updated:
                 output.append(replacement)
                 updated = True
-            else:
-                output.append(line)
         else:
             output.append(line)
 
@@ -87,11 +95,15 @@ def write_env_value(path: Path, key: str, value: str) -> None:
 
 def _save_service_key(config: dict[str, object], service_key: str) -> None:
     write_env_value(ENV_PATH, INNATE_SERVICE_KEY, service_key)
+    _use_service_key_for_run(config, service_key)
+    success(f"Saved {INNATE_SERVICE_KEY} to {ENV_PATH}.")
+
+
+def _use_service_key_for_run(config: dict[str, object], service_key: str) -> None:
     raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
     user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
     raw_env[INNATE_SERVICE_KEY] = service_key
     user_env[INNATE_SERVICE_KEY] = service_key
-    success(f"Saved {INNATE_SERVICE_KEY} to {ENV_PATH}.")
 
 
 def configure_hosted_service_key(config: dict[str, object]) -> None:
@@ -105,6 +117,7 @@ def configure_hosted_service_key(config: dict[str, object]) -> None:
     shell_value = os.environ.get(INNATE_SERVICE_KEY, "").strip()
     if is_configured_secret(shell_value):
         if not is_interactive_terminal():
+            _use_service_key_for_run(config, shell_value)
             success(f"Using {INNATE_SERVICE_KEY} from the current shell.")
             return
         if _prompt_yes_no(
@@ -113,6 +126,7 @@ def configure_hosted_service_key(config: dict[str, object]) -> None:
         ):
             _save_service_key(config, shell_value)
         else:
+            _use_service_key_for_run(config, shell_value)
             success(f"Using {INNATE_SERVICE_KEY} from the current shell for this run.")
         return
 

--- a/dev/launcher/setup_wizard.py
+++ b/dev/launcher/setup_wizard.py
@@ -5,17 +5,10 @@ import os
 import sys
 from pathlib import Path
 
-from config import ENV_PATH, HOSTED_MODE, warn, success
+from config import ENV_PATH, HOSTED_MODE, is_configured_secret_value, warn, success
 from dashboard import BOLD, CYAN, DIM, GREEN, NC, YELLOW
 
 INNATE_SERVICE_KEY = "INNATE_SERVICE_KEY"
-MIN_SERVICE_KEY_LENGTH = 16
-SERVICE_KEY_PLACEHOLDERS = {
-    "",
-    "your_service_key_here",
-    "your-innate-service-key",
-    "your-generated-token-here",
-}
 
 
 def is_interactive_terminal() -> bool:
@@ -26,13 +19,7 @@ def is_interactive_terminal() -> bool:
 
 
 def is_configured_secret(value: str | None) -> bool:
-    if value is None:
-        return False
-    stripped = value.strip()
-    return (
-        stripped not in SERVICE_KEY_PLACEHOLDERS
-        and len(stripped) >= MIN_SERVICE_KEY_LENGTH
-    )
+    return is_configured_secret_value(INNATE_SERVICE_KEY, value)
 
 
 def _is_active_env_assignment(line: str, key: str) -> bool:

--- a/dev/launcher/setup_wizard.py
+++ b/dev/launcher/setup_wizard.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import getpass
+import os
+import sys
+from pathlib import Path
+
+from config import ENV_PATH, HOSTED_MODE, warn, success
+from dashboard import BOLD, CYAN, DIM, GREEN, NC, YELLOW
+
+INNATE_SERVICE_KEY = "INNATE_SERVICE_KEY"
+SERVICE_KEY_PLACEHOLDERS = {
+    "",
+    "your_service_key_here",
+    "your-innate-service-key",
+    "your-generated-token-here",
+}
+
+
+def is_interactive_terminal() -> bool:
+    try:
+        return sys.stdin.isatty() and sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+def is_configured_secret(value: str | None) -> bool:
+    if value is None:
+        return False
+    stripped = value.strip()
+    return stripped not in SERVICE_KEY_PLACEHOLDERS
+
+
+def _prompt_yes_no(question: str, *, default: bool = False) -> bool:
+    default_label = "Y/n" if default else "y/N"
+    while True:
+        try:
+            value = input(f"{YELLOW}{question} [{default_label}]: {NC}").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            raise SystemExit(1)
+        if not value:
+            return default
+        if value in {"y", "yes"}:
+            return True
+        if value in {"n", "no"}:
+            return False
+        print(f"{YELLOW}Please enter y or n.{NC}")
+
+
+def _prompt_secret(question: str) -> str:
+    try:
+        return getpass.getpass(f"{YELLOW}{question}: {NC}").strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        raise SystemExit(1)
+
+
+def write_env_value(path: Path, key: str, value: str) -> None:
+    if "\n" in value or "\r" in value:
+        raise ValueError(f"{key} cannot contain newlines")
+
+    replacement = f"{key}={value}"
+    lines = path.read_text().splitlines() if path.exists() else []
+    updated = False
+    output: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        uncommented = stripped[1:].strip() if stripped.startswith("#") else stripped
+        if uncommented.startswith(f"{key}="):
+            if not updated:
+                output.append(replacement)
+                updated = True
+            else:
+                output.append(line)
+        else:
+            output.append(line)
+
+    if not updated:
+        if output and output[-1].strip():
+            output.append("")
+        output.append(replacement)
+
+    path.write_text("\n".join(output) + "\n")
+
+
+def _save_service_key(config: dict[str, object], service_key: str) -> None:
+    write_env_value(ENV_PATH, INNATE_SERVICE_KEY, service_key)
+    raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
+    user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
+    raw_env[INNATE_SERVICE_KEY] = service_key
+    user_env[INNATE_SERVICE_KEY] = service_key
+    success(f"Saved {INNATE_SERVICE_KEY} to {ENV_PATH}.")
+
+
+def configure_hosted_service_key(config: dict[str, object]) -> None:
+    if config["mode"] != HOSTED_MODE:
+        return
+
+    user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
+    if is_configured_secret(user_env.get(INNATE_SERVICE_KEY)):
+        return
+
+    shell_value = os.environ.get(INNATE_SERVICE_KEY, "").strip()
+    if is_configured_secret(shell_value):
+        if not is_interactive_terminal():
+            success(f"Using {INNATE_SERVICE_KEY} from the current shell.")
+            return
+        if _prompt_yes_no(
+            f"Found {INNATE_SERVICE_KEY} in your shell. Save it to {ENV_PATH.name}?",
+            default=True,
+        ):
+            _save_service_key(config, shell_value)
+        else:
+            success(f"Using {INNATE_SERVICE_KEY} from the current shell for this run.")
+        return
+
+    if not is_interactive_terminal():
+        warn(
+            f"Hosted brain mode needs {INNATE_SERVICE_KEY}. "
+            f"Add it to {ENV_PATH} or switch sim/config.toml cloud_agent.mode to local-source."
+        )
+        return
+
+    print()
+    print(f"{CYAN}{BOLD}Hosted Brain Backend{NC}")
+    print(
+        f"{DIM}Hosted mode connects the simulator to Innate's hosted brain. "
+        f"It needs an Innate service key saved in {ENV_PATH.name}.{NC}"
+    )
+    print()
+
+    if not _prompt_yes_no("Do you have an Innate service key?", default=False):
+        warn(
+            f"Skipping hosted brain credentials. Add {INNATE_SERVICE_KEY} to {ENV_PATH} later, "
+            "or use local-source cloud agent mode."
+        )
+        return
+
+    while True:
+        service_key = _prompt_secret(f"Paste {INNATE_SERVICE_KEY}")
+        if is_configured_secret(service_key):
+            _save_service_key(config, service_key)
+            print(f"{GREEN}Hosted brain credentials are ready.{NC}")
+            return
+        warn("That does not look like a service key. Press Ctrl+C to cancel.")

--- a/dev/launcher/setup_wizard.py
+++ b/dev/launcher/setup_wizard.py
@@ -49,17 +49,23 @@ def _prompt_yes_no(question: str, *, default: bool = False) -> bool:
 
 def _prompt_secret(question: str) -> str:
     try:
-        return getpass.getpass(f"{YELLOW}{question}: {NC}").strip()
+        return getpass.getpass(f"{YELLOW}{question}: {NC}", stream=sys.stdout).strip()
     except (KeyboardInterrupt, EOFError):
         print()
         raise SystemExit(1)
+
+
+def _quote_env_value(value: str) -> str:
+    if "'" in value:
+        raise ValueError("secret values saved to .env cannot contain single quotes")
+    return f"'{value}'"
 
 
 def write_env_value(path: Path, key: str, value: str) -> None:
     if "\n" in value or "\r" in value:
         raise ValueError(f"{key} cannot contain newlines")
 
-    replacement = f"{key}={value}"
+    replacement = f"{key}={_quote_env_value(value)}"
     lines = path.read_text().splitlines() if path.exists() else []
     updated = False
     output: list[str] = []


### PR DESCRIPTION
## Summary
- add a setup-time hosted brain credential prompt for missing/placeholder INNATE_SERVICE_KEY
- add a top-level ./innate setup alias for the simulator setup path
- allow INNATE_SERVICE_KEY from the current shell to override .env without persisting unless the user confirms

## Tests
- python3 -m py_compile dev/launcher/*.py
- ./innate --help
- ./innate setup --help
- ./innate sim setup --help
- setup_wizard helper checks via PYTHONPATH=dev/launcher python3