### PR TITLE
(AFTER REFACTO) Start Training Manager on boot

### DIFF
--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -202,7 +202,7 @@ fi
 log "Stopping services to begin update..."
 
 # Stop systemd services first (if they exist)
-for service in jetson-perf.service zenoh-router.service ros-app.service ble-provisioner.service speaker-keepalive.service; do
+for service in jetson-perf.service zenoh-router.service ros-app.service training-manager.service ble-provisioner.service speaker-keepalive.service; do
     if systemctl is-active --quiet "$service" 2>/dev/null; then
         log "Stopping $service"
         systemctl stop "$service"
@@ -721,7 +721,7 @@ done
 log "Enabling and starting services..."
 
 # List of services to enable/start
-SERVICES=("jetson-perf.service" "zenoh-router.service" "ros-app.service")
+SERVICES=("jetson-perf.service" "zenoh-router.service" "ros-app.service" "training-manager.service")
 
 # Add ble-provisioner if the service file exists
 if [ -f "/etc/systemd/system/ble-provisioner.service" ]; then
@@ -798,5 +798,4 @@ fi
 ensure_log_ownership
 
 exit 0
-
 

--- a/systemd/training-manager.service
+++ b/systemd/training-manager.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Innate Training Manager Web UI
+Documentation=https://github.com/innate-inc/innate-os
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=jetson1
+Environment="INNATE_OS_ROOT=/home/jetson1/innate-os" "SKILLS_DIR=/home/jetson1/skills" "PORT=8080"
+WorkingDirectory=/home/jetson1/innate-os
+ExecStartPre=/bin/mkdir -p /home/jetson1/skills
+ExecStart=/bin/bash -c 'source "$INNATE_OS_ROOT/ros2_ws/install/setup.bash" && eval "$(python3 "$INNATE_OS_ROOT/scripts/print_runtime_env.py" --shell)" && exec python3 -m training_client.cli ui --skills-dir "$SKILLS_DIR" --port "$PORT"'
+Restart=on-failure
+RestartSec=5
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a dedicated systemd service for the Training Manager web UI on port 8080
- load the ROS install environment and Innate runtime env before launching the UI
- stop/start and enable the Training Manager service during post-update alongside the robot services

## Notes
- This is a stacked PR against `axel/training-manager-startup-ui-base` so the diff stays focused on the startup/UI-manager change. The local source branch was created from a divergent `axel/innate-diag-software` worktree.

## Test plan
- `bash -n scripts/update/post_update.sh`
- launch command syntax check:

```bash
bash -n -c 'source "$INNATE_OS_ROOT/ros2_ws/install/setup.bash" && eval "$(python3 "$INNATE_OS_ROOT/scripts/print_runtime_env.py" --shell)" && exec python3 -m training_client.cli ui --skills-dir "$SKILLS_DIR" --port "$PORT"'
```