### PR TITLE
feat(update): keep VS Code Remote-SSH sessions alive fleet-wide

### DIFF
--- a/config/ssh/10-innate-fleet.conf
+++ b/config/ssh/10-innate-fleet.conf
@@ -1,0 +1,17 @@
+# Innate-OS fleet SSH tuning — installed to /etc/ssh/sshd_config.d/ by post_update.sh
+#
+# Keeps VS Code Remote-SSH (and plain ssh) sessions alive across Wi-Fi sleep,
+# roaming, and NAT/router idle-timeouts so the tunnel is not silently dropped.
+# With password auth, a dropped tunnel forces a reconnect and re-entering the
+# password, which is the main remaining connection friction.
+#
+# The server sends an encrypted keepalive probe every ClientAliveInterval
+# seconds of inactivity; after ClientAliveCountMax unanswered probes it reclaims
+# the dead session. This both preserves NAT mappings and prevents stale sshd
+# sessions from piling up.
+#
+# Only touches keepalive behavior — does NOT change authentication, ciphers, or
+# port — so it cannot lock anyone out of a robot.
+ClientAliveInterval 30
+ClientAliveCountMax 4
+TCPKeepAlive yes

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -355,7 +355,7 @@ if [ -f "$SSH_DROPIN_SRC" ] && [ -d "$(dirname "$SSH_DROPIN_DST")" ]; then
         chmod 644 "$SSH_DROPIN_DST"
         # Validate the full sshd config; back out the drop-in if invalid so we
         # never leave a broken config that could block sshd on its next restart.
-        if sshd -t 2>/dev/null; then
+        if SSHD_VALIDATE_ERR=$(sshd -t 2>&1); then
             if systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null; then
                 log "  SSH keepalive config installed and ssh reloaded"
             else
@@ -363,6 +363,7 @@ if [ -f "$SSH_DROPIN_SRC" ] && [ -d "$(dirname "$SSH_DROPIN_DST")" ]; then
             fi
         else
             log "  WARNING: sshd config validation failed; removing keepalive drop-in"
+            log "  sshd -t output: $SSHD_VALIDATE_ERR"
             rm -f "$SSH_DROPIN_DST"
         fi
     fi

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -336,7 +336,39 @@ if [ -d "$REPO_DIR/config/udev" ]; then
     log "Udev rules reloaded"
 fi
 
-
+# -----------------------------------------------------------------------------
+# 3b. Install SSH keepalive drop-in
+# Keeps VS Code Remote-SSH (and plain ssh) tunnels alive across Wi-Fi sleep and
+# NAT idle-timeouts so they are not silently dropped — which, with password
+# auth, would force a reconnect and password re-entry. Only sets keepalive,
+# never touches auth. Validated before applying and reloaded (not restarted) so
+# existing connections are never dropped; backs out cleanly if validation fails.
+# -----------------------------------------------------------------------------
+log "Installing SSH keepalive configuration..."
+SSH_DROPIN_SRC="$REPO_DIR/config/ssh/10-innate-fleet.conf"
+SSH_DROPIN_DST="/etc/ssh/sshd_config.d/10-innate-fleet.conf"
+if [ -f "$SSH_DROPIN_SRC" ] && [ -d "$(dirname "$SSH_DROPIN_DST")" ]; then
+    if [ -f "$SSH_DROPIN_DST" ] && diff -q "$SSH_DROPIN_SRC" "$SSH_DROPIN_DST" >/dev/null 2>&1; then
+        log "  SSH keepalive config already up to date"
+    else
+        cp "$SSH_DROPIN_SRC" "$SSH_DROPIN_DST"
+        chmod 644 "$SSH_DROPIN_DST"
+        # Validate the full sshd config; back out the drop-in if invalid so we
+        # never leave a broken config that could block sshd on its next restart.
+        if sshd -t 2>/dev/null; then
+            if systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null; then
+                log "  SSH keepalive config installed and ssh reloaded"
+            else
+                log "  SSH keepalive config installed (reload skipped; applies on next ssh restart)"
+            fi
+        else
+            log "  WARNING: sshd config validation failed; removing keepalive drop-in"
+            rm -f "$SSH_DROPIN_DST"
+        fi
+    fi
+else
+    log "  Skipping SSH keepalive config (source or sshd_config.d not present)"
+fi
 
 # 4. Configure passwordless shutdown for ROS app
 log "Configuring passwordless shutdown..."


### PR DESCRIPTION
SSH / VS Code keeps disconnecting from robots when the session is idle.

We ruled out file watching, Git scanning, and slow SSH login. The likely issue is idle network tunnels dying because of Wi-Fi, roaming, or router/NAT timeouts.

This change adds SSH keepalives on every robot:

ClientAliveInterval 30
ClientAliveCountMax 4
TCPKeepAlive yes

So the robot pings idle SSH sessions every 30 seconds. This should keep VS Code / SSH connected longer and avoid repeated password prompts after idle disconnects.

It is safe because it only changes keepalive behavior, validates the SSH config before applying, reloads SSH instead of restarting it, and will not block the robot update if something goes wrong.