### PR TITLE
Support updating to arbitrary remote branches

### DIFF
--- a/scripts/innate
+++ b/scripts/innate
@@ -2197,9 +2197,9 @@ class _UpdateManager:
 
         # Tags are fetched up front; treat any non-tag target as a branch to track.
         if not self.git.is_tag(target):
-            # The configured branch is already fetched at the call site; only other
-            # branches need an explicit fetch, which also confirms they exist.
-            if target != self.config.branch and not self.git.fetch_branch(target):
+            # Always fetch right before the destructive checkout so we reset onto a
+            # fresh, verified ref; this also confirms the branch exists on the remote.
+            if not self.git.fetch_branch(target):
                 self.logger.error(f"Unknown target: {target}")
                 self._remove_update_lock()
                 return 1

--- a/scripts/innate
+++ b/scripts/innate
@@ -1851,10 +1851,10 @@ class _GitRepo:
         )
         return result.returncode == 0
 
-    def is_remote_branch(self, name: str) -> bool:
-        """Return True if `name` is a branch on origin."""
-        result = self._run(["ls-remote", "--heads", "origin", name], check=False)
-        return result.returncode == 0 and bool(result.stdout.strip())
+    def is_tag(self, name: str) -> bool:
+        """Return True if `name` is a local tag (tags are fetched up front)."""
+        result = self._run(["show-ref", "--verify", "--quiet", f"refs/tags/{name}"], check=False)
+        return result.returncode == 0
 
     def prune_stale_local_tags(self) -> list[str]:
         """Delete local tags that no longer exist on the remote.
@@ -2195,10 +2195,10 @@ class _UpdateManager:
         """Apply updates to a specific target (tag or branch)."""
         target = self.target
 
-        # If target is a branch on the remote, track it (covers main + feature branches)
-        if self.git.is_remote_branch(target):
+        # Tags are fetched up front; treat any non-tag target as a branch to track.
+        if not self.git.is_tag(target):
             if not self.git.fetch_branch(target):
-                self.logger.error(f"Failed to fetch branch '{target}' from remote")
+                self.logger.error(f"Unknown target: {target}")
                 self._remove_update_lock()
                 return 1
 
@@ -2221,13 +2221,8 @@ class _UpdateManager:
                 track_remote=remote_ref,
             )
 
-        # Target is a tag — verify it exists
+        # Target is a tag
         tag_commit = self.git.resolve_ref(target)
-        if tag_commit == "unknown":
-            self.logger.error(f"Unknown target: {target}")
-            self._remove_update_lock()
-            return 1
-
         if tag_commit == current:
             self.logger.success(f"Already at {target}")
             self._remove_update_lock()

--- a/scripts/innate
+++ b/scripts/innate
@@ -2203,12 +2203,12 @@ class _UpdateManager:
                 return 1
 
             remote_ref = f"origin/{target}"
-            if self.git.resolve_ref(remote_ref) == current:
+            commits_behind = self.git.commits_between("HEAD", remote_ref)
+            if commits_behind == 0:
                 self.logger.success(f"Already up to date with {target}")
                 self._remove_update_lock()
                 return 0
 
-            commits_behind = self.git.commits_between("HEAD", remote_ref)
             self.logger.info(f"Updating to latest on {target} ({commits_behind} commits)")
             print()
             print("Changes to be applied:")

--- a/scripts/innate
+++ b/scripts/innate
@@ -2197,7 +2197,9 @@ class _UpdateManager:
 
         # Tags are fetched up front; treat any non-tag target as a branch to track.
         if not self.git.is_tag(target):
-            if not self.git.fetch_branch(target):
+            # The configured branch is already fetched at the call site; only other
+            # branches need an explicit fetch, which also confirms they exist.
+            if target != self.config.branch and not self.git.fetch_branch(target):
                 self.logger.error(f"Unknown target: {target}")
                 self._remove_update_lock()
                 return 1

--- a/scripts/innate
+++ b/scripts/innate
@@ -1843,6 +1843,19 @@ class _GitRepo:
         result = self._run(["fetch", "origin", "--tags", "--force", "--prune"], check=False)
         return result.returncode == 0
 
+    def fetch_branch(self, branch: str) -> bool:
+        """Fetch a specific branch from origin, updating its remote-tracking ref."""
+        result = self._run(
+            ["fetch", "origin", f"{branch}:refs/remotes/origin/{branch}", "--force"],
+            check=False,
+        )
+        return result.returncode == 0
+
+    def is_remote_branch(self, name: str) -> bool:
+        """Return True if `name` is a branch on origin."""
+        result = self._run(["ls-remote", "--heads", "origin", name], check=False)
+        return result.returncode == 0 and bool(result.stdout.strip())
+
     def prune_stale_local_tags(self) -> list[str]:
         """Delete local tags that no longer exist on the remote.
 
