### PR TITLE
Rebuild stale sim frontend on up

### DIFF
--- a/dev/launcher/runtime.py
+++ b/dev/launcher/runtime.py
@@ -48,6 +48,24 @@ from config import (
     warn,
 )
 
+FRONTEND_BUILD_INPUT_FILES = (
+    ".env",
+    ".env.development",
+    ".env.local",
+    ".env.production",
+    "index.html",
+    "package.json",
+    "tsconfig.app.json",
+    "tsconfig.json",
+    "tsconfig.node.json",
+    "vite.config.js",
+    "vite.config.mjs",
+    "vite.config.ts",
+    "yarn.lock",
+)
+FRONTEND_BUILD_INPUT_DIRS = ("public", "src")
+FRONTEND_DEPENDENCY_INPUT_FILES = ("package.json", "yarn.lock")
+
 
 def run_logged(
     cmd: list[str],
@@ -147,10 +165,111 @@ def python_import_succeeds(python_path: Path, module: str) -> bool:
     return result.returncode == 0
 
 
+def frontend_build_inputs(frontend_dir: Path) -> list[Path]:
+    inputs: list[Path] = []
+    for rel_path in FRONTEND_BUILD_INPUT_FILES:
+        path = frontend_dir / rel_path
+        if path.is_file():
+            inputs.append(path)
+
+    for rel_dir in FRONTEND_BUILD_INPUT_DIRS:
+        path = frontend_dir / rel_dir
+        if not path.is_dir():
+            continue
+        inputs.extend(child for child in path.rglob("*") if child.is_file())
+
+    return inputs
+
+
+def newest_mtime(paths: list[Path]) -> float:
+    newest = 0.0
+    for path in paths:
+        try:
+            newest = max(newest, path.stat().st_mtime)
+        except OSError:
+            continue
+    return newest
+
+
+def frontend_build_is_stale(frontend_dir: Path, dist_index: Path) -> bool:
+    if not dist_index.exists():
+        return True
+    try:
+        dist_mtime = dist_index.stat().st_mtime
+    except OSError:
+        return True
+    return newest_mtime(frontend_build_inputs(frontend_dir)) > dist_mtime
+
+
+def frontend_dependencies_are_stale(frontend_dir: Path) -> bool:
+    node_modules = frontend_dir / "node_modules"
+    if not node_modules.exists():
+        return True
+
+    install_marker = node_modules / ".yarn-integrity"
+    if not install_marker.exists():
+        return False
+
+    dependency_inputs = [
+        frontend_dir / rel_path
+        for rel_path in FRONTEND_DEPENDENCY_INPUT_FILES
+        if (frontend_dir / rel_path).is_file()
+    ]
+    return newest_mtime(dependency_inputs) > newest_mtime([install_marker])
+
+
+def ensure_frontend_build(frontend_dir: Path, *, allow_setup: bool) -> None:
+    dist_index = frontend_dir / "dist" / "index.html"
+    build_exists = dist_index.exists()
+    build_stale = frontend_build_is_stale(frontend_dir, dist_index)
+    if not build_stale:
+        return
+
+    if not build_exists and not allow_setup:
+        raise StackError(
+            "Simulator frontend build is missing.\n"
+            f"Run `{CLI_SIM} setup` before `{CLI_SIM} up`."
+        )
+
+    ensure_dependency("yarn")
+    node_modules = frontend_dir / "node_modules"
+    if not node_modules.exists():
+        if not allow_setup:
+            raise StackError(
+                "Simulator frontend dependencies are missing.\n"
+                f"Run `{CLI_SIM} setup` before `{CLI_SIM} up`."
+            )
+        log("Installing simulator frontend dependencies...")
+        run_logged(
+            ["yarn", "install"],
+            cwd=frontend_dir,
+            log_path=FRONTEND_LOG_PATH,
+            failure_message="Simulator frontend dependency install failed.",
+        )
+    elif frontend_dependencies_are_stale(frontend_dir):
+        log("Updating simulator frontend dependencies...")
+        run_logged(
+            ["yarn", "install"],
+            cwd=frontend_dir,
+            log_path=FRONTEND_LOG_PATH,
+            failure_message="Simulator frontend dependency install failed.",
+        )
+
+    if build_exists:
+        log("Simulator frontend build is stale. Rebuilding...")
+    else:
+        log("Building simulator frontend...")
+    run_logged(
+        ["yarn", "build"],
+        cwd=frontend_dir,
+        log_path=FRONTEND_LOG_PATH,
+        failure_message="Simulator frontend build failed.",
+    )
+
+
 def ensure_sim_setup(config: dict[str, object], *, allow_setup: bool) -> Path:
     sim_repo: Path = config["sim_repo"]  # type: ignore[assignment]
     frontend_dir = sim_repo / "frontend"
-    dist_index = frontend_dir / "dist" / "index.html"
     sim_python = sim_repo / ".venv" / "bin" / "python"
 
     ensure_dependency("python3")
@@ -187,28 +306,7 @@ def ensure_sim_setup(config: dict[str, object], *, allow_setup: bool) -> Path:
             f"Check: {BOOTSTRAP_LOG_PATH}"
         )
 
-    if not dist_index.exists():
-        if not allow_setup:
-            raise StackError(
-                "Simulator frontend build is missing.\n"
-                f"Run `{CLI_SIM} setup` before `{CLI_SIM} up`."
-            )
-        ensure_dependency("yarn")
-        if not (frontend_dir / "node_modules").exists():
-            log("Installing simulator frontend dependencies...")
-            run_logged(
-                ["yarn", "install"],
-                cwd=frontend_dir,
-                log_path=FRONTEND_LOG_PATH,
-                failure_message="Simulator frontend dependency install failed.",
-            )
-        log("Building simulator frontend...")
-        run_logged(
-            ["yarn", "build"],
-            cwd=frontend_dir,
-            log_path=FRONTEND_LOG_PATH,
-            failure_message="Simulator frontend build failed.",
-        )
+    ensure_frontend_build(frontend_dir, allow_setup=allow_setup)
 
     return sim_python
 


### PR DESCRIPTION
## Summary
- Make `./innate sim up` verify the served frontend bundle against current frontend inputs instead of only checking that `dist/index.html` exists.
- Rebuild `sim/frontend/dist` when `src/`, `public/`, Vite config, package files, tsconfig files, or frontend env files are newer than the current build.
- Refresh frontend dependencies when `package.json` or `yarn.lock` are newer than Yarn's install marker.

## Validation
- `python3 -m py_compile dev/launcher/runtime.py dev/launcher/*.py`
- `PYTHONPATH=dev/launcher python3 - <<'PY' ... ensure_frontend_build(...) ... PY` detected stale build, rebuilt it, then reported fresh
- `git diff --check`