### PR TITLE
Update simulator to Genesis 1.0

### DIFF
--- a/scripts/validate_sim_ros_install.zsh
+++ b/scripts/validate_sim_ros_install.zsh
@@ -63,6 +63,9 @@ current_source_hash() {
 record_local_install_marker() {
     mkdir -p install
     current_source_hash > install/.innate-local-source.sha256
+    if [[ -n "${INNATE_OS_HOST_REPO_ID:-}" ]]; then
+        print -r -- "$INNATE_OS_HOST_REPO_ID" > install/.innate-local-repo-id
+    fi
 }
 
 seed_prebuilt_install() {
@@ -104,10 +107,29 @@ install_is_stale() {
     [[ ! -f install/setup.zsh ]] && return 0
     find install -xtype l -print -quit | grep -q . && return 0
 
+    if [[ -n "${INNATE_OS_HOST_REPO_ID:-}" ]]; then
+        local installed_repo_id
+        installed_repo_id="$(cat install/.innate-local-repo-id 2>/dev/null || true)"
+        [[ "$installed_repo_id" != "$INNATE_OS_HOST_REPO_ID" ]] && return 0
+    fi
+
     local installed_source_hash
     installed_source_hash="$(cat install/.innate-local-source.sha256 2>/dev/null || true)"
     [[ -z "$installed_source_hash" ]] && return 0
     [[ "$(current_source_hash)" != "$installed_source_hash" ]] && return 0
+
+    return 1
+}
+
+install_needs_clean_rebuild() {
+    [[ ! -f install/setup.zsh ]] && return 0
+    find install -xtype l -print -quit | grep -q . && return 0
+
+    if [[ -n "${INNATE_OS_HOST_REPO_ID:-}" ]]; then
+        local installed_repo_id
+        installed_repo_id="$(cat install/.innate-local-repo-id 2>/dev/null || true)"
+        [[ "$installed_repo_id" != "$INNATE_OS_HOST_REPO_ID" ]] && return 0
+    fi
 
     return 1
 }
@@ -117,8 +139,8 @@ if [[ "${INNATE_OS_ALWAYS_BUILD:-0}" == "1" ]]; then
 elif seed_prebuilt_install; then
     :
 elif install_is_stale; then
-    if [[ -d install ]] && find install -xtype l -print -quit | grep -q .; then
-        echo "Removing unusable ROS install before rebuild."
+    if install_needs_clean_rebuild; then
+        echo "Removing stale ROS build/install/log volumes before rebuild."
         clean_ros_build_artifacts
     fi
     colcon_build_with_retry

--- a/scripts/validate_sim_ros_install.zsh
+++ b/scripts/validate_sim_ros_install.zsh
@@ -14,11 +14,55 @@ colcon_build() {
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 }
 
+clean_ros_build_artifacts() {
+    mkdir -p build install log
+    find build install log -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+}
+
+is_stale_symlink_build_failure() {
+    local output_file="$1"
+    grep -q "failed to create symbolic link" "$output_file" &&
+        grep -q "existing path cannot be removed: Is a directory" "$output_file"
+}
+
+colcon_build_with_retry() {
+    local output_file
+    output_file="$(mktemp)"
+
+    set +e
+    colcon_build 2>&1 | tee "$output_file"
+    local colcon_status="${pipestatus[1]}"
+    set -e
+
+    if [[ "$colcon_status" -eq 0 ]]; then
+        record_local_install_marker
+        rm -f "$output_file"
+        return 0
+    fi
+
+    if is_stale_symlink_build_failure "$output_file"; then
+        echo "Detected stale ROS symlink-install build artifacts; cleaning build/install/log and retrying."
+        clean_ros_build_artifacts
+        rm -f "$output_file"
+        colcon_build
+        record_local_install_marker
+        return
+    fi
+
+    rm -f "$output_file"
+    return "$colcon_status"
+}
+
 current_source_hash() {
     find src -type f \
         ! -path '*/__pycache__/*' \
         ! -name '*.pyc' \
         -print0 | sort -z | xargs -0 -r sha256sum | sha256sum | awk '{print $1}'
+}
+
+record_local_install_marker() {
+    mkdir -p install
+    current_source_hash > install/.innate-local-source.sha256
 }
 
 seed_prebuilt_install() {
@@ -59,21 +103,25 @@ seed_prebuilt_install() {
 install_is_stale() {
     [[ ! -f install/setup.zsh ]] && return 0
     find install -xtype l -print -quit | grep -q . && return 0
-    find src -type f -newer install/setup.zsh -print -quit | grep -q . && return 0
+
+    local installed_source_hash
+    installed_source_hash="$(cat install/.innate-local-source.sha256 2>/dev/null || true)"
+    [[ -z "$installed_source_hash" ]] && return 0
+    [[ "$(current_source_hash)" != "$installed_source_hash" ]] && return 0
+
     return 1
 }
 
 if [[ "${INNATE_OS_ALWAYS_BUILD:-0}" == "1" ]]; then
-    colcon_build
+    colcon_build_with_retry
 elif seed_prebuilt_install; then
     :
 elif install_is_stale; then
     if [[ -d install ]] && find install -xtype l -print -quit | grep -q .; then
         echo "Removing unusable ROS install before rebuild."
-        mkdir -p build install log
-        find build install log -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+        clean_ros_build_artifacts
     fi
-    colcon_build
+    colcon_build_with_retry
 else
     echo "ROS workspace install is current; skipping rebuild."
 fi

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import socket
@@ -468,9 +469,13 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
     if os_image:
         compose_values["INNATE_OS_IMAGE"] = os_image
     compose_env = os_compose_env(compose_values, env_file=os_env_file)
+    host_repo_id = hashlib.sha256(str(os_repo.resolve()).encode("utf-8")).hexdigest()[
+        :16
+    ]
 
     build_cmd = (
         f"INNATE_OS_ALWAYS_BUILD={1 if config['os_always_build'] else 0} "
+        f"INNATE_OS_HOST_REPO_ID={shlex.quote(host_repo_id)} "
         "~/innate-os/scripts/validate_sim_ros_install.zsh"
     )
 

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -444,6 +444,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path) -> None:
                     f"Pull details are in {COMPOSE_LOG_PATH}."
                 )
                 os_image = ""
+                up_cmd.append("--build")
             else:
                 up_cmd.append("--no-build")
 
@@ -820,8 +821,8 @@ def collect_os_process_status(config: dict[str, object]) -> dict[str, bool]:
         os_compose_zsh_cmd(
             f"tmux has-session -t {shlex.quote(TMUX_SESSION_NAME)} >/dev/null 2>&1; "
             "echo tmux=$?; "
-            "pgrep -f rws_server >/dev/null; echo rosbridge=$?; "
-            "pgrep -f brain_client_node.py >/dev/null; echo brain=$?"
+            "pgrep -f '[r]ws_server' >/dev/null; echo rosbridge=$?; "
+            "pgrep -f '[b]rain_client_node.py' >/dev/null; echo brain=$?"
         ),
         cwd=os_repo,
         env=compose_env,

--- a/sim/requirements.macos.txt
+++ b/sim/requirements.macos.txt
@@ -21,6 +21,7 @@ coacd==1.0.7
 colorama==0.4.6
 comm==0.2.2
 contourpy==1.3.3
+cryptography==48.0.0
 cycler==0.12.1
 dataclasses-json==0.6.7
 debugpy==1.8.15
@@ -28,6 +29,8 @@ decorator==5.2.1
 defusedxml==0.7.1
 deprecated==1.3.1
 dill==0.4.0
+distro==1.9.0
+dracopy==2.0.0
 ecdsa==0.19.1
 etils==1.13.0
 executing==2.2.0
@@ -38,12 +41,12 @@ filelock==3.18.0
 fonttools==4.61.1
 fqdn==1.5.1
 freetype-py==2.5.1
+frozendict==2.4.7
 fsspec==2025.12.0
-genesis-world==0.4.6
+genesis-world==1.0.0
 glfw==2.10.0
 google-auth==2.49.1
 google-genai==1.66.0
-quadrants==0.6.2
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
@@ -140,6 +143,7 @@ python-utils==3.9.1
 pyvista==0.46.4
 pyyaml==6.0.2
 pyzmq==27.0.0
+quadrants==0.8.0
 referencing==0.36.2
 requests==2.32.5
 rfc3339-validator==0.1.4
@@ -165,7 +169,7 @@ terminado==0.18.1
 tetgen==0.8.2
 tifffile==2025.12.20
 tinycss2==1.4.0
-torch==2.7.1
+torch==2.11.0
 tornado==6.5.1
 tqdm==4.67.1
 traitlets==5.14.3
@@ -186,5 +190,6 @@ websocket-client==1.8.0
 websockets==15.0.1
 widgetsnbextension==4.0.14
 wrapt==2.0.1
+xacro==2.1.1
 z3-solver==4.15.4.0
 zipp==3.23.0

--- a/sim/requirements.ubuntu.txt
+++ b/sim/requirements.ubuntu.txt
@@ -52,6 +52,7 @@ docker==7.1.0
 dockerpty==0.4.1
 docopt==0.6.2
 docutils==0.21.2
+dracopy==2.0.0
 durationpy==0.10
 ecdsa==0.19.1
 empy==4.2
@@ -59,6 +60,7 @@ etils==1.13.0
 exceptiongroup==1.3.0
 executing==2.2.0
 fake-useragent==2.2.0
+fast-simplification==0.1.13
 fastapi==0.116.1
 fasteners==0.19
 fastjsonschema==2.21.1
@@ -69,19 +71,21 @@ flatbuffers==25.2.10
 fonttools==4.59.0
 fqdn==1.5.1
 freetype-py==2.5.1
+frozendict==2.4.7
 frozenlist==1.7.0
 fs==2.4.16
 fsspec==2025.7.0
 future==1.0.0
 gast==0.6.0
 gdown==5.2.0
-genesis-world==0.4.6
+genesis-world==1.0.0
 glfw==2.9.0
 google-auth==2.49.1
 google-auth-oauthlib==1.2.2
 google-genai==1.66.0
 google-pasta==0.2.0
 grpcio==1.73.1
+gs-madrona==0.0.7.post2
 h11==0.16.0
 h5py==3.14.0
 hf-xet==1.1.5
@@ -256,6 +260,7 @@ PyQt5_sip==12.17.0
 pyRFC3339==1.1
 pyrsistent==0.20.0
 PySocks==1.7.1
+pysplashsurf==0.14.0.0
 pytest==8.4.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
@@ -274,6 +279,7 @@ PyYAML==6.0.2
 pyzed==1.3.0
 pyzmq==27.0.0
 Qt.py==1.4.6
+quadrants==0.8.0
 referencing==0.36.2
 reportlab==4.4.2
 requests==2.32.4
@@ -325,14 +331,14 @@ timm==1.0.17
 tinycss2==1.4.0
 toml==0.10.2
 tomli==2.2.1
-torch  # pinned to nightly cu128 at runtime for Blackwell (RTX 50xx) - see setup.sh
+torch==2.11.0  # upgraded to nightly cu128 at runtime for Blackwell (RTX 50xx) - see setup.sh
 torchmetrics==1.7.4
-torchvision  # see above
+torchvision==0.26.0  # see above
 tornado==6.5.1
 tqdm==4.67.1
 traitlets==5.14.3
-trimesh==4.7.1
-triton==3.3.1
+trimesh==4.10.1
+triton==3.6.0
 typer==0.12.5
 types-pyside2==5.15.2.1.7
 types-python-dateutil==2.9.0.20250708
@@ -356,6 +362,7 @@ websockets==15.0.1
 Werkzeug==3.1.3
 widgetsnbextension==4.0.14
 wrapt==1.17.2
+xacro==2.1.1
 xmltodict==0.14.2
 yarl==1.20.1
 youtube-dl==2021.12.17

--- a/sim/src/simulation/simulation_node.py
+++ b/sim/src/simulation/simulation_node.py
@@ -313,7 +313,7 @@ class SimulationNode:
             vis_options=gs.options.VisOptions(
                 ambient_light=(0.5, 0.5, 0.5),
             ),
-            show_FPS=False,
+            profiling_options=gs.options.ProfilingOptions(show_FPS=False),
             show_viewer=self.enable_vis,
             **scene_kwargs,
         )
@@ -391,7 +391,7 @@ class SimulationNode:
                 pos=(0, 0, 0),
                 convexify=False,
                 collision=False,
-                file_meshes_are_zup=False,  # genesis 0.4.x defaults to True for GLB; preserve manual euler
+                file_meshes_are_zup=False,  # Preserve explicit Y-up GLB handling.
             )
         )
 