@@ -2182,23 +2195,28 @@ class _UpdateManager:
         """Apply updates to a specific target (tag or branch)."""
         target = self.target
 
-        # If target is the branch name, track remote branch
-        if target == self.config.branch:
-            remote_ref = f"origin/{self.config.branch}"
-            commits_behind = self.git.commits_between("HEAD", remote_ref)
-            if commits_behind == 0:
-                self.logger.success(f"Already up to date with {self.config.branch}")
+        # If target is a branch on the remote, track it (covers main + feature branches)
+        if self.git.is_remote_branch(target):
+            if not self.git.fetch_branch(target):
+                self.logger.error(f"Failed to fetch branch '{target}' from remote")
+                self._remove_update_lock()
+                return 1
+
+            remote_ref = f"origin/{target}"
+            if self.git.resolve_ref(remote_ref) == current:
+                self.logger.success(f"Already up to date with {target}")
                 self._remove_update_lock()
                 return 0
 
-            self.logger.info(f"Updating to latest on {self.config.branch} ({commits_behind} commits)")
+            commits_behind = self.git.commits_between("HEAD", remote_ref)
+            self.logger.info(f"Updating to latest on {target} ({commits_behind} commits)")
             print()
             print("Changes to be applied:")
             self._show_commits("HEAD", remote_ref, commits_behind, max_show=20)
 
             return self._do_git_update(
-                self.config.branch,
-                f"latest on {self.config.branch}",
+                target,
+                f"latest on {target}",
                 current,
                 track_remote=remote_ref,
             )
@@ -2733,6 +2751,7 @@ def apply(ctx, yes, background, in_tmux, target):
       innate update apply                    Apply latest stable tag
       innate update --dev apply 0.5.0-rc1    Apply a specific tag
       innate update --dev apply main         Update to latest commit on main
+      innate update --dev apply my-feature   Update to latest commit on a branch
       innate update apply 0.5.0              Apply a specific target
     """
     dev = ctx.obj["dev"]


### PR DESCRIPTION
## Summary

Extends `innate update apply` so dev-mode updates can target **any branch on `origin`**, not just the configured `main` branch. Previously only `main` and tags were valid targets; an arbitrary feature branch failed with `Unknown target` because `fetch()` only pulled the configured branch + tags, so `origin/<branch>` was never available.

## What changed

All in `scripts/innate`:

- **New `_GitRepo` helpers:**
  - `fetch_branch(branch)` → `git fetch origin <branch>:refs/remotes/origin/<branch> --force`, guaranteeing the remote-tracking ref exists before checkout.
  - `is_remote_branch(name)` → `git ls-remote --heads origin <name>` to detect branch targets.
- **Generalized the branch-tracking path** in `_apply_dev_mode`: the block that was hardcoded to `target == config.branch` now triggers for any remote branch. It fetches the branch, short-circuits if already at the tip, shows incoming commits, then `git checkout -B <branch> origin/<branch>` and runs the normal post-update flow.
- **Help text:** added a feature-branch example.

The `main` case is unchanged — it's now just one instance of the general case. Non-branch targets still fall through to the existing tag handling, and the stable-tag default path is untouched.

## Usage

```
innate update --dev apply my-feature-branch
innate update --dev apply axel/inn-548
```

## Reviewer notes

- Syntax-checked with `py_compile`; not exercised end-to-end (needs a robot/repo with the remote), but it reuses the already-proven `_do_git_update` / `checkout_branch` machinery.
- Behavioral choice: if local HEAD has **diverged** from the target branch, this resets onto the remote tip (after auto-stashing) rather than refusing — consistent with "go to this branch." Flag if you'd prefer it to bail on divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)