### PR TITLE
ci: run integration tests on Cloud Build (off the self-hosted runner)

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -14,7 +14,7 @@ sim/.venv/
 !.dockerignore
 !.github/
 !ci/
-!ci/cloudbuild.sim-images.yaml
+!ci/**
 !sim/
 !sim/Dockerfile
 !sim/Dockerfile.ros-prebuilt
@@ -23,7 +23,13 @@ sim/.venv/
 !ros2_ws/
 !ros2_ws/apt-dependencies.common.txt
 !ros2_ws/apt-dependencies.hardware.txt
+!ros2_ws/pip-requirements.txt
 !ros2_ws/src/
 !ros2_ws/src/**
+# Needed by ci/Dockerfile.test (COPY config/ and workspace/).
+!config/
+!config/**
+!workspace/
+!workspace/**
 __pycache__/
 *.pyc

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,28 +7,41 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+# Required for Workload Identity Federation (OIDC) auth to Google Cloud.
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: integration-test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration-test:
-    runs-on: selfhosted
-    env:
-      TEST_IMAGE: innate-os-test:latest
+    # Runs on a GitHub-hosted runner, but the heavy build+test executes on
+    # Google Cloud Build (ci/cloudbuild.integration-test.yaml). This runner only
+    # authenticates and submits the build — no Docker work happens here, so it no
+    # longer needs a self-hosted machine.
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Build test image
-        run: |
-          docker build --progress=plain -t ${TEST_IMAGE} -f ci/Dockerfile.test . 2>&1
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
-      - name: Run integration tests
-        run: |
-          INNATE_TEST_IMAGE=${TEST_IMAGE} docker compose -f ci/docker-compose.test.yml up \
-            --abort-on-container-exit \
-            --exit-code-from integration-test
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
 
-      - name: Cleanup
-        if: always()
+      - name: Submit integration tests to Cloud Build
         run: |
-          docker compose -f ci/docker-compose.test.yml down || true
-          docker rmi ${TEST_IMAGE} || true
+          gcloud builds submit \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \
+            --service-account="projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_CLOUD_BUILD_SERVICE_ACCOUNT }}" \
+            --config=ci/cloudbuild.integration-test.yaml

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -1,0 +1,39 @@
+# Runs the innate-os integration tests on Google Cloud Build instead of a
+# self-hosted runner. Submitted by .github/workflows/integration-test.yml via
+# `gcloud builds submit` (GitHub Actions authenticates with Workload Identity
+# Federation — same setup as ci/cloudbuild.sim-images.yaml).
+#
+# It builds ci/Dockerfile.test and then runs the *same* test flow as a local
+# `docker compose -f ci/docker-compose.test.yml up`, so there is a single source
+# of truth for what "the tests" are.
+timeout: 3600s
+
+options:
+  machineType: E2_HIGHCPU_8
+  diskSizeGb: "150"
+  logging: CLOUD_LOGGING_ONLY
+
+steps:
+  - id: build-test-image
+    name: gcr.io/cloud-builders/docker
+    env:
+      - DOCKER_BUILDKIT=1
+    args:
+      - build
+      - --progress=plain
+      - -t
+      - innate-os-test:latest
+      - -f
+      - ci/Dockerfile.test
+      - .
+
+  - id: run-tests
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -ceu
+      - |
+        INNATE_TEST_IMAGE=innate-os-test:latest \
+          docker compose -f ci/docker-compose.test.yml up \
+            --abort-on-container-exit \
+            --exit-code-from integration-test

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -29,11 +29,13 @@ steps:
 
   - id: run-tests
     name: gcr.io/cloud-builders/docker
-    entrypoint: bash
+    env:
+      - INNATE_TEST_IMAGE=innate-os-test:latest
     args:
-      - -ceu
-      - |
-        INNATE_TEST_IMAGE=innate-os-test:latest \
-          docker compose -f ci/docker-compose.test.yml up \
-            --abort-on-container-exit \
-            --exit-code-from integration-test
+      - compose
+      - -f
+      - ci/docker-compose.test.yml
+      - up
+      - --abort-on-container-exit
+      - --exit-code-from
+      - integration-test


### PR DESCRIPTION
Moves the innate-os **integration test** off the self-hosted machine
(`runs-on: selfhosted`) and onto **Google Cloud Build**.

## How (mirrors the existing `publish-sim-images` setup)
- `integration-test.yml` now runs on `ubuntu-latest`, authenticates to GCP via
  **Workload Identity Federation** (the existing `GCP_*` repo vars), and calls
  `gcloud builds submit` — no Docker work on the runner.
- **`ci/cloudbuild.integration-test.yaml`** builds `ci/Dockerfile.test` then runs
  the *same* `docker compose -f ci/docker-compose.test.yml up` flow on Cloud Build
  (`E2_HIGHCPU_8`). Both steps use the documented `gcr.io/cloud-builders/docker`
  form (default `docker` entrypoint + `args:`).
- **`.gcloudignore`**: re-includes `config/`, `workspace/`, `pip-requirements.txt`,
  and `ci/**` so the Cloud Build source upload has everything `Dockerfile.test`
  COPYs (the allowlist was previously tuned only for the sim-images build).

Reuses the existing WIF provider, Cloud Build builder SA, and staging bucket —
**no new GCP infra**.

## Stacked on #417
Depends on the `topic_tools=humble` pin + `Dockerfile.test` fixes from
[#417](https://github.com/innate-inc/innate-os/pull/417); based on that branch,
merge after #417.

## Verification
Verified locally:
- `docker compose` v2.35.1 **is** present in `gcr.io/cloud-builders/docker`.
- The full `docker build` (20-package image) is green.
- The `docker compose ... up --exit-code-from integration-test` run-tests flow
  passes and propagates exit 0 (`test_fake_cloud_loop` 5/5, selftest + others 7/7).

Can only be verified by the **first CI run** (needs GitHub OIDC, can't run locally):
- the WIF auth + `gcloud builds submit` path, and
- the `.gcloudignore` source upload is complete.
Also confirm the Cloud Build builder SA is permitted to run this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)