@@ -407,7 +407,7 @@ class SimulationNode:
             )
         elif collision_stage_config:
             # ReplicaCAD stage metadata remains in the original Y-up-authored frame
-            # even though Genesis 0.4.x now auto-converts the visible GLB to Z-up.
+            # while Genesis handles the visible GLB as Y-up.
             self._add_collision_from_stage_config(
                 self._resolve_project_path(collision_stage_config),
                 scene_euler=(90, 0, 0),
@@ -514,7 +514,7 @@ class SimulationNode:
                                 visualization=False,  # Invisible collision only
                                 collision=True,
                                 convexify=True,  # Individual objects can be safely convexified
-                                file_meshes_are_zup=False,  # genesis 0.4.x: preserve pre-0.4 rotation behavior
+                                file_meshes_are_zup=False,  # Preserve explicit Y-up GLB handling.
                             )
                         )
 
@@ -1312,7 +1312,7 @@ class SimulationNode:
                     scale=normalized_scale,
                     collision=False,
                     convexify=False,
-                    file_meshes_are_zup=False,  # genesis 0.4.x: preserve pre-0.4 rotation behavior
+                    file_meshes_are_zup=False,  # Preserve explicit Y-up GLB handling.
                 )
             )
             self.managed_entities[name] = entity_obj


