### PR TITLE
fix: wait briefly for learned behavior sensors

### DIFF
--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -281,10 +281,14 @@ class ManipulationServer(Node):
             if not self._load_policy_for_behavior(checkpoint_path, action_dim):
                 return "FAILURE", f"Failed to load policy from {checkpoint_path}"
             
-            # Check sensor availability before starting
-            if not self._check_sensor_availability():
-                self.get_logger().error("Required sensors not available. Cannot execute learned behavior.")
-                return "FAILURE", "Required sensors not available (cameras or joint state)"
+            # Wait for sensor data to arrive after subscription creation
+            sensor_wait_deadline = time.time() + 5.0
+            while not self._check_sensor_availability():
+                if time.time() > sensor_wait_deadline:
+                    self.get_logger().error("Required sensors not available after 5s. Cannot execute learned behavior.")
+                    return "FAILURE", "Required sensors not available (cameras or joint state)"
+                time.sleep(0.1)
+            self.get_logger().info("All sensors available")
             
             # Set head to AI position for optimal camera angle
             self.get_logger().info("Setting head to AI position for optimal camera angle")

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -282,10 +282,10 @@ class ManipulationServer(Node):
                 return "FAILURE", f"Failed to load policy from {checkpoint_path}"
             
             # Wait for sensor data to arrive after subscription creation
-            sensor_wait_deadline = time.time() + 5.0
+            sensor_wait_deadline = time.time() + 2.0
             while not self._check_sensor_availability():
                 if time.time() > sensor_wait_deadline:
-                    self.get_logger().error("Required sensors not available after 5s. Cannot execute learned behavior.")
+                    self.get_logger().error("Required sensors not available after 2s. Cannot execute learned behavior.")
                     return "FAILURE", "Required sensors not available (cameras or joint state)"
                 time.sleep(0.1)
             self.get_logger().info("All sensors available")


### PR DESCRIPTION
Replacement for #374 with the sensor retry timeout tuned to 2 seconds.

Includes Aryan's original fix for retrying sensor availability after learned-behavior subscriptions are created, plus a follow-up commit changing the wait deadline/log from 5s to 2s.

Verification:
- git diff --check
- python3 -m py_compile ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py