### PR TITLE
Start simulator without a default selected agent

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py
@@ -156,7 +156,8 @@ class BrainClientNode(Node):
         )  # Default to sending single image
 
         # --- New: Brain active state flag ---
-        self.is_brain_active = False  # Brain starts active
+        self.is_brain_active = False
+        self._activate_when_directive_selected = False
 
         # --- New: Simulator mode parameter ---
         self.declare_parameter("simulator_mode", False)
@@ -2274,8 +2275,12 @@ class BrainClientNode(Node):
                 f"Successfully registered {primitive_count} primitives and directive: {directive_registered}"
             )
 
-            # Auto-activate brain in simulator mode
-            if self.simulator_mode and not self.is_brain_active:
+            # Auto-activate brain in simulator mode once a directive exists.
+            if (
+                self.simulator_mode
+                and self.current_directive is not None
+                and not self.is_brain_active
+            ):
                 self.get_logger().info(
                     "\033[1;92m[BrainClient] Auto-activating brain in simulator mode\033[0m"
                 )
@@ -2427,14 +2432,25 @@ class BrainClientNode(Node):
             )
             self.ws_bridge.send_message(reset_msg)
 
-            # Re-register primitives and directive with the server to update
-            self.register_primitives_and_directive()
+            should_activate = (
+                self._activate_when_directive_selected and not self.is_brain_active
+            )
+            self._activate_when_directive_selected = False
 
-            # Activate input devices required by this directive
-            self.activate_directive_inputs()
+            if should_activate:
+                self.get_logger().info(
+                    "\033[1;92m[BrainClient] Activating brain after directive selection\033[0m"
+                )
+                self._reactivate_brain()
+            else:
+                # Re-register primitives and directive with the server to update
+                self.register_primitives_and_directive()
 
-            # Update gaze tracker for new directive
-            self._update_gaze_tracker()
+                # Activate input devices required by this directive
+                self.activate_directive_inputs()
+
+                # Update gaze tracker for new directive
+                self._update_gaze_tracker()
 
             # Publish confirmation
             chat_entry = {
@@ -2478,7 +2494,9 @@ class BrainClientNode(Node):
 
         # Convert the detailed info to JSON string for the directives field
         response.directives = [json.dumps(directive_details)]
-        response.current_directive = self.current_directive.id
+        response.current_directive = (
+            self.current_directive.id if self.current_directive else ""
+        )
 
         return response
 
@@ -2755,6 +2773,10 @@ class BrainClientNode(Node):
             # Deactivate brain: stops agent loop, cancels running primitive
             self._deactivate_brain()
 
+            previous_directive_id = (
+                self.current_directive.id if self.current_directive else None
+            )
+
             # Clear current state so queries during reload return empty
             self.directives = {}
             self.primitives_dict = {}
@@ -2795,9 +2817,11 @@ class BrainClientNode(Node):
                 )
 
             # Reload directives locally