### PR DESCRIPTION
## Verification update

Axel manually verified the stale ROS Docker volume fix by putting the checkout into the prior failing configuration and confirming the new startup path cleans the stale build/install/log volumes before rebuilding instead of failing on the `maurice_msgs` symlink-install error.

## Reviewer note: fresh-clone sim startup

While validating this on a brand-new worktree, `sim up` exposed a non-Genesis-but-important startup issue: Docker Compose uses stable named volumes for `ros2_ws/build`, `install`, and `log`, so a "fresh" checkout can still inherit ROS build artifacts from a previous checkout. That stale `ament_cmake_python` symlink-install state made `maurice_msgs` fail before the simulator could start.

I did not want to leave this as a janky fail-once-then-retry path. The fix now records a checkout marker in the ROS install volume and proactively clears `build/install/log` when the mounted volume belongs to another checkout or predates the marker. Once the marker matches the current checkout, validation skips rebuild normally, so this should clean once for stale shared volumes without turning every startup into a full rebuild.

There was a second local-fallback issue in the same path: when the prebuilt OS image was missing, the launcher said it would build locally but Docker Compose could reuse an old `innate-os-sim-clean-innate:latest` image. The launcher now forces `docker compose up --build` in that fallback. I also tightened the ROSBridge/brain `pgrep` checks so they cannot match their own probe command.

## Summary
- bump simulator Genesis dependencies to `genesis-world==1.0.0` on macOS and Ubuntu
- add new Genesis 1.0 dependency pins and align PyTorch/Quadrants/Trimesh versions
- switch Scene FPS suppression to `ProfilingOptions` and refresh GLB orientation comments
- harden sim startup against stale ROS Docker volumes and stale local fallback images

## Validation
- `uv pip compile sim/requirements.macos.txt --python-version 3.11 --python-platform aarch64-apple-darwin --no-header --no-annotate`
- `uv pip compile sim/requirements.ubuntu.txt --python-version 3.11 --python-platform x86_64-manylinux_2_31 --no-header --no-annotate`
- `python3.12 -m compileall -q sim/src/simulation sim/main.py`
- `python3.12 -m compileall -q sim/launcher/runtime.py`
- `zsh -n scripts/validate_sim_ros_install.zsh`
- `git diff --check`
- `python sim/launcher/main.py sim up` after stale shared ROS volumes: cleaned before `colcon`, built 17 packages, loaded 6 brain directives, and served `http://localhost:8000`
- immediate re-run of ROS install validation: `ROS workspace install is current; skipping rebuild.`
- GitHub `validate-assets` check passed
