### PR TITLE
Add manual behavior agent reload

### DIFF
--- a/dev/launcher/runtime.py
+++ b/dev/launcher/runtime.py
@@ -713,7 +713,11 @@ def collect_runtime_probe(
         True if config["mode"] == HOSTED_MODE else container_running("stack-cloud-agent")
     )
     metrics = fetch_simulator_metrics(simulator_port) if sim_running else {}
-    backend_status = fetch_brain_backend_status(simulator_port) if sim_running else {}
+    backend_status = {}
+    if isinstance(metrics, dict):
+        raw_backend_status = metrics.get("brain_backend_status")
+        if isinstance(raw_backend_status, dict):
+            backend_status = raw_backend_status
     backend_level, backend_label = health_from_brain_backend(
         backend_status, str(config["mode"])
     )
@@ -1139,12 +1143,6 @@ def simulator_ready(port: str) -> bool:
 
 def fetch_simulator_metrics(port: str) -> dict[str, object]:
     return sim_get_json(port, "stack_metrics")
-
-
-def fetch_brain_backend_status(port: str) -> dict[str, object]:
-    payload = fetch_available_agents_payload(port)
-    status = payload.get("brain_backend_status")
-    return status if isinstance(status, dict) else {}
 
 
 def fetch_available_agents_payload(port: str) -> dict[str, object]:

--- a/dev/launcher/runtime.py
+++ b/dev/launcher/runtime.py
@@ -1248,14 +1248,10 @@ def fetch_simulator_metrics(port: str) -> dict[str, object]:
     return sim_get_json(port, "stack_metrics")
 
 
-def fetch_available_agents_payload(port: str) -> dict[str, object]:
-    return sim_get_json(port, "get_available_agents")
-
-
 def available_agent_count(port: str) -> int:
-    payload = fetch_available_agents_payload(port)
-    agents = payload.get("agents")
-    return len(agents) if isinstance(agents, list) else 0
+    metrics = fetch_simulator_metrics(port)
+    count = metrics.get("available_agent_count")
+    return count if isinstance(count, int) else 0
 
 
 def wait_for_brain_directives(port: str, *, timeout_seconds: float = 30.0) -> int:

--- a/dev/launcher/runtime.py
+++ b/dev/launcher/runtime.py
@@ -48,6 +48,24 @@ from config import (
     warn,
 )
 
