### PR TITLE
Mirror dashboard robot gripper

### DIFF
--- a/dev/launcher/dashboard.py
+++ b/dev/launcher/dashboard.py
@@ -56,6 +56,8 @@ ASCII_MIRROR_MAP = str.maketrans(
         "}": "{",
         "<": ">",
         ">": "<",
+        "C": "Ɔ",
+        "Ɔ": "C",
     }
 )
 


### PR DESCRIPTION
## Summary
- Mirror the dashboard robot gripper `C` as `Ɔ` when the marquee reverses direction.
- Preserve round-trip mirroring so the sprite flips cleanly both ways.

## Validation
- `python3 -m py_compile dev/launcher/dashboard.py`
- `PYTHONPATH=dev/launcher python3 - <<'PY' ... mirror_ascii_line sample ... PY`