### PR TITLE
Support agents/skills in ~/ or workspace/custom_* (scan both, no move)

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/initializers.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/initializers.py
@@ -12,7 +12,6 @@ from brain_client.agent_loader import AgentLoader
 from brain_client.script_paths import (
     ensure_user_directories,
     get_agent_directories,
-    migrate_legacy_home_directories,
 )
 
 
@@ -33,9 +32,9 @@ def initialize_agents(
     """
     agent_loader = AgentLoader(logger)
 
-    # Ensure custom dirs exist and migrate any legacy ~/agents content into them.
+    # Ensure custom dirs exist. Agents are scanned from workspace/custom_agents
+    # and, if present, ~/agents (in place — never moved).
     ensure_user_directories()
-    migrate_legacy_home_directories(logger)
 
     agents_directories = [str(p) for p in get_agent_directories()]
 

--- a/ros2_ws/src/brain/brain_client/brain_client/script_paths.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/script_paths.py
@@ -63,32 +63,31 @@ def get_home_skills_dir() -> Path:
     return Path.home() / "skills"
 
 
-def get_agent_directories() -> list[Path]:
-    """Ordered list of directories to scan for agents.
+def _scan_dirs(innate: Path, custom: Path, home: Path) -> list[Path]:
+    """Ordered scan list: shipped first, then user (custom + home).
 
-    Shipped agents first, then user agents from workspace/custom_agents and,
-    when it exists, the home directory (~/agents). Home content is scanned in
-    place and never moved, so users may keep agents in either location.
+    The home directory is appended only when it exists, so it can be used as an
+    in-place alternative to custom_* without ever being moved, and consumers
+    (loaders, hot-reload watcher) never receive a non-existent path.
     """
-    dirs = [get_innate_agents_dir(), get_custom_agents_dir()]
-    home = get_home_agents_dir()
+    dirs = [innate, custom]
     if home.is_dir():
         dirs.append(home)
     return dirs
+
+
+def get_agent_directories() -> list[Path]:
+    """Directories to scan for agents: innate, custom_agents, then ~/agents."""
+    return _scan_dirs(
+        get_innate_agents_dir(), get_custom_agents_dir(), get_home_agents_dir()
+    )
 
 
 def get_skill_directories() -> list[Path]:
-    """Ordered list of directories to scan for skills.
-
-    Shipped skills first, then user skills from workspace/custom_skills and,
-    when it exists, the home directory (~/skills). Home content is scanned in
-    place and never moved, so users may keep skills in either location.
-    """
-    dirs = [get_innate_skills_dir(), get_custom_skills_dir()]
-    home = get_home_skills_dir()
-    if home.is_dir():
-        dirs.append(home)
-    return dirs
+    """Directories to scan for skills: innate, custom_skills, then ~/skills."""
+    return _scan_dirs(
+        get_innate_skills_dir(), get_custom_skills_dir(), get_home_skills_dir()
+    )
 
 
 def classify_source(path: str | os.PathLike) -> Source:

--- a/ros2_ws/src/brain/brain_client/brain_client/script_paths.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/script_paths.py
@@ -6,6 +6,11 @@ Layout:
     $INNATE_OS_ROOT/workspace/custom_agents/   # user agents   (gitignored)
     $INNATE_OS_ROOT/workspace/innate_skills/   # shipped skills (tracked)
     $INNATE_OS_ROOT/workspace/custom_skills/   # user skills   (gitignored)
+    ~/agents/                                  # user agents   (alternative, in place)
+    ~/skills/                                  # user skills   (alternative, in place)
+
+User content is supported in either workspace/custom_* or the home directory
+(~/agents, ~/skills); both are scanned and home content is never moved.
 
 Provenance is determined by which directory a script came from:
 "shipped" if the path is under innate_*/, "user" otherwise.
@@ -14,7 +19,6 @@ Provenance is determined by which directory a script came from:
 from __future__ import annotations
 
 import os
-import shutil
 from pathlib import Path
 from typing import Literal
 
@@ -49,14 +53,42 @@ def get_custom_skills_dir() -> Path:
     return _workspace() / "custom_skills"
 
 
+def get_home_agents_dir() -> Path:
+    """Optional user location ~/agents (an alternative to custom_agents)."""
+    return Path.home() / "agents"
+
+
+def get_home_skills_dir() -> Path:
+    """Optional user location ~/skills (an alternative to custom_skills)."""
+    return Path.home() / "skills"
+
+
 def get_agent_directories() -> list[Path]:
-    """Ordered list of directories to scan for agents."""
-    return [get_innate_agents_dir(), get_custom_agents_dir()]
+    """Ordered list of directories to scan for agents.
+
+    Shipped agents first, then user agents from workspace/custom_agents and,
+    when it exists, the home directory (~/agents). Home content is scanned in
+    place and never moved, so users may keep agents in either location.
+    """
+    dirs = [get_innate_agents_dir(), get_custom_agents_dir()]
+    home = get_home_agents_dir()
+    if home.is_dir():
+        dirs.append(home)
+    return dirs
 
 
 def get_skill_directories() -> list[Path]:
-    """Ordered list of directories to scan for skills."""
-    return [get_innate_skills_dir(), get_custom_skills_dir()]
+    """Ordered list of directories to scan for skills.
+
+    Shipped skills first, then user skills from workspace/custom_skills and,
+    when it exists, the home directory (~/skills). Home content is scanned in
+    place and never moved, so users may keep skills in either location.
+    """
+    dirs = [get_innate_skills_dir(), get_custom_skills_dir()]
+    home = get_home_skills_dir()
+    if home.is_dir():
+        dirs.append(home)
+    return dirs
 
 
 def classify_source(path: str | os.PathLike) -> Source:
@@ -76,36 +108,3 @@ def ensure_user_directories() -> None:
     """Create custom_* directories if they don't exist yet."""
     get_custom_agents_dir().mkdir(parents=True, exist_ok=True)
     get_custom_skills_dir().mkdir(parents=True, exist_ok=True)
-
-
-def migrate_legacy_home_directories(logger=None) -> None:
-    """Move any leftover ~/agents and ~/skills content into the custom_* dirs.
-
-    One-shot migration. Skips files that already exist at the destination.
-    Safe to call on every startup.
-    """
-    pairs = [
-        (Path.home() / "agents", get_custom_agents_dir()),
-        (Path.home() / "skills", get_custom_skills_dir()),
-    ]
-    for src, dst in pairs:
-        if not src.exists() or not src.is_dir():
-            continue
-        dst.mkdir(parents=True, exist_ok=True)
-        for entry in src.iterdir():
-            if entry.name in ("__pycache__",):
-                continue
-            target = dst / entry.name
-            if target.exists():
-                if logger:
-                    logger.warning(
-                        f"Skipping migration of {entry} — {target} already exists."
-                    )
-                continue
-            try:
-                shutil.move(str(entry), str(target))
-                if logger:
-                    logger.info(f"Migrated {entry} -> {target}")
-            except Exception as e:
-                if logger:
-                    logger.error(f"Failed to migrate {entry}: {e}")

--- a/ros2_ws/src/brain/brain_client/brain_client/skills_action_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills_action_server.py
@@ -49,7 +49,6 @@ from brain_client.script_paths import (
     get_custom_skills_dir,
     get_innate_skills_dir,
     get_skill_directories,
-    migrate_legacy_home_directories,
 )
 from brain_client.skill_loader import SkillLoader
 from brain_client.skill_types import (
@@ -553,20 +552,24 @@ class SkillsActionServer(Node):
         self._publish_skills_list()
 
     def _resolve_skills_directories(self) -> list[str]:
-        """Build the ordered list of skill directories to scan."""
+        """Build the ordered list of skill directories to scan.
+
+        Shipped (innate_skills), then user skills from workspace/custom_skills
+        and, when present, ~/skills. Home skills are scanned in place — never
+        moved — so users may keep skills in either location.
+        """
         innate_skills_dir = str(get_innate_skills_dir())
-        custom_skills_dir = str(get_custom_skills_dir())
 
         if not os.path.exists(innate_skills_dir):
             self.get_logger().fatal(f"Skills directory not found: {innate_skills_dir}")
             raise FileNotFoundError(f"Skills directory must exist at {innate_skills_dir}")
 
         ensure_user_directories()
-        migrate_legacy_home_directories(self.get_logger())
 
-        self.get_logger().info(f"Scanning innate skills directory: {innate_skills_dir}")
-        self.get_logger().info(f"Scanning custom skills directory: {custom_skills_dir}")
-        return [innate_skills_dir, custom_skills_dir]
+        directories = [str(p) for p in get_skill_directories()]
+        for directory in directories:
+            self.get_logger().info(f"Scanning skills directory: {directory}")
+        return directories
 
     def _apply_sim_swap(self, id_keyed: dict[str, tuple[str, type, Path]]) -> None:
         """Swap navigate_to_position_sim → navigate_to_position in sim mode, or remove it.

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/datasets.py
@@ -26,7 +26,11 @@ from training_client.src.skill_manager import (
 )
 from training_client.src.types import ClientConfig, ProgressUpdate
 
-from training_manager.api.skill_paths import iter_skill_dirs, skills_dir
+from training_manager.api.skill_paths import (
+    iter_all_skill_dirs,
+    resolve_skill_dir,
+    skills_dir,
+)
 
 logger = logging.getLogger("training_manager.api.datasets")
 
@@ -74,7 +78,7 @@ def _dataset_status(skill_path: Path) -> str:
 async def list_datasets(request: Request) -> list[dict[str, Any]]:
     """List all skills with their dataset info."""
     datasets: list[dict[str, Any]] = []
-    for child in iter_skill_dirs(skills_dir(request)):
+    for child in iter_all_skill_dirs(request):
         with _locked_metadata(child) as meta_path:
             meta = _read_meta(meta_path)
         if not meta:
@@ -100,7 +104,7 @@ async def list_datasets(request: Request) -> list[dict[str, Any]]:
 @router.get("/{skill_name}")
 async def get_dataset(request: Request, skill_name: str) -> dict[str, Any]:
     """Full dataset details including per-episode info."""
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     if not skill_path.is_dir():
         raise HTTPException(404, f"Skill not found: {skill_name}")
 
@@ -132,7 +136,7 @@ async def get_episode_video(
     request: Request, skill_name: str, episode_id: int, camera: int = 0
 ) -> FileResponse:
     """Stream an episode MP4 file."""
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     ds_meta = _read_dataset_metadata(skill_path)
     if ds_meta is None:
         raise HTTPException(404, "No dataset metadata")
@@ -169,7 +173,7 @@ async def submit_skill(
     training client, which handles H.264 conversion, signed-URL uploads,
     verification, and metadata updates.
     """
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     if not skill_path.is_dir():
         raise HTTPException(404, f"Skill not found: {skill_name}")
 
@@ -299,13 +303,12 @@ async def copy_dataset(
     Clears training_skill_id, checkpoint, stats_file, and removes run
     directories from the copy.
     """
-    root = skills_dir(request)
-    source = root / skill_name
+    source = resolve_skill_dir(request, skill_name)
     if not source.is_dir():
         raise HTTPException(404, f"Skill not found: {skill_name}")
 
     dest_dir_name = body.new_name.replace(" ", "-").lower()
-    dest = root / dest_dir_name
+    dest = skills_dir(request) / dest_dir_name
     if dest.exists():
         raise HTTPException(409, f"Destination already exists: {dest_dir_name}")
 
@@ -398,9 +401,8 @@ async def merge_datasets(request: Request, body: MergeRequest) -> dict[str, str]
     Uses the training client's locked metadata for safe reads from source
     skills.  The new skill gets a fresh metadata.json with empty execution.
     """
-    root = skills_dir(request)
     dest_dir_name = body.new_name.replace(" ", "-").lower()
-    dest = root / dest_dir_name
+    dest = skills_dir(request) / dest_dir_name
     if dest.exists():
         raise HTTPException(409, f"Destination already exists: {dest_dir_name}")
 
@@ -427,7 +429,7 @@ async def merge_datasets(request: Request, body: MergeRequest) -> dict[str, str]
         new_idx = 0
 
         for src in body.sources:
-            src_path = root / src.skill_name
+            src_path = resolve_skill_dir(request, src.skill_name)
             if not src_path.is_dir():
                 raise HTTPException(404, f"Source skill not found: {src.skill_name}")
 

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skill_paths.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skill_paths.py
@@ -1,4 +1,10 @@
-"""Shared helpers for locating skill directories."""
+"""Shared helpers for locating skill directories.
+
+Skills are read from the configured primary directory (workspace/custom_skills)
+and, when it exists, the home directory (~/skills). This supports users who
+keep — or previously trained — skills in ~/skills. New skills are always
+created in the primary directory.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +15,31 @@ from fastapi import Request
 
 
 def skills_dir(request: Request) -> Path:
+    """Primary skills directory — where new skills are created."""
     return Path(request.app.state.skills_dir)
+
+
+def skill_roots(request: Request) -> list[Path]:
+    """Ordered skill roots to read from: primary, then ~/skills if present."""
+    roots = [skills_dir(request)]
+    home = Path.home() / "skills"
+    if home.is_dir() and home.resolve() not in {r.resolve() for r in roots}:
+        roots.append(home)
+    return roots
+
+
+def resolve_skill_dir(request: Request, skill_name: str) -> Path:
+    """Locate an existing skill across the roots, else fall back to primary.
+
+    Returns the first root that already contains ``skill_name``; if none does,
+    returns ``primary/skill_name`` so callers' ``is_dir()`` 404 checks still
+    fire and any newly created skill lands in the primary directory.
+    """
+    for root in skill_roots(request):
+        candidate = root / skill_name
+        if candidate.is_dir():
+            return candidate
+    return skills_dir(request) / skill_name
 
 
 def is_skill_dir(path: Path) -> bool:
@@ -27,4 +57,15 @@ def iter_skill_dirs(root: Path) -> Iterator[Path]:
 
     for child in sorted(root.iterdir()):
         if is_skill_dir(child):
+            yield child
+
+
+def iter_all_skill_dirs(request: Request) -> Iterator[Path]:
+    """Iterate skill dirs across all roots, de-duplicated by name (primary wins)."""
+    seen: set[str] = set()
+    for root in skill_roots(request):
+        for child in iter_skill_dirs(root):
+            if child.name in seen:
+                continue
+            seen.add(child.name)
             yield child

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skills.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/skills.py
@@ -14,7 +14,7 @@ from training_client.src.skill_manager import (
     _write_meta,
 )
 
-from training_manager.api.skill_paths import iter_skill_dirs, skills_dir
+from training_manager.api.skill_paths import iter_all_skill_dirs, resolve_skill_dir
 
 logger = logging.getLogger("training_manager.api.skills")
 
@@ -58,7 +58,7 @@ def _skill_summary(skill_path: Path) -> dict[str, Any] | None:
 async def list_skills(request: Request) -> list[dict[str, Any]]:
     """List all skills found in the skills directory."""
     skills: list[dict[str, Any]] = []
-    for child in iter_skill_dirs(skills_dir(request)):
+    for child in iter_all_skill_dirs(request):
         summary = _skill_summary(child)
         if summary is not None:
             skills.append(summary)
@@ -69,7 +69,7 @@ async def list_skills(request: Request) -> list[dict[str, Any]]:
 @router.get("/{skill_name}")
 async def get_skill(request: Request, skill_name: str) -> dict[str, Any]:
     """Return the full metadata.json for a skill."""
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     if not skill_path.is_dir():
         raise HTTPException(404, f"Skill directory not found: {skill_name}")
 
@@ -104,7 +104,7 @@ async def update_skill(
     Uses the training client's locked metadata pattern for safe
     concurrent access.
     """
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     if not skill_path.is_dir():
         raise HTTPException(404, f"Skill directory not found: {skill_name}")
 

--- a/ros2_ws/src/cloud/clients/training-manager/training_manager/api/training.py
+++ b/ros2_ws/src/cloud/clients/training-manager/training_manager/api/training.py
@@ -24,7 +24,7 @@ from training_client.src.skill_manager import (
 )
 from training_client.src.types import ClientConfig, ProgressUpdate, RunInfo
 
-from training_manager.api.skill_paths import iter_skill_dirs, skills_dir
+from training_manager.api.skill_paths import iter_all_skill_dirs, resolve_skill_dir
 
 logger = logging.getLogger("training_manager.api.training")
 
@@ -117,7 +117,7 @@ async def list_all_runs(request: Request) -> list[dict[str, Any]]:
     manager = _make_manager()
     all_runs: list[dict[str, Any]] = []
 
-    for child in iter_skill_dirs(skills_dir(request)):
+    for child in iter_all_skill_dirs(request):
         skill_id = read_skill_id(child)
         if not skill_id:
             continue
@@ -142,7 +142,7 @@ async def list_all_runs(request: Request) -> list[dict[str, Any]]:
 @router.get("/runs/{skill_name}/{run_id}")
 async def get_run(request: Request, skill_name: str, run_id: int) -> dict[str, Any]:
     """Get details for a specific training run via SkillManager.run_status()."""
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     skill_id = read_skill_id(skill_path)
     if not skill_id:
         raise HTTPException(404, f"No training_skill_id for {skill_name}")
@@ -165,7 +165,7 @@ async def watch_run(
     request: Request, skill_name: str, run_id: int
 ) -> StreamingResponse:
     """SSE endpoint that polls run status using SkillManager.run_status()."""
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     skill_id = read_skill_id(skill_path)
     if not skill_id:
         raise HTTPException(404, f"No training_skill_id for {skill_name}")
@@ -215,7 +215,7 @@ async def create_run(
     Builds the training_params dict in the same format as the training
     CLI's `run` command, including source_dir for result download.
     """
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     skill_id = read_skill_id(skill_path)
     if not skill_id:
         raise HTTPException(404, f"No training_skill_id for {skill_name}")
@@ -315,7 +315,7 @@ async def download_run(
     Uses SkillManager.download() which writes into the run's
     ``source_dir/{run_id}/`` and marks the run ``downloaded`` on success.
     """
-    skill_path = skills_dir(request) / skill_name
+    skill_path = resolve_skill_dir(request, skill_name)
     skill_id = read_skill_id(skill_path)
     if not skill_id:
         raise HTTPException(404, f"No training_skill_id for {skill_name}")


### PR DESCRIPTION
## Summary
Lets users keep agents and skills in **either** location and never relocates their files:
- `~/agents` / `~/skills` (home), **or**
- `workspace/custom_agents` / `workspace/custom_skills`

Previously `migrate_legacy_home_directories()` **moved** `~/agents`/`~/skills` into `workspace/custom_*` at brain startup. This removes that move and instead **scans both** locations in place — and extends the **training-manager** to do the same.

## Changes
**Brain (load/run from both):**
- `script_paths.py`: add `get_home_agents_dir()` / `get_home_skills_dir()`; a single `_scan_dirs()` helper appends the home dir **only when it exists**; `get_agent_directories()` / `get_skill_directories()` use it. Removed `migrate_legacy_home_directories()` and the unused `shutil` import.
- `initializers.py` + `skills_action_server.py`: drop the migrate call; skills resolve via the now home-aware `get_skill_directories()`. Hot-reload watcher, reload-by-name, physical-skill load, and agent-icon loading all inherit both dirs via the centralized helpers.

**Training-manager (manage from both):**
- `api/skill_paths.py`: add `skill_roots()`, `resolve_skill_dir()`, `iter_all_skill_dirs()`.
- `api/skills.py`, `api/datasets.py`, `api/training.py`: listing spans both roots; existing-skill access (incl. copy/merge **sources**) resolves across roots; copy/merge **destinations** and new skills stay on the primary `custom_skills`.

## Behavior
- Scan order: shipped (`innate_*`) → `custom_*` → `~/` (when present).
- Home dirs included only if present, so robots without them are unaffected and watchers/loaders never see a missing path.
- On a same-name collision: the brain scans home last (home wins at runtime); the training UI de-dupes with the primary winning. New skills are always created in `custom_*`.

## Verification (local)
- Real `AgentLoader`: an agent in `custom_agents` **and** one in `~/agents` are both discovered; `~/agents` left in place (not moved); missing `~/agents` excluded without crashing.
- `get_skill_directories()` includes `~/skills` only when present; `classify_source(~/skills/...) == "user"`.
- Training-manager helpers: `~/skills` surfaced in listing; an existing home skill resolves to home; collision → primary; new skill → primary.
- No new ruff lint errors vs `main`.

## Notes
- Skill *runtime execution* (`skill_loader`/`mode_manager`) still needs the ROS lane to exercise end-to-end; the directory-resolution changes are verified above.
- The repo-wide `format` CI check is already red on `main` (pre-existing) — not introduced here.

## Test plan
- [ ] Put an agent in `~/agents` and a skill in `~/skills`; confirm both load on the robot and the skill appears in the training-manager UI.
- [ ] Confirm nothing under `~/` is moved after the brain starts.
- [ ] Confirm a newly created/recorded skill lands in `workspace/custom_skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)