+FRONTEND_BUILD_INPUT_FILES = (
+    ".env",
+    ".env.development",
+    ".env.local",
+    ".env.production",
+    "index.html",
+    "package.json",
+    "tsconfig.app.json",
+    "tsconfig.json",
+    "tsconfig.node.json",
+    "vite.config.js",
+    "vite.config.mjs",
+    "vite.config.ts",
+    "yarn.lock",
+)
+FRONTEND_BUILD_INPUT_DIRS = ("public", "src")
+FRONTEND_DEPENDENCY_INPUT_FILES = ("package.json", "yarn.lock")
+
 
 def run_logged(
     cmd: list[str],
@@ -147,10 +165,111 @@ def python_import_succeeds(python_path: Path, module: str) -> bool:
     return result.returncode == 0
 
 
+def frontend_build_inputs(frontend_dir: Path) -> list[Path]:
+    inputs: list[Path] = []
+    for rel_path in FRONTEND_BUILD_INPUT_FILES:
+        path = frontend_dir / rel_path
+        if path.is_file():
+            inputs.append(path)
+
+    for rel_dir in FRONTEND_BUILD_INPUT_DIRS:
+        path = frontend_dir / rel_dir
+        if not path.is_dir():
+            continue
+        inputs.extend(child for child in path.rglob("*") if child.is_file())
+
+    return inputs
+
+
+def newest_mtime(paths: list[Path]) -> float:
+    newest = 0.0
+    for path in paths:
+        try:
+            newest = max(newest, path.stat().st_mtime)
+        except OSError:
+            continue
+    return newest
+
+
+def frontend_build_is_stale(frontend_dir: Path, dist_index: Path) -> bool:
+    if not dist_index.exists():
+        return True
+    try:
+        dist_mtime = dist_index.stat().st_mtime
+    except OSError:
+        return True
+    return newest_mtime(frontend_build_inputs(frontend_dir)) > dist_mtime
+
+
+def frontend_dependencies_are_stale(frontend_dir: Path) -> bool:
+    node_modules = frontend_dir / "node_modules"
+    if not node_modules.exists():
+        return True
+
+    install_marker = node_modules / ".yarn-integrity"
+    if not install_marker.exists():
+        return False
+
+    dependency_inputs = [
+        frontend_dir / rel_path
+        for rel_path in FRONTEND_DEPENDENCY_INPUT_FILES
+        if (frontend_dir / rel_path).is_file()
+    ]
+    return newest_mtime(dependency_inputs) > newest_mtime([install_marker])
+
+
+def ensure_frontend_build(frontend_dir: Path, *, allow_setup: bool) -> None:
+    dist_index = frontend_dir / "dist" / "index.html"
+    build_exists = dist_index.exists()
+    build_stale = frontend_build_is_stale(frontend_dir, dist_index)
+    if not build_stale:
+        return
+
+    if not build_exists and not allow_setup:
+        raise StackError(
+            "Simulator frontend build is missing.\n"
+            f"Run `{CLI_SIM} setup` before `{CLI_SIM} up`."
+        )
+
+    ensure_dependency("yarn")
+    node_modules = frontend_dir / "node_modules"
+    if not node_modules.exists():
+        if not allow_setup:
+            raise StackError(
+                "Simulator frontend dependencies are missing.\n"
+                f"Run `{CLI_SIM} setup` before `{CLI_SIM} up`."
+            )
+        log("Installing simulator frontend dependencies...")
+        run_logged(
+            ["yarn", "install"],
+            cwd=frontend_dir,
+            log_path=FRONTEND_LOG_PATH,
+            failure_message="Simulator frontend dependency install failed.",
+        )
+    elif frontend_dependencies_are_stale(frontend_dir):
+        log("Updating simulator frontend dependencies...")
+        run_logged(
+            ["yarn", "install"],
+            cwd=frontend_dir,
+            log_path=FRONTEND_LOG_PATH,
+            failure_message="Simulator frontend dependency install failed.",
+        )
+
+    if build_exists:
+        log("Simulator frontend build is stale. Rebuilding...")
+    else:
+        log("Building simulator frontend...")
+    run_logged(
+        ["yarn", "build"],
+        cwd=frontend_dir,
+        log_path=FRONTEND_LOG_PATH,
+        failure_message="Simulator frontend build failed.",
+    )
+
+
 def ensure_sim_setup(config: dict[str, object], *, allow_setup: bool) -> Path:
     sim_repo: Path = config["sim_repo"]  # type: ignore[assignment]
     frontend_dir = sim_repo / "frontend"
-    dist_index = frontend_dir / "dist" / "index.html"
     sim_python = sim_repo / ".venv" / "bin" / "python"
 
     ensure_dependency("python3")
@@ -187,28 +306,7 @@ def ensure_sim_setup(config: dict[str, object], *, allow_setup: bool) -> Path:
             f"Check: {BOOTSTRAP_LOG_PATH}"
         )
 
-    if not dist_index.exists():
-        if not allow_setup:
-            raise StackError(
-                "Simulator frontend build is missing.\n"
-                f"Run `{CLI_SIM} setup` before `{CLI_SIM} up`."
-            )
-        ensure_dependency("yarn")
-        if not (frontend_dir / "node_modules").exists():
-            log("Installing simulator frontend dependencies...")
-            run_logged(
-                ["yarn", "install"],
-                cwd=frontend_dir,
-                log_path=FRONTEND_LOG_PATH,
-                failure_message="Simulator frontend dependency install failed.",
-            )
-        log("Building simulator frontend...")
-        run_logged(
-            ["yarn", "build"],
-            cwd=frontend_dir,
-            log_path=FRONTEND_LOG_PATH,
-            failure_message="Simulator frontend build failed.",
-        )
+    ensure_frontend_build(frontend_dir, allow_setup=allow_setup)
 
     return sim_python
 

--- a/dev/launcher/runtime.py
+++ b/dev/launcher/runtime.py
@@ -208,7 +208,7 @@ def frontend_dependencies_are_stale(frontend_dir: Path) -> bool:
 
     install_marker = node_modules / ".yarn-integrity"
     if not install_marker.exists():