-            self.directives, self.current_directive = initialize_agents(
+            self.directives, _ = initialize_agents(
                 self.get_logger(), self.primitives_dict
             )
+            if previous_directive_id in self.directives:
+                self.current_directive = self.directives[previous_directive_id]
 
             # Re-register with server
             self.register_primitives_and_directive()
@@ -2817,6 +2841,7 @@ class BrainClientNode(Node):
         """Deactivates the brain's main operational loops and interactions."""
         self.get_logger().info("\033[1;93m[BrainClient] Deactivating brain...\033[0m")
         self.is_brain_active = False
+        self._activate_when_directive_selected = False
         self._stop_brain_subscriptions()
 
         # Stop timers
@@ -2891,8 +2916,8 @@ class BrainClientNode(Node):
             self.get_logger().warn(
                 "\033[1;93m[BrainClient] No directive configured. Brain remains inactive.\033[0m"
             )
-            return
-        
+            return False
+
         self.is_brain_active = True
         self._start_brain_subscriptions()
 
@@ -2933,20 +2958,32 @@ class BrainClientNode(Node):
         self.get_logger().info(
             "\033[1;92m[BrainClient] Brain reactivated and reset initiated.\033[0m"
         )
+        return True
 
     def handle_set_brain_active(self, request, response):
         """Service handler for activating or deactivating the brain."""
         if request.data:  # True means activate
+            if self.current_directive is None:
+                self._activate_when_directive_selected = True
+                msg = "No directive selected. Brain will activate after an agent is selected."
+                self.get_logger().warn(msg)
+                response.success = True
+                response.message = msg
+                return response
             if self.is_brain_active:
                 msg = "Brain is already active."
                 self.get_logger().info(msg)
                 response.success = True
                 response.message = msg
             else:
-                self._reactivate_brain()
-                response.success = True
-                response.message = "Brain reactivated and reset initiated."
+                response.success = self._reactivate_brain()
+                response.message = (
+                    "Brain reactivated and reset initiated."
+                    if response.success
+                    else "No directive selected. Select an agent before activating the brain."
+                )
         else:  # False means deactivate
+            self._activate_when_directive_selected = False
             if not self.is_brain_active:
                 msg = "Brain is already inactive."
                 self.get_logger().info(msg)

--- a/ros2_ws/src/brain/brain_client/brain_client/initializers.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/initializers.py
@@ -26,9 +26,9 @@ def initialize_agents(
         skills_dict: Optional dictionary of available skills for validation
 
     Returns:
-        Tuple of (agents_dict, default_agent) where:
+        Tuple of (agents_dict, current_agent) where:
         - agents_dict: Dictionary mapping agent names to their instances
-        - default_agent: The default agent instance to use
+        - current_agent: None until the user selects an agent
     """
     agent_loader = AgentLoader(logger)
 
@@ -52,17 +52,9 @@ def initialize_agents(
 
     logger.info(f"Successfully loaded {len(agents)} agents")
 
-    # Set default agent (fallback to first available if empty_directive not found)
-    # Note: This doesn't mean the agent runs - is_brain_active controls that
-    default_agent = None
-    if "empty_directive" in agents:
-        default_agent = agents["empty_directive"]
-        logger.debug("Using empty_directive as default")
-    elif agents:
-        first_agent_name = next(iter(agents))
-        default_agent = agents[first_agent_name]
-        logger.debug(f"Using {first_agent_name} as default agent")
+    if agents:
+        logger.info("No default agent selected; waiting for /brain/set_directive")
     else:
         logger.error("No agents loaded! This will cause issues.")
 
-    return agents, default_agent
+    return agents, None

--- a/sim/frontend/src/services/rosbridgeService.ts
+++ b/sim/frontend/src/services/rosbridgeService.ts
@@ -234,8 +234,8 @@ export async function getAvailableAgentsDirect(
 
   return {
     agents,
-    current_agent_id: values.current_directive ?? null,
-    startup_agent_id: values.startup_directive ?? null,
+    current_agent_id: values.current_directive || null,
+    startup_agent_id: values.startup_directive || null,
   };
 }
 

--- a/sim/src/agent/agent_websocket_bridge.py
+++ b/sim/src/agent/agent_websocket_bridge.py
@@ -388,8 +388,8 @@ async def inbound_service_loop(ws, shared_queues):
 
                 values = inbound_data.get("values", {})
                 directives_raw = values.get("directives", "[]")
-                current_directive = values.get("current_directive", "")
-                startup_directive = values.get("startup_directive", "")
+                current_directive = values.get("current_directive", "") or None
+                startup_directive = values.get("startup_directive", "") or None
 
                 agents = []
 


### PR DESCRIPTION
## Summary
- load available brain agents without selecting the first one by default
- skip brain primitive/directive registration until an agent is selected
- defer activate-before-select requests and complete activation through the normal reactivation path after agent selection
- clear deferred activation on deactivate/reload and preserve the selected directive across reload
- normalize empty ROS directive ids to null for simulator/direct ROS agent responses

## Validation
- python3 -m py_compile ros2_ws/src/brain/brain_client/brain_client/initializers.py ros2_ws/src/brain/brain_client/brain_client/brain_client_node.py sim/src/agent/agent_websocket_bridge.py
- git diff --check
- cd sim/frontend && yarn install --frozen-lockfile
- cd sim/frontend && yarn tsc -b --pretty false