-        return False
+        return True
 
     dependency_inputs = [
         frontend_dir / rel_path
@@ -247,6 +247,11 @@ def ensure_frontend_build(frontend_dir: Path, *, allow_setup: bool) -> None:
             failure_message="Simulator frontend dependency install failed.",
         )
     elif frontend_dependencies_are_stale(frontend_dir):
+        if not allow_setup:
+            raise StackError(
+                "Simulator frontend dependencies are stale.\n"
+                f"Run `{CLI_SIM} setup` before `{CLI_SIM} up`."
+            )
         log("Updating simulator frontend dependencies...")
         run_logged(
             ["yarn", "install"],

--- a/sim/frontend/src/App.tsx
+++ b/sim/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { IoMic, IoMicOff } from "react-icons/io5";
+import { IoMic, IoMicOff, IoRefresh } from "react-icons/io5";
 import styled from "styled-components";
 import "./App.css";
 import { ImageDisplay } from "./components/ImageDisplay";
@@ -243,6 +243,42 @@ const PanelHeader = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.colors.foreground};
   font-weight: 700;
   opacity: 0.7;
+`;
+
+const PanelHeaderRow = styled(PanelHeader)`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+const AgentReloadButton = styled.button<{ $isLoading?: boolean }>`
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.foreground};
+  border: 1px solid ${({ theme }) => theme.colors.foreground};
+  cursor: pointer;
+  opacity: ${({ disabled }) => (disabled ? 0.35 : 0.85)};
+  transition:
+    background 0.1s,
+    color 0.1s,
+    opacity 0.1s;
+
+  svg {
+    animation: ${({ $isLoading }) =>
+      $isLoading ? "spin 0.8s linear infinite" : "none"};
+  }
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => theme.colors.foreground};
+    color: ${({ theme }) => theme.colors.background};
+    opacity: 1;
+  }
 `;
 
 const BigStat = styled.div`
@@ -560,12 +596,11 @@ export default function App() {
     useState<BrainBackendStatus | null>(null);
   const [agentLoadTimedOut, setAgentLoadTimedOut] = useState(false);
   const [backendWarmupTimedOut, setBackendWarmupTimedOut] = useState(false);
-  const hasAgentsRef = useRef(false);
   const isFetchingAgentsRef = useRef(false);
-  const blockedAgentsFetchUntilRef = useRef(0);
   const agentsLoadStartedAtRef = useRef(Date.now());
   const useDirectRobot = import.meta.env.VITE_DIRECT_ROBOT === "true";
   const robotWsUrl = import.meta.env.VITE_ROBOT_WS_URL ?? "ws://localhost:9090";
+  const simBaseUrl = import.meta.env.VITE_SIM_BASE_URL ?? "http://localhost:8000";
   const [viewMode, setViewMode] = useState<"frontFocus" | "map">("frontFocus");
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -655,27 +690,36 @@ export default function App() {
     };
   }, [isVoiceActive]);
 
-  // Fetch available agents from the robot on mount
-  useEffect(() => {
-    const fetchAgents = async () => {
-      const now = Date.now();
-      if (
-        isFetchingAgentsRef.current ||
-        now < blockedAgentsFetchUntilRef.current
-      ) {
+  const fetchAgents = useCallback(
+    async ({ requestRefresh = false }: { requestRefresh?: boolean } = {}) => {
+      if (isFetchingAgentsRef.current) {
         return;
       }
 
+      agentsLoadStartedAtRef.current = Date.now();
       isFetchingAgentsRef.current = true;
+      setIsLoadingAgents(true);
+      setAgentLoadTimedOut(false);
+      setBackendWarmupTimedOut(false);
+
       try {
         let data: AvailableAgentsResponse;
 
         if (useDirectRobot) {
           data = await getAvailableAgentsDirect(robotWsUrl);
         } else {
-          const baseUrl =
-            import.meta.env.VITE_SIM_BASE_URL ?? "http://localhost:8000";
-          const response = await fetch(`${baseUrl}/get_available_agents`);
+          if (requestRefresh) {
+            const refreshResponse = await fetch(
+              `${simBaseUrl}/reload_available_agents`,
+              { method: "POST" },
+            );
+            if (!refreshResponse.ok) {
+              throw new Error(`Reload failed: HTTP ${refreshResponse.status}`);
+            }
+            await new Promise((resolve) => setTimeout(resolve, 300));
+          }
+
+          const response = await fetch(`${simBaseUrl}/get_available_agents`);
           if (!response.ok) {
             throw new Error(`HTTP ${response.status}`);
           }
@@ -696,10 +740,8 @@ export default function App() {
 
         if (data.agents && data.agents.length > 0) {
           setAgents(data.agents);
-          hasAgentsRef.current = true;
           setAgentAvailabilityWarning(null);
           setAgentLoadTimedOut(false);
-          setIsLoadingAgents(false);
           setActiveAgent((previousAgentId) =>
             previousAgentId &&
             data.agents.some((agent) => agent.id === previousAgentId)
@@ -707,12 +749,9 @@ export default function App() {
               : null,
           );
         } else {
-          const timedOut = warningDelayElapsed;
-          setAgentLoadTimedOut(timedOut);
-          if (timedOut || backendWarnsNow) {
-            setIsLoadingAgents(false);
-          }
-          if (timedOut) {
+          setAgents([]);
+          setAgentLoadTimedOut(backendWarnsNow);
+          if (backendWarnsNow) {
             setAgentAvailabilityWarning(
               data.error ||
                 "The brain has not reported any available behavior agents yet.",
@@ -724,41 +763,26 @@ export default function App() {
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
-        if (useDirectRobot && errorMessage.includes("timed out")) {
-          blockedAgentsFetchUntilRef.current = Date.now() + 60_000;
-          console.warn(
-            "[Agents] /brain/get_available_directives timed out. Pausing retries for 60s.",
-          );
-        }
-        const timedOut =
-          Date.now() - agentsLoadStartedAtRef.current >=
-            AGENT_BACKEND_WARNING_DELAY_MS ||
-          errorMessage.includes("timed out");
-        setAgentLoadTimedOut(timedOut);
-        if (timedOut) {
-          setIsLoadingAgents(false);
-          setAgentAvailabilityWarning(
-            `Unable to load behavior agents: ${errorMessage}`,
-          );
-        }
+        setAgentLoadTimedOut(true);
+        setAgentAvailabilityWarning(
+          `Unable to load behavior agents: ${errorMessage}`,
+        );
         console.error("Error fetching agents:", error);
       } finally {
+        setIsLoadingAgents(false);
         isFetchingAgentsRef.current = false;
       }
-    };
+    },
+    [robotWsUrl, simBaseUrl, useDirectRobot],
+  );
 
-    fetchAgents();
+  useEffect(() => {
+    void fetchAgents();
+  }, [fetchAgents]);
 
-    // Poll until agents are loaded, and keep polling the sim backend so
-    // brain/cloud-agent connection warnings can recover without a refresh.
-    const intervalId = setInterval(async () => {
-      if (!useDirectRobot || !hasAgentsRef.current) {
-        await fetchAgents();
-      }
-    }, 5000);
-
-    return () => clearInterval(intervalId);
-  }, [useDirectRobot, robotWsUrl]);
+  const handleReloadAgents = useCallback(() => {
+    void fetchAgents({ requestRefresh: true });
+  }, [fetchAgents]);
 
   // Voice recognition functions
   const SILENCE_DURATION = 1500; // ms of silence before processing speech
@@ -1178,7 +1202,19 @@ export default function App() {
           </PanelSection>
 
           <PanelSection style={{ flex: 1 }}>
-            <PanelHeader>Behavior Agents</PanelHeader>
+            <PanelHeaderRow>
+              <span>Behavior Agents</span>
+              <AgentReloadButton
+                type="button"
+                onClick={handleReloadAgents}
+                disabled={isLoadingAgents}
+                $isLoading={isLoadingAgents}
+                aria-label="Reload behavior agents"
+                title="Reload behavior agents"
+              >
+                <IoRefresh size={15} />
+              </AgentReloadButton>
+            </PanelHeaderRow>
             <div>
               {agentWarning && (
                 <AgentNotice role="alert">

--- a/sim/frontend/src/App.tsx
+++ b/sim/frontend/src/App.tsx
@@ -716,14 +716,14 @@ export default function App() {
             if (!refreshResponse.ok) {
               throw new Error(`Reload failed: HTTP ${refreshResponse.status}`);
             }
-            await new Promise((resolve) => setTimeout(resolve, 300));
+            data = (await refreshResponse.json()) as AvailableAgentsResponse;
+          } else {
+            const response = await fetch(`${simBaseUrl}/get_available_agents`);
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status}`);
+            }
+            data = (await response.json()) as AvailableAgentsResponse;
           }
-
-          const response = await fetch(`${simBaseUrl}/get_available_agents`);
-          if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-          }
-          data = (await response.json()) as AvailableAgentsResponse;
         }
 
         if (data.brain_backend_status) {

--- a/sim/frontend/src/App.tsx
+++ b/sim/frontend/src/App.tsx
@@ -718,7 +718,7 @@ export default function App() {
             }
             data = (await refreshResponse.json()) as AvailableAgentsResponse;
           } else {
-            const response = await fetch(`${simBaseUrl}/get_available_agents`);
+            const response = await fetch(`${simBaseUrl}/available_agents`);
             if (!response.ok) {
               throw new Error(`HTTP ${response.status}`);
             }

--- a/sim/main.py
+++ b/sim/main.py
@@ -52,6 +52,15 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+@app.middleware("http")
+async def disable_frontend_cache(request, call_next):
+    response = await call_next(request)
+    if request.url.path == "/" or request.url.path.startswith("/static/"):
+        response.headers["Cache-Control"] = "no-store"
+    return response
+
+
 # Mount the React build directory
 frontend_build_path = os.path.join(os.path.dirname(__file__), "frontend", "dist")
 app.mount("/static", StaticFiles(directory=frontend_build_path), name="static")

--- a/sim/src/agent/agent_websocket_bridge.py
+++ b/sim/src/agent/agent_websocket_bridge.py
@@ -23,6 +23,7 @@ from src.agent.types import (
     DirectiveCmd,
     ResetRobotCmd,
     BrainActiveCmd,
+    RefreshAgentsCmd,
     NavigationPathMsg,
     NavigationWaypoint,
     NavigationCancelMsg,
@@ -658,6 +659,14 @@ async def outbound_data_loop(ws, shared_queues, service_call_queue):
 
                 print(f"[ROSBridge] Setting brain active: {msg.active}")
                 await service_call_queue.put(brain_active_srv)
+
+            elif isinstance(msg, RefreshAgentsCmd):
+                refresh_agents_srv = rosbridge_call_service(
+                    "/brain/get_available_directives",
+                    "brain_messages/srv/GetAvailableDirectives",
+                )
+                print("[ROSBridge] Refreshing available brain directives")
+                await service_call_queue.put(refresh_agents_srv)
 
             elif isinstance(msg, dict) and "clock" in msg:
                 outbound = rosbridge_publish("/clock", msg)

--- a/sim/src/agent/types.py
+++ b/sim/src/agent/types.py
@@ -144,6 +144,14 @@ class DirectiveCmd(NamedTuple):
     directive: str
 
 
+class RefreshAgentsCmd(NamedTuple):
+    """
+    A command to refresh available robot directives from the brain.
+    """
+
+    pass
+
+
 class SetEnvironmentCmd(NamedTuple):
     """Command to set the simulation environment from a configuration dict."""
 

--- a/sim/src/routes/video_api.py
+++ b/sim/src/routes/video_api.py
@@ -140,6 +140,33 @@ def stack_metrics(request: Request):
     )
 
 
+@router.get("/available_agents")
+def available_agents(request: Request):
+    """Return the cached available directives list without asking ROS to refresh."""
+    shared_queues = request.app.state.SHARED_QUEUES
+
+    if shared_queues is None:
+        return JSONResponse(
+            {
+                "agents": [],
+                "current_agent_id": None,
+                "startup_agent_id": None,
+                "error": "Simulation not initialized",
+                "brain_backend_status": {
+                    "state": "sim_not_initialized",
+                    "connected": False,
+                    "message": "Simulation not initialized",
+                    "updated_at": time.time(),
+                    "uri": None,
+                    "hosted": None,
+                },
+            },
+            status_code=200,
+        )
+
+    return JSONResponse(available_agents_payload(shared_queues))
+
+
 @router.get("/video_feed", include_in_schema=False)
 def video_feed(request: Request):
     """
@@ -241,32 +268,11 @@ async def set_brain_active(request: Request, brain_request: SetBrainActiveReques
 @router.get("/get_available_agents")
 def get_available_agents(request: Request):
     """
-    Returns the list of available agents/directives from the robot brain.
+    Backwards-compatible alias for the cached available directives list.
     Each agent includes: id, display_name, display_icon, prompt, skills.
     Also returns the current and startup agent IDs.
     """
-    shared_queues = request.app.state.SHARED_QUEUES
-
-    if shared_queues is None:
-        return JSONResponse(
-            {
-                "agents": [],
-                "current_agent_id": None,
-                "startup_agent_id": None,
-                "error": "Simulation not initialized",
-                "brain_backend_status": {
-                    "state": "sim_not_initialized",
-                    "connected": False,
-                    "message": "Simulation not initialized",
-                    "updated_at": time.time(),
-                    "uri": None,
-                    "hosted": None,
-                },
-            },
-            status_code=200,
-        )
-
-    return JSONResponse(available_agents_payload(shared_queues))
+    return available_agents(request)
 
 
 @router.post("/reload_available_agents")

--- a/sim/src/routes/video_api.py
+++ b/sim/src/routes/video_api.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse, JSONResponse
+import asyncio
 import time
 import cv2
 from typing import Optional
@@ -8,6 +9,8 @@ from pydantic import BaseModel
 from src.agent.types import DirectiveCmd, BrainActiveCmd, RefreshAgentsCmd
 
 router = APIRouter()
+AGENT_REFRESH_TIMEOUT_SECONDS = 5.0
+AGENT_REFRESH_POLL_SECONDS = 0.05
 
 
 # Create a model for the reset robot request
@@ -20,6 +23,41 @@ class ResetRobotRequest(BaseModel):
 # Create a model for the brain activation request
 class SetBrainActiveRequest(BaseModel):
     active: bool
+
+
+def available_agents_payload(shared_queues, error: str | None = None) -> dict:
+    agents, current_agent_id, startup_agent_id = shared_queues.get_available_agents()
+    brain_backend_status = shared_queues.get_brain_backend_status()
+
+    agents_data = [
+        {
+            "id": agent.id,
+            "display_name": agent.display_name,
+            "display_icon": agent.display_icon,
+            "prompt": agent.prompt,
+            "skills": agent.skills,
+        }
+        for agent in agents
+    ]
+
+    payload = {
+        "agents": agents_data,
+        "current_agent_id": current_agent_id,
+        "startup_agent_id": startup_agent_id,
+        "brain_backend_status": brain_backend_status,
+    }
+    if error:
+        payload["error"] = error
+    return payload
+
+
+async def wait_for_available_agents_update(shared_queues, previous_updated_at: float):
+    deadline = time.time() + AGENT_REFRESH_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        await asyncio.sleep(AGENT_REFRESH_POLL_SECONDS)
+        if shared_queues.get_available_agents_updated_at() > previous_updated_at:
+            return True
+    return False
 
 
 def mjpeg_generator(shared_queues, camera_name="first_person"):
@@ -228,33 +266,11 @@ def get_available_agents(request: Request):
             status_code=200,
         )
 
-    agents, current_agent_id, startup_agent_id = shared_queues.get_available_agents()
-    brain_backend_status = shared_queues.get_brain_backend_status()
-
-    # Convert AgentInfo namedtuples to dicts for JSON serialization
-    agents_data = [
-        {
-            "id": agent.id,
-            "display_name": agent.display_name,
-            "display_icon": agent.display_icon,
-            "prompt": agent.prompt,
-            "skills": agent.skills,
-        }
-        for agent in agents
-    ]
-
-    return JSONResponse(
-        {
-            "agents": agents_data,
-            "current_agent_id": current_agent_id,
-            "startup_agent_id": startup_agent_id,
-            "brain_backend_status": brain_backend_status,
-        }
-    )
+    return JSONResponse(available_agents_payload(shared_queues))
 
 
 @router.post("/reload_available_agents")
-def reload_available_agents(request: Request):
+async def reload_available_agents(request: Request):
     """Ask the robot brain to refresh its available directives list."""
     shared_queues = request.app.state.SHARED_QUEUES
     if shared_queues is None:
@@ -264,8 +280,21 @@ def reload_available_agents(request: Request):
         )
 
     try:
+        previous_updated_at = shared_queues.get_available_agents_updated_at()
         shared_queues.sim_to_agent.put_nowait(RefreshAgentsCmd())
-        return {"status": "agent_refresh_enqueued"}
+        refreshed = await wait_for_available_agents_update(
+            shared_queues, previous_updated_at
+        )
+        payload = available_agents_payload(shared_queues)
+        payload["status"] = (
+            "agent_refresh_completed" if refreshed else "agent_refresh_pending"
+        )
+        payload["refresh_pending"] = not refreshed
+        if not refreshed:
+            payload["error"] = (
+                "Agent refresh was queued, but no updated directives arrived yet."
+            )
+        return JSONResponse(payload)
     except Exception:
         return JSONResponse(
             {"status": "queue_full", "error": "Could not enqueue agent refresh"},

--- a/sim/src/routes/video_api.py
+++ b/sim/src/routes/video_api.py
@@ -5,7 +5,7 @@ import cv2
 from typing import Optional
 from pydantic import BaseModel
 
-from src.agent.types import DirectiveCmd, BrainActiveCmd
+from src.agent.types import DirectiveCmd, BrainActiveCmd, RefreshAgentsCmd
 
 router = APIRouter()
 
@@ -81,11 +81,25 @@ def stack_metrics(request: Request):
                 "queue_sizes": {},
                 "fps_by_camera": {},
                 "latest_frame_age_by_camera": {},
+                "brain_backend_status": {
+                    "state": "sim_not_initialized",
+                    "connected": False,
+                    "message": "Simulation not initialized",
+                    "updated_at": time.time(),
+                    "uri": None,
+                    "hosted": None,
+                },
             }
         )
 
     metrics = shared_queues.get_runtime_metrics()
-    return JSONResponse({"ready": True, **metrics})
+    return JSONResponse(
+        {
+            "ready": True,
+            **metrics,
+            "brain_backend_status": shared_queues.get_brain_backend_status(),
+        }
+    )
 
 
 @router.get("/video_feed", include_in_schema=False)
@@ -237,3 +251,23 @@ def get_available_agents(request: Request):
             "brain_backend_status": brain_backend_status,
         }
     )
+
+
+@router.post("/reload_available_agents")
+def reload_available_agents(request: Request):
+    """Ask the robot brain to refresh its available directives list."""
+    shared_queues = request.app.state.SHARED_QUEUES
+    if shared_queues is None:
+        return JSONResponse(
+            {"status": "no_shared_queues", "error": "Simulation not initialized"},
+            status_code=503,
+        )
+
+    try:
+        shared_queues.sim_to_agent.put_nowait(RefreshAgentsCmd())
+        return {"status": "agent_refresh_enqueued"}
+    except Exception:
+        return JSONResponse(
+            {"status": "queue_full", "error": "Could not enqueue agent refresh"},
+            status_code=503,
+        )

--- a/sim/src/runtime_logging.py
+++ b/sim/src/runtime_logging.py
@@ -10,7 +10,7 @@ SIM_LOG_MODES = (SIM_LOG_MODE_DEBUG, SIM_LOG_MODE_QUIET)
 DEFAULT_SIM_LOG_MODE = SIM_LOG_MODE_DEBUG
 
 NOISY_PATTERNS = [
-    re.compile(r'^INFO:\s+\d+\.\d+\.\d+\.\d+:\d+\s+-\s+"GET /(video_feeds_ready|stack_metrics)\b'),
+    re.compile(r'^INFO:\s+\d+\.\d+\.\d+\.\d+:\d+\s+-\s+"GET /(video_feeds_ready|stack_metrics|available_agents)\b'),
     re.compile(r"^\[ROSBridge\] Received navigation path with \d+ waypoints"),
     re.compile(r"^\[ROSBridge\] Target final orientation: "),
     re.compile(r"^\[NavController\] Received navigation path with \d+ waypoints"),

--- a/sim/src/shared_queues.py
+++ b/sim/src/shared_queues.py
@@ -73,6 +73,7 @@ class SharedQueues:
         self.available_agents: List[AgentInfo] = []
         self.current_agent_id: Optional[str] = None
         self.startup_agent_id: Optional[str] = None
+        self.available_agents_updated_at: float = 0.0
         self.agents_lock = threading.Lock()  # For thread-safe updates
 
         # Store the brain client's cloud/local-agent websocket state for the UI.
@@ -164,6 +165,7 @@ class SharedQueues:
             self.available_agents = agents
             self.current_agent_id = current_agent_id
             self.startup_agent_id = startup_agent_id
+            self.available_agents_updated_at = time.time()
 
     def get_available_agents(
         self,
@@ -175,6 +177,11 @@ class SharedQueues:
                 self.current_agent_id,
                 self.startup_agent_id,
             )
+
+    def get_available_agents_updated_at(self) -> float:
+        """Thread-safe method to get the latest available-agents update time."""
+        with self.agents_lock:
+            return self.available_agents_updated_at
 
     def update_brain_backend_status(self, status: Dict[str, Any]):
         """Thread-safe method to update brain/cloud backend connection status."""

--- a/sim/src/shared_queues.py
+++ b/sim/src/shared_queues.py
@@ -254,6 +254,10 @@ class SharedQueues:
                     now - timestamps[-1], 3
                 ) if timestamps else None
 
+        with self.agents_lock:
+            available_agent_count = len(self.available_agents)
+            available_agents_updated_at = self.available_agents_updated_at
+
         return {
             "queue_sizes": {
                 "sim_to_agent": self.sim_to_agent.qsize(),
@@ -265,5 +269,7 @@ class SharedQueues:
             },
             "fps_by_camera": fps_by_camera,
             "latest_frame_age_by_camera": latest_frame_age_by_camera,
+            "available_agent_count": available_agent_count,
+            "available_agents_updated_at": available_agents_updated_at,
             "sim_log_mode": self.get_sim_log_mode(),
         }


### PR DESCRIPTION
## Summary
- Stop the launcher dashboard and startup readiness checks from calling `/get_available_agents`; they now read cached brain status and agent count from `/stack_metrics`.
- Add cached `GET /available_agents` for the frontend initial load, while keeping `GET /get_available_agents` only as a backwards-compatible alias.
- Add `POST /reload_available_agents` so the frontend can explicitly ask the ROS bridge to refresh available directives.
- Replace frontend agent polling with an initial cached load plus a manual reload icon in the Behavior Agents panel.
- Make `./innate sim up` rebuild the served frontend bundle when frontend source/package inputs are newer than `sim/frontend/dist`.
- Disable browser caching for the local sim frontend (`/` and `/static/*`) so reloading a long-lived tab picks up the rebuilt bundle instead of stale JS.
- Address Greptile feedback: keep `sim up` from running `yarn install`, treat missing Yarn install markers as stale, and remove the fixed 300 ms reload delay by waiting for the ROS agent-list update.

## Validation
- `python3 -m py_compile sim/main.py dev/launcher/runtime.py dev/launcher/*.py sim/src/shared_queues.py sim/src/routes/video_api.py sim/src/runtime_logging.py sim/src/agent/types.py sim/src/agent/agent_websocket_bridge.py`
- `PYTHONPATH=dev/launcher python3 - <<'PY' ... frontend dependency stale checks ... PY`
- `yarn build` from `sim/frontend`
- `./node_modules/.bin/eslint src/App.tsx` from `sim/frontend`
- `git diff --check`
- `rg -n "get_available_agents" dev sim/frontend sim/src -S` confirms no launcher/frontend callers remain
- Browser sanity check: `http://127.0.0.1:5173/static/` renders the Behavior Agents reload button

## Note
- Full `yarn lint` still fails on pre-existing `sim/frontend/src/components/Chat.tsx` issues unrelated to this PR.
- If an already-open browser tab loaded the previous bundle, it can keep executing that old polling loop until the tab is reloaded or closed; the current served bundle is clean.