### PR TITLE
style: clang-format all C++ + enforce it via a pinned pre-commit hook

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,22 +17,9 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install ruff
-        # Pinned to match .pre-commit-config.yaml so local and CI agree.
-        run: pip install ruff==0.15.15
-
-      - name: Check Python formatting
-        # Whole repo (build/install/log excluded via pyproject extend-exclude).
-        run: ruff format --check .
-
-      - name: Check Python linting
-        run: ruff check .
-
-      - name: Install clang-format
-        run: sudo apt-get install -y clang-format
-
-      - name: Check C++ formatting
+      - name: Run pre-commit (ruff + clang-format)
+        # Single source of truth: hooks and their versions are pinned in
+        # .pre-commit-config.yaml, so CI and local `git commit` agree exactly.
         run: |
-          find ros2_ws/src -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) | while read file; do
-            clang-format --dry-run --Werror "$file"
-          done
+          pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 # Pre-commit hooks for innate-os.
 #
-# Mirrors the ruff checks enforced in CI (.github/workflows/format.yml) so
-# violations are caught locally before they reach a PR. The ruff version is
-# pinned here and in the CI workflow to keep local and CI results identical.
+# These are the same checks CI enforces (.github/workflows/format.yml runs
+# `pre-commit run --all-files`), so violations are caught locally before they
+# reach a PR. Hook versions are pinned here, so local and CI results are
+# identical regardless of any system-installed tools.
 #
 # One-time setup:
 #   pip install pre-commit
@@ -18,3 +19,14 @@ repos:
         args: [--fix]
       # Format.
       - id: ruff-format
+
+  # C++ formatting. The mirror installs clang-format from pip at this pinned
+  # version, so every contributor (and CI) uses the exact same formatter,
+  # independent of any system clang-format.
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.3
+    hooks:
+      - id: clang-format
+        # C/C++ only. The hook otherwise also targets json/js/java, which the
+        # C++-only .clang-format can't format.
+        types_or: [c, c++]

--- a/ros2_ws/src/brain/manipulation/include/manipulation/episode_data.hpp
+++ b/ros2_ws/src/brain/manipulation/include/manipulation/episode_data.hpp
@@ -23,7 +23,7 @@ namespace manipulation {
 //
 // Move-only: HDF5 handles must not be duplicated.
 class EpisodeData {
-public:
+   public:
     EpisodeData();
     explicit EpisodeData(const std::vector<std::string>& camera_names);
     ~EpisodeData();
@@ -38,13 +38,9 @@ public:
 
     // Append one timestep to the file. On the first call we create the
     // HDF5 file and all chunked extendable datasets sized from the inputs.
-    void add_timestep(
-        const std::vector<double>& action,
-        const std::vector<double>& qpos,
-        const std::vector<double>& qvel,
-        const std::vector<cv::Mat>& images,
-        double arm_timestamp = -1.0,
-        const std::vector<double>& image_timestamps = {});
+    void add_timestep(const std::vector<double>& action, const std::vector<double>& qpos,
+                      const std::vector<double>& qvel, const std::vector<cv::Mat>& images, double arm_timestamp = -1.0,
+                      const std::vector<double>& image_timestamps = {});
 
     // Write the termination columns of /action, then close the file.
     // Safe to call when no timesteps were written; in that case behaves
@@ -54,16 +50,19 @@ public:
     // Close any open handles and delete the file on disk.
     void cancel();
 
-    size_t get_episode_length() const { return timestep_count_; }
-    bool is_open() const { return file_id_ >= 0; }
-    const std::string& get_file_path() const { return file_path_; }
+    size_t get_episode_length() const {
+        return timestep_count_;
+    }
+    bool is_open() const {
+        return file_id_ >= 0;
+    }
+    const std::string& get_file_path() const {
+        return file_path_;
+    }
 
-private:
-    void create_file_and_datasets(
-        const std::vector<double>& action,
-        const std::vector<double>& qpos,
-        const std::vector<double>& qvel,
-        const std::vector<cv::Mat>& images);
+   private:
+    void create_file_and_datasets(const std::vector<double>& action, const std::vector<double>& qpos,
+                                  const std::vector<double>& qvel, const std::vector<cv::Mat>& images);
     void close_handles();
     // Best-effort rollback: shrink every streaming dataset back to `rows`
     // along its time axis. Used to recover from a partial failed timestep.

--- a/ros2_ws/src/brain/manipulation/include/manipulation/recorder_node.hpp
+++ b/ros2_ws/src/brain/manipulation/include/manipulation/recorder_node.hpp
@@ -30,27 +30,16 @@
 namespace manipulation {
 
 class RecorderNode : public rclcpp::Node {
-public:
+   public:
     RecorderNode();
     ~RecorderNode() override = default;
 
-private:
+   private:
     // State enum
-    enum class State {
-        IDLE,
-        TASK_ACTIVE,
-        EPISODE_ACTIVE,
-        EPISODE_STOPPED
-    };
+    enum class State { IDLE, TASK_ACTIVE, EPISODE_ACTIVE, EPISODE_STOPPED };
 
     // Replay state enum
-    enum class ReplayState {
-        IDLE,
-        READY,
-        PLAYING,
-        PAUSED,
-        FINISHED
-    };
+    enum class ReplayState { IDLE, READY, PLAYING, PAUSED, FINISHED };
 
     // Callbacks
     void image_callback(const sensor_msgs::msg::Image::SharedPtr msg, const std::string& topic);
@@ -64,38 +53,28 @@ private:
     void activate_physical_primitive(
         const std::shared_ptr<brain_messages::srv::ActivateManipulationTask::Request> request,
         std::shared_ptr<brain_messages::srv::ActivateManipulationTask::Response> response);
-    void handle_new_episode(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void handle_save_episode(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void handle_cancel_episode(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void handle_stop_episode(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void handle_end_task(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void handle_get_task_metadata(
-        const std::shared_ptr<brain_messages::srv::GetTaskMetadata::Request> request,
-        std::shared_ptr<brain_messages::srv::GetTaskMetadata::Response> response);
+    void handle_new_episode(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                            std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void handle_save_episode(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                             std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void handle_cancel_episode(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                               std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void handle_stop_episode(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                             std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void handle_end_task(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                         std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void handle_get_task_metadata(const std::shared_ptr<brain_messages::srv::GetTaskMetadata::Request> request,
+                                  std::shared_ptr<brain_messages::srv::GetTaskMetadata::Response> response);
 
     // Replay service handlers
-    void handle_load_episode(
-        const std::shared_ptr<brain_messages::srv::LoadEpisode::Request> request,
-        std::shared_ptr<brain_messages::srv::LoadEpisode::Response> response);
-    void handle_play_replay(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void handle_pause_replay(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void handle_stop_replay(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void handle_load_episode(const std::shared_ptr<brain_messages::srv::LoadEpisode::Request> request,
+                             std::shared_ptr<brain_messages::srv::LoadEpisode::Response> response);
+    void handle_play_replay(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                            std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void handle_pause_replay(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                             std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void handle_stop_replay(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                            std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
     // Helper methods
     void check_all_topics_received();

--- a/ros2_ws/src/brain/manipulation/include/manipulation/task_manager.hpp
+++ b/ros2_ws/src/brain/manipulation/include/manipulation/task_manager.hpp
@@ -12,11 +12,11 @@
 namespace manipulation {
 
 class TaskManager {
-public:
+   public:
     explicit TaskManager(const std::string& base_data_directory);
 
     void start_new_task_at_directory(const std::string& task_name, const std::string& task_directory,
-                                      double data_frequency);
+                                     double data_frequency);
     void resume_task_at_directory(const std::string& task_name, const std::string& task_directory);
 
     // Path the recorder should stream the in-flight episode to. Stable across
@@ -26,8 +26,7 @@ public:
 
     // Rename the already-finalized streaming file at `temp_file_path` to its
     // final episode slot and update the dataset metadata.
-    void add_episode(const std::string& temp_file_path,
-                     const std::string& start_timestamp,
+    void add_episode(const std::string& temp_file_path, const std::string& start_timestamp,
                      const std::string& end_timestamp);
 
     void end_task();
@@ -36,18 +35,26 @@ public:
     std::tuple<bool, std::string, std::string> get_task_metadata_by_directory(const std::string& task_directory);
 
     // Accessors
-    const std::string& get_current_task_name() const { return current_task_name_; }
-    const std::string& get_current_task_dir() const { return current_task_dir_; }
-    const nlohmann::json& get_metadata() const { return metadata_; }
-    bool has_metadata() const { return !metadata_.is_null(); }
+    const std::string& get_current_task_name() const {
+        return current_task_name_;
+    }
+    const std::string& get_current_task_dir() const {
+        return current_task_dir_;
+    }
+    const nlohmann::json& get_metadata() const {
+        return metadata_;
+    }
+    bool has_metadata() const {
+        return !metadata_.is_null();
+    }
     int get_number_of_episodes() const;
 
-private:
+   private:
     void save_metadata();
     void load_metadata();
     void cleanup_stale_streaming_files();
-    std::optional<nlohmann::json> get_enriched_metadata_for_task(const std::string& task_directory, 
-                                                                   std::string& error_msg);
+    std::optional<nlohmann::json> get_enriched_metadata_for_task(const std::string& task_directory,
+                                                                 std::string& error_msg);
 
     std::string base_data_directory_;
     std::string current_task_name_;

--- a/ros2_ws/src/brain/manipulation/src/episode_data.cpp
+++ b/ros2_ws/src/brain/manipulation/src/episode_data.cpp
@@ -21,8 +21,7 @@ inline void h5_check(long long result, const std::string& what) {
 
 // Wrapper around H5Dcreate2 that creates a chunked, extendable dataset with
 // auto-created intermediate groups. Returns the dataset hid.
-hid_t create_chunked_dataset(hid_t file, const std::string& path, hid_t dtype,
-                             int rank, const hsize_t* init_dims,
+hid_t create_chunked_dataset(hid_t file, const std::string& path, hid_t dtype, int rank, const hsize_t* init_dims,
                              const hsize_t* max_dims, const hsize_t* chunk_dims) {
     hid_t fspace = H5Screate_simple(rank, init_dims, max_dims);
     hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
@@ -58,8 +57,7 @@ EpisodeData::EpisodeData()
       qvel_dset_(-1),
       arm_ts_dset_(-1) {}
 
-EpisodeData::EpisodeData(const std::vector<std::string>& camera_names)
-    : EpisodeData() {
+EpisodeData::EpisodeData(const std::vector<std::string>& camera_names) : EpisodeData() {
     camera_names_ = camera_names;
     camera_names_set_ = true;
 }
@@ -149,12 +147,8 @@ void EpisodeData::open_file(const std::string& path) {
     timestep_count_ = 0;
 }
 
-void EpisodeData::create_file_and_datasets(
-    const std::vector<double>& action,
-    const std::vector<double>& qpos,
-    const std::vector<double>& qvel,
-    const std::vector<cv::Mat>& images) {
-
+void EpisodeData::create_file_and_datasets(const std::vector<double>& action, const std::vector<double>& qpos,
+                                           const std::vector<double>& qvel, const std::vector<cv::Mat>& images) {
     if (file_path_.empty()) {
         throw std::runtime_error("EpisodeData: open_file() must be called before add_timestep()");
     }
@@ -169,9 +163,8 @@ void EpisodeData::create_file_and_datasets(
         }
         camera_names_set_ = true;
     } else if (images.size() != camera_names_.size()) {
-        throw std::runtime_error(
-            "EpisodeData: expected " + std::to_string(camera_names_.size()) +
-            " images, but got " + std::to_string(images.size()));
+        throw std::runtime_error("EpisodeData: expected " + std::to_string(camera_names_.size()) + " images, but got " +
+                                 std::to_string(images.size()));
     }
 
     if (!images.empty()) {
@@ -198,8 +191,8 @@ void EpisodeData::create_file_and_datasets(
         const hsize_t init_dims[2] = {0, action_dim_ + 2};
         const hsize_t max_dims[2] = {H5S_UNLIMITED, action_dim_ + 2};
         const hsize_t chunk_dims[2] = {30, action_dim_ + 2};
-        action_dset_ = create_chunked_dataset(file_id_, "/action", H5T_NATIVE_DOUBLE,
-                                              2, init_dims, max_dims, chunk_dims);
+        action_dset_ =
+            create_chunked_dataset(file_id_, "/action", H5T_NATIVE_DOUBLE, 2, init_dims, max_dims, chunk_dims);
     }
 
     // /timestamps/arm
@@ -207,24 +200,24 @@ void EpisodeData::create_file_and_datasets(
         const hsize_t init_dims[1] = {0};
         const hsize_t max_dims[1] = {H5S_UNLIMITED};
         const hsize_t chunk_dims[1] = {30};
-        arm_ts_dset_ = create_chunked_dataset(file_id_, "/timestamps/arm", H5T_NATIVE_DOUBLE,
-                                              1, init_dims, max_dims, chunk_dims);
+        arm_ts_dset_ =
+            create_chunked_dataset(file_id_, "/timestamps/arm", H5T_NATIVE_DOUBLE, 1, init_dims, max_dims, chunk_dims);
     }
 
     if (qpos_dim_ > 0) {
         const hsize_t init_dims[2] = {0, qpos_dim_};
         const hsize_t max_dims[2] = {H5S_UNLIMITED, qpos_dim_};
         const hsize_t chunk_dims[2] = {30, qpos_dim_};
-        qpos_dset_ = create_chunked_dataset(file_id_, "/observations/qpos", H5T_NATIVE_DOUBLE,
-                                            2, init_dims, max_dims, chunk_dims);
+        qpos_dset_ = create_chunked_dataset(file_id_, "/observations/qpos", H5T_NATIVE_DOUBLE, 2, init_dims, max_dims,
+                                            chunk_dims);
     }
 
     if (qvel_dim_ > 0) {
         const hsize_t init_dims[2] = {0, qvel_dim_};
         const hsize_t max_dims[2] = {H5S_UNLIMITED, qvel_dim_};
         const hsize_t chunk_dims[2] = {30, qvel_dim_};
-        qvel_dset_ = create_chunked_dataset(file_id_, "/observations/qvel", H5T_NATIVE_DOUBLE,
-                                            2, init_dims, max_dims, chunk_dims);
+        qvel_dset_ = create_chunked_dataset(file_id_, "/observations/qvel", H5T_NATIVE_DOUBLE, 2, init_dims, max_dims,
+                                            chunk_dims);
     }
 
     // Per-camera image and timestamp datasets. One image per chunk keeps each
@@ -235,42 +228,34 @@ void EpisodeData::create_file_and_datasets(
         const hsize_t img_init[4] = {0, (hsize_t)img_h_, (hsize_t)img_w_, (hsize_t)img_c_};
         const hsize_t img_max[4] = {H5S_UNLIMITED, (hsize_t)img_h_, (hsize_t)img_w_, (hsize_t)img_c_};
         const hsize_t img_chunk[4] = {1, (hsize_t)img_h_, (hsize_t)img_w_, (hsize_t)img_c_};
-        image_dsets_[cam] = create_chunked_dataset(file_id_, img_path, H5T_NATIVE_UINT8,
-                                                   4, img_init, img_max, img_chunk);
+        image_dsets_[cam] =
+            create_chunked_dataset(file_id_, img_path, H5T_NATIVE_UINT8, 4, img_init, img_max, img_chunk);
 
         const std::string ts_path = "/timestamps/images/" + cam;
         const hsize_t ts_init[1] = {0};
         const hsize_t ts_max[1] = {H5S_UNLIMITED};
         const hsize_t ts_chunk[1] = {30};
-        image_ts_dsets_[cam] = create_chunked_dataset(file_id_, ts_path, H5T_NATIVE_DOUBLE,
-                                                      1, ts_init, ts_max, ts_chunk);
+        image_ts_dsets_[cam] =
+            create_chunked_dataset(file_id_, ts_path, H5T_NATIVE_DOUBLE, 1, ts_init, ts_max, ts_chunk);
     }
 
     file_created_ = true;
 }
 
-void EpisodeData::add_timestep(
-    const std::vector<double>& action,
-    const std::vector<double>& qpos,
-    const std::vector<double>& qvel,
-    const std::vector<cv::Mat>& images,
-    double arm_timestamp,
-    const std::vector<double>& image_timestamps) {
-
+void EpisodeData::add_timestep(const std::vector<double>& action, const std::vector<double>& qpos,
+                               const std::vector<double>& qvel, const std::vector<cv::Mat>& images,
+                               double arm_timestamp, const std::vector<double>& image_timestamps) {
     if (!file_created_) {
         create_file_and_datasets(action, qpos, qvel, images);
     } else if (images.size() != camera_names_.size()) {
-        throw std::runtime_error(
-            "EpisodeData: image count changed mid-episode (expected " +
-            std::to_string(camera_names_.size()) + ", got " +
-            std::to_string(images.size()) + ")");
+        throw std::runtime_error("EpisodeData: image count changed mid-episode (expected " +
+                                 std::to_string(camera_names_.size()) + ", got " + std::to_string(images.size()) + ")");
     }
 
     const hsize_t t = static_cast<hsize_t>(timestep_count_);
     const hsize_t new_t = t + 1;
 
-    auto write_2d_row = [&](hid_t dset, hsize_t width, const double* data,
-                            const std::string& name) {
+    auto write_2d_row = [&](hid_t dset, hsize_t width, const double* data, const std::string& name) {
         const hsize_t new_extent[2] = {new_t, width};
         h5_check(H5Dset_extent(dset, new_extent), "H5Dset_extent(" + name + ")");
 
@@ -337,9 +322,7 @@ void EpisodeData::add_timestep(
         if (arm_ts_dset_ >= 0) {
             // Always extend so its row count matches timestep_count_; use 0.0
             // as a sentinel when no timestamp was given.
-            write_1d_scalar(arm_ts_dset_,
-                            arm_timestamp >= 0.0 ? arm_timestamp : 0.0,
-                            "/timestamps/arm");
+            write_1d_scalar(arm_ts_dset_, arm_timestamp >= 0.0 ? arm_timestamp : 0.0, "/timestamps/arm");
         }
 
         for (size_t c = 0; c < camera_names_.size(); ++c) {
@@ -352,8 +335,7 @@ void EpisodeData::add_timestep(
 
             const std::string img_name = "/observations/images/" + cam;
             const hsize_t new_extent[4] = {new_t, (hsize_t)img_h_, (hsize_t)img_w_, (hsize_t)img_c_};
-            h5_check(H5Dset_extent(image_dsets_[cam], new_extent),
-                     "H5Dset_extent(" + img_name + ")");
+            h5_check(H5Dset_extent(image_dsets_[cam], new_extent), "H5Dset_extent(" + img_name + ")");
 
             hid_t fspace = H5Dget_space(image_dsets_[cam]);
             h5_check(fspace, "H5Dget_space(" + img_name + ")");
@@ -368,8 +350,7 @@ void EpisodeData::add_timestep(
                 H5Sclose(fspace);
                 h5_check(mspace, "H5Screate_simple(" + img_name + " mem)");
             }
-            herr_t wr = H5Dwrite(image_dsets_[cam], H5T_NATIVE_UINT8, mspace, fspace,
-                                 H5P_DEFAULT, continuous.data);
+            herr_t wr = H5Dwrite(image_dsets_[cam], H5T_NATIVE_UINT8, mspace, fspace, H5P_DEFAULT, continuous.data);
             H5Sclose(mspace);
             H5Sclose(fspace);
             h5_check(wr, "H5Dwrite(" + img_name + ")");
@@ -391,24 +372,28 @@ void EpisodeData::add_timestep(
 
 void EpisodeData::truncate_datasets_to(size_t rows) noexcept {
     auto shrink_1d = [&](hid_t dset) {
-        if (dset < 0) return;
+        if (dset < 0)
+            return;
         const hsize_t extent[1] = {static_cast<hsize_t>(rows)};
         H5Dset_extent(dset, extent);
     };
     auto shrink_2d = [&](hid_t dset, hsize_t width) {
-        if (dset < 0) return;
+        if (dset < 0)
+            return;
         const hsize_t extent[2] = {static_cast<hsize_t>(rows), width};
         H5Dset_extent(dset, extent);
     };
 
     shrink_2d(action_dset_, action_dim_ + 2);
-    if (qpos_dset_ >= 0) shrink_2d(qpos_dset_, qpos_dim_);
-    if (qvel_dset_ >= 0) shrink_2d(qvel_dset_, qvel_dim_);
+    if (qpos_dset_ >= 0)
+        shrink_2d(qpos_dset_, qpos_dim_);
+    if (qvel_dset_ >= 0)
+        shrink_2d(qvel_dset_, qvel_dim_);
     shrink_1d(arm_ts_dset_);
     for (auto& [name, dset] : image_dsets_) {
-        if (dset < 0) continue;
-        const hsize_t extent[4] = {static_cast<hsize_t>(rows),
-                                   (hsize_t)img_h_, (hsize_t)img_w_, (hsize_t)img_c_};
+        if (dset < 0)
+            continue;
+        const hsize_t extent[4] = {static_cast<hsize_t>(rows), (hsize_t)img_h_, (hsize_t)img_w_, (hsize_t)img_c_};
         H5Dset_extent(dset, extent);
     }
     for (auto& [name, dset] : image_ts_dsets_) {
@@ -450,8 +435,7 @@ void EpisodeData::finalize() {
         H5Sclose(fspace);
         h5_check(mspace, "H5Screate_simple(/action finalize mem)");
     }
-    herr_t wr = H5Dwrite(action_dset_, H5T_NATIVE_DOUBLE, mspace, fspace,
-                         H5P_DEFAULT, term.data());
+    herr_t wr = H5Dwrite(action_dset_, H5T_NATIVE_DOUBLE, mspace, fspace, H5P_DEFAULT, term.data());
     H5Sclose(mspace);
     H5Sclose(fspace);
     h5_check(wr, "H5Dwrite(/action finalize)");

--- a/ros2_ws/src/brain/manipulation/src/recorder_main.cpp
+++ b/ros2_ws/src/brain/manipulation/src/recorder_main.cpp
@@ -4,21 +4,21 @@
 
 int main(int argc, char** argv) {
     rclcpp::init(argc, argv);
-    
+
     auto node = std::make_shared<manipulation::RecorderNode>();
-    
+
     // Use MultiThreadedExecutor for concurrent callback handling
     rclcpp::executors::MultiThreadedExecutor executor;
     executor.add_node(node);
-    
+
     RCLCPP_INFO(node->get_logger(), "Recorder Node (C++) starting with MultiThreadedExecutor");
-    
+
     try {
         executor.spin();
     } catch (const std::exception& e) {
         RCLCPP_ERROR(node->get_logger(), "Exception: %s", e.what());
     }
-    
+
     RCLCPP_INFO(node->get_logger(), "Recorder Node shutting down.");
     rclcpp::shutdown();
     return 0;

--- a/ros2_ws/src/brain/manipulation/src/recorder_node.cpp
+++ b/ros2_ws/src/brain/manipulation/src/recorder_node.cpp
@@ -22,7 +22,6 @@ RecorderNode::RecorderNode()
       replay_frame_index_(0),
       replay_total_frames_(0),
       replay_fps_(10.0) {
-    
     // Declare parameters
     this->declare_parameter("data_directory", "/path/to/data");
     this->declare_parameter("data_frequency", 10);
@@ -47,7 +46,7 @@ RecorderNode::RecorderNode()
     } else {
         data_directory_ = data_dir_param;
     }
-    
+
     data_frequency_ = this->get_parameter("data_frequency").as_int();
     image_topics_ = this->get_parameter("image_topics").as_string_array();
     arm_state_topic_ = this->get_parameter("arm_state_topic").as_string();
@@ -78,28 +77,22 @@ RecorderNode::RecorderNode()
     for (const auto& topic : image_topics_) {
         auto sub = this->create_subscription<sensor_msgs::msg::Image>(
             topic, image_qos,
-            [this, topic](const sensor_msgs::msg::Image::SharedPtr msg) {
-                this->image_callback(msg, topic);
-            });
+            [this, topic](const sensor_msgs::msg::Image::SharedPtr msg) { this->image_callback(msg, topic); });
         image_subs_.push_back(sub);
     }
 
     // Create other subscribers
     arm_state_sub_ = this->create_subscription<sensor_msgs::msg::JointState>(
-        arm_state_topic_, 10,
-        std::bind(&RecorderNode::arm_state_callback, this, std::placeholders::_1));
-    
+        arm_state_topic_, 10, std::bind(&RecorderNode::arm_state_callback, this, std::placeholders::_1));
+
     leader_command_sub_ = this->create_subscription<std_msgs::msg::Float64MultiArray>(
-        leader_command_topic_, 10,
-        std::bind(&RecorderNode::leader_command_callback, this, std::placeholders::_1));
-    
+        leader_command_topic_, 10, std::bind(&RecorderNode::leader_command_callback, this, std::placeholders::_1));
+
     cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
-        velocity_topic_, 10,
-        std::bind(&RecorderNode::cmd_vel_callback, this, std::placeholders::_1));
-    
+        velocity_topic_, 10, std::bind(&RecorderNode::cmd_vel_callback, this, std::placeholders::_1));
+
     odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-        odom_topic_, 10,
-        std::bind(&RecorderNode::odom_callback, this, std::placeholders::_1));
+        odom_topic_, 10, std::bind(&RecorderNode::odom_callback, this, std::placeholders::_1));
 
     // Log subscriptions
     RCLCPP_INFO(this->get_logger(), "Subscribing to image topics:");
@@ -118,27 +111,27 @@ RecorderNode::RecorderNode()
     activate_physical_primitive_srv_ = this->create_service<brain_messages::srv::ActivateManipulationTask>(
         "brain/recorder/activate_physical_primitive",
         std::bind(&RecorderNode::activate_physical_primitive, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     new_episode_srv_ = this->create_service<std_srvs::srv::Trigger>(
         "brain/recorder/new_episode",
         std::bind(&RecorderNode::handle_new_episode, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     save_episode_srv_ = this->create_service<std_srvs::srv::Trigger>(
         "brain/recorder/save_episode",
         std::bind(&RecorderNode::handle_save_episode, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     cancel_episode_srv_ = this->create_service<std_srvs::srv::Trigger>(
         "brain/recorder/cancel_episode",
         std::bind(&RecorderNode::handle_cancel_episode, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     stop_episode_srv_ = this->create_service<std_srvs::srv::Trigger>(
         "brain/recorder/stop_episode",
         std::bind(&RecorderNode::handle_stop_episode, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     end_task_srv_ = this->create_service<std_srvs::srv::Trigger>(
         "brain/recorder/end_task",
         std::bind(&RecorderNode::handle_end_task, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     get_task_metadata_srv_ = this->create_service<brain_messages::srv::GetTaskMetadata>(
         "brain/recorder/get_task_metadata",
         std::bind(&RecorderNode::handle_get_task_metadata, this, std::placeholders::_1, std::placeholders::_2));
@@ -165,23 +158,22 @@ RecorderNode::RecorderNode()
     replay_qos.best_effort();
     replay_main_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
         "/brain/recorder/replay/main_camera/left/image_raw", replay_qos);
-    replay_arm_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
-        "/brain/recorder/replay/arm_camera/image_raw", replay_qos);
-    replay_status_pub_ = this->create_publisher<brain_messages::msg::ReplayStatus>(
-        "/brain/recorder/replay_status", 10);
+    replay_arm_pub_ =
+        this->create_publisher<sensor_msgs::msg::Image>("/brain/recorder/replay/arm_camera/image_raw", replay_qos);
+    replay_status_pub_ = this->create_publisher<brain_messages::msg::ReplayStatus>("/brain/recorder/replay_status", 10);
 
     load_episode_srv_ = this->create_service<brain_messages::srv::LoadEpisode>(
         "brain/recorder/load_episode",
         std::bind(&RecorderNode::handle_load_episode, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     play_replay_srv_ = this->create_service<std_srvs::srv::Trigger>(
         "brain/recorder/play_replay",
         std::bind(&RecorderNode::handle_play_replay, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     pause_replay_srv_ = this->create_service<std_srvs::srv::Trigger>(
         "brain/recorder/pause_replay",
         std::bind(&RecorderNode::handle_pause_replay, this, std::placeholders::_1, std::placeholders::_2));
-    
+
     stop_replay_srv_ = this->create_service<std_srvs::srv::Trigger>(
         "brain/recorder/stop_replay",
         std::bind(&RecorderNode::handle_stop_replay, this, std::placeholders::_1, std::placeholders::_2));
@@ -233,7 +225,8 @@ void RecorderNode::leader_command_callback(const std_msgs::msg::Float64MultiArra
     latest_leader_command_ = msg;
     if (!topics_received_[leader_command_topic_]) {
         topics_received_[leader_command_topic_] = true;
-        RCLCPP_INFO(this->get_logger(), "First message received on leader command topic: %s", leader_command_topic_.c_str());
+        RCLCPP_INFO(this->get_logger(), "First message received on leader command topic: %s",
+                    leader_command_topic_.c_str());
         check_all_topics_received();
     }
 }
@@ -259,7 +252,8 @@ void RecorderNode::timer_callback() {
     // Check for required sensor data
     for (const auto& topic : image_topics_) {
         if (!latest_images_[topic]) {
-            RCLCPP_WARN(this->get_logger(), "Incomplete sensor data; missing image from topic %s. Skipping timestep.", topic.c_str());
+            RCLCPP_WARN(this->get_logger(), "Incomplete sensor data; missing image from topic %s. Skipping timestep.",
+                        topic.c_str());
             return;
         }
     }
@@ -296,17 +290,16 @@ void RecorderNode::timer_callback() {
     std::vector<double> qvel(latest_arm_state_->velocity.begin(), latest_arm_state_->velocity.end());
 
     // Get arm timestamp
-    double arm_timestamp = latest_arm_state_->header.stamp.sec + 
-                           latest_arm_state_->header.stamp.nanosec * 1e-9;
+    double arm_timestamp = latest_arm_state_->header.stamp.sec + latest_arm_state_->header.stamp.nanosec * 1e-9;
 
     // Convert images
     std::vector<cv::Mat> images_converted;
     std::vector<double> image_timestamps;
-    
+
     for (const auto& topic : image_topics_) {
         try {
             auto cv_ptr = cv_bridge::toCvCopy(latest_images_[topic], "bgr8");
-            
+
             // Only resize if dimensions don't match
             if (cv_ptr->image.cols != image_size_[0] || cv_ptr->image.rows != image_size_[1]) {
                 cv::Mat resized;
@@ -318,8 +311,8 @@ void RecorderNode::timer_callback() {
                 images_converted.push_back(cv_ptr->image);
             }
 
-            double img_ts = latest_images_[topic]->header.stamp.sec +
-                            latest_images_[topic]->header.stamp.nanosec * 1e-9;
+            double img_ts =
+                latest_images_[topic]->header.stamp.sec + latest_images_[topic]->header.stamp.nanosec * 1e-9;
             image_timestamps.push_back(img_ts);
         } catch (const cv_bridge::Exception& e) {
             RCLCPP_ERROR(this->get_logger(), "Error converting image from topic %s: %s", topic.c_str(), e.what());
@@ -330,15 +323,16 @@ void RecorderNode::timer_callback() {
     try {
         current_episode_->add_timestep(action_data, qpos, qvel, images_converted, arm_timestamp, image_timestamps);
         size_t timestep_count = current_episode_->get_episode_length();
-        
+
         // Check if timestep limit reached
         if (timestep_count >= static_cast<size_t>(max_timesteps_)) {
-            RCLCPP_INFO(this->get_logger(), "Timestep limit (%d) reached. Automatically stopping episode.", max_timesteps_);
+            RCLCPP_INFO(this->get_logger(), "Timestep limit (%d) reached. Automatically stopping episode.",
+                        max_timesteps_);
             state_ = State::EPISODE_STOPPED;
             publish_status("stopped", std::to_string(episode_count_));
             return;
         }
-        
+
         if (timestep_count % 20 == 0) {
             auto now = std::chrono::steady_clock::now();
             double elapsed = std::chrono::duration<double>(now - episode_start_time_).count();
@@ -367,22 +361,33 @@ void RecorderNode::set_head_ai_position() {
 
 std::string RecorderNode::state_to_string(State state) {
     switch (state) {
-        case State::IDLE: return "IDLE";
-        case State::TASK_ACTIVE: return "TASK_ACTIVE";
-        case State::EPISODE_ACTIVE: return "EPISODE_ACTIVE";
-        case State::EPISODE_STOPPED: return "EPISODE_STOPPED";
-        default: return "UNKNOWN";
+        case State::IDLE:
+            return "IDLE";
+        case State::TASK_ACTIVE:
+            return "TASK_ACTIVE";
+        case State::EPISODE_ACTIVE:
+            return "EPISODE_ACTIVE";
+        case State::EPISODE_STOPPED:
+            return "EPISODE_STOPPED";
+        default:
+            return "UNKNOWN";
     }
 }
 
 std::string RecorderNode::replay_state_to_string(ReplayState state) {
     switch (state) {
-        case ReplayState::IDLE: return "idle";
-        case ReplayState::READY: return "ready";
-        case ReplayState::PLAYING: return "playing";
-        case ReplayState::PAUSED: return "paused";
-        case ReplayState::FINISHED: return "finished";
-        default: return "unknown";
+        case ReplayState::IDLE:
+            return "idle";
+        case ReplayState::READY:
+            return "ready";
+        case ReplayState::PLAYING:
+            return "playing";
+        case ReplayState::PAUSED:
+            return "paused";
+        case ReplayState::FINISHED:
+            return "finished";
+        default:
+            return "unknown";
     }
 }
 
@@ -407,9 +412,9 @@ std::string get_timestamp_string() {
 void RecorderNode::activate_physical_primitive(
     const std::shared_ptr<brain_messages::srv::ActivateManipulationTask::Request> request,
     std::shared_ptr<brain_messages::srv::ActivateManipulationTask::Response> response) {
-    
     if (state_ == State::EPISODE_ACTIVE || state_ == State::EPISODE_STOPPED) {
-        RCLCPP_WARN(this->get_logger(), "New physical primitive requested during an %s episode; canceling current episode.",
+        RCLCPP_WARN(this->get_logger(),
+                    "New physical primitive requested during an %s episode; canceling current episode.",
                     state_to_string(state_).c_str());
         publish_status("cancelled", std::to_string(episode_count_));
         if (current_episode_) {
@@ -431,17 +436,15 @@ void RecorderNode::activate_physical_primitive(
     // Validate that the directory was previously created by /brain/create_physical_skill
     if (!fs::is_directory(task_dir)) {
         response->success = false;
-        RCLCPP_ERROR(this->get_logger(),
-            "task_directory '%s' does not exist. Call /brain/create_physical_skill first.",
-            task_dir.c_str());
+        RCLCPP_ERROR(this->get_logger(), "task_directory '%s' does not exist. Call /brain/create_physical_skill first.",
+                     task_dir.c_str());
         return;
     }
     std::string metadata_path = task_dir + "/metadata.json";
     if (!fs::exists(metadata_path)) {
         response->success = false;
-        RCLCPP_ERROR(this->get_logger(),
-            "No metadata.json in '%s'. Call /brain/create_physical_skill first.",
-            metadata_path.c_str());
+        RCLCPP_ERROR(this->get_logger(), "No metadata.json in '%s'. Call /brain/create_physical_skill first.",
+                     metadata_path.c_str());
         return;
     }
 
@@ -463,19 +466,18 @@ void RecorderNode::activate_physical_primitive(
     } else {
         episode_count_ = 0;
     }
-    
+
     current_task_name_ = display_name;
     current_task_dir_ = task_dir;
     state_ = State::TASK_ACTIVE;
-    RCLCPP_INFO(this->get_logger(), "New physical primitive '%s' started at %s.", display_name.c_str(), task_dir.c_str());
+    RCLCPP_INFO(this->get_logger(), "New physical primitive '%s' started at %s.", display_name.c_str(),
+                task_dir.c_str());
     publish_status("active");
     response->success = true;
 }
 
-void RecorderNode::handle_new_episode(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-    
+void RecorderNode::handle_new_episode(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                      std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     if (state_ == State::IDLE) {
         RCLCPP_ERROR(this->get_logger(), "Cannot start a new episode unless a task is active.");
         publish_status("failed - no active task");
@@ -483,13 +485,14 @@ void RecorderNode::handle_new_episode(
         response->message = "No active task. Please start a task first.";
         return;
     }
-    
+
     if (state_ == State::EPISODE_ACTIVE || state_ == State::EPISODE_STOPPED) {
-        RCLCPP_ERROR(this->get_logger(), "Cannot start a new episode while an episode is %s.", 
+        RCLCPP_ERROR(this->get_logger(), "Cannot start a new episode while an episode is %s.",
                      state_to_string(state_).c_str());
         publish_status("failed - episode " + state_to_string(state_), std::to_string(episode_count_));
         response->success = false;
-        response->message = "An episode is already " + state_to_string(state_) + ". Please save or cancel the current episode first.";
+        response->message =
+            "An episode is already " + state_to_string(state_) + ". Please save or cancel the current episode first.";
         return;
     }
 
@@ -508,21 +511,19 @@ void RecorderNode::handle_new_episode(
     episode_start_system_time_ = std::chrono::system_clock::now();
     state_ = State::EPISODE_ACTIVE;
     episode_count_++;
-    
+
     std::string episode_str = std::to_string(episode_count_);
     RCLCPP_INFO(this->get_logger(), "=== RECORDING STARTED ===");
     RCLCPP_INFO(this->get_logger(), "Task: %s, Episode: %s", current_task_name_.c_str(), episode_str.c_str());
     RCLCPP_INFO(this->get_logger(), "Recording at %d Hz", data_frequency_);
-    
+
     publish_status("active", episode_str);
     response->success = true;
     response->message = "Episode started.";
 }
 
-void RecorderNode::handle_save_episode(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-    
+void RecorderNode::handle_save_episode(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                       std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     if ((state_ != State::EPISODE_ACTIVE && state_ != State::EPISODE_STOPPED) || !current_episode_) {
         RCLCPP_ERROR(this->get_logger(), "No active or stopped episode to save.");
         if (state_ == State::TASK_ACTIVE) {
@@ -563,8 +564,7 @@ void RecorderNode::handle_save_episode(
     // Roll the state machine back to TASK_ACTIVE on any save failure so the
     // recorder stays usable for the next episode instead of wedging with a
     // null current_episode_ but EPISODE_ACTIVE/STOPPED state.
-    auto abort_save_with_error = [&](const std::string& reason,
-                                     const std::string& status_tag,
+    auto abort_save_with_error = [&](const std::string& reason, const std::string& status_tag,
                                      const std::string& message) {
         RCLCPP_ERROR(this->get_logger(), "%s", reason.c_str());
         current_episode_.reset();
@@ -583,10 +583,8 @@ void RecorderNode::handle_save_episode(
     } catch (const std::exception& e) {
         // Try to clean up the partial file so we don't leave a broken slot.
         current_episode_->cancel();
-        abort_save_with_error(
-            std::string("Failed to finalize streaming HDF5 file: ") + e.what(),
-            "failed - finalize error",
-            std::string("Failed to finalize episode: ") + e.what());
+        abort_save_with_error(std::string("Failed to finalize streaming HDF5 file: ") + e.what(),
+                              "failed - finalize error", std::string("Failed to finalize episode: ") + e.what());
         return;
     }
 
@@ -597,10 +595,8 @@ void RecorderNode::handle_save_episode(
         // remove it so we don't leak a stranded file.
         std::error_code ec;
         std::filesystem::remove(temp_path, ec);
-        abort_save_with_error(
-            std::string("Failed to register saved episode: ") + e.what(),
-            "failed - rename error",
-            std::string("Failed to register episode: ") + e.what());
+        abort_save_with_error(std::string("Failed to register saved episode: ") + e.what(), "failed - rename error",
+                              std::string("Failed to register episode: ") + e.what());
         return;
     }
 
@@ -615,10 +611,8 @@ void RecorderNode::handle_save_episode(
     response->message = "Episode saved.";
 }
 
-void RecorderNode::handle_cancel_episode(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-    
+void RecorderNode::handle_cancel_episode(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                         std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     if ((state_ != State::EPISODE_ACTIVE && state_ != State::EPISODE_STOPPED) || !current_episode_) {
         RCLCPP_ERROR(this->get_logger(), "No active or stopped episode to cancel.");
         if (state_ == State::TASK_ACTIVE) {
@@ -643,10 +637,8 @@ void RecorderNode::handle_cancel_episode(
     response->message = "Episode canceled.";
 }
 
-void RecorderNode::handle_stop_episode(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-    
+void RecorderNode::handle_stop_episode(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                       std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     if (state_ == State::EPISODE_ACTIVE) {
         state_ = State::EPISODE_STOPPED;
         RCLCPP_INFO(this->get_logger(), "Episode recording stopped. Waiting for save or cancel command.");
@@ -671,10 +663,8 @@ void RecorderNode::handle_stop_episode(
     }
 }
 
-void RecorderNode::handle_end_task(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-    
+void RecorderNode::handle_end_task(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                   std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     if (state_ == State::EPISODE_ACTIVE || state_ == State::EPISODE_STOPPED) {
         RCLCPP_WARN(this->get_logger(), "Ending task during an %s episode; canceling current episode first.",
                     state_to_string(state_).c_str());
@@ -684,7 +674,7 @@ void RecorderNode::handle_end_task(
         }
         current_episode_.reset();
     }
-    
+
     task_manager_->end_task();
     state_ = State::IDLE;
     RCLCPP_INFO(this->get_logger(), "Task ended; recorder state set to IDLE.");
@@ -696,15 +686,12 @@ void RecorderNode::handle_end_task(
     response->message = "Task ended.";
 }
 
-
-
 void RecorderNode::handle_get_task_metadata(
     const std::shared_ptr<brain_messages::srv::GetTaskMetadata::Request> request,
     std::shared_ptr<brain_messages::srv::GetTaskMetadata::Response> response) {
-    
     RCLCPP_INFO(this->get_logger(), "Received request to get metadata for task directory: %s",
                 request->task_directory.c_str());
-    
+
     try {
         auto [success, message, metadata_json] = task_manager_->get_task_metadata_by_directory(request->task_directory);
         response->success = success;
@@ -729,13 +716,10 @@ void RecorderNode::handle_get_task_metadata(
 
 // ========== REPLAY FUNCTIONALITY ==========
 
-void RecorderNode::handle_load_episode(
-    const std::shared_ptr<brain_messages::srv::LoadEpisode::Request> request,
-    std::shared_ptr<brain_messages::srv::LoadEpisode::Response> response) {
-    
-    RCLCPP_INFO(this->get_logger(), "Loading episode %d from %s", 
-                request->episode_id, request->task_directory.c_str());
-    
+void RecorderNode::handle_load_episode(const std::shared_ptr<brain_messages::srv::LoadEpisode::Request> request,
+                                       std::shared_ptr<brain_messages::srv::LoadEpisode::Response> response) {
+    RCLCPP_INFO(this->get_logger(), "Loading episode %d from %s", request->episode_id, request->task_directory.c_str());
+
     try {
         // Stop any current replay
         if (replay_state_ == ReplayState::PLAYING || replay_state_ == ReplayState::PAUSED) {
@@ -792,7 +776,7 @@ void RecorderNode::handle_load_episode(
         }
 
         hid_t img_group = H5Gopen2(file_id, "/observations/images", H5P_DEFAULT);
-        
+
         // Get camera names
         std::vector<std::string> camera_names;
         hsize_t num_objs;
@@ -820,7 +804,7 @@ void RecorderNode::handle_load_episode(
         for (const auto& cam_name : camera_names) {
             hid_t dataset = H5Dopen2(img_group, cam_name.c_str(), H5P_DEFAULT);
             hid_t dataspace = H5Dget_space(dataset);
-            
+
             int ndims = H5Sget_simple_extent_ndims(dataspace);
             std::vector<hsize_t> dims(ndims);
             H5Sget_simple_extent_dims(dataspace, dims.data(), nullptr);
@@ -842,9 +826,9 @@ void RecorderNode::handle_load_episode(
                 frames.push_back(frame.clone());
             }
             replay_buffer_[cam_name] = std::move(frames);
-            
-            RCLCPP_INFO(this->get_logger(), "Loaded %s: [%zu, %d, %d, %d]", 
-                        cam_name.c_str(), num_frames, height, width, channels);
+
+            RCLCPP_INFO(this->get_logger(), "Loaded %s: [%zu, %d, %d, %d]", cam_name.c_str(), num_frames, height, width,
+                        channels);
 
             H5Sclose(dataspace);
             H5Dclose(dataset);
@@ -867,10 +851,10 @@ void RecorderNode::handle_load_episode(
             hid_t ts_space = H5Dget_space(ts_dataset);
             hsize_t ts_dims[1];
             H5Sget_simple_extent_dims(ts_space, ts_dims, nullptr);
-            
+
             std::vector<double> arm_ts(ts_dims[0]);
             H5Dread(ts_dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, arm_ts.data());
-            
+
             if (!arm_ts.empty()) {
                 double first_ts = arm_ts[0];
                 for (auto& ts : arm_ts) {
@@ -878,7 +862,7 @@ void RecorderNode::handle_load_episode(
                 }
             }
             RCLCPP_INFO(this->get_logger(), "Loaded arm timestamps: %zu frames", arm_ts.size());
-            
+
             H5Sclose(ts_space);
             H5Dclose(ts_dataset);
         } else {
@@ -895,10 +879,10 @@ void RecorderNode::handle_load_episode(
             hid_t qpos_space = H5Dget_space(qpos_dataset);
             hsize_t qpos_dims[2];
             H5Sget_simple_extent_dims(qpos_space, qpos_dims, nullptr);
-            
+
             std::vector<double> qpos_data(qpos_dims[0] * qpos_dims[1]);
             H5Dread(qpos_dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, qpos_data.data());
-            
+
             for (size_t i = 0; i < qpos_dims[0]; i++) {
                 nlohmann::json row = nlohmann::json::array();
                 for (size_t j = 0; j < qpos_dims[1]; j++) {
@@ -907,7 +891,7 @@ void RecorderNode::handle_load_episode(
                 arm_data["qpos"].push_back(row);
             }
             RCLCPP_INFO(this->get_logger(), "Loaded qpos: [%llu, %llu]", qpos_dims[0], qpos_dims[1]);
-            
+
             H5Sclose(qpos_space);
             H5Dclose(qpos_dataset);
         }
@@ -918,10 +902,10 @@ void RecorderNode::handle_load_episode(
             hid_t qvel_space = H5Dget_space(qvel_dataset);
             hsize_t qvel_dims[2];
             H5Sget_simple_extent_dims(qvel_space, qvel_dims, nullptr);
-            
+
             std::vector<double> qvel_data(qvel_dims[0] * qvel_dims[1]);
             H5Dread(qvel_dataset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, qvel_data.data());
-            
+
             for (size_t i = 0; i < qvel_dims[0]; i++) {
                 nlohmann::json row = nlohmann::json::array();
                 for (size_t j = 0; j < qvel_dims[1]; j++) {
@@ -930,7 +914,7 @@ void RecorderNode::handle_load_episode(
                 arm_data["qvel"].push_back(row);
             }
             RCLCPP_INFO(this->get_logger(), "Loaded qvel: [%llu, %llu]", qvel_dims[0], qvel_dims[1]);
-            
+
             H5Sclose(qvel_space);
             H5Dclose(qvel_dataset);
         }
@@ -943,8 +927,8 @@ void RecorderNode::handle_load_episode(
         replay_state_ = ReplayState::READY;
 
         double duration = static_cast<double>(replay_total_frames_) / replay_fps_;
-        RCLCPP_INFO(this->get_logger(), "Episode loaded: %d frames, %.1f fps, %.1fs", 
-                    replay_total_frames_, replay_fps_, duration);
+        RCLCPP_INFO(this->get_logger(), "Episode loaded: %d frames, %.1f fps, %.1fs", replay_total_frames_, replay_fps_,
+                    duration);
 
         publish_replay_status();
 
@@ -966,10 +950,8 @@ void RecorderNode::handle_load_episode(
     }
 }
 
-void RecorderNode::handle_play_replay(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-    
+void RecorderNode::handle_play_replay(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                      std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     if (replay_state_ == ReplayState::IDLE) {
         response->success = false;
         response->message = "No episode loaded. Call load_episode first.";
@@ -988,18 +970,16 @@ void RecorderNode::handle_play_replay(
 
     start_replay_timer();
     replay_state_ = ReplayState::PLAYING;
-    
+
     RCLCPP_INFO(this->get_logger(), "Replay started from frame %d", replay_frame_index_);
     publish_replay_status();
-    
+
     response->success = true;
     response->message = "Replay started from frame " + std::to_string(replay_frame_index_);
 }
 
-void RecorderNode::handle_pause_replay(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-    
+void RecorderNode::handle_pause_replay(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                       std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     if (replay_state_ != ReplayState::PLAYING) {
         response->success = false;
         response->message = "Cannot pause: replay is " + replay_state_to_string(replay_state_);
@@ -1008,18 +988,16 @@ void RecorderNode::handle_pause_replay(
 
     stop_replay_timer();
     replay_state_ = ReplayState::PAUSED;
-    
+
     RCLCPP_INFO(this->get_logger(), "Replay paused at frame %d", replay_frame_index_);
     publish_replay_status();
-    
+
     response->success = true;
     response->message = "Replay paused at frame " + std::to_string(replay_frame_index_);
 }
 
-void RecorderNode::handle_stop_replay(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
-    
+void RecorderNode::handle_stop_replay(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                      std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     if (replay_state_ == ReplayState::IDLE) {
         response->success = false;
         response->message = "No episode loaded.";
@@ -1029,10 +1007,10 @@ void RecorderNode::handle_stop_replay(
     stop_replay_timer();
     replay_frame_index_ = 0;
     replay_state_ = ReplayState::READY;
-    
+
     RCLCPP_INFO(this->get_logger(), "Replay stopped and reset to frame 0");
     publish_replay_status();
-    
+
     response->success = true;
     response->message = "Replay stopped and reset to frame 0";
 }

--- a/ros2_ws/src/brain/manipulation/src/task_manager.cpp
+++ b/ros2_ws/src/brain/manipulation/src/task_manager.cpp
@@ -10,11 +10,10 @@ namespace fs = std::filesystem;
 
 namespace manipulation {
 
-TaskManager::TaskManager(const std::string& base_data_directory)
-    : base_data_directory_(base_data_directory) {}
+TaskManager::TaskManager(const std::string& base_data_directory) : base_data_directory_(base_data_directory) {}
 
 void TaskManager::start_new_task_at_directory(const std::string& task_name, const std::string& task_directory,
-                                               double data_frequency) {
+                                              double data_frequency) {
     current_task_name_ = task_name;
     current_task_dir_ = task_directory;
     std::string data_dir = current_task_dir_ + "/data";
@@ -31,12 +30,10 @@ void TaskManager::start_new_task_at_directory(const std::string& task_name, cons
     cleanup_stale_streaming_files();
 
     // Initialize metadata
-    metadata_ = {
-        {"data_frequency", data_frequency},
-        {"dataset_type", "h5"},
-        {"number_of_episodes", 0},
-        {"episodes", nlohmann::json::array()}
-    };
+    metadata_ = {{"data_frequency", data_frequency},
+                 {"dataset_type", "h5"},
+                 {"number_of_episodes", 0},
+                 {"episodes", nlohmann::json::array()}};
     save_metadata();
 }
 
@@ -47,12 +44,10 @@ void TaskManager::resume_task_at_directory(const std::string& task_name, const s
 
     if (!fs::exists(metadata_path)) {
         std::cerr << "No dataset_metadata.json for '" << task_name << "'. Starting fresh." << std::endl;
-        metadata_ = {
-            {"data_frequency", 0},
-            {"dataset_type", "h5"},
-            {"number_of_episodes", 0},
-            {"episodes", nlohmann::json::array()}
-        };
+        metadata_ = {{"data_frequency", 0},
+                     {"dataset_type", "h5"},
+                     {"number_of_episodes", 0},
+                     {"episodes", nlohmann::json::array()}};
         save_metadata();
         cleanup_stale_streaming_files();
         return;
@@ -80,15 +75,13 @@ void TaskManager::cleanup_stale_streaming_files() {
     }
 }
 
-void TaskManager::add_episode(const std::string& temp_file_path,
-                               const std::string& start_timestamp,
-                               const std::string& end_timestamp) {
+void TaskManager::add_episode(const std::string& temp_file_path, const std::string& start_timestamp,
+                              const std::string& end_timestamp) {
     std::string data_dir = current_task_dir_ + "/data";
     fs::create_directories(data_dir);
 
     if (!fs::exists(temp_file_path)) {
-        throw std::runtime_error("TaskManager::add_episode: streaming file does not exist: " +
-                                 temp_file_path);
+        throw std::runtime_error("TaskManager::add_episode: streaming file does not exist: " + temp_file_path);
     }
 
     int episode_id = metadata_["number_of_episodes"].get<int>();
@@ -101,26 +94,22 @@ void TaskManager::add_episode(const std::string& temp_file_path,
     // restore-from-git, partial crash, etc.). Better to fail loudly here and
     // let the operator reconcile than to lose an episode silently.
     if (fs::exists(file_path)) {
-        throw std::runtime_error(
-            "TaskManager::add_episode: destination already exists; refusing to overwrite '" +
-            file_path + "' (metadata/disk out of sync?)");
+        throw std::runtime_error("TaskManager::add_episode: destination already exists; refusing to overwrite '" +
+                                 file_path + "' (metadata/disk out of sync?)");
     }
 
     // Atomic-ish rename (same filesystem) of finalized streaming file into slot.
     std::error_code ec;
     fs::rename(temp_file_path, file_path, ec);
     if (ec) {
-        throw std::runtime_error("TaskManager::add_episode: failed to rename '" +
-                                 temp_file_path + "' -> '" + file_path + "': " +
-                                 ec.message());
+        throw std::runtime_error("TaskManager::add_episode: failed to rename '" + temp_file_path + "' -> '" +
+                                 file_path + "': " + ec.message());
     }
 
-    nlohmann::json episode_info = {
-        {"episode_id", episode_id},
-        {"file_name", file_name},
-        {"start_timestamp", start_timestamp},
-        {"end_timestamp", end_timestamp}
-    };
+    nlohmann::json episode_info = {{"episode_id", episode_id},
+                                   {"file_name", file_name},
+                                   {"start_timestamp", start_timestamp},
+                                   {"end_timestamp", end_timestamp}};
     metadata_["episodes"].push_back(episode_info);
     metadata_["number_of_episodes"] = episode_id + 1;
     save_metadata();
@@ -147,7 +136,7 @@ void TaskManager::save_metadata() {
     std::string data_dir = current_task_dir_ + "/data";
     fs::create_directories(data_dir);
     std::string metadata_path = data_dir + "/dataset_metadata.json";
-    
+
     std::ofstream file(metadata_path);
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open metadata file for writing: " + metadata_path);
@@ -160,16 +149,14 @@ void TaskManager::load_metadata() {
         throw std::runtime_error("No active task directory to load metadata from.");
     }
     std::string metadata_path = current_task_dir_ + "/data/dataset_metadata.json";
-    
+
     std::ifstream file(metadata_path);
     if (!file.is_open()) {
         std::cerr << "Cannot open " << metadata_path << ". Reinitializing metadata." << std::endl;
-        metadata_ = {
-            {"data_frequency", 0},
-            {"dataset_type", "h5"},
-            {"number_of_episodes", 0},
-            {"episodes", nlohmann::json::array()}
-        };
+        metadata_ = {{"data_frequency", 0},
+                     {"dataset_type", "h5"},
+                     {"number_of_episodes", 0},
+                     {"episodes", nlohmann::json::array()}};
         save_metadata();
         return;
     }
@@ -177,26 +164,23 @@ void TaskManager::load_metadata() {
 }
 
 std::optional<nlohmann::json> TaskManager::get_enriched_metadata_for_task(const std::string& task_directory,
-                                                                            std::string& error_msg) {
+                                                                          std::string& error_msg) {
     std::string data_dir = task_directory + "/data";
     std::string metadata_file_path = data_dir + "/dataset_metadata.json";
     std::string task_name = fs::path(task_directory).filename().string();
 
     // Helper: return a zero-episode response for any "no data yet" state.
     auto empty_metadata = [&]() -> nlohmann::json {
-        return {
-            {"task_name", task_name},
-            {"task_directory", task_directory},
-            {"data_frequency", 0},
-            {"number_of_episodes", 0},
-            {"episodes", nlohmann::json::array()}
-        };
+        return {{"task_name", task_name},
+                {"task_directory", task_directory},
+                {"data_frequency", 0},
+                {"number_of_episodes", 0},
+                {"episodes", nlohmann::json::array()}};
     };
 
     // No data yet — folder missing, no data/ subfolder, no metadata file, or empty file.
-    if (!fs::exists(task_directory) || !fs::is_directory(task_directory) ||
-        !fs::exists(data_dir) || !fs::is_directory(data_dir) ||
-        !fs::exists(metadata_file_path) || fs::file_size(metadata_file_path) == 0) {
+    if (!fs::exists(task_directory) || !fs::is_directory(task_directory) || !fs::exists(data_dir) ||
+        !fs::is_directory(data_dir) || !fs::exists(metadata_file_path) || fs::file_size(metadata_file_path) == 0) {
         return empty_metadata();
     }
 
@@ -240,29 +224,27 @@ std::optional<nlohmann::json> TaskManager::get_enriched_metadata_for_task(const 
                 }
             }
 
-            processed_episodes.push_back({
-                {"episode_id", "episode_" + std::to_string(episode_info.value("episode_id", 0))},
-                {"start_time", episode_info.value("start_timestamp", "N/A")},
-                {"end_time", episode_info.value("end_timestamp", "N/A")},
-                {"num_timesteps", num_timesteps},
-                {"file_name", episode_file_name}
-            });
+            processed_episodes.push_back(
+                {{"episode_id", "episode_" + std::to_string(episode_info.value("episode_id", 0))},
+                 {"start_time", episode_info.value("start_timestamp", "N/A")},
+                 {"end_time", episode_info.value("end_timestamp", "N/A")},
+                 {"num_timesteps", num_timesteps},
+                 {"file_name", episode_file_name}});
         }
     }
 
-    nlohmann::json enriched_metadata = {
-        {"task_name", task_name},
-        {"task_directory", task_directory},
-        {"data_frequency", dataset_metadata.value("data_frequency", 0)},
-        {"dataset_type", dataset_metadata.value("dataset_type", "h5")},
-        {"number_of_episodes", dataset_metadata.value("number_of_episodes", 0)},
-        {"episodes", processed_episodes}
-    };
+    nlohmann::json enriched_metadata = {{"task_name", task_name},
+                                        {"task_directory", task_directory},
+                                        {"data_frequency", dataset_metadata.value("data_frequency", 0)},
+                                        {"dataset_type", dataset_metadata.value("dataset_type", "h5")},
+                                        {"number_of_episodes", dataset_metadata.value("number_of_episodes", 0)},
+                                        {"episodes", processed_episodes}};
 
     return enriched_metadata;
 }
 
-std::tuple<bool, std::string, std::string> TaskManager::get_task_metadata_by_directory(const std::string& task_directory) {
+std::tuple<bool, std::string, std::string> TaskManager::get_task_metadata_by_directory(
+    const std::string& task_directory) {
     std::string error_msg;
     auto metadata_opt = get_enriched_metadata_for_task(task_directory, error_msg);
 

--- a/ros2_ws/src/maurice_bot/maurice_arm/include/maurice_arm/arm_node.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/include/maurice_arm/arm_node.hpp
@@ -30,18 +30,17 @@
 namespace maurice_arm {
 
 class MauriceArmNode : public rclcpp::Node {
-public:
+   public:
     MauriceArmNode();
     ~MauriceArmNode() = default;
 
     // ── Configuration (arm_config.cpp) ──────────────────────────────────
     void loadJointConfigs(const std::vector<std::string>& joint_names);
-    rcl_interfaces::msg::SetParametersResult onParameterChange(
-        const std::vector<rclcpp::Parameter>& parameters);
+    rcl_interfaces::msg::SetParametersResult onParameterChange(const std::vector<rclcpp::Parameter>& parameters);
 
     // ── Servo init & helpers (arm_services.cpp) ─────────────────────────
     void initializeServos();
-    template<typename Func>
+    template <typename Func>
     void retryServoOp(int servo_id, const char* op_name, Func&& fn, int max_retries = 3);
     void configureServoByIdLocked(int servo_id, bool enable_torque = true);
     void configureServosLocked(bool enable_torque = true);
@@ -57,18 +56,14 @@ public:
 
     // ── Service & topic callbacks (arm_services.cpp) ────────────────────
     void armCommandCallback(const std_msgs::msg::Float64MultiArray::SharedPtr msg);
-    void armTorqueOnCallback(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void armTorqueOffCallback(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void armRebootServosCallback(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void armFixErrorCallback(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void armTorqueOnCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                             std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void armTorqueOffCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                              std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void armRebootServosCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                                 std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void armFixErrorCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                             std::shared_ptr<std_srvs::srv::Trigger::Response> response);
     void healthMonitorCallback();
     std::string describeHardwareError(uint8_t status, int servo_id) const;
 
@@ -79,33 +74,25 @@ public:
     void moveHeadToAngleLocked(double logical_angle_deg);
     void publishHeadPosition(int encoder_value);
     void headPositionCallback(const std_msgs::msg::Int32::SharedPtr msg);
-    void headAiPositionCallback(
-        const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-        std::shared_ptr<std_srvs::srv::Trigger::Response> response);
-    void headEnableServoCallback(
-        const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-        std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+    void headAiPositionCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                                std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+    void headEnableServoCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                 std::shared_ptr<std_srvs::srv::SetBool::Response> response);
 
     // ── Trajectory planning & execution (arm_trajectory.cpp) ────────────
-    std::vector<std::vector<double>> computeCubicSplineTrajectory(
-        const std::vector<double>& start,
-        const std::vector<double>& goal,
-        double duration,
-        double dt);
+    std::vector<std::vector<double>> computeCubicSplineTrajectory(const std::vector<double>& start,
+                                                                  const std::vector<double>& goal, double duration,
+                                                                  double dt);
     bool planAndExecuteTrajectory(const std::vector<double>& target_positions, double trajectory_time,
-                                   GainMode trajectory_gain_mode = GainMode::SCHEDULED);
-    bool planAndExecuteMultiWaypointTrajectory(
-        const std::vector<std::vector<double>>& waypoints,
-        const std::vector<double>& segment_durations);
-    void armGotoJSCallback(
-        const std::shared_ptr<maurice_msgs::srv::GotoJS::Request> request,
-        std::shared_ptr<maurice_msgs::srv::GotoJS::Response> response);
-    void armGotoJSV2Callback(
-        const std::shared_ptr<maurice_msgs::srv::GotoJS::Request> request,
-        std::shared_ptr<maurice_msgs::srv::GotoJS::Response> response);
-    void armGotoJSTrajectoryCallback(
-        const std::shared_ptr<maurice_msgs::srv::GotoJSTrajectory::Request> request,
-        std::shared_ptr<maurice_msgs::srv::GotoJSTrajectory::Response> response);
+                                  GainMode trajectory_gain_mode = GainMode::SCHEDULED);
+    bool planAndExecuteMultiWaypointTrajectory(const std::vector<std::vector<double>>& waypoints,
+                                               const std::vector<double>& segment_durations);
+    void armGotoJSCallback(const std::shared_ptr<maurice_msgs::srv::GotoJS::Request> request,
+                           std::shared_ptr<maurice_msgs::srv::GotoJS::Response> response);
+    void armGotoJSV2Callback(const std::shared_ptr<maurice_msgs::srv::GotoJS::Request> request,
+                             std::shared_ptr<maurice_msgs::srv::GotoJS::Response> response);
+    void armGotoJSTrajectoryCallback(const std::shared_ptr<maurice_msgs::srv::GotoJSTrajectory::Request> request,
+                                     std::shared_ptr<maurice_msgs::srv::GotoJSTrajectory::Response> response);
 
     // ── Member variables ────────────────────────────────────────────────
 
@@ -124,7 +111,7 @@ public:
     rclcpp::Service<maurice_msgs::srv::GotoJS>::SharedPtr arm_goto_js_service_;
     rclcpp::Service<maurice_msgs::srv::GotoJS>::SharedPtr arm_goto_js_v2_service_;
     rclcpp::Service<maurice_msgs::srv::GotoJSTrajectory>::SharedPtr arm_goto_js_traj_service_;
-    sensor_msgs::msg::JointState arm_state_msg_;   // 6-joint message for /mars/arm/state
+    sensor_msgs::msg::JointState arm_state_msg_;    // 6-joint message for /mars/arm/state
     sensor_msgs::msg::JointState joint_state_msg_;  // 7-joint message for /joint_states
     std::vector<int> latest_arm_command_;
     std::mutex arm_command_mutex_;
@@ -185,41 +172,35 @@ public:
     // Motor stress protection (overload cooldown)
     // Leaky integrator: score += (A * |PWM| - C) * dt, clamped >= 0
     std::array<MotorStressTracker, 7> stress_trackers_;
-    bool stress_enabled_{false};              // master enable for leaky integrator
-    double stress_threshold_{100.0};      // score at which cooldown triggers
-    double stress_cooldown_sec_{2.0};     // how long to rest (seconds)
-    double stress_multiplier_{1.0};       // A: multiplier on |load|
-    double stress_leak_{0.0};             // C: constant leak rate
+    bool stress_enabled_{false};       // master enable for leaky integrator
+    double stress_threshold_{100.0};   // score at which cooldown triggers
+    double stress_cooldown_sec_{2.0};  // how long to rest (seconds)
+    double stress_multiplier_{1.0};    // A: multiplier on |load|
+    double stress_leak_{0.0};          // C: constant leak rate
 
     // Control loop timing instrumentation
-    std::array<TimingAccumulator, 10> timing_stats_{{
-        TimingAccumulator{"total"},
-        TimingAccumulator{"lock_wait"},
-        TimingAccumulator{"readState"},
-        TimingAccumulator{"readEffort"},
-        TimingAccumulator{"pubArm"},
-        TimingAccumulator{"pubHead+JS"},
-        TimingAccumulator{"gainSched"},
-        TimingAccumulator{"cmdWrite"},
-        TimingAccumulator{"syncWritePID"},
-        TimingAccumulator{"misc"}
-    }};
+    std::array<TimingAccumulator, 10> timing_stats_{{TimingAccumulator{"total"}, TimingAccumulator{"lock_wait"},
+                                                     TimingAccumulator{"readState"}, TimingAccumulator{"readEffort"},
+                                                     TimingAccumulator{"pubArm"}, TimingAccumulator{"pubHead+JS"},
+                                                     TimingAccumulator{"gainSched"}, TimingAccumulator{"cmdWrite"},
+                                                     TimingAccumulator{"syncWritePID"}, TimingAccumulator{"misc"}}};
 };
 
 // Template implementation must be in the header
-template<typename Func>
+template <typename Func>
 void MauriceArmNode::retryServoOp(int servo_id, const char* op_name, Func&& fn, int max_retries) {
     for (int attempt = 1; attempt <= max_retries; ++attempt) {
         try {
             fn();
             return;
         } catch (const std::exception& e) {
-            RCLCPP_WARN(this->get_logger(), "Servo %d %s attempt %d/%d failed: %s",
-                servo_id, op_name, attempt, max_retries, e.what());
-            if (attempt == max_retries) throw;
+            RCLCPP_WARN(this->get_logger(), "Servo %d %s attempt %d/%d failed: %s", servo_id, op_name, attempt,
+                        max_retries, e.what());
+            if (attempt == max_retries)
+                throw;
             std::this_thread::sleep_for(std::chrono::milliseconds(200));
         }
     }
 }
 
-} // namespace maurice_arm
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/include/maurice_arm/arm_types.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/include/maurice_arm/arm_types.hpp
@@ -13,9 +13,9 @@ namespace maurice_arm {
 // x330 motors (XL330, XC330) have current control hw (addr 38/102, modes 0/5)
 // x430 motors do not. addr 38 max = 1750 mA for all x330.
 static constexpr int kX330MaxCurrentLimit = 1750;
-static constexpr int kLoadWarningThreshold = 800;   // ~80% load (0.1% units)
+static constexpr int kLoadWarningThreshold = 800;  // ~80% load (0.1% units)
 static constexpr int kTemperatureWarningC = 70;
-static constexpr int kGainScheduleInterval = 20;     // control cycles between updates
+static constexpr int kGainScheduleInterval = 20;  // control cycles between updates
 
 inline bool isX330(const std::string& motor_type) {
     return motor_type.find("330") != std::string::npos;
@@ -48,7 +48,9 @@ struct GainProfile {
     bool operator==(const GainProfile& o) const {
         return kp == o.kp && ki == o.ki && kd == o.kd && ff1 == o.ff1 && ff2 == o.ff2;
     }
-    bool operator!=(const GainProfile& o) const { return !(*this == o); }
+    bool operator!=(const GainProfile& o) const {
+        return !(*this == o);
+    }
 };
 
 // Gain mode: SCHEDULED = interpolate near/far by extension, TELEOP = flat teleop gains
@@ -57,18 +59,23 @@ enum class GainMode { SCHEDULED, TELEOP };
 inline GainProfile parseGainsArray(const std::vector<int64_t>& arr) {
     constexpr int kMaxGain = 16383;
     GainProfile g;
-    if (arr.size() >= 1) g.kp  = std::clamp(static_cast<int>(arr[0]), 0, kMaxGain);
-    if (arr.size() >= 2) g.ki  = std::clamp(static_cast<int>(arr[1]), 0, kMaxGain);
-    if (arr.size() >= 3) g.kd  = std::clamp(static_cast<int>(arr[2]), 0, kMaxGain);
-    if (arr.size() >= 4) g.ff1 = std::clamp(static_cast<int>(arr[3]), 0, kMaxGain);
-    if (arr.size() >= 5) g.ff2 = std::clamp(static_cast<int>(arr[4]), 0, kMaxGain);
+    if (arr.size() >= 1)
+        g.kp = std::clamp(static_cast<int>(arr[0]), 0, kMaxGain);
+    if (arr.size() >= 2)
+        g.ki = std::clamp(static_cast<int>(arr[1]), 0, kMaxGain);
+    if (arr.size() >= 3)
+        g.kd = std::clamp(static_cast<int>(arr[2]), 0, kMaxGain);
+    if (arr.size() >= 4)
+        g.ff1 = std::clamp(static_cast<int>(arr[3]), 0, kMaxGain);
+    if (arr.size() >= 5)
+        g.ff2 = std::clamp(static_cast<int>(arr[4]), 0, kMaxGain);
     return g;
 }
 
 // Per-motor stress tracking for overload protection
 struct MotorStressTracker {
-    double score = 0.0;           // accumulated stress score
-    bool in_cooldown = false;     // currently resting?
+    double score = 0.0;                                    // accumulated stress score
+    bool in_cooldown = false;                              // currently resting?
     std::chrono::steady_clock::time_point cooldown_until;  // when to re-enable
 };
 
@@ -89,4 +96,4 @@ struct TimingAccumulator {
     }
 };
 
-} // namespace maurice_arm
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/include/maurice_arm/dynamixel.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/include/maurice_arm/dynamixel.hpp
@@ -28,7 +28,7 @@ enum class OperatingMode {
 };
 
 class Dynamixel {
-public:
+   public:
     struct Config {
         int baudrate = 57600;
         float protocol_version = 2.0;
@@ -42,7 +42,7 @@ public:
     // Torque control
     void enableTorque(int motor_id);
     void disableTorque(int motor_id);
-    
+
     // Configuration
     void setOperatingMode(int motor_id, OperatingMode mode);
     void setMinPositionLimit(int motor_id, int min_position);
@@ -63,7 +63,7 @@ public:
     // Write profile acceleration + velocity to multiple servos in a single GroupSyncWrite packet
     // Each entry: {servo_id, profile_acceleration, profile_velocity}
     void syncWriteProfile(const std::vector<std::tuple<int, int, int>>& profile_data);
-    
+
     // Read/Write
     int readPosition(int motor_id);
     int readVelocity(int motor_id);
@@ -72,18 +72,22 @@ public:
     uint8_t readHardwareErrorStatus(int motor_id);
     int16_t readPresentLoad(int motor_id);
     uint8_t readPresentTemperature(int motor_id);
-    
-    // Access to SDK objects for GroupSync operations
-    dynamixel::PortHandler* portHandler() { return port_handler_; }
-    dynamixel::PacketHandler* packetHandler() { return packet_handler_; }
 
-private:
+    // Access to SDK objects for GroupSync operations
+    dynamixel::PortHandler* portHandler() {
+        return port_handler_;
+    }
+    dynamixel::PacketHandler* packetHandler() {
+        return packet_handler_;
+    }
+
+   private:
     void connect();
-    
+
     Config config_;
     dynamixel::PortHandler* port_handler_;
     dynamixel::PacketHandler* packet_handler_;
-    
+
     // Control table addresses
     static constexpr int ADDR_RETURN_DELAY_TIME = 9;
     static constexpr int ADDR_TORQUE_ENABLE = 64;
@@ -109,5 +113,4 @@ private:
     static constexpr int ADDR_PRESENT_TEMPERATURE = 146;
 };
 
-} // namespace maurice_arm
-
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/include/maurice_arm/robot.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/include/maurice_arm/robot.hpp
@@ -9,7 +9,7 @@
 namespace maurice_arm {
 
 class Robot {
-public:
+   public:
     Robot(std::shared_ptr<Dynamixel> dynamixel, const std::vector<int>& servo_ids);
     ~Robot();
 
@@ -24,20 +24,19 @@ public:
     long last_read_txrx_us = 0;
     long last_write_txrx_us = 0;
 
-private:
+   private:
     std::shared_ptr<Dynamixel> dynamixel_;
     std::vector<int> servo_ids_;
-    
+
     std::unique_ptr<dynamixel::GroupSyncRead> position_reader_;
     std::unique_ptr<dynamixel::GroupSyncRead> velocity_reader_;
     std::unique_ptr<dynamixel::GroupSyncRead> state_reader_;  // Combined reader for both velocity and position
     std::unique_ptr<dynamixel::GroupSyncWrite> pos_writer_;
-    
+
     static constexpr int ADDR_PRESENT_LOAD = 126;
     static constexpr int ADDR_PRESENT_POSITION = 132;
     static constexpr int ADDR_PRESENT_VELOCITY = 128;
     static constexpr int ADDR_GOAL_POSITION = 116;
 };
 
-} // namespace maurice_arm
-
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_config.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_config.cpp
@@ -37,10 +37,9 @@ void MauriceArmNode::loadJointConfigs(const std::vector<std::string>& joint_name
         // Validate motor_type vs control_mode
         if (!config.motor_type.empty() && !isX330(config.motor_type) &&
             (config.control_mode == 0 || config.control_mode == 5)) {
-            throw std::runtime_error(
-                jn + " (" + config.motor_type +
-                "): control_mode " + std::to_string(config.control_mode) +
-                " requires current hw — only x330 motors support modes 0/5");
+            throw std::runtime_error(jn + " (" + config.motor_type + "): control_mode " +
+                                     std::to_string(config.control_mode) +
+                                     " requires current hw — only x330 motors support modes 0/5");
         }
 
         // Current limit: x330 defaults to hw max, x430 has no current hw
@@ -49,21 +48,22 @@ void MauriceArmNode::loadJointConfigs(const std::vector<std::string>& joint_name
             config.current_limit = (cl > 0) ? cl : kX330MaxCurrentLimit;
             if (config.current_limit > kX330MaxCurrentLimit) {
                 throw std::runtime_error(jn + ": current_limit out of range [1, " +
-                    std::to_string(kX330MaxCurrentLimit) + "]");
+                                         std::to_string(kX330MaxCurrentLimit) + "]");
             }
         } else if (cl > 0) {
             throw std::runtime_error(jn + " (" + config.motor_type +
-                "): current_limit not supported — no current control hw");
+                                     "): current_limit not supported — no current control hw");
         }
 
         config.homing_offset = static_cast<int>(this->get_parameter(jn + ".homing_offset").as_int());
         config.profile_velocity = static_cast<int>(this->get_parameter(jn + ".profile_velocity").as_int());
         config.profile_acceleration = static_cast<int>(this->get_parameter(jn + ".profile_acceleration").as_int());
 
-        RCLCPP_INFO(this->get_logger(), "Joint %zu (%s): servo_id=%d, motor=%s, limits=[%.3f, %.3f] rad, pwm=%d, mode=%d, current=%d",
-            i + 1, jn.c_str(), config.servo_id,
-            config.motor_type.empty() ? "(unset)" : config.motor_type.c_str(),
-            config.min_pos_rad, config.max_pos_rad, config.pwm_limit, config.control_mode, config.current_limit);
+        RCLCPP_INFO(this->get_logger(),
+                    "Joint %zu (%s): servo_id=%d, motor=%s, limits=[%.3f, %.3f] rad, pwm=%d, mode=%d, current=%d",
+                    i + 1, jn.c_str(), config.servo_id,
+                    config.motor_type.empty() ? "(unset)" : config.motor_type.c_str(), config.min_pos_rad,
+                    config.max_pos_rad, config.pwm_limit, config.control_mode, config.current_limit);
         if (config.homing_offset != 0)
             RCLCPP_INFO(this->get_logger(), "  Homing offset: %d", config.homing_offset);
 
@@ -77,7 +77,8 @@ void MauriceArmNode::loadJointConfigs(const std::vector<std::string>& joint_name
             if (!far_arr.empty()) {
                 far_gains = parseGainsArray(far_arr);
             }
-        } catch (...) {}  // empty [] in YAML may not parse as integer array
+        } catch (...) {
+        }  // empty [] in YAML may not parse as integer array
 
         GainProfile teleop_gains{};  // teleop gains (November tuning)
         bool has_teleop_gains = false;
@@ -87,30 +88,32 @@ void MauriceArmNode::loadJointConfigs(const std::vector<std::string>& joint_name
                 teleop_gains = parseGainsArray(teleop_arr);
                 has_teleop_gains = true;
             }
-        } catch (...) {}
+        } catch (...) {
+        }
 
         // Set joint config gains from near (initial operating gains)
-        config.kp  = near_gains.kp;
-        config.ki  = near_gains.ki;
-        config.kd  = near_gains.kd;
+        config.kp = near_gains.kp;
+        config.ki = near_gains.ki;
+        config.kd = near_gains.kd;
         config.ff1 = near_gains.ff1;
         config.ff2 = near_gains.ff2;
 
         // Store gain scheduling profiles
         gs_near_[i] = near_gains;
-        gs_far_[i]  = far_gains;
+        gs_far_[i] = far_gains;
         gs_teleop_[i] = has_teleop_gains ? teleop_gains : near_gains;
         gs_last_applied_[i] = near_gains;
 
         RCLCPP_INFO(this->get_logger(), "  Gains near: [%d, %d, %d, %d, %d]  far: [%d, %d, %d, %d, %d]%s",
-            near_gains.kp, near_gains.ki, near_gains.kd, near_gains.ff1, near_gains.ff2,
-            far_gains.kp, far_gains.ki, far_gains.kd, far_gains.ff1, far_gains.ff2,
-            (near_gains != far_gains) ? "  (gain scheduling active)" : "");
+                    near_gains.kp, near_gains.ki, near_gains.kd, near_gains.ff1, near_gains.ff2, far_gains.kp,
+                    far_gains.ki, far_gains.kd, far_gains.ff1, far_gains.ff2,
+                    (near_gains != far_gains) ? "  (gain scheduling active)" : "");
         if (has_teleop_gains)
-            RCLCPP_INFO(this->get_logger(), "  Gains teleop: [%d, %d, %d, %d, %d]",
-                teleop_gains.kp, teleop_gains.ki, teleop_gains.kd, teleop_gains.ff1, teleop_gains.ff2);
+            RCLCPP_INFO(this->get_logger(), "  Gains teleop: [%d, %d, %d, %d, %d]", teleop_gains.kp, teleop_gains.ki,
+                        teleop_gains.kd, teleop_gains.ff1, teleop_gains.ff2);
         if (config.profile_velocity > 0 || config.profile_acceleration > 0)
-            RCLCPP_INFO(this->get_logger(), "  Profile: vel=%d, accel=%d", config.profile_velocity, config.profile_acceleration);
+            RCLCPP_INFO(this->get_logger(), "  Profile: vel=%d, accel=%d", config.profile_velocity,
+                        config.profile_acceleration);
 
         // Head-specific config for joint 7 (index 6)
         if (i == 6) {
@@ -130,8 +133,8 @@ void MauriceArmNode::loadJointConfigs(const std::vector<std::string>& joint_name
             }
 
             RCLCPP_INFO(this->get_logger(), "  Head config: range=[%.1f, %.1f] deg, AI pos=%.1f deg, reversed=%s",
-                config.head_min_angle_deg, config.head_max_angle_deg, config.head_ai_position_deg,
-                config.head_direction_reversed ? "true" : "false");
+                        config.head_min_angle_deg, config.head_max_angle_deg, config.head_ai_position_deg,
+                        config.head_direction_reversed ? "true" : "false");
         }
 
         joint_configs_.push_back(config);
@@ -141,7 +144,6 @@ void MauriceArmNode::loadJointConfigs(const std::vector<std::string>& joint_name
 
 rcl_interfaces::msg::SetParametersResult MauriceArmNode::onParameterChange(
     const std::vector<rclcpp::Parameter>& parameters) {
-
     rcl_interfaces::msg::SetParametersResult result;
     result.successful = true;
 
@@ -161,14 +163,18 @@ rcl_interfaces::msg::SetParametersResult MauriceArmNode::onParameterChange(
         // Match pattern: joint_N.<suffix>
         if (name.size() >= 8 && name.substr(0, 6) == "joint_") {
             size_t dot = name.find('.', 6);
-            if (dot == std::string::npos) continue;
+            if (dot == std::string::npos)
+                continue;
 
             int joint_num = 0;
             try {
                 joint_num = std::stoi(name.substr(6, dot - 6));
-            } catch (...) { continue; }
+            } catch (...) {
+                continue;
+            }
 
-            if (joint_num < 1 || joint_num > static_cast<int>(joint_configs_.size())) continue;
+            if (joint_num < 1 || joint_num > static_cast<int>(joint_configs_.size()))
+                continue;
             int ji = joint_num - 1;
 
             std::string suffix = name.substr(dot + 1);
@@ -177,14 +183,14 @@ rcl_interfaces::msg::SetParametersResult MauriceArmNode::onParameterChange(
                 auto arr = param.as_integer_array();
                 GainProfile g = parseGainsArray(arr);
                 gs_near_[ji] = g;
-                joint_configs_[ji].kp  = g.kp;
-                joint_configs_[ji].ki  = g.ki;
-                joint_configs_[ji].kd  = g.kd;
+                joint_configs_[ji].kp = g.kp;
+                joint_configs_[ji].ki = g.ki;
+                joint_configs_[ji].kd = g.kd;
                 joint_configs_[ji].ff1 = g.ff1;
                 joint_configs_[ji].ff2 = g.ff2;
                 pid_changed_joints.insert(joint_num);
-                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.gains_near = [%d, %d, %d, %d, %d]",
-                    joint_num, g.kp, g.ki, g.kd, g.ff1, g.ff2);
+                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.gains_near = [%d, %d, %d, %d, %d]", joint_num,
+                            g.kp, g.ki, g.kd, g.ff1, g.ff2);
             } else if (suffix == "gains_far") {
                 try {
                     auto arr = param.as_integer_array();
@@ -192,8 +198,8 @@ rcl_interfaces::msg::SetParametersResult MauriceArmNode::onParameterChange(
                 } catch (...) {
                     gs_far_[ji] = gs_near_[ji];
                 }
-                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.gains_far = [%d, %d, %d, %d, %d]",
-                    joint_num, gs_far_[ji].kp, gs_far_[ji].ki, gs_far_[ji].kd, gs_far_[ji].ff1, gs_far_[ji].ff2);
+                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.gains_far = [%d, %d, %d, %d, %d]", joint_num,
+                            gs_far_[ji].kp, gs_far_[ji].ki, gs_far_[ji].kd, gs_far_[ji].ff1, gs_far_[ji].ff2);
             } else if (suffix == "gains_teleop") {
                 try {
                     auto arr = param.as_integer_array();
@@ -201,18 +207,19 @@ rcl_interfaces::msg::SetParametersResult MauriceArmNode::onParameterChange(
                 } catch (...) {
                     gs_teleop_[ji] = gs_near_[ji];
                 }
-                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.gains_teleop = [%d, %d, %d, %d, %d]",
-                    joint_num, gs_teleop_[ji].kp, gs_teleop_[ji].ki, gs_teleop_[ji].kd, gs_teleop_[ji].ff1, gs_teleop_[ji].ff2);
+                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.gains_teleop = [%d, %d, %d, %d, %d]", joint_num,
+                            gs_teleop_[ji].kp, gs_teleop_[ji].ki, gs_teleop_[ji].kd, gs_teleop_[ji].ff1,
+                            gs_teleop_[ji].ff2);
             } else if (suffix == "profile_velocity") {
                 joint_configs_[ji].profile_velocity = static_cast<int>(param.as_int());
                 profile_changed_joints.insert(joint_num);
-                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.profile_velocity = %d",
-                    joint_num, joint_configs_[ji].profile_velocity);
+                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.profile_velocity = %d", joint_num,
+                            joint_configs_[ji].profile_velocity);
             } else if (suffix == "profile_acceleration") {
                 joint_configs_[ji].profile_acceleration = static_cast<int>(param.as_int());
                 profile_changed_joints.insert(joint_num);
-                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.profile_acceleration = %d",
-                    joint_num, joint_configs_[ji].profile_acceleration);
+                RCLCPP_INFO(this->get_logger(), "Hot-reload: joint_%d.profile_acceleration = %d", joint_num,
+                            joint_configs_[ji].profile_acceleration);
             }
         }
     }
@@ -249,4 +256,4 @@ rcl_interfaces::msg::SetParametersResult MauriceArmNode::onParameterChange(
     return result;
 }
 
-} // namespace maurice_arm
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_control.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_control.cpp
@@ -21,9 +21,9 @@ void MauriceArmNode::controlTimerCallback() {
         std::vector<double> efforts;
         for (size_t j = 0; j < loads.size() && j < joint_configs_.size(); ++j) {
             if (joint_configs_[j].current_limit > 0) {
-                efforts.push_back(static_cast<double>(loads[j]));        // mA
+                efforts.push_back(static_cast<double>(loads[j]));  // mA
             } else {
-                efforts.push_back(static_cast<double>(loads[j]) / 10.0); // %
+                efforts.push_back(static_cast<double>(loads[j]) / 10.0);  // %
             }
         }
         ts[3] = std::chrono::steady_clock::now();
@@ -93,17 +93,19 @@ void MauriceArmNode::controlTimerCallback() {
 
         // ========== PERIODIC GAIN DUMP (every 2s) ==========
         RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-            "Gains: J1[P=%d I=%d D=%d F1=%d F2=%d] J2[P=%d I=%d D=%d F1=%d F2=%d] "
-            "J3[P=%d I=%d D=%d F1=%d F2=%d] J4[P=%d I=%d D=%d F1=%d F2=%d] "
-            "J5[P=%d I=%d D=%d F1=%d F2=%d] J6[P=%d I=%d D=%d F1=%d F2=%d] "
-            "J7[P=%d I=%d D=%d F1=%d F2=%d]",
-            joint_configs_[0].kp, joint_configs_[0].ki, joint_configs_[0].kd, joint_configs_[0].ff1, joint_configs_[0].ff2,
-            joint_configs_[1].kp, joint_configs_[1].ki, joint_configs_[1].kd, joint_configs_[1].ff1, joint_configs_[1].ff2,
-            joint_configs_[2].kp, joint_configs_[2].ki, joint_configs_[2].kd, joint_configs_[2].ff1, joint_configs_[2].ff2,
-            joint_configs_[3].kp, joint_configs_[3].ki, joint_configs_[3].kd, joint_configs_[3].ff1, joint_configs_[3].ff2,
-            joint_configs_[4].kp, joint_configs_[4].ki, joint_configs_[4].kd, joint_configs_[4].ff1, joint_configs_[4].ff2,
-            joint_configs_[5].kp, joint_configs_[5].ki, joint_configs_[5].kd, joint_configs_[5].ff1, joint_configs_[5].ff2,
-            joint_configs_[6].kp, joint_configs_[6].ki, joint_configs_[6].kd, joint_configs_[6].ff1, joint_configs_[6].ff2);
+                             "Gains: J1[P=%d I=%d D=%d F1=%d F2=%d] J2[P=%d I=%d D=%d F1=%d F2=%d] "
+                             "J3[P=%d I=%d D=%d F1=%d F2=%d] J4[P=%d I=%d D=%d F1=%d F2=%d] "
+                             "J5[P=%d I=%d D=%d F1=%d F2=%d] J6[P=%d I=%d D=%d F1=%d F2=%d] "
+                             "J7[P=%d I=%d D=%d F1=%d F2=%d]",
+                             joint_configs_[0].kp, joint_configs_[0].ki, joint_configs_[0].kd, joint_configs_[0].ff1,
+                             joint_configs_[0].ff2, joint_configs_[1].kp, joint_configs_[1].ki, joint_configs_[1].kd,
+                             joint_configs_[1].ff1, joint_configs_[1].ff2, joint_configs_[2].kp, joint_configs_[2].ki,
+                             joint_configs_[2].kd, joint_configs_[2].ff1, joint_configs_[2].ff2, joint_configs_[3].kp,
+                             joint_configs_[3].ki, joint_configs_[3].kd, joint_configs_[3].ff1, joint_configs_[3].ff2,
+                             joint_configs_[4].kp, joint_configs_[4].ki, joint_configs_[4].kd, joint_configs_[4].ff1,
+                             joint_configs_[4].ff2, joint_configs_[5].kp, joint_configs_[5].ki, joint_configs_[5].kd,
+                             joint_configs_[5].ff1, joint_configs_[5].ff2, joint_configs_[6].kp, joint_configs_[6].ki,
+                             joint_configs_[6].kd, joint_configs_[6].ff1, joint_configs_[6].ff2);
 
         // ========== GAIN SCHEDULING ==========
         // TELEOP mode: use flat teleop gains (no extension-based interpolation)
@@ -122,7 +124,8 @@ void MauriceArmNode::controlTimerCallback() {
                         dynamixel_->setProfileVelocity(joint_configs_[i].servo_id, 0);
                         dynamixel_->setProfileAcceleration(joint_configs_[i].servo_id, 0);
                     }
-                    RCLCPP_INFO(this->get_logger(), "TELEOP: profile velocity/acceleration set to 0 (unlimited) for joints 1-6");
+                    RCLCPP_INFO(this->get_logger(),
+                                "TELEOP: profile velocity/acceleration set to 0 (unlimited) for joints 1-6");
                 }
 
                 // TELEOP: apply flat teleop gains for joints 1-6
@@ -131,26 +134,28 @@ void MauriceArmNode::controlTimerCallback() {
                     if (target != gs_last_applied_[i]) {
                         gs_changed = true;
                         gs_last_applied_[i] = target;
-                        joint_configs_[i].kp  = target.kp;
-                        joint_configs_[i].ki  = target.ki;
-                        joint_configs_[i].kd  = target.kd;
+                        joint_configs_[i].kp = target.kp;
+                        joint_configs_[i].ki = target.ki;
+                        joint_configs_[i].kd = target.kd;
                         joint_configs_[i].ff1 = target.ff1;
                         joint_configs_[i].ff2 = target.ff2;
                     }
-                    gs_pid_data.emplace_back(joint_configs_[i].servo_id, target.ff2, target.ff1, target.kd, target.ki, target.kp);
+                    gs_pid_data.emplace_back(joint_configs_[i].servo_id, target.ff2, target.ff1, target.kd, target.ki,
+                                             target.kp);
                 }
                 if (gs_changed) {
                     auto pid_start = std::chrono::steady_clock::now();
                     dynamixel_->syncWritePID(gs_pid_data);
                     auto pid_us = std::chrono::duration_cast<std::chrono::microseconds>(
-                        std::chrono::steady_clock::now() - pid_start).count();
+                                      std::chrono::steady_clock::now() - pid_start)
+                                      .count();
                     timing_stats_[8].add(pid_us);
                     RCLCPP_INFO(this->get_logger(),
-                        "TELEOP gains applied | J1 P=%d I=%d D=%d | J2 P=%d I=%d D=%d | J3 P=%d I=%d D=%d | J4 P=%d I=%d D=%d",
-                        gs_teleop_[0].kp, gs_teleop_[0].ki, gs_teleop_[0].kd,
-                        gs_teleop_[1].kp, gs_teleop_[1].ki, gs_teleop_[1].kd,
-                        gs_teleop_[2].kp, gs_teleop_[2].ki, gs_teleop_[2].kd,
-                        gs_teleop_[3].kp, gs_teleop_[3].ki, gs_teleop_[3].kd);
+                                "TELEOP gains applied | J1 P=%d I=%d D=%d | J2 P=%d I=%d D=%d | J3 P=%d I=%d D=%d | J4 "
+                                "P=%d I=%d D=%d",
+                                gs_teleop_[0].kp, gs_teleop_[0].ki, gs_teleop_[0].kd, gs_teleop_[1].kp,
+                                gs_teleop_[1].ki, gs_teleop_[1].kd, gs_teleop_[2].kp, gs_teleop_[2].ki,
+                                gs_teleop_[2].kd, gs_teleop_[3].kp, gs_teleop_[3].ki, gs_teleop_[3].kd);
                 }
             } else {
                 // On transition to SCHEDULED: restore profile limits from config
@@ -158,25 +163,26 @@ void MauriceArmNode::controlTimerCallback() {
                     last_applied_gain_mode_ = GainMode::SCHEDULED;
                     for (int i = 0; i < 6; i++) {
                         if (joint_configs_[i].profile_velocity > 0)
-                            dynamixel_->setProfileVelocity(joint_configs_[i].servo_id, joint_configs_[i].profile_velocity);
+                            dynamixel_->setProfileVelocity(joint_configs_[i].servo_id,
+                                                           joint_configs_[i].profile_velocity);
                         if (joint_configs_[i].profile_acceleration > 0)
-                            dynamixel_->setProfileAcceleration(joint_configs_[i].servo_id, joint_configs_[i].profile_acceleration);
+                            dynamixel_->setProfileAcceleration(joint_configs_[i].servo_id,
+                                                               joint_configs_[i].profile_acceleration);
                     }
                     RCLCPP_INFO(this->get_logger(), "SCHEDULED: profile velocity/acceleration restored from config");
                 }
 
                 // SCHEDULED: interpolate near/far by arm extension for joints 1-4
                 constexpr double L2_x = 0.02825, L2_z = 0.12125;
-                constexpr double L3_x = 0.1375,  L3_z = 0.0045;
+                constexpr double L3_x = 0.1375, L3_z = 0.0045;
                 constexpr double L45_x = 0.110838;
                 constexpr double kMaxReach = 0.37291;
 
                 double q2 = positions_rad[1], q3 = positions_rad[2], q4 = positions_rad[3];
                 double a2 = q2, a23 = q2 + q3, a234 = q2 + q3 + q4;
 
-                double ee_x = L2_x*std::cos(a2)  + L2_z*std::sin(a2)
-                            + L3_x*std::cos(a23) + L3_z*std::sin(a23)
-                            + L45_x*std::cos(a234);
+                double ee_x = L2_x * std::cos(a2) + L2_z * std::sin(a2) + L3_x * std::cos(a23) + L3_z * std::sin(a23) +
+                              L45_x * std::cos(a234);
 
                 double horiz_reach = std::abs(ee_x);
                 double extension_linear = std::clamp((horiz_reach / kMaxReach - 0.1) / 0.9, 0.0, 1.0);
@@ -193,27 +199,28 @@ void MauriceArmNode::controlTimerCallback() {
                     if (interp != gs_last_applied_[i]) {
                         gs_changed = true;
                         gs_last_applied_[i] = interp;
-                        joint_configs_[i].kp  = interp.kp;
-                        joint_configs_[i].ki  = interp.ki;
-                        joint_configs_[i].kd  = interp.kd;
+                        joint_configs_[i].kp = interp.kp;
+                        joint_configs_[i].ki = interp.ki;
+                        joint_configs_[i].kd = interp.kd;
                         joint_configs_[i].ff1 = interp.ff1;
                         joint_configs_[i].ff2 = interp.ff2;
                     }
-                    gs_pid_data.emplace_back(joint_configs_[i].servo_id, interp.ff2, interp.ff1, interp.kd, interp.ki, interp.kp);
+                    gs_pid_data.emplace_back(joint_configs_[i].servo_id, interp.ff2, interp.ff1, interp.kd, interp.ki,
+                                             interp.kp);
                 }
                 if (gs_changed) {
                     auto pid_start = std::chrono::steady_clock::now();
                     dynamixel_->syncWritePID(gs_pid_data);
                     auto pid_us = std::chrono::duration_cast<std::chrono::microseconds>(
-                        std::chrono::steady_clock::now() - pid_start).count();
+                                      std::chrono::steady_clock::now() - pid_start)
+                                      .count();
                     timing_stats_[8].add(pid_us);
-                    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 500,
+                    RCLCPP_INFO_THROTTLE(
+                        this->get_logger(), *this->get_clock(), 500,
                         "GainSched ext=%.2f (h=%.3fm) | J1 P=%d D=%d | J2 P=%d D=%d | J3 P=%d D=%d | J4 P=%d D=%d",
-                        extension, horiz_reach,
-                        gs_last_applied_[0].kp, gs_last_applied_[0].kd,
-                        gs_last_applied_[1].kp, gs_last_applied_[1].kd,
-                        gs_last_applied_[2].kp, gs_last_applied_[2].kd,
-                        gs_last_applied_[3].kp, gs_last_applied_[3].kd);
+                        extension, horiz_reach, gs_last_applied_[0].kp, gs_last_applied_[0].kd, gs_last_applied_[1].kp,
+                        gs_last_applied_[1].kd, gs_last_applied_[2].kp, gs_last_applied_[2].kd, gs_last_applied_[3].kp,
+                        gs_last_applied_[3].kd);
                 }
             }
         }
@@ -253,7 +260,8 @@ void MauriceArmNode::controlTimerCallback() {
                 cmd_msg.position.resize(6);
                 for (int i = 0; i < 6; ++i) {
                     double rad = ((full_command[i] - 2048) * 2 * M_PI) / 4096.0;
-                    if (i == 1 || i == 2 || i == 3 || i == 5) rad = -rad;
+                    if (i == 1 || i == 2 || i == 3 || i == 5)
+                        rad = -rad;
                     cmd_msg.position[i] = rad;
                 }
                 arm_command_state_pub_->publish(cmd_msg);
@@ -279,7 +287,8 @@ void MauriceArmNode::controlTimerCallback() {
 
 void MauriceArmNode::recordLoopTiming(std::array<std::chrono::steady_clock::time_point, 9>& ts) {
     for (size_t i = 1; i < ts.size(); ++i)
-        if (ts[i] < ts[i - 1]) ts[i] = ts[i - 1];
+        if (ts[i] < ts[i - 1])
+            ts[i] = ts[i - 1];
 
     std::array<long, 10> us{};
     us[0] = std::chrono::duration_cast<std::chrono::microseconds>(ts[8] - ts[0]).count();
@@ -288,7 +297,8 @@ void MauriceArmNode::recordLoopTiming(std::array<std::chrono::steady_clock::time
     us[9] = std::chrono::duration_cast<std::chrono::microseconds>(ts[8] - ts[7]).count();
 
     for (size_t i = 0; i < timing_stats_.size(); ++i)
-        if (i != 8) timing_stats_[i].add(us[i]);
+        if (i != 8)
+            timing_stats_[i].add(us[i]);
 
     long avg_total = timing_stats_[0].avg();
 
@@ -306,8 +316,8 @@ void MauriceArmNode::recordLoopTiming(std::array<std::chrono::steady_clock::time
     RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 2000, "%s", pct.str().c_str());
 
     RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-        "SerialBus(us): readState_txrx=%ld  write_txrx=%ld",
-        robot_->last_read_txrx_us, robot_->last_write_txrx_us);
+                         "SerialBus(us): readState_txrx=%ld  write_txrx=%ld", robot_->last_read_txrx_us,
+                         robot_->last_write_txrx_us);
 }
 
 std::vector<int> MauriceArmNode::applyLimitsAndConvertToEncoder(std::vector<double>& command_data) {
@@ -329,7 +339,7 @@ std::vector<int> MauriceArmNode::applyLimitsAndConvertToEncoder(std::vector<doub
         if (joint1_pos < -1.35) {
             // Negative side clear — no restriction
         } else if (joint1_pos < -1.0) {
-            double t = - (joint1_pos - (-1.0)) / (-1.0 - (-1.35));
+            double t = -(joint1_pos - (-1.0)) / (-1.0 - (-1.35));
             double interpolated_limit = restricted_limit + t * (original_min_limit - restricted_limit);
             joint2_min_limit = std::max(joint2_min_limit, interpolated_limit);
         } else if (joint1_pos < 1.0) {
@@ -342,8 +352,8 @@ std::vector<int> MauriceArmNode::applyLimitsAndConvertToEncoder(std::vector<doub
 
         if (joint2_pos < joint2_min_limit) {
             RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
-                "Joint2 limited due to joint1=%.3f: requested %.3f, clamped to %.3f",
-                joint1_pos, joint2_pos, joint2_min_limit);
+                                 "Joint2 limited due to joint1=%.3f: requested %.3f, clamped to %.3f", joint1_pos,
+                                 joint2_pos, joint2_min_limit);
         }
 
         command_data[1] = std::clamp(joint2_pos, joint2_min_limit, joint2_max_limit);
@@ -380,15 +390,13 @@ void MauriceArmNode::updateMotorStress(double dt, const std::vector<int>& loads)
 
                 // Re-enable torque on this servo
                 int servo_id = joint_configs_[j].servo_id;
-                RCLCPP_WARN(this->get_logger(),
-                    "Stress cooldown ended for joint %zu (servo %d) — re-enabling torque",
-                    j + 1, servo_id);
+                RCLCPP_WARN(this->get_logger(), "Stress cooldown ended for joint %zu (servo %d) — re-enabling torque",
+                            j + 1, servo_id);
                 try {
                     dynamixel_->enableTorque(servo_id);
                 } catch (const std::exception& e) {
-                    RCLCPP_ERROR(this->get_logger(),
-                        "Failed to re-enable torque on servo %d after cooldown: %s",
-                        servo_id, e.what());
+                    RCLCPP_ERROR(this->get_logger(), "Failed to re-enable torque on servo %d after cooldown: %s",
+                                 servo_id, e.what());
                 }
             }
             continue;  // skip scoring while in cooldown
@@ -403,31 +411,30 @@ void MauriceArmNode::updateMotorStress(double dt, const std::vector<int>& loads)
         // Check threshold
         if (tracker.score >= stress_threshold_) {
             int servo_id = joint_configs_[j].servo_id;
-            RCLCPP_WARN(this->get_logger(),
+            RCLCPP_WARN(
+                this->get_logger(),
                 "Stress threshold exceeded for joint %zu (servo %d): score=%.1f >= %.1f — disabling torque for %.1fs",
                 j + 1, servo_id, tracker.score, stress_threshold_, stress_cooldown_sec_);
 
             tracker.in_cooldown = true;
             tracker.cooldown_until = now + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-                std::chrono::duration<double>(stress_cooldown_sec_));
+                                               std::chrono::duration<double>(stress_cooldown_sec_));
 
             try {
                 dynamixel_->disableTorque(servo_id);
             } catch (const std::exception& e) {
-                RCLCPP_ERROR(this->get_logger(),
-                    "Failed to disable torque on servo %d for stress cooldown: %s",
-                    servo_id, e.what());
+                RCLCPP_ERROR(this->get_logger(), "Failed to disable torque on servo %d for stress cooldown: %s",
+                             servo_id, e.what());
             }
         }
     }
 
     // Periodic log of stress scores
     RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-        "StressScores: J1=%.1f J2=%.1f J3=%.1f J4=%.1f J5=%.1f J6=%.1f (threshold=%.1f)",
-        stress_trackers_[0].score, stress_trackers_[1].score,
-        stress_trackers_[2].score, stress_trackers_[3].score,
-        stress_trackers_[4].score, stress_trackers_[5].score,
-        stress_threshold_);
+                         "StressScores: J1=%.1f J2=%.1f J3=%.1f J4=%.1f J5=%.1f J6=%.1f (threshold=%.1f)",
+                         stress_trackers_[0].score, stress_trackers_[1].score, stress_trackers_[2].score,
+                         stress_trackers_[3].score, stress_trackers_[4].score, stress_trackers_[5].score,
+                         stress_threshold_);
 }
 
-} // namespace maurice_arm
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_node.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_node.cpp
@@ -21,7 +21,8 @@ std::string discoverArmDevice(const rclcpp::Logger& logger) {
 
     auto read_trim = [](const fs::path& p) -> std::string {
         std::ifstream f(p);
-        if (!f.is_open()) return {};
+        if (!f.is_open())
+            return {};
         std::string s;
         std::getline(f, s);
         while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' ')) {
@@ -34,7 +35,8 @@ std::string discoverArmDevice(const rclcpp::Logger& logger) {
     std::error_code ec;
     for (const auto& entry : fs::directory_iterator(kTtyClass, ec)) {
         const std::string name = entry.path().filename().string();
-        if (name.rfind("ttyACM", 0) != 0) continue;
+        if (name.rfind("ttyACM", 0) != 0)
+            continue;
 
         // /sys/class/tty/ttyACMn/device is a symlink to the USB interface
         // (e.g. .../1-1/1-1:1.0); its parent (..) is the USB device that
@@ -45,8 +47,7 @@ std::string discoverArmDevice(const rclcpp::Logger& logger) {
 
         if (vid == kTargetVid && pid == kTargetPid) {
             const std::string dev_path = "/dev/" + name;
-            RCLCPP_INFO(logger, "Discovered arm device: %s (%s:%s)",
-                        dev_path.c_str(), vid.c_str(), pid.c_str());
+            RCLCPP_INFO(logger, "Discovered arm device: %s (%s:%s)", dev_path.c_str(), vid.c_str(), pid.c_str());
             return dev_path;
         }
         candidates.push_back(name + " [" + (vid.empty() ? "?" : vid) + ":" + (pid.empty() ? "?" : pid) + "]");
@@ -54,13 +55,12 @@ std::string discoverArmDevice(const rclcpp::Logger& logger) {
 
     std::string joined;
     for (const auto& c : candidates) {
-        if (!joined.empty()) joined += ", ";
+        if (!joined.empty())
+            joined += ", ";
         joined += c;
     }
-    RCLCPP_ERROR(logger,
-                 "No ttyACM device with VID:PID %s:%s found. Candidates: %s. Falling back to /dev/ttyACM0.",
-                 kTargetVid, kTargetPid,
-                 joined.empty() ? "(none)" : joined.c_str());
+    RCLCPP_ERROR(logger, "No ttyACM device with VID:PID %s:%s found. Candidates: %s. Falling back to /dev/ttyACM0.",
+                 kTargetVid, kTargetPid, joined.empty() ? "(none)" : joined.c_str());
     return "/dev/ttyACM0";
 }
 
@@ -78,12 +78,12 @@ MauriceArmNode::MauriceArmNode() : Node("maurice_arm") {
     this->declare_parameter("baud_rate", 1000000);
     this->declare_parameter("control_frequency", 100.0);
     this->declare_parameter("trajectory_rate_hz", 30.0);
-    this->declare_parameter("max_jerk", 0.0);  // rad/s³, 0 = disabled
-    this->declare_parameter("stress_enabled", false);      // enable/disable leaky integrator
-    this->declare_parameter("stress_threshold", 100.0);     // score to trigger cooldown
-    this->declare_parameter("stress_cooldown_sec", 2.0);    // seconds to rest
-    this->declare_parameter("stress_multiplier", 1.0);      // A in leaky integrator: A*|PWM| - C
-    this->declare_parameter("stress_leak", 0.0);             // C in leaky integrator: A*|PWM| - C
+    this->declare_parameter("max_jerk", 0.0);             // rad/s³, 0 = disabled
+    this->declare_parameter("stress_enabled", false);     // enable/disable leaky integrator
+    this->declare_parameter("stress_threshold", 100.0);   // score to trigger cooldown
+    this->declare_parameter("stress_cooldown_sec", 2.0);  // seconds to rest
+    this->declare_parameter("stress_multiplier", 1.0);    // A in leaky integrator: A*|PWM| - C
+    this->declare_parameter("stress_leak", 0.0);          // C in leaky integrator: A*|PWM| - C
     this->declare_parameter("joints", std::vector<std::string>{});
 
     int baud_rate = this->get_parameter("baud_rate").as_int();
@@ -124,8 +124,7 @@ MauriceArmNode::MauriceArmNode() : Node("maurice_arm") {
 
     auto cmd_qos = rclcpp::QoS(1).best_effort();
     arm_command_sub_ = this->create_subscription<std_msgs::msg::Float64MultiArray>(
-        "/mars/arm/commands", cmd_qos,
-        std::bind(&MauriceArmNode::armCommandCallback, this, std::placeholders::_1));
+        "/mars/arm/commands", cmd_qos, std::bind(&MauriceArmNode::armCommandCallback, this, std::placeholders::_1));
 
     arm_torque_on_service_ = this->create_service<std_srvs::srv::Trigger>(
         "/mars/arm/torque_on",
@@ -167,8 +166,7 @@ MauriceArmNode::MauriceArmNode() : Node("maurice_arm") {
     head_position_pub_ = this->create_publisher<std_msgs::msg::String>("/mars/head/current_position", 10);
     joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/joint_states", 10);
     head_position_sub_ = this->create_subscription<std_msgs::msg::Int32>(
-        "/mars/head/set_position", 10,
-        std::bind(&MauriceArmNode::headPositionCallback, this, std::placeholders::_1));
+        "/mars/head/set_position", 10, std::bind(&MauriceArmNode::headPositionCallback, this, std::placeholders::_1));
 
     head_ai_position_service_ = this->create_service<std_srvs::srv::Trigger>(
         "/mars/head/set_ai_position",
@@ -185,7 +183,7 @@ MauriceArmNode::MauriceArmNode() : Node("maurice_arm") {
     arm_state_msg_.name = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6"};
     joint_state_msg_.name = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint_head"};
 
-    home_position_ = {1.445009902188274, -1.3882526130365052, 1.517106999218899,
+    home_position_ = {1.445009902188274,   -1.3882526130365052,  1.517106999218899,
                       0.44638840927472156, -0.08897088569736719, 0.0015339807878856412};
 
     // Initialize command buffers with current positions
@@ -198,16 +196,14 @@ MauriceArmNode::MauriceArmNode() : Node("maurice_arm") {
     // ── Timers ──
     RCLCPP_INFO(this->get_logger(), "Creating control timer at %.1f Hz", control_frequency_);
     auto period = std::chrono::duration<double>(1.0 / control_frequency_);
-    control_timer_ = this->create_wall_timer(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(period),
-        std::bind(&MauriceArmNode::controlTimerCallback, this),
-        timer_callback_group_);
+    control_timer_ =
+        this->create_wall_timer(std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+                                std::bind(&MauriceArmNode::controlTimerCallback, this), timer_callback_group_);
 
     RCLCPP_INFO(this->get_logger(), "Creating health monitor timer at 0.2 Hz");
-    health_timer_ = this->create_wall_timer(
-        std::chrono::milliseconds(5000),
-        std::bind(&MauriceArmNode::healthMonitorCallback, this),
-        health_callback_group_);
+    health_timer_ =
+        this->create_wall_timer(std::chrono::milliseconds(5000),
+                                std::bind(&MauriceArmNode::healthMonitorCallback, this), health_callback_group_);
 
     // Register parameter change callback for PID hot-reload
     param_callback_handle_ = this->add_on_set_parameters_callback(
@@ -225,7 +221,7 @@ MauriceArmNode::MauriceArmNode() : Node("maurice_arm") {
     }
 }
 
-} // namespace maurice_arm
+}  // namespace maurice_arm
 
 int main(int argc, char** argv) {
     rclcpp::init(argc, argv);

--- a/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_services.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_services.cpp
@@ -29,9 +29,9 @@ void MauriceArmNode::configureServoByIdLocked(int servo_id, bool enable_torque) 
     const auto& config = *config_ptr;
 
     RCLCPP_INFO(this->get_logger(), "Configuring servo %d (%s)", config.servo_id,
-        config.motor_type.empty() ? "unknown" : config.motor_type.c_str());
+                config.motor_type.empty() ? "unknown" : config.motor_type.c_str());
 
-    retryServoOp(config.servo_id, "disableTorque", [&]{ dynamixel_->disableTorque(config.servo_id); });
+    retryServoOp(config.servo_id, "disableTorque", [&] { dynamixel_->disableTorque(config.servo_id); });
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     dynamixel_->setReturnDelayTime(config.servo_id, 100);
@@ -53,13 +53,26 @@ void MauriceArmNode::configureServoByIdLocked(int servo_id, bool enable_torque) 
 
     OperatingMode mode;
     switch (config.control_mode) {
-        case 0:  mode = OperatingMode::CURRENT; break;
-        case 1:  mode = OperatingMode::VELOCITY; break;
-        case 3:  mode = OperatingMode::POSITION; break;
-        case 4:  mode = OperatingMode::EXTENDED_POSITION; break;
-        case 5:  mode = OperatingMode::CURRENT_CONTROLLED_POSITION; break;
-        case 16: mode = OperatingMode::PWM; break;
-        default: throw std::runtime_error("Servo " + std::to_string(config.servo_id) + ": invalid control_mode");
+        case 0:
+            mode = OperatingMode::CURRENT;
+            break;
+        case 1:
+            mode = OperatingMode::VELOCITY;
+            break;
+        case 3:
+            mode = OperatingMode::POSITION;
+            break;
+        case 4:
+            mode = OperatingMode::EXTENDED_POSITION;
+            break;
+        case 5:
+            mode = OperatingMode::CURRENT_CONTROLLED_POSITION;
+            break;
+        case 16:
+            mode = OperatingMode::PWM;
+            break;
+        default:
+            throw std::runtime_error("Servo " + std::to_string(config.servo_id) + ": invalid control_mode");
     }
     dynamixel_->setOperatingMode(config.servo_id, mode);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -89,12 +102,12 @@ void MauriceArmNode::configureServoByIdLocked(int servo_id, bool enable_torque) 
 
     if (enable_torque) {
         RCLCPP_INFO(this->get_logger(), "  Enabling torque on servo %d", config.servo_id);
-        retryServoOp(config.servo_id, "enableTorque", [&]{ dynamixel_->enableTorque(config.servo_id); });
+        retryServoOp(config.servo_id, "enableTorque", [&] { dynamixel_->enableTorque(config.servo_id); });
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    RCLCPP_INFO(this->get_logger(), "Servo %d configured and torque %s",
-        config.servo_id, enable_torque ? "enabled" : "disabled");
+    RCLCPP_INFO(this->get_logger(), "Servo %d configured and torque %s", config.servo_id,
+                enable_torque ? "enabled" : "disabled");
 }
 
 void MauriceArmNode::configureServosLocked(bool enable_torque) {
@@ -104,8 +117,7 @@ void MauriceArmNode::configureServosLocked(bool enable_torque) {
         try {
             configureServoByIdLocked(config.servo_id, enable_torque);
         } catch (const std::exception& e) {
-            RCLCPP_ERROR(this->get_logger(), "Failed to configure servo %d, skipping: %s",
-                config.servo_id, e.what());
+            RCLCPP_ERROR(this->get_logger(), "Failed to configure servo %d, skipping: %s", config.servo_id, e.what());
         }
     }
 
@@ -122,12 +134,14 @@ void MauriceArmNode::configureServosLocked(bool enable_torque) {
 
 void MauriceArmNode::syncTargetToMotorPositions() {
     auto [positions, velocities, loads] = robot_->readState();
-    (void)velocities; (void)loads;
+    (void)velocities;
+    (void)loads;
     {
         std::lock_guard<std::mutex> arm_lock(arm_command_mutex_);
         for (int i = 0; i < 6 && i < static_cast<int>(positions.size()); ++i) {
             double rad = ((positions[i] - 2048) * 2 * M_PI) / 4096.0;
-            if (i == 1 || i == 2 || i == 3 || i == 5) rad = -rad;
+            if (i == 1 || i == 2 || i == 3 || i == 5)
+                rad = -rad;
             latest_target_[i] = rad;
         }
         has_target_ = false;
@@ -160,16 +174,16 @@ void MauriceArmNode::healthMonitorCallback() {
             if (std::abs(static_cast<int>(present_load)) >= kLoadWarningThreshold) {
                 status_msg.is_ok = false;
                 double load_percent = static_cast<double>(present_load) / 10.0;
-                status_msg.error = "Servo " + std::to_string(servo_id) +
-                    " high load (" + std::to_string(load_percent) + "%)";
+                status_msg.error =
+                    "Servo " + std::to_string(servo_id) + " high load (" + std::to_string(load_percent) + "%)";
                 break;
             }
 
             uint8_t temperature = dynamixel_->readPresentTemperature(servo_id);
             if (temperature >= kTemperatureWarningC) {
                 status_msg.is_ok = false;
-                status_msg.error = "Servo " + std::to_string(servo_id) +
-                    " high temperature (" + std::to_string(static_cast<int>(temperature)) + " C)";
+                status_msg.error = "Servo " + std::to_string(servo_id) + " high temperature (" +
+                                   std::to_string(static_cast<int>(temperature)) + " C)";
                 break;
             }
         }
@@ -192,18 +206,29 @@ void MauriceArmNode::healthMonitorCallback() {
 
 std::string MauriceArmNode::describeHardwareError(uint8_t status, int servo_id) const {
     std::vector<std::string> error_bits;
-    if (status & 0x20) { error_bits.emplace_back("overload"); }
-    if (status & 0x10) { error_bits.emplace_back("electrical fault"); }
-    if (status & 0x08) { error_bits.emplace_back("encoder fault"); }
-    if (status & 0x04) { error_bits.emplace_back("overheating"); }
-    if (status & 0x01) { error_bits.emplace_back("input voltage"); }
+    if (status & 0x20) {
+        error_bits.emplace_back("overload");
+    }
+    if (status & 0x10) {
+        error_bits.emplace_back("electrical fault");
+    }
+    if (status & 0x08) {
+        error_bits.emplace_back("encoder fault");
+    }
+    if (status & 0x04) {
+        error_bits.emplace_back("overheating");
+    }
+    if (status & 0x01) {
+        error_bits.emplace_back("input voltage");
+    }
 
     std::ostringstream oss;
     oss << "Servo " << servo_id << " hardware error";
     if (!error_bits.empty()) {
         oss << ": ";
         for (size_t i = 0; i < error_bits.size(); ++i) {
-            if (i > 0) oss << ", ";
+            if (i > 0)
+                oss << ", ";
             oss << error_bits[i];
         }
     } else {
@@ -217,7 +242,8 @@ std::string MauriceArmNode::describeHardwareError(uint8_t status, int servo_id) 
 void MauriceArmNode::armCommandCallback(const std_msgs::msg::Float64MultiArray::SharedPtr msg) {
     try {
         if (msg->data.size() != 6) {
-            RCLCPP_ERROR(this->get_logger(), "Action size must match number of servos. Expected 6, got %zu", msg->data.size());
+            RCLCPP_ERROR(this->get_logger(), "Action size must match number of servos. Expected 6, got %zu",
+                         msg->data.size());
             return;
         }
 
@@ -239,9 +265,8 @@ void MauriceArmNode::armCommandCallback(const std_msgs::msg::Float64MultiArray::
 
 // ========== TORQUE / REBOOT / FIX-ERROR SERVICE CALLBACKS ==========
 
-void MauriceArmNode::armTorqueOnCallback(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+void MauriceArmNode::armTorqueOnCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                         std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     RCLCPP_INFO(this->get_logger(), "Service called: /mars/arm/torque_on");
     try {
         std::lock_guard<std::mutex> lock(dynamixel_mutex_);
@@ -251,8 +276,9 @@ void MauriceArmNode::armTorqueOnCallback(
             dynamixel_->enableTorque(id);
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
-        try { syncTargetToMotorPositions(); }
-        catch (const std::exception& e) {
+        try {
+            syncTargetToMotorPositions();
+        } catch (const std::exception& e) {
             RCLCPP_WARN(this->get_logger(), "Failed to sync on torque on: %s", e.what());
         }
 
@@ -267,9 +293,8 @@ void MauriceArmNode::armTorqueOnCallback(
     }
 }
 
-void MauriceArmNode::armTorqueOffCallback(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+void MauriceArmNode::armTorqueOffCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                          std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     RCLCPP_INFO(this->get_logger(), "Service called: /mars/arm/torque_off");
     try {
         std::lock_guard<std::mutex> lock(dynamixel_mutex_);
@@ -290,9 +315,8 @@ void MauriceArmNode::armTorqueOffCallback(
     }
 }
 
-void MauriceArmNode::armRebootServosCallback(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+void MauriceArmNode::armRebootServosCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                             std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     RCLCPP_INFO(this->get_logger(), "Service called: /mars/arm/reboot");
     try {
         std::lock_guard<std::mutex> lock(dynamixel_mutex_);
@@ -318,9 +342,8 @@ void MauriceArmNode::armRebootServosCallback(
     }
 }
 
-void MauriceArmNode::armFixErrorCallback(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+void MauriceArmNode::armFixErrorCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                         std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     RCLCPP_INFO(this->get_logger(), "Service called: /mars/arm/fix_error");
     try {
         std::lock_guard<std::mutex> lock(dynamixel_mutex_);
@@ -330,8 +353,8 @@ void MauriceArmNode::armFixErrorCallback(
         for (const auto& config : joint_configs_) {
             uint8_t hw_status = dynamixel_->readHardwareErrorStatus(config.servo_id);
             if (hw_status != 0) {
-                RCLCPP_WARN(this->get_logger(), "Servo %d has hardware error: %s",
-                    config.servo_id, describeHardwareError(hw_status, config.servo_id).c_str());
+                RCLCPP_WARN(this->get_logger(), "Servo %d has hardware error: %s", config.servo_id,
+                            describeHardwareError(hw_status, config.servo_id).c_str());
                 error_servo_ids.push_back(config.servo_id);
             }
         }
@@ -375,8 +398,7 @@ void MauriceArmNode::armFixErrorCallback(
 
         response->success = true;
         response->message = result.dump();
-        RCLCPP_INFO(this->get_logger(), "Fixed %zu servo(s): %s",
-            error_servo_ids.size(), response->message.c_str());
+        RCLCPP_INFO(this->get_logger(), "Fixed %zu servo(s): %s", error_servo_ids.size(), response->message.c_str());
     } catch (const std::exception& e) {
         response->success = false;
         json err_result;
@@ -437,10 +459,9 @@ void MauriceArmNode::headPositionCallback(const std_msgs::msg::Int32::SharedPtr 
 
         const auto& head_config = joint_configs_[6];  // Index 6 = joint 7
 
-        if (logical_position < head_config.head_min_angle_deg ||
-            logical_position > head_config.head_max_angle_deg) {
-            RCLCPP_ERROR(this->get_logger(), "Head position %f out of range [%f, %f]",
-                logical_position, head_config.head_min_angle_deg, head_config.head_max_angle_deg);
+        if (logical_position < head_config.head_min_angle_deg || logical_position > head_config.head_max_angle_deg) {
+            RCLCPP_ERROR(this->get_logger(), "Head position %f out of range [%f, %f]", logical_position,
+                         head_config.head_min_angle_deg, head_config.head_max_angle_deg);
             return;
         }
 
@@ -455,14 +476,12 @@ void MauriceArmNode::headPositionCallback(const std_msgs::msg::Int32::SharedPtr 
     }
 }
 
-void MauriceArmNode::headAiPositionCallback(
-    const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
-    std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+void MauriceArmNode::headAiPositionCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                            std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
     try {
         const auto& head_config = joint_configs_[6];  // Index 6 = joint 7
 
-        RCLCPP_INFO(this->get_logger(), "Moving head to AI position (%f deg)",
-            head_config.head_ai_position_deg);
+        RCLCPP_INFO(this->get_logger(), "Moving head to AI position (%f deg)", head_config.head_ai_position_deg);
 
         int head_goal_encoder = logicalAngleToEncoder(head_config.head_ai_position_deg);
 
@@ -480,10 +499,10 @@ void MauriceArmNode::headAiPositionCallback(
     }
 }
 
-void MauriceArmNode::headEnableServoCallback(
-    const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-    std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
-    RCLCPP_INFO(this->get_logger(), "Service called: /mars/head/enable_servo (enable=%s)", request->data ? "true" : "false");
+void MauriceArmNode::headEnableServoCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                             std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+    RCLCPP_INFO(this->get_logger(), "Service called: /mars/head/enable_servo (enable=%s)",
+                request->data ? "true" : "false");
     try {
         std::lock_guard<std::mutex> lock(dynamixel_mutex_);
 
@@ -502,9 +521,8 @@ void MauriceArmNode::headEnableServoCallback(
     } catch (const std::exception& e) {
         response->success = false;
         response->message = std::string("Failed: ") + e.what();
-        RCLCPP_ERROR(this->get_logger(), "Failed to %s head servo: %s",
-            request->data ? "enable" : "disable", e.what());
+        RCLCPP_ERROR(this->get_logger(), "Failed to %s head servo: %s", request->data ? "enable" : "disable", e.what());
     }
 }
 
-} // namespace maurice_arm
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_trajectory.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/arm_trajectory.cpp
@@ -5,12 +5,9 @@ namespace maurice_arm {
 
 // ========== CUBIC SPLINE (QUINTIC SMOOTHERSTEP) ==========
 
-std::vector<std::vector<double>> MauriceArmNode::computeCubicSplineTrajectory(
-    const std::vector<double>& start,
-    const std::vector<double>& goal,
-    double duration,
-    double dt) {
-
+std::vector<std::vector<double>> MauriceArmNode::computeCubicSplineTrajectory(const std::vector<double>& start,
+                                                                              const std::vector<double>& goal,
+                                                                              double duration, double dt) {
     std::vector<std::vector<double>> trajectory;
 
     if (start.size() != goal.size() || start.empty()) {
@@ -29,14 +26,15 @@ std::vector<std::vector<double>> MauriceArmNode::computeCubicSplineTrajectory(
         double min_duration = std::cbrt(60.0 * max_delta / max_jerk);
         if (min_duration > duration) {
             RCLCPP_INFO(this->get_logger(),
-                "Jerk limit %.1f rad/s³: extending trajectory %.2fs → %.2fs (Δθ_max=%.3f rad)",
-                max_jerk, duration, min_duration, max_delta);
+                        "Jerk limit %.1f rad/s³: extending trajectory %.2fs → %.2fs (Δθ_max=%.3f rad)", max_jerk,
+                        duration, min_duration, max_delta);
             duration = min_duration;
         }
     }
 
     int num_steps = static_cast<int>(duration / dt);
-    if (num_steps < 1) num_steps = 1;
+    if (num_steps < 1)
+        num_steps = 1;
 
     for (int step = 0; step <= num_steps; ++step) {
         double t = step * dt;
@@ -57,7 +55,7 @@ std::vector<std::vector<double>> MauriceArmNode::computeCubicSplineTrajectory(
 // ========== PLAN AND EXECUTE ==========
 
 bool MauriceArmNode::planAndExecuteTrajectory(const std::vector<double>& target_positions, double trajectory_time,
-                                               GainMode trajectory_gain_mode) {
+                                              GainMode trajectory_gain_mode) {
     // Switch gains for trajectory execution
     if (gain_mode_ != trajectory_gain_mode) {
         gain_mode_ = trajectory_gain_mode;
@@ -95,7 +93,8 @@ bool MauriceArmNode::planAndExecuteTrajectory(const std::vector<double>& target_
     // Use simple cubic spline planning (fast, smooth trajectory)
     RCLCPP_INFO(this->get_logger(), "Planning with cubic spline for 6-DOF arm (including gripper)...");
     const double dt = 1.0 / this->get_parameter("trajectory_rate_hz").as_double();
-    auto interpolated_trajectory = computeCubicSplineTrajectory(current_positions, target_positions, trajectory_time, dt);
+    auto interpolated_trajectory =
+        computeCubicSplineTrajectory(current_positions, target_positions, trajectory_time, dt);
 
     if (interpolated_trajectory.empty()) {
         RCLCPP_ERROR(this->get_logger(), "Cubic spline trajectory computation failed");
@@ -105,10 +104,8 @@ bool MauriceArmNode::planAndExecuteTrajectory(const std::vector<double>& target_
     // Detect if jerk limiting extended the duration
     double actual_duration = (interpolated_trajectory.size() - 1) * dt;
     if (actual_duration > trajectory_time * 1.01) {
-        RCLCPP_WARN(this->get_logger(),
-            "Jerk-limited: requested %.2fs but executing %.2fs (+%.0f%%)",
-            trajectory_time, actual_duration,
-            100.0 * (actual_duration - trajectory_time) / trajectory_time);
+        RCLCPP_WARN(this->get_logger(), "Jerk-limited: requested %.2fs but executing %.2fs (+%.0f%%)", trajectory_time,
+                    actual_duration, 100.0 * (actual_duration - trajectory_time) / trajectory_time);
     }
 
     RCLCPP_INFO(this->get_logger(), "Executing trajectory with %zu waypoints over %.2f seconds",
@@ -145,10 +142,8 @@ bool MauriceArmNode::planAndExecuteTrajectory(const std::vector<double>& target_
     return true;
 }
 
-bool MauriceArmNode::planAndExecuteMultiWaypointTrajectory(
-    const std::vector<std::vector<double>>& waypoints,
-    const std::vector<double>& segment_durations) {
-
+bool MauriceArmNode::planAndExecuteMultiWaypointTrajectory(const std::vector<std::vector<double>>& waypoints,
+                                                           const std::vector<double>& segment_durations) {
     // Switch to scheduled gains for planned trajectories
     if (gain_mode_ != GainMode::SCHEDULED) {
         gain_mode_ = GainMode::SCHEDULED;
@@ -161,7 +156,7 @@ bool MauriceArmNode::planAndExecuteMultiWaypointTrajectory(
     }
     if (segment_durations.size() != waypoints.size() - 1) {
         RCLCPP_ERROR(this->get_logger(), "segment_durations size (%zu) must equal waypoints-1 (%zu)",
-                    segment_durations.size(), waypoints.size() - 1);
+                     segment_durations.size(), waypoints.size() - 1);
         return false;
     }
 
@@ -237,7 +232,6 @@ bool MauriceArmNode::planAndExecuteMultiWaypointTrajectory(
 void MauriceArmNode::armGotoJSTrajectoryCallback(
     const std::shared_ptr<maurice_msgs::srv::GotoJSTrajectory::Request> request,
     std::shared_ptr<maurice_msgs::srv::GotoJSTrajectory::Response> response) {
-
     RCLCPP_INFO(this->get_logger(), "Service called: /mars/arm/goto_js_trajectory");
 
     int num_joints = request->num_joints;
@@ -245,8 +239,8 @@ void MauriceArmNode::armGotoJSTrajectoryCallback(
     const auto& seg_durs = request->segment_durations;
 
     if (num_joints <= 0 || flat.size() % num_joints != 0) {
-        RCLCPP_ERROR(this->get_logger(), "Invalid waypoints: %zu values not divisible by %d joints",
-                    flat.size(), num_joints);
+        RCLCPP_ERROR(this->get_logger(), "Invalid waypoints: %zu values not divisible by %d joints", flat.size(),
+                     num_joints);
         response->success = false;
         return;
     }
@@ -255,14 +249,12 @@ void MauriceArmNode::armGotoJSTrajectoryCallback(
     size_t num_waypoints = flat.size() / num_joints;
     std::vector<std::vector<double>> waypoints;
     for (size_t i = 0; i < num_waypoints; ++i) {
-        waypoints.emplace_back(flat.begin() + i * num_joints,
-                               flat.begin() + (i + 1) * num_joints);
+        waypoints.emplace_back(flat.begin() + i * num_joints, flat.begin() + (i + 1) * num_joints);
     }
 
     std::vector<double> durations(seg_durs.begin(), seg_durs.end());
 
-    RCLCPP_INFO(this->get_logger(), "Trajectory: %zu waypoints, %zu segments",
-                waypoints.size(), durations.size());
+    RCLCPP_INFO(this->get_logger(), "Trajectory: %zu waypoints, %zu segments", waypoints.size(), durations.size());
 
     // Prepend current position as waypoint[0] so the arm starts from where it is
     {
@@ -280,10 +272,8 @@ void MauriceArmNode::armGotoJSTrajectoryCallback(
     response->success = planAndExecuteMultiWaypointTrajectory(waypoints, durations);
 }
 
-void MauriceArmNode::armGotoJSCallback(
-    const std::shared_ptr<maurice_msgs::srv::GotoJS::Request> request,
-    std::shared_ptr<maurice_msgs::srv::GotoJS::Response> response) {
-
+void MauriceArmNode::armGotoJSCallback(const std::shared_ptr<maurice_msgs::srv::GotoJS::Request> request,
+                                       std::shared_ptr<maurice_msgs::srv::GotoJS::Response> response) {
     RCLCPP_INFO(this->get_logger(), "Service called: /mars/arm/goto_js (TELEOP gains)");
 
     // Extract target positions and time from request
@@ -296,8 +286,7 @@ void MauriceArmNode::armGotoJSCallback(
                 target_positions.size() > 2 ? target_positions[2] : 0.0,
                 target_positions.size() > 3 ? target_positions[3] : 0.0,
                 target_positions.size() > 4 ? target_positions[4] : 0.0,
-                target_positions.size() > 5 ? target_positions[5] : 0.0,
-                trajectory_time);
+                target_positions.size() > 5 ? target_positions[5] : 0.0, trajectory_time);
 
     // goto_js uses teleop gains (flat, no extension-based interpolation)
     response->success = planAndExecuteTrajectory(target_positions, trajectory_time, GainMode::TELEOP);
@@ -309,10 +298,8 @@ void MauriceArmNode::armGotoJSCallback(
     }
 }
 
-void MauriceArmNode::armGotoJSV2Callback(
-    const std::shared_ptr<maurice_msgs::srv::GotoJS::Request> request,
-    std::shared_ptr<maurice_msgs::srv::GotoJS::Response> response) {
-
+void MauriceArmNode::armGotoJSV2Callback(const std::shared_ptr<maurice_msgs::srv::GotoJS::Request> request,
+                                         std::shared_ptr<maurice_msgs::srv::GotoJS::Response> response) {
     RCLCPP_INFO(this->get_logger(), "Service called: /mars/arm/goto_js_v2 (SCHEDULED gains)");
 
     // Extract target positions and time from request
@@ -325,8 +312,7 @@ void MauriceArmNode::armGotoJSV2Callback(
                 target_positions.size() > 2 ? target_positions[2] : 0.0,
                 target_positions.size() > 3 ? target_positions[3] : 0.0,
                 target_positions.size() > 4 ? target_positions[4] : 0.0,
-                target_positions.size() > 5 ? target_positions[5] : 0.0,
-                trajectory_time);
+                target_positions.size() > 5 ? target_positions[5] : 0.0, trajectory_time);
 
     // goto_js_v2 uses scheduled gains (near/far interpolated by extension)
     response->success = planAndExecuteTrajectory(target_positions, trajectory_time, GainMode::SCHEDULED);
@@ -338,4 +324,4 @@ void MauriceArmNode::armGotoJSV2Callback(
     }
 }
 
-} // namespace maurice_arm
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/dynamixel.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/dynamixel.cpp
@@ -25,21 +25,21 @@ void Dynamixel::connect() {
         glob_t glob_result;
         glob("/dev/ttyUSB*", GLOB_TILDE, NULL, &glob_result);
         glob("/dev/ttyACM*", GLOB_APPEND | GLOB_TILDE, NULL, &glob_result);
-        
+
         if (glob_result.gl_pathc > 0) {
             config_.device_name = glob_result.gl_pathv[0];
             std::cout << "Using device: " << config_.device_name << std::endl;
         }
         globfree(&glob_result);
     }
-    
+
     port_handler_ = PortHandler::getPortHandler(config_.device_name.c_str());
     packet_handler_ = PacketHandler::getPacketHandler(config_.protocol_version);
-    
+
     if (!port_handler_->openPort()) {
         throw std::runtime_error("Failed to open port " + config_.device_name);
     }
-    
+
     if (!port_handler_->setBaudRate(config_.baudrate)) {
         throw std::runtime_error("Failed to set baudrate to " + std::to_string(config_.baudrate));
     }
@@ -47,9 +47,8 @@ void Dynamixel::connect() {
 
 void Dynamixel::enableTorque(int motor_id) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write1ByteTxRx(
-        port_handler_, motor_id, ADDR_TORQUE_ENABLE, 1, &dxl_error);
-    
+    int dxl_comm_result = packet_handler_->write1ByteTxRx(port_handler_, motor_id, ADDR_TORQUE_ENABLE, 1, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to enable torque for motor " + std::to_string(motor_id));
     }
@@ -57,9 +56,8 @@ void Dynamixel::enableTorque(int motor_id) {
 
 void Dynamixel::disableTorque(int motor_id) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write1ByteTxRx(
-        port_handler_, motor_id, ADDR_TORQUE_ENABLE, 0, &dxl_error);
-    
+    int dxl_comm_result = packet_handler_->write1ByteTxRx(port_handler_, motor_id, ADDR_TORQUE_ENABLE, 0, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to disable torque for motor " + std::to_string(motor_id));
     }
@@ -67,9 +65,9 @@ void Dynamixel::disableTorque(int motor_id) {
 
 void Dynamixel::setOperatingMode(int motor_id, OperatingMode mode) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write1ByteTxRx(
-        port_handler_, motor_id, OPERATING_MODE_ADDR, static_cast<uint8_t>(mode), &dxl_error);
-    
+    int dxl_comm_result = packet_handler_->write1ByteTxRx(port_handler_, motor_id, OPERATING_MODE_ADDR,
+                                                          static_cast<uint8_t>(mode), &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set operating mode for motor " + std::to_string(motor_id));
     }
@@ -77,9 +75,9 @@ void Dynamixel::setOperatingMode(int motor_id, OperatingMode mode) {
 
 void Dynamixel::setMinPositionLimit(int motor_id, int min_position) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write4ByteTxRx(
-        port_handler_, motor_id, ADDR_MIN_POSITION_LIMIT, min_position, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->write4ByteTxRx(port_handler_, motor_id, ADDR_MIN_POSITION_LIMIT, min_position, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set min position limit for motor " + std::to_string(motor_id));
     }
@@ -87,9 +85,9 @@ void Dynamixel::setMinPositionLimit(int motor_id, int min_position) {
 
 void Dynamixel::setMaxPositionLimit(int motor_id, int max_position) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write4ByteTxRx(
-        port_handler_, motor_id, ADDR_MAX_POSITION_LIMIT, max_position, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->write4ByteTxRx(port_handler_, motor_id, ADDR_MAX_POSITION_LIMIT, max_position, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set max position limit for motor " + std::to_string(motor_id));
     }
@@ -99,11 +97,10 @@ void Dynamixel::setPwmLimit(int motor_id, int limit) {
     if (limit < 0 || limit > 885) {
         throw std::invalid_argument("PWM limit must be between 0 and 885");
     }
-    
+
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write2ByteTxRx(
-        port_handler_, motor_id, ADDR_PWM_LIMIT, limit, &dxl_error);
-    
+    int dxl_comm_result = packet_handler_->write2ByteTxRx(port_handler_, motor_id, ADDR_PWM_LIMIT, limit, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set PWM limit for motor " + std::to_string(motor_id));
     }
@@ -111,9 +108,9 @@ void Dynamixel::setPwmLimit(int motor_id, int limit) {
 
 void Dynamixel::setCurrentLimit(int motor_id, int current_limit) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write2ByteTxRx(
-        port_handler_, motor_id, ADDR_CURRENT_LIMIT, current_limit, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->write2ByteTxRx(port_handler_, motor_id, ADDR_CURRENT_LIMIT, current_limit, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set current limit for motor " + std::to_string(motor_id));
     }
@@ -121,9 +118,8 @@ void Dynamixel::setCurrentLimit(int motor_id, int current_limit) {
 
 void Dynamixel::setP(int motor_id, int p) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write2ByteTxRx(
-        port_handler_, motor_id, POSITION_P, p, &dxl_error);
-    
+    int dxl_comm_result = packet_handler_->write2ByteTxRx(port_handler_, motor_id, POSITION_P, p, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set P gain for motor " + std::to_string(motor_id));
     }
@@ -131,9 +127,8 @@ void Dynamixel::setP(int motor_id, int p) {
 
 void Dynamixel::setI(int motor_id, int i) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write2ByteTxRx(
-        port_handler_, motor_id, POSITION_I, i, &dxl_error);
-    
+    int dxl_comm_result = packet_handler_->write2ByteTxRx(port_handler_, motor_id, POSITION_I, i, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set I gain for motor " + std::to_string(motor_id));
     }
@@ -141,9 +136,8 @@ void Dynamixel::setI(int motor_id, int i) {
 
 void Dynamixel::setD(int motor_id, int d) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write2ByteTxRx(
-        port_handler_, motor_id, POSITION_D, d, &dxl_error);
-    
+    int dxl_comm_result = packet_handler_->write2ByteTxRx(port_handler_, motor_id, POSITION_D, d, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set D gain for motor " + std::to_string(motor_id));
     }
@@ -153,7 +147,7 @@ void Dynamixel::syncWritePID(const std::vector<std::tuple<int, int, int, int, in
     // Addresses 80-91: D(2) + I(2) + P(2) + reserved(2) + FF2(2) + FF1(2) = 12 bytes
     // addr 86-87 is a reserved gap — we write 0x0000 there (harmless)
     dynamixel::GroupSyncWrite syncWrite(port_handler_, packet_handler_, POSITION_D, 12);
-    
+
     for (const auto& [servo_id, ff2, ff1, kd, ki, kp] : pid_data) {
         uint8_t param[12];
         // Position D gain at offset 0 (addr 80)
@@ -174,15 +168,16 @@ void Dynamixel::syncWritePID(const std::vector<std::tuple<int, int, int, int, in
         // FF1 (velocity feedforward) at offset 10 (addr 90)
         param[10] = DXL_LOBYTE(static_cast<uint16_t>(ff1));
         param[11] = DXL_HIBYTE(static_cast<uint16_t>(ff1));
-        
+
         if (!syncWrite.addParam(servo_id, param)) {
             throw std::runtime_error("Failed to add PID param for servo " + std::to_string(servo_id));
         }
     }
-    
+
     int dxl_comm_result = syncWrite.txPacket();
     if (dxl_comm_result != COMM_SUCCESS) {
-        throw std::runtime_error("SyncWrite PID failed: " + std::string(packet_handler_->getTxRxResult(dxl_comm_result)));
+        throw std::runtime_error("SyncWrite PID failed: " +
+                                 std::string(packet_handler_->getTxRxResult(dxl_comm_result)));
     }
     syncWrite.clearParam();
 }
@@ -190,7 +185,7 @@ void Dynamixel::syncWritePID(const std::vector<std::tuple<int, int, int, int, in
 void Dynamixel::syncWriteProfile(const std::vector<std::tuple<int, int, int>>& profile_data) {
     // Addresses 108-115: Profile Acceleration(4 bytes) + Profile Velocity(4 bytes) = 8 bytes contiguous
     dynamixel::GroupSyncWrite syncWrite(port_handler_, packet_handler_, ADDR_PROFILE_ACCELERATION, 8);
-    
+
     for (const auto& [servo_id, accel, vel] : profile_data) {
         uint8_t param[8];
         // Profile Acceleration at offset 0 (addr 108), little-endian 4 bytes
@@ -203,24 +198,25 @@ void Dynamixel::syncWriteProfile(const std::vector<std::tuple<int, int, int>>& p
         param[5] = DXL_HIBYTE(DXL_LOWORD(static_cast<uint32_t>(vel)));
         param[6] = DXL_LOBYTE(DXL_HIWORD(static_cast<uint32_t>(vel)));
         param[7] = DXL_HIBYTE(DXL_HIWORD(static_cast<uint32_t>(vel)));
-        
+
         if (!syncWrite.addParam(servo_id, param)) {
             throw std::runtime_error("Failed to add profile param for servo " + std::to_string(servo_id));
         }
     }
-    
+
     int dxl_comm_result = syncWrite.txPacket();
     if (dxl_comm_result != COMM_SUCCESS) {
-        throw std::runtime_error("SyncWrite profile failed: " + std::string(packet_handler_->getTxRxResult(dxl_comm_result)));
+        throw std::runtime_error("SyncWrite profile failed: " +
+                                 std::string(packet_handler_->getTxRxResult(dxl_comm_result)));
     }
     syncWrite.clearParam();
 }
 
 void Dynamixel::setHomeOffset(int motor_id, int home_position) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write4ByteTxRx(
-        port_handler_, motor_id, ADDR_HOMING_OFFSET, home_position, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->write4ByteTxRx(port_handler_, motor_id, ADDR_HOMING_OFFSET, home_position, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set home offset for motor " + std::to_string(motor_id));
     }
@@ -228,9 +224,9 @@ void Dynamixel::setHomeOffset(int motor_id, int home_position) {
 
 void Dynamixel::setProfileVelocity(int motor_id, int velocity) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write4ByteTxRx(
-        port_handler_, motor_id, ADDR_PROFILE_VELOCITY, velocity, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->write4ByteTxRx(port_handler_, motor_id, ADDR_PROFILE_VELOCITY, velocity, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set profile velocity for motor " + std::to_string(motor_id));
     }
@@ -238,9 +234,9 @@ void Dynamixel::setProfileVelocity(int motor_id, int velocity) {
 
 void Dynamixel::setProfileAcceleration(int motor_id, int acceleration) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write4ByteTxRx(
-        port_handler_, motor_id, ADDR_PROFILE_ACCELERATION, acceleration, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->write4ByteTxRx(port_handler_, motor_id, ADDR_PROFILE_ACCELERATION, acceleration, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set profile acceleration for motor " + std::to_string(motor_id));
     }
@@ -249,46 +245,46 @@ void Dynamixel::setProfileAcceleration(int motor_id, int acceleration) {
 int Dynamixel::readPosition(int motor_id) {
     uint32_t position = 0;
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->read4ByteTxRx(
-        port_handler_, motor_id, ADDR_PRESENT_POSITION, &position, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->read4ByteTxRx(port_handler_, motor_id, ADDR_PRESENT_POSITION, &position, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to read position for motor " + std::to_string(motor_id));
     }
-    
+
     // Convert to signed
     int signed_position = static_cast<int>(position);
     if (signed_position > (1LL << 31)) {
         signed_position -= (1LL << 32);
     }
-    
+
     return signed_position;
 }
 
 int Dynamixel::readVelocity(int motor_id) {
     uint32_t velocity = 0;
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->read4ByteTxRx(
-        port_handler_, motor_id, ADDR_PRESENT_VELOCITY, &velocity, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->read4ByteTxRx(port_handler_, motor_id, ADDR_PRESENT_VELOCITY, &velocity, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to read velocity for motor " + std::to_string(motor_id));
     }
-    
+
     // Convert to signed
     int signed_velocity = static_cast<int>(velocity);
     if (signed_velocity > (1LL << 31)) {
         signed_velocity -= (1LL << 32);
     }
-    
+
     return signed_velocity;
 }
 
 void Dynamixel::setGoalPosition(int motor_id, int goal_position) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write4ByteTxRx(
-        port_handler_, motor_id, ADDR_GOAL_POSITION, goal_position, &dxl_error);
-    
+    int dxl_comm_result =
+        packet_handler_->write4ByteTxRx(port_handler_, motor_id, ADDR_GOAL_POSITION, goal_position, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set goal position for motor " + std::to_string(motor_id));
     }
@@ -296,9 +292,8 @@ void Dynamixel::setGoalPosition(int motor_id, int goal_position) {
 
 void Dynamixel::reboot(int motor_id) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->reboot(
-        port_handler_, motor_id, &dxl_error);
-    
+    int dxl_comm_result = packet_handler_->reboot(port_handler_, motor_id, &dxl_error);
+
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to reboot motor " + std::to_string(motor_id));
     }
@@ -307,8 +302,8 @@ void Dynamixel::reboot(int motor_id) {
 uint8_t Dynamixel::readHardwareErrorStatus(int motor_id) {
     uint8_t status = 0;
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->read1ByteTxRx(
-        port_handler_, motor_id, ADDR_HARDWARE_ERROR_STATUS, &status, &dxl_error);
+    int dxl_comm_result =
+        packet_handler_->read1ByteTxRx(port_handler_, motor_id, ADDR_HARDWARE_ERROR_STATUS, &status, &dxl_error);
 
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to read hardware error status for motor " + std::to_string(motor_id));
@@ -320,8 +315,7 @@ uint8_t Dynamixel::readHardwareErrorStatus(int motor_id) {
 int16_t Dynamixel::readPresentLoad(int motor_id) {
     uint16_t load = 0;
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->read2ByteTxRx(
-        port_handler_, motor_id, ADDR_PRESENT_LOAD, &load, &dxl_error);
+    int dxl_comm_result = packet_handler_->read2ByteTxRx(port_handler_, motor_id, ADDR_PRESENT_LOAD, &load, &dxl_error);
 
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to read load for motor " + std::to_string(motor_id));
@@ -333,8 +327,8 @@ int16_t Dynamixel::readPresentLoad(int motor_id) {
 uint8_t Dynamixel::readPresentTemperature(int motor_id) {
     uint8_t temperature = 0;
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->read1ByteTxRx(
-        port_handler_, motor_id, ADDR_PRESENT_TEMPERATURE, &temperature, &dxl_error);
+    int dxl_comm_result =
+        packet_handler_->read1ByteTxRx(port_handler_, motor_id, ADDR_PRESENT_TEMPERATURE, &temperature, &dxl_error);
 
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to read temperature for motor " + std::to_string(motor_id));
@@ -345,12 +339,11 @@ uint8_t Dynamixel::readPresentTemperature(int motor_id) {
 
 void Dynamixel::setReturnDelayTime(int motor_id, int value) {
     uint8_t dxl_error = 0;
-    int dxl_comm_result = packet_handler_->write1ByteTxRx(
-        port_handler_, motor_id, ADDR_RETURN_DELAY_TIME, value, &dxl_error);
+    int dxl_comm_result =
+        packet_handler_->write1ByteTxRx(port_handler_, motor_id, ADDR_RETURN_DELAY_TIME, value, &dxl_error);
     if (dxl_comm_result != COMM_SUCCESS) {
         throw std::runtime_error("Failed to set return delay time for motor " + std::to_string(motor_id));
     }
 }
 
-} // namespace maurice_arm
-
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/robot.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_arm/maurice_arm/robot.cpp
@@ -9,51 +9,42 @@ namespace maurice_arm {
 
 Robot::Robot(std::shared_ptr<Dynamixel> dynamixel, const std::vector<int>& servo_ids)
     : dynamixel_(dynamixel), servo_ids_(servo_ids) {
-    
     // Initialize GroupSyncRead for positions
-    position_reader_ = std::make_unique<GroupSyncRead>(
-        dynamixel_->portHandler(),
-        dynamixel_->packetHandler(),
-        ADDR_PRESENT_POSITION,
-        4  // 4 bytes for position
-    );
-    
+    position_reader_ =
+        std::make_unique<GroupSyncRead>(dynamixel_->portHandler(), dynamixel_->packetHandler(), ADDR_PRESENT_POSITION,
+                                        4  // 4 bytes for position
+        );
+
     for (int id : servo_ids_) {
         position_reader_->addParam(id);
     }
-    
+
     // Initialize GroupSyncRead for velocities
-    velocity_reader_ = std::make_unique<GroupSyncRead>(
-        dynamixel_->portHandler(),
-        dynamixel_->packetHandler(),
-        ADDR_PRESENT_VELOCITY,
-        4  // 4 bytes for velocity
-    );
-    
+    velocity_reader_ =
+        std::make_unique<GroupSyncRead>(dynamixel_->portHandler(), dynamixel_->packetHandler(), ADDR_PRESENT_VELOCITY,
+                                        4  // 4 bytes for velocity
+        );
+
     for (int id : servo_ids_) {
         velocity_reader_->addParam(id);
     }
-    
+
     // Initialize GroupSyncRead for combined state (velocity + position in one transaction)
-    state_reader_ = std::make_unique<GroupSyncRead>(
-        dynamixel_->portHandler(),
-        dynamixel_->packetHandler(),
-        ADDR_PRESENT_LOAD,  // Start at load (126)
-        10  // 10 bytes: 2 load + 4 velocity + 4 position
+    state_reader_ = std::make_unique<GroupSyncRead>(dynamixel_->portHandler(), dynamixel_->packetHandler(),
+                                                    ADDR_PRESENT_LOAD,  // Start at load (126)
+                                                    10                  // 10 bytes: 2 load + 4 velocity + 4 position
     );
-    
+
     for (int id : servo_ids_) {
         state_reader_->addParam(id);
     }
-    
+
     // Initialize GroupSyncWrite for positions
-    pos_writer_ = std::make_unique<GroupSyncWrite>(
-        dynamixel_->portHandler(),
-        dynamixel_->packetHandler(),
-        ADDR_GOAL_POSITION,
-        4  // 4 bytes for position
-    );
-    
+    pos_writer_ =
+        std::make_unique<GroupSyncWrite>(dynamixel_->portHandler(), dynamixel_->packetHandler(), ADDR_GOAL_POSITION,
+                                         4  // 4 bytes for position
+        );
+
     // Initialize parameters for each servo with dummy data
     // This is required before using changeParam()
     for (int id : servo_ids_) {
@@ -68,7 +59,7 @@ Robot::~Robot() {
 
 std::vector<int> Robot::readPosition(int tries) {
     int result = position_reader_->txRxPacket();
-    
+
     if (result != COMM_SUCCESS) {
         if (tries > 0) {
             return readPosition(tries - 1);
@@ -77,47 +68,48 @@ std::vector<int> Robot::readPosition(int tries) {
             return std::vector<int>(servo_ids_.size(), 0);
         }
     }
-    
+
     std::vector<int> positions;
     for (int id : servo_ids_) {
         uint32_t position = position_reader_->getData(id, ADDR_PRESENT_POSITION, 4);
-        
+
         // Convert to signed
         int signed_position = static_cast<int>(position);
         if (signed_position > (1LL << 31)) {
             signed_position -= (1LL << 32);
         }
-        
+
         positions.push_back(signed_position);
     }
-    
+
     return positions;
 }
 
 std::vector<int> Robot::readVelocity() {
     velocity_reader_->txRxPacket();
-    
+
     std::vector<int> velocities;
     for (int id : servo_ids_) {
         uint32_t velocity = velocity_reader_->getData(id, ADDR_PRESENT_VELOCITY, 4);
-        
+
         // Convert to signed
         int signed_velocity = static_cast<int>(velocity);
         if (signed_velocity > (1LL << 31)) {
             signed_velocity -= (1LL << 32);
         }
-        
+
         velocities.push_back(signed_velocity);
     }
-    
+
     return velocities;
 }
 
 std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> Robot::readState(int tries) {
     auto t0 = std::chrono::steady_clock::now();
     int result = state_reader_->txRxPacket();
-    last_read_txrx_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t0).count();
-    
+    last_read_txrx_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t0).count();
+
     if (result != COMM_SUCCESS) {
         if (tries > 0) {
             return readState(tries - 1);
@@ -127,16 +119,16 @@ std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> Robot::readStat
             return {z, z, z};
         }
     }
-    
+
     std::vector<int> positions;
     std::vector<int> velocities;
     std::vector<int> loads;
-    
+
     for (int id : servo_ids_) {
         // Load: 2 bytes at address 126 (signed 16-bit)
         int16_t load = static_cast<int16_t>(state_reader_->getData(id, ADDR_PRESENT_LOAD, 2));
         loads.push_back(static_cast<int>(load));
-        
+
         // Velocity: 4 bytes at address 128
         uint32_t velocity = state_reader_->getData(id, ADDR_PRESENT_VELOCITY, 4);
         int signed_velocity = static_cast<int>(velocity);
@@ -144,7 +136,7 @@ std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> Robot::readStat
             signed_velocity -= (1LL << 32);
         }
         velocities.push_back(signed_velocity);
-        
+
         // Position: 4 bytes at address 132
         uint32_t position = state_reader_->getData(id, ADDR_PRESENT_POSITION, 4);
         int signed_position = static_cast<int>(position);
@@ -153,7 +145,7 @@ std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> Robot::readStat
         }
         positions.push_back(signed_position);
     }
-    
+
     return {positions, velocities, loads};
 }
 
@@ -161,7 +153,7 @@ void Robot::setGoalPos(const std::vector<int>& action) {
     if (action.size() != servo_ids_.size()) {
         throw std::invalid_argument("Action size must match number of servos");
     }
-    
+
     // Add parameters for each servo
     for (size_t i = 0; i < servo_ids_.size(); ++i) {
         uint8_t param[4];
@@ -169,14 +161,15 @@ void Robot::setGoalPos(const std::vector<int>& action) {
         param[1] = DXL_HIBYTE(DXL_LOWORD(action[i]));
         param[2] = DXL_LOBYTE(DXL_HIWORD(action[i]));
         param[3] = DXL_HIBYTE(DXL_HIWORD(action[i]));
-        
+
         pos_writer_->changeParam(servo_ids_[i], param);
     }
-    
+
     // Send packet
     auto t0 = std::chrono::steady_clock::now();
     pos_writer_->txPacket();
-    last_write_txrx_us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t0).count();
+    last_write_txrx_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t0).count();
 }
 
 void Robot::rebootAllServos() {
@@ -184,10 +177,9 @@ void Robot::rebootAllServos() {
         dynamixel_->reboot(id);
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
-    
+
     // Give servos time to complete reboot before next command
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
-} // namespace maurice_arm
-
+}  // namespace maurice_arm

--- a/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/arm_camera_driver.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/arm_camera_driver.hpp
@@ -9,78 +9,76 @@
 #include <atomic>
 #include <mutex>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 /**
  * @brief GStreamer-based arm camera driver node for Maurice robot
- * 
- * This node uses GStreamer with YUYV format to capture frames from the 
+ *
+ * This node uses GStreamer with YUYV format to capture frames from the
  * arm-mounted Arducam USB camera and publishes both raw and compressed images.
- * 
+ *
  * GStreamer provides robust device handling and hardware-accelerated
  * color conversion on Jetson platforms.
  */
-class ArmCameraDriver : public rclcpp::Node
-{
-public:
-  /**
-   * @brief Constructor
-   * @param options Node options for component composition
-   */
-  explicit ArmCameraDriver(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+class ArmCameraDriver : public rclcpp::Node {
+   public:
+    /**
+     * @brief Constructor
+     * @param options Node options for component composition
+     */
+    explicit ArmCameraDriver(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
-  /**
-   * @brief Destructor
-   */
-  ~ArmCameraDriver();
+    /**
+     * @brief Destructor
+     */
+    ~ArmCameraDriver();
 
-private:
-  /**
-   * @brief Initialize camera with GStreamer pipeline
-   * @return true if successful, false otherwise
-   */
-  bool initializeCamera();
+   private:
+    /**
+     * @brief Initialize camera with GStreamer pipeline
+     * @return true if successful, false otherwise
+     */
+    bool initializeCamera();
 
-  /**
-   * @brief Create GStreamer pipeline string for YUYV capture
-   * @return GStreamer pipeline string
-   */
-  std::string createGStreamerPipeline();
+    /**
+     * @brief Create GStreamer pipeline string for YUYV capture
+     * @return GStreamer pipeline string
+     */
+    std::string createGStreamerPipeline();
 
-  /**
-   * @brief Frame processing loop (runs in separate thread)
-   */
-  void frameProcessingLoop();
+    /**
+     * @brief Frame processing loop (runs in separate thread)
+     */
+    void frameProcessingLoop();
 
-  /**
-   * @brief Process and publish a captured frame
-   * @param frame The captured frame
-   */
-  void processAndPublishFrame(const cv::Mat& frame);
+    /**
+     * @brief Process and publish a captured frame
+     * @param frame The captured frame
+     */
+    void processAndPublishFrame(const cv::Mat& frame);
 
-  // ROS 2 publishers
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressed_pub_;
+    // ROS 2 publishers
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressed_pub_;
 
-  // OpenCV VideoCapture with GStreamer backend
-  cv::VideoCapture cap_;
-  mutable std::mutex cap_mutex_;  // Protects cap_ access across threads
+    // OpenCV VideoCapture with GStreamer backend
+    cv::VideoCapture cap_;
+    mutable std::mutex cap_mutex_;  // Protects cap_ access across threads
 
-  // Frame processing thread
-  std::thread frame_thread_;
-  std::atomic<bool> frame_thread_running_{false};
+    // Frame processing thread
+    std::thread frame_thread_;
+    std::atomic<bool> frame_thread_running_{false};
 
-  // Camera parameters
-  std::string device_path_;
-  int width_;
-  int height_;
-  double fps_;
+    // Camera parameters
+    std::string device_path_;
+    int width_;
+    int height_;
+    double fps_;
 
-  // Compressed image publishing settings
-  bool publish_compressed_{false};
-  int compressed_frame_interval_{5};
-  int compressed_frame_counter_{0};
+    // Compressed image publishing settings
+    bool publish_compressed_{false};
+    int compressed_frame_interval_{5};
+    int compressed_frame_counter_{0};
 };
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/main_camera_driver.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/main_camera_driver.hpp
@@ -27,310 +27,299 @@
 
 #include <opencv2/opencv.hpp>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 /**
  * @brief Hardware-accelerated JPEG encoder using libturbojpeg
- * 
+ *
  * Provides faster JPEG encoding compared to cv::imencode by using
  * libjpeg-turbo's optimized SIMD routines.
  */
 class JpegTurboEncoder {
-public:
-  JpegTurboEncoder() {
-    handle_ = tjInitCompress();
-    if (!handle_) throw std::runtime_error("tjInitCompress failed");
-  }
-
-  ~JpegTurboEncoder() {
-    if (handle_) tjDestroy(handle_);
-  }
-
-  // Non-copyable
-  JpegTurboEncoder(const JpegTurboEncoder&) = delete;
-  JpegTurboEncoder& operator=(const JpegTurboEncoder&) = delete;
-
-  /**
-   * @brief Encode BGR8 cv::Mat into JPEG
-   * @param bgr Input BGR image (CV_8UC3)
-   * @param quality JPEG quality (1-100)
-   * @param out Output buffer for compressed JPEG data
-   */
-  void encodeBGR(const cv::Mat& bgr, int quality, std::vector<uint8_t>& out) {
-    if (bgr.empty()) throw std::runtime_error("encodeBGR: empty image");
-    if (bgr.type() != CV_8UC3) throw std::runtime_error("encodeBGR: expected CV_8UC3 (BGR)");
-    
-    if (!bgr.isContinuous()) {
-      // Make it continuous (rare case)
-      cv::Mat tmp = bgr.clone();
-      encodeBGR(tmp, quality, out);
-      return;
+   public:
+    JpegTurboEncoder() {
+        handle_ = tjInitCompress();
+        if (!handle_)
+            throw std::runtime_error("tjInitCompress failed");
     }
 
-    unsigned char* jpegBuf = nullptr;
-    unsigned long jpegSize = 0;
-
-    // TJSAMP_420 is fastest/most common; TJFLAG_FASTDCT prioritizes speed
-    int flags = TJFLAG_FASTDCT;
-    int rc = tjCompress2(
-      handle_,
-      bgr.data,
-      bgr.cols,
-      0,                // pitch 0 => infer from width * pixelSize (works because continuous)
-      bgr.rows,
-      TJPF_BGR,
-      &jpegBuf,
-      &jpegSize,
-      TJSAMP_420,
-      quality,
-      flags
-    );
-
-    if (rc != 0) {
-      const char* err = tjGetErrorStr2(handle_);
-      throw std::runtime_error(std::string("tjCompress2 failed: ") + (err ? err : ""));
+    ~JpegTurboEncoder() {
+        if (handle_)
+            tjDestroy(handle_);
     }
 
-    out.assign(jpegBuf, jpegBuf + jpegSize);
-    tjFree(jpegBuf);
-  }
+    // Non-copyable
+    JpegTurboEncoder(const JpegTurboEncoder&) = delete;
+    JpegTurboEncoder& operator=(const JpegTurboEncoder&) = delete;
 
-private:
-  tjhandle handle_{nullptr};
+    /**
+     * @brief Encode BGR8 cv::Mat into JPEG
+     * @param bgr Input BGR image (CV_8UC3)
+     * @param quality JPEG quality (1-100)
+     * @param out Output buffer for compressed JPEG data
+     */
+    void encodeBGR(const cv::Mat& bgr, int quality, std::vector<uint8_t>& out) {
+        if (bgr.empty())
+            throw std::runtime_error("encodeBGR: empty image");
+        if (bgr.type() != CV_8UC3)
+            throw std::runtime_error("encodeBGR: expected CV_8UC3 (BGR)");
+
+        if (!bgr.isContinuous()) {
+            // Make it continuous (rare case)
+            cv::Mat tmp = bgr.clone();
+            encodeBGR(tmp, quality, out);
+            return;
+        }
+
+        unsigned char* jpegBuf = nullptr;
+        unsigned long jpegSize = 0;
+
+        // TJSAMP_420 is fastest/most common; TJFLAG_FASTDCT prioritizes speed
+        int flags = TJFLAG_FASTDCT;
+        int rc = tjCompress2(handle_, bgr.data, bgr.cols,
+                             0,  // pitch 0 => infer from width * pixelSize (works because continuous)
+                             bgr.rows, TJPF_BGR, &jpegBuf, &jpegSize, TJSAMP_420, quality, flags);
+
+        if (rc != 0) {
+            const char* err = tjGetErrorStr2(handle_);
+            throw std::runtime_error(std::string("tjCompress2 failed: ") + (err ? err : ""));
+        }
+
+        out.assign(jpegBuf, jpegBuf + jpegSize);
+        tjFree(jpegBuf);
+    }
+
+   private:
+    tjhandle handle_{nullptr};
 };
 
 /**
  * @brief PID-based auto exposure controller with center weighting
  */
-class AutoExposureController
-{
-public:
-  AutoExposureController();
-  
-  /**
-   * @brief Initialize the controller with exposure limits and proportional gain
-   * @param min_exposure Minimum exposure value
-   * @param max_exposure Maximum exposure value
-   * @param target_brightness Target brightness (0-255)
-   * @param kp Proportional gain
-   */
-  void initialize(int min_exposure, int max_exposure, double target_brightness = 128.0,
-                 double kp = 0.8);
-  
-  /**
-   * @brief Calculate new exposure value based on frame brightness
-   * @param frame Input frame
-   * @param current_exposure Current exposure value
-   * @return New exposure value
-   */
-  int calculateExposure(const cv::Mat& frame, int current_exposure);
-  
-  /**
-   * @brief Update proportional gain
-   */
-  void setPID(double kp);
-  
-  /**
-   * @brief Update target brightness
-   */
-  void setTargetBrightness(double target);
+class AutoExposureController {
+   public:
+    AutoExposureController();
 
-private:
-  /**
-   * @brief Calculate center-weighted brightness of the frame
-   * @param frame Input frame
-   * @return Center-weighted brightness (0-255)
-   */
-  double calculateCenterWeightedBrightness(const cv::Mat& frame);
-  
-  // Proportional controller parameters
-  double kp_;
-  double target_brightness_;
-  
-  // Exposure limits
-  int min_exposure_, max_exposure_;
-  
-  // Center weighting parameters
-  double center_weight_;  // Weight for center region (0.0-1.0)
-  double center_region_size_;  // Size of center region (0.0-1.0)
+    /**
+     * @brief Initialize the controller with exposure limits and proportional gain
+     * @param min_exposure Minimum exposure value
+     * @param max_exposure Maximum exposure value
+     * @param target_brightness Target brightness (0-255)
+     * @param kp Proportional gain
+     */
+    void initialize(int min_exposure, int max_exposure, double target_brightness = 128.0, double kp = 0.8);
+
+    /**
+     * @brief Calculate new exposure value based on frame brightness
+     * @param frame Input frame
+     * @param current_exposure Current exposure value
+     * @return New exposure value
+     */
+    int calculateExposure(const cv::Mat& frame, int current_exposure);
+
+    /**
+     * @brief Update proportional gain
+     */
+    void setPID(double kp);
+
+    /**
+     * @brief Update target brightness
+     */
+    void setTargetBrightness(double target);
+
+   private:
+    /**
+     * @brief Calculate center-weighted brightness of the frame
+     * @param frame Input frame
+     * @return Center-weighted brightness (0-255)
+     */
+    double calculateCenterWeightedBrightness(const cv::Mat& frame);
+
+    // Proportional controller parameters
+    double kp_;
+    double target_brightness_;
+
+    // Exposure limits
+    int min_exposure_, max_exposure_;
+
+    // Center weighting parameters
+    double center_weight_;       // Weight for center region (0.0-1.0)
+    double center_region_size_;  // Size of center region (0.0-1.0)
 };
 
 /**
  * @brief GStreamer-based main camera driver node for Maurice robot
- * 
+ *
  * This node provides a clean interface to capture frames from the main USB camera
  * using GStreamer pipeline and publishes both raw and compressed images.
  */
-class MainCameraDriver : public rclcpp::Node
-{
-public:
-  /**
-   * @brief Auto exposure mode selection
-   */
-  enum class AutoExposureMode : int {
-    HARDWARE = 0,   // Camera built-in AE (aperture priority)
-    CUSTOM_PID = 1, // Custom PID controller (manual V4L2 mode)
-    MANUAL = 2,     // Pure manual, no AE
-  };
+class MainCameraDriver : public rclcpp::Node {
+   public:
+    /**
+     * @brief Auto exposure mode selection
+     */
+    enum class AutoExposureMode : int {
+        HARDWARE = 0,    // Camera built-in AE (aperture priority)
+        CUSTOM_PID = 1,  // Custom PID controller (manual V4L2 mode)
+        MANUAL = 2,      // Pure manual, no AE
+    };
 
-  /**
-   * @brief Constructor
-   * @param options Node options for component composition
-   */
-  explicit MainCameraDriver(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+    /**
+     * @brief Constructor
+     * @param options Node options for component composition
+     */
+    explicit MainCameraDriver(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
 
-  /**
-   * @brief Destructor
-   */
-  ~MainCameraDriver();
+    /**
+     * @brief Destructor
+     */
+    ~MainCameraDriver();
 
-private:
-  /**
-   * @brief Initialize camera with GStreamer pipeline
-   * @return true if successful, false otherwise
-   */
-  bool initializeCamera();
+   private:
+    /**
+     * @brief Initialize camera with GStreamer pipeline
+     * @return true if successful, false otherwise
+     */
+    bool initializeCamera();
 
-  /**
-   * @brief Create GStreamer pipeline string
-   * @return Pipeline string for camera capture
-   */
-  std::string createGStreamerPipeline();
+    /**
+     * @brief Create GStreamer pipeline string
+     * @return Pipeline string for camera capture
+     */
+    std::string createGStreamerPipeline();
 
-  /**
-   * @brief Initialize V4L2 controls for manual exposure/gain control
-   * @return true if successful, false otherwise
-   */
-  bool initializeV4L2Controls();
+    /**
+     * @brief Initialize V4L2 controls for manual exposure/gain control
+     * @return true if successful, false otherwise
+     */
+    bool initializeV4L2Controls();
 
-  /**
-   * @brief Set a V4L2 control value
-   * @param control_id V4L2 control ID
-   * @param value Value to set
-   * @return true if successful, false otherwise
-   */
-  bool setV4L2Control(int control_id, int value);
+    /**
+     * @brief Set a V4L2 control value
+     * @param control_id V4L2 control ID
+     * @param value Value to set
+     * @return true if successful, false otherwise
+     */
+    bool setV4L2Control(int control_id, int value);
 
-  /**
-   * @brief Get a V4L2 control value
-   * @param control_id V4L2 control ID
-   * @return Control value, or -1 if failed
-   */
-  int getV4L2Control(int control_id);
+    /**
+     * @brief Get a V4L2 control value
+     * @param control_id V4L2 control ID
+     * @return Control value, or -1 if failed
+     */
+    int getV4L2Control(int control_id);
 
-  /**
-   * @brief Main frame processing loop
-   */
-  void frameProcessingLoop();
+    /**
+     * @brief Main frame processing loop
+     */
+    void frameProcessingLoop();
 
-  /**
-   * @brief Update frame statistics
-   */
-  void updateFrameStats();
+    /**
+     * @brief Update frame statistics
+     */
+    void updateFrameStats();
 
-  /**
-   * @brief Print frame statistics
-   */
-  void printFrameStats();
+    /**
+     * @brief Print frame statistics
+     */
+    void printFrameStats();
 
-  /**
-   * @brief Process captured frame and publish messages
-   * @param frame Captured frame from camera
-   */
-  void processAndPublishFrame(const cv::Mat& frame);
+    /**
+     * @brief Process captured frame and publish messages
+     * @param frame Captured frame from camera
+     */
+    void processAndPublishFrame(const cv::Mat& frame);
 
-  /**
-   * @brief Apply auto exposure control to frame
-   * @param frame Input frame for brightness analysis
-   */
-  void applyAutoExposure(const cv::Mat& frame);
+    /**
+     * @brief Apply auto exposure control to frame
+     * @param frame Input frame for brightness analysis
+     */
+    void applyAutoExposure(const cv::Mat& frame);
 
-  /**
-   * @brief Timer callback: check if stereo calibration file changed and reload.
-   */
-  void checkCalibrationFile();
+    /**
+     * @brief Timer callback: check if stereo calibration file changed and reload.
+     */
+    void checkCalibrationFile();
 
-  // ROS 2 publishers
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_pub_;   // Left camera raw
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_pub_;  // Right camera raw
-  rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressed_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr stereo_pub_;
+    // ROS 2 publishers
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_pub_;   // Left camera raw
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_pub_;  // Right camera raw
+    rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressed_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr stereo_pub_;
 
-  // Camera info publishers + calibration
-  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr left_info_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr right_info_pub_;
-  std::shared_ptr<StereoCalibration> stereo_calib_;
-  sensor_msgs::msg::CameraInfo left_info_msg_;
-  sensor_msgs::msg::CameraInfo right_info_msg_;
-  bool calibration_loaded_{false};
-  std::mutex calib_mutex_;
-  rclcpp::TimerBase::SharedPtr calib_watch_timer_;
-  std::filesystem::file_time_type calib_last_write_;
+    // Camera info publishers + calibration
+    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr left_info_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr right_info_pub_;
+    std::shared_ptr<StereoCalibration> stereo_calib_;
+    sensor_msgs::msg::CameraInfo left_info_msg_;
+    sensor_msgs::msg::CameraInfo right_info_msg_;
+    bool calibration_loaded_{false};
+    std::mutex calib_mutex_;
+    rclcpp::TimerBase::SharedPtr calib_watch_timer_;
+    std::filesystem::file_time_type calib_last_write_;
 
-  // Frame processing thread
-  std::thread frame_thread_;
-  std::atomic<bool> frame_thread_running_{false};
+    // Frame processing thread
+    std::thread frame_thread_;
+    std::atomic<bool> frame_thread_running_{false};
 
-  // Camera parameters
-  std::string data_directory_;
-  std::string camera_device_;
-  int capture_width_;      // Capture resolution (full FOV)
-  int capture_height_;
-  int left_width_;         // Left camera at capture resolution
-  int left_height_;
-  int publish_left_width_;   // Publish left at this resolution
-  int publish_left_height_;
-  int publish_stereo_width_; // Publish stereo at this resolution
-  int publish_stereo_height_;
-  double fps_;
-  std::string frame_id_;
-  std::string right_frame_id_;
-  int jpeg_quality_;
+    // Camera parameters
+    std::string data_directory_;
+    std::string camera_device_;
+    int capture_width_;  // Capture resolution (full FOV)
+    int capture_height_;
+    int left_width_;  // Left camera at capture resolution
+    int left_height_;
+    int publish_left_width_;  // Publish left at this resolution
+    int publish_left_height_;
+    int publish_stereo_width_;  // Publish stereo at this resolution
+    int publish_stereo_height_;
+    double fps_;
+    std::string frame_id_;
+    std::string right_frame_id_;
+    int jpeg_quality_;
 
-  // Compressed image publishing settings
-  bool publish_compressed_{true};
-  int compressed_frame_interval_{3};  // Publish compressed every N frames
-  int compressed_frame_counter_{0};
+    // Compressed image publishing settings
+    bool publish_compressed_{true};
+    int compressed_frame_interval_{3};  // Publish compressed every N frames
+    int compressed_frame_counter_{0};
 
-  // Stereo image publishing (combined left+right for legacy compatibility)
-  bool publish_stereo_{false};
+    // Stereo image publishing (combined left+right for legacy compatibility)
+    bool publish_stereo_{false};
 
-  // V4L2 control interface
-  int camera_fd_{-1};
-  
-  // Camera control parameters
-  int exposure_min_, exposure_max_;
-  int gain_min_, gain_max_;
-  int current_exposure_;
-  int current_gain_;
-  bool v4l2_controls_initialized_{false};
-  int exposure_setting_{-1};
-  int gain_setting_{-1};
-  int default_gain_param_{110};
+    // V4L2 control interface
+    int camera_fd_{-1};
 
-  // Auto exposure control
-  AutoExposureController auto_exposure_controller_;
-  AutoExposureMode auto_exposure_mode_{AutoExposureMode::HARDWARE};
-  double target_brightness_{128.0};
-  double ae_kp_{0.8};
-  int auto_exposure_update_interval_{3};  // Update every N frames (10Hz for 30Hz camera)
-  int frame_counter_{0};
+    // Camera control parameters
+    int exposure_min_, exposure_max_;
+    int gain_min_, gain_max_;
+    int current_exposure_;
+    int current_gain_;
+    bool v4l2_controls_initialized_{false};
+    int exposure_setting_{-1};
+    int gain_setting_{-1};
+    int default_gain_param_{110};
 
-  // OpenCV camera capture
-  cv::VideoCapture cap_;
+    // Auto exposure control
+    AutoExposureController auto_exposure_controller_;
+    AutoExposureMode auto_exposure_mode_{AutoExposureMode::HARDWARE};
+    double target_brightness_{128.0};
+    double ae_kp_{0.8};
+    int auto_exposure_update_interval_{3};  // Update every N frames (10Hz for 30Hz camera)
+    int frame_counter_{0};
 
-  // Frame timing tracking
-  std::deque<rclcpp::Time> frame_timestamps_;
-  rclcpp::Time last_stats_print_;
-  
-  // Statistics
-  std::atomic<int> frame_count_{0};
-  std::atomic<bool> camera_initialized_{false};
+    // OpenCV camera capture
+    cv::VideoCapture cap_;
 
-  // TurboJPEG encoder for faster JPEG compression
-  std::unique_ptr<JpegTurboEncoder> jpeg_encoder_;
+    // Frame timing tracking
+    std::deque<rclcpp::Time> frame_timestamps_;
+    rclcpp::Time last_stats_print_;
+
+    // Statistics
+    std::atomic<int> frame_count_{0};
+    std::atomic<bool> camera_initialized_{false};
+
+    // TurboJPEG encoder for faster JPEG compression
+    std::unique_ptr<JpegTurboEncoder> jpeg_encoder_;
 };
 
-} // namespace maurice_cam
-
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/stereo_calibration.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/stereo_calibration.hpp
@@ -8,8 +8,7 @@
 #include <opencv2/opencv.hpp>
 #include "sensor_msgs/msg/camera_info.hpp"
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 /**
  * @brief Shared stereo-calibration utility — NOT a ROS node.
@@ -23,98 +22,122 @@ namespace maurice_cam
  * Designed to be shared among MainCameraDriver, StereoDepthEstimator, etc.,
  * eliminating the duplicated findCalibrationConfigDir / loadCalibration code.
  */
-class StereoCalibration
-{
-public:
-  // ── Factory methods ────────────────────────────────────────────────────
+class StereoCalibration {
+   public:
+    // ── Factory methods ────────────────────────────────────────────────────
 
-  /**
-   * @brief Auto-discover calibration directory under `data_directory` and load.
-   *
-   * Reads robot_info.json → calibration_config_<model>/stereo_calib.yaml.
-   * Throws on failure.
-   */
-  static std::shared_ptr<StereoCalibration> load(const std::string& data_directory);
+    /**
+     * @brief Auto-discover calibration directory under `data_directory` and load.
+     *
+     * Reads robot_info.json → calibration_config_<model>/stereo_calib.yaml.
+     * Throws on failure.
+     */
+    static std::shared_ptr<StereoCalibration> load(const std::string& data_directory);
 
-  /**
-   * @brief Load directly from a YAML file path.
-   */
-  static std::shared_ptr<StereoCalibration> loadFromFile(const std::filesystem::path& yaml_path);
+    /**
+     * @brief Load directly from a YAML file path.
+     */
+    static std::shared_ptr<StereoCalibration> loadFromFile(const std::filesystem::path& yaml_path);
 
-  // ── CameraInfo builders ────────────────────────────────────────────────
+    // ── CameraInfo builders ────────────────────────────────────────────────
 
-  /** Build a sensor_msgs::CameraInfo for the LEFT camera. */
-  sensor_msgs::msg::CameraInfo buildLeftCameraInfo(const std::string& frame_id = "camera_optical_frame") const;
+    /** Build a sensor_msgs::CameraInfo for the LEFT camera. */
+    sensor_msgs::msg::CameraInfo buildLeftCameraInfo(const std::string& frame_id = "camera_optical_frame") const;
 
-  /** Build a sensor_msgs::CameraInfo for the RIGHT camera. */
-  sensor_msgs::msg::CameraInfo buildRightCameraInfo(const std::string& frame_id = "right_camera_optical_frame") const;
+    /** Build a sensor_msgs::CameraInfo for the RIGHT camera. */
+    sensor_msgs::msg::CameraInfo buildRightCameraInfo(const std::string& frame_id = "right_camera_optical_frame") const;
 
-  // ── Rectification maps ────────────────────────────────────────────────
+    // ── Rectification maps ────────────────────────────────────────────────
 
-  /**
-   * @brief Compute rectification maps at the calibration resolution.
-   * @param[out] map1_left, map2_left   Left remap pair (CV_32FC1)
-   * @param[out] map1_right, map2_right Right remap pair (CV_32FC1)
-   */
-  void getRectificationMaps(
-    cv::Mat& map1_left, cv::Mat& map2_left,
-    cv::Mat& map1_right, cv::Mat& map2_right) const;
+    /**
+     * @brief Compute rectification maps at the calibration resolution.
+     * @param[out] map1_left, map2_left   Left remap pair (CV_32FC1)
+     * @param[out] map1_right, map2_right Right remap pair (CV_32FC1)
+     */
+    void getRectificationMaps(cv::Mat& map1_left, cv::Mat& map2_left, cv::Mat& map1_right, cv::Mat& map2_right) const;
 
-  /**
-   * @brief Compute rectification maps at an arbitrary resolution.
-   * Scales K and P to the requested size.
-   */
-  void getRectificationMaps(
-    int width, int height,
-    cv::Mat& map1_left, cv::Mat& map2_left,
-    cv::Mat& map1_right, cv::Mat& map2_right) const;
+    /**
+     * @brief Compute rectification maps at an arbitrary resolution.
+     * Scales K and P to the requested size.
+     */
+    void getRectificationMaps(int width, int height, cv::Mat& map1_left, cv::Mat& map2_left, cv::Mat& map1_right,
+                              cv::Mat& map2_right) const;
 
-  // ── Accessors ──────────────────────────────────────────────────────────
+    // ── Accessors ──────────────────────────────────────────────────────────
 
-  const cv::Mat& K1() const { return K1_; }
-  const cv::Mat& D1() const { return D1_; }
-  const cv::Mat& K2() const { return K2_; }
-  const cv::Mat& D2() const { return D2_; }
-  const cv::Mat& R()  const { return R_;  }
-  const cv::Mat& T()  const { return T_;  }
-  const cv::Mat& R1() const { return R1_; }
-  const cv::Mat& R2() const { return R2_; }
-  const cv::Mat& P1() const { return P1_; }
-  const cv::Mat& P2() const { return P2_; }
-  const cv::Mat& Q()  const { return Q_;  }
+    const cv::Mat& K1() const {
+        return K1_;
+    }
+    const cv::Mat& D1() const {
+        return D1_;
+    }
+    const cv::Mat& K2() const {
+        return K2_;
+    }
+    const cv::Mat& D2() const {
+        return D2_;
+    }
+    const cv::Mat& R() const {
+        return R_;
+    }
+    const cv::Mat& T() const {
+        return T_;
+    }
+    const cv::Mat& R1() const {
+        return R1_;
+    }
+    const cv::Mat& R2() const {
+        return R2_;
+    }
+    const cv::Mat& P1() const {
+        return P1_;
+    }
+    const cv::Mat& P2() const {
+        return P2_;
+    }
+    const cv::Mat& Q() const {
+        return Q_;
+    }
 
-  double baseline()    const { return baseline_;    }
-  double focalLength() const { return focal_length_; }
-  int calibWidth()     const { return calib_width_;  }
-  int calibHeight()    const { return calib_height_; }
+    double baseline() const {
+        return baseline_;
+    }
+    double focalLength() const {
+        return focal_length_;
+    }
+    int calibWidth() const {
+        return calib_width_;
+    }
+    int calibHeight() const {
+        return calib_height_;
+    }
 
-  /** Path to the loaded YAML file. */
-  const std::filesystem::path& filePath() const { return file_path_; }
+    /** Path to the loaded YAML file. */
+    const std::filesystem::path& filePath() const {
+        return file_path_;
+    }
 
-private:
-  StereoCalibration() = default;  // Only created via factories
+   private:
+    StereoCalibration() = default;  // Only created via factories
 
-  /** Auto-discover calibration_config_* directory. */
-  static std::filesystem::path findCalibrationConfigDir(const std::string& data_directory);
+    /** Auto-discover calibration_config_* directory. */
+    static std::filesystem::path findCalibrationConfigDir(const std::string& data_directory);
 
-  /** Build CameraInfo for either camera. */
-  sensor_msgs::msg::CameraInfo buildCameraInfo(
-    const cv::Mat& K, const cv::Mat& D,
-    const cv::Mat& R, const cv::Mat& P,
-    const std::string& frame_id,
-    bool negate_tx) const;
+    /** Build CameraInfo for either camera. */
+    sensor_msgs::msg::CameraInfo buildCameraInfo(const cv::Mat& K, const cv::Mat& D, const cv::Mat& R, const cv::Mat& P,
+                                                 const std::string& frame_id, bool negate_tx) const;
 
-  // Calibration matrices
-  cv::Mat K1_, D1_, K2_, D2_;
-  cv::Mat R_, T_;
-  cv::Mat R1_, R2_, P1_, P2_, Q_;
+    // Calibration matrices
+    cv::Mat K1_, D1_, K2_, D2_;
+    cv::Mat R_, T_;
+    cv::Mat R1_, R2_, P1_, P2_, Q_;
 
-  int calib_width_{0};
-  int calib_height_{0};
-  double baseline_{0.0};
-  double focal_length_{0.0};
+    int calib_width_{0};
+    int calib_height_{0};
+    double baseline_{0.0};
+    double focal_length_{0.0};
 
-  std::filesystem::path file_path_;
+    std::filesystem::path file_path_;
 };
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/stereo_depth_estimator.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/include/maurice_cam/stereo_depth_estimator.hpp
@@ -27,8 +27,7 @@
 #include <vpi/OpenCVInterop.hpp>
 #include <vpi/algo/StereoDisparity.h>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 /**
  * @brief Stereo depth estimator with integrated disparity filtering and
@@ -41,220 +40,211 @@ namespace maurice_cam
  *   Median → Bilateral → Hole Fill → Depth Clamp → Edge Invalidation
  *   → Speckle Removal → Domain Transform → Temporal Smoothing
  */
-class StereoDepthEstimator : public rclcpp::Node
-{
-public:
-  explicit StereoDepthEstimator(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
-  ~StereoDepthEstimator();
+class StereoDepthEstimator : public rclcpp::Node {
+   public:
+    explicit StereoDepthEstimator(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+    ~StereoDepthEstimator();
 
-private:
-  // ── VPI Stereo (depth_estimator/vpi_stereo.cpp) ─────────────────────────
-  bool initializeVPI();
-  void cleanupVPI();
-  bool submitSGM(const cv::Mat& left_rect, const cv::Mat& right_rect);
-  void syncSGM();
-  cv::Mat extractDisparity();
-  void cleanupSGMWraps();
+   private:
+    // ── VPI Stereo (depth_estimator/vpi_stereo.cpp) ─────────────────────────
+    bool initializeVPI();
+    void cleanupVPI();
+    bool submitSGM(const cv::Mat& left_rect, const cv::Mat& right_rect);
+    void syncSGM();
+    cv::Mat extractDisparity();
+    void cleanupSGMWraps();
 
-  // ── Rectification (depth_estimator/rectification.cpp) ──────────────────
-  void scaleToCalibRes(const cv::Mat& left_in, const cv::Mat& right_in,
-                       cv::Mat& left_out, cv::Mat& right_out);
-  void rectifyMono(const cv::Mat& left_scaled, const cv::Mat& right_scaled,
-                   cv::Mat& left_rect, cv::Mat& right_rect);
-  void rectifyColor(const cv::Mat& left_scaled, cv::Mat& left_color_rect);
-  bool initVPIRemap();
-  void cleanupVPIRemap();
+    // ── Rectification (depth_estimator/rectification.cpp) ──────────────────
+    void scaleToCalibRes(const cv::Mat& left_in, const cv::Mat& right_in, cv::Mat& left_out, cv::Mat& right_out);
+    void rectifyMono(const cv::Mat& left_scaled, const cv::Mat& right_scaled, cv::Mat& left_rect, cv::Mat& right_rect);
+    void rectifyColor(const cv::Mat& left_scaled, cv::Mat& left_color_rect);
+    bool initVPIRemap();
+    void cleanupVPIRemap();
 
-  // ── Publishing (depth_estimator/publishing.cpp) ────────────────────────
-  void publishMonoRectified(const cv::Mat& left_rect, const cv::Mat& right_rect,
-                            const rclcpp::Time& ts, bool pub_left, bool pub_right);
-  void publishColorRectified(const cv::Mat& color_rect, const cv::Mat& mono_rect,
-                             bool has_color_input, const rclcpp::Time& ts,
-                             bool pub_color, bool pub_compressed);
-  void publishDisparityMsg(const cv::Mat& disparity_float, const rclcpp::Time& ts,
-                           rclcpp::Publisher<stereo_msgs::msg::DisparityImage>::SharedPtr& pub);
-  void publishDepth(const cv::Mat& disparity_float, const rclcpp::Time& ts);
+    // ── Publishing (depth_estimator/publishing.cpp) ────────────────────────
+    void publishMonoRectified(const cv::Mat& left_rect, const cv::Mat& right_rect, const rclcpp::Time& ts,
+                              bool pub_left, bool pub_right);
+    void publishColorRectified(const cv::Mat& color_rect, const cv::Mat& mono_rect, bool has_color_input,
+                               const rclcpp::Time& ts, bool pub_color, bool pub_compressed);
+    void publishDisparityMsg(const cv::Mat& disparity_float, const rclcpp::Time& ts,
+                             rclcpp::Publisher<stereo_msgs::msg::DisparityImage>::SharedPtr& pub);
+    void publishDepth(const cv::Mat& disparity_float, const rclcpp::Time& ts);
 
-  // ── Point Cloud (depth_estimator/pointcloud.cpp) ───────────────────────
-  void publishPointCloudXYZ(const cv::Mat& disparity_lowres, const rclcpp::Time& ts);
-  void publishPointCloudColor(const cv::Mat& disparity_lowres, const cv::Mat& color_rect,
-                              const rclcpp::Time& ts);
-  // ── Footprint Overlay, Mask & Cutout (depth_estimator/publishing.cpp) ──
-  void computeFootprintMaskCalib();
-  void publishFootprintOverlay(const cv::Mat& color_rect, const rclcpp::Time& ts);
-  void publishFootprintMask(const rclcpp::Time& ts);
-  void publishFootprintCutout(const cv::Mat& color_rect, const rclcpp::Time& ts);
-  void applyFootprintMask(cv::Mat& disparity);
-  // ── Callback / Pipeline ────────────────────────────────────────────────
-  void syncCallback(
-    const sensor_msgs::msg::Image::ConstSharedPtr& left_msg,
-    const sensor_msgs::msg::Image::ConstSharedPtr& right_msg);
-  void processFrame(const cv::Mat& left_img, const cv::Mat& right_img,
-                    const rclcpp::Time& timestamp);
+    // ── Point Cloud (depth_estimator/pointcloud.cpp) ───────────────────────
+    void publishPointCloudXYZ(const cv::Mat& disparity_lowres, const rclcpp::Time& ts);
+    void publishPointCloudColor(const cv::Mat& disparity_lowres, const cv::Mat& color_rect, const rclcpp::Time& ts);
+    // ── Footprint Overlay, Mask & Cutout (depth_estimator/publishing.cpp) ──
+    void computeFootprintMaskCalib();
+    void publishFootprintOverlay(const cv::Mat& color_rect, const rclcpp::Time& ts);
+    void publishFootprintMask(const rclcpp::Time& ts);
+    void publishFootprintCutout(const cv::Mat& color_rect, const rclcpp::Time& ts);
+    void applyFootprintMask(cv::Mat& disparity);
+    // ── Callback / Pipeline ────────────────────────────────────────────────
+    void syncCallback(const sensor_msgs::msg::Image::ConstSharedPtr& left_msg,
+                      const sensor_msgs::msg::Image::ConstSharedPtr& right_msg);
+    void processFrame(const cv::Mat& left_img, const cv::Mat& right_img, const rclcpp::Time& timestamp);
 
-  // ── Camera Info Calibration ────────────────────────────────────────────
-  void leftCameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
-  void rightCameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
-  bool initCalibrationFromCameraInfo();
+    // ── Camera Info Calibration ────────────────────────────────────────────
+    void leftCameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
+    void rightCameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
+    bool initCalibrationFromCameraInfo();
 
-  // ── Disparity Filter Chain (filters/*.cpp) ──────────────────────────
-  struct FilterTimings {
-    double footprint_mask_ms{0};
-    double downsample_ms{0}, upsample_ms{0};
-    double depth_clamp_ms{0}, domain_transform_ms{0}, speckle_ms{0};
-    double edge_inv_ms{0}, median_ms{0}, bilateral_ms{0};
-    double hole_fill_ms{0}, temporal_ms{0};
-  };
-  void initFilterParams();      // filters/filter_chain.cpp
-  void logFilterConfig() const; // filters/filter_chain.cpp
-  void applyFilterChain(cv::Mat& disparity, cv::Mat& disparity_lowres,
-                        FilterTimings& timings, float focal_length, float baseline);
-  // Individual filters (filters/simple_filters.cpp, filters/advanced_filters.cpp)
-  void applyMedian(cv::Mat& img);
-  void applyBilateral(cv::Mat& img);
-  void fillHoles(cv::Mat& img);
-  void clampByDepth(cv::Mat& img, float f, float t);
-  void invalidateEdges(cv::Mat& img);
-  void filterSpeckles(cv::Mat& img);
-  void applyDomainTransform(cv::Mat& img);
-  void dtPass(cv::Mat& img, bool horizontal);
-  void applyTemporal(cv::Mat& img);
+    // ── Disparity Filter Chain (filters/*.cpp) ──────────────────────────
+    struct FilterTimings {
+        double footprint_mask_ms{0};
+        double downsample_ms{0}, upsample_ms{0};
+        double depth_clamp_ms{0}, domain_transform_ms{0}, speckle_ms{0};
+        double edge_inv_ms{0}, median_ms{0}, bilateral_ms{0};
+        double hole_fill_ms{0}, temporal_ms{0};
+    };
+    void initFilterParams();       // filters/filter_chain.cpp
+    void logFilterConfig() const;  // filters/filter_chain.cpp
+    void applyFilterChain(cv::Mat& disparity, cv::Mat& disparity_lowres, FilterTimings& timings, float focal_length,
+                          float baseline);
+    // Individual filters (filters/simple_filters.cpp, filters/advanced_filters.cpp)
+    void applyMedian(cv::Mat& img);
+    void applyBilateral(cv::Mat& img);
+    void fillHoles(cv::Mat& img);
+    void clampByDepth(cv::Mat& img, float f, float t);
+    void invalidateEdges(cv::Mat& img);
+    void filterSpeckles(cv::Mat& img);
+    void applyDomainTransform(cv::Mat& img);
+    void dtPass(cv::Mat& img, bool horizontal);
+    void applyTemporal(cv::Mat& img);
 
-  // ── Sync ───────────────────────────────────────────────────────────────
-  using SyncPolicy = message_filters::sync_policies::ApproximateTime<
-    sensor_msgs::msg::Image, sensor_msgs::msg::Image>;
-  using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
+    // ── Sync ───────────────────────────────────────────────────────────────
+    using SyncPolicy =
+        message_filters::sync_policies::ApproximateTime<sensor_msgs::msg::Image, sensor_msgs::msg::Image>;
+    using Synchronizer = message_filters::Synchronizer<SyncPolicy>;
 
-  std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> left_sub_;
-  std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> right_sub_;
-  std::shared_ptr<Synchronizer> sync_;
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> left_sub_;
+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> right_sub_;
+    std::shared_ptr<Synchronizer> sync_;
 
-  // Camera info subscribers (persistent — detect recalibration)
-  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr left_info_sub_;
-  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr right_info_sub_;
-  sensor_msgs::msg::CameraInfo::ConstSharedPtr left_camera_info_;
-  sensor_msgs::msg::CameraInfo::ConstSharedPtr right_camera_info_;
-  std::mutex calib_mutex_;  // guards VPI teardown/init vs processFrame
+    // Camera info subscribers (persistent — detect recalibration)
+    rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr left_info_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr right_info_sub_;
+    sensor_msgs::msg::CameraInfo::ConstSharedPtr left_camera_info_;
+    sensor_msgs::msg::CameraInfo::ConstSharedPtr right_camera_info_;
+    std::mutex calib_mutex_;  // guards VPI teardown/init vs processFrame
 
-  // Footprint pointcloud subscriber (for overlay projection)
-  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr footprint_sub_;
-  sensor_msgs::msg::PointCloud2::ConstSharedPtr latest_footprint_cloud_;
-  std::mutex footprint_mutex_;
+    // Footprint pointcloud subscriber (for overlay projection)
+    rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr footprint_sub_;
+    sensor_msgs::msg::PointCloud2::ConstSharedPtr latest_footprint_cloud_;
+    std::mutex footprint_mutex_;
 
-  // ── Publishers ─────────────────────────────────────────────────────────
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_pub_;
-  rclcpp::Publisher<stereo_msgs::msg::DisparityImage>::SharedPtr disparity_pub_;
-  rclcpp::Publisher<stereo_msgs::msg::DisparityImage>::SharedPtr disparity_unfiltered_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_rectified_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_rectified_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_rectified_color_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr left_rectified_compressed_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_color_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr footprint_overlay_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr footprint_mask_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr footprint_cutout_pub_;
+    // ── Publishers ─────────────────────────────────────────────────────────
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr depth_pub_;
+    rclcpp::Publisher<stereo_msgs::msg::DisparityImage>::SharedPtr disparity_pub_;
+    rclcpp::Publisher<stereo_msgs::msg::DisparityImage>::SharedPtr disparity_unfiltered_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_rectified_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_rectified_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_rectified_color_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr left_rectified_compressed_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_color_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr footprint_overlay_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr footprint_mask_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr footprint_cutout_pub_;
 
-  // ── General Parameters ─────────────────────────────────────────────────
-  std::string left_camera_info_topic_, right_camera_info_topic_;
-  std::string left_topic_, right_topic_;
-  std::string depth_topic_, disparity_topic_, disparity_unfiltered_topic_;
-  std::string left_rectified_topic_, right_rectified_topic_;
-  std::string left_rectified_color_topic_;
-  std::string left_rectified_compressed_topic_;
-  std::string pointcloud_topic_;
-  std::string pointcloud_color_topic_;
-  std::string footprint_cloud_topic_;
-  std::string footprint_overlay_topic_;
-  std::string footprint_mask_topic_;
-  std::string footprint_cutout_topic_;
-  std::string frame_id_;
-  int max_disparity_;
-  double max_fps_{10.0};
-  std::chrono::steady_clock::duration min_process_interval_{};
-  int pointcloud_decimation_;
+    // ── General Parameters ─────────────────────────────────────────────────
+    std::string left_camera_info_topic_, right_camera_info_topic_;
+    std::string left_topic_, right_topic_;
+    std::string depth_topic_, disparity_topic_, disparity_unfiltered_topic_;
+    std::string left_rectified_topic_, right_rectified_topic_;
+    std::string left_rectified_color_topic_;
+    std::string left_rectified_compressed_topic_;
+    std::string pointcloud_topic_;
+    std::string pointcloud_color_topic_;
+    std::string footprint_cloud_topic_;
+    std::string footprint_overlay_topic_;
+    std::string footprint_mask_topic_;
+    std::string footprint_cutout_topic_;
+    std::string frame_id_;
+    int max_disparity_;
+    double max_fps_{10.0};
+    std::chrono::steady_clock::duration min_process_interval_{};
+    int pointcloud_decimation_;
 
-  // VPI SGM parameters
-  int include_diagonals_;
-  int confidence_threshold_;
-  int min_disparity_;
-  int p1_, p2_;
-  double uniqueness_;
-  int disparity_border_margin_;
+    // VPI SGM parameters
+    int include_diagonals_;
+    int confidence_threshold_;
+    int min_disparity_;
+    int p1_, p2_;
+    double uniqueness_;
+    int disparity_border_margin_;
 
-  // Image dimensions
-  int image_width_, image_height_;       // input (from camera)
-  int calib_width_, calib_height_;       // calibration (processing)
-  double depth_scale_;
+    // Image dimensions
+    int image_width_, image_height_;  // input (from camera)
+    int calib_width_, calib_height_;  // calibration (processing)
+    double depth_scale_;
 
-  // Calibration (from camera_info topics)
-  cv::Mat P1_;  // left projection matrix (3×4), for point cloud intrinsics
-  double baseline_, focal_length_;
-  int jpeg_quality_{80};
+    // Calibration (from camera_info topics)
+    cv::Mat P1_;  // left projection matrix (3×4), for point cloud intrinsics
+    double baseline_, focal_length_;
+    int jpeg_quality_{80};
 
-  // Rectification maps (calibration resolution)
-  cv::Mat map1_left_, map2_left_;
-  cv::Mat map1_right_, map2_right_;
+    // Rectification maps (calibration resolution)
+    cv::Mat map1_left_, map2_left_;
+    cv::Mat map1_right_, map2_right_;
 
-  // VPI resources
-  VPIStream vpi_stream_{nullptr};
-  VPIImage vpi_disparity_{nullptr};
-  VPIImage vpi_confidence_{nullptr};
-  VPIPayload stereo_payload_{nullptr};
+    // VPI resources
+    VPIStream vpi_stream_{nullptr};
+    VPIImage vpi_disparity_{nullptr};
+    VPIImage vpi_confidence_{nullptr};
+    VPIPayload stereo_payload_{nullptr};
 
-  // Per-frame VPI image wraps (created in submitSGM, destroyed in cleanupSGMWraps)
-  VPIImage vpi_left_wrap_{nullptr};
-  VPIImage vpi_right_wrap_{nullptr};
+    // Per-frame VPI image wraps (created in submitSGM, destroyed in cleanupSGMWraps)
+    VPIImage vpi_left_wrap_{nullptr};
+    VPIImage vpi_right_wrap_{nullptr};
 
-  // VPI remap resources (persistent across frames)
-  VPIPayload vpi_remap_left_{nullptr};
-  VPIPayload vpi_remap_right_{nullptr};
-  VPIPayload vpi_remap_color_{nullptr};
-  VPIImage   vpi_rect_left_out_{nullptr};
-  VPIImage   vpi_rect_right_out_{nullptr};
-  VPIImage   vpi_rect_color_out_{nullptr};
+    // VPI remap resources (persistent across frames)
+    VPIPayload vpi_remap_left_{nullptr};
+    VPIPayload vpi_remap_right_{nullptr};
+    VPIPayload vpi_remap_color_{nullptr};
+    VPIImage vpi_rect_left_out_{nullptr};
+    VPIImage vpi_rect_right_out_{nullptr};
+    VPIImage vpi_rect_color_out_{nullptr};
 
-  bool vpi_initialized_{false};
-  bool calibration_loaded_{false};
-  int frame_count_{0};
-  int input_frame_count_{0};
-  rclcpp::Time last_stats_time_;
-  std::chrono::steady_clock::time_point last_process_time_{};
+    bool vpi_initialized_{false};
+    bool calibration_loaded_{false};
+    int frame_count_{0};
+    int input_frame_count_{0};
+    rclcpp::Time last_stats_time_;
+    std::chrono::steady_clock::time_point last_process_time_{};
 
-  // ── Filter Parameters ──────────────────────────────────────────────────
-  bool filter_downsample_enabled_{false};
-  int filter_downsample_factor_{4};
-  bool median_enabled_{false};
-  int median_kernel_size_{5};
-  bool bilateral_enabled_{false};
-  int bilateral_diameter_{5};
-  double bilateral_sigma_color_{10.0}, bilateral_sigma_space_{10.0};
-  bool hole_filling_enabled_{false};
-  int hole_fill_radius_{2};
-  int hole_fill_strategy_{1};
-  bool depth_clamp_enabled_{false};
-  double min_depth_meters_{0.25}, max_depth_meters_{5.0};
-  bool edge_inv_enabled_{false};
-  int edge_inv_width_{3};
-  double edge_canny_low_{10.0}, edge_canny_high_{30.0};
-  bool speckle_enabled_{false};
-  int speckle_max_size_{200};
-  double speckle_max_diff_{1.0};
-  bool dt_enabled_{false};
-  int dt_iterations_{2}, dt_delta_{20};
-  double dt_alpha_{0.5};
-  bool temporal_enabled_{false};
-  double temporal_alpha_{0.4};
-  int temporal_delta_{20};
-  int temporal_persistence_{3};
-  cv::Mat prev_disparity_frame_;
-  std::vector<uint8_t> temporal_history_;
-  std::vector<std::string> filter_order_;
+    // ── Filter Parameters ──────────────────────────────────────────────────
+    bool filter_downsample_enabled_{false};
+    int filter_downsample_factor_{4};
+    bool median_enabled_{false};
+    int median_kernel_size_{5};
+    bool bilateral_enabled_{false};
+    int bilateral_diameter_{5};
+    double bilateral_sigma_color_{10.0}, bilateral_sigma_space_{10.0};
+    bool hole_filling_enabled_{false};
+    int hole_fill_radius_{2};
+    int hole_fill_strategy_{1};
+    bool depth_clamp_enabled_{false};
+    double min_depth_meters_{0.25}, max_depth_meters_{5.0};
+    bool edge_inv_enabled_{false};
+    int edge_inv_width_{3};
+    double edge_canny_low_{10.0}, edge_canny_high_{30.0};
+    bool speckle_enabled_{false};
+    int speckle_max_size_{200};
+    double speckle_max_diff_{1.0};
+    bool dt_enabled_{false};
+    int dt_iterations_{2}, dt_delta_{20};
+    double dt_alpha_{0.5};
+    bool temporal_enabled_{false};
+    double temporal_alpha_{0.4};
+    int temporal_delta_{20};
+    int temporal_persistence_{3};
+    cv::Mat prev_disparity_frame_;
+    std::vector<uint8_t> temporal_history_;
+    std::vector<std::string> filter_order_;
 
-  // Per-frame footprint mask at calibration resolution (255 = robot body, 0 = free)
-  cv::Mat footprint_mask_calib_;
-
-
+    // Per-frame footprint mask at calibration resolution (255 = robot body, 0 = free)
+    cv::Mat footprint_mask_calib_;
 };
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/arm_camera_driver.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/arm_camera_driver.cpp
@@ -3,12 +3,9 @@
 
 using namespace std::chrono_literals;
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
-ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions & options) 
-  : Node("arm_camera_driver", options)
-{
+ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions& options) : Node("arm_camera_driver", options) {
     RCLCPP_INFO(this->get_logger(), "Initializing arm camera driver...");
 
     // Parameters
@@ -32,7 +29,7 @@ ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions & options)
     std::string camera_pattern = camera_symlink;
     std::string symlink_path;
     std::string v4l_dir = "/dev/v4l/by-id/";
-    
+
     std::vector<std::string> matching_symlinks;
     if (std::filesystem::exists(v4l_dir)) {
         for (const auto& entry : std::filesystem::directory_iterator(v4l_dir)) {
@@ -42,13 +39,13 @@ ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions & options)
             }
         }
     }
-    
+
     if (matching_symlinks.empty()) {
-        RCLCPP_ERROR(this->get_logger(), "Camera symlink matching pattern '%s' not found in %s", 
-                     camera_pattern.c_str(), v4l_dir.c_str());
+        RCLCPP_ERROR(this->get_logger(), "Camera symlink matching pattern '%s' not found in %s", camera_pattern.c_str(),
+                     v4l_dir.c_str());
         throw std::runtime_error("Camera symlink not found");
     }
-    
+
     // Prefer -video-index0 if available (typically the capture device)
     bool found_index0 = false;
     for (const auto& symlink : matching_symlinks) {
@@ -56,22 +53,23 @@ ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions & options)
         if (filename.find("-video-index0") != std::string::npos) {
             symlink_path = symlink;
             found_index0 = true;
-            RCLCPP_INFO(this->get_logger(), "Found camera symlink matching pattern '%s': %s (preferred -video-index0)", 
+            RCLCPP_INFO(this->get_logger(), "Found camera symlink matching pattern '%s': %s (preferred -video-index0)",
                         camera_pattern.c_str(), filename.c_str());
             break;
         }
     }
-    
+
     if (!found_index0) {
         symlink_path = matching_symlinks[0];
         std::string filename = std::filesystem::path(symlink_path).filename().string();
-        RCLCPP_INFO(this->get_logger(), "Found camera symlink matching pattern '%s': %s (no -video-index0 found, using first match)", 
+        RCLCPP_INFO(this->get_logger(),
+                    "Found camera symlink matching pattern '%s': %s (no -video-index0 found, using first match)",
                     camera_pattern.c_str(), filename.c_str());
     }
-    
+
     // Resolve the symlink to get actual device path
     std::string resolved_path = std::filesystem::read_symlink(symlink_path).string();
-    
+
     if (resolved_path.find("/dev/") == 0) {
         device_path_ = resolved_path;
     } else {
@@ -89,36 +87,34 @@ ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions & options)
     RCLCPP_INFO(this->get_logger(), "Pixel Format: YUYV (via GStreamer)");
 
     // Create publishers with sensor data QoS profile
-    rclcpp::QoS qos = rclcpp::SensorDataQoS()
-        .keep_last(2)
-        .best_effort()
-        .durability_volatile();
+    rclcpp::QoS qos = rclcpp::SensorDataQoS().keep_last(2).best_effort().durability_volatile();
 
     image_pub_ = this->create_publisher<sensor_msgs::msg::Image>("/mars/arm/image_raw", qos);
-    
+
     if (publish_compressed_) {
-        compressed_pub_ = this->create_publisher<sensor_msgs::msg::CompressedImage>("/mars/arm/image_raw/compressed", qos);
+        compressed_pub_ =
+            this->create_publisher<sensor_msgs::msg::CompressedImage>("/mars/arm/image_raw/compressed", qos);
     }
 
     // Initialize camera with retry logic
     const int max_retries = 3;
     const int retry_delay_ms = 1000;
     bool camera_initialized = false;
-    
+
     for (int attempt = 1; attempt <= max_retries; attempt++) {
         RCLCPP_INFO(this->get_logger(), "Initializing camera (attempt %d/%d)...", attempt, max_retries);
-        
+
         if (initializeCamera()) {
             camera_initialized = true;
             break;
         }
-        
+
         if (attempt < max_retries) {
             RCLCPP_WARN(this->get_logger(), "Camera initialization failed, retrying in %d ms...", retry_delay_ms);
             std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
         }
     }
-    
+
     if (!camera_initialized) {
         RCLCPP_ERROR(this->get_logger(), "Failed to initialize arm camera after %d attempts", max_retries);
         throw std::runtime_error("Arm camera initialization failed");
@@ -133,13 +129,13 @@ ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions & options)
 
 ArmCameraDriver::~ArmCameraDriver() {
     RCLCPP_INFO(this->get_logger(), "Shutting down arm camera driver...");
-    
+
     // Stop frame processing thread
     frame_thread_running_ = false;
     if (frame_thread_.joinable()) {
         frame_thread_.join();
     }
-    
+
     // Release camera with mutex protection
     {
         std::lock_guard<std::mutex> lock(cap_mutex_);
@@ -147,7 +143,7 @@ ArmCameraDriver::~ArmCameraDriver() {
             cap_.release();
         }
     }
-    
+
     RCLCPP_INFO(this->get_logger(), "Arm camera driver shutdown complete");
 }
 
@@ -166,7 +162,7 @@ bool ArmCameraDriver::initializeCamera() {
     {
         std::lock_guard<std::mutex> lock(cap_mutex_);
         cap_.open(pipeline, cv::CAP_GSTREAMER);
-        
+
         if (!cap_.isOpened()) {
             RCLCPP_ERROR(this->get_logger(), "Failed to open camera with GStreamer pipeline");
             return false;
@@ -176,15 +172,14 @@ bool ArmCameraDriver::initializeCamera() {
         int actual_width = static_cast<int>(cap_.get(cv::CAP_PROP_FRAME_WIDTH));
         int actual_height = static_cast<int>(cap_.get(cv::CAP_PROP_FRAME_HEIGHT));
         double actual_fps = cap_.get(cv::CAP_PROP_FPS);
-        
+
         RCLCPP_INFO(this->get_logger(), "Camera opened successfully:");
         RCLCPP_INFO(this->get_logger(), "  Actual resolution: %dx%d", actual_width, actual_height);
         RCLCPP_INFO(this->get_logger(), "  Actual FPS: %.1f", actual_fps);
 
         if (actual_width != width_ || actual_height != height_) {
-            RCLCPP_WARN(this->get_logger(), 
-                "Resolution mismatch! Requested: %dx%d, Got: %dx%d",
-                width_, height_, actual_width, actual_height);
+            RCLCPP_WARN(this->get_logger(), "Resolution mismatch! Requested: %dx%d, Got: %dx%d", width_, height_,
+                        actual_width, actual_height);
         }
     }
 
@@ -200,24 +195,25 @@ std::string ArmCameraDriver::createGStreamerPipeline() {
     //   max-buffers=1: only keep newest frame
     //   drop=true: drop old frames if not consumed
     //   sync=false: don't sync to clock (process ASAP)
-    
-    std::string pipeline = 
-        "v4l2src device=" + device_path_ + " io-mode=2 do-timestamp=true ! "
-        "video/x-raw,format=YUY2,width=" + std::to_string(width_) + 
-        ",height=" + std::to_string(height_) + 
-        ",framerate=" + std::to_string(static_cast<int>(fps_)) + "/1 ! "
-        "videoconvert ! video/x-raw,format=BGR ! "
-        "appsink max-buffers=1 drop=true sync=false";
-    
+
+    std::string pipeline = "v4l2src device=" + device_path_ +
+                           " io-mode=2 do-timestamp=true ! "
+                           "video/x-raw,format=YUY2,width=" +
+                           std::to_string(width_) + ",height=" + std::to_string(height_) +
+                           ",framerate=" + std::to_string(static_cast<int>(fps_)) +
+                           "/1 ! "
+                           "videoconvert ! video/x-raw,format=BGR ! "
+                           "appsink max-buffers=1 drop=true sync=false";
+
     return pipeline;
 }
 
 void ArmCameraDriver::frameProcessingLoop() {
     RCLCPP_INFO(this->get_logger(), "Frame processing loop started");
-    
+
     cv::Mat frame;
     int frame_count = 0;
-    
+
     while (frame_thread_running_ && rclcpp::ok()) {
         try {
             // Capture frame with mutex protection
@@ -228,52 +224,52 @@ void ArmCameraDriver::frameProcessingLoop() {
                     success = cap_.read(frame);
                 }
             }
-            
+
             if (!success || frame.empty()) {
                 RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                    "Failed to capture frame, attempting recovery...");
-                
+                                     "Failed to capture frame, attempting recovery...");
+
                 // Release camera with mutex protection
                 {
                     std::lock_guard<std::mutex> lock(cap_mutex_);
                     cap_.release();
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-                
+
                 // Check if we should still be running before attempting recovery
                 if (!frame_thread_running_ || !rclcpp::ok()) {
                     break;
                 }
-                
+
                 if (initializeCamera()) {
                     RCLCPP_INFO(this->get_logger(), "Camera reconnected successfully");
                 }
                 continue;
             }
-            
+
             frame_count++;
-            
+
             // Log every 1000 frames for health monitoring
             if (frame_count % 1000 == 0) {
-                RCLCPP_INFO(this->get_logger(), "Camera health check - Frame %d, Device: %s", 
-                            frame_count, device_path_.c_str());
+                RCLCPP_INFO(this->get_logger(), "Camera health check - Frame %d, Device: %s", frame_count,
+                            device_path_.c_str());
             }
-            
+
             // Process and publish frame
             processAndPublishFrame(frame);
-            
+
         } catch (const std::exception& e) {
             RCLCPP_ERROR(this->get_logger(), "Error in frame processing: %s", e.what());
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
     }
-    
+
     RCLCPP_INFO(this->get_logger(), "Frame processing loop ended");
 }
 
 void ArmCameraDriver::processAndPublishFrame(const cv::Mat& frame) {
     auto current_time = this->now();
-    
+
     // Create raw image message
     auto img_msg = std::make_unique<sensor_msgs::msg::Image>();
     img_msg->header.stamp = current_time;
@@ -293,7 +289,7 @@ void ArmCameraDriver::processAndPublishFrame(const cv::Mat& frame) {
         compressed_frame_counter_++;
         if (compressed_frame_counter_ >= compressed_frame_interval_) {
             compressed_frame_counter_ = 0;
-            
+
             auto compressed_msg = std::make_unique<sensor_msgs::msg::CompressedImage>();
             compressed_msg->header.stamp = current_time;
             compressed_msg->header.frame_id = "arm_camera";
@@ -303,14 +299,13 @@ void ArmCameraDriver::processAndPublishFrame(const cv::Mat& frame) {
             if (cv::imencode(".jpg", frame, compressed_msg->data, params)) {
                 compressed_pub_->publish(std::move(compressed_msg));
             } else {
-                RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                    "Failed to compress image to JPEG");
+                RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000, "Failed to compress image to JPEG");
             }
         }
     }
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam
 
 // Register the component
 RCLCPP_COMPONENTS_REGISTER_NODE(maurice_cam::ArmCameraDriver)
@@ -318,7 +313,7 @@ RCLCPP_COMPONENTS_REGISTER_NODE(maurice_cam::ArmCameraDriver)
 #ifndef BUILDING_COMPONENT_LIBRARY
 int main(int argc, char** argv) {
     rclcpp::init(argc, argv);
-    
+
     try {
         auto node = std::make_shared<maurice_cam::ArmCameraDriver>();
         rclcpp::spin(node);
@@ -326,7 +321,7 @@ int main(int argc, char** argv) {
         RCLCPP_ERROR(rclcpp::get_logger("main"), "Exception: %s", e.what());
         return 1;
     }
-    
+
     rclcpp::shutdown();
     return 0;
 }

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/calibration.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/calibration.cpp
@@ -4,128 +4,121 @@
 
 #include "maurice_cam/stereo_depth_estimator.hpp"
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // Camera info callbacks — collect left/right, (re-)init when data changes
 // =============================================================================
-static bool cameraInfoEqual(const sensor_msgs::msg::CameraInfo& a,
-                            const sensor_msgs::msg::CameraInfo& b)
-{
-  return a.width == b.width && a.height == b.height
-      && a.k == b.k && a.d == b.d && a.r == b.r && a.p == b.p;
+static bool cameraInfoEqual(const sensor_msgs::msg::CameraInfo& a, const sensor_msgs::msg::CameraInfo& b) {
+    return a.width == b.width && a.height == b.height && a.k == b.k && a.d == b.d && a.r == b.r && a.p == b.p;
 }
 
-void StereoDepthEstimator::leftCameraInfoCallback(
-    const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg)
-{
-  if (left_camera_info_ && cameraInfoEqual(*left_camera_info_, *msg)) return;
-  left_camera_info_ = msg;
-  RCLCPP_INFO(this->get_logger(), "Received left camera_info (%dx%d)", msg->width, msg->height);
-  if (right_camera_info_) initCalibrationFromCameraInfo();
+void StereoDepthEstimator::leftCameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg) {
+    if (left_camera_info_ && cameraInfoEqual(*left_camera_info_, *msg))
+        return;
+    left_camera_info_ = msg;
+    RCLCPP_INFO(this->get_logger(), "Received left camera_info (%dx%d)", msg->width, msg->height);
+    if (right_camera_info_)
+        initCalibrationFromCameraInfo();
 }
 
-void StereoDepthEstimator::rightCameraInfoCallback(
-    const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg)
-{
-  if (right_camera_info_ && cameraInfoEqual(*right_camera_info_, *msg)) return;
-  right_camera_info_ = msg;
-  RCLCPP_INFO(this->get_logger(), "Received right camera_info (%dx%d)", msg->width, msg->height);
-  if (left_camera_info_) initCalibrationFromCameraInfo();
+void StereoDepthEstimator::rightCameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg) {
+    if (right_camera_info_ && cameraInfoEqual(*right_camera_info_, *msg))
+        return;
+    right_camera_info_ = msg;
+    RCLCPP_INFO(this->get_logger(), "Received right camera_info (%dx%d)", msg->width, msg->height);
+    if (left_camera_info_)
+        initCalibrationFromCameraInfo();
 }
 
-bool StereoDepthEstimator::initCalibrationFromCameraInfo()
-{
-  std::lock_guard<std::mutex> lock(calib_mutex_);
+bool StereoDepthEstimator::initCalibrationFromCameraInfo() {
+    std::lock_guard<std::mutex> lock(calib_mutex_);
 
-  const auto& left  = *left_camera_info_;
-  const auto& right = *right_camera_info_;
+    const auto& left = *left_camera_info_;
+    const auto& right = *right_camera_info_;
 
-  // Check if cameras are calibrated (K[0] == 0.0 indicates uncalibrated)
-  if (left.k[0] == 0.0 || right.k[0] == 0.0) {
-    RCLCPP_WARN(this->get_logger(), 
-                "Camera is uncalibrated (K[0] == 0.0). Depth estimation disabled.");
-    calibration_loaded_ = false;
-    return false;
-  }
+    // Check if cameras are calibrated (K[0] == 0.0 indicates uncalibrated)
+    if (left.k[0] == 0.0 || right.k[0] == 0.0) {
+        RCLCPP_WARN(this->get_logger(), "Camera is uncalibrated (K[0] == 0.0). Depth estimation disabled.");
+        calibration_loaded_ = false;
+        return false;
+    }
 
-  calib_width_  = static_cast<int>(left.width);
-  calib_height_ = static_cast<int>(left.height);
-  depth_scale_  = static_cast<double>(calib_width_) / static_cast<double>(image_width_);
+    calib_width_ = static_cast<int>(left.width);
+    calib_height_ = static_cast<int>(left.height);
+    depth_scale_ = static_cast<double>(calib_width_) / static_cast<double>(image_width_);
 
-  // ── Extract matrices from CameraInfo messages ───────────────────────────
-  // k/r/p are contiguous row-major doubles — same layout as cv::Mat(CV_64F).
-  auto mat33  = [](const auto& a) { return cv::Mat(3, 3, CV_64F, const_cast<double*>(a.data())).clone(); };
-  auto mat34  = [](const auto& a) { return cv::Mat(3, 4, CV_64F, const_cast<double*>(a.data())).clone(); };
-  auto vecD   = [](const auto& v) { return cv::Mat(1, static_cast<int>(v.size()), CV_64F, const_cast<double*>(v.data())).clone(); };
+    // ── Extract matrices from CameraInfo messages ───────────────────────────
+    // k/r/p are contiguous row-major doubles — same layout as cv::Mat(CV_64F).
+    auto mat33 = [](const auto& a) { return cv::Mat(3, 3, CV_64F, const_cast<double*>(a.data())).clone(); };
+    auto mat34 = [](const auto& a) { return cv::Mat(3, 4, CV_64F, const_cast<double*>(a.data())).clone(); };
+    auto vecD = [](const auto& v) {
+        return cv::Mat(1, static_cast<int>(v.size()), CV_64F, const_cast<double*>(v.data())).clone();
+    };
 
-  cv::Mat K1 = mat33(left.k),  R1 = mat33(left.r);
-  P1_        = mat34(left.p);
-  cv::Mat D1 = vecD(left.d);
+    cv::Mat K1 = mat33(left.k), R1 = mat33(left.r);
+    P1_ = mat34(left.p);
+    cv::Mat D1 = vecD(left.d);
 
-  cv::Mat K2 = mat33(right.k), R2 = mat33(right.r), P2 = mat34(right.p);
-  cv::Mat D2 = vecD(right.d);
+    cv::Mat K2 = mat33(right.k), R2 = mat33(right.r), P2 = mat34(right.p);
+    cv::Mat D2 = vecD(right.d);
 
-  // ── Derive stereo parameters ───────────────────────────────────────────
-  focal_length_ = P1_.at<double>(0, 0);
+    // ── Derive stereo parameters ───────────────────────────────────────────
+    focal_length_ = P1_.at<double>(0, 0);
 
-  // The camera driver negates P2[0,3] when building the ROS CameraInfo:
-  //   OpenCV convention: P2[0,3] = +fx'·baseline
-  //   ROS convention:    P2[0,3] = −fx'·baseline
-  // We need |P2[0,3]| / fx' = baseline, and we must undo the sign flip
-  // before passing P2 to initUndistortRectifyMap (which expects OpenCV convention).
-  double tx_fx = P2.at<double>(0, 3);
-  if (std::abs(tx_fx) > 1e-6) {
-    baseline_ = std::abs(tx_fx) / P2.at<double>(0, 0);
-  } else {
-    RCLCPP_ERROR(this->get_logger(),
-                 "Cannot determine baseline from camera_info (P2[0,3] ≈ 0)");
-    return false;
-  }
+    // The camera driver negates P2[0,3] when building the ROS CameraInfo:
+    //   OpenCV convention: P2[0,3] = +fx'·baseline
+    //   ROS convention:    P2[0,3] = −fx'·baseline
+    // We need |P2[0,3]| / fx' = baseline, and we must undo the sign flip
+    // before passing P2 to initUndistortRectifyMap (which expects OpenCV convention).
+    double tx_fx = P2.at<double>(0, 3);
+    if (std::abs(tx_fx) > 1e-6) {
+        baseline_ = std::abs(tx_fx) / P2.at<double>(0, 0);
+    } else {
+        RCLCPP_ERROR(this->get_logger(), "Cannot determine baseline from camera_info (P2[0,3] ≈ 0)");
+        return false;
+    }
 
-  // Restore OpenCV sign convention for P2[0,3] before computing remap tables.
-  // OpenCV expects P2[0,3] = +fx'·baseline (positive).
-  cv::Mat P2_cv = P2.clone();
-  P2_cv.at<double>(0, 3) = std::abs(P2_cv.at<double>(0, 3));
+    // Restore OpenCV sign convention for P2[0,3] before computing remap tables.
+    // OpenCV expects P2[0,3] = +fx'·baseline (positive).
+    cv::Mat P2_cv = P2.clone();
+    P2_cv.at<double>(0, 3) = std::abs(P2_cv.at<double>(0, 3));
 
-  // ── Compute rectification maps ─────────────────────────────────────────
-  cv::initUndistortRectifyMap(K1, D1, R1, P1_,
-                               cv::Size(calib_width_, calib_height_),
-                               CV_32FC1, map1_left_, map2_left_);
-  cv::initUndistortRectifyMap(K2, D2, R2, P2_cv,
-                               cv::Size(calib_width_, calib_height_),
-                               CV_32FC1, map1_right_, map2_right_);
+    // ── Compute rectification maps ─────────────────────────────────────────
+    cv::initUndistortRectifyMap(K1, D1, R1, P1_, cv::Size(calib_width_, calib_height_), CV_32FC1, map1_left_,
+                                map2_left_);
+    cv::initUndistortRectifyMap(K2, D2, R2, P2_cv, cv::Size(calib_width_, calib_height_), CV_32FC1, map1_right_,
+                                map2_right_);
 
-  RCLCPP_INFO(this->get_logger(), "Calibration extracted from camera_info:");
-  RCLCPP_INFO(this->get_logger(), "  Resolution: %dx%d", calib_width_, calib_height_);
-  RCLCPP_INFO(this->get_logger(), "  Scale: input %dx%d -> calib %dx%d (scale=%.3f)",
-              image_width_, image_height_, calib_width_, calib_height_, depth_scale_);
-  RCLCPP_INFO(this->get_logger(), "  Stereo: focal=%.2f px, baseline=%.4f m (%.1f mm)",
-              focal_length_, baseline_, baseline_ * 1000.0);
+    RCLCPP_INFO(this->get_logger(), "Calibration extracted from camera_info:");
+    RCLCPP_INFO(this->get_logger(), "  Resolution: %dx%d", calib_width_, calib_height_);
+    RCLCPP_INFO(this->get_logger(), "  Scale: input %dx%d -> calib %dx%d (scale=%.3f)", image_width_, image_height_,
+                calib_width_, calib_height_, depth_scale_);
+    RCLCPP_INFO(this->get_logger(), "  Stereo: focal=%.2f px, baseline=%.4f m (%.1f mm)", focal_length_, baseline_,
+                baseline_ * 1000.0);
 
-  // ── (Re-)Initialize VPI (remap + SGM) ──────────────────────────────────
-  // Tear down existing resources if this is a recalibration.
-  if (vpi_initialized_) {
-    calibration_loaded_ = false;  // gate processFrame while we reinit
-    vpi_initialized_    = false;
-    cleanupVPIRemap();
-    cleanupVPI();
-    RCLCPP_INFO(this->get_logger(), "Recalibration: cleaned up previous VPI resources");
-  }
+    // ── (Re-)Initialize VPI (remap + SGM) ──────────────────────────────────
+    // Tear down existing resources if this is a recalibration.
+    if (vpi_initialized_) {
+        calibration_loaded_ = false;  // gate processFrame while we reinit
+        vpi_initialized_ = false;
+        cleanupVPIRemap();
+        cleanupVPI();
+        RCLCPP_INFO(this->get_logger(), "Recalibration: cleaned up previous VPI resources");
+    }
 
-  if (!initVPIRemap()) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to initialize VPI remap from camera_info");
-    return false;
-  }
-  if (!initializeVPI()) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to initialize VPI from camera_info");
-    return false;
-  }
-  vpi_initialized_ = true;
-  calibration_loaded_ = true;
-  RCLCPP_INFO(this->get_logger(), "VPI initialized (SGM CUDA, diagonals=%d)", include_diagonals_);
-  return true;
+    if (!initVPIRemap()) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to initialize VPI remap from camera_info");
+        return false;
+    }
+    if (!initializeVPI()) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to initialize VPI from camera_info");
+        return false;
+    }
+    vpi_initialized_ = true;
+    calibration_loaded_ = true;
+    RCLCPP_INFO(this->get_logger(), "VPI initialized (SGM CUDA, diagonals=%d)", include_diagonals_);
+    return true;
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/pointcloud.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/pointcloud.cpp
@@ -6,158 +6,155 @@
 #include <cstring>
 #include <limits>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // XYZ-only point cloud (no colour overhead)
 // =============================================================================
-void StereoDepthEstimator::publishPointCloudXYZ(
-    const cv::Mat& disparity_lowres, const rclcpp::Time& ts)
-{
-  const int dw = disparity_lowres.cols;
-  const int dh = disparity_lowres.rows;
-  const float MAX_DEPTH_M = 10.0f;
+void StereoDepthEstimator::publishPointCloudXYZ(const cv::Mat& disparity_lowres, const rclcpp::Time& ts) {
+    const int dw = disparity_lowres.cols;
+    const int dh = disparity_lowres.rows;
+    const float MAX_DEPTH_M = 10.0f;
 
-  // Scale pixel-coordinate intrinsics to the downsampled grid.
-  // Depth focal length stays at calibration-res (disparity values are in those units).
-  const float s  = static_cast<float>(dw) / static_cast<float>(calib_width_);
-  const float fx = static_cast<float>(P1_.at<double>(0, 0)) * s;
-  const float fy = static_cast<float>(P1_.at<double>(1, 1)) * s;
-  const float cx = static_cast<float>(P1_.at<double>(0, 2)) * s;
-  const float cy = static_cast<float>(P1_.at<double>(1, 2)) * s;
-  const float f_depth  = static_cast<float>(focal_length_);
-  const float baseline = static_cast<float>(baseline_);
+    // Scale pixel-coordinate intrinsics to the downsampled grid.
+    // Depth focal length stays at calibration-res (disparity values are in those units).
+    const float s = static_cast<float>(dw) / static_cast<float>(calib_width_);
+    const float fx = static_cast<float>(P1_.at<double>(0, 0)) * s;
+    const float fy = static_cast<float>(P1_.at<double>(1, 1)) * s;
+    const float cx = static_cast<float>(P1_.at<double>(0, 2)) * s;
+    const float cy = static_cast<float>(P1_.at<double>(1, 2)) * s;
+    const float f_depth = static_cast<float>(focal_length_);
+    const float baseline = static_cast<float>(baseline_);
 
-  const int step = pointcloud_decimation_;
-  const int pc_w = dw / step;
-  const int pc_h = dh / step;
+    const int step = pointcloud_decimation_;
+    const int pc_w = dw / step;
+    const int pc_h = dh / step;
 
-  auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
-  cloud->header.stamp    = ts;
-  cloud->header.frame_id = frame_id_;
-  cloud->height = pc_h;
-  cloud->width  = pc_w;
-  cloud->is_dense = false;
-  cloud->is_bigendian = false;
+    auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
+    cloud->header.stamp = ts;
+    cloud->header.frame_id = frame_id_;
+    cloud->height = pc_h;
+    cloud->width = pc_w;
+    cloud->is_dense = false;
+    cloud->is_bigendian = false;
 
-  sensor_msgs::PointCloud2Modifier mod(*cloud);
-  mod.setPointCloud2FieldsByString(1, "xyz");
-  mod.resize(pc_w * pc_h);
+    sensor_msgs::PointCloud2Modifier mod(*cloud);
+    mod.setPointCloud2FieldsByString(1, "xyz");
+    mod.resize(pc_w * pc_h);
 
-  sensor_msgs::PointCloud2Iterator<float> ix(*cloud, "x");
-  sensor_msgs::PointCloud2Iterator<float> iy(*cloud, "y");
-  sensor_msgs::PointCloud2Iterator<float> iz(*cloud, "z");
+    sensor_msgs::PointCloud2Iterator<float> ix(*cloud, "x");
+    sensor_msgs::PointCloud2Iterator<float> iy(*cloud, "y");
+    sensor_msgs::PointCloud2Iterator<float> iz(*cloud, "z");
 
-  for (int v = 0; v < pc_h; ++v) {
-    for (int u = 0; u < pc_w; ++u, ++ix, ++iy, ++iz) {
-      const int px = u * step;
-      const int py = v * step;
-      const float d = disparity_lowres.at<float>(py, px);
+    for (int v = 0; v < pc_h; ++v) {
+        for (int u = 0; u < pc_w; ++u, ++ix, ++iy, ++iz) {
+            const int px = u * step;
+            const int py = v * step;
+            const float d = disparity_lowres.at<float>(py, px);
 
-      if (d > 0.0f && std::isfinite(d)) {
-        float z = f_depth * baseline / d;
-        if (z > 0.0f && z <= MAX_DEPTH_M) {
-          *ix = (static_cast<float>(px) - cx) * z / fx;
-          *iy = (static_cast<float>(py) - cy) * z / fy;
-          *iz = z;
-          continue;
+            if (d > 0.0f && std::isfinite(d)) {
+                float z = f_depth * baseline / d;
+                if (z > 0.0f && z <= MAX_DEPTH_M) {
+                    *ix = (static_cast<float>(px) - cx) * z / fx;
+                    *iy = (static_cast<float>(py) - cy) * z / fy;
+                    *iz = z;
+                    continue;
+                }
+            }
+            *ix = std::numeric_limits<float>::quiet_NaN();
+            *iy = std::numeric_limits<float>::quiet_NaN();
+            *iz = std::numeric_limits<float>::quiet_NaN();
         }
-      }
-      *ix = std::numeric_limits<float>::quiet_NaN();
-      *iy = std::numeric_limits<float>::quiet_NaN();
-      *iz = std::numeric_limits<float>::quiet_NaN();
     }
-  }
 
-  pointcloud_pub_->publish(std::move(cloud));
+    pointcloud_pub_->publish(std::move(cloud));
 }
 
 // =============================================================================
 // Colour point cloud (xyz + rgb)
 // =============================================================================
-void StereoDepthEstimator::publishPointCloudColor(
-    const cv::Mat& disparity_lowres, const cv::Mat& color_rect,
-    const rclcpp::Time& ts)
-{
-  const int dw = disparity_lowres.cols;
-  const int dh = disparity_lowres.rows;
-  const float MAX_DEPTH_M = 10.0f;
+void StereoDepthEstimator::publishPointCloudColor(const cv::Mat& disparity_lowres, const cv::Mat& color_rect,
+                                                  const rclcpp::Time& ts) {
+    const int dw = disparity_lowres.cols;
+    const int dh = disparity_lowres.rows;
+    const float MAX_DEPTH_M = 10.0f;
 
-  const float s  = static_cast<float>(dw) / static_cast<float>(calib_width_);
-  const float fx = static_cast<float>(P1_.at<double>(0, 0)) * s;
-  const float fy = static_cast<float>(P1_.at<double>(1, 1)) * s;
-  const float cx = static_cast<float>(P1_.at<double>(0, 2)) * s;
-  const float cy = static_cast<float>(P1_.at<double>(1, 2)) * s;
-  const float f_depth  = static_cast<float>(focal_length_);
-  const float baseline = static_cast<float>(baseline_);
+    const float s = static_cast<float>(dw) / static_cast<float>(calib_width_);
+    const float fx = static_cast<float>(P1_.at<double>(0, 0)) * s;
+    const float fy = static_cast<float>(P1_.at<double>(1, 1)) * s;
+    const float cx = static_cast<float>(P1_.at<double>(0, 2)) * s;
+    const float cy = static_cast<float>(P1_.at<double>(1, 2)) * s;
+    const float f_depth = static_cast<float>(focal_length_);
+    const float baseline = static_cast<float>(baseline_);
 
-  // Downsample rectified colour image to match disparity resolution
-  cv::Mat color_ds;
-  const bool has_color = !color_rect.empty();
-  if (has_color) {
-    cv::resize(color_rect, color_ds, cv::Size(dw, dh), 0, 0, cv::INTER_AREA);
-  }
-
-  const int step = pointcloud_decimation_;
-  const int pc_w = dw / step;
-  const int pc_h = dh / step;
-
-  auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
-  cloud->header.stamp    = ts;
-  cloud->header.frame_id = frame_id_;
-  cloud->height = pc_h;
-  cloud->width  = pc_w;
-  cloud->is_dense = false;
-  cloud->is_bigendian = false;
-
-  sensor_msgs::PointCloud2Modifier mod(*cloud);
-  mod.setPointCloud2FieldsByString(2, "xyz", "rgb");
-  mod.resize(pc_w * pc_h);
-
-  sensor_msgs::PointCloud2Iterator<float> ix(*cloud, "x");
-  sensor_msgs::PointCloud2Iterator<float> iy(*cloud, "y");
-  sensor_msgs::PointCloud2Iterator<float> iz(*cloud, "z");
-  sensor_msgs::PointCloud2Iterator<float> irgb(*cloud, "rgb");
-
-  for (int v = 0; v < pc_h; ++v) {
-    for (int u = 0; u < pc_w; ++u, ++ix, ++iy, ++iz, ++irgb) {
-      const int px = u * step;
-      const int py = v * step;
-      const float d = disparity_lowres.at<float>(py, px);
-
-      if (d > 0.0f && std::isfinite(d)) {
-        float z = f_depth * baseline / d;
-        if (z > 0.0f && z <= MAX_DEPTH_M) {
-          *ix = (static_cast<float>(px) - cx) * z / fx;
-          *iy = (static_cast<float>(py) - cy) * z / fy;
-          *iz = z;
-
-          if (has_color) {
-            const cv::Vec3b& bgr = color_ds.at<cv::Vec3b>(py, px);
-            uint32_t rgb_packed = (static_cast<uint32_t>(bgr[2]) << 16) |
-                                  (static_cast<uint32_t>(bgr[1]) << 8)  |
-                                  (static_cast<uint32_t>(bgr[0]));
-            float rgb_float; std::memcpy(&rgb_float, &rgb_packed, sizeof(float));
-            *irgb = rgb_float;
-          } else {
-            uint32_t rgb_packed = 0x00808080;
-            float rgb_float; std::memcpy(&rgb_float, &rgb_packed, sizeof(float));
-            *irgb = rgb_float;
-          }
-          continue;
-        }
-      }
-      *ix = std::numeric_limits<float>::quiet_NaN();
-      *iy = std::numeric_limits<float>::quiet_NaN();
-      *iz = std::numeric_limits<float>::quiet_NaN();
-      uint32_t rgb_packed = 0x00000000;
-      float rgb_float; std::memcpy(&rgb_float, &rgb_packed, sizeof(float));
-      *irgb = rgb_float;
+    // Downsample rectified colour image to match disparity resolution
+    cv::Mat color_ds;
+    const bool has_color = !color_rect.empty();
+    if (has_color) {
+        cv::resize(color_rect, color_ds, cv::Size(dw, dh), 0, 0, cv::INTER_AREA);
     }
-  }
 
-  pointcloud_color_pub_->publish(std::move(cloud));
+    const int step = pointcloud_decimation_;
+    const int pc_w = dw / step;
+    const int pc_h = dh / step;
+
+    auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
+    cloud->header.stamp = ts;
+    cloud->header.frame_id = frame_id_;
+    cloud->height = pc_h;
+    cloud->width = pc_w;
+    cloud->is_dense = false;
+    cloud->is_bigendian = false;
+
+    sensor_msgs::PointCloud2Modifier mod(*cloud);
+    mod.setPointCloud2FieldsByString(2, "xyz", "rgb");
+    mod.resize(pc_w * pc_h);
+
+    sensor_msgs::PointCloud2Iterator<float> ix(*cloud, "x");
+    sensor_msgs::PointCloud2Iterator<float> iy(*cloud, "y");
+    sensor_msgs::PointCloud2Iterator<float> iz(*cloud, "z");
+    sensor_msgs::PointCloud2Iterator<float> irgb(*cloud, "rgb");
+
+    for (int v = 0; v < pc_h; ++v) {
+        for (int u = 0; u < pc_w; ++u, ++ix, ++iy, ++iz, ++irgb) {
+            const int px = u * step;
+            const int py = v * step;
+            const float d = disparity_lowres.at<float>(py, px);
+
+            if (d > 0.0f && std::isfinite(d)) {
+                float z = f_depth * baseline / d;
+                if (z > 0.0f && z <= MAX_DEPTH_M) {
+                    *ix = (static_cast<float>(px) - cx) * z / fx;
+                    *iy = (static_cast<float>(py) - cy) * z / fy;
+                    *iz = z;
+
+                    if (has_color) {
+                        const cv::Vec3b& bgr = color_ds.at<cv::Vec3b>(py, px);
+                        uint32_t rgb_packed = (static_cast<uint32_t>(bgr[2]) << 16) |
+                                              (static_cast<uint32_t>(bgr[1]) << 8) | (static_cast<uint32_t>(bgr[0]));
+                        float rgb_float;
+                        std::memcpy(&rgb_float, &rgb_packed, sizeof(float));
+                        *irgb = rgb_float;
+                    } else {
+                        uint32_t rgb_packed = 0x00808080;
+                        float rgb_float;
+                        std::memcpy(&rgb_float, &rgb_packed, sizeof(float));
+                        *irgb = rgb_float;
+                    }
+                    continue;
+                }
+            }
+            *ix = std::numeric_limits<float>::quiet_NaN();
+            *iy = std::numeric_limits<float>::quiet_NaN();
+            *iz = std::numeric_limits<float>::quiet_NaN();
+            uint32_t rgb_packed = 0x00000000;
+            float rgb_float;
+            std::memcpy(&rgb_float, &rgb_packed, sizeof(float));
+            *irgb = rgb_float;
+        }
+    }
+
+    pointcloud_color_pub_->publish(std::move(cloud));
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/publishing.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/publishing.cpp
@@ -6,173 +6,161 @@
 #include <algorithm>
 #include <cmath>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // Publish mono-rectified left/right images (upscaled to input resolution)
 // =============================================================================
-void StereoDepthEstimator::publishMonoRectified(
-    const cv::Mat& left_rect, const cv::Mat& right_rect,
-    const rclcpp::Time& ts, bool pub_left, bool pub_right)
-{
-  cv::Mat left_full, right_full;
-  cv::resize(left_rect,  left_full,  cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
-  cv::resize(right_rect, right_full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
+void StereoDepthEstimator::publishMonoRectified(const cv::Mat& left_rect, const cv::Mat& right_rect,
+                                                const rclcpp::Time& ts, bool pub_left, bool pub_right) {
+    cv::Mat left_full, right_full;
+    cv::resize(left_rect, left_full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
+    cv::resize(right_rect, right_full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
 
-  auto make_msg = [&](const cv::Mat& img) {
-    auto msg = std::make_unique<sensor_msgs::msg::Image>();
-    msg->header.stamp = ts;
-    msg->header.frame_id = frame_id_;
-    msg->height = image_height_;
-    msg->width  = image_width_;
-    msg->encoding = "mono8";
-    msg->is_bigendian = false;
-    msg->step = image_width_;
-    msg->data.resize(msg->height * msg->step);
-    memcpy(msg->data.data(), img.data, msg->data.size());
-    return msg;
-  };
+    auto make_msg = [&](const cv::Mat& img) {
+        auto msg = std::make_unique<sensor_msgs::msg::Image>();
+        msg->header.stamp = ts;
+        msg->header.frame_id = frame_id_;
+        msg->height = image_height_;
+        msg->width = image_width_;
+        msg->encoding = "mono8";
+        msg->is_bigendian = false;
+        msg->step = image_width_;
+        msg->data.resize(msg->height * msg->step);
+        memcpy(msg->data.data(), img.data, msg->data.size());
+        return msg;
+    };
 
-  if (pub_left)  left_rectified_pub_->publish(make_msg(left_full));
-  if (pub_right) right_rectified_pub_->publish(make_msg(right_full));
+    if (pub_left)
+        left_rectified_pub_->publish(make_msg(left_full));
+    if (pub_right)
+        right_rectified_pub_->publish(make_msg(right_full));
 }
 
 // =============================================================================
 // Publish colour-rectified image (BGR) and/or JPEG-compressed version
 // =============================================================================
-void StereoDepthEstimator::publishColorRectified(
-    const cv::Mat& color_rect, const cv::Mat& mono_rect,
-    bool has_color_input, const rclcpp::Time& ts,
-    bool pub_color, bool pub_compressed)
-{
-  // Build colour source: use rectified colour if available, else convert mono
-  cv::Mat src;
-  if (has_color_input) {
-    src = color_rect;
-  } else {
-    cv::cvtColor(mono_rect, src, cv::COLOR_GRAY2BGR);
-  }
-
-  cv::Mat full;
-  cv::resize(src, full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
-
-  if (pub_color) {
-    auto msg = std::make_unique<sensor_msgs::msg::Image>();
-    msg->header.stamp = ts;
-    msg->header.frame_id = frame_id_;
-    msg->height = image_height_;
-    msg->width  = image_width_;
-    msg->encoding = "bgr8";
-    msg->is_bigendian = false;
-    msg->step = image_width_ * 3;
-    msg->data.resize(msg->height * msg->step);
-    memcpy(msg->data.data(), full.data, msg->data.size());
-    left_rectified_color_pub_->publish(std::move(msg));
-  }
-
-  if (pub_compressed) {
-    auto msg = std::make_unique<sensor_msgs::msg::CompressedImage>();
-    msg->header.stamp = ts;
-    msg->header.frame_id = frame_id_;
-    msg->format = "jpeg";
-
-    tjhandle tj = tjInitCompress();
-    if (tj) {
-      unsigned char* jpeg_buf = nullptr;
-      unsigned long jpeg_size = 0;
-      int rc = tjCompress2(tj, full.data,
-                           full.cols, 0, full.rows,
-                           TJPF_BGR, &jpeg_buf, &jpeg_size,
-                           TJSAMP_420, jpeg_quality_, TJFLAG_FASTDCT);
-      if (rc == 0 && jpeg_buf) {
-        msg->data.assign(jpeg_buf, jpeg_buf + jpeg_size);
-        left_rectified_compressed_pub_->publish(std::move(msg));
-      }
-      if (jpeg_buf) tjFree(jpeg_buf);
-      tjDestroy(tj);
+void StereoDepthEstimator::publishColorRectified(const cv::Mat& color_rect, const cv::Mat& mono_rect,
+                                                 bool has_color_input, const rclcpp::Time& ts, bool pub_color,
+                                                 bool pub_compressed) {
+    // Build colour source: use rectified colour if available, else convert mono
+    cv::Mat src;
+    if (has_color_input) {
+        src = color_rect;
+    } else {
+        cv::cvtColor(mono_rect, src, cv::COLOR_GRAY2BGR);
     }
-  }
+
+    cv::Mat full;
+    cv::resize(src, full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
+
+    if (pub_color) {
+        auto msg = std::make_unique<sensor_msgs::msg::Image>();
+        msg->header.stamp = ts;
+        msg->header.frame_id = frame_id_;
+        msg->height = image_height_;
+        msg->width = image_width_;
+        msg->encoding = "bgr8";
+        msg->is_bigendian = false;
+        msg->step = image_width_ * 3;
+        msg->data.resize(msg->height * msg->step);
+        memcpy(msg->data.data(), full.data, msg->data.size());
+        left_rectified_color_pub_->publish(std::move(msg));
+    }
+
+    if (pub_compressed) {
+        auto msg = std::make_unique<sensor_msgs::msg::CompressedImage>();
+        msg->header.stamp = ts;
+        msg->header.frame_id = frame_id_;
+        msg->format = "jpeg";
+
+        tjhandle tj = tjInitCompress();
+        if (tj) {
+            unsigned char* jpeg_buf = nullptr;
+            unsigned long jpeg_size = 0;
+            int rc = tjCompress2(tj, full.data, full.cols, 0, full.rows, TJPF_BGR, &jpeg_buf, &jpeg_size, TJSAMP_420,
+                                 jpeg_quality_, TJFLAG_FASTDCT);
+            if (rc == 0 && jpeg_buf) {
+                msg->data.assign(jpeg_buf, jpeg_buf + jpeg_size);
+                left_rectified_compressed_pub_->publish(std::move(msg));
+            }
+            if (jpeg_buf)
+                tjFree(jpeg_buf);
+            tjDestroy(tj);
+        }
+    }
 }
 
 // =============================================================================
 // Publish a DisparityImage message (upscaled to input resolution)
 // =============================================================================
-void StereoDepthEstimator::publishDisparityMsg(
-    const cv::Mat& disparity_float, const rclcpp::Time& ts,
-    rclcpp::Publisher<stereo_msgs::msg::DisparityImage>::SharedPtr& pub)
-{
-  cv::Mat disp_full;
-  cv::resize(disparity_float, disp_full, cv::Size(image_width_, image_height_),
-             0, 0, cv::INTER_NEAREST);
+void StereoDepthEstimator::publishDisparityMsg(const cv::Mat& disparity_float, const rclcpp::Time& ts,
+                                               rclcpp::Publisher<stereo_msgs::msg::DisparityImage>::SharedPtr& pub) {
+    cv::Mat disp_full;
+    cv::resize(disparity_float, disp_full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_NEAREST);
 
-  auto msg = std::make_unique<stereo_msgs::msg::DisparityImage>();
-  msg->header.stamp = ts;
-  msg->header.frame_id = frame_id_;
-  msg->image.header = msg->header;
-  msg->image.height = image_height_;
-  msg->image.width  = image_width_;
-  msg->image.encoding = "32FC1";
-  msg->image.is_bigendian = false;
-  msg->image.step = image_width_ * sizeof(float);
-  msg->image.data.resize(msg->image.height * msg->image.step);
-  memcpy(msg->image.data.data(), disp_full.data, msg->image.data.size());
+    auto msg = std::make_unique<stereo_msgs::msg::DisparityImage>();
+    msg->header.stamp = ts;
+    msg->header.frame_id = frame_id_;
+    msg->image.header = msg->header;
+    msg->image.height = image_height_;
+    msg->image.width = image_width_;
+    msg->image.encoding = "32FC1";
+    msg->image.is_bigendian = false;
+    msg->image.step = image_width_ * sizeof(float);
+    msg->image.data.resize(msg->image.height * msg->image.step);
+    memcpy(msg->image.data.data(), disp_full.data, msg->image.data.size());
 
-  const float scale_up = 1.0f / static_cast<float>(depth_scale_);
-  msg->f = static_cast<float>(focal_length_) * scale_up;
-  msg->t = static_cast<float>(baseline_);
-  msg->min_disparity = static_cast<float>(min_disparity_);
-  msg->max_disparity = static_cast<float>(max_disparity_);
-  msg->delta_d = 1.0f / 32.0f;  // VPI Q10.5
+    const float scale_up = 1.0f / static_cast<float>(depth_scale_);
+    msg->f = static_cast<float>(focal_length_) * scale_up;
+    msg->t = static_cast<float>(baseline_);
+    msg->min_disparity = static_cast<float>(min_disparity_);
+    msg->max_disparity = static_cast<float>(max_disparity_);
+    msg->delta_d = 1.0f / 32.0f;  // VPI Q10.5
 
-  pub->publish(std::move(msg));
+    pub->publish(std::move(msg));
 }
 
 // =============================================================================
 // Convert disparity → 16SC1 depth (mm) and publish
 // =============================================================================
-void StereoDepthEstimator::publishDepth(
-    const cv::Mat& disparity_float, const rclcpp::Time& ts)
-{
-  const float fb = static_cast<float>(focal_length_) *
-                   std::abs(static_cast<float>(baseline_));
-  const float MAX_DEPTH_M = 10.0f;
+void StereoDepthEstimator::publishDepth(const cv::Mat& disparity_float, const rclcpp::Time& ts) {
+    const float fb = static_cast<float>(focal_length_) * std::abs(static_cast<float>(baseline_));
+    const float MAX_DEPTH_M = 10.0f;
 
-  cv::Mat depth_calib(calib_height_, calib_width_, CV_16SC1);
-  for (int y = 0; y < calib_height_; y++) {
-    const float* disp_row = disparity_float.ptr<float>(y);
-    int16_t* depth_row = depth_calib.ptr<int16_t>(y);
-    for (int x = 0; x < calib_width_; x++) {
-      const float d = disp_row[x];
-      if (d > 0.0f) {
-        float z = fb / d;
-        if (z > 0.0f && z <= MAX_DEPTH_M) {
-          depth_row[x] = static_cast<int16_t>(
-              std::clamp(z * 1000.0f, -32768.0f, 32767.0f));
-        } else {
-          depth_row[x] = 0;
+    cv::Mat depth_calib(calib_height_, calib_width_, CV_16SC1);
+    for (int y = 0; y < calib_height_; y++) {
+        const float* disp_row = disparity_float.ptr<float>(y);
+        int16_t* depth_row = depth_calib.ptr<int16_t>(y);
+        for (int x = 0; x < calib_width_; x++) {
+            const float d = disp_row[x];
+            if (d > 0.0f) {
+                float z = fb / d;
+                if (z > 0.0f && z <= MAX_DEPTH_M) {
+                    depth_row[x] = static_cast<int16_t>(std::clamp(z * 1000.0f, -32768.0f, 32767.0f));
+                } else {
+                    depth_row[x] = 0;
+                }
+            } else {
+                depth_row[x] = 0;
+            }
         }
-      } else {
-        depth_row[x] = 0;
-      }
     }
-  }
 
-  cv::Mat depth_full;
-  cv::resize(depth_calib, depth_full, cv::Size(image_width_, image_height_),
-             0, 0, cv::INTER_NEAREST);
+    cv::Mat depth_full;
+    cv::resize(depth_calib, depth_full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_NEAREST);
 
-  auto msg = std::make_unique<sensor_msgs::msg::Image>();
-  msg->header.stamp = ts;
-  msg->header.frame_id = frame_id_;
-  msg->height = image_height_;
-  msg->width  = image_width_;
-  msg->encoding = "16SC1";
-  msg->is_bigendian = false;
-  msg->step = image_width_ * sizeof(int16_t);
-  msg->data.resize(msg->height * msg->step);
-  memcpy(msg->data.data(), depth_full.data, msg->data.size());
-  depth_pub_->publish(std::move(msg));
+    auto msg = std::make_unique<sensor_msgs::msg::Image>();
+    msg->header.stamp = ts;
+    msg->header.frame_id = frame_id_;
+    msg->height = image_height_;
+    msg->width = image_width_;
+    msg->encoding = "16SC1";
+    msg->is_bigendian = false;
+    msg->step = image_width_ * sizeof(int16_t);
+    msg->data.resize(msg->height * msg->step);
+    memcpy(msg->data.data(), depth_full.data, msg->data.size());
+    depth_pub_->publish(std::move(msg));
 }
 
 // =============================================================================
@@ -180,171 +168,164 @@ void StereoDepthEstimator::publishDepth(
 // Stores the result in footprint_mask_calib_ (255 = robot body, 0 = free).
 // Called once per frame — reused by publishing and the disparity filter chain.
 // =============================================================================
-void StereoDepthEstimator::computeFootprintMaskCalib()
-{
-  sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud;
-  {
-    std::lock_guard<std::mutex> lock(footprint_mutex_);
-    cloud = latest_footprint_cloud_;
-  }
+void StereoDepthEstimator::computeFootprintMaskCalib() {
+    sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud;
+    {
+        std::lock_guard<std::mutex> lock(footprint_mutex_);
+        cloud = latest_footprint_cloud_;
+    }
 
-  footprint_mask_calib_ = cv::Mat::zeros(calib_height_, calib_width_, CV_8UC1);
+    footprint_mask_calib_ = cv::Mat::zeros(calib_height_, calib_width_, CV_8UC1);
 
-  if (!cloud || cloud->width * cloud->height == 0) return;
+    if (!cloud || cloud->width * cloud->height == 0)
+        return;
 
-  const float fx = static_cast<float>(P1_.at<double>(0, 0));
-  const float fy = static_cast<float>(P1_.at<double>(1, 1));
-  const float cx = static_cast<float>(P1_.at<double>(0, 2));
-  const float cy = static_cast<float>(P1_.at<double>(1, 2));
-
-  std::vector<cv::Point2f> projected_pts;
-
-  sensor_msgs::PointCloud2ConstIterator<float> ix(*cloud, "x");
-  sensor_msgs::PointCloud2ConstIterator<float> iy(*cloud, "y");
-  sensor_msgs::PointCloud2ConstIterator<float> iz(*cloud, "z");
-
-  for (; ix != ix.end(); ++ix, ++iy, ++iz) {
-    const float X = *ix;
-    const float Y = *iy;
-    const float Z = *iz;
-    if (Z <= 0.0f || !std::isfinite(X) || !std::isfinite(Y) || !std::isfinite(Z))
-      continue;
-    projected_pts.emplace_back(fx * X / Z + cx, fy * Y / Z + cy);
-  }
-
-  if (projected_pts.size() >= 3) {
-    std::vector<cv::Point2f> hull;
-    cv::convexHull(projected_pts, hull);
-    std::vector<cv::Point> hull_int;
-    hull_int.reserve(hull.size());
-    for (const auto& p : hull)
-      hull_int.emplace_back(static_cast<int>(p.x), static_cast<int>(p.y));
-    cv::fillConvexPoly(footprint_mask_calib_, hull_int, cv::Scalar(255));
-  }
-}
-
-// =============================================================================
-// Project /footprint/camera_optical pointcloud onto the rectified colour image
-// (points only — no convex hull)
-// =============================================================================
-void StereoDepthEstimator::publishFootprintOverlay(
-    const cv::Mat& color_rect, const rclcpp::Time& ts)
-{
-  cv::Mat overlay = color_rect.clone();
-
-  // Grab the latest footprint pointcloud for individual point drawing
-  sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud;
-  {
-    std::lock_guard<std::mutex> lock(footprint_mutex_);
-    cloud = latest_footprint_cloud_;
-  }
-
-  if (cloud && cloud->width * cloud->height > 0) {
     const float fx = static_cast<float>(P1_.at<double>(0, 0));
     const float fy = static_cast<float>(P1_.at<double>(1, 1));
     const float cx = static_cast<float>(P1_.at<double>(0, 2));
     const float cy = static_cast<float>(P1_.at<double>(1, 2));
+
+    std::vector<cv::Point2f> projected_pts;
 
     sensor_msgs::PointCloud2ConstIterator<float> ix(*cloud, "x");
     sensor_msgs::PointCloud2ConstIterator<float> iy(*cloud, "y");
     sensor_msgs::PointCloud2ConstIterator<float> iz(*cloud, "z");
 
     for (; ix != ix.end(); ++ix, ++iy, ++iz) {
-      const float X = *ix;
-      const float Y = *iy;
-      const float Z = *iz;
-      if (Z <= 0.0f || !std::isfinite(X) || !std::isfinite(Y) || !std::isfinite(Z))
-        continue;
-
-      const int u = static_cast<int>(fx * X / Z + cx);
-      const int v = static_cast<int>(fy * Y / Z + cy);
-      cv::circle(overlay, cv::Point(u, v), 4, cv::Scalar(0, 255, 0), -1);
+        const float X = *ix;
+        const float Y = *iy;
+        const float Z = *iz;
+        if (Z <= 0.0f || !std::isfinite(X) || !std::isfinite(Y) || !std::isfinite(Z))
+            continue;
+        projected_pts.emplace_back(fx * X / Z + cx, fy * Y / Z + cy);
     }
-  }
 
-  // Upscale to input resolution and publish
-  cv::Mat full;
-  cv::resize(overlay, full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
+    if (projected_pts.size() >= 3) {
+        std::vector<cv::Point2f> hull;
+        cv::convexHull(projected_pts, hull);
+        std::vector<cv::Point> hull_int;
+        hull_int.reserve(hull.size());
+        for (const auto& p : hull)
+            hull_int.emplace_back(static_cast<int>(p.x), static_cast<int>(p.y));
+        cv::fillConvexPoly(footprint_mask_calib_, hull_int, cv::Scalar(255));
+    }
+}
 
-  auto msg = std::make_unique<sensor_msgs::msg::Image>();
-  msg->header.stamp = ts;
-  msg->header.frame_id = frame_id_;
-  msg->height = image_height_;
-  msg->width  = image_width_;
-  msg->encoding = "bgr8";
-  msg->is_bigendian = false;
-  msg->step = image_width_ * 3;
-  msg->data.resize(msg->height * msg->step);
-  memcpy(msg->data.data(), full.data, msg->data.size());
-  footprint_overlay_pub_->publish(std::move(msg));
+// =============================================================================
+// Project /footprint/camera_optical pointcloud onto the rectified colour image
+// (points only — no convex hull)
+// =============================================================================
+void StereoDepthEstimator::publishFootprintOverlay(const cv::Mat& color_rect, const rclcpp::Time& ts) {
+    cv::Mat overlay = color_rect.clone();
+
+    // Grab the latest footprint pointcloud for individual point drawing
+    sensor_msgs::msg::PointCloud2::ConstSharedPtr cloud;
+    {
+        std::lock_guard<std::mutex> lock(footprint_mutex_);
+        cloud = latest_footprint_cloud_;
+    }
+
+    if (cloud && cloud->width * cloud->height > 0) {
+        const float fx = static_cast<float>(P1_.at<double>(0, 0));
+        const float fy = static_cast<float>(P1_.at<double>(1, 1));
+        const float cx = static_cast<float>(P1_.at<double>(0, 2));
+        const float cy = static_cast<float>(P1_.at<double>(1, 2));
+
+        sensor_msgs::PointCloud2ConstIterator<float> ix(*cloud, "x");
+        sensor_msgs::PointCloud2ConstIterator<float> iy(*cloud, "y");
+        sensor_msgs::PointCloud2ConstIterator<float> iz(*cloud, "z");
+
+        for (; ix != ix.end(); ++ix, ++iy, ++iz) {
+            const float X = *ix;
+            const float Y = *iy;
+            const float Z = *iz;
+            if (Z <= 0.0f || !std::isfinite(X) || !std::isfinite(Y) || !std::isfinite(Z))
+                continue;
+
+            const int u = static_cast<int>(fx * X / Z + cx);
+            const int v = static_cast<int>(fy * Y / Z + cy);
+            cv::circle(overlay, cv::Point(u, v), 4, cv::Scalar(0, 255, 0), -1);
+        }
+    }
+
+    // Upscale to input resolution and publish
+    cv::Mat full;
+    cv::resize(overlay, full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
+
+    auto msg = std::make_unique<sensor_msgs::msg::Image>();
+    msg->header.stamp = ts;
+    msg->header.frame_id = frame_id_;
+    msg->height = image_height_;
+    msg->width = image_width_;
+    msg->encoding = "bgr8";
+    msg->is_bigendian = false;
+    msg->step = image_width_ * 3;
+    msg->data.resize(msg->height * msg->step);
+    memcpy(msg->data.data(), full.data, msg->data.size());
+    footprint_overlay_pub_->publish(std::move(msg));
 }
 
 // =============================================================================
 // Binary mask of the footprint convex hull (mono8: 255 inside, 0 outside).
 // Reuses footprint_mask_calib_ computed by computeFootprintMaskCalib().
 // =============================================================================
-void StereoDepthEstimator::publishFootprintMask(const rclcpp::Time& ts)
-{
-  cv::Mat full;
-  cv::resize(footprint_mask_calib_, full,
-             cv::Size(image_width_, image_height_), 0, 0, cv::INTER_NEAREST);
+void StereoDepthEstimator::publishFootprintMask(const rclcpp::Time& ts) {
+    cv::Mat full;
+    cv::resize(footprint_mask_calib_, full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_NEAREST);
 
-  auto msg = std::make_unique<sensor_msgs::msg::Image>();
-  msg->header.stamp = ts;
-  msg->header.frame_id = frame_id_;
-  msg->height = image_height_;
-  msg->width  = image_width_;
-  msg->encoding = "mono8";
-  msg->is_bigendian = false;
-  msg->step = image_width_;
-  msg->data.resize(msg->height * msg->step);
-  memcpy(msg->data.data(), full.data, msg->data.size());
-  footprint_mask_pub_->publish(std::move(msg));
+    auto msg = std::make_unique<sensor_msgs::msg::Image>();
+    msg->header.stamp = ts;
+    msg->header.frame_id = frame_id_;
+    msg->height = image_height_;
+    msg->width = image_width_;
+    msg->encoding = "mono8";
+    msg->is_bigendian = false;
+    msg->step = image_width_;
+    msg->data.resize(msg->height * msg->step);
+    memcpy(msg->data.data(), full.data, msg->data.size());
+    footprint_mask_pub_->publish(std::move(msg));
 }
 
 // =============================================================================
 // Rectified colour image with the footprint mask region blacked out.
 // =============================================================================
-void StereoDepthEstimator::publishFootprintCutout(
-    const cv::Mat& color_rect, const rclcpp::Time& ts)
-{
-  cv::Mat cutout = color_rect.clone();
-  cutout.setTo(cv::Scalar(0, 0, 0), footprint_mask_calib_);
+void StereoDepthEstimator::publishFootprintCutout(const cv::Mat& color_rect, const rclcpp::Time& ts) {
+    cv::Mat cutout = color_rect.clone();
+    cutout.setTo(cv::Scalar(0, 0, 0), footprint_mask_calib_);
 
-  cv::Mat full;
-  cv::resize(cutout, full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
+    cv::Mat full;
+    cv::resize(cutout, full, cv::Size(image_width_, image_height_), 0, 0, cv::INTER_LINEAR);
 
-  auto msg = std::make_unique<sensor_msgs::msg::Image>();
-  msg->header.stamp = ts;
-  msg->header.frame_id = frame_id_;
-  msg->height = image_height_;
-  msg->width  = image_width_;
-  msg->encoding = "bgr8";
-  msg->is_bigendian = false;
-  msg->step = image_width_ * 3;
-  msg->data.resize(msg->height * msg->step);
-  memcpy(msg->data.data(), full.data, msg->data.size());
-  footprint_cutout_pub_->publish(std::move(msg));
+    auto msg = std::make_unique<sensor_msgs::msg::Image>();
+    msg->header.stamp = ts;
+    msg->header.frame_id = frame_id_;
+    msg->height = image_height_;
+    msg->width = image_width_;
+    msg->encoding = "bgr8";
+    msg->is_bigendian = false;
+    msg->step = image_width_ * 3;
+    msg->data.resize(msg->height * msg->step);
+    memcpy(msg->data.data(), full.data, msg->data.size());
+    footprint_cutout_pub_->publish(std::move(msg));
 }
 
 // =============================================================================
 // Zero out disparity pixels inside the footprint mask.
 // Called as step 1 of the filter chain (always runs).
 // =============================================================================
-void StereoDepthEstimator::applyFootprintMask(cv::Mat& disparity)
-{
-  if (footprint_mask_calib_.empty()) return;
+void StereoDepthEstimator::applyFootprintMask(cv::Mat& disparity) {
+    if (footprint_mask_calib_.empty())
+        return;
 
-  // Mask may be at a different resolution than disparity (if downsample happened
-  // before this call, which it shouldn't — this runs first).  Resize if needed.
-  if (footprint_mask_calib_.size() != disparity.size()) {
-    cv::Mat mask_resized;
-    cv::resize(footprint_mask_calib_, mask_resized, disparity.size(),
-               0, 0, cv::INTER_NEAREST);
-    disparity.setTo(0.0f, mask_resized);
-  } else {
-    disparity.setTo(0.0f, footprint_mask_calib_);
-  }
+    // Mask may be at a different resolution than disparity (if downsample happened
+    // before this call, which it shouldn't — this runs first).  Resize if needed.
+    if (footprint_mask_calib_.size() != disparity.size()) {
+        cv::Mat mask_resized;
+        cv::resize(footprint_mask_calib_, mask_resized, disparity.size(), 0, 0, cv::INTER_NEAREST);
+        disparity.setTo(0.0f, mask_resized);
+    } else {
+        disparity.setTo(0.0f, footprint_mask_calib_);
+    }
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/rectification.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/rectification.cpp
@@ -5,18 +5,15 @@
 #include <vpi/WarpMap.h>
 #include <vpi/algo/Remap.h>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // Resize both images to calibration resolution
 // =============================================================================
-void StereoDepthEstimator::scaleToCalibRes(
-    const cv::Mat& left_in, const cv::Mat& right_in,
-    cv::Mat& left_out, cv::Mat& right_out)
-{
-  cv::resize(left_in,  left_out,  cv::Size(calib_width_, calib_height_), 0, 0, cv::INTER_LINEAR);
-  cv::resize(right_in, right_out, cv::Size(calib_width_, calib_height_), 0, 0, cv::INTER_LINEAR);
+void StereoDepthEstimator::scaleToCalibRes(const cv::Mat& left_in, const cv::Mat& right_in, cv::Mat& left_out,
+                                           cv::Mat& right_out) {
+    cv::resize(left_in, left_out, cv::Size(calib_width_, calib_height_), 0, 0, cv::INTER_LINEAR);
+    cv::resize(right_in, right_out, cv::Size(calib_width_, calib_height_), 0, 0, cv::INTER_LINEAR);
 }
 
 // =============================================================================
@@ -26,182 +23,208 @@ void StereoDepthEstimator::scaleToCalibRes(
 // ---------------------------------------------------------------------------
 // Convert OpenCV remap maps (CV_32FC1 x + y) into a VPI dense warp map
 // ---------------------------------------------------------------------------
-static bool buildVPIWarpMap(const cv::Mat& map_x, const cv::Mat& map_y,
-                            VPIWarpMap& warp)
-{
-  const int w = map_x.cols;
-  const int h = map_x.rows;
+static bool buildVPIWarpMap(const cv::Mat& map_x, const cv::Mat& map_y, VPIWarpMap& warp) {
+    const int w = map_x.cols;
+    const int h = map_x.rows;
 
-  memset(&warp, 0, sizeof(warp));
-  warp.grid.numHorizRegions  = 1;
-  warp.grid.numVertRegions   = 1;
-  warp.grid.regionWidth[0]   = static_cast<int16_t>(w);
-  warp.grid.regionHeight[0]  = static_cast<int16_t>(h);
-  warp.grid.horizInterval[0] = 1;   // dense
-  warp.grid.vertInterval[0]  = 1;
+    memset(&warp, 0, sizeof(warp));
+    warp.grid.numHorizRegions = 1;
+    warp.grid.numVertRegions = 1;
+    warp.grid.regionWidth[0] = static_cast<int16_t>(w);
+    warp.grid.regionHeight[0] = static_cast<int16_t>(h);
+    warp.grid.horizInterval[0] = 1;  // dense
+    warp.grid.vertInterval[0] = 1;
 
-  VPIStatus st = vpiWarpMapAllocData(&warp);
-  if (st != VPI_SUCCESS) return false;
+    VPIStatus st = vpiWarpMapAllocData(&warp);
+    if (st != VPI_SUCCESS)
+        return false;
 
-  // Fill keypoints from OpenCV maps
-  for (int y = 0; y < h; ++y) {
-    const float* mx = map_x.ptr<float>(y);
-    const float* my = map_y.ptr<float>(y);
-    auto* row = reinterpret_cast<VPIKeypointF32*>(
-        reinterpret_cast<uint8_t*>(warp.keypoints) + y * warp.pitchBytes);
-    for (int x = 0; x < w; ++x) {
-      row[x].x = mx[x];
-      row[x].y = my[x];
+    // Fill keypoints from OpenCV maps
+    for (int y = 0; y < h; ++y) {
+        const float* mx = map_x.ptr<float>(y);
+        const float* my = map_y.ptr<float>(y);
+        auto* row = reinterpret_cast<VPIKeypointF32*>(reinterpret_cast<uint8_t*>(warp.keypoints) + y * warp.pitchBytes);
+        for (int x = 0; x < w; ++x) {
+            row[x].x = mx[x];
+            row[x].y = my[x];
+        }
     }
-  }
-  return true;
+    return true;
 }
 
 // ---------------------------------------------------------------------------
 // One-time init: build warp maps + VPI payloads for left, right, and colour
 // ---------------------------------------------------------------------------
-bool StereoDepthEstimator::initVPIRemap()
-{
-  VPIWarpMap warp_left, warp_right;
+bool StereoDepthEstimator::initVPIRemap() {
+    VPIWarpMap warp_left, warp_right;
 
-  if (!buildVPIWarpMap(map1_left_, map2_left_, warp_left)) {
-    RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to build left warp map");
-    return false;
-  }
-  if (!buildVPIWarpMap(map1_right_, map2_right_, warp_right)) {
-    vpiWarpMapFreeData(&warp_left);
-    RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to build right warp map");
-    return false;
-  }
+    if (!buildVPIWarpMap(map1_left_, map2_left_, warp_left)) {
+        RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to build left warp map");
+        return false;
+    }
+    if (!buildVPIWarpMap(map1_right_, map2_right_, warp_right)) {
+        vpiWarpMapFreeData(&warp_left);
+        RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to build right warp map");
+        return false;
+    }
 
-  VPIStatus st;
+    VPIStatus st;
 
-  // Mono payloads (U8)
-  st = vpiCreateRemap(VPI_BACKEND_CUDA, &warp_left, &vpi_remap_left_);
-  if (st != VPI_SUCCESS) {
+    // Mono payloads (U8)
+    st = vpiCreateRemap(VPI_BACKEND_CUDA, &warp_left, &vpi_remap_left_);
+    if (st != VPI_SUCCESS) {
+        vpiWarpMapFreeData(&warp_left);
+        vpiWarpMapFreeData(&warp_right);
+        RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to create left remap payload");
+        return false;
+    }
+
+    st = vpiCreateRemap(VPI_BACKEND_CUDA, &warp_right, &vpi_remap_right_);
+    if (st != VPI_SUCCESS) {
+        vpiPayloadDestroy(vpi_remap_left_);
+        vpi_remap_left_ = nullptr;
+        vpiWarpMapFreeData(&warp_left);
+        vpiWarpMapFreeData(&warp_right);
+        RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to create right remap payload");
+        return false;
+    }
+
+    // Colour payload reuses the left warp map
+    st = vpiCreateRemap(VPI_BACKEND_CUDA, &warp_left, &vpi_remap_color_);
+    if (st != VPI_SUCCESS) {
+        vpiPayloadDestroy(vpi_remap_left_);
+        vpi_remap_left_ = nullptr;
+        vpiPayloadDestroy(vpi_remap_right_);
+        vpi_remap_right_ = nullptr;
+        vpiWarpMapFreeData(&warp_left);
+        vpiWarpMapFreeData(&warp_right);
+        RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to create colour remap payload");
+        return false;
+    }
+
+    // Pre-allocate VPI output images (persistent across frames)
+    st = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_U8, VPI_BACKEND_CUDA | VPI_BACKEND_CPU,
+                        &vpi_rect_left_out_);
+    if (st != VPI_SUCCESS) {
+        cleanupVPIRemap();
+        return false;
+    }
+
+    st = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_U8, VPI_BACKEND_CUDA | VPI_BACKEND_CPU,
+                        &vpi_rect_right_out_);
+    if (st != VPI_SUCCESS) {
+        cleanupVPIRemap();
+        return false;
+    }
+
+    st = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_BGR8, VPI_BACKEND_CUDA | VPI_BACKEND_CPU,
+                        &vpi_rect_color_out_);
+    if (st != VPI_SUCCESS) {
+        cleanupVPIRemap();
+        return false;
+    }
+
+    // Warp map data can be freed after payload creation
     vpiWarpMapFreeData(&warp_left);
     vpiWarpMapFreeData(&warp_right);
-    RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to create left remap payload");
-    return false;
-  }
 
-  st = vpiCreateRemap(VPI_BACKEND_CUDA, &warp_right, &vpi_remap_right_);
-  if (st != VPI_SUCCESS) {
-    vpiPayloadDestroy(vpi_remap_left_); vpi_remap_left_ = nullptr;
-    vpiWarpMapFreeData(&warp_left);
-    vpiWarpMapFreeData(&warp_right);
-    RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to create right remap payload");
-    return false;
-  }
-
-  // Colour payload reuses the left warp map
-  st = vpiCreateRemap(VPI_BACKEND_CUDA, &warp_left, &vpi_remap_color_);
-  if (st != VPI_SUCCESS) {
-    vpiPayloadDestroy(vpi_remap_left_);  vpi_remap_left_  = nullptr;
-    vpiPayloadDestroy(vpi_remap_right_); vpi_remap_right_ = nullptr;
-    vpiWarpMapFreeData(&warp_left);
-    vpiWarpMapFreeData(&warp_right);
-    RCLCPP_ERROR(this->get_logger(), "VPI remap: failed to create colour remap payload");
-    return false;
-  }
-
-  // Pre-allocate VPI output images (persistent across frames)
-  st = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_U8,
-                       VPI_BACKEND_CUDA | VPI_BACKEND_CPU, &vpi_rect_left_out_);
-  if (st != VPI_SUCCESS) { cleanupVPIRemap(); return false; }
-
-  st = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_U8,
-                       VPI_BACKEND_CUDA | VPI_BACKEND_CPU, &vpi_rect_right_out_);
-  if (st != VPI_SUCCESS) { cleanupVPIRemap(); return false; }
-
-  st = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_BGR8,
-                       VPI_BACKEND_CUDA | VPI_BACKEND_CPU, &vpi_rect_color_out_);
-  if (st != VPI_SUCCESS) { cleanupVPIRemap(); return false; }
-
-  // Warp map data can be freed after payload creation
-  vpiWarpMapFreeData(&warp_left);
-  vpiWarpMapFreeData(&warp_right);
-
-  RCLCPP_INFO(this->get_logger(),
-              "VPI remap initialized: %dx%d (CUDA, dense, bilinear)",
-              calib_width_, calib_height_);
-  return true;
+    RCLCPP_INFO(this->get_logger(), "VPI remap initialized: %dx%d (CUDA, dense, bilinear)", calib_width_,
+                calib_height_);
+    return true;
 }
 
 // ---------------------------------------------------------------------------
 // Cleanup VPI remap resources
 // ---------------------------------------------------------------------------
-void StereoDepthEstimator::cleanupVPIRemap()
-{
-  if (vpi_remap_left_)      { vpiPayloadDestroy(vpi_remap_left_);      vpi_remap_left_      = nullptr; }
-  if (vpi_remap_right_)     { vpiPayloadDestroy(vpi_remap_right_);     vpi_remap_right_     = nullptr; }
-  if (vpi_remap_color_)     { vpiPayloadDestroy(vpi_remap_color_);     vpi_remap_color_     = nullptr; }
-  if (vpi_rect_left_out_)   { vpiImageDestroy(vpi_rect_left_out_);     vpi_rect_left_out_   = nullptr; }
-  if (vpi_rect_right_out_)  { vpiImageDestroy(vpi_rect_right_out_);    vpi_rect_right_out_  = nullptr; }
-  if (vpi_rect_color_out_)  { vpiImageDestroy(vpi_rect_color_out_);    vpi_rect_color_out_  = nullptr; }
+void StereoDepthEstimator::cleanupVPIRemap() {
+    if (vpi_remap_left_) {
+        vpiPayloadDestroy(vpi_remap_left_);
+        vpi_remap_left_ = nullptr;
+    }
+    if (vpi_remap_right_) {
+        vpiPayloadDestroy(vpi_remap_right_);
+        vpi_remap_right_ = nullptr;
+    }
+    if (vpi_remap_color_) {
+        vpiPayloadDestroy(vpi_remap_color_);
+        vpi_remap_color_ = nullptr;
+    }
+    if (vpi_rect_left_out_) {
+        vpiImageDestroy(vpi_rect_left_out_);
+        vpi_rect_left_out_ = nullptr;
+    }
+    if (vpi_rect_right_out_) {
+        vpiImageDestroy(vpi_rect_right_out_);
+        vpi_rect_right_out_ = nullptr;
+    }
+    if (vpi_rect_color_out_) {
+        vpiImageDestroy(vpi_rect_color_out_);
+        vpi_rect_color_out_ = nullptr;
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Helper: wrap input cv::Mat, submit remap, sync, lock output, export cv::Mat
 // ---------------------------------------------------------------------------
-static cv::Mat vpiRemapSync(VPIStream stream, VPIPayload payload,
-                            const cv::Mat& input, VPIImage vpi_out,
-                            VPIImageFormat fmt)
-{
-  // Wrap input
-  VPIImage vpi_in = nullptr;
-  VPIStatus st = vpiImageCreateWrapperOpenCVMat(input, fmt, VPI_BACKEND_CUDA, &vpi_in);
-  if (st != VPI_SUCCESS) return {};
+static cv::Mat vpiRemapSync(VPIStream stream, VPIPayload payload, const cv::Mat& input, VPIImage vpi_out,
+                            VPIImageFormat fmt) {
+    // Wrap input
+    VPIImage vpi_in = nullptr;
+    VPIStatus st = vpiImageCreateWrapperOpenCVMat(input, fmt, VPI_BACKEND_CUDA, &vpi_in);
+    if (st != VPI_SUCCESS)
+        return {};
 
-  // Submit remap (async)
-  st = vpiSubmitRemap(stream, VPI_BACKEND_CUDA, payload,
-                      vpi_in, vpi_out, VPI_INTERP_LINEAR, VPI_BORDER_ZERO, 0);
-  if (st != VPI_SUCCESS) { vpiImageDestroy(vpi_in); return {}; }
+    // Submit remap (async)
+    st = vpiSubmitRemap(stream, VPI_BACKEND_CUDA, payload, vpi_in, vpi_out, VPI_INTERP_LINEAR, VPI_BORDER_ZERO, 0);
+    if (st != VPI_SUCCESS) {
+        vpiImageDestroy(vpi_in);
+        return {};
+    }
 
-  // Sync — block until GPU done
-  vpiStreamSync(stream);
+    // Sync — block until GPU done
+    vpiStreamSync(stream);
 
-  // Lock output and export to cv::Mat
-  VPIImageData out_data;
-  st = vpiImageLockData(vpi_out, VPI_LOCK_READ, VPI_IMAGE_BUFFER_HOST_PITCH_LINEAR, &out_data);
-  if (st != VPI_SUCCESS) { vpiImageDestroy(vpi_in); return {}; }
+    // Lock output and export to cv::Mat
+    VPIImageData out_data;
+    st = vpiImageLockData(vpi_out, VPI_LOCK_READ, VPI_IMAGE_BUFFER_HOST_PITCH_LINEAR, &out_data);
+    if (st != VPI_SUCCESS) {
+        vpiImageDestroy(vpi_in);
+        return {};
+    }
 
-  cv::Mat result;
-  vpiImageDataExportOpenCVMat(out_data, &result);
-  result = result.clone();   // deep copy — we're about to unlock
-  vpiImageUnlock(vpi_out);
-  vpiImageDestroy(vpi_in);
+    cv::Mat result;
+    vpiImageDataExportOpenCVMat(out_data, &result);
+    result = result.clone();  // deep copy — we're about to unlock
+    vpiImageUnlock(vpi_out);
+    vpiImageDestroy(vpi_in);
 
-  return result;
+    return result;
 }
 
 // =============================================================================
 // Convert to grayscale (if colour) then apply stereo rectification maps
 // =============================================================================
-void StereoDepthEstimator::rectifyMono(
-    const cv::Mat& left_scaled, const cv::Mat& right_scaled,
-    cv::Mat& left_rect, cv::Mat& right_rect)
-{
-  cv::Mat left_gray, right_gray;
-  if (left_scaled.channels() == 3) {
-    cv::cvtColor(left_scaled,  left_gray,  cv::COLOR_BGR2GRAY);
-    cv::cvtColor(right_scaled, right_gray, cv::COLOR_BGR2GRAY);
-  } else {
-    left_gray  = left_scaled;
-    right_gray = right_scaled;
-  }
+void StereoDepthEstimator::rectifyMono(const cv::Mat& left_scaled, const cv::Mat& right_scaled, cv::Mat& left_rect,
+                                       cv::Mat& right_rect) {
+    cv::Mat left_gray, right_gray;
+    if (left_scaled.channels() == 3) {
+        cv::cvtColor(left_scaled, left_gray, cv::COLOR_BGR2GRAY);
+        cv::cvtColor(right_scaled, right_gray, cv::COLOR_BGR2GRAY);
+    } else {
+        left_gray = left_scaled;
+        right_gray = right_scaled;
+    }
 
-  left_rect  = vpiRemapSync(vpi_stream_, vpi_remap_left_,  left_gray,  vpi_rect_left_out_,  VPI_IMAGE_FORMAT_U8);
-  right_rect = vpiRemapSync(vpi_stream_, vpi_remap_right_, right_gray, vpi_rect_right_out_, VPI_IMAGE_FORMAT_U8);
+    left_rect = vpiRemapSync(vpi_stream_, vpi_remap_left_, left_gray, vpi_rect_left_out_, VPI_IMAGE_FORMAT_U8);
+    right_rect = vpiRemapSync(vpi_stream_, vpi_remap_right_, right_gray, vpi_rect_right_out_, VPI_IMAGE_FORMAT_U8);
 }
 
 // =============================================================================
 // Rectify the colour image (needed for colour point cloud / colour rect topic)
 // =============================================================================
-void StereoDepthEstimator::rectifyColor(
-    const cv::Mat& left_scaled, cv::Mat& left_color_rect)
-{
-  left_color_rect = vpiRemapSync(vpi_stream_, vpi_remap_color_, left_scaled, vpi_rect_color_out_, VPI_IMAGE_FORMAT_BGR8);
+void StereoDepthEstimator::rectifyColor(const cv::Mat& left_scaled, cv::Mat& left_color_rect) {
+    left_color_rect =
+        vpiRemapSync(vpi_stream_, vpi_remap_color_, left_scaled, vpi_rect_color_out_, VPI_IMAGE_FORMAT_BGR8);
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/vpi_stereo.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/depth_estimator/vpi_stereo.cpp
@@ -3,182 +3,183 @@
 #include "maurice_cam/stereo_depth_estimator.hpp"
 
 // Macro to check VPI status and log errors (bool-returning functions only)
-#define CHECK_VPI_STATUS(status, msg) \
-  if ((status) != VPI_SUCCESS) { \
-    char vpi_err[256]; \
-    vpiGetLastStatusMessage(vpi_err, sizeof(vpi_err)); \
-    RCLCPP_ERROR(this->get_logger(), "%s: %s", msg, vpi_err); \
-    return false; \
-  }
+#define CHECK_VPI_STATUS(status, msg)                             \
+    if ((status) != VPI_SUCCESS) {                                \
+        char vpi_err[256];                                        \
+        vpiGetLastStatusMessage(vpi_err, sizeof(vpi_err));        \
+        RCLCPP_ERROR(this->get_logger(), "%s: %s", msg, vpi_err); \
+        return false;                                             \
+    }
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // Initialise VPI stream, images, and SGM payload
 // =============================================================================
-bool StereoDepthEstimator::initializeVPI()
-{
-  VPIStatus status;
+bool StereoDepthEstimator::initializeVPI() {
+    VPIStatus status;
 
-  // Create VPI stream with CUDA backend
-  status = vpiStreamCreate(VPI_BACKEND_CUDA, &vpi_stream_);
-  CHECK_VPI_STATUS(status, "Failed to create VPI stream");
+    // Create VPI stream with CUDA backend
+    status = vpiStreamCreate(VPI_BACKEND_CUDA, &vpi_stream_);
+    CHECK_VPI_STATUS(status, "Failed to create VPI stream");
 
-  // Disparity output — S16 Q10.5 (divide by 32 → pixels)
-  status = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_S16,
-                          VPI_BACKEND_CUDA | VPI_BACKEND_CPU, &vpi_disparity_);
-  CHECK_VPI_STATUS(status, "Failed to create disparity image");
+    // Disparity output — S16 Q10.5 (divide by 32 → pixels)
+    status = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_S16, VPI_BACKEND_CUDA | VPI_BACKEND_CPU,
+                            &vpi_disparity_);
+    CHECK_VPI_STATUS(status, "Failed to create disparity image");
 
-  // Confidence map
-  status = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_U16,
-                          VPI_BACKEND_CUDA | VPI_BACKEND_CPU, &vpi_confidence_);
-  CHECK_VPI_STATUS(status, "Failed to create confidence image");
+    // Confidence map
+    status = vpiImageCreate(calib_width_, calib_height_, VPI_IMAGE_FORMAT_U16, VPI_BACKEND_CUDA | VPI_BACKEND_CPU,
+                            &vpi_confidence_);
+    CHECK_VPI_STATUS(status, "Failed to create confidence image");
 
-  // SGM payload
-  VPIStereoDisparityEstimatorCreationParams create_params;
-  vpiInitStereoDisparityEstimatorCreationParams(&create_params);
-  create_params.maxDisparity = max_disparity_;
-  create_params.includeDiagonals = include_diagonals_;
+    // SGM payload
+    VPIStereoDisparityEstimatorCreationParams create_params;
+    vpiInitStereoDisparityEstimatorCreationParams(&create_params);
+    create_params.maxDisparity = max_disparity_;
+    create_params.includeDiagonals = include_diagonals_;
 
-  status = vpiCreateStereoDisparityEstimator(VPI_BACKEND_CUDA, calib_width_, calib_height_,
-                                              VPI_IMAGE_FORMAT_U8, &create_params, &stereo_payload_);
-  CHECK_VPI_STATUS(status, "Failed to create stereo disparity estimator");
+    status = vpiCreateStereoDisparityEstimator(VPI_BACKEND_CUDA, calib_width_, calib_height_, VPI_IMAGE_FORMAT_U8,
+                                               &create_params, &stereo_payload_);
+    CHECK_VPI_STATUS(status, "Failed to create stereo disparity estimator");
 
-  RCLCPP_INFO(this->get_logger(), "VPI SGM CUDA created: %dx%d, maxDisp=%d, diagonals=%d",
-              calib_width_, calib_height_, max_disparity_, include_diagonals_);
-  return true;
+    RCLCPP_INFO(this->get_logger(), "VPI SGM CUDA created: %dx%d, maxDisp=%d, diagonals=%d", calib_width_,
+                calib_height_, max_disparity_, include_diagonals_);
+    return true;
 }
 
 // =============================================================================
 // Release all VPI resources
 // =============================================================================
-void StereoDepthEstimator::cleanupVPI()
-{
-  if (vpi_stream_) vpiStreamSync(vpi_stream_);
-  if (stereo_payload_) vpiPayloadDestroy(stereo_payload_);
-  if (vpi_disparity_) vpiImageDestroy(vpi_disparity_);
-  if (vpi_confidence_) vpiImageDestroy(vpi_confidence_);
-  if (vpi_stream_) vpiStreamDestroy(vpi_stream_);
+void StereoDepthEstimator::cleanupVPI() {
+    if (vpi_stream_)
+        vpiStreamSync(vpi_stream_);
+    if (stereo_payload_)
+        vpiPayloadDestroy(stereo_payload_);
+    if (vpi_disparity_)
+        vpiImageDestroy(vpi_disparity_);
+    if (vpi_confidence_)
+        vpiImageDestroy(vpi_confidence_);
+    if (vpi_stream_)
+        vpiStreamDestroy(vpi_stream_);
 
-  vpi_stream_ = nullptr;
-  stereo_payload_ = nullptr;
-  vpi_disparity_ = nullptr;
-  vpi_confidence_ = nullptr;
+    vpi_stream_ = nullptr;
+    stereo_payload_ = nullptr;
+    vpi_disparity_ = nullptr;
+    vpi_confidence_ = nullptr;
 }
 
 // =============================================================================
 // Wrap rectified mono images and submit SGM to CUDA (async)
 // =============================================================================
-bool StereoDepthEstimator::submitSGM(const cv::Mat& left_rect, const cv::Mat& right_rect)
-{
-  VPIStatus status;
+bool StereoDepthEstimator::submitSGM(const cv::Mat& left_rect, const cv::Mat& right_rect) {
+    VPIStatus status;
 
-  status = vpiImageCreateWrapperOpenCVMat(left_rect, VPI_IMAGE_FORMAT_U8,
-                                           VPI_BACKEND_CUDA, &vpi_left_wrap_);
-  if (status != VPI_SUCCESS) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to wrap left rectified image");
-    return false;
-  }
+    status = vpiImageCreateWrapperOpenCVMat(left_rect, VPI_IMAGE_FORMAT_U8, VPI_BACKEND_CUDA, &vpi_left_wrap_);
+    if (status != VPI_SUCCESS) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to wrap left rectified image");
+        return false;
+    }
 
-  status = vpiImageCreateWrapperOpenCVMat(right_rect, VPI_IMAGE_FORMAT_U8,
-                                           VPI_BACKEND_CUDA, &vpi_right_wrap_);
-  if (status != VPI_SUCCESS) {
-    vpiImageDestroy(vpi_left_wrap_); vpi_left_wrap_ = nullptr;
-    RCLCPP_ERROR(this->get_logger(), "Failed to wrap right rectified image");
-    return false;
-  }
+    status = vpiImageCreateWrapperOpenCVMat(right_rect, VPI_IMAGE_FORMAT_U8, VPI_BACKEND_CUDA, &vpi_right_wrap_);
+    if (status != VPI_SUCCESS) {
+        vpiImageDestroy(vpi_left_wrap_);
+        vpi_left_wrap_ = nullptr;
+        RCLCPP_ERROR(this->get_logger(), "Failed to wrap right rectified image");
+        return false;
+    }
 
-  VPIStereoDisparityEstimatorParams params;
-  vpiInitStereoDisparityEstimatorParams(&params);
-  params.maxDisparity = max_disparity_;
-  params.confidenceThreshold = confidence_threshold_;
-  params.minDisparity = min_disparity_;
-  params.p1 = p1_;
-  params.p2 = p2_;
-  params.uniqueness = static_cast<float>(uniqueness_);
+    VPIStereoDisparityEstimatorParams params;
+    vpiInitStereoDisparityEstimatorParams(&params);
+    params.maxDisparity = max_disparity_;
+    params.confidenceThreshold = confidence_threshold_;
+    params.minDisparity = min_disparity_;
+    params.p1 = p1_;
+    params.p2 = p2_;
+    params.uniqueness = static_cast<float>(uniqueness_);
 
-  vpiStreamSync(vpi_stream_);
-  status = vpiSubmitStereoDisparityEstimator(vpi_stream_, VPI_BACKEND_CUDA, stereo_payload_,
-                                              vpi_left_wrap_, vpi_right_wrap_,
-                                              vpi_disparity_, vpi_confidence_, &params);
-  if (status != VPI_SUCCESS) {
-    cleanupSGMWraps();
-    RCLCPP_ERROR(this->get_logger(), "Failed to compute stereo disparity");
-    return false;
-  }
+    vpiStreamSync(vpi_stream_);
+    status = vpiSubmitStereoDisparityEstimator(vpi_stream_, VPI_BACKEND_CUDA, stereo_payload_, vpi_left_wrap_,
+                                               vpi_right_wrap_, vpi_disparity_, vpi_confidence_, &params);
+    if (status != VPI_SUCCESS) {
+        cleanupSGMWraps();
+        RCLCPP_ERROR(this->get_logger(), "Failed to compute stereo disparity");
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 // =============================================================================
 // Wait for the GPU to finish the SGM computation
 // =============================================================================
-void StereoDepthEstimator::syncSGM()
-{
-  vpiStreamSync(vpi_stream_);
+void StereoDepthEstimator::syncSGM() {
+    vpiStreamSync(vpi_stream_);
 }
 
 // =============================================================================
 // Lock VPI result, convert Q10.5 → float, zero border, return CV_32FC1
 // =============================================================================
-cv::Mat StereoDepthEstimator::extractDisparity()
-{
-  VPIImageData data;
-  VPIStatus status = vpiImageLockData(vpi_disparity_, VPI_LOCK_READ,
-                                       VPI_IMAGE_BUFFER_HOST_PITCH_LINEAR, &data);
-  if (status != VPI_SUCCESS) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to lock disparity image");
-    return {};
-  }
-
-  const float SCALE = 32.0f;
-  const float max_valid = static_cast<float>(max_disparity_);
-  const int16_t* src = reinterpret_cast<const int16_t*>(data.buffer.pitch.planes[0].data);
-  const int pitch = data.buffer.pitch.planes[0].pitchBytes / sizeof(int16_t);
-
-  cv::Mat disp(calib_height_, calib_width_, CV_32FC1);
-  for (int y = 0; y < calib_height_; y++) {
-    const int16_t* row_src = src + y * pitch;
-    float* row_dst = disp.ptr<float>(y);
-    for (int x = 0; x < calib_width_; x++) {
-      float d = static_cast<float>(row_src[x]) / SCALE;
-      row_dst[x] = (d >= max_valid || d <= 0.0f) ? 0.0f : d;
+cv::Mat StereoDepthEstimator::extractDisparity() {
+    VPIImageData data;
+    VPIStatus status = vpiImageLockData(vpi_disparity_, VPI_LOCK_READ, VPI_IMAGE_BUFFER_HOST_PITCH_LINEAR, &data);
+    if (status != VPI_SUCCESS) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to lock disparity image");
+        return {};
     }
-  }
 
-  vpiImageUnlock(vpi_disparity_);
+    const float SCALE = 32.0f;
+    const float max_valid = static_cast<float>(max_disparity_);
+    const int16_t* src = reinterpret_cast<const int16_t*>(data.buffer.pitch.planes[0].data);
+    const int pitch = data.buffer.pitch.planes[0].pitchBytes / sizeof(int16_t);
 
-  // Zero out border pixels to eliminate edge artifacts from stereo matching
-  if (disparity_border_margin_ > 0) {
-    const int m = disparity_border_margin_;
-    for (int y = 0; y < m && y < calib_height_; y++) {
-      float* top = disp.ptr<float>(y);
-      float* bot = disp.ptr<float>(calib_height_ - 1 - y);
-      for (int x = 0; x < calib_width_; x++) {
-        top[x] = 0.0f;
-        bot[x] = 0.0f;
-      }
+    cv::Mat disp(calib_height_, calib_width_, CV_32FC1);
+    for (int y = 0; y < calib_height_; y++) {
+        const int16_t* row_src = src + y * pitch;
+        float* row_dst = disp.ptr<float>(y);
+        for (int x = 0; x < calib_width_; x++) {
+            float d = static_cast<float>(row_src[x]) / SCALE;
+            row_dst[x] = (d >= max_valid || d <= 0.0f) ? 0.0f : d;
+        }
     }
-    for (int y = m; y < calib_height_ - m; y++) {
-      float* row = disp.ptr<float>(y);
-      for (int x = 0; x < m && x < calib_width_; x++) {
-        row[x] = 0.0f;
-        row[calib_width_ - 1 - x] = 0.0f;
-      }
-    }
-  }
 
-  return disp;
+    vpiImageUnlock(vpi_disparity_);
+
+    // Zero out border pixels to eliminate edge artifacts from stereo matching
+    if (disparity_border_margin_ > 0) {
+        const int m = disparity_border_margin_;
+        for (int y = 0; y < m && y < calib_height_; y++) {
+            float* top = disp.ptr<float>(y);
+            float* bot = disp.ptr<float>(calib_height_ - 1 - y);
+            for (int x = 0; x < calib_width_; x++) {
+                top[x] = 0.0f;
+                bot[x] = 0.0f;
+            }
+        }
+        for (int y = m; y < calib_height_ - m; y++) {
+            float* row = disp.ptr<float>(y);
+            for (int x = 0; x < m && x < calib_width_; x++) {
+                row[x] = 0.0f;
+                row[calib_width_ - 1 - x] = 0.0f;
+            }
+        }
+    }
+
+    return disp;
 }
 
 // =============================================================================
 // Destroy temporary per-frame VPI image wrappers
 // =============================================================================
-void StereoDepthEstimator::cleanupSGMWraps()
-{
-  if (vpi_left_wrap_)  { vpiImageDestroy(vpi_left_wrap_);  vpi_left_wrap_  = nullptr; }
-  if (vpi_right_wrap_) { vpiImageDestroy(vpi_right_wrap_); vpi_right_wrap_ = nullptr; }
+void StereoDepthEstimator::cleanupSGMWraps() {
+    if (vpi_left_wrap_) {
+        vpiImageDestroy(vpi_left_wrap_);
+        vpi_left_wrap_ = nullptr;
+    }
+    if (vpi_right_wrap_) {
+        vpiImageDestroy(vpi_right_wrap_);
+        vpi_right_wrap_ = nullptr;
+    }
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/filters/advanced_filters.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/filters/advanced_filters.cpp
@@ -6,140 +6,160 @@
 #include <cmath>
 #include <cstdint>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // Domain-transform edge-preserving filter
 // =============================================================================
-void StereoDepthEstimator::applyDomainTransform(cv::Mat& img)
-{
-  for (int i = 0; i < dt_iterations_; ++i) {
-    dtPass(img, true);
-    dtPass(img, false);
-  }
+void StereoDepthEstimator::applyDomainTransform(cv::Mat& img) {
+    for (int i = 0; i < dt_iterations_; ++i) {
+        dtPass(img, true);
+        dtPass(img, false);
+    }
 }
 
 // Fast exp approximation (Schraudolph 1999) — ~4× faster than std::exp,
 // accurate to ~0.3% in the range [-4, 0] which is our operating range.
 static inline float fast_expf(float x) {
-  union { float f; int32_t i; } u;
-  u.i = static_cast<int32_t>(12102203.0f * x + 1065353216.0f);
-  return u.f;
+    union {
+        float f;
+        int32_t i;
+    } u;
+    u.i = static_cast<int32_t>(12102203.0f * x + 1065353216.0f);
+    return u.f;
 }
 
-void StereoDepthEstimator::dtPass(cv::Mat& img, bool horizontal)
-{
-  const float a = static_cast<float>(dt_alpha_);
-  const float inv_d = -1.0f / static_cast<float>(dt_delta_);
+void StereoDepthEstimator::dtPass(cv::Mat& img, bool horizontal) {
+    const float a = static_cast<float>(dt_alpha_);
+    const float inv_d = -1.0f / static_cast<float>(dt_delta_);
 
-  if (horizontal) {
-    const int rows = img.rows, cols = img.cols;
-    for (int y = 0; y < rows; ++y) {
-      float* r = img.ptr<float>(y);
-      for (int x = 1; x < cols; ++x) {
-        if (r[x] <= 0 || r[x - 1] <= 0) continue;
-        float w = a * fast_expf(std::abs(r[x] - r[x - 1]) * inv_d);
-        r[x] = r[x] * (1.f - w) + r[x - 1] * w;
-      }
-      for (int x = cols - 2; x >= 0; --x) {
-        if (r[x] <= 0 || r[x + 1] <= 0) continue;
-        float w = a * fast_expf(std::abs(r[x] - r[x + 1]) * inv_d);
-        r[x] = r[x] * (1.f - w) + r[x + 1] * w;
-      }
+    if (horizontal) {
+        const int rows = img.rows, cols = img.cols;
+        for (int y = 0; y < rows; ++y) {
+            float* r = img.ptr<float>(y);
+            for (int x = 1; x < cols; ++x) {
+                if (r[x] <= 0 || r[x - 1] <= 0)
+                    continue;
+                float w = a * fast_expf(std::abs(r[x] - r[x - 1]) * inv_d);
+                r[x] = r[x] * (1.f - w) + r[x - 1] * w;
+            }
+            for (int x = cols - 2; x >= 0; --x) {
+                if (r[x] <= 0 || r[x + 1] <= 0)
+                    continue;
+                float w = a * fast_expf(std::abs(r[x] - r[x + 1]) * inv_d);
+                r[x] = r[x] * (1.f - w) + r[x + 1] * w;
+            }
+        }
+    } else {
+        // Transpose → horizontal pass → transpose back (cache-friendly)
+        cv::Mat t;
+        cv::transpose(img, t);
+        const int rows = t.rows, cols = t.cols;
+        for (int y = 0; y < rows; ++y) {
+            float* r = t.ptr<float>(y);
+            for (int x = 1; x < cols; ++x) {
+                if (r[x] <= 0 || r[x - 1] <= 0)
+                    continue;
+                float w = a * fast_expf(std::abs(r[x] - r[x - 1]) * inv_d);
+                r[x] = r[x] * (1.f - w) + r[x - 1] * w;
+            }
+            for (int x = cols - 2; x >= 0; --x) {
+                if (r[x] <= 0 || r[x + 1] <= 0)
+                    continue;
+                float w = a * fast_expf(std::abs(r[x] - r[x + 1]) * inv_d);
+                r[x] = r[x] * (1.f - w) + r[x + 1] * w;
+            }
+        }
+        cv::transpose(t, img);
     }
-  } else {
-    // Transpose → horizontal pass → transpose back (cache-friendly)
-    cv::Mat t;
-    cv::transpose(img, t);
-    const int rows = t.rows, cols = t.cols;
-    for (int y = 0; y < rows; ++y) {
-      float* r = t.ptr<float>(y);
-      for (int x = 1; x < cols; ++x) {
-        if (r[x] <= 0 || r[x - 1] <= 0) continue;
-        float w = a * fast_expf(std::abs(r[x] - r[x - 1]) * inv_d);
-        r[x] = r[x] * (1.f - w) + r[x - 1] * w;
-      }
-      for (int x = cols - 2; x >= 0; --x) {
-        if (r[x] <= 0 || r[x + 1] <= 0) continue;
-        float w = a * fast_expf(std::abs(r[x] - r[x + 1]) * inv_d);
-        r[x] = r[x] * (1.f - w) + r[x + 1] * w;
-      }
-    }
-    cv::transpose(t, img);
-  }
 }
 
 // =============================================================================
 // Temporal filter (IIR blend + RealSense-style persistence)
 // =============================================================================
-void StereoDepthEstimator::applyTemporal(cv::Mat& img)
-{
-  const int total = img.rows * img.cols;
+void StereoDepthEstimator::applyTemporal(cv::Mat& img) {
+    const int total = img.rows * img.cols;
 
-  // First frame or resolution change: initialise history
-  if (prev_disparity_frame_.empty() || prev_disparity_frame_.size() != img.size()) {
+    // First frame or resolution change: initialise history
+    if (prev_disparity_frame_.empty() || prev_disparity_frame_.size() != img.size()) {
+        prev_disparity_frame_ = img.clone();
+        temporal_history_.assign(total, 0);
+        return;
+    }
+
+    const float a = static_cast<float>(temporal_alpha_);
+    const float delta = static_cast<float>(temporal_delta_);
+    const int persist = temporal_persistence_;
+
+    // Pre-compute persistence bitmask LUT (same as RealSense).
+    std::array<bool, 256> persist_lut;
+    persist_lut.fill(false);
+    if (persist > 0) {
+        for (int i = 0; i < 256; ++i) {
+            int b7 = !!(i & 1), b6 = !!(i & 2), b5 = !!(i & 4), b4 = !!(i & 8);
+            int b3 = !!(i & 16), b2 = !!(i & 32), b1 = !!(i & 64), b0 = !!(i & 128);
+            int sum8 = b0 + b1 + b2 + b3 + b4 + b5 + b6 + b7;
+            int sum3 = b0 + b1 + b2;
+            int sum4 = b0 + b1 + b2 + b3;
+            int sum2 = b0 + b1;
+            int sum5 = b0 + b1 + b2 + b3 + b4;
+            switch (persist) {
+                case 1:
+                    persist_lut[i] = (sum8 >= 8);
+                    break;
+                case 2:
+                    persist_lut[i] = (sum3 >= 2);
+                    break;
+                case 3:
+                    persist_lut[i] = (sum4 >= 2);
+                    break;
+                case 4:
+                    persist_lut[i] = (sum8 >= 2);
+                    break;
+                case 5:
+                    persist_lut[i] = (sum2 >= 1);
+                    break;
+                case 6:
+                    persist_lut[i] = (sum5 >= 1);
+                    break;
+                case 7:
+                    persist_lut[i] = (sum8 >= 1);
+                    break;
+                case 8:
+                    persist_lut[i] = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    for (int y = 0; y < img.rows; ++y) {
+        float* cur = img.ptr<float>(y);
+        const float* prv = prev_disparity_frame_.ptr<float>(y);
+        const int row_off = y * img.cols;
+        for (int x = 0; x < img.cols; ++x) {
+            const int idx = row_off + x;
+            const bool cur_valid = (cur[x] > 0);
+            const bool prv_valid = (prv[x] > 0);
+
+            uint8_t h = temporal_history_[idx];
+            h = static_cast<uint8_t>((h << 1) | (cur_valid ? 1 : 0));
+            temporal_history_[idx] = h;
+
+            if (cur_valid && prv_valid) {
+                float diff = std::abs(cur[x] - prv[x]);
+                if (diff < delta) {
+                    cur[x] = a * cur[x] + (1.f - a) * prv[x];
+                }
+            } else if (!cur_valid && prv_valid && persist > 0) {
+                if (persist_lut[h]) {
+                    cur[x] = prv[x];
+                }
+            }
+        }
+    }
     prev_disparity_frame_ = img.clone();
-    temporal_history_.assign(total, 0);
-    return;
-  }
-
-  const float a = static_cast<float>(temporal_alpha_);
-  const float delta = static_cast<float>(temporal_delta_);
-  const int persist = temporal_persistence_;
-
-  // Pre-compute persistence bitmask LUT (same as RealSense).
-  std::array<bool, 256> persist_lut;
-  persist_lut.fill(false);
-  if (persist > 0) {
-    for (int i = 0; i < 256; ++i) {
-      int b7 = !!(i & 1), b6 = !!(i & 2), b5 = !!(i & 4), b4 = !!(i & 8);
-      int b3 = !!(i & 16), b2 = !!(i & 32), b1 = !!(i & 64), b0 = !!(i & 128);
-      int sum8 = b0+b1+b2+b3+b4+b5+b6+b7;
-      int sum3 = b0+b1+b2;
-      int sum4 = b0+b1+b2+b3;
-      int sum2 = b0+b1;
-      int sum5 = b0+b1+b2+b3+b4;
-      switch (persist) {
-        case 1: persist_lut[i] = (sum8 >= 8); break;
-        case 2: persist_lut[i] = (sum3 >= 2); break;
-        case 3: persist_lut[i] = (sum4 >= 2); break;
-        case 4: persist_lut[i] = (sum8 >= 2); break;
-        case 5: persist_lut[i] = (sum2 >= 1); break;
-        case 6: persist_lut[i] = (sum5 >= 1); break;
-        case 7: persist_lut[i] = (sum8 >= 1); break;
-        case 8: persist_lut[i] = true; break;
-        default: break;
-      }
-    }
-  }
-
-  for (int y = 0; y < img.rows; ++y) {
-    float* cur = img.ptr<float>(y);
-    const float* prv = prev_disparity_frame_.ptr<float>(y);
-    const int row_off = y * img.cols;
-    for (int x = 0; x < img.cols; ++x) {
-      const int idx = row_off + x;
-      const bool cur_valid = (cur[x] > 0);
-      const bool prv_valid = (prv[x] > 0);
-
-      uint8_t h = temporal_history_[idx];
-      h = static_cast<uint8_t>((h << 1) | (cur_valid ? 1 : 0));
-      temporal_history_[idx] = h;
-
-      if (cur_valid && prv_valid) {
-        float diff = std::abs(cur[x] - prv[x]);
-        if (diff < delta) {
-          cur[x] = a * cur[x] + (1.f - a) * prv[x];
-        }
-      } else if (!cur_valid && prv_valid && persist > 0) {
-        if (persist_lut[h]) {
-          cur[x] = prv[x];
-        }
-      }
-    }
-  }
-  prev_disparity_frame_ = img.clone();
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/filters/filter_chain.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/filters/filter_chain.cpp
@@ -7,215 +7,209 @@
 #include <chrono>
 #include <string>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // Parameter initialisation
 // =============================================================================
-void StereoDepthEstimator::initFilterParams()
-{
-  // 0. Downsample — run all filters at reduced resolution
-  this->declare_parameter<bool>("filter_downsample.enabled", true);
-  this->declare_parameter<int>("filter_downsample.factor", 4);
-  filter_downsample_enabled_ = this->get_parameter("filter_downsample.enabled").as_bool();
-  filter_downsample_factor_ = std::clamp(
-      static_cast<int>(this->get_parameter("filter_downsample.factor").as_int()), 1, 8);
+void StereoDepthEstimator::initFilterParams() {
+    // 0. Downsample — run all filters at reduced resolution
+    this->declare_parameter<bool>("filter_downsample.enabled", true);
+    this->declare_parameter<int>("filter_downsample.factor", 4);
+    filter_downsample_enabled_ = this->get_parameter("filter_downsample.enabled").as_bool();
+    filter_downsample_factor_ =
+        std::clamp(static_cast<int>(this->get_parameter("filter_downsample.factor").as_int()), 1, 8);
 
-  // 1. Median
-  this->declare_parameter<bool>("median.enabled", false);
-  this->declare_parameter<int>("median.kernel_size", 5);
-  median_enabled_ = this->get_parameter("median.enabled").as_bool();
-  median_kernel_size_ = static_cast<int>(this->get_parameter("median.kernel_size").as_int());
-  if (median_kernel_size_ % 2 == 0) median_kernel_size_ += 1;
-  median_kernel_size_ = std::max(3, median_kernel_size_);
+    // 1. Median
+    this->declare_parameter<bool>("median.enabled", false);
+    this->declare_parameter<int>("median.kernel_size", 5);
+    median_enabled_ = this->get_parameter("median.enabled").as_bool();
+    median_kernel_size_ = static_cast<int>(this->get_parameter("median.kernel_size").as_int());
+    if (median_kernel_size_ % 2 == 0)
+        median_kernel_size_ += 1;
+    median_kernel_size_ = std::max(3, median_kernel_size_);
 
-  // 2. Bilateral
-  this->declare_parameter<bool>("bilateral.enabled", false);
-  this->declare_parameter<int>("bilateral.diameter", 5);
-  this->declare_parameter<double>("bilateral.sigma_color", 10.0);
-  this->declare_parameter<double>("bilateral.sigma_space", 10.0);
-  bilateral_enabled_ = this->get_parameter("bilateral.enabled").as_bool();
-  bilateral_diameter_ = static_cast<int>(this->get_parameter("bilateral.diameter").as_int());
-  bilateral_sigma_color_ = this->get_parameter("bilateral.sigma_color").as_double();
-  bilateral_sigma_space_ = this->get_parameter("bilateral.sigma_space").as_double();
+    // 2. Bilateral
+    this->declare_parameter<bool>("bilateral.enabled", false);
+    this->declare_parameter<int>("bilateral.diameter", 5);
+    this->declare_parameter<double>("bilateral.sigma_color", 10.0);
+    this->declare_parameter<double>("bilateral.sigma_space", 10.0);
+    bilateral_enabled_ = this->get_parameter("bilateral.enabled").as_bool();
+    bilateral_diameter_ = static_cast<int>(this->get_parameter("bilateral.diameter").as_int());
+    bilateral_sigma_color_ = this->get_parameter("bilateral.sigma_color").as_double();
+    bilateral_sigma_space_ = this->get_parameter("bilateral.sigma_space").as_double();
 
-  // 3. Hole Filling
-  this->declare_parameter<bool>("hole_filling.enabled", false);
-  this->declare_parameter<int>("hole_filling.mode", 1);
-  this->declare_parameter<int>("hole_filling.strategy", 1);
-  hole_filling_enabled_ = this->get_parameter("hole_filling.enabled").as_bool();
-  int hf_mode = std::clamp(static_cast<int>(this->get_parameter("hole_filling.mode").as_int()), 0, 5);
-  const int hf_map[] = {0, 2, 4, 8, 16, 9999};
-  hole_fill_radius_ = hf_map[hf_mode];
-  hole_fill_strategy_ = std::clamp(static_cast<int>(this->get_parameter("hole_filling.strategy").as_int()), 0, 2);
+    // 3. Hole Filling
+    this->declare_parameter<bool>("hole_filling.enabled", false);
+    this->declare_parameter<int>("hole_filling.mode", 1);
+    this->declare_parameter<int>("hole_filling.strategy", 1);
+    hole_filling_enabled_ = this->get_parameter("hole_filling.enabled").as_bool();
+    int hf_mode = std::clamp(static_cast<int>(this->get_parameter("hole_filling.mode").as_int()), 0, 5);
+    const int hf_map[] = {0, 2, 4, 8, 16, 9999};
+    hole_fill_radius_ = hf_map[hf_mode];
+    hole_fill_strategy_ = std::clamp(static_cast<int>(this->get_parameter("hole_filling.strategy").as_int()), 0, 2);
 
-  // 4. Depth Clamping
-  this->declare_parameter<bool>("depth_clamp.enabled", false);
-  this->declare_parameter<double>("depth_clamp.min_depth_meters", 0.25);
-  this->declare_parameter<double>("depth_clamp.max_depth_meters", 5.0);
-  depth_clamp_enabled_ = this->get_parameter("depth_clamp.enabled").as_bool();
-  min_depth_meters_ = this->get_parameter("depth_clamp.min_depth_meters").as_double();
-  max_depth_meters_ = this->get_parameter("depth_clamp.max_depth_meters").as_double();
+    // 4. Depth Clamping
+    this->declare_parameter<bool>("depth_clamp.enabled", false);
+    this->declare_parameter<double>("depth_clamp.min_depth_meters", 0.25);
+    this->declare_parameter<double>("depth_clamp.max_depth_meters", 5.0);
+    depth_clamp_enabled_ = this->get_parameter("depth_clamp.enabled").as_bool();
+    min_depth_meters_ = this->get_parameter("depth_clamp.min_depth_meters").as_double();
+    max_depth_meters_ = this->get_parameter("depth_clamp.max_depth_meters").as_double();
 
-  // 5. Edge Invalidation
-  this->declare_parameter<bool>("edge_invalidation.enabled", false);
-  this->declare_parameter<int>("edge_invalidation.width", 3);
-  this->declare_parameter<double>("edge_invalidation.canny_low", 10.0);
-  this->declare_parameter<double>("edge_invalidation.canny_high", 30.0);
-  edge_inv_enabled_ = this->get_parameter("edge_invalidation.enabled").as_bool();
-  edge_inv_width_ = std::max(1, static_cast<int>(this->get_parameter("edge_invalidation.width").as_int()));
-  edge_canny_low_ = this->get_parameter("edge_invalidation.canny_low").as_double();
-  edge_canny_high_ = this->get_parameter("edge_invalidation.canny_high").as_double();
+    // 5. Edge Invalidation
+    this->declare_parameter<bool>("edge_invalidation.enabled", false);
+    this->declare_parameter<int>("edge_invalidation.width", 3);
+    this->declare_parameter<double>("edge_invalidation.canny_low", 10.0);
+    this->declare_parameter<double>("edge_invalidation.canny_high", 30.0);
+    edge_inv_enabled_ = this->get_parameter("edge_invalidation.enabled").as_bool();
+    edge_inv_width_ = std::max(1, static_cast<int>(this->get_parameter("edge_invalidation.width").as_int()));
+    edge_canny_low_ = this->get_parameter("edge_invalidation.canny_low").as_double();
+    edge_canny_high_ = this->get_parameter("edge_invalidation.canny_high").as_double();
 
-  // 6. Speckle
-  this->declare_parameter<bool>("speckle.enabled", false);
-  this->declare_parameter<int>("speckle.max_size", 200);
-  this->declare_parameter<double>("speckle.max_diff", 1.0);
-  speckle_enabled_ = this->get_parameter("speckle.enabled").as_bool();
-  speckle_max_size_ = std::max(1, static_cast<int>(this->get_parameter("speckle.max_size").as_int()));
-  speckle_max_diff_ = std::max(0.0, this->get_parameter("speckle.max_diff").as_double());
+    // 6. Speckle
+    this->declare_parameter<bool>("speckle.enabled", false);
+    this->declare_parameter<int>("speckle.max_size", 200);
+    this->declare_parameter<double>("speckle.max_diff", 1.0);
+    speckle_enabled_ = this->get_parameter("speckle.enabled").as_bool();
+    speckle_max_size_ = std::max(1, static_cast<int>(this->get_parameter("speckle.max_size").as_int()));
+    speckle_max_diff_ = std::max(0.0, this->get_parameter("speckle.max_diff").as_double());
 
-  // 7. Domain Transform
-  this->declare_parameter<bool>("domain_transform.enabled", false);
-  this->declare_parameter<int>("domain_transform.iterations", 2);
-  this->declare_parameter<double>("domain_transform.alpha", 0.5);
-  this->declare_parameter<int>("domain_transform.delta", 20);
-  dt_enabled_ = this->get_parameter("domain_transform.enabled").as_bool();
-  dt_iterations_ = std::clamp(static_cast<int>(this->get_parameter("domain_transform.iterations").as_int()), 1, 5);
-  dt_alpha_ = std::clamp(this->get_parameter("domain_transform.alpha").as_double(), 0.25, 1.0);
-  dt_delta_ = std::clamp(static_cast<int>(this->get_parameter("domain_transform.delta").as_int()), 1, 50);
+    // 7. Domain Transform
+    this->declare_parameter<bool>("domain_transform.enabled", false);
+    this->declare_parameter<int>("domain_transform.iterations", 2);
+    this->declare_parameter<double>("domain_transform.alpha", 0.5);
+    this->declare_parameter<int>("domain_transform.delta", 20);
+    dt_enabled_ = this->get_parameter("domain_transform.enabled").as_bool();
+    dt_iterations_ = std::clamp(static_cast<int>(this->get_parameter("domain_transform.iterations").as_int()), 1, 5);
+    dt_alpha_ = std::clamp(this->get_parameter("domain_transform.alpha").as_double(), 0.25, 1.0);
+    dt_delta_ = std::clamp(static_cast<int>(this->get_parameter("domain_transform.delta").as_int()), 1, 50);
 
-  // 8. Temporal
-  this->declare_parameter<bool>("temporal.enabled", false);
-  this->declare_parameter<double>("temporal.alpha", 0.4);
-  this->declare_parameter<int>("temporal.delta", 20);
-  this->declare_parameter<int>("temporal.persistence", 3);
-  temporal_enabled_ = this->get_parameter("temporal.enabled").as_bool();
-  temporal_alpha_ = std::clamp(this->get_parameter("temporal.alpha").as_double(), 0.0, 1.0);
-  temporal_delta_ = std::clamp(static_cast<int>(this->get_parameter("temporal.delta").as_int()), 1, 100);
-  temporal_persistence_ = std::clamp(static_cast<int>(this->get_parameter("temporal.persistence").as_int()), 0, 8);
+    // 8. Temporal
+    this->declare_parameter<bool>("temporal.enabled", false);
+    this->declare_parameter<double>("temporal.alpha", 0.4);
+    this->declare_parameter<int>("temporal.delta", 20);
+    this->declare_parameter<int>("temporal.persistence", 3);
+    temporal_enabled_ = this->get_parameter("temporal.enabled").as_bool();
+    temporal_alpha_ = std::clamp(this->get_parameter("temporal.alpha").as_double(), 0.0, 1.0);
+    temporal_delta_ = std::clamp(static_cast<int>(this->get_parameter("temporal.delta").as_int()), 1, 100);
+    temporal_persistence_ = std::clamp(static_cast<int>(this->get_parameter("temporal.persistence").as_int()), 0, 8);
 
-  // Filter execution order
-  this->declare_parameter<std::vector<std::string>>("filter_order", {
-    "median", "bilateral", "hole_filling", "depth_clamp",
-    "edge_invalidation", "speckle", "domain_transform", "temporal"});
-  filter_order_ = this->get_parameter("filter_order").as_string_array();
+    // Filter execution order
+    this->declare_parameter<std::vector<std::string>>(
+        "filter_order", {"median", "bilateral", "hole_filling", "depth_clamp", "edge_invalidation", "speckle",
+                         "domain_transform", "temporal"});
+    filter_order_ = this->get_parameter("filter_order").as_string_array();
 }
 
 // =============================================================================
 // Logging
 // =============================================================================
-void StereoDepthEstimator::logFilterConfig() const
-{
-  auto log = [this](const char* name, bool on, const std::string & detail = "") {
-    RCLCPP_INFO(this->get_logger(), "  %-22s %s%s", name, on ? "ON" : "OFF", detail.c_str());
-  };
+void StereoDepthEstimator::logFilterConfig() const {
+    auto log = [this](const char* name, bool on, const std::string& detail = "") {
+        RCLCPP_INFO(this->get_logger(), "  %-22s %s%s", name, on ? "ON" : "OFF", detail.c_str());
+    };
 
-  RCLCPP_INFO(this->get_logger(), "=== Disparity Filter Chain ===");
-  log("Downsample", filter_downsample_enabled_,
-      filter_downsample_enabled_ ? "  factor=" + std::to_string(filter_downsample_factor_) : "");
+    RCLCPP_INFO(this->get_logger(), "=== Disparity Filter Chain ===");
+    log("Downsample", filter_downsample_enabled_,
+        filter_downsample_enabled_ ? "  factor=" + std::to_string(filter_downsample_factor_) : "");
 
-  // Print execution order
-  std::string order_str;
-  for (const auto& name : filter_order_) {
-    if (!order_str.empty()) order_str += " → ";
-    order_str += name;
-  }
-  RCLCPP_INFO(this->get_logger(), "  Order: %s", order_str.c_str());
+    // Print execution order
+    std::string order_str;
+    for (const auto& name : filter_order_) {
+        if (!order_str.empty())
+            order_str += " → ";
+        order_str += name;
+    }
+    RCLCPP_INFO(this->get_logger(), "  Order: %s", order_str.c_str());
 
-  log("Median", median_enabled_,
-      median_enabled_ ? "  kernel=" + std::to_string(median_kernel_size_) : "");
-  log("Bilateral", bilateral_enabled_,
-      bilateral_enabled_ ? "  d=" + std::to_string(bilateral_diameter_) : "");
-  log("Hole Filling", hole_filling_enabled_,
-      hole_filling_enabled_ ? "  radius=" + std::to_string(hole_fill_radius_)
-        + " strategy=" + std::to_string(hole_fill_strategy_) : "");
-  log("Depth Clamping", depth_clamp_enabled_,
-      depth_clamp_enabled_ ? "  min=" + std::to_string(min_depth_meters_)
-        + "m max=" + std::to_string(max_depth_meters_) + "m" : "");
-  log("Edge Invalidation", edge_inv_enabled_,
-      edge_inv_enabled_ ? "  width=" + std::to_string(edge_inv_width_) : "");
-  log("Speckle Removal", speckle_enabled_,
-      speckle_enabled_ ? "  size=" + std::to_string(speckle_max_size_) : "");
-  log("Domain Transform", dt_enabled_,
-      dt_enabled_ ? "  iter=" + std::to_string(dt_iterations_)
-        + " a=" + std::to_string(dt_alpha_)
-        + " d=" + std::to_string(dt_delta_) : "");
-  log("Temporal", temporal_enabled_,
-      temporal_enabled_ ? "  alpha=" + std::to_string(temporal_alpha_)
-        + " delta=" + std::to_string(temporal_delta_)
-        + " persist=" + std::to_string(temporal_persistence_) : "");
+    log("Median", median_enabled_, median_enabled_ ? "  kernel=" + std::to_string(median_kernel_size_) : "");
+    log("Bilateral", bilateral_enabled_, bilateral_enabled_ ? "  d=" + std::to_string(bilateral_diameter_) : "");
+    log("Hole Filling", hole_filling_enabled_,
+        hole_filling_enabled_
+            ? "  radius=" + std::to_string(hole_fill_radius_) + " strategy=" + std::to_string(hole_fill_strategy_)
+            : "");
+    log("Depth Clamping", depth_clamp_enabled_,
+        depth_clamp_enabled_
+            ? "  min=" + std::to_string(min_depth_meters_) + "m max=" + std::to_string(max_depth_meters_) + "m"
+            : "");
+    log("Edge Invalidation", edge_inv_enabled_, edge_inv_enabled_ ? "  width=" + std::to_string(edge_inv_width_) : "");
+    log("Speckle Removal", speckle_enabled_, speckle_enabled_ ? "  size=" + std::to_string(speckle_max_size_) : "");
+    log("Domain Transform", dt_enabled_,
+        dt_enabled_ ? "  iter=" + std::to_string(dt_iterations_) + " a=" + std::to_string(dt_alpha_) +
+                          " d=" + std::to_string(dt_delta_)
+                    : "");
+    log("Temporal", temporal_enabled_,
+        temporal_enabled_ ? "  alpha=" + std::to_string(temporal_alpha_) + " delta=" + std::to_string(temporal_delta_) +
+                                " persist=" + std::to_string(temporal_persistence_)
+                          : "");
 }
 
 // =============================================================================
 // Filter chain orchestration
 // =============================================================================
-void StereoDepthEstimator::applyFilterChain(cv::Mat& disparity, cv::Mat& disparity_lowres,
-                                        FilterTimings& timings, float focal_length, float baseline)
-{
-  using clock = std::chrono::steady_clock;
-  const cv::Size orig_size = disparity.size();
-  const int f = filter_downsample_factor_;
+void StereoDepthEstimator::applyFilterChain(cv::Mat& disparity, cv::Mat& disparity_lowres, FilterTimings& timings,
+                                            float focal_length, float baseline) {
+    using clock = std::chrono::steady_clock;
+    const cv::Size orig_size = disparity.size();
+    const int f = filter_downsample_factor_;
 
-  // Downsample for faster filtering (INTER_AREA averages the pixel block → free noise reduction)
-  auto t0 = clock::now();
-  if (filter_downsample_enabled_ && f > 1) {
-    cv::resize(disparity, disparity,
-               cv::Size(orig_size.width / f, orig_size.height / f),
-               0, 0, cv::INTER_AREA);
-  }
-  auto t1 = clock::now();
-  timings.downsample_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
-
-  // Run filters in configured order
-  for (const auto& name : filter_order_) {
-    t0 = clock::now();
-    if (name == "median" && median_enabled_) {
-      applyMedian(disparity);
-      t1 = clock::now();
-      timings.median_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
-    } else if (name == "bilateral" && bilateral_enabled_) {
-      applyBilateral(disparity);
-      t1 = clock::now();
-      timings.bilateral_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
-    } else if (name == "hole_filling" && hole_filling_enabled_) {
-      fillHoles(disparity);
-      t1 = clock::now();
-      timings.hole_fill_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
-    } else if (name == "depth_clamp" && depth_clamp_enabled_) {
-      clampByDepth(disparity, focal_length, baseline);
-      t1 = clock::now();
-      timings.depth_clamp_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
-    } else if (name == "edge_invalidation" && edge_inv_enabled_) {
-      invalidateEdges(disparity);
-      t1 = clock::now();
-      timings.edge_inv_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
-    } else if (name == "speckle" && speckle_enabled_) {
-      filterSpeckles(disparity);
-      t1 = clock::now();
-      timings.speckle_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
-    } else if (name == "domain_transform" && dt_enabled_) {
-      applyDomainTransform(disparity);
-      t1 = clock::now();
-      timings.domain_transform_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
-    } else if (name == "temporal" && temporal_enabled_) {
-      applyTemporal(disparity);
-      t1 = clock::now();
-      timings.temporal_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+    // Downsample for faster filtering (INTER_AREA averages the pixel block → free noise reduction)
+    auto t0 = clock::now();
+    if (filter_downsample_enabled_ && f > 1) {
+        cv::resize(disparity, disparity, cv::Size(orig_size.width / f, orig_size.height / f), 0, 0, cv::INTER_AREA);
     }
-  }
+    auto t1 = clock::now();
+    timings.downsample_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
 
-  // Save low-res filtered result for point cloud before upsampling
-  disparity_lowres = disparity.clone();
+    // Run filters in configured order
+    for (const auto& name : filter_order_) {
+        t0 = clock::now();
+        if (name == "median" && median_enabled_) {
+            applyMedian(disparity);
+            t1 = clock::now();
+            timings.median_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        } else if (name == "bilateral" && bilateral_enabled_) {
+            applyBilateral(disparity);
+            t1 = clock::now();
+            timings.bilateral_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        } else if (name == "hole_filling" && hole_filling_enabled_) {
+            fillHoles(disparity);
+            t1 = clock::now();
+            timings.hole_fill_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        } else if (name == "depth_clamp" && depth_clamp_enabled_) {
+            clampByDepth(disparity, focal_length, baseline);
+            t1 = clock::now();
+            timings.depth_clamp_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        } else if (name == "edge_invalidation" && edge_inv_enabled_) {
+            invalidateEdges(disparity);
+            t1 = clock::now();
+            timings.edge_inv_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        } else if (name == "speckle" && speckle_enabled_) {
+            filterSpeckles(disparity);
+            t1 = clock::now();
+            timings.speckle_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        } else if (name == "domain_transform" && dt_enabled_) {
+            applyDomainTransform(disparity);
+            t1 = clock::now();
+            timings.domain_transform_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        } else if (name == "temporal" && temporal_enabled_) {
+            applyTemporal(disparity);
+            t1 = clock::now();
+            timings.temporal_ms += std::chrono::duration<double, std::milli>(t1 - t0).count();
+        }
+    }
 
-  // Upsample back to original resolution for disparity publishing / depth map
-  t0 = clock::now();
-  if (filter_downsample_enabled_ && f > 1) {
-    cv::resize(disparity, disparity, orig_size, 0, 0, cv::INTER_LINEAR);
-  }
-  t1 = clock::now();
-  timings.upsample_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    // Save low-res filtered result for point cloud before upsampling
+    disparity_lowres = disparity.clone();
+
+    // Upsample back to original resolution for disparity publishing / depth map
+    t0 = clock::now();
+    if (filter_downsample_enabled_ && f > 1) {
+        cv::resize(disparity, disparity, orig_size, 0, 0, cv::INTER_LINEAR);
+    }
+    t1 = clock::now();
+    timings.upsample_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/filters/simple_filters.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/filters/simple_filters.cpp
@@ -7,166 +7,183 @@
 #include <cmath>
 #include <limits>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // Median
 // =============================================================================
-void StereoDepthEstimator::applyMedian(cv::Mat& img)
-{
-  if (median_kernel_size_ <= 5) {
-    cv::medianBlur(img, img, median_kernel_size_);
-  } else {
-    double mn, mx;
-    cv::minMaxLoc(img, &mn, &mx);
-    if (mx <= 0) return;
-    cv::Mat u8;
-    img.convertTo(u8, CV_8U, 255.0 / mx);
-    cv::medianBlur(u8, u8, median_kernel_size_);
-    u8.convertTo(img, CV_32F, mx / 255.0);
-  }
+void StereoDepthEstimator::applyMedian(cv::Mat& img) {
+    if (median_kernel_size_ <= 5) {
+        cv::medianBlur(img, img, median_kernel_size_);
+    } else {
+        double mn, mx;
+        cv::minMaxLoc(img, &mn, &mx);
+        if (mx <= 0)
+            return;
+        cv::Mat u8;
+        img.convertTo(u8, CV_8U, 255.0 / mx);
+        cv::medianBlur(u8, u8, median_kernel_size_);
+        u8.convertTo(img, CV_32F, mx / 255.0);
+    }
 }
 
 // =============================================================================
 // Bilateral
 // =============================================================================
-void StereoDepthEstimator::applyBilateral(cv::Mat& img)
-{
-  cv::Mat src = img.clone();
-  cv::bilateralFilter(src, img, bilateral_diameter_,
-                      bilateral_sigma_color_, bilateral_sigma_space_);
+void StereoDepthEstimator::applyBilateral(cv::Mat& img) {
+    cv::Mat src = img.clone();
+    cv::bilateralFilter(src, img, bilateral_diameter_, bilateral_sigma_color_, bilateral_sigma_space_);
 }
 
 // =============================================================================
 // Hole filling (4-neighbour search, configurable strategy)
 // =============================================================================
-void StereoDepthEstimator::fillHoles(cv::Mat& img)
-{
-  const int rows = img.rows, cols = img.cols;
-  const int max_r = (hole_fill_radius_ >= 9999) ? std::max(rows, cols) : hole_fill_radius_;
+void StereoDepthEstimator::fillHoles(cv::Mat& img) {
+    const int rows = img.rows, cols = img.cols;
+    const int max_r = (hole_fill_radius_ >= 9999) ? std::max(rows, cols) : hole_fill_radius_;
 
-  // Strategy 0: fill from left neighbour only (RealSense mode 0)
-  // Strategy 1: farthest from around — pick neighbour with smallest disparity
-  //             (= farthest depth). Safest, avoids foreground bleed. (RS default)
-  // Strategy 2: nearest from around — pick neighbour with largest disparity
-  //             (= nearest depth).
-  const int strategy = hole_fill_strategy_;
+    // Strategy 0: fill from left neighbour only (RealSense mode 0)
+    // Strategy 1: farthest from around — pick neighbour with smallest disparity
+    //             (= farthest depth). Safest, avoids foreground bleed. (RS default)
+    // Strategy 2: nearest from around — pick neighbour with largest disparity
+    //             (= nearest depth).
+    const int strategy = hole_fill_strategy_;
 
-  // Work on a clone so reads don't see writes from this pass
-  cv::Mat src = img.clone();
+    // Work on a clone so reads don't see writes from this pass
+    cv::Mat src = img.clone();
 
-  for (int y = 0; y < rows; ++y) {
-    float* dst_row = img.ptr<float>(y);
-    for (int x = 0; x < cols; ++x) {
-      if (src.at<float>(y, x) > 0) continue;
+    for (int y = 0; y < rows; ++y) {
+        float* dst_row = img.ptr<float>(y);
+        for (int x = 0; x < cols; ++x) {
+            if (src.at<float>(y, x) > 0)
+                continue;
 
-      // Gather up to 4 neighbours (left, right, up, down)
-      float candidates[4] = {0, 0, 0, 0};
-      int count = 0;
+            // Gather up to 4 neighbours (left, right, up, down)
+            float candidates[4] = {0, 0, 0, 0};
+            int count = 0;
 
-      // Left
-      for (int d = 1; d <= max_r && x - d >= 0; ++d)
-        if (src.at<float>(y, x - d) > 0) { candidates[count++] = src.at<float>(y, x - d); break; }
-      // Right
-      for (int d = 1; d <= max_r && x + d < cols; ++d)
-        if (src.at<float>(y, x + d) > 0) { candidates[count++] = src.at<float>(y, x + d); break; }
-      // Up
-      for (int d = 1; d <= max_r && y - d >= 0; ++d)
-        if (src.at<float>(y - d, x) > 0) { candidates[count++] = src.at<float>(y - d, x); break; }
-      // Down
-      for (int d = 1; d <= max_r && y + d < rows; ++d)
-        if (src.at<float>(y + d, x) > 0) { candidates[count++] = src.at<float>(y + d, x); break; }
+            // Left
+            for (int d = 1; d <= max_r && x - d >= 0; ++d)
+                if (src.at<float>(y, x - d) > 0) {
+                    candidates[count++] = src.at<float>(y, x - d);
+                    break;
+                }
+            // Right
+            for (int d = 1; d <= max_r && x + d < cols; ++d)
+                if (src.at<float>(y, x + d) > 0) {
+                    candidates[count++] = src.at<float>(y, x + d);
+                    break;
+                }
+            // Up
+            for (int d = 1; d <= max_r && y - d >= 0; ++d)
+                if (src.at<float>(y - d, x) > 0) {
+                    candidates[count++] = src.at<float>(y - d, x);
+                    break;
+                }
+            // Down
+            for (int d = 1; d <= max_r && y + d < rows; ++d)
+                if (src.at<float>(y + d, x) > 0) {
+                    candidates[count++] = src.at<float>(y + d, x);
+                    break;
+                }
 
-      if (count == 0) continue;
+            if (count == 0)
+                continue;
 
-      if (strategy == 0) {
-        dst_row[x] = candidates[0];
-      } else if (strategy == 1) {
-        float best = candidates[0];
-        for (int i = 1; i < count; ++i)
-          if (candidates[i] < best) best = candidates[i];
-        dst_row[x] = best;
-      } else {
-        float best = candidates[0];
-        for (int i = 1; i < count; ++i)
-          if (candidates[i] > best) best = candidates[i];
-        dst_row[x] = best;
-      }
+            if (strategy == 0) {
+                dst_row[x] = candidates[0];
+            } else if (strategy == 1) {
+                float best = candidates[0];
+                for (int i = 1; i < count; ++i)
+                    if (candidates[i] < best)
+                        best = candidates[i];
+                dst_row[x] = best;
+            } else {
+                float best = candidates[0];
+                for (int i = 1; i < count; ++i)
+                    if (candidates[i] > best)
+                        best = candidates[i];
+                dst_row[x] = best;
+            }
+        }
     }
-  }
 }
 
 // =============================================================================
 // Depth clamping (disparity ↔ depth conversion)
 // =============================================================================
-void StereoDepthEstimator::clampByDepth(cv::Mat& img, float f, float t)
-{
-  const float abs_t = std::abs(t);
-  if (f <= 0 || abs_t <= 0) return;
-  float max_d = (min_depth_meters_ > 0)
-    ? f * abs_t / static_cast<float>(min_depth_meters_)
-    : std::numeric_limits<float>::max();
-  float min_d = (max_depth_meters_ > 0)
-    ? f * abs_t / static_cast<float>(max_depth_meters_)
-    : 0.0f;
-  int killed_near = 0, killed_far = 0, total_valid = 0;
-  float d_min_seen = std::numeric_limits<float>::max(), d_max_seen = 0.0f;
-  for (int y = 0; y < img.rows; ++y) {
-    float* row = img.ptr<float>(y);
-    for (int x = 0; x < img.cols; ++x) {
-      float d = row[x];
-      if (d <= 0) continue;
-      total_valid++;
-      if (d < d_min_seen) d_min_seen = d;
-      if (d > d_max_seen) d_max_seen = d;
-      if (d > max_d) { row[x] = 0.0f; killed_near++; }
-      else if (d < min_d) { row[x] = 0.0f; killed_far++; }
+void StereoDepthEstimator::clampByDepth(cv::Mat& img, float f, float t) {
+    const float abs_t = std::abs(t);
+    if (f <= 0 || abs_t <= 0)
+        return;
+    float max_d =
+        (min_depth_meters_ > 0) ? f * abs_t / static_cast<float>(min_depth_meters_) : std::numeric_limits<float>::max();
+    float min_d = (max_depth_meters_ > 0) ? f * abs_t / static_cast<float>(max_depth_meters_) : 0.0f;
+    int killed_near = 0, killed_far = 0, total_valid = 0;
+    float d_min_seen = std::numeric_limits<float>::max(), d_max_seen = 0.0f;
+    for (int y = 0; y < img.rows; ++y) {
+        float* row = img.ptr<float>(y);
+        for (int x = 0; x < img.cols; ++x) {
+            float d = row[x];
+            if (d <= 0)
+                continue;
+            total_valid++;
+            if (d < d_min_seen)
+                d_min_seen = d;
+            if (d > d_max_seen)
+                d_max_seen = d;
+            if (d > max_d) {
+                row[x] = 0.0f;
+                killed_near++;
+            } else if (d < min_d) {
+                row[x] = 0.0f;
+                killed_far++;
+            }
+        }
     }
-  }
-  RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
-    "depth_clamp: f=%.2f t=%.5f | min_depth=%.3fm -> max_d=%.1f | max_depth=%.1fm -> min_d=%.1f | "
-    "disp_range=[%.2f, %.2f] | killed: %d near + %d far / %d valid",
-    f, abs_t, min_depth_meters_, max_d, max_depth_meters_, min_d,
-    d_min_seen, d_max_seen, killed_near, killed_far, total_valid);
+    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                         "depth_clamp: f=%.2f t=%.5f | min_depth=%.3fm -> max_d=%.1f | max_depth=%.1fm -> min_d=%.1f | "
+                         "disp_range=[%.2f, %.2f] | killed: %d near + %d far / %d valid",
+                         f, abs_t, min_depth_meters_, max_d, max_depth_meters_, min_d, d_min_seen, d_max_seen,
+                         killed_near, killed_far, total_valid);
 }
 
 // =============================================================================
 // Edge invalidation (Canny + dilation → zero out edge-adjacent disparities)
 // =============================================================================
-void StereoDepthEstimator::invalidateEdges(cv::Mat& img)
-{
-  double mn, mx;
-  cv::minMaxLoc(img, &mn, &mx);
-  if (mx <= 0) return;
-  cv::Mat u8;
-  img.convertTo(u8, CV_8U, 255.0 / mx);
-  cv::GaussianBlur(u8, u8, cv::Size(3, 3), 0.8);
-  cv::Mat edges;
-  cv::Canny(u8, edges, edge_canny_low_, edge_canny_high_);
-  if (edge_inv_width_ > 1) {
-    int k = edge_inv_width_ | 1;
-    cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(k, k));
-    cv::dilate(edges, edges, kernel);
-  }
-  for (int y = 0; y < img.rows; ++y) {
-    float* dr = img.ptr<float>(y);
-    const uchar* er = edges.ptr<uchar>(y);
-    for (int x = 0; x < img.cols; ++x)
-      if (er[x] > 0 && dr[x] > 0) dr[x] = 0.0f;
-  }
+void StereoDepthEstimator::invalidateEdges(cv::Mat& img) {
+    double mn, mx;
+    cv::minMaxLoc(img, &mn, &mx);
+    if (mx <= 0)
+        return;
+    cv::Mat u8;
+    img.convertTo(u8, CV_8U, 255.0 / mx);
+    cv::GaussianBlur(u8, u8, cv::Size(3, 3), 0.8);
+    cv::Mat edges;
+    cv::Canny(u8, edges, edge_canny_low_, edge_canny_high_);
+    if (edge_inv_width_ > 1) {
+        int k = edge_inv_width_ | 1;
+        cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(k, k));
+        cv::dilate(edges, edges, kernel);
+    }
+    for (int y = 0; y < img.rows; ++y) {
+        float* dr = img.ptr<float>(y);
+        const uchar* er = edges.ptr<uchar>(y);
+        for (int x = 0; x < img.cols; ++x)
+            if (er[x] > 0 && dr[x] > 0)
+                dr[x] = 0.0f;
+    }
 }
 
 // =============================================================================
 // Speckle removal (via OpenCV)
 // =============================================================================
-void StereoDepthEstimator::filterSpeckles(cv::Mat& img)
-{
-  const float scale = 16.0f;
-  cv::Mat s16;
-  img.convertTo(s16, CV_16SC1, scale);
-  cv::filterSpeckles(s16, 0, speckle_max_size_, speckle_max_diff_ * scale);
-  s16.convertTo(img, CV_32FC1, 1.0 / scale);
+void StereoDepthEstimator::filterSpeckles(cv::Mat& img) {
+    const float scale = 16.0f;
+    cv::Mat s16;
+    img.convertTo(s16, CV_16SC1, scale);
+    cv::filterSpeckles(s16, 0, speckle_max_size_, speckle_max_diff_ * scale);
+    s16.convertTo(img, CV_32FC1, 1.0 / scale);
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/main_camera_driver.cpp
@@ -3,898 +3,858 @@
 
 using namespace std::chrono_literals;
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
-MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions & options)
-: Node("main_camera_driver", options)
-{
-  // Declare parameters with defaults
-  this->declare_parameter<std::string>("data_directory", "/home/jetson1/innate-os/data");
-  this->declare_parameter<std::string>("camera_symlink", "3D");
-  this->declare_parameter<int>("width", 1280);  // Capture at 1280x480 (640x480 per side)
-  this->declare_parameter<int>("height", 480);
-  this->declare_parameter<int>("publish_left_width", 640);   // Publish left at 640x480
-  this->declare_parameter<int>("publish_left_height", 480);
-  this->declare_parameter<int>("publish_stereo_width", 1280); // Publish stereo at 1280x480
-  this->declare_parameter<int>("publish_stereo_height", 480);
-  this->declare_parameter<double>("fps", 30.0);
-  this->declare_parameter<std::string>("frame_id", "camera_optical_frame");
-  this->declare_parameter<std::string>("right_frame_id", "right_camera_optical_frame");
-  this->declare_parameter<int>("jpeg_quality", 80);
-  this->declare_parameter<bool>("publish_compressed", true);
-  this->declare_parameter<int>("compressed_frame_interval", 3);
-  this->declare_parameter<bool>("publish_stereo", false);  // Combined stereo image for legacy compatibility
-  this->declare_parameter<int>("exposure", -1);  // -1 means use current value
-  this->declare_parameter<int>("gain", -1);      // -1 means use current value
-  this->declare_parameter<int>("default_gain", 110);  // Default gain for auto-exposure mode
-  
-  // Auto exposure parameters
-  this->declare_parameter<int>("auto_exposure_mode", 0);
-  this->declare_parameter<double>("target_brightness", 128.0);
-  this->declare_parameter<double>("ae_kp", 0.8);
-  this->declare_parameter<int>("auto_exposure_update_interval", 3);
+MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions& options) : Node("main_camera_driver", options) {
+    // Declare parameters with defaults
+    this->declare_parameter<std::string>("data_directory", "/home/jetson1/innate-os/data");
+    this->declare_parameter<std::string>("camera_symlink", "3D");
+    this->declare_parameter<int>("width", 1280);  // Capture at 1280x480 (640x480 per side)
+    this->declare_parameter<int>("height", 480);
+    this->declare_parameter<int>("publish_left_width", 640);  // Publish left at 640x480
+    this->declare_parameter<int>("publish_left_height", 480);
+    this->declare_parameter<int>("publish_stereo_width", 1280);  // Publish stereo at 1280x480
+    this->declare_parameter<int>("publish_stereo_height", 480);
+    this->declare_parameter<double>("fps", 30.0);
+    this->declare_parameter<std::string>("frame_id", "camera_optical_frame");
+    this->declare_parameter<std::string>("right_frame_id", "right_camera_optical_frame");
+    this->declare_parameter<int>("jpeg_quality", 80);
+    this->declare_parameter<bool>("publish_compressed", true);
+    this->declare_parameter<int>("compressed_frame_interval", 3);
+    this->declare_parameter<bool>("publish_stereo", false);  // Combined stereo image for legacy compatibility
+    this->declare_parameter<int>("exposure", -1);            // -1 means use current value
+    this->declare_parameter<int>("gain", -1);                // -1 means use current value
+    this->declare_parameter<int>("default_gain", 110);       // Default gain for auto-exposure mode
 
-  // Get parameter values
-  data_directory_ = this->get_parameter("data_directory").as_string();
-  std::string camera_symlink = this->get_parameter("camera_symlink").as_string();
-  capture_width_ = this->get_parameter("width").as_int();
-  capture_height_ = this->get_parameter("height").as_int();
-  publish_left_width_ = this->get_parameter("publish_left_width").as_int();
-  publish_left_height_ = this->get_parameter("publish_left_height").as_int();
-  publish_stereo_width_ = this->get_parameter("publish_stereo_width").as_int();
-  publish_stereo_height_ = this->get_parameter("publish_stereo_height").as_int();
-  fps_ = this->get_parameter("fps").as_double();
-  frame_id_ = this->get_parameter("frame_id").as_string();
-  right_frame_id_ = this->get_parameter("right_frame_id").as_string();
-  jpeg_quality_ = this->get_parameter("jpeg_quality").as_int();
-  publish_compressed_ = this->get_parameter("publish_compressed").as_bool();
-  compressed_frame_interval_ = this->get_parameter("compressed_frame_interval").as_int();
-  publish_stereo_ = this->get_parameter("publish_stereo").as_bool();
-  
-  // Get V4L2 control parameters
-  exposure_setting_ = this->get_parameter("exposure").as_int();
-  gain_setting_ = this->get_parameter("gain").as_int();
-  default_gain_param_ = this->get_parameter("default_gain").as_int();
-  
-  // Get auto exposure parameter values
-  auto_exposure_mode_ = static_cast<AutoExposureMode>(this->get_parameter("auto_exposure_mode").as_int());
-  target_brightness_ = this->get_parameter("target_brightness").as_double();
-  ae_kp_ = this->get_parameter("ae_kp").as_double();
-  auto_exposure_update_interval_ = this->get_parameter("auto_exposure_update_interval").as_int();
+    // Auto exposure parameters
+    this->declare_parameter<int>("auto_exposure_mode", 0);
+    this->declare_parameter<double>("target_brightness", 128.0);
+    this->declare_parameter<double>("ae_kp", 0.8);
+    this->declare_parameter<int>("auto_exposure_update_interval", 3);
 
-  // Find camera symlink by pattern matching
-  std::string camera_pattern = camera_symlink;  // Parameter now contains pattern
-  std::string symlink_path;
-  std::string v4l_dir = "/dev/v4l/by-id/";
-  
-  std::vector<std::string> matching_symlinks;
-  if (std::filesystem::exists(v4l_dir)) {
-    for (const auto& entry : std::filesystem::directory_iterator(v4l_dir)) {
-      std::string filename = entry.path().filename().string();
-      if (filename.find(camera_pattern) != std::string::npos) {
-        matching_symlinks.push_back(entry.path().string());
-      }
-    }
-  }
-  
-  if (matching_symlinks.empty()) {
-    RCLCPP_ERROR(this->get_logger(), "Camera symlink matching pattern '%s' not found in %s", 
-                 camera_pattern.c_str(), v4l_dir.c_str());
-    throw std::runtime_error("Camera symlink not found");
-  }
-  
-  // Prefer -video-index0 if available (typically the capture device)
-  // Otherwise use the first match
-  bool found_index0 = false;
-  for (const auto& symlink : matching_symlinks) {
-    std::string filename = std::filesystem::path(symlink).filename().string();
-    if (filename.find("-video-index0") != std::string::npos) {
-      symlink_path = symlink;
-      found_index0 = true;
-      RCLCPP_INFO(this->get_logger(), "Found camera symlink matching pattern '%s': %s (preferred -video-index0)", 
-                  camera_pattern.c_str(), filename.c_str());
-      break;
-    }
-  }
-  
-  if (!found_index0) {
-    // Fall back to first match
-    symlink_path = matching_symlinks[0];
-    std::string filename = std::filesystem::path(symlink_path).filename().string();
-    RCLCPP_INFO(this->get_logger(), "Found camera symlink matching pattern '%s': %s (no -video-index0 found, using first match)", 
-                camera_pattern.c_str(), filename.c_str());
-  }
-  
-  // Resolve the symlink to get actual device path
-  std::string resolved_path = std::filesystem::read_symlink(symlink_path).string();
-  
-  // Handle relative paths properly
-  if (resolved_path.find("/dev/") == 0) {
-    // Already absolute path
-    camera_device_ = resolved_path;
-  } else {
-    // Relative path, resolve it properly
-    std::filesystem::path symlink_dir = std::filesystem::path(symlink_path).parent_path();
-    std::filesystem::path full_path = std::filesystem::canonical(symlink_dir / resolved_path);
-    camera_device_ = full_path.string();
-  }
+    // Get parameter values
+    data_directory_ = this->get_parameter("data_directory").as_string();
+    std::string camera_symlink = this->get_parameter("camera_symlink").as_string();
+    capture_width_ = this->get_parameter("width").as_int();
+    capture_height_ = this->get_parameter("height").as_int();
+    publish_left_width_ = this->get_parameter("publish_left_width").as_int();
+    publish_left_height_ = this->get_parameter("publish_left_height").as_int();
+    publish_stereo_width_ = this->get_parameter("publish_stereo_width").as_int();
+    publish_stereo_height_ = this->get_parameter("publish_stereo_height").as_int();
+    fps_ = this->get_parameter("fps").as_double();
+    frame_id_ = this->get_parameter("frame_id").as_string();
+    right_frame_id_ = this->get_parameter("right_frame_id").as_string();
+    jpeg_quality_ = this->get_parameter("jpeg_quality").as_int();
+    publish_compressed_ = this->get_parameter("publish_compressed").as_bool();
+    compressed_frame_interval_ = this->get_parameter("compressed_frame_interval").as_int();
+    publish_stereo_ = this->get_parameter("publish_stereo").as_bool();
 
-  // Calculate left image dimensions (half width for stereo camera at publish resolution)
-  // Note: Frame is downscaled in GStreamer pipeline, so left is half of publish_stereo_width
-  left_width_ = publish_stereo_width_ / 2;
-  left_height_ = publish_stereo_height_;
+    // Get V4L2 control parameters
+    exposure_setting_ = this->get_parameter("exposure").as_int();
+    gain_setting_ = this->get_parameter("gain").as_int();
+    default_gain_param_ = this->get_parameter("default_gain").as_int();
 
-  RCLCPP_INFO(this->get_logger(), "=== Maurice Main Camera Driver ===");
-  RCLCPP_INFO(this->get_logger(), "Camera pattern: %s", camera_pattern.c_str());
-  RCLCPP_INFO(this->get_logger(), "Camera symlink: %s", symlink_path.c_str());
-  RCLCPP_INFO(this->get_logger(), "Resolved device: %s", camera_device_.c_str());
-  RCLCPP_INFO(this->get_logger(), "Capture resolution: %dx%d (full FOV)", capture_width_, capture_height_);
-  RCLCPP_INFO(this->get_logger(), "Publish stereo: %dx%d (downscaled in GStreamer)", publish_stereo_width_, publish_stereo_height_);
-  RCLCPP_INFO(this->get_logger(), "Publish left: %dx%d (natural split: %dx%d)", publish_left_width_, publish_left_height_, left_width_, left_height_);
-  RCLCPP_INFO(this->get_logger(), "FPS: %.1f", fps_);
-  RCLCPP_INFO(this->get_logger(), "Frame ID: %s", frame_id_.c_str());
-  RCLCPP_INFO(this->get_logger(), "JPEG Quality: %d", jpeg_quality_);
+    // Get auto exposure parameter values
+    auto_exposure_mode_ = static_cast<AutoExposureMode>(this->get_parameter("auto_exposure_mode").as_int());
+    target_brightness_ = this->get_parameter("target_brightness").as_double();
+    ae_kp_ = this->get_parameter("ae_kp").as_double();
+    auto_exposure_update_interval_ = this->get_parameter("auto_exposure_update_interval").as_int();
 
-  // Initialize publishers
-  left_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
-    "/mars/main_camera/left/image_raw",
-    rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort)
-  );
+    // Find camera symlink by pattern matching
+    std::string camera_pattern = camera_symlink;  // Parameter now contains pattern
+    std::string symlink_path;
+    std::string v4l_dir = "/dev/v4l/by-id/";
 
-  right_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
-    "/mars/main_camera/right/image_raw",
-    rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort)
-  );
-
-  if (publish_compressed_) {
-    compressed_pub_ = this->create_publisher<sensor_msgs::msg::CompressedImage>(
-      "/mars/main_camera/left/image_raw/compressed",
-      rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort)
-    );
-  }
-
-  if (publish_stereo_) {
-    stereo_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
-      "/mars/main_camera/stereo",
-      rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort)
-    );
-  }
-
-  RCLCPP_INFO(this->get_logger(), "Publishers created:");
-  RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/left/image_raw (%dx%d)", left_width_, left_height_);
-  RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/right/image_raw (%dx%d)", left_width_, left_height_);
-  if (publish_compressed_) {
-    RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/left/image_raw/compressed (%dx%d)", left_width_, left_height_);
-  }
-  if (publish_stereo_) {
-    RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/stereo (%dx%d)", publish_stereo_width_, publish_stereo_height_);
-  }
-
-  // Initialize TurboJPEG encoder
-  jpeg_encoder_ = std::make_unique<JpegTurboEncoder>();
-  RCLCPP_INFO(this->get_logger(), "TurboJPEG encoder initialized");
-
-  // Create camera_info publishers (always — calibration may arrive later via file watch)
-  auto sensor_qos = rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort);
-  left_info_pub_  = this->create_publisher<sensor_msgs::msg::CameraInfo>(
-    "/mars/main_camera/left/camera_info", sensor_qos);
-  right_info_pub_ = this->create_publisher<sensor_msgs::msg::CameraInfo>(
-    "/mars/main_camera/right/camera_info", sensor_qos);
-
-  // Load stereo calibration (initial attempt + watch for changes every 3s)
-  checkCalibrationFile();
-  calib_watch_timer_ = this->create_wall_timer(3s,
-    std::bind(&MainCameraDriver::checkCalibrationFile, this));
-
-  // Initialize camera
-  if (initializeCamera()) {
-    camera_initialized_ = true;
-    
-    // Initialize frame timing tracking
-    frame_timestamps_.clear();
-    last_stats_print_ = this->now();
-    
-    // Start frame processing thread
-    frame_thread_running_ = true;
-    frame_thread_ = std::thread(&MainCameraDriver::frameProcessingLoop, this);
-    
-    RCLCPP_INFO(this->get_logger(), "Main camera driver initialized successfully");
-  } else {
-    RCLCPP_ERROR(this->get_logger(), "Failed to initialize main camera");
-    throw std::runtime_error("Main camera initialization failed");
-  }
-}
-
-MainCameraDriver::~MainCameraDriver()
-{
-  RCLCPP_INFO(this->get_logger(), "Shutting down main camera driver...");
-  
-  // Stop frame processing thread
-  if (frame_thread_running_) {
-    frame_thread_running_ = false;
-    if (frame_thread_.joinable()) {
-      frame_thread_.join();
-    }
-  }
-  
-  // Release camera
-  if (cap_.isOpened()) {
-    cap_.release();
-  }
-  
-  // Close V4L2 control file descriptor
-  if (camera_fd_ != -1) {
-    close(camera_fd_);
-    camera_fd_ = -1;
-  }
-  
-  RCLCPP_INFO(this->get_logger(), "Main camera driver shutdown complete");
-}
-
-bool MainCameraDriver::initializeCamera()
-{
-  RCLCPP_DEBUG(this->get_logger(), "Initializing main camera...");
-  
-  // Check if device exists
-  if (!std::filesystem::exists(camera_device_)) {
-    RCLCPP_ERROR(this->get_logger(), "Camera device not found: %s", camera_device_.c_str());
-    return false;
-  }
-
-  // Create GStreamer pipeline
-  std::string pipeline = createGStreamerPipeline();
-  RCLCPP_DEBUG(this->get_logger(), "GStreamer pipeline: %s", pipeline.c_str());
-
-  // Open camera with GStreamer backend
-  cap_.open(pipeline, cv::CAP_GSTREAMER);
-  
-  if (!cap_.isOpened()) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to open camera with GStreamer");
-    return false;
-  }
-
-  // Verify camera settings
-  int actual_width = static_cast<int>(cap_.get(cv::CAP_PROP_FRAME_WIDTH));
-  int actual_height = static_cast<int>(cap_.get(cv::CAP_PROP_FRAME_HEIGHT));
-  double actual_fps = cap_.get(cv::CAP_PROP_FPS);
-  
-  RCLCPP_DEBUG(this->get_logger(), "Camera opened successfully:");
-  RCLCPP_DEBUG(this->get_logger(), "  Actual resolution: %dx%d", actual_width, actual_height);
-  RCLCPP_DEBUG(this->get_logger(), "  Actual FPS: %.1f", actual_fps);
-
-  if (actual_width != capture_width_ || actual_height != capture_height_) {
-    RCLCPP_WARN(this->get_logger(), 
-      "Resolution mismatch! Requested: %dx%d, Got: %dx%d",
-      capture_width_, capture_height_, actual_width, actual_height);
-  }
-
-  // Initialize V4L2 controls
-  if (!initializeV4L2Controls()) {
-    RCLCPP_WARN(this->get_logger(), "Failed to initialize V4L2 controls, using default settings");
-  } else {
-    // Configure V4L2 and initialize AE controller based on mode
-    switch (auto_exposure_mode_) {
-      case AutoExposureMode::HARDWARE:
-        // Camera built-in AE (aperture priority) — no PID, reset gain to default
-        if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_APERTURE_PRIORITY)) {
-          RCLCPP_DEBUG(this->get_logger(), "AE mode: HARDWARE (aperture priority)");
-          if (setV4L2Control(V4L2_CID_GAIN, default_gain_param_)) {
-            current_gain_ = default_gain_param_;
-            RCLCPP_DEBUG(this->get_logger(), "Reset gain to default: %d", default_gain_param_);
-          }
+    std::vector<std::string> matching_symlinks;
+    if (std::filesystem::exists(v4l_dir)) {
+        for (const auto& entry : std::filesystem::directory_iterator(v4l_dir)) {
+            std::string filename = entry.path().filename().string();
+            if (filename.find(camera_pattern) != std::string::npos) {
+                matching_symlinks.push_back(entry.path().string());
+            }
         }
-        break;
+    }
 
-      case AutoExposureMode::CUSTOM_PID:
-        // Custom PID AE — set V4L2 manual mode, initialize and run PID controller
-        if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL)) {
-          RCLCPP_DEBUG(this->get_logger(), "AE mode: CUSTOM_PID (manual V4L2 + PID controller)");
+    if (matching_symlinks.empty()) {
+        RCLCPP_ERROR(this->get_logger(), "Camera symlink matching pattern '%s' not found in %s", camera_pattern.c_str(),
+                     v4l_dir.c_str());
+        throw std::runtime_error("Camera symlink not found");
+    }
+
+    // Prefer -video-index0 if available (typically the capture device)
+    // Otherwise use the first match
+    bool found_index0 = false;
+    for (const auto& symlink : matching_symlinks) {
+        std::string filename = std::filesystem::path(symlink).filename().string();
+        if (filename.find("-video-index0") != std::string::npos) {
+            symlink_path = symlink;
+            found_index0 = true;
+            RCLCPP_INFO(this->get_logger(), "Found camera symlink matching pattern '%s': %s (preferred -video-index0)",
+                        camera_pattern.c_str(), filename.c_str());
+            break;
         }
-        auto_exposure_controller_.initialize(exposure_min_, exposure_max_,
-                                             target_brightness_, ae_kp_);
-        RCLCPP_DEBUG(this->get_logger(), "Auto exposure controller initialized:");
-        RCLCPP_DEBUG(this->get_logger(), "  Target brightness: %.1f", target_brightness_);
-        RCLCPP_DEBUG(this->get_logger(), "  Proportional gain: Kp=%.2f", ae_kp_);
-        RCLCPP_DEBUG(this->get_logger(), "  Update interval: every %d frames (%.1f Hz)",
-                    auto_exposure_update_interval_, fps_ / auto_exposure_update_interval_);
-        break;
+    }
 
-      case AutoExposureMode::MANUAL:
-        // Pure manual — set V4L2 manual mode, no PID controller
-        if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL)) {
-          RCLCPP_DEBUG(this->get_logger(), "AE mode: MANUAL (pure manual, no PID)");
+    if (!found_index0) {
+        // Fall back to first match
+        symlink_path = matching_symlinks[0];
+        std::string filename = std::filesystem::path(symlink_path).filename().string();
+        RCLCPP_INFO(this->get_logger(),
+                    "Found camera symlink matching pattern '%s': %s (no -video-index0 found, using first match)",
+                    camera_pattern.c_str(), filename.c_str());
+    }
+
+    // Resolve the symlink to get actual device path
+    std::string resolved_path = std::filesystem::read_symlink(symlink_path).string();
+
+    // Handle relative paths properly
+    if (resolved_path.find("/dev/") == 0) {
+        // Already absolute path
+        camera_device_ = resolved_path;
+    } else {
+        // Relative path, resolve it properly
+        std::filesystem::path symlink_dir = std::filesystem::path(symlink_path).parent_path();
+        std::filesystem::path full_path = std::filesystem::canonical(symlink_dir / resolved_path);
+        camera_device_ = full_path.string();
+    }
+
+    // Calculate left image dimensions (half width for stereo camera at publish resolution)
+    // Note: Frame is downscaled in GStreamer pipeline, so left is half of publish_stereo_width
+    left_width_ = publish_stereo_width_ / 2;
+    left_height_ = publish_stereo_height_;
+
+    RCLCPP_INFO(this->get_logger(), "=== Maurice Main Camera Driver ===");
+    RCLCPP_INFO(this->get_logger(), "Camera pattern: %s", camera_pattern.c_str());
+    RCLCPP_INFO(this->get_logger(), "Camera symlink: %s", symlink_path.c_str());
+    RCLCPP_INFO(this->get_logger(), "Resolved device: %s", camera_device_.c_str());
+    RCLCPP_INFO(this->get_logger(), "Capture resolution: %dx%d (full FOV)", capture_width_, capture_height_);
+    RCLCPP_INFO(this->get_logger(), "Publish stereo: %dx%d (downscaled in GStreamer)", publish_stereo_width_,
+                publish_stereo_height_);
+    RCLCPP_INFO(this->get_logger(), "Publish left: %dx%d (natural split: %dx%d)", publish_left_width_,
+                publish_left_height_, left_width_, left_height_);
+    RCLCPP_INFO(this->get_logger(), "FPS: %.1f", fps_);
+    RCLCPP_INFO(this->get_logger(), "Frame ID: %s", frame_id_.c_str());
+    RCLCPP_INFO(this->get_logger(), "JPEG Quality: %d", jpeg_quality_);
+
+    // Initialize publishers
+    left_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
+        "/mars/main_camera/left/image_raw", rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort));
+
+    right_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
+        "/mars/main_camera/right/image_raw",
+        rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort));
+
+    if (publish_compressed_) {
+        compressed_pub_ = this->create_publisher<sensor_msgs::msg::CompressedImage>(
+            "/mars/main_camera/left/image_raw/compressed",
+            rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort));
+    }
+
+    if (publish_stereo_) {
+        stereo_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
+            "/mars/main_camera/stereo", rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort));
+    }
+
+    RCLCPP_INFO(this->get_logger(), "Publishers created:");
+    RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/left/image_raw (%dx%d)", left_width_, left_height_);
+    RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/right/image_raw (%dx%d)", left_width_, left_height_);
+    if (publish_compressed_) {
+        RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/left/image_raw/compressed (%dx%d)", left_width_,
+                    left_height_);
+    }
+    if (publish_stereo_) {
+        RCLCPP_INFO(this->get_logger(), "  - /mars/main_camera/stereo (%dx%d)", publish_stereo_width_,
+                    publish_stereo_height_);
+    }
+
+    // Initialize TurboJPEG encoder
+    jpeg_encoder_ = std::make_unique<JpegTurboEncoder>();
+    RCLCPP_INFO(this->get_logger(), "TurboJPEG encoder initialized");
+
+    // Create camera_info publishers (always — calibration may arrive later via file watch)
+    auto sensor_qos = rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort);
+    left_info_pub_ =
+        this->create_publisher<sensor_msgs::msg::CameraInfo>("/mars/main_camera/left/camera_info", sensor_qos);
+    right_info_pub_ =
+        this->create_publisher<sensor_msgs::msg::CameraInfo>("/mars/main_camera/right/camera_info", sensor_qos);
+
+    // Load stereo calibration (initial attempt + watch for changes every 3s)
+    checkCalibrationFile();
+    calib_watch_timer_ = this->create_wall_timer(3s, std::bind(&MainCameraDriver::checkCalibrationFile, this));
+
+    // Initialize camera
+    if (initializeCamera()) {
+        camera_initialized_ = true;
+
+        // Initialize frame timing tracking
+        frame_timestamps_.clear();
+        last_stats_print_ = this->now();
+
+        // Start frame processing thread
+        frame_thread_running_ = true;
+        frame_thread_ = std::thread(&MainCameraDriver::frameProcessingLoop, this);
+
+        RCLCPP_INFO(this->get_logger(), "Main camera driver initialized successfully");
+    } else {
+        RCLCPP_ERROR(this->get_logger(), "Failed to initialize main camera");
+        throw std::runtime_error("Main camera initialization failed");
+    }
+}
+
+MainCameraDriver::~MainCameraDriver() {
+    RCLCPP_INFO(this->get_logger(), "Shutting down main camera driver...");
+
+    // Stop frame processing thread
+    if (frame_thread_running_) {
+        frame_thread_running_ = false;
+        if (frame_thread_.joinable()) {
+            frame_thread_.join();
         }
-        break;
     }
-    
-    if (exposure_setting_ >= 0) {
-      if (setV4L2Control(V4L2_CID_EXPOSURE_ABSOLUTE, exposure_setting_)) {
-        current_exposure_ = exposure_setting_;
-        RCLCPP_DEBUG(this->get_logger(), "Set exposure to %d", exposure_setting_);
-      }
+
+    // Release camera
+    if (cap_.isOpened()) {
+        cap_.release();
     }
-    
-    if (gain_setting_ >= 0) {
-      if (setV4L2Control(V4L2_CID_GAIN, gain_setting_)) {
-        current_gain_ = gain_setting_;
-        RCLCPP_DEBUG(this->get_logger(), "Set gain to %d", gain_setting_);
-      }
+
+    // Close V4L2 control file descriptor
+    if (camera_fd_ != -1) {
+        close(camera_fd_);
+        camera_fd_ = -1;
     }
-  }
 
-  return true;
+    RCLCPP_INFO(this->get_logger(), "Main camera driver shutdown complete");
 }
 
-std::string MainCameraDriver::createGStreamerPipeline()
-{
-  // Use MJPG format for better performance with this camera
-  // Pipeline: capture at full resolution, then downscale in GStreamer (hardware accelerated)
-  // appsink properties:
-  //   max-buffers=1  - Only keep 1 frame in queue (always get newest)
-  //   drop=true      - Drop old frames if queue is full (prevents memory buildup)
-  //   sync=false     - Don't sync to clock (process as fast as possible)
-  
-  // For Jetson, use nvv4l2decoder for hardware JPEG decode (NVDEC engine) and
-  // nvvidconv for hardware-accelerated scaling and rotation (VIC engine).
-  // The two NVIDIA elements communicate via NVMM zero-copy buffers.
-  // flip-method=2 rotates 180 degrees, interpolation-method=4 uses Smart interpolation
-  // videoconvert handles final BGRx→BGR for OpenCV.
-  std::string pipeline = 
-    "v4l2src device=" + camera_device_ + " io-mode=2 do-timestamp=true ! "
-    "image/jpeg,width=" + std::to_string(capture_width_) + 
-    ",height=" + std::to_string(capture_height_) + 
-    ",framerate=" + std::to_string(static_cast<int>(fps_)) + "/1 ! "
-    "nvv4l2decoder mjpeg=true ! "
-    "nvvidconv flip-method=2 interpolation-method=4 ! "
-    "video/x-raw,width=" + std::to_string(publish_stereo_width_) + 
-    ",height=" + std::to_string(publish_stereo_height_) + ",format=BGRx ! "
-    "videoconvert ! video/x-raw,format=BGR ! "
-    "appsink max-buffers=1 drop=true sync=false";
-  
-  // Alternative pipeline using videoscale (fallback if nvvidconv fails):
-  // "v4l2src device=" + camera_device_ + " io-mode=2 do-timestamp=true ! "
-  // "image/jpeg,width=" + std::to_string(capture_width_) + 
-  // ",height=" + std::to_string(capture_height_) + 
-  // ",framerate=" + std::to_string(static_cast<int>(fps_)) + "/1 ! "
-  // "jpegdec ! "
-  // "videoscale ! "
-  // "video/x-raw,width=" + std::to_string(publish_stereo_width_) + 
-  // ",height=" + std::to_string(publish_stereo_height_) + " ! "
-  // "videoconvert ! video/x-raw,format=BGR ! "
-  // "appsink max-buffers=1 drop=true sync=false";
-  // Note: Rotation would need to be done in OpenCV with this fallback
-  
-  return pipeline;
+bool MainCameraDriver::initializeCamera() {
+    RCLCPP_DEBUG(this->get_logger(), "Initializing main camera...");
+
+    // Check if device exists
+    if (!std::filesystem::exists(camera_device_)) {
+        RCLCPP_ERROR(this->get_logger(), "Camera device not found: %s", camera_device_.c_str());
+        return false;
+    }
+
+    // Create GStreamer pipeline
+    std::string pipeline = createGStreamerPipeline();
+    RCLCPP_DEBUG(this->get_logger(), "GStreamer pipeline: %s", pipeline.c_str());
+
+    // Open camera with GStreamer backend
+    cap_.open(pipeline, cv::CAP_GSTREAMER);
+
+    if (!cap_.isOpened()) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to open camera with GStreamer");
+        return false;
+    }
+
+    // Verify camera settings
+    int actual_width = static_cast<int>(cap_.get(cv::CAP_PROP_FRAME_WIDTH));
+    int actual_height = static_cast<int>(cap_.get(cv::CAP_PROP_FRAME_HEIGHT));
+    double actual_fps = cap_.get(cv::CAP_PROP_FPS);
+
+    RCLCPP_DEBUG(this->get_logger(), "Camera opened successfully:");
+    RCLCPP_DEBUG(this->get_logger(), "  Actual resolution: %dx%d", actual_width, actual_height);
+    RCLCPP_DEBUG(this->get_logger(), "  Actual FPS: %.1f", actual_fps);
+
+    if (actual_width != capture_width_ || actual_height != capture_height_) {
+        RCLCPP_WARN(this->get_logger(), "Resolution mismatch! Requested: %dx%d, Got: %dx%d", capture_width_,
+                    capture_height_, actual_width, actual_height);
+    }
+
+    // Initialize V4L2 controls
+    if (!initializeV4L2Controls()) {
+        RCLCPP_WARN(this->get_logger(), "Failed to initialize V4L2 controls, using default settings");
+    } else {
+        // Configure V4L2 and initialize AE controller based on mode
+        switch (auto_exposure_mode_) {
+            case AutoExposureMode::HARDWARE:
+                // Camera built-in AE (aperture priority) — no PID, reset gain to default
+                if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_APERTURE_PRIORITY)) {
+                    RCLCPP_DEBUG(this->get_logger(), "AE mode: HARDWARE (aperture priority)");
+                    if (setV4L2Control(V4L2_CID_GAIN, default_gain_param_)) {
+                        current_gain_ = default_gain_param_;
+                        RCLCPP_DEBUG(this->get_logger(), "Reset gain to default: %d", default_gain_param_);
+                    }
+                }
+                break;
+
+            case AutoExposureMode::CUSTOM_PID:
+                // Custom PID AE — set V4L2 manual mode, initialize and run PID controller
+                if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL)) {
+                    RCLCPP_DEBUG(this->get_logger(), "AE mode: CUSTOM_PID (manual V4L2 + PID controller)");
+                }
+                auto_exposure_controller_.initialize(exposure_min_, exposure_max_, target_brightness_, ae_kp_);
+                RCLCPP_DEBUG(this->get_logger(), "Auto exposure controller initialized:");
+                RCLCPP_DEBUG(this->get_logger(), "  Target brightness: %.1f", target_brightness_);
+                RCLCPP_DEBUG(this->get_logger(), "  Proportional gain: Kp=%.2f", ae_kp_);
+                RCLCPP_DEBUG(this->get_logger(), "  Update interval: every %d frames (%.1f Hz)",
+                             auto_exposure_update_interval_, fps_ / auto_exposure_update_interval_);
+                break;
+
+            case AutoExposureMode::MANUAL:
+                // Pure manual — set V4L2 manual mode, no PID controller
+                if (setV4L2Control(V4L2_CID_EXPOSURE_AUTO, V4L2_EXPOSURE_MANUAL)) {
+                    RCLCPP_DEBUG(this->get_logger(), "AE mode: MANUAL (pure manual, no PID)");
+                }
+                break;
+        }
+
+        if (exposure_setting_ >= 0) {
+            if (setV4L2Control(V4L2_CID_EXPOSURE_ABSOLUTE, exposure_setting_)) {
+                current_exposure_ = exposure_setting_;
+                RCLCPP_DEBUG(this->get_logger(), "Set exposure to %d", exposure_setting_);
+            }
+        }
+
+        if (gain_setting_ >= 0) {
+            if (setV4L2Control(V4L2_CID_GAIN, gain_setting_)) {
+                current_gain_ = gain_setting_;
+                RCLCPP_DEBUG(this->get_logger(), "Set gain to %d", gain_setting_);
+            }
+        }
+    }
+
+    return true;
 }
 
-bool MainCameraDriver::initializeV4L2Controls()
-{
-  RCLCPP_DEBUG(this->get_logger(), "Initializing V4L2 controls...");
-  
-  // Open camera device for control access
-  camera_fd_ = open(camera_device_.c_str(), O_RDWR);
-  if (camera_fd_ == -1) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to open camera for V4L2 controls: %s", 
-                 strerror(errno));
-    return false;
-  }
-  
-  // Get exposure control range
-  struct v4l2_queryctrl qctrl;
-  qctrl.id = V4L2_CID_EXPOSURE_ABSOLUTE;
-  if (ioctl(camera_fd_, VIDIOC_QUERYCTRL, &qctrl) == 0) {
-    exposure_min_ = qctrl.minimum;
-    exposure_max_ = qctrl.maximum;
-    RCLCPP_DEBUG(this->get_logger(), "Exposure range: %d - %d", exposure_min_, exposure_max_);
-  } else {
-    RCLCPP_WARN(this->get_logger(), "Failed to query exposure control");
-    exposure_min_ = 1;
-    exposure_max_ = 10000;
-  }
-  
-  // Get gain control range
-  qctrl.id = V4L2_CID_GAIN;
-  if (ioctl(camera_fd_, VIDIOC_QUERYCTRL, &qctrl) == 0) {
-    gain_min_ = qctrl.minimum;
-    gain_max_ = qctrl.maximum;
-    RCLCPP_DEBUG(this->get_logger(), "Gain range: %d - %d", gain_min_, gain_max_);
-  } else {
-    RCLCPP_WARN(this->get_logger(), "Failed to query gain control");
-    gain_min_ = 0;
-    gain_max_ = 255;
-  }
-  
-  // Get current values
-  current_exposure_ = getV4L2Control(V4L2_CID_EXPOSURE_ABSOLUTE);
-  current_gain_ = getV4L2Control(V4L2_CID_GAIN);
-  
-  RCLCPP_DEBUG(this->get_logger(), "Current exposure: %d, gain: %d", current_exposure_, current_gain_);
-  
-  v4l2_controls_initialized_ = true;
-  RCLCPP_DEBUG(this->get_logger(), "V4L2 controls initialized successfully");
-  
-  return true;
+std::string MainCameraDriver::createGStreamerPipeline() {
+    // Use MJPG format for better performance with this camera
+    // Pipeline: capture at full resolution, then downscale in GStreamer (hardware accelerated)
+    // appsink properties:
+    //   max-buffers=1  - Only keep 1 frame in queue (always get newest)
+    //   drop=true      - Drop old frames if queue is full (prevents memory buildup)
+    //   sync=false     - Don't sync to clock (process as fast as possible)
+
+    // For Jetson, use nvv4l2decoder for hardware JPEG decode (NVDEC engine) and
+    // nvvidconv for hardware-accelerated scaling and rotation (VIC engine).
+    // The two NVIDIA elements communicate via NVMM zero-copy buffers.
+    // flip-method=2 rotates 180 degrees, interpolation-method=4 uses Smart interpolation
+    // videoconvert handles final BGRx→BGR for OpenCV.
+    std::string pipeline = "v4l2src device=" + camera_device_ +
+                           " io-mode=2 do-timestamp=true ! "
+                           "image/jpeg,width=" +
+                           std::to_string(capture_width_) + ",height=" + std::to_string(capture_height_) +
+                           ",framerate=" + std::to_string(static_cast<int>(fps_)) +
+                           "/1 ! "
+                           "nvv4l2decoder mjpeg=true ! "
+                           "nvvidconv flip-method=2 interpolation-method=4 ! "
+                           "video/x-raw,width=" +
+                           std::to_string(publish_stereo_width_) + ",height=" + std::to_string(publish_stereo_height_) +
+                           ",format=BGRx ! "
+                           "videoconvert ! video/x-raw,format=BGR ! "
+                           "appsink max-buffers=1 drop=true sync=false";
+
+    // Alternative pipeline using videoscale (fallback if nvvidconv fails):
+    // "v4l2src device=" + camera_device_ + " io-mode=2 do-timestamp=true ! "
+    // "image/jpeg,width=" + std::to_string(capture_width_) +
+    // ",height=" + std::to_string(capture_height_) +
+    // ",framerate=" + std::to_string(static_cast<int>(fps_)) + "/1 ! "
+    // "jpegdec ! "
+    // "videoscale ! "
+    // "video/x-raw,width=" + std::to_string(publish_stereo_width_) +
+    // ",height=" + std::to_string(publish_stereo_height_) + " ! "
+    // "videoconvert ! video/x-raw,format=BGR ! "
+    // "appsink max-buffers=1 drop=true sync=false";
+    // Note: Rotation would need to be done in OpenCV with this fallback
+
+    return pipeline;
 }
 
-bool MainCameraDriver::setV4L2Control(int control_id, int value)
-{
-  if (camera_fd_ == -1) {
-    RCLCPP_WARN(this->get_logger(), "Camera file descriptor not open");
-    return false;
-  }
-  
-  struct v4l2_control ctrl;
-  ctrl.id = control_id;
-  ctrl.value = value;
-  
-  if (ioctl(camera_fd_, VIDIOC_S_CTRL, &ctrl) == -1) {
-    RCLCPP_WARN(this->get_logger(), "Failed to set control %d to %d: %s", 
-                control_id, value, strerror(errno));
-    return false;
-  }
-  
-  return true;
+bool MainCameraDriver::initializeV4L2Controls() {
+    RCLCPP_DEBUG(this->get_logger(), "Initializing V4L2 controls...");
+
+    // Open camera device for control access
+    camera_fd_ = open(camera_device_.c_str(), O_RDWR);
+    if (camera_fd_ == -1) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to open camera for V4L2 controls: %s", strerror(errno));
+        return false;
+    }
+
+    // Get exposure control range
+    struct v4l2_queryctrl qctrl;
+    qctrl.id = V4L2_CID_EXPOSURE_ABSOLUTE;
+    if (ioctl(camera_fd_, VIDIOC_QUERYCTRL, &qctrl) == 0) {
+        exposure_min_ = qctrl.minimum;
+        exposure_max_ = qctrl.maximum;
+        RCLCPP_DEBUG(this->get_logger(), "Exposure range: %d - %d", exposure_min_, exposure_max_);
+    } else {
+        RCLCPP_WARN(this->get_logger(), "Failed to query exposure control");
+        exposure_min_ = 1;
+        exposure_max_ = 10000;
+    }
+
+    // Get gain control range
+    qctrl.id = V4L2_CID_GAIN;
+    if (ioctl(camera_fd_, VIDIOC_QUERYCTRL, &qctrl) == 0) {
+        gain_min_ = qctrl.minimum;
+        gain_max_ = qctrl.maximum;
+        RCLCPP_DEBUG(this->get_logger(), "Gain range: %d - %d", gain_min_, gain_max_);
+    } else {
+        RCLCPP_WARN(this->get_logger(), "Failed to query gain control");
+        gain_min_ = 0;
+        gain_max_ = 255;
+    }
+
+    // Get current values
+    current_exposure_ = getV4L2Control(V4L2_CID_EXPOSURE_ABSOLUTE);
+    current_gain_ = getV4L2Control(V4L2_CID_GAIN);
+
+    RCLCPP_DEBUG(this->get_logger(), "Current exposure: %d, gain: %d", current_exposure_, current_gain_);
+
+    v4l2_controls_initialized_ = true;
+    RCLCPP_DEBUG(this->get_logger(), "V4L2 controls initialized successfully");
+
+    return true;
 }
 
-int MainCameraDriver::getV4L2Control(int control_id)
-{
-  if (camera_fd_ == -1) {
-    RCLCPP_WARN(this->get_logger(), "Camera file descriptor not open");
-    return -1;
-  }
-  
-  struct v4l2_control ctrl;
-  ctrl.id = control_id;
-  
-  if (ioctl(camera_fd_, VIDIOC_G_CTRL, &ctrl) == -1) {
-    RCLCPP_WARN(this->get_logger(), "Failed to get control %d: %s", 
-                control_id, strerror(errno));
-    return -1;
-  }
-  
-  return ctrl.value;
+bool MainCameraDriver::setV4L2Control(int control_id, int value) {
+    if (camera_fd_ == -1) {
+        RCLCPP_WARN(this->get_logger(), "Camera file descriptor not open");
+        return false;
+    }
+
+    struct v4l2_control ctrl;
+    ctrl.id = control_id;
+    ctrl.value = value;
+
+    if (ioctl(camera_fd_, VIDIOC_S_CTRL, &ctrl) == -1) {
+        RCLCPP_WARN(this->get_logger(), "Failed to set control %d to %d: %s", control_id, value, strerror(errno));
+        return false;
+    }
+
+    return true;
 }
 
-void MainCameraDriver::frameProcessingLoop()
-{
-  RCLCPP_INFO(this->get_logger(), "Frame processing loop started");
-  
-  cv::Mat frame;
-  
-  while (frame_thread_running_ && rclcpp::ok()) {
+int MainCameraDriver::getV4L2Control(int control_id) {
+    if (camera_fd_ == -1) {
+        RCLCPP_WARN(this->get_logger(), "Camera file descriptor not open");
+        return -1;
+    }
+
+    struct v4l2_control ctrl;
+    ctrl.id = control_id;
+
+    if (ioctl(camera_fd_, VIDIOC_G_CTRL, &ctrl) == -1) {
+        RCLCPP_WARN(this->get_logger(), "Failed to get control %d: %s", control_id, strerror(errno));
+        return -1;
+    }
+
+    return ctrl.value;
+}
+
+void MainCameraDriver::frameProcessingLoop() {
+    RCLCPP_INFO(this->get_logger(), "Frame processing loop started");
+
+    cv::Mat frame;
+
+    while (frame_thread_running_ && rclcpp::ok()) {
+        try {
+            // Capture frame
+            bool success = cap_.read(frame);
+
+            if (!success || frame.empty()) {
+                RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Failed to capture frame");
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                continue;
+            }
+
+            // Increment frame counter
+            frame_count_++;
+
+            // Process and publish frame
+            processAndPublishFrame(frame);
+
+            // Update statistics and log every 1000 frames (~33 seconds at 30 fps)
+            updateFrameStats();
+            if (frame_count_ % 1000 == 0) {
+                printFrameStats();
+            }
+
+        } catch (const std::exception& e) {
+            RCLCPP_ERROR(this->get_logger(), "Error in frame processing: %s", e.what());
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    }
+
+    RCLCPP_INFO(this->get_logger(), "Frame processing loop ended");
+}
+
+void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame) {
+    auto current_time = this->now();
+
+    // Frame is already rotated and downscaled to publish_stereo_width x publish_stereo_height by GStreamer
+    // Verify dimensions match expected publish resolution
+    if (static_cast<int>(frame.cols) != publish_stereo_width_ ||
+        static_cast<int>(frame.rows) != publish_stereo_height_) {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                             "Frame size mismatch: got %dx%d, expected %dx%d", frame.cols, frame.rows,
+                             publish_stereo_width_, publish_stereo_height_);
+        return;
+    }
+
+    // Apply auto exposure control (frame is already rotated and downscaled)
+    if (auto_exposure_mode_ == AutoExposureMode::CUSTOM_PID && v4l2_controls_initialized_) {
+        frame_counter_++;
+        if (frame_counter_ >= auto_exposure_update_interval_) {
+            // Use left half of the already-downscaled frame
+            cv::Mat left_roi_for_ae = frame(cv::Rect(0, 0, publish_stereo_width_ / 2, publish_stereo_height_));
+            applyAutoExposure(left_roi_for_ae);
+            frame_counter_ = 0;
+        }
+    }
+
+    // -------------------------
+    // (A1) Stereo msg: Frame is already at publish_stereo_width x publish_stereo_height
+    // -------------------------
+    auto stereo_msg = std::make_unique<sensor_msgs::msg::Image>();
+    stereo_msg->header.stamp = current_time;
+    stereo_msg->header.frame_id = frame_id_;
+    stereo_msg->height = publish_stereo_height_;
+    stereo_msg->width = publish_stereo_width_;
+    stereo_msg->encoding = "bgr8";
+    stereo_msg->is_bigendian = false;
+    stereo_msg->step = publish_stereo_width_ * 3;
+    stereo_msg->data.resize(stereo_msg->height * stereo_msg->step);
+
+    // Wrap the ROS message data buffer as a cv::Mat view
+    cv::Mat stereo_out(publish_stereo_height_, publish_stereo_width_, CV_8UC3, stereo_msg->data.data(),
+                       stereo_msg->step);
+
+    // Copy frame directly (already rotated and downscaled by GStreamer)
+    // Ensure frame is BGR format (GStreamer might output RGB)
+    if (frame.type() == CV_8UC3) {
+        // Check if we need to convert RGB to BGR
+        // GStreamer videoconvert typically outputs BGR, but verify
+        frame.copyTo(stereo_out);
+    } else {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                             "Unexpected frame type: %d, expected CV_8UC3", frame.type());
+        return;
+    }
+
+    // -------------------------
+    // (A2) Left ROI view from frame (already at publish resolution)
+    // After 180° rotation in GStreamer, original right half appears on the left half.
+    // -------------------------
+    cv::Rect left_roi(0, 0, left_width_, left_height_);
+    cv::Mat left_view = stereo_out(left_roi);  // Use stereo_out which is guaranteed BGR
+
+    // -------------------------
+    // (A3) Left msg: Use publish_left_width x publish_left_height, scale only if needed
+    // -------------------------
+    auto left_msg = std::make_unique<sensor_msgs::msg::Image>();
+    left_msg->header.stamp = current_time;
+    left_msg->header.frame_id = frame_id_;
+    left_msg->height = publish_left_height_;
+    left_msg->width = publish_left_width_;
+    left_msg->encoding = "bgr8";
+    left_msg->is_bigendian = false;
+    left_msg->step = publish_left_width_ * 3;
+    left_msg->data.resize(left_msg->height * left_msg->step);
+
+    // Wrap left ROS message buffer as cv::Mat view
+    cv::Mat left_out(publish_left_height_, publish_left_width_, CV_8UC3, left_msg->data.data(), left_msg->step);
+
+    // Only resize if the natural split size doesn't match the requested publish size
+    if (left_width_ == publish_left_width_ && left_height_ == publish_left_height_) {
+        // No scaling needed, copy directly
+        left_view.copyTo(left_out);
+    } else {
+        // Scale to requested size
+        cv::resize(left_view, left_out, cv::Size(publish_left_width_, publish_left_height_), 0, 0, cv::INTER_LINEAR);
+    }
+
+    // -------------------------
+    // (A4) Right ROI view and msg
+    // -------------------------
+    cv::Rect right_roi(left_width_, 0, left_width_, left_height_);
+    cv::Mat right_view = stereo_out(right_roi);
+
+    auto right_msg = std::make_unique<sensor_msgs::msg::Image>();
+    right_msg->header.stamp = current_time;
+    right_msg->header.frame_id = right_frame_id_;
+    right_msg->height = publish_left_height_;
+    right_msg->width = publish_left_width_;
+    right_msg->encoding = "bgr8";
+    right_msg->is_bigendian = false;
+    right_msg->step = publish_left_width_ * 3;
+    right_msg->data.resize(right_msg->height * right_msg->step);
+
+    cv::Mat right_out(publish_left_height_, publish_left_width_, CV_8UC3, right_msg->data.data(), right_msg->step);
+
+    if (left_width_ == publish_left_width_ && left_height_ == publish_left_height_) {
+        right_view.copyTo(right_out);
+    } else {
+        cv::resize(right_view, right_out, cv::Size(publish_left_width_, publish_left_height_), 0, 0, cv::INTER_LINEAR);
+    }
+
+    // -------------------------
+    // Publish with std::move() for zero-copy intra-process communication
+    // Inter-process subscribers (via DDS) still receive serialized copies automatically
+    // -------------------------
+    if (publish_stereo_) {
+        stereo_pub_->publish(std::move(stereo_msg));
+    }
+    left_pub_->publish(std::move(left_msg));
+    right_pub_->publish(std::move(right_msg));
+
+    // Publish camera_info with same timestamp
+    {
+        std::lock_guard<std::mutex> lock(calib_mutex_);
+        if (calibration_loaded_) {
+            left_info_msg_.header.stamp = current_time;
+            right_info_msg_.header.stamp = current_time;
+            left_info_pub_->publish(left_info_msg_);
+            right_info_pub_->publish(right_info_msg_);
+        }
+    }
+
+    // Conditionally create and publish compressed image at specified interval
+    if (publish_compressed_) {
+        compressed_frame_counter_++;
+        if (compressed_frame_counter_ >= compressed_frame_interval_) {
+            compressed_frame_counter_ = 0;
+
+            auto left_compressed_msg = std::make_unique<sensor_msgs::msg::CompressedImage>();
+            left_compressed_msg->header.stamp = current_time;
+            left_compressed_msg->header.frame_id = frame_id_;
+            left_compressed_msg->format = "jpeg";
+
+            // Encode from the left view using TurboJPEG
+            try {
+                if (left_view.type() == CV_8UC3 && left_view.channels() == 3) {
+                    jpeg_encoder_->encodeBGR(left_view, jpeg_quality_, left_compressed_msg->data);
+                    compressed_pub_->publish(std::move(left_compressed_msg));
+                } else {
+                    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                                         "Left image format invalid for JPEG encoding: type=%d, channels=%d",
+                                         left_view.type(), left_view.channels());
+                }
+            } catch (const std::exception& e) {
+                RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000, "JPEG turbo encode failed: %s",
+                                     e.what());
+            }
+        }
+    }
+}
+
+void MainCameraDriver::applyAutoExposure(const cv::Mat& frame) {
+    // Calculate new exposure value using PID controller
+    int new_exposure = auto_exposure_controller_.calculateExposure(frame, current_exposure_);
+
+    // Only update if there's a meaningful change
+    if (abs(new_exposure - current_exposure_) > 5) {
+        if (setV4L2Control(V4L2_CID_EXPOSURE_ABSOLUTE, new_exposure)) {
+            current_exposure_ = new_exposure;
+            RCLCPP_INFO(this->get_logger(), "Auto exposure: %d -> %d", current_exposure_, new_exposure);
+        }
+    }
+}
+
+void MainCameraDriver::updateFrameStats() {
+    auto current_time = this->now();
+    frame_timestamps_.push_back(current_time);
+
+    // Remove timestamps older than 1 second
+    auto one_second_ago = current_time - rclcpp::Duration::from_nanoseconds(1000000000);
+    while (!frame_timestamps_.empty() && frame_timestamps_.front() < one_second_ago) {
+        frame_timestamps_.pop_front();
+    }
+}
+
+void MainCameraDriver::printFrameStats() {
+    if (frame_timestamps_.size() < 2) {
+        return;
+    }
+
+    // Calculate current framerate
+    double current_fps = static_cast<double>(frame_timestamps_.size());
+
+    // Calculate frame intervals for jitter analysis
+    std::vector<double> intervals;
+    for (size_t i = 1; i < frame_timestamps_.size(); ++i) {
+        double interval = (frame_timestamps_[i] - frame_timestamps_[i - 1]).seconds();
+        intervals.push_back(interval);
+    }
+
+    if (intervals.empty()) {
+        return;
+    }
+
+    // Calculate statistics
+    double mean_interval = 0.0;
+    for (double interval : intervals) {
+        mean_interval += interval;
+    }
+    mean_interval /= intervals.size();
+
+    // Calculate jitter (standard deviation)
+    double variance = 0.0;
+    for (double interval : intervals) {
+        double diff = interval - mean_interval;
+        variance += diff * diff;
+    }
+    variance /= intervals.size();
+    double jitter_ms = std::sqrt(variance) * 1000.0;
+
+    double expected_interval = 1.0 / fps_;
+    double timing_error_ms = (mean_interval - expected_interval) * 1000.0;
+
+    RCLCPP_INFO(this->get_logger(),
+                "Frame Stats - FPS: %.1f (target: %.1f) | Jitter: %.1f ms | Error: %.1f ms | Samples: %zu | Exposure: "
+                "%d | Gain: %d",
+                current_fps, fps_, jitter_ms, timing_error_ms, frame_timestamps_.size(), current_exposure_,
+                current_gain_);
+}
+
+void MainCameraDriver::checkCalibrationFile() {
     try {
-      // Capture frame
-      bool success = cap_.read(frame);
-      
-      if (!success || frame.empty()) {
-        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
-          "Failed to capture frame");
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        continue;
-      }
-      
-      // Increment frame counter
-      frame_count_++;
-      
-      // Process and publish frame
-      processAndPublishFrame(frame);
-      
-      // Update statistics and log every 1000 frames (~33 seconds at 30 fps)
-      updateFrameStats();
-      if (frame_count_ % 1000 == 0) {
-        printFrameStats();
-      }
-      
-    } catch (const std::exception& e) {
-      RCLCPP_ERROR(this->get_logger(), "Error in frame processing: %s", e.what());
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-  }
-  
-  RCLCPP_INFO(this->get_logger(), "Frame processing loop ended");
-}
+        // Always load from scratch (re-discovers calibration dir + file)
+        auto cal = StereoCalibration::load(data_directory_);
 
-void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame)
-{
-  auto current_time = this->now();
-  
-  // Frame is already rotated and downscaled to publish_stereo_width x publish_stereo_height by GStreamer
-  // Verify dimensions match expected publish resolution
-  if (static_cast<int>(frame.cols) != publish_stereo_width_ || 
-      static_cast<int>(frame.rows) != publish_stereo_height_) {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                         "Frame size mismatch: got %dx%d, expected %dx%d",
-                         frame.cols, frame.rows, publish_stereo_width_, publish_stereo_height_);
-    return;
-  }
-  
-  // Apply auto exposure control (frame is already rotated and downscaled)
-  if (auto_exposure_mode_ == AutoExposureMode::CUSTOM_PID && v4l2_controls_initialized_) {
-    frame_counter_++;
-    if (frame_counter_ >= auto_exposure_update_interval_) {
-      // Use left half of the already-downscaled frame
-      cv::Mat left_roi_for_ae = frame(cv::Rect(0, 0, publish_stereo_width_ / 2, publish_stereo_height_));
-      applyAutoExposure(left_roi_for_ae);
-      frame_counter_ = 0;
-    }
-  }
-  
-  // -------------------------
-  // (A1) Stereo msg: Frame is already at publish_stereo_width x publish_stereo_height
-  // -------------------------
-  auto stereo_msg = std::make_unique<sensor_msgs::msg::Image>();
-  stereo_msg->header.stamp = current_time;
-  stereo_msg->header.frame_id = frame_id_;
-  stereo_msg->height = publish_stereo_height_;
-  stereo_msg->width = publish_stereo_width_;
-  stereo_msg->encoding = "bgr8";
-  stereo_msg->is_bigendian = false;
-  stereo_msg->step = publish_stereo_width_ * 3;
-  stereo_msg->data.resize(stereo_msg->height * stereo_msg->step);
-  
-  // Wrap the ROS message data buffer as a cv::Mat view
-  cv::Mat stereo_out(
-    publish_stereo_height_, publish_stereo_width_, CV_8UC3,
-    stereo_msg->data.data(),
-    stereo_msg->step
-  );
-  
-  // Copy frame directly (already rotated and downscaled by GStreamer)
-  // Ensure frame is BGR format (GStreamer might output RGB)
-  if (frame.type() == CV_8UC3) {
-    // Check if we need to convert RGB to BGR
-    // GStreamer videoconvert typically outputs BGR, but verify
-    frame.copyTo(stereo_out);
-  } else {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                         "Unexpected frame type: %d, expected CV_8UC3", frame.type());
-    return;
-  }
-  
-  // -------------------------
-  // (A2) Left ROI view from frame (already at publish resolution)
-  // After 180° rotation in GStreamer, original right half appears on the left half.
-  // -------------------------
-  cv::Rect left_roi(0, 0, left_width_, left_height_);
-  cv::Mat left_view = stereo_out(left_roi);  // Use stereo_out which is guaranteed BGR
-  
-  // -------------------------
-  // (A3) Left msg: Use publish_left_width x publish_left_height, scale only if needed
-  // -------------------------
-  auto left_msg = std::make_unique<sensor_msgs::msg::Image>();
-  left_msg->header.stamp = current_time;
-  left_msg->header.frame_id = frame_id_;
-  left_msg->height = publish_left_height_;
-  left_msg->width = publish_left_width_;
-  left_msg->encoding = "bgr8";
-  left_msg->is_bigendian = false;
-  left_msg->step = publish_left_width_ * 3;
-  left_msg->data.resize(left_msg->height * left_msg->step);
-  
-  // Wrap left ROS message buffer as cv::Mat view
-  cv::Mat left_out(
-    publish_left_height_, publish_left_width_, CV_8UC3,
-    left_msg->data.data(),
-    left_msg->step
-  );
-  
-  // Only resize if the natural split size doesn't match the requested publish size
-  if (left_width_ == publish_left_width_ && left_height_ == publish_left_height_) {
-    // No scaling needed, copy directly
-    left_view.copyTo(left_out);
-  } else {
-    // Scale to requested size
-    cv::resize(left_view, left_out, cv::Size(publish_left_width_, publish_left_height_), 0, 0, cv::INTER_LINEAR);
-  }
-
-  // -------------------------
-  // (A4) Right ROI view and msg
-  // -------------------------
-  cv::Rect right_roi(left_width_, 0, left_width_, left_height_);
-  cv::Mat right_view = stereo_out(right_roi);
-  
-  auto right_msg = std::make_unique<sensor_msgs::msg::Image>();
-  right_msg->header.stamp = current_time;
-  right_msg->header.frame_id = right_frame_id_;
-  right_msg->height = publish_left_height_;
-  right_msg->width = publish_left_width_;
-  right_msg->encoding = "bgr8";
-  right_msg->is_bigendian = false;
-  right_msg->step = publish_left_width_ * 3;
-  right_msg->data.resize(right_msg->height * right_msg->step);
-  
-  cv::Mat right_out(
-    publish_left_height_, publish_left_width_, CV_8UC3,
-    right_msg->data.data(),
-    right_msg->step
-  );
-  
-  if (left_width_ == publish_left_width_ && left_height_ == publish_left_height_) {
-    right_view.copyTo(right_out);
-  } else {
-    cv::resize(right_view, right_out, cv::Size(publish_left_width_, publish_left_height_), 0, 0, cv::INTER_LINEAR);
-  }
-  
-  // -------------------------
-  // Publish with std::move() for zero-copy intra-process communication
-  // Inter-process subscribers (via DDS) still receive serialized copies automatically
-  // -------------------------
-  if (publish_stereo_) {
-    stereo_pub_->publish(std::move(stereo_msg));
-  }
-  left_pub_->publish(std::move(left_msg));
-  right_pub_->publish(std::move(right_msg));
-
-  // Publish camera_info with same timestamp
-  {
-    std::lock_guard<std::mutex> lock(calib_mutex_);
-    if (calibration_loaded_) {
-      left_info_msg_.header.stamp = current_time;
-      right_info_msg_.header.stamp = current_time;
-      left_info_pub_->publish(left_info_msg_);
-      right_info_pub_->publish(right_info_msg_);
-    }
-  }
-  
-  // Conditionally create and publish compressed image at specified interval
-  if (publish_compressed_) {
-    compressed_frame_counter_++;
-    if (compressed_frame_counter_ >= compressed_frame_interval_) {
-      compressed_frame_counter_ = 0;
-      
-      auto left_compressed_msg = std::make_unique<sensor_msgs::msg::CompressedImage>();
-      left_compressed_msg->header.stamp = current_time;
-      left_compressed_msg->header.frame_id = frame_id_;
-      left_compressed_msg->format = "jpeg";
-      
-      // Encode from the left view using TurboJPEG
-      try {
-        if (left_view.type() == CV_8UC3 && left_view.channels() == 3) {
-          jpeg_encoder_->encodeBGR(left_view, jpeg_quality_, left_compressed_msg->data);
-          compressed_pub_->publish(std::move(left_compressed_msg));
-        } else {
-          RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-                               "Left image format invalid for JPEG encoding: type=%d, channels=%d",
-                               left_view.type(), left_view.channels());
+        // Check if anything actually changed (skip rebuild if identical file & mtime)
+        auto new_write = std::filesystem::last_write_time(cal->filePath());
+        if (calibration_loaded_ && stereo_calib_ && cal->filePath() == stereo_calib_->filePath() &&
+            new_write == calib_last_write_) {
+            return;
         }
-      } catch (const std::exception& e) {
-        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-                             "JPEG turbo encode failed: %s", e.what());
-      }
+
+        auto left_info = cal->buildLeftCameraInfo(frame_id_);
+        auto right_info = cal->buildRightCameraInfo(right_frame_id_);
+
+        {
+            std::lock_guard<std::mutex> lock(calib_mutex_);
+            stereo_calib_ = cal;
+            left_info_msg_ = left_info;
+            right_info_msg_ = right_info;
+            calib_last_write_ = new_write;
+            calibration_loaded_ = true;
+        }
+
+        RCLCPP_INFO(this->get_logger(), "Stereo calibration (re)loaded: %s", cal->filePath().string().c_str());
+    } catch (const std::exception& e) {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 10000, "Calibration file watch: %s", e.what());
+
+        // Set uncalibrated camera_info (all zeros) if previously loaded (e.g., file was deleted)
+        // Per ROS convention: K[0] == 0.0 indicates an uncalibrated camera
+        {
+            std::lock_guard<std::mutex> lock(calib_mutex_);
+            if (calibration_loaded_) {
+                stereo_calib_ = nullptr;
+
+                // Create zeroed-out camera_info messages to indicate uncalibrated state
+                left_info_msg_ = sensor_msgs::msg::CameraInfo();
+                left_info_msg_.header.frame_id = frame_id_;
+                left_info_msg_.width = publish_left_width_;
+                left_info_msg_.height = publish_left_height_;
+
+                right_info_msg_ = sensor_msgs::msg::CameraInfo();
+                right_info_msg_.header.frame_id = right_frame_id_;
+                right_info_msg_.width = publish_left_width_;
+                right_info_msg_.height = publish_left_height_;
+
+                // Keep calibration_loaded_ = true so we continue publishing the zeroed messages
+                RCLCPP_INFO(this->get_logger(), "Calibration cleared - publishing uncalibrated camera_info (K[0]=0)");
+            }
+        }
     }
-  }
-}
-
-void MainCameraDriver::applyAutoExposure(const cv::Mat& frame)
-{
-  // Calculate new exposure value using PID controller
-  int new_exposure = auto_exposure_controller_.calculateExposure(frame, current_exposure_);
-  
-  // Only update if there's a meaningful change
-  if (abs(new_exposure - current_exposure_) > 5) {
-    if (setV4L2Control(V4L2_CID_EXPOSURE_ABSOLUTE, new_exposure)) {
-      current_exposure_ = new_exposure;
-      RCLCPP_INFO(this->get_logger(), "Auto exposure: %d -> %d", current_exposure_, new_exposure);
-    }
-  }
-}
-
-void MainCameraDriver::updateFrameStats()
-{
-  auto current_time = this->now();
-  frame_timestamps_.push_back(current_time);
-  
-  // Remove timestamps older than 1 second
-  auto one_second_ago = current_time - rclcpp::Duration::from_nanoseconds(1000000000);
-  while (!frame_timestamps_.empty() && frame_timestamps_.front() < one_second_ago) {
-    frame_timestamps_.pop_front();
-  }
-}
-
-void MainCameraDriver::printFrameStats()
-{
-  if (frame_timestamps_.size() < 2) {
-    return;
-  }
-  
-  // Calculate current framerate
-  double current_fps = static_cast<double>(frame_timestamps_.size());
-  
-  // Calculate frame intervals for jitter analysis
-  std::vector<double> intervals;
-  for (size_t i = 1; i < frame_timestamps_.size(); ++i) {
-    double interval = (frame_timestamps_[i] - frame_timestamps_[i-1]).seconds();
-    intervals.push_back(interval);
-  }
-  
-  if (intervals.empty()) {
-    return;
-  }
-  
-  // Calculate statistics
-  double mean_interval = 0.0;
-  for (double interval : intervals) {
-    mean_interval += interval;
-  }
-  mean_interval /= intervals.size();
-  
-  // Calculate jitter (standard deviation)
-  double variance = 0.0;
-  for (double interval : intervals) {
-    double diff = interval - mean_interval;
-    variance += diff * diff;
-  }
-  variance /= intervals.size();
-  double jitter_ms = std::sqrt(variance) * 1000.0;
-  
-  double expected_interval = 1.0 / fps_;
-  double timing_error_ms = (mean_interval - expected_interval) * 1000.0;
-  
-  RCLCPP_INFO(this->get_logger(), 
-    "Frame Stats - FPS: %.1f (target: %.1f) | Jitter: %.1f ms | Error: %.1f ms | Samples: %zu | Exposure: %d | Gain: %d",
-    current_fps, fps_, jitter_ms, timing_error_ms, frame_timestamps_.size(), current_exposure_, current_gain_);
-}
-
-void MainCameraDriver::checkCalibrationFile()
-{
-  try {
-    // Always load from scratch (re-discovers calibration dir + file)
-    auto cal = StereoCalibration::load(data_directory_);
-
-    // Check if anything actually changed (skip rebuild if identical file & mtime)
-    auto new_write = std::filesystem::last_write_time(cal->filePath());
-    if (calibration_loaded_ && stereo_calib_
-        && cal->filePath() == stereo_calib_->filePath()
-        && new_write == calib_last_write_) {
-      return;
-    }
-
-    auto left_info  = cal->buildLeftCameraInfo(frame_id_);
-    auto right_info = cal->buildRightCameraInfo(right_frame_id_);
-
-    {
-      std::lock_guard<std::mutex> lock(calib_mutex_);
-      stereo_calib_   = cal;
-      left_info_msg_  = left_info;
-      right_info_msg_ = right_info;
-      calib_last_write_ = new_write;
-      calibration_loaded_ = true;
-    }
-
-    RCLCPP_INFO(this->get_logger(), "Stereo calibration (re)loaded: %s",
-                cal->filePath().string().c_str());
-  } catch (const std::exception& e) {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 10000,
-      "Calibration file watch: %s", e.what());
-    
-    // Set uncalibrated camera_info (all zeros) if previously loaded (e.g., file was deleted)
-    // Per ROS convention: K[0] == 0.0 indicates an uncalibrated camera
-    {
-      std::lock_guard<std::mutex> lock(calib_mutex_);
-      if (calibration_loaded_) {
-        stereo_calib_ = nullptr;
-        
-        // Create zeroed-out camera_info messages to indicate uncalibrated state
-        left_info_msg_ = sensor_msgs::msg::CameraInfo();
-        left_info_msg_.header.frame_id = frame_id_;
-        left_info_msg_.width = publish_left_width_;
-        left_info_msg_.height = publish_left_height_;
-        
-        right_info_msg_ = sensor_msgs::msg::CameraInfo();
-        right_info_msg_.header.frame_id = right_frame_id_;
-        right_info_msg_.width = publish_left_width_;
-        right_info_msg_.height = publish_left_height_;
-        
-        // Keep calibration_loaded_ = true so we continue publishing the zeroed messages
-        RCLCPP_INFO(this->get_logger(), "Calibration cleared - publishing uncalibrated camera_info (K[0]=0)");
-      }
-    }
-  }
 }
 
 // AutoExposureController Implementation
 AutoExposureController::AutoExposureController()
-: kp_(0.8), target_brightness_(128.0),
-  min_exposure_(1), max_exposure_(10000),
-  center_weight_(0.7), center_region_size_(0.6)
-{
+    : kp_(0.8),
+      target_brightness_(128.0),
+      min_exposure_(1),
+      max_exposure_(10000),
+      center_weight_(0.7),
+      center_region_size_(0.6) {}
+
+void AutoExposureController::initialize(int min_exposure, int max_exposure, double target_brightness, double kp) {
+    min_exposure_ = min_exposure;
+    max_exposure_ = max_exposure;
+    target_brightness_ = target_brightness;
+    kp_ = kp;
 }
 
-void AutoExposureController::initialize(int min_exposure, int max_exposure, 
-                                       double target_brightness, double kp)
-{
-  min_exposure_ = min_exposure;
-  max_exposure_ = max_exposure;
-  target_brightness_ = target_brightness;
-  kp_ = kp;
+int AutoExposureController::calculateExposure(const cv::Mat& frame, int current_exposure) {
+    // Calculate center-weighted brightness
+    double brightness = calculateCenterWeightedBrightness(frame);
+
+    // Calculate error (target - current)
+    double error = target_brightness_ - brightness;
+
+    // Simple proportional control
+    double output = kp_ * error;
+
+    // Scale output to exposure range (15% of range per brightness unit error)
+    double exposure_range = max_exposure_ - min_exposure_;
+    double normalized_output = output / 128.0;  // Scale by target brightness
+    int exposure_adjustment = static_cast<int>(normalized_output * exposure_range * 0.15);
+
+    // Calculate new exposure value
+    int new_exposure = current_exposure + exposure_adjustment;
+
+    // Clamp to limits
+    return std::clamp(new_exposure, min_exposure_, max_exposure_);
 }
 
-int AutoExposureController::calculateExposure(const cv::Mat& frame, int current_exposure)
-{
-  // Calculate center-weighted brightness
-  double brightness = calculateCenterWeightedBrightness(frame);
-  
-  // Calculate error (target - current)
-  double error = target_brightness_ - brightness;
-  
-  // Simple proportional control
-  double output = kp_ * error;
-  
-  // Scale output to exposure range (15% of range per brightness unit error)
-  double exposure_range = max_exposure_ - min_exposure_;
-  double normalized_output = output / 128.0; // Scale by target brightness
-  int exposure_adjustment = static_cast<int>(normalized_output * exposure_range * 0.15);
-  
-  // Calculate new exposure value
-  int new_exposure = current_exposure + exposure_adjustment;
-  
-  // Clamp to limits
-  return std::clamp(new_exposure, min_exposure_, max_exposure_);
+double AutoExposureController::calculateCenterWeightedBrightness(const cv::Mat& frame) {
+    // Convert to grayscale if needed
+    cv::Mat gray;
+    if (frame.channels() == 3) {
+        cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
+    } else {
+        gray = frame;
+    }
+
+    // Get image dimensions
+    int h = gray.rows;
+    int w = gray.cols;
+
+    // Define center region
+    int center_h = static_cast<int>(h * center_region_size_);
+    int center_w = static_cast<int>(w * center_region_size_);
+    int start_h = (h - center_h) / 2;
+    int start_w = (w - center_w) / 2;
+
+    cv::Rect center_roi(start_w, start_h, center_w, center_h);
+
+    // Calculate brightness for center region
+    cv::Scalar center_mean = cv::mean(gray(center_roi));
+
+    // Calculate brightness for entire image
+    cv::Scalar full_mean = cv::mean(gray);
+
+    // Return weighted average (center gets higher weight)
+    return center_weight_ * center_mean[0] + (1.0 - center_weight_) * full_mean[0];
 }
 
-double AutoExposureController::calculateCenterWeightedBrightness(const cv::Mat& frame)
-{
-  // Convert to grayscale if needed
-  cv::Mat gray;
-  if (frame.channels() == 3) {
-    cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
-  } else {
-    gray = frame;
-  }
-  
-  // Get image dimensions
-  int h = gray.rows;
-  int w = gray.cols;
-  
-  // Define center region
-  int center_h = static_cast<int>(h * center_region_size_);
-  int center_w = static_cast<int>(w * center_region_size_);
-  int start_h = (h - center_h) / 2;
-  int start_w = (w - center_w) / 2;
-  
-  cv::Rect center_roi(start_w, start_h, center_w, center_h);
-  
-  // Calculate brightness for center region
-  cv::Scalar center_mean = cv::mean(gray(center_roi));
-  
-  // Calculate brightness for entire image
-  cv::Scalar full_mean = cv::mean(gray);
-  
-  // Return weighted average (center gets higher weight)
-  return center_weight_ * center_mean[0] + (1.0 - center_weight_) * full_mean[0];
+void AutoExposureController::setPID(double kp) {
+    kp_ = kp;
 }
 
-void AutoExposureController::setPID(double kp)
-{
-  kp_ = kp;
+void AutoExposureController::setTargetBrightness(double target) {
+    target_brightness_ = target;
 }
 
-void AutoExposureController::setTargetBrightness(double target)
-{
-  target_brightness_ = target;
-}
-
-} // namespace maurice_cam
+}  // namespace maurice_cam
 
 // Register the component
 RCLCPP_COMPONENTS_REGISTER_NODE(maurice_cam::MainCameraDriver)
 
 #ifndef BUILDING_COMPONENT_LIBRARY
-int main(int argc, char** argv)
-{
-  rclcpp::init(argc, argv);
-  
-  try {
-    auto node = std::make_shared<maurice_cam::MainCameraDriver>();
-    rclcpp::spin(node);
-  } catch (const std::exception& e) {
-    RCLCPP_ERROR(rclcpp::get_logger("main"), "Exception: %s", e.what());
-    return 1;
-  }
-  
-  rclcpp::shutdown();
-  return 0;
+int main(int argc, char** argv) {
+    rclcpp::init(argc, argv);
+
+    try {
+        auto node = std::make_shared<maurice_cam::MainCameraDriver>();
+        rclcpp::spin(node);
+    } catch (const std::exception& e) {
+        RCLCPP_ERROR(rclcpp::get_logger("main"), "Exception: %s", e.what());
+        return 1;
+    }
+
+    rclcpp::shutdown();
+    return 0;
 }
 #endif
-

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/stereo_calibration.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/stereo_calibration.cpp
@@ -3,249 +3,241 @@
 #include <fstream>
 #include <iostream>
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Factory: auto-discover calibration dir then load
 // ─────────────────────────────────────────────────────────────────────────────
-std::shared_ptr<StereoCalibration> StereoCalibration::load(const std::string& data_directory)
-{
-  auto calib_dir = findCalibrationConfigDir(data_directory);
-  auto calib_file = calib_dir / "stereo_calib.yaml";
-  return loadFromFile(calib_file);
+std::shared_ptr<StereoCalibration> StereoCalibration::load(const std::string& data_directory) {
+    auto calib_dir = findCalibrationConfigDir(data_directory);
+    auto calib_file = calib_dir / "stereo_calib.yaml";
+    return loadFromFile(calib_file);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Factory: load from explicit YAML path
 // ─────────────────────────────────────────────────────────────────────────────
-std::shared_ptr<StereoCalibration> StereoCalibration::loadFromFile(const std::filesystem::path& yaml_path)
-{
-  if (!std::filesystem::exists(yaml_path)) {
-    throw std::runtime_error("Calibration file not found: " + yaml_path.string());
-  }
+std::shared_ptr<StereoCalibration> StereoCalibration::loadFromFile(const std::filesystem::path& yaml_path) {
+    if (!std::filesystem::exists(yaml_path)) {
+        throw std::runtime_error("Calibration file not found: " + yaml_path.string());
+    }
 
-  cv::FileStorage fs(yaml_path.string(), cv::FileStorage::READ);
-  if (!fs.isOpened()) {
-    throw std::runtime_error("Failed to open calibration file: " + yaml_path.string());
-  }
+    cv::FileStorage fs(yaml_path.string(), cv::FileStorage::READ);
+    if (!fs.isOpened()) {
+        throw std::runtime_error("Failed to open calibration file: " + yaml_path.string());
+    }
 
-  // Version check — file must declare version 2
-  int version = 0;
-  fs["version"] >> version;
-  if (version != 2) {
-    throw std::runtime_error("Calibration file version must be 2, got " + std::to_string(version) + ": " + yaml_path.string());
-  }
+    // Version check — file must declare version 2
+    int version = 0;
+    fs["version"] >> version;
+    if (version != 2) {
+        throw std::runtime_error("Calibration file version must be 2, got " + std::to_string(version) + ": " +
+                                 yaml_path.string());
+    }
 
-  auto cal = std::shared_ptr<StereoCalibration>(new StereoCalibration());
-  cal->file_path_ = yaml_path;
+    auto cal = std::shared_ptr<StereoCalibration>(new StereoCalibration());
+    cal->file_path_ = yaml_path;
 
-  fs["K1"] >> cal->K1_;
-  fs["D1"] >> cal->D1_;
-  fs["K2"] >> cal->K2_;
-  fs["D2"] >> cal->D2_;
-  fs["R"]  >> cal->R_;
-  fs["T"]  >> cal->T_;
-  fs["R1"] >> cal->R1_;
-  fs["R2"] >> cal->R2_;
-  fs["P1"] >> cal->P1_;
-  fs["P2"] >> cal->P2_;
-  fs["Q"]  >> cal->Q_;
+    fs["K1"] >> cal->K1_;
+    fs["D1"] >> cal->D1_;
+    fs["K2"] >> cal->K2_;
+    fs["D2"] >> cal->D2_;
+    fs["R"] >> cal->R_;
+    fs["T"] >> cal->T_;
+    fs["R1"] >> cal->R1_;
+    fs["R2"] >> cal->R2_;
+    fs["P1"] >> cal->P1_;
+    fs["P2"] >> cal->P2_;
+    fs["Q"] >> cal->Q_;
 
-  fs["image_width"]  >> cal->calib_width_;
-  fs["image_height"] >> cal->calib_height_;
+    fs["image_width"] >> cal->calib_width_;
+    fs["image_height"] >> cal->calib_height_;
 
-  fs.release();
+    fs.release();
 
-  // Validate essential matrices
-  if (cal->K1_.empty() || cal->K2_.empty() ||
-      cal->R1_.empty() || cal->R2_.empty() ||
-      cal->P1_.empty() || cal->P2_.empty() ||
-      cal->Q_.empty()) {
-    throw std::runtime_error("Missing required calibration matrices in: " + yaml_path.string());
-  }
+    // Validate essential matrices
+    if (cal->K1_.empty() || cal->K2_.empty() || cal->R1_.empty() || cal->R2_.empty() || cal->P1_.empty() ||
+        cal->P2_.empty() || cal->Q_.empty()) {
+        throw std::runtime_error("Missing required calibration matrices in: " + yaml_path.string());
+    }
 
-  // Extract baseline and focal length from Q matrix
-  // Q[2,3] = focal length, Q[3,2] = -1/Tx where Tx = baseline
-  cal->focal_length_ = cal->Q_.at<double>(2, 3);
-  double neg_inv_tx = cal->Q_.at<double>(3, 2);
-  if (std::abs(neg_inv_tx) > 1e-6) {
-    cal->baseline_ = std::abs(1.0 / neg_inv_tx);
-  } else {
-    cal->baseline_ = std::abs(cal->T_.at<double>(0, 0));
-  }
+    // Extract baseline and focal length from Q matrix
+    // Q[2,3] = focal length, Q[3,2] = -1/Tx where Tx = baseline
+    cal->focal_length_ = cal->Q_.at<double>(2, 3);
+    double neg_inv_tx = cal->Q_.at<double>(3, 2);
+    if (std::abs(neg_inv_tx) > 1e-6) {
+        cal->baseline_ = std::abs(1.0 / neg_inv_tx);
+    } else {
+        cal->baseline_ = std::abs(cal->T_.at<double>(0, 0));
+    }
 
-  return cal;
+    return cal;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CameraInfo builders
 // ─────────────────────────────────────────────────────────────────────────────
-sensor_msgs::msg::CameraInfo StereoCalibration::buildLeftCameraInfo(const std::string& frame_id) const
-{
-  return buildCameraInfo(K1_, D1_, R1_, P1_, frame_id, /*negate_tx=*/false);
+sensor_msgs::msg::CameraInfo StereoCalibration::buildLeftCameraInfo(const std::string& frame_id) const {
+    return buildCameraInfo(K1_, D1_, R1_, P1_, frame_id, /*negate_tx=*/false);
 }
 
-sensor_msgs::msg::CameraInfo StereoCalibration::buildRightCameraInfo(const std::string& frame_id) const
-{
-  return buildCameraInfo(K2_, D2_, R2_, P2_, frame_id, /*negate_tx=*/true);
+sensor_msgs::msg::CameraInfo StereoCalibration::buildRightCameraInfo(const std::string& frame_id) const {
+    return buildCameraInfo(K2_, D2_, R2_, P2_, frame_id, /*negate_tx=*/true);
 }
 
-sensor_msgs::msg::CameraInfo StereoCalibration::buildCameraInfo(
-    const cv::Mat& K, const cv::Mat& D,
-    const cv::Mat& R, const cv::Mat& P,
-    const std::string& frame_id,
-    bool negate_tx) const
-{
-  sensor_msgs::msg::CameraInfo info;
+sensor_msgs::msg::CameraInfo StereoCalibration::buildCameraInfo(const cv::Mat& K, const cv::Mat& D, const cv::Mat& R,
+                                                                const cv::Mat& P, const std::string& frame_id,
+                                                                bool negate_tx) const {
+    sensor_msgs::msg::CameraInfo info;
 
-  info.header.frame_id = frame_id;
-  info.height = calib_height_;
-  info.width  = calib_width_;
-  info.distortion_model = "plumb_bob";
+    info.header.frame_id = frame_id;
+    info.height = calib_height_;
+    info.width = calib_width_;
+    info.distortion_model = "plumb_bob";
 
-  // D — distortion coefficients (k1, k2, t1, t2, k3)
-  info.d.resize(5);
-  if (!D.empty() && D.total() >= 5) {
-    const double* d_ptr = D.ptr<double>();
-    for (int i = 0; i < 5; i++) {
-      info.d[i] = d_ptr[i];
+    // D — distortion coefficients (k1, k2, t1, t2, k3)
+    info.d.resize(5);
+    if (!D.empty() && D.total() >= 5) {
+        const double* d_ptr = D.ptr<double>();
+        for (int i = 0; i < 5; i++) {
+            info.d[i] = d_ptr[i];
+        }
     }
-  }
 
-  // K — 3×3 intrinsic matrix
-  if (!K.empty()) {
-    for (int i = 0; i < 3; i++)
-      for (int j = 0; j < 3; j++)
-        info.k[i * 3 + j] = K.at<double>(i, j);
-  }
-
-  // R — 3×3 rectification rotation
-  if (!R.empty()) {
-    for (int i = 0; i < 3; i++)
-      for (int j = 0; j < 3; j++)
-        info.r[i * 3 + j] = R.at<double>(i, j);
-  }
-
-  // P — 3×4 projection matrix
-  // OpenCV: P2[0,3] = +fx'·baseline   ROS: P2[0,3] = −fx'·baseline
-  if (!P.empty()) {
-    for (int i = 0; i < 3; i++) {
-      for (int j = 0; j < 4; j++) {
-        double value = P.at<double>(i, j);
-        if (negate_tx && i == 0 && j == 3)
-          value = -value;
-        info.p[i * 4 + j] = value;
-      }
+    // K — 3×3 intrinsic matrix
+    if (!K.empty()) {
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                info.k[i * 3 + j] = K.at<double>(i, j);
     }
-  }
 
-  info.binning_x = 0;
-  info.binning_y = 0;
-  info.roi.x_offset = 0;
-  info.roi.y_offset = 0;
-  info.roi.width  = 0;
-  info.roi.height = 0;
-  info.roi.do_rectify = false;
+    // R — 3×3 rectification rotation
+    if (!R.empty()) {
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                info.r[i * 3 + j] = R.at<double>(i, j);
+    }
 
-  return info;
+    // P — 3×4 projection matrix
+    // OpenCV: P2[0,3] = +fx'·baseline   ROS: P2[0,3] = −fx'·baseline
+    if (!P.empty()) {
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 4; j++) {
+                double value = P.at<double>(i, j);
+                if (negate_tx && i == 0 && j == 3)
+                    value = -value;
+                info.p[i * 4 + j] = value;
+            }
+        }
+    }
+
+    info.binning_x = 0;
+    info.binning_y = 0;
+    info.roi.x_offset = 0;
+    info.roi.y_offset = 0;
+    info.roi.width = 0;
+    info.roi.height = 0;
+    info.roi.do_rectify = false;
+
+    return info;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Rectification maps — at calibration resolution
 // ─────────────────────────────────────────────────────────────────────────────
-void StereoCalibration::getRectificationMaps(
-    cv::Mat& map1_left, cv::Mat& map2_left,
-    cv::Mat& map1_right, cv::Mat& map2_right) const
-{
-  cv::initUndistortRectifyMap(K1_, D1_, R1_, P1_,
-                               cv::Size(calib_width_, calib_height_),
-                               CV_32FC1, map1_left, map2_left);
-  cv::initUndistortRectifyMap(K2_, D2_, R2_, P2_,
-                               cv::Size(calib_width_, calib_height_),
-                               CV_32FC1, map1_right, map2_right);
+void StereoCalibration::getRectificationMaps(cv::Mat& map1_left, cv::Mat& map2_left, cv::Mat& map1_right,
+                                             cv::Mat& map2_right) const {
+    cv::initUndistortRectifyMap(K1_, D1_, R1_, P1_, cv::Size(calib_width_, calib_height_), CV_32FC1, map1_left,
+                                map2_left);
+    cv::initUndistortRectifyMap(K2_, D2_, R2_, P2_, cv::Size(calib_width_, calib_height_), CV_32FC1, map1_right,
+                                map2_right);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Rectification maps — at arbitrary resolution (scale K + P)
 // ─────────────────────────────────────────────────────────────────────────────
-void StereoCalibration::getRectificationMaps(
-    int width, int height,
-    cv::Mat& map1_left, cv::Mat& map2_left,
-    cv::Mat& map1_right, cv::Mat& map2_right) const
-{
-  double sx = static_cast<double>(width)  / static_cast<double>(calib_width_);
-  double sy = static_cast<double>(height) / static_cast<double>(calib_height_);
+void StereoCalibration::getRectificationMaps(int width, int height, cv::Mat& map1_left, cv::Mat& map2_left,
+                                             cv::Mat& map1_right, cv::Mat& map2_right) const {
+    double sx = static_cast<double>(width) / static_cast<double>(calib_width_);
+    double sy = static_cast<double>(height) / static_cast<double>(calib_height_);
 
-  // Scale K matrices
-  cv::Mat K1s = K1_.clone();
-  K1s.at<double>(0, 0) *= sx; K1s.at<double>(0, 2) *= sx;
-  K1s.at<double>(1, 1) *= sy; K1s.at<double>(1, 2) *= sy;
+    // Scale K matrices
+    cv::Mat K1s = K1_.clone();
+    K1s.at<double>(0, 0) *= sx;
+    K1s.at<double>(0, 2) *= sx;
+    K1s.at<double>(1, 1) *= sy;
+    K1s.at<double>(1, 2) *= sy;
 
-  cv::Mat K2s = K2_.clone();
-  K2s.at<double>(0, 0) *= sx; K2s.at<double>(0, 2) *= sx;
-  K2s.at<double>(1, 1) *= sy; K2s.at<double>(1, 2) *= sy;
+    cv::Mat K2s = K2_.clone();
+    K2s.at<double>(0, 0) *= sx;
+    K2s.at<double>(0, 2) *= sx;
+    K2s.at<double>(1, 1) *= sy;
+    K2s.at<double>(1, 2) *= sy;
 
-  // Scale P matrices (only the 3×3 part and Tx element)
-  cv::Mat P1s = P1_.clone();
-  P1s.at<double>(0, 0) *= sx; P1s.at<double>(0, 2) *= sx; P1s.at<double>(0, 3) *= sx;
-  P1s.at<double>(1, 1) *= sy; P1s.at<double>(1, 2) *= sy;
+    // Scale P matrices (only the 3×3 part and Tx element)
+    cv::Mat P1s = P1_.clone();
+    P1s.at<double>(0, 0) *= sx;
+    P1s.at<double>(0, 2) *= sx;
+    P1s.at<double>(0, 3) *= sx;
+    P1s.at<double>(1, 1) *= sy;
+    P1s.at<double>(1, 2) *= sy;
 
-  cv::Mat P2s = P2_.clone();
-  P2s.at<double>(0, 0) *= sx; P2s.at<double>(0, 2) *= sx; P2s.at<double>(0, 3) *= sx;
-  P2s.at<double>(1, 1) *= sy; P2s.at<double>(1, 2) *= sy;
+    cv::Mat P2s = P2_.clone();
+    P2s.at<double>(0, 0) *= sx;
+    P2s.at<double>(0, 2) *= sx;
+    P2s.at<double>(0, 3) *= sx;
+    P2s.at<double>(1, 1) *= sy;
+    P2s.at<double>(1, 2) *= sy;
 
-  cv::initUndistortRectifyMap(K1s, D1_, R1_, P1s,
-                               cv::Size(width, height),
-                               CV_32FC1, map1_left, map2_left);
-  cv::initUndistortRectifyMap(K2s, D2_, R2_, P2s,
-                               cv::Size(width, height),
-                               CV_32FC1, map1_right, map2_right);
+    cv::initUndistortRectifyMap(K1s, D1_, R1_, P1s, cv::Size(width, height), CV_32FC1, map1_left, map2_left);
+    cv::initUndistortRectifyMap(K2s, D2_, R2_, P2s, cv::Size(width, height), CV_32FC1, map1_right, map2_right);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Calibration directory discovery
 // ─────────────────────────────────────────────────────────────────────────────
-std::filesystem::path StereoCalibration::findCalibrationConfigDir(const std::string& data_directory)
-{
-  std::filesystem::path data_path(data_directory);
-  std::filesystem::path robot_info_path = data_path / "robot_info.json";
+std::filesystem::path StereoCalibration::findCalibrationConfigDir(const std::string& data_directory) {
+    std::filesystem::path data_path(data_directory);
+    std::filesystem::path robot_info_path = data_path / "robot_info.json";
 
-  // Try to read robot_info.json to get the robot model
-  std::string robot_model;
-  if (std::filesystem::exists(robot_info_path)) {
-    try {
-      std::ifstream file(robot_info_path);
-      nlohmann::json robot_info;
-      file >> robot_info;
-      if (robot_info.contains("model")) {
-        robot_model = robot_info["model"].get<std::string>();
-      }
-    } catch (...) {
-      // Ignore parse errors — fall through to directory scan
+    // Try to read robot_info.json to get the robot model
+    std::string robot_model;
+    if (std::filesystem::exists(robot_info_path)) {
+        try {
+            std::ifstream file(robot_info_path);
+            nlohmann::json robot_info;
+            file >> robot_info;
+            if (robot_info.contains("model")) {
+                robot_model = robot_info["model"].get<std::string>();
+            }
+        } catch (...) {
+            // Ignore parse errors — fall through to directory scan
+        }
     }
-  }
 
-  // First pass: prefer directory matching robot model
-  for (const auto& entry : std::filesystem::directory_iterator(data_path)) {
-    if (!entry.is_directory()) continue;
-    std::string dirname = entry.path().filename().string();
-    if (dirname.find("calibration_config") == std::string::npos) continue;
-    if (!robot_model.empty() && dirname.find(robot_model) != std::string::npos)
-      return entry.path();
-    if (robot_model.empty())
-      return entry.path();
-  }
+    // First pass: prefer directory matching robot model
+    for (const auto& entry : std::filesystem::directory_iterator(data_path)) {
+        if (!entry.is_directory())
+            continue;
+        std::string dirname = entry.path().filename().string();
+        if (dirname.find("calibration_config") == std::string::npos)
+            continue;
+        if (!robot_model.empty() && dirname.find(robot_model) != std::string::npos)
+            return entry.path();
+        if (robot_model.empty())
+            return entry.path();
+    }
 
-  // Second pass: fall back to any calibration_config dir
-  for (const auto& entry : std::filesystem::directory_iterator(data_path)) {
-    if (!entry.is_directory()) continue;
-    std::string dirname = entry.path().filename().string();
-    if (dirname.find("calibration_config") != std::string::npos)
-      return entry.path();
-  }
+    // Second pass: fall back to any calibration_config dir
+    for (const auto& entry : std::filesystem::directory_iterator(data_path)) {
+        if (!entry.is_directory())
+            continue;
+        std::string dirname = entry.path().filename().string();
+        if (dirname.find("calibration_config") != std::string::npos)
+            return entry.path();
+    }
 
-  throw std::runtime_error("No calibration_config directory found in: " + data_directory);
+    throw std::runtime_error("No calibration_config directory found in: " + data_directory);
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam

--- a/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/stereo_depth_estimator.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_cam/maurice_cam/stereo_depth_estimator.cpp
@@ -16,453 +16,454 @@
 
 using namespace std::chrono_literals;
 
-namespace maurice_cam
-{
+namespace maurice_cam {
 
 // =============================================================================
 // Constructor — parameter declaration, calibration, publishers, subscribers
 // =============================================================================
-StereoDepthEstimator::StereoDepthEstimator(const rclcpp::NodeOptions & options)
-: Node("stereo_depth_estimator", options)
-{
-  // Declare parameters with defaults
-  this->declare_parameter<std::string>("left_camera_info_topic", "/mars/main_camera/left/camera_info");
-  this->declare_parameter<std::string>("right_camera_info_topic", "/mars/main_camera/right/camera_info");
-  this->declare_parameter<std::string>("left_topic", "/mars/main_camera/left/image_raw");
-  this->declare_parameter<std::string>("right_topic", "/mars/main_camera/right/image_raw");
-  this->declare_parameter<std::string>("depth_topic", "/mars/main_camera/depth");
-  this->declare_parameter<std::string>("disparity_topic", "/mars/main_camera/disparity");
-  this->declare_parameter<std::string>("disparity_unfiltered_topic", "/mars/main_camera/disparity_unfiltered");
-  this->declare_parameter<std::string>("left_rectified_topic", "/mars/main_camera/left/image_rect");
-  this->declare_parameter<std::string>("right_rectified_topic", "/mars/main_camera/right/image_rect");
-  this->declare_parameter<std::string>("left_rectified_color_topic", "/mars/main_camera/left/image_rect_color");
-  this->declare_parameter<std::string>("left_rectified_compressed_topic", "/mars/main_camera/left/image_rect_color/compressed");
-  this->declare_parameter<std::string>("frame_id", "camera_optical_frame");
-  this->declare_parameter<int>("jpeg_quality", 80);
-  this->declare_parameter<int>("image_width", 640);
-  this->declare_parameter<int>("image_height", 480);
-  this->declare_parameter<double>("max_fps", 10.0);
-  this->declare_parameter<std::string>("pointcloud_topic", "/mars/main_camera/points");
-  this->declare_parameter<std::string>("pointcloud_color_topic", "/mars/main_camera/points_color");
-  this->declare_parameter<int>("pointcloud_decimation", 2);
-  this->declare_parameter<std::string>("footprint_cloud_topic", "/footprint/camera_optical");
-  this->declare_parameter<std::string>("footprint_overlay_topic", "/mars/main_camera/left/image_rect_footprint");
-  this->declare_parameter<std::string>("footprint_mask_topic", "/mars/main_camera/left/footprint_mask");
-  this->declare_parameter<std::string>("footprint_cutout_topic", "/mars/main_camera/left/image_rect_cutout");
+StereoDepthEstimator::StereoDepthEstimator(const rclcpp::NodeOptions& options)
+    : Node("stereo_depth_estimator", options) {
+    // Declare parameters with defaults
+    this->declare_parameter<std::string>("left_camera_info_topic", "/mars/main_camera/left/camera_info");
+    this->declare_parameter<std::string>("right_camera_info_topic", "/mars/main_camera/right/camera_info");
+    this->declare_parameter<std::string>("left_topic", "/mars/main_camera/left/image_raw");
+    this->declare_parameter<std::string>("right_topic", "/mars/main_camera/right/image_raw");
+    this->declare_parameter<std::string>("depth_topic", "/mars/main_camera/depth");
+    this->declare_parameter<std::string>("disparity_topic", "/mars/main_camera/disparity");
+    this->declare_parameter<std::string>("disparity_unfiltered_topic", "/mars/main_camera/disparity_unfiltered");
+    this->declare_parameter<std::string>("left_rectified_topic", "/mars/main_camera/left/image_rect");
+    this->declare_parameter<std::string>("right_rectified_topic", "/mars/main_camera/right/image_rect");
+    this->declare_parameter<std::string>("left_rectified_color_topic", "/mars/main_camera/left/image_rect_color");
+    this->declare_parameter<std::string>("left_rectified_compressed_topic",
+                                         "/mars/main_camera/left/image_rect_color/compressed");
+    this->declare_parameter<std::string>("frame_id", "camera_optical_frame");
+    this->declare_parameter<int>("jpeg_quality", 80);
+    this->declare_parameter<int>("image_width", 640);
+    this->declare_parameter<int>("image_height", 480);
+    this->declare_parameter<double>("max_fps", 10.0);
+    this->declare_parameter<std::string>("pointcloud_topic", "/mars/main_camera/points");
+    this->declare_parameter<std::string>("pointcloud_color_topic", "/mars/main_camera/points_color");
+    this->declare_parameter<int>("pointcloud_decimation", 2);
+    this->declare_parameter<std::string>("footprint_cloud_topic", "/footprint/camera_optical");
+    this->declare_parameter<std::string>("footprint_overlay_topic", "/mars/main_camera/left/image_rect_footprint");
+    this->declare_parameter<std::string>("footprint_mask_topic", "/mars/main_camera/left/footprint_mask");
+    this->declare_parameter<std::string>("footprint_cutout_topic", "/mars/main_camera/left/image_rect_cutout");
 
-  // VPI creation parameters
-  this->declare_parameter<int>("max_disparity", 64);
-  this->declare_parameter<int>("include_diagonals", 1);
+    // VPI creation parameters
+    this->declare_parameter<int>("max_disparity", 64);
+    this->declare_parameter<int>("include_diagonals", 1);
 
-  // VPI runtime parameters (CUDA backend)
-  this->declare_parameter<int>("confidence_threshold", 32767);
-  this->declare_parameter<int>("min_disparity", 0);
-  this->declare_parameter<int>("p1", 3);
-  this->declare_parameter<int>("p2", 48);
-  this->declare_parameter<double>("uniqueness", 0.15);
-  this->declare_parameter<int>("disparity_border_margin", 10);
+    // VPI runtime parameters (CUDA backend)
+    this->declare_parameter<int>("confidence_threshold", 32767);
+    this->declare_parameter<int>("min_disparity", 0);
+    this->declare_parameter<int>("p1", 3);
+    this->declare_parameter<int>("p2", 48);
+    this->declare_parameter<double>("uniqueness", 0.15);
+    this->declare_parameter<int>("disparity_border_margin", 10);
 
-  // Get parameter values
-  left_camera_info_topic_ = this->get_parameter("left_camera_info_topic").as_string();
-  right_camera_info_topic_ = this->get_parameter("right_camera_info_topic").as_string();
-  left_topic_ = this->get_parameter("left_topic").as_string();
-  right_topic_ = this->get_parameter("right_topic").as_string();
-  depth_topic_ = this->get_parameter("depth_topic").as_string();
-  disparity_topic_ = this->get_parameter("disparity_topic").as_string();
-  disparity_unfiltered_topic_ = this->get_parameter("disparity_unfiltered_topic").as_string();
-  left_rectified_topic_ = this->get_parameter("left_rectified_topic").as_string();
-  right_rectified_topic_ = this->get_parameter("right_rectified_topic").as_string();
-  left_rectified_color_topic_ = this->get_parameter("left_rectified_color_topic").as_string();
-  left_rectified_compressed_topic_ = this->get_parameter("left_rectified_compressed_topic").as_string();
-  frame_id_ = this->get_parameter("frame_id").as_string();
-  jpeg_quality_ = this->get_parameter("jpeg_quality").as_int();
-  image_width_ = this->get_parameter("image_width").as_int();
-  image_height_ = this->get_parameter("image_height").as_int();
-  max_fps_ = this->get_parameter("max_fps").as_double();
-  if (max_fps_ < 0.0) max_fps_ = 0.0;
-  min_process_interval_ = (max_fps_ > 0.0)
-      ? std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-            std::chrono::duration<double>(1.0 / max_fps_))
-      : std::chrono::steady_clock::duration::zero();
-  pointcloud_topic_ = this->get_parameter("pointcloud_topic").as_string();
-  pointcloud_color_topic_ = this->get_parameter("pointcloud_color_topic").as_string();
-  pointcloud_decimation_ = this->get_parameter("pointcloud_decimation").as_int();
-  if (pointcloud_decimation_ < 1) pointcloud_decimation_ = 1;
-  footprint_cloud_topic_ = this->get_parameter("footprint_cloud_topic").as_string();
-  footprint_overlay_topic_ = this->get_parameter("footprint_overlay_topic").as_string();
-  footprint_mask_topic_ = this->get_parameter("footprint_mask_topic").as_string();
-  footprint_cutout_topic_ = this->get_parameter("footprint_cutout_topic").as_string();
+    // Get parameter values
+    left_camera_info_topic_ = this->get_parameter("left_camera_info_topic").as_string();
+    right_camera_info_topic_ = this->get_parameter("right_camera_info_topic").as_string();
+    left_topic_ = this->get_parameter("left_topic").as_string();
+    right_topic_ = this->get_parameter("right_topic").as_string();
+    depth_topic_ = this->get_parameter("depth_topic").as_string();
+    disparity_topic_ = this->get_parameter("disparity_topic").as_string();
+    disparity_unfiltered_topic_ = this->get_parameter("disparity_unfiltered_topic").as_string();
+    left_rectified_topic_ = this->get_parameter("left_rectified_topic").as_string();
+    right_rectified_topic_ = this->get_parameter("right_rectified_topic").as_string();
+    left_rectified_color_topic_ = this->get_parameter("left_rectified_color_topic").as_string();
+    left_rectified_compressed_topic_ = this->get_parameter("left_rectified_compressed_topic").as_string();
+    frame_id_ = this->get_parameter("frame_id").as_string();
+    jpeg_quality_ = this->get_parameter("jpeg_quality").as_int();
+    image_width_ = this->get_parameter("image_width").as_int();
+    image_height_ = this->get_parameter("image_height").as_int();
+    max_fps_ = this->get_parameter("max_fps").as_double();
+    if (max_fps_ < 0.0)
+        max_fps_ = 0.0;
+    min_process_interval_ = (max_fps_ > 0.0) ? std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                                                   std::chrono::duration<double>(1.0 / max_fps_))
+                                             : std::chrono::steady_clock::duration::zero();
+    pointcloud_topic_ = this->get_parameter("pointcloud_topic").as_string();
+    pointcloud_color_topic_ = this->get_parameter("pointcloud_color_topic").as_string();
+    pointcloud_decimation_ = this->get_parameter("pointcloud_decimation").as_int();
+    if (pointcloud_decimation_ < 1)
+        pointcloud_decimation_ = 1;
+    footprint_cloud_topic_ = this->get_parameter("footprint_cloud_topic").as_string();
+    footprint_overlay_topic_ = this->get_parameter("footprint_overlay_topic").as_string();
+    footprint_mask_topic_ = this->get_parameter("footprint_mask_topic").as_string();
+    footprint_cutout_topic_ = this->get_parameter("footprint_cutout_topic").as_string();
 
-  max_disparity_ = this->get_parameter("max_disparity").as_int();
-  include_diagonals_ = this->get_parameter("include_diagonals").as_int();
-  if (max_disparity_ < 1) max_disparity_ = 1;
-  if (max_disparity_ > 256) max_disparity_ = 256;
+    max_disparity_ = this->get_parameter("max_disparity").as_int();
+    include_diagonals_ = this->get_parameter("include_diagonals").as_int();
+    if (max_disparity_ < 1)
+        max_disparity_ = 1;
+    if (max_disparity_ > 256)
+        max_disparity_ = 256;
 
-  confidence_threshold_ = this->get_parameter("confidence_threshold").as_int();
-  min_disparity_ = this->get_parameter("min_disparity").as_int();
-  p1_ = this->get_parameter("p1").as_int();
-  p2_ = this->get_parameter("p2").as_int();
-  uniqueness_ = this->get_parameter("uniqueness").as_double();
-  disparity_border_margin_ = this->get_parameter("disparity_border_margin").as_int();
+    confidence_threshold_ = this->get_parameter("confidence_threshold").as_int();
+    min_disparity_ = this->get_parameter("min_disparity").as_int();
+    p1_ = this->get_parameter("p1").as_int();
+    p2_ = this->get_parameter("p2").as_int();
+    uniqueness_ = this->get_parameter("uniqueness").as_double();
+    disparity_border_margin_ = this->get_parameter("disparity_border_margin").as_int();
 
-  if (p2_ >= 256) {
-    RCLCPP_WARN(this->get_logger(), "CUDA requires p2 < 256, clamping %d -> 255", p2_);
-    p2_ = 255;
-  }
+    if (p2_ >= 256) {
+        RCLCPP_WARN(this->get_logger(), "CUDA requires p2 < 256, clamping %d -> 255", p2_);
+        p2_ = 255;
+    }
 
-  // Initialize disparity filter parameters
-  initFilterParams();
+    // Initialize disparity filter parameters
+    initFilterParams();
 
-  RCLCPP_INFO(this->get_logger(), "=== Maurice Stereo Depth Estimator (VPI SGM CUDA) ===");
-  RCLCPP_INFO(this->get_logger(), "Left camera info: %s", left_camera_info_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "Right camera info: %s", right_camera_info_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "Left topic: %s", left_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "Right topic: %s", right_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "Depth topic: %s", depth_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "Input image dimensions: %dx%d", image_width_, image_height_);
-  RCLCPP_INFO(this->get_logger(), "Max disparity: %d", max_disparity_);
-  RCLCPP_INFO(this->get_logger(), "SGM params: diagonals=%d, p1=%d, p2=%d, confThreshold=%d, uniqueness=%.2f",
-              include_diagonals_, p1_, p2_, confidence_threshold_, uniqueness_);
-  if (max_fps_ > 0.0) {
-    RCLCPP_INFO(this->get_logger(), "Max processing rate: %.1f Hz", max_fps_);
-  } else {
-    RCLCPP_INFO(this->get_logger(), "Max processing rate: unlimited");
-  }
+    RCLCPP_INFO(this->get_logger(), "=== Maurice Stereo Depth Estimator (VPI SGM CUDA) ===");
+    RCLCPP_INFO(this->get_logger(), "Left camera info: %s", left_camera_info_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "Right camera info: %s", right_camera_info_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "Left topic: %s", left_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "Right topic: %s", right_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "Depth topic: %s", depth_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "Input image dimensions: %dx%d", image_width_, image_height_);
+    RCLCPP_INFO(this->get_logger(), "Max disparity: %d", max_disparity_);
+    RCLCPP_INFO(this->get_logger(), "SGM params: diagonals=%d, p1=%d, p2=%d, confThreshold=%d, uniqueness=%.2f",
+                include_diagonals_, p1_, p2_, confidence_threshold_, uniqueness_);
+    if (max_fps_ > 0.0) {
+        RCLCPP_INFO(this->get_logger(), "Max processing rate: %.1f Hz", max_fps_);
+    } else {
+        RCLCPP_INFO(this->get_logger(), "Max processing rate: unlimited");
+    }
 
-  // Subscribe to camera_info topics for calibration.
-  // VPI initialisation is deferred until both CameraInfo messages arrive.
-  {
-    auto info_qos = rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort);
-    left_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
-        left_camera_info_topic_, info_qos,
-        std::bind(&StereoDepthEstimator::leftCameraInfoCallback, this, std::placeholders::_1));
-    right_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
-        right_camera_info_topic_, info_qos,
-        std::bind(&StereoDepthEstimator::rightCameraInfoCallback, this, std::placeholders::_1));
-  }
-  RCLCPP_INFO(this->get_logger(), "Waiting for camera_info on [%s] and [%s]",
-              left_camera_info_topic_.c_str(), right_camera_info_topic_.c_str());
+    // Subscribe to camera_info topics for calibration.
+    // VPI initialisation is deferred until both CameraInfo messages arrive.
+    {
+        auto info_qos = rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort);
+        left_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
+            left_camera_info_topic_, info_qos,
+            std::bind(&StereoDepthEstimator::leftCameraInfoCallback, this, std::placeholders::_1));
+        right_info_sub_ = this->create_subscription<sensor_msgs::msg::CameraInfo>(
+            right_camera_info_topic_, info_qos,
+            std::bind(&StereoDepthEstimator::rightCameraInfoCallback, this, std::placeholders::_1));
+    }
+    RCLCPP_INFO(this->get_logger(), "Waiting for camera_info on [%s] and [%s]", left_camera_info_topic_.c_str(),
+                right_camera_info_topic_.c_str());
 
-  // Subscribe to footprint pointcloud (for overlay projection onto rectified image)
-  footprint_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
-      footprint_cloud_topic_, rclcpp::SensorDataQoS(),
-      [this](sensor_msgs::msg::PointCloud2::ConstSharedPtr msg) {
-        std::lock_guard<std::mutex> lock(footprint_mutex_);
-        latest_footprint_cloud_ = msg;
-      });
+    // Subscribe to footprint pointcloud (for overlay projection onto rectified image)
+    footprint_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+        footprint_cloud_topic_, rclcpp::SensorDataQoS(), [this](sensor_msgs::msg::PointCloud2::ConstSharedPtr msg) {
+            std::lock_guard<std::mutex> lock(footprint_mutex_);
+            latest_footprint_cloud_ = msg;
+        });
 
-  // Create publishers (lazy publishing — only publish when subscribed)
-  auto sensor_qos = rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort);
-  depth_pub_                    = this->create_publisher<sensor_msgs::msg::Image>(depth_topic_, sensor_qos);
-  disparity_pub_                = this->create_publisher<stereo_msgs::msg::DisparityImage>(disparity_topic_, sensor_qos);
-  disparity_unfiltered_pub_     = this->create_publisher<stereo_msgs::msg::DisparityImage>(disparity_unfiltered_topic_, sensor_qos);
-  left_rectified_pub_           = this->create_publisher<sensor_msgs::msg::Image>(left_rectified_topic_, sensor_qos);
-  right_rectified_pub_          = this->create_publisher<sensor_msgs::msg::Image>(right_rectified_topic_, sensor_qos);
-  left_rectified_color_pub_     = this->create_publisher<sensor_msgs::msg::Image>(left_rectified_color_topic_, sensor_qos);
-  left_rectified_compressed_pub_= this->create_publisher<sensor_msgs::msg::CompressedImage>(left_rectified_compressed_topic_, sensor_qos);
-  pointcloud_pub_               = this->create_publisher<sensor_msgs::msg::PointCloud2>(pointcloud_topic_, sensor_qos);
-  pointcloud_color_pub_         = this->create_publisher<sensor_msgs::msg::PointCloud2>(pointcloud_color_topic_, sensor_qos);
-  footprint_overlay_pub_        = this->create_publisher<sensor_msgs::msg::Image>(footprint_overlay_topic_, sensor_qos);
-  footprint_mask_pub_            = this->create_publisher<sensor_msgs::msg::Image>(footprint_mask_topic_, sensor_qos);
-  footprint_cutout_pub_           = this->create_publisher<sensor_msgs::msg::Image>(footprint_cutout_topic_, sensor_qos);
+    // Create publishers (lazy publishing — only publish when subscribed)
+    auto sensor_qos = rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort);
+    depth_pub_ = this->create_publisher<sensor_msgs::msg::Image>(depth_topic_, sensor_qos);
+    disparity_pub_ = this->create_publisher<stereo_msgs::msg::DisparityImage>(disparity_topic_, sensor_qos);
+    disparity_unfiltered_pub_ =
+        this->create_publisher<stereo_msgs::msg::DisparityImage>(disparity_unfiltered_topic_, sensor_qos);
+    left_rectified_pub_ = this->create_publisher<sensor_msgs::msg::Image>(left_rectified_topic_, sensor_qos);
+    right_rectified_pub_ = this->create_publisher<sensor_msgs::msg::Image>(right_rectified_topic_, sensor_qos);
+    left_rectified_color_pub_ =
+        this->create_publisher<sensor_msgs::msg::Image>(left_rectified_color_topic_, sensor_qos);
+    left_rectified_compressed_pub_ =
+        this->create_publisher<sensor_msgs::msg::CompressedImage>(left_rectified_compressed_topic_, sensor_qos);
+    pointcloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(pointcloud_topic_, sensor_qos);
+    pointcloud_color_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(pointcloud_color_topic_, sensor_qos);
+    footprint_overlay_pub_ = this->create_publisher<sensor_msgs::msg::Image>(footprint_overlay_topic_, sensor_qos);
+    footprint_mask_pub_ = this->create_publisher<sensor_msgs::msg::Image>(footprint_mask_topic_, sensor_qos);
+    footprint_cutout_pub_ = this->create_publisher<sensor_msgs::msg::Image>(footprint_cutout_topic_, sensor_qos);
 
-  RCLCPP_INFO(this->get_logger(), "Publishers created (lazy publishing - only publish when subscribed)");
-  RCLCPP_INFO(this->get_logger(), "  Point cloud: %s (decimation: %d)", pointcloud_topic_.c_str(), pointcloud_decimation_);
-  RCLCPP_INFO(this->get_logger(), "  Point cloud color: %s", pointcloud_color_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "  Footprint overlay: %s (from %s)",
-              footprint_overlay_topic_.c_str(), footprint_cloud_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "  Footprint mask: %s",
-              footprint_mask_topic_.c_str());
-  RCLCPP_INFO(this->get_logger(), "  Footprint cutout: %s",
-              footprint_cutout_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "Publishers created (lazy publishing - only publish when subscribed)");
+    RCLCPP_INFO(this->get_logger(), "  Point cloud: %s (decimation: %d)", pointcloud_topic_.c_str(),
+                pointcloud_decimation_);
+    RCLCPP_INFO(this->get_logger(), "  Point cloud color: %s", pointcloud_color_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "  Footprint overlay: %s (from %s)", footprint_overlay_topic_.c_str(),
+                footprint_cloud_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "  Footprint mask: %s", footprint_mask_topic_.c_str());
+    RCLCPP_INFO(this->get_logger(), "  Footprint cutout: %s", footprint_cutout_topic_.c_str());
 
-  logFilterConfig();
+    logFilterConfig();
 
-  // Synchronized subscriptions for left and right images
-  auto qos = rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort);
-  left_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
-      this, left_topic_, qos.get_rmw_qos_profile());
-  right_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
-      this, right_topic_, qos.get_rmw_qos_profile());
-  sync_ = std::make_shared<Synchronizer>(SyncPolicy(5), *left_sub_, *right_sub_);
-  sync_->registerCallback(std::bind(&StereoDepthEstimator::syncCallback, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Synchronized subscriptions for left and right images
+    auto qos = rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort);
+    left_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(this, left_topic_,
+                                                                                       qos.get_rmw_qos_profile());
+    right_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(this, right_topic_,
+                                                                                        qos.get_rmw_qos_profile());
+    sync_ = std::make_shared<Synchronizer>(SyncPolicy(5), *left_sub_, *right_sub_);
+    sync_->registerCallback(
+        std::bind(&StereoDepthEstimator::syncCallback, this, std::placeholders::_1, std::placeholders::_2));
 
-  last_stats_time_ = this->now();
-  RCLCPP_INFO(this->get_logger(), "Stereo Depth Estimator initialized successfully");
+    last_stats_time_ = this->now();
+    RCLCPP_INFO(this->get_logger(), "Stereo Depth Estimator initialized successfully");
 }
 
 // =============================================================================
 // Destructor
 // =============================================================================
-StereoDepthEstimator::~StereoDepthEstimator()
-{
-  RCLCPP_INFO(this->get_logger(), "Shutting down Stereo Depth Estimator...");
-  cleanupVPIRemap();
-  cleanupVPI();
-  RCLCPP_INFO(this->get_logger(), "Stereo Depth Estimator shutdown complete");
+StereoDepthEstimator::~StereoDepthEstimator() {
+    RCLCPP_INFO(this->get_logger(), "Shutting down Stereo Depth Estimator...");
+    cleanupVPIRemap();
+    cleanupVPI();
+    RCLCPP_INFO(this->get_logger(), "Stereo Depth Estimator shutdown complete");
 }
 
 // =============================================================================
 // Synchronized callback — decode ROS images, gate frame rate, call pipeline
 // =============================================================================
-void StereoDepthEstimator::syncCallback(
-    const sensor_msgs::msg::Image::ConstSharedPtr& left_msg,
-    const sensor_msgs::msg::Image::ConstSharedPtr& right_msg)
-{
-  // Try-lock: skip this frame if a recalibration is in progress.
-  std::unique_lock<std::mutex> lock(calib_mutex_, std::try_to_lock);
-  if (!lock.owns_lock()) return;
+void StereoDepthEstimator::syncCallback(const sensor_msgs::msg::Image::ConstSharedPtr& left_msg,
+                                        const sensor_msgs::msg::Image::ConstSharedPtr& right_msg) {
+    // Try-lock: skip this frame if a recalibration is in progress.
+    std::unique_lock<std::mutex> lock(calib_mutex_, std::try_to_lock);
+    if (!lock.owns_lock())
+        return;
 
-  if (!vpi_initialized_ || !calibration_loaded_) {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 10000,
-                         "VPI or calibration not ready, skipping frame");
-    return;
-  }
-
-  // Frame rate control — advance deadline by interval (not snap to now)
-  // so leftover time carries forward for accurate average rate.
-  if (min_process_interval_.count() > 0) {
-    const auto now = std::chrono::steady_clock::now();
-    if (now - last_process_time_ < min_process_interval_) return;
-    last_process_time_ += min_process_interval_;
-    // If we fell behind by more than one interval, reset to prevent burst
-    if (now - last_process_time_ > min_process_interval_)
-      last_process_time_ = now;
-  }
-  input_frame_count_++;
-
-  // Validate dimensions
-  if (static_cast<int>(left_msg->width) != image_width_ ||
-      static_cast<int>(left_msg->height) != image_height_) {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-        "Left image size mismatch: got %dx%d, expected %dx%d",
-        left_msg->width, left_msg->height, image_width_, image_height_);
-    return;
-  }
-  if (static_cast<int>(right_msg->width) != image_width_ ||
-      static_cast<int>(right_msg->height) != image_height_) {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-        "Right image size mismatch: got %dx%d, expected %dx%d",
-        right_msg->width, right_msg->height, image_width_, image_height_);
-    return;
-  }
-
-  // Decode left image
-  cv::Mat left_frame;
-  if (left_msg->encoding == "bgr8") {
-    left_frame = cv::Mat(left_msg->height, left_msg->width, CV_8UC3,
-                         const_cast<uint8_t*>(left_msg->data.data()), left_msg->step).clone();
-  } else if (left_msg->encoding == "rgb8") {
-    cv::Mat rgb(left_msg->height, left_msg->width, CV_8UC3,
-                const_cast<uint8_t*>(left_msg->data.data()), left_msg->step);
-    cv::cvtColor(rgb, left_frame, cv::COLOR_RGB2BGR);
-  } else if (left_msg->encoding == "mono8") {
-    left_frame = cv::Mat(left_msg->height, left_msg->width, CV_8UC1,
-                         const_cast<uint8_t*>(left_msg->data.data()), left_msg->step).clone();
-  } else {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                         "Unsupported left encoding: %s", left_msg->encoding.c_str());
-    return;
-  }
-
-  // Decode right image
-  cv::Mat right_frame;
-  if (right_msg->encoding == "bgr8") {
-    right_frame = cv::Mat(right_msg->height, right_msg->width, CV_8UC3,
-                          const_cast<uint8_t*>(right_msg->data.data()), right_msg->step).clone();
-  } else if (right_msg->encoding == "rgb8") {
-    cv::Mat rgb(right_msg->height, right_msg->width, CV_8UC3,
-                const_cast<uint8_t*>(right_msg->data.data()), right_msg->step);
-    cv::cvtColor(rgb, right_frame, cv::COLOR_RGB2BGR);
-  } else if (right_msg->encoding == "mono8") {
-    right_frame = cv::Mat(right_msg->height, right_msg->width, CV_8UC1,
-                          const_cast<uint8_t*>(right_msg->data.data()), right_msg->step).clone();
-  } else {
-    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                         "Unsupported right encoding: %s", right_msg->encoding.c_str());
-    return;
-  }
-
-  try {
-    processFrame(left_frame, right_frame, rclcpp::Time(left_msg->header.stamp));
-    frame_count_++;
-    if (frame_count_ % 100 == 0) {
-      auto now = this->now();
-      double elapsed = (now - last_stats_time_).seconds();
-      RCLCPP_INFO(this->get_logger(), "Depth estimation: %.1f FPS, %d frames processed",
-                  100.0 / elapsed, frame_count_);
-      last_stats_time_ = now;
+    if (!vpi_initialized_ || !calibration_loaded_) {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 10000,
+                             "VPI or calibration not ready, skipping frame");
+        return;
     }
-  } catch (const std::exception& e) {
-    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-                          "Error processing frame: %s", e.what());
-  }
+
+    // Frame rate control — advance deadline by interval (not snap to now)
+    // so leftover time carries forward for accurate average rate.
+    if (min_process_interval_.count() > 0) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now - last_process_time_ < min_process_interval_)
+            return;
+        last_process_time_ += min_process_interval_;
+        // If we fell behind by more than one interval, reset to prevent burst
+        if (now - last_process_time_ > min_process_interval_)
+            last_process_time_ = now;
+    }
+    input_frame_count_++;
+
+    // Validate dimensions
+    if (static_cast<int>(left_msg->width) != image_width_ || static_cast<int>(left_msg->height) != image_height_) {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                             "Left image size mismatch: got %dx%d, expected %dx%d", left_msg->width, left_msg->height,
+                             image_width_, image_height_);
+        return;
+    }
+    if (static_cast<int>(right_msg->width) != image_width_ || static_cast<int>(right_msg->height) != image_height_) {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                             "Right image size mismatch: got %dx%d, expected %dx%d", right_msg->width,
+                             right_msg->height, image_width_, image_height_);
+        return;
+    }
+
+    // Decode left image
+    cv::Mat left_frame;
+    if (left_msg->encoding == "bgr8") {
+        left_frame = cv::Mat(left_msg->height, left_msg->width, CV_8UC3, const_cast<uint8_t*>(left_msg->data.data()),
+                             left_msg->step)
+                         .clone();
+    } else if (left_msg->encoding == "rgb8") {
+        cv::Mat rgb(left_msg->height, left_msg->width, CV_8UC3, const_cast<uint8_t*>(left_msg->data.data()),
+                    left_msg->step);
+        cv::cvtColor(rgb, left_frame, cv::COLOR_RGB2BGR);
+    } else if (left_msg->encoding == "mono8") {
+        left_frame = cv::Mat(left_msg->height, left_msg->width, CV_8UC1, const_cast<uint8_t*>(left_msg->data.data()),
+                             left_msg->step)
+                         .clone();
+    } else {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000, "Unsupported left encoding: %s",
+                             left_msg->encoding.c_str());
+        return;
+    }
+
+    // Decode right image
+    cv::Mat right_frame;
+    if (right_msg->encoding == "bgr8") {
+        right_frame = cv::Mat(right_msg->height, right_msg->width, CV_8UC3,
+                              const_cast<uint8_t*>(right_msg->data.data()), right_msg->step)
+                          .clone();
+    } else if (right_msg->encoding == "rgb8") {
+        cv::Mat rgb(right_msg->height, right_msg->width, CV_8UC3, const_cast<uint8_t*>(right_msg->data.data()),
+                    right_msg->step);
+        cv::cvtColor(rgb, right_frame, cv::COLOR_RGB2BGR);
+    } else if (right_msg->encoding == "mono8") {
+        right_frame = cv::Mat(right_msg->height, right_msg->width, CV_8UC1,
+                              const_cast<uint8_t*>(right_msg->data.data()), right_msg->step)
+                          .clone();
+    } else {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000, "Unsupported right encoding: %s",
+                             right_msg->encoding.c_str());
+        return;
+    }
+
+    try {
+        processFrame(left_frame, right_frame, rclcpp::Time(left_msg->header.stamp));
+        frame_count_++;
+        if (frame_count_ % 100 == 0) {
+            auto now = this->now();
+            double elapsed = (now - last_stats_time_).seconds();
+            RCLCPP_INFO(this->get_logger(), "Depth estimation: %.1f FPS, %d frames processed", 100.0 / elapsed,
+                        frame_count_);
+            last_stats_time_ = now;
+        }
+    } catch (const std::exception& e) {
+        RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 2000, "Error processing frame: %s", e.what());
+    }
 }
 
 // =============================================================================
 // Pipeline orchestrator — calls helpers, owns timing
 // =============================================================================
-void StereoDepthEstimator::processFrame(
-    const cv::Mat& left_input, const cv::Mat& right_input,
-    const rclcpp::Time& timestamp)
-{
-  using clock = std::chrono::steady_clock;
-  const auto t_start = clock::now();
+void StereoDepthEstimator::processFrame(const cv::Mat& left_input, const cv::Mat& right_input,
+                                        const rclcpp::Time& timestamp) {
+    using clock = std::chrono::steady_clock;
+    const auto t_start = clock::now();
 
-  // ── Subscriber checks ──────────────────────────────────────────────────
-  const bool pub_left_rect       = left_rectified_pub_->get_subscription_count() > 0;
-  const bool pub_right_rect      = right_rectified_pub_->get_subscription_count() > 0;
-  const bool pub_left_color      = left_rectified_color_pub_->get_subscription_count() > 0;
-  const bool pub_left_compressed = left_rectified_compressed_pub_->get_subscription_count() > 0;
-  const bool pub_pointcloud      = pointcloud_pub_->get_subscription_count() > 0;
-  const bool pub_pointcloud_color= pointcloud_color_pub_->get_subscription_count() > 0;
-  const bool pub_unfiltered      = disparity_unfiltered_pub_->get_subscription_count() > 0;
-  const bool pub_disparity       = disparity_pub_->get_subscription_count() > 0;
-  const bool pub_depth           = depth_pub_->get_subscription_count() > 0;
-  const bool pub_footprint_overlay = footprint_overlay_pub_->get_subscription_count() > 0;
-  const bool pub_footprint_mask    = footprint_mask_pub_->get_subscription_count() > 0;
-  const bool pub_footprint_cutout  = footprint_cutout_pub_->get_subscription_count() > 0;
-  const auto t_sub = clock::now();
+    // ── Subscriber checks ──────────────────────────────────────────────────
+    const bool pub_left_rect = left_rectified_pub_->get_subscription_count() > 0;
+    const bool pub_right_rect = right_rectified_pub_->get_subscription_count() > 0;
+    const bool pub_left_color = left_rectified_color_pub_->get_subscription_count() > 0;
+    const bool pub_left_compressed = left_rectified_compressed_pub_->get_subscription_count() > 0;
+    const bool pub_pointcloud = pointcloud_pub_->get_subscription_count() > 0;
+    const bool pub_pointcloud_color = pointcloud_color_pub_->get_subscription_count() > 0;
+    const bool pub_unfiltered = disparity_unfiltered_pub_->get_subscription_count() > 0;
+    const bool pub_disparity = disparity_pub_->get_subscription_count() > 0;
+    const bool pub_depth = depth_pub_->get_subscription_count() > 0;
+    const bool pub_footprint_overlay = footprint_overlay_pub_->get_subscription_count() > 0;
+    const bool pub_footprint_mask = footprint_mask_pub_->get_subscription_count() > 0;
+    const bool pub_footprint_cutout = footprint_cutout_pub_->get_subscription_count() > 0;
+    const auto t_sub = clock::now();
 
-  const bool has_color     = left_input.channels() == 3;
-  const bool need_color_rect = has_color &&
-      (pub_left_color || pub_left_compressed || pub_pointcloud_color
-       || pub_footprint_overlay || pub_footprint_cutout);
+    const bool has_color = left_input.channels() == 3;
+    const bool need_color_rect = has_color && (pub_left_color || pub_left_compressed || pub_pointcloud_color ||
+                                               pub_footprint_overlay || pub_footprint_cutout);
 
-  // ── Scale to calibration resolution ────────────────────────────────────
-  cv::Mat left_scaled, right_scaled;
-  scaleToCalibRes(left_input, right_input, left_scaled, right_scaled);
-  const auto t_scale = clock::now();
+    // ── Scale to calibration resolution ────────────────────────────────────
+    cv::Mat left_scaled, right_scaled;
+    scaleToCalibRes(left_input, right_input, left_scaled, right_scaled);
+    const auto t_scale = clock::now();
 
-  // ── Rectify mono (gray + remap) ────────────────────────────────────────
-  cv::Mat left_rect, right_rect;
-  rectifyMono(left_scaled, right_scaled, left_rect, right_rect);
-  const auto t_rect = clock::now();
+    // ── Rectify mono (gray + remap) ────────────────────────────────────────
+    cv::Mat left_rect, right_rect;
+    rectifyMono(left_scaled, right_scaled, left_rect, right_rect);
+    const auto t_rect = clock::now();
 
-  // ── Submit SGM to GPU (async) ──────────────────────────────────────────
-  if (!submitSGM(left_rect, right_rect)) return;
-  const auto t_submit = clock::now();
+    // ── Submit SGM to GPU (async) ──────────────────────────────────────────
+    if (!submitSGM(left_rect, right_rect))
+        return;
+    const auto t_submit = clock::now();
 
-  // ── CPU work while GPU computes ────────────────────────────────────────
-  cv::Mat left_color_rect;
-  if (need_color_rect) rectifyColor(left_scaled, left_color_rect);
-  const auto t_color_remap = clock::now();
+    // ── CPU work while GPU computes ────────────────────────────────────────
+    cv::Mat left_color_rect;
+    if (need_color_rect)
+        rectifyColor(left_scaled, left_color_rect);
+    const auto t_color_remap = clock::now();
 
-  if (pub_left_rect || pub_right_rect)
-    publishMonoRectified(left_rect, right_rect, timestamp, pub_left_rect, pub_right_rect);
-  const auto t_mono_pub = clock::now();
+    if (pub_left_rect || pub_right_rect)
+        publishMonoRectified(left_rect, right_rect, timestamp, pub_left_rect, pub_right_rect);
+    const auto t_mono_pub = clock::now();
 
-  if (pub_left_color || pub_left_compressed)
-    publishColorRectified(left_color_rect, left_rect, has_color, timestamp,
-                          pub_left_color, pub_left_compressed);
-  const auto t_color_pub = clock::now();
+    if (pub_left_color || pub_left_compressed)
+        publishColorRectified(left_color_rect, left_rect, has_color, timestamp, pub_left_color, pub_left_compressed);
+    const auto t_color_pub = clock::now();
 
-  // ── Footprint mask (always computed — filter chain needs it) ───────
-  computeFootprintMaskCalib();
-  if (pub_footprint_overlay)
-    publishFootprintOverlay(left_color_rect, timestamp);
-  if (pub_footprint_mask)
-    publishFootprintMask(timestamp);
-  if (pub_footprint_cutout)
-    publishFootprintCutout(left_color_rect, timestamp);
-  const auto t_footprint = clock::now();
+    // ── Footprint mask (always computed — filter chain needs it) ───────
+    computeFootprintMaskCalib();
+    if (pub_footprint_overlay)
+        publishFootprintOverlay(left_color_rect, timestamp);
+    if (pub_footprint_mask)
+        publishFootprintMask(timestamp);
+    if (pub_footprint_cutout)
+        publishFootprintCutout(left_color_rect, timestamp);
+    const auto t_footprint = clock::now();
 
-  // ── Sync GPU ───────────────────────────────────────────────────────────
-  syncSGM();
-  const auto t_sgm = clock::now();
+    // ── Sync GPU ───────────────────────────────────────────────────────────
+    syncSGM();
+    const auto t_sgm = clock::now();
 
-  // ── Extract disparity from VPI ─────────────────────────────────────────
-  cv::Mat disparity_float = extractDisparity();
-  if (disparity_float.empty()) { cleanupSGMWraps(); return; }
-  const auto t_extract = clock::now();
+    // ── Extract disparity from VPI ─────────────────────────────────────────
+    cv::Mat disparity_float = extractDisparity();
+    if (disparity_float.empty()) {
+        cleanupSGMWraps();
+        return;
+    }
+    const auto t_extract = clock::now();
 
-  // ── Publish unfiltered disparity ───────────────────────────────────────
-  if (pub_unfiltered) publishDisparityMsg(disparity_float, timestamp, disparity_unfiltered_pub_);
-  const auto t_unfilt = clock::now();
+    // ── Publish unfiltered disparity ───────────────────────────────────────
+    if (pub_unfiltered)
+        publishDisparityMsg(disparity_float, timestamp, disparity_unfiltered_pub_);
+    const auto t_unfilt = clock::now();
 
-  // ── Footprint mask on disparity (always, before filter chain) ────────
-  cv::Mat disparity_lowres;
-  FilterTimings ft;
-  {
-    const auto t_fp0 = clock::now();
-    applyFootprintMask(disparity_float);
-    ft.footprint_mask_ms = std::chrono::duration<double, std::milli>(
-        clock::now() - t_fp0).count();
-  }
+    // ── Footprint mask on disparity (always, before filter chain) ────────
+    cv::Mat disparity_lowres;
+    FilterTimings ft;
+    {
+        const auto t_fp0 = clock::now();
+        applyFootprintMask(disparity_float);
+        ft.footprint_mask_ms = std::chrono::duration<double, std::milli>(clock::now() - t_fp0).count();
+    }
 
-  // ── Filter chain ───────────────────────────────────────────────────────
-  applyFilterChain(disparity_float, disparity_lowres, ft,
-                            static_cast<float>(focal_length_), static_cast<float>(baseline_));
-  const auto t_filter = clock::now();
+    // ── Filter chain ───────────────────────────────────────────────────────
+    applyFilterChain(disparity_float, disparity_lowres, ft, static_cast<float>(focal_length_),
+                     static_cast<float>(baseline_));
+    const auto t_filter = clock::now();
 
-  // ── Publish filtered disparity ─────────────────────────────────────────
-  if (pub_disparity) publishDisparityMsg(disparity_float, timestamp, disparity_pub_);
+    // ── Publish filtered disparity ─────────────────────────────────────────
+    if (pub_disparity)
+        publishDisparityMsg(disparity_float, timestamp, disparity_pub_);
 
-  // ── Depth ──────────────────────────────────────────────────────────────
-  if (pub_depth) publishDepth(disparity_float, timestamp);
-  const auto t_depth = clock::now();
+    // ── Depth ──────────────────────────────────────────────────────────────
+    if (pub_depth)
+        publishDepth(disparity_float, timestamp);
+    const auto t_depth = clock::now();
 
-  // ── Point clouds ───────────────────────────────────────────────────────
-  if (pub_pointcloud)       publishPointCloudXYZ(disparity_lowres, timestamp);
-  if (pub_pointcloud_color) publishPointCloudColor(disparity_lowres, left_color_rect, timestamp);
-  const auto t_pc = clock::now();
+    // ── Point clouds ───────────────────────────────────────────────────────
+    if (pub_pointcloud)
+        publishPointCloudXYZ(disparity_lowres, timestamp);
+    if (pub_pointcloud_color)
+        publishPointCloudColor(disparity_lowres, left_color_rect, timestamp);
+    const auto t_pc = clock::now();
 
-  // ── Cleanup per-frame VPI wraps ────────────────────────────────────────
-  cleanupSGMWraps();
-  const auto t_end = clock::now();
+    // ── Cleanup per-frame VPI wraps ────────────────────────────────────────
+    cleanupSGMWraps();
+    const auto t_end = clock::now();
 
-  // ── Pipeline timing (1 Hz) ─────────────────────────────────────────────
-  auto ms = [](std::chrono::steady_clock::duration d) {
-    return std::chrono::duration<double, std::milli>(d).count();
-  };
+    // ── Pipeline timing (1 Hz) ─────────────────────────────────────────────
+    auto ms = [](std::chrono::steady_clock::duration d) {
+        return std::chrono::duration<double, std::milli>(d).count();
+    };
 
-  RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-    "Pipeline %.1fms | sub %.1f | scale %.1f | rectify %.1f | sgm_submit %.1f | "
-    "color_remap %.1f | mono_pub %.1f | color_pub %.1f | footprint %.1f | sgm_sync %.1f | "
-    "extract %.1f | unfilt %.1f | filter %.1f | depth %.1f | pc %.1f | "
-    "subs[L:%d R:%d C:%d J:%d PC:%d PCC:%d D:%d Di:%d Du:%d FP:%d FM:%d FC:%d col:%d]",
-    ms(t_end - t_start),
-    ms(t_sub - t_start), ms(t_scale - t_sub), ms(t_rect - t_scale),
-    ms(t_submit - t_rect), ms(t_color_remap - t_submit),
-    ms(t_mono_pub - t_color_remap), ms(t_color_pub - t_mono_pub),
-    ms(t_footprint - t_color_pub), ms(t_sgm - t_footprint),
-    ms(t_extract - t_sgm),
-    ms(t_unfilt - t_extract), ms(t_filter - t_unfilt),
-    ms(t_depth - t_filter), ms(t_pc - t_depth),
-    (int)pub_left_rect, (int)pub_right_rect, (int)pub_left_color,
-    (int)pub_left_compressed, (int)pub_pointcloud, (int)pub_pointcloud_color,
-    (int)pub_depth, (int)pub_disparity, (int)pub_unfiltered,
-    (int)pub_footprint_overlay, (int)pub_footprint_mask,
-    (int)pub_footprint_cutout, (int)has_color);
+    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                         "Pipeline %.1fms | sub %.1f | scale %.1f | rectify %.1f | sgm_submit %.1f | "
+                         "color_remap %.1f | mono_pub %.1f | color_pub %.1f | footprint %.1f | sgm_sync %.1f | "
+                         "extract %.1f | unfilt %.1f | filter %.1f | depth %.1f | pc %.1f | "
+                         "subs[L:%d R:%d C:%d J:%d PC:%d PCC:%d D:%d Di:%d Du:%d FP:%d FM:%d FC:%d col:%d]",
+                         ms(t_end - t_start), ms(t_sub - t_start), ms(t_scale - t_sub), ms(t_rect - t_scale),
+                         ms(t_submit - t_rect), ms(t_color_remap - t_submit), ms(t_mono_pub - t_color_remap),
+                         ms(t_color_pub - t_mono_pub), ms(t_footprint - t_color_pub), ms(t_sgm - t_footprint),
+                         ms(t_extract - t_sgm), ms(t_unfilt - t_extract), ms(t_filter - t_unfilt),
+                         ms(t_depth - t_filter), ms(t_pc - t_depth), (int)pub_left_rect, (int)pub_right_rect,
+                         (int)pub_left_color, (int)pub_left_compressed, (int)pub_pointcloud, (int)pub_pointcloud_color,
+                         (int)pub_depth, (int)pub_disparity, (int)pub_unfiltered, (int)pub_footprint_overlay,
+                         (int)pub_footprint_mask, (int)pub_footprint_cutout, (int)has_color);
 
-  RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-    "Filter detail %.1fms | fp_mask %.1f | down %.1f | clamp %.1f | domain %.1f | speckle %.1f | "
-    "edge %.1f | median %.1f | bilateral %.1f | hole %.1f | temporal %.1f | up %.1f",
-    ms(t_filter - t_unfilt),
-    ft.footprint_mask_ms, ft.downsample_ms, ft.depth_clamp_ms, ft.domain_transform_ms,
-    ft.speckle_ms, ft.edge_inv_ms, ft.median_ms, ft.bilateral_ms,
-    ft.hole_fill_ms, ft.temporal_ms, ft.upsample_ms);
+    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                         "Filter detail %.1fms | fp_mask %.1f | down %.1f | clamp %.1f | domain %.1f | speckle %.1f | "
+                         "edge %.1f | median %.1f | bilateral %.1f | hole %.1f | temporal %.1f | up %.1f",
+                         ms(t_filter - t_unfilt), ft.footprint_mask_ms, ft.downsample_ms, ft.depth_clamp_ms,
+                         ft.domain_transform_ms, ft.speckle_ms, ft.edge_inv_ms, ft.median_ms, ft.bilateral_ms,
+                         ft.hole_fill_ms, ft.temporal_ms, ft.upsample_ms);
 }
 
-} // namespace maurice_cam
+}  // namespace maurice_cam
 
 // Register the component
 RCLCPP_COMPONENTS_REGISTER_NODE(maurice_cam::StereoDepthEstimator)
 
 #ifndef BUILDING_COMPONENT_LIBRARY
-int main(int argc, char** argv)
-{
-  rclcpp::init(argc, argv);
-  try {
-    auto node = std::make_shared<maurice_cam::StereoDepthEstimator>();
-    rclcpp::spin(node);
-  } catch (const std::exception& e) {
-    RCLCPP_ERROR(rclcpp::get_logger("main"), "Exception: %s", e.what());
-    return 1;
-  }
-  rclcpp::shutdown();
-  return 0;
+int main(int argc, char** argv) {
+    rclcpp::init(argc, argv);
+    try {
+        auto node = std::make_shared<maurice_cam::StereoDepthEstimator>();
+        rclcpp::spin(node);
+    } catch (const std::exception& e) {
+        RCLCPP_ERROR(rclcpp::get_logger("main"), "Exception: %s", e.what());
+        return 1;
+    }
+    rclcpp::shutdown();
+    return 0;
 }
 #endif
 

--- a/ros2_ws/src/maurice_bot/maurice_control/maurice_control/udp_leader_receiver.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_control/maurice_control/udp_leader_receiver.cpp
@@ -78,7 +78,7 @@ static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
 #endif
 
 class UdpLeaderReceiver : public rclcpp::Node {
-public:
+   public:
     UdpLeaderReceiver() : Node("udp_leader_receiver") {
         // Declare parameters
         this->declare_parameter("port", 9999);
@@ -92,14 +92,12 @@ public:
 
         // Publisher for arm commands (best effort QoS for low-latency teleoperation)
         auto qos = rclcpp::QoS(1).best_effort();
-        commands_pub_ = this->create_publisher<std_msgs::msg::Float64MultiArray>(
-            "/mars/arm/commands", qos);
+        commands_pub_ = this->create_publisher<std_msgs::msg::Float64MultiArray>("/mars/arm/commands", qos);
 
         // Service for start/stop
         start_stop_service_ = this->create_service<std_srvs::srv::SetBool>(
             "/udp_leader_receiver/start",
-            std::bind(&UdpLeaderReceiver::handle_start_stop, this,
-                      std::placeholders::_1, std::placeholders::_2));
+            std::bind(&UdpLeaderReceiver::handle_start_stop, this, std::placeholders::_1, std::placeholders::_2));
 
         // Initialize state
         socket_fd_ = -1;
@@ -110,8 +108,8 @@ public:
         last_sequence_ = -1;
         last_log_time_ = std::chrono::steady_clock::now();
 
-        RCLCPP_INFO(this->get_logger(), 
-            "UDP Leader Receiver initialized on port %d -> /mars/arm/commands [C++]", port_);
+        RCLCPP_INFO(this->get_logger(), "UDP Leader Receiver initialized on port %d -> /mars/arm/commands [C++]",
+                    port_);
 
         // Auto-start if configured
         if (auto_start_) {
@@ -123,7 +121,7 @@ public:
         stop_receiver();
     }
 
-private:
+   private:
     bool start_receiver() {
         std::lock_guard<std::mutex> lock(mutex_);
 
@@ -246,8 +244,7 @@ private:
 
             if (pfd.revents & POLLIN) {
                 ssize_t recv_len = recvfrom(socket_fd_, buffer.data(), buffer.size(), 0,
-                                            reinterpret_cast<struct sockaddr*>(&sender_addr),
-                                            &sender_len);
+                                            reinterpret_cast<struct sockaddr*>(&sender_addr), &sender_len);
 
                 if (recv_len < 0) {
                     if (errno != EAGAIN && errno != EWOULDBLOCK && running_.load()) {
@@ -276,9 +273,8 @@ private:
         if (len != PACKET_SIZE) {
             char addr_str[INET_ADDRSTRLEN];
             inet_ntop(AF_INET, &addr.sin_addr, addr_str, sizeof(addr_str));
-            RCLCPP_WARN(this->get_logger(),
-                        "Invalid packet size: %zu bytes (expected %zu) from %s:%d",
-                        len, PACKET_SIZE, addr_str, ntohs(addr.sin_port));
+            RCLCPP_WARN(this->get_logger(), "Invalid packet size: %zu bytes (expected %zu) from %s:%d", len,
+                        PACKET_SIZE, addr_str, ntohs(addr.sin_port));
             error_count_++;
             return;
         }
@@ -290,8 +286,7 @@ private:
         if (packet->magic_header != MAGIC_HEADER) {
             char addr_str[INET_ADDRSTRLEN];
             inet_ntop(AF_INET, &addr.sin_addr, addr_str, sizeof(addr_str));
-            RCLCPP_WARN(this->get_logger(),
-                        "Invalid magic header: 0x%04X (expected 0x%04X) from %s:%d",
+            RCLCPP_WARN(this->get_logger(), "Invalid magic header: 0x%04X (expected 0x%04X) from %s:%d",
                         packet->magic_header, MAGIC_HEADER, addr_str, ntohs(addr.sin_port));
             error_count_++;
             return;
@@ -311,8 +306,7 @@ private:
         msg.data.reserve(NUM_SERVOS);
         for (size_t i = 0; i < NUM_SERVOS; ++i) {
             // Convert: radians = (position - 2048) * (2π / 4096)
-            double radians = (static_cast<double>(packet->servo_positions[i]) - 2048.0) 
-                             * (2.0 * M_PI / 4096.0);
+            double radians = (static_cast<double>(packet->servo_positions[i]) - 2048.0) * (2.0 * M_PI / 4096.0);
             msg.data.push_back(radians);
         }
         commands_pub_->publish(msg);
@@ -327,11 +321,10 @@ private:
             RCLCPP_INFO(this->get_logger(),
                         "Stats - Packets: %lu, Errors: %lu, Out-of-order: %lu, "
                         "Last seq: %ld, Timestamp: %.2fms, Positions: [%d, %d, %d, %d, %d, %d]",
-                        packet_count_.load(), error_count_.load(), out_of_order_count_.load(),
-                        last_sequence_.load(), packet->timestamp,
-                        packet->servo_positions[0], packet->servo_positions[1],
-                        packet->servo_positions[2], packet->servo_positions[3],
-                        packet->servo_positions[4], packet->servo_positions[5]);
+                        packet_count_.load(), error_count_.load(), out_of_order_count_.load(), last_sequence_.load(),
+                        packet->timestamp, packet->servo_positions[0], packet->servo_positions[1],
+                        packet->servo_positions[2], packet->servo_positions[3], packet->servo_positions[4],
+                        packet->servo_positions[5]);
             last_log_time_ = current_time;
         }
     }
@@ -343,8 +336,7 @@ private:
         if (packet->magic_header != RESET_MAGIC_HEADER) {
             char addr_str[INET_ADDRSTRLEN];
             inet_ntop(AF_INET, &addr.sin_addr, addr_str, sizeof(addr_str));
-            RCLCPP_WARN(this->get_logger(),
-                        "Invalid reset magic header: 0x%04X (expected 0x%04X) from %s:%d",
+            RCLCPP_WARN(this->get_logger(), "Invalid reset magic header: 0x%04X (expected 0x%04X) from %s:%d",
                         packet->magic_header, RESET_MAGIC_HEADER, addr_str, ntohs(addr.sin_port));
             error_count_++;
             return;
@@ -373,10 +365,8 @@ private:
         return sequence <= static_cast<uint32_t>(last_sequence_);
     }
 
-    void handle_start_stop(
-        const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-        std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
-
+    void handle_start_stop(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                           std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
         if (request->data) {
             // Start request
             bool success = start_receiver();

--- a/ros2_ws/src/maurice_bot/maurice_nav/include/maurice_nav/plugins/dynamic_goal_checker.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_nav/include/maurice_nav/plugins/dynamic_goal_checker.hpp
@@ -17,8 +17,7 @@
 #include "nav2_core/goal_checker.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 
-namespace maurice_nav
-{
+namespace maurice_nav {
 
 /**
  * @class DynamicGoalChecker
@@ -28,86 +27,78 @@ namespace maurice_nav
  * based on configurable parameters. Extend this class to implement
  * custom goal checking logic.
  */
-class DynamicGoalChecker : public nav2_core::GoalChecker
-{
-public:
-  DynamicGoalChecker();
-  ~DynamicGoalChecker() override = default;
+class DynamicGoalChecker : public nav2_core::GoalChecker {
+   public:
+    DynamicGoalChecker();
+    ~DynamicGoalChecker() override = default;
 
-  /**
-   * @brief Initialize the goal checker
-   * @param parent Weak pointer to the parent lifecycle node
-   * @param plugin_name Name of this plugin instance
-   * @param costmap_ros Shared pointer to the costmap
-   */
-  void initialize(
-    const rclcpp_lifecycle::LifecycleNode::WeakPtr & parent,
-    const std::string & plugin_name,
-    const std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros) override;
+    /**
+     * @brief Initialize the goal checker
+     * @param parent Weak pointer to the parent lifecycle node
+     * @param plugin_name Name of this plugin instance
+     * @param costmap_ros Shared pointer to the costmap
+     */
+    void initialize(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& plugin_name,
+                    const std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros) override;
 
-  /**
-   * @brief Reset the goal checker state
-   */
-  void reset() override;
+    /**
+     * @brief Reset the goal checker state
+     */
+    void reset() override;
 
-  /**
-   * @brief Check if the goal has been reached
-   * @param query_pose Current robot pose
-   * @param goal_pose Target goal pose
-   * @param velocity Current robot velocity
-   * @return True if goal is reached, false otherwise
-   */
-  bool isGoalReached(
-    const geometry_msgs::msg::Pose & query_pose,
-    const geometry_msgs::msg::Pose & goal_pose,
-    const geometry_msgs::msg::Twist & velocity) override;
+    /**
+     * @brief Check if the goal has been reached
+     * @param query_pose Current robot pose
+     * @param goal_pose Target goal pose
+     * @param velocity Current robot velocity
+     * @return True if goal is reached, false otherwise
+     */
+    bool isGoalReached(const geometry_msgs::msg::Pose& query_pose, const geometry_msgs::msg::Pose& goal_pose,
+                       const geometry_msgs::msg::Twist& velocity) override;
 
-  /**
-   * @brief Get the current tolerances
-   * @param pose_tolerance Output pose tolerance
-   * @param vel_tolerance Output velocity tolerance
-   * @return True if tolerances are valid
-   */
-  bool getTolerances(
-    geometry_msgs::msg::Pose & pose_tolerance,
-    geometry_msgs::msg::Twist & vel_tolerance) override;
+    /**
+     * @brief Get the current tolerances
+     * @param pose_tolerance Output pose tolerance
+     * @param vel_tolerance Output velocity tolerance
+     * @return True if tolerances are valid
+     */
+    bool getTolerances(geometry_msgs::msg::Pose& pose_tolerance, geometry_msgs::msg::Twist& vel_tolerance) override;
 
-protected:
-  // Goal tolerance parameters (parallel arrays defining tolerance tiers)
-  // Each tier: if robot stays within all tolerances for time_thresholds[i] seconds,
-  // the goal is considered reached
-  std::vector<double> time_thresholds_;       // Required duration in each tolerance zone (seconds)
-  std::vector<double> xy_tolerances_;         // XY distance tolerance for each tier (meters)
-  std::vector<double> yaw_tolerances_;        // Yaw tolerance for each tier (radians)
-  std::vector<double> linear_vel_tolerances_; // Max linear velocity for each tier (m/s)
-  std::vector<double> angular_vel_tolerances_;// Max angular velocity for each tier (rad/s)
+   protected:
+    // Goal tolerance parameters (parallel arrays defining tolerance tiers)
+    // Each tier: if robot stays within all tolerances for time_thresholds[i] seconds,
+    // the goal is considered reached
+    std::vector<double> time_thresholds_;         // Required duration in each tolerance zone (seconds)
+    std::vector<double> xy_tolerances_;           // XY distance tolerance for each tier (meters)
+    std::vector<double> yaw_tolerances_;          // Yaw tolerance for each tier (radians)
+    std::vector<double> linear_vel_tolerances_;   // Max linear velocity for each tier (m/s)
+    std::vector<double> angular_vel_tolerances_;  // Max angular velocity for each tier (rad/s)
 
-  // Per-tier timing: tracks how long robot has been in each tolerance zone
-  std::vector<rclcpp::Time> tier_start_times_;  // When robot entered each tier
-  std::vector<bool> tier_active_;               // Whether robot is currently in each tier
+    // Per-tier timing: tracks how long robot has been in each tolerance zone
+    std::vector<rclcpp::Time> tier_start_times_;  // When robot entered each tier
+    std::vector<bool> tier_active_;               // Whether robot is currently in each tier
 
-  // Current active tier (for reporting tolerances)
-  size_t current_tier_;
+    // Current active tier (for reporting tolerances)
+    size_t current_tier_;
 
-  // Plugin name for parameter namespacing
-  std::string plugin_name_;
+    // Plugin name for parameter namespacing
+    std::string plugin_name_;
 
-  // Clock for time tracking
-  rclcpp::Clock::SharedPtr clock_;
+    // Clock for time tracking
+    rclcpp::Clock::SharedPtr clock_;
 
-  // Logger for this plugin
-  rclcpp::Logger logger_{rclcpp::get_logger("DynamicGoalChecker")};
+    // Logger for this plugin
+    rclcpp::Logger logger_{rclcpp::get_logger("DynamicGoalChecker")};
 
-  // Dynamic parameters handler
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
+    // Dynamic parameters handler
+    rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
 
-  /**
-   * @brief Callback executed when a parameter change is detected
-   * @param parameters List of changed parameters
-   * @return Result of the parameter change
-   */
-  rcl_interfaces::msg::SetParametersResult
-  dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
+    /**
+     * @brief Callback executed when a parameter change is detected
+     * @param parameters List of changed parameters
+     * @return Result of the parameter change
+     */
+    rcl_interfaces::msg::SetParametersResult dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
 };
 
 }  // namespace maurice_nav

--- a/ros2_ws/src/maurice_bot/maurice_nav/include/maurice_nav/set_head_position_bt_node.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_nav/include/maurice_nav/set_head_position_bt_node.hpp
@@ -11,74 +11,67 @@
 #include "std_msgs/msg/int32.hpp"
 #include "behaviortree_cpp_v3/action_node.h"
 
-namespace maurice_nav
-{
+namespace maurice_nav {
 
 /**
  * @brief A BT action node that publishes head position to /mars/head/set_position.
- * 
+ *
  * Usage in behavior tree XML:
  * <SetHeadPosition position="-20" topic="/mars/head/set_position"/>
- * 
+ *
  * Parameters:
  *   - position: The head angle in degrees (integer). Default: -20
  *               Negative = looking down, Positive = looking up
  *               Typical range: -25 to +15
  *   - topic: The topic to publish to. Default: /mars/head/set_position
  */
-class SetHeadPosition : public BT::SyncActionNode
-{
-public:
-  SetHeadPosition(const std::string& name, const BT::NodeConfiguration& config)
-    : BT::SyncActionNode(name, config)
-  {
-    // Create a minimal ROS2 node for publishing
-    if (!rclcpp::ok()) {
-      rclcpp::init(0, nullptr);
-    }
-    
-    node_ = std::make_shared<rclcpp::Node>("set_head_position_bt_node");
-  }
+class SetHeadPosition : public BT::SyncActionNode {
+   public:
+    SetHeadPosition(const std::string& name, const BT::NodeConfiguration& config) : BT::SyncActionNode(name, config) {
+        // Create a minimal ROS2 node for publishing
+        if (!rclcpp::ok()) {
+            rclcpp::init(0, nullptr);
+        }
 
-  static BT::PortsList providedPorts()
-  {
-    return {
-      BT::InputPort<int>("position", -20, "Head position in degrees (-25 to +15)"),
-      BT::InputPort<std::string>("topic", "/mars/head/set_position", "Topic to publish head position to"),
-    };
-  }
-
-  BT::NodeStatus tick() override
-  {
-    int position = -20;
-    std::string topic = "/mars/head/set_position";
-    
-    getInput("position", position);
-    getInput("topic", topic);
-
-    // Create publisher if not exists or topic changed
-    if (!publisher_ || current_topic_ != topic) {
-      publisher_ = node_->create_publisher<std_msgs::msg::Int32>(topic, 10);
-      current_topic_ = topic;
-      // Small delay to allow publisher to be discovered
-      rclcpp::sleep_for(std::chrono::milliseconds(50));
+        node_ = std::make_shared<rclcpp::Node>("set_head_position_bt_node");
     }
 
-    // Publish the head position
-    auto msg = std_msgs::msg::Int32();
-    msg.data = position;
-    publisher_->publish(msg);
+    static BT::PortsList providedPorts() {
+        return {
+            BT::InputPort<int>("position", -20, "Head position in degrees (-25 to +15)"),
+            BT::InputPort<std::string>("topic", "/mars/head/set_position", "Topic to publish head position to"),
+        };
+    }
 
-    RCLCPP_INFO(node_->get_logger(), "SetHeadPosition: Published head position %d to %s", 
-                position, topic.c_str());
+    BT::NodeStatus tick() override {
+        int position = -20;
+        std::string topic = "/mars/head/set_position";
 
-    return BT::NodeStatus::SUCCESS;
-  }
+        getInput("position", position);
+        getInput("topic", topic);
 
-private:
-  std::shared_ptr<rclcpp::Node> node_;
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher_;
-  std::string current_topic_;
+        // Create publisher if not exists or topic changed
+        if (!publisher_ || current_topic_ != topic) {
+            publisher_ = node_->create_publisher<std_msgs::msg::Int32>(topic, 10);
+            current_topic_ = topic;
+            // Small delay to allow publisher to be discovered
+            rclcpp::sleep_for(std::chrono::milliseconds(50));
+        }
+
+        // Publish the head position
+        auto msg = std_msgs::msg::Int32();
+        msg.data = position;
+        publisher_->publish(msg);
+
+        RCLCPP_INFO(node_->get_logger(), "SetHeadPosition: Published head position %d to %s", position, topic.c_str());
+
+        return BT::NodeStatus::SUCCESS;
+    }
+
+   private:
+    std::shared_ptr<rclcpp::Node> node_;
+    rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr publisher_;
+    std::string current_topic_;
 };
 
 }  // namespace maurice_nav

--- a/ros2_ws/src/maurice_bot/maurice_nav/include/maurice_nav/switch_bt_node.hpp
+++ b/ros2_ws/src/maurice_bot/maurice_nav/include/maurice_nav/switch_bt_node.hpp
@@ -6,78 +6,70 @@
 #include <string>
 #include "behaviortree_cpp_v3/control_node.h"
 
-namespace maurice_nav
-{
+namespace maurice_nav {
 
 /**
- * @brief A Switch control node that selects which child to execute based on a 
+ * @brief A Switch control node that selects which child to execute based on a
  * string variable matching child names. Children should have name="value" attributes.
- * 
+ *
  * Usage:
  * <Switch variable="{selected_planner}">
  *     <SomeNode name="mapfree" .../>
  *     <SomeNode name="navigation" .../>
  * </Switch>
- * 
+ *
  * The child whose name matches the variable value will be ticked.
  * If no match is found, the first child is ticked as default.
  */
-class Switch : public BT::ControlNode
-{
-public:
-  Switch(const std::string& name, const BT::NodeConfiguration& config)
-    : BT::ControlNode(name, config)
-  {
-  }
+class Switch : public BT::ControlNode {
+   public:
+    Switch(const std::string& name, const BT::NodeConfiguration& config) : BT::ControlNode(name, config) {}
 
-  static BT::PortsList providedPorts()
-  {
-    return {
-      BT::InputPort<std::string>("variable", "The blackboard variable to switch on"),
-    };
-  }
-
-  BT::NodeStatus tick() override
-  {
-    std::string variable_value;
-    if (!getInput("variable", variable_value)) {
-      // If we can't get the variable, use first child as default
-      variable_value = "";
+    static BT::PortsList providedPorts() {
+        return {
+            BT::InputPort<std::string>("variable", "The blackboard variable to switch on"),
+        };
     }
 
-    // Find child with matching name
-    int selected_child = 0;  // Default to first child
-    for (size_t i = 0; i < children_nodes_.size(); i++) {
-      if (children_nodes_[i]->name() == variable_value) {
-        selected_child = static_cast<int>(i);
-        break;
-      }
+    BT::NodeStatus tick() override {
+        std::string variable_value;
+        if (!getInput("variable", variable_value)) {
+            // If we can't get the variable, use first child as default
+            variable_value = "";
+        }
+
+        // Find child with matching name
+        int selected_child = 0;  // Default to first child
+        for (size_t i = 0; i < children_nodes_.size(); i++) {
+            if (children_nodes_[i]->name() == variable_value) {
+                selected_child = static_cast<int>(i);
+                break;
+            }
+        }
+
+        // Halt all non-selected children that might be running
+        for (size_t i = 0; i < children_nodes_.size(); i++) {
+            if (static_cast<int>(i) != selected_child) {
+                haltChild(i);
+            }
+        }
+
+        // Tick the selected child
+        BT::NodeStatus child_status = children_nodes_[selected_child]->executeTick();
+
+        if (child_status == BT::NodeStatus::RUNNING) {
+            return BT::NodeStatus::RUNNING;
+        }
+
+        // Reset all children for next tick
+        haltChildren();
+        return child_status;
     }
 
-    // Halt all non-selected children that might be running
-    for (size_t i = 0; i < children_nodes_.size(); i++) {
-      if (static_cast<int>(i) != selected_child) {
-        haltChild(i);
-      }
+    void halt() override {
+        haltChildren();
+        ControlNode::halt();
     }
-
-    // Tick the selected child
-    BT::NodeStatus child_status = children_nodes_[selected_child]->executeTick();
-    
-    if (child_status == BT::NodeStatus::RUNNING) {
-      return BT::NodeStatus::RUNNING;
-    }
-
-    // Reset all children for next tick
-    haltChildren();
-    return child_status;
-  }
-
-  void halt() override
-  {
-    haltChildren();
-    ControlNode::halt();
-  }
 };
 
 }  // namespace maurice_nav

--- a/ros2_ws/src/maurice_bot/maurice_nav/src/dynamic_footprint.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_nav/src/dynamic_footprint.cpp
@@ -28,679 +28,642 @@ using namespace std::chrono_literals;
 
 /**
  * DynamicFootprint Node
- * 
+ *
  * Subscribes to:
  * - /robot_description (via ROS parameter)
  * - /tf (dynamic transforms)
  * - /tf_static (static transforms)
  */
-class DynamicFootprint : public rclcpp::Node
-{
-public:
-  explicit DynamicFootprint(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
-  : rclcpp::Node("dynamic_footprint", options),
-    tf_buffer_(this->get_clock()),
-    tf_listener_(tf_buffer_)
-  {
-    RCLCPP_INFO(this->get_logger(), "DynamicFootprint node initialized");
+class DynamicFootprint : public rclcpp::Node {
+   public:
+    explicit DynamicFootprint(const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
+        : rclcpp::Node("dynamic_footprint", options), tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_) {
+        RCLCPP_INFO(this->get_logger(), "DynamicFootprint node initialized");
 
-    this->declare_parameter<double>("padding", 0.03);
-    this->declare_parameter<double>("update_frequency", 15.0);
-    this->declare_parameter<bool>("debug", false);
+        this->declare_parameter<double>("padding", 0.03);
+        this->declare_parameter<double>("update_frequency", 15.0);
+        this->declare_parameter<bool>("debug", false);
 
-    const double update_freq = this->get_parameter("update_frequency").as_double();
-    const bool debug_mode = this->get_parameter("debug").as_bool();
+        const double update_freq = this->get_parameter("update_frequency").as_double();
+        const bool debug_mode = this->get_parameter("debug").as_bool();
 
-    // tf2_ros::TransformListener automatically subscribes to /tf and /tf_static
-    // and maintains them in tf_buffer_
+        // tf2_ros::TransformListener automatically subscribes to /tf and /tf_static
+        // and maintains them in tf_buffer_
 
-    // Create publisher for footprint (Polygon type for costmaps)
-    footprint_publisher_ = this->create_publisher<geometry_msgs::msg::Polygon>("/footprint", 10);
-    
-    // Create publisher for robot height
-    height_publisher_ = this->create_publisher<std_msgs::msg::Float64>("/footprint/height", 10);
+        // Create publisher for footprint (Polygon type for costmaps)
+        footprint_publisher_ = this->create_publisher<geometry_msgs::msg::Polygon>("/footprint", 10);
 
-    // Create publisher for arm collision points in camera optical frame
-    camera_footprint_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("/footprint/camera_optical", 10);
+        // Create publisher for robot height
+        height_publisher_ = this->create_publisher<std_msgs::msg::Float64>("/footprint/height", 10);
 
-    // Only create debug publishers if debug mode is enabled
-    if (debug_mode) {
-      collision_points_publisher_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("/footprint/collision_points", 10);
-      collision_boxes_publisher_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("/footprint/collision_boxes", 10);
-      robot_hull_publisher_ = this->create_publisher<visualization_msgs::msg::Marker>("/footprint/robot_convex_hull", 10);
-      height_point_publisher_ = this->create_publisher<geometry_msgs::msg::PointStamped>("/footprint/height_point", 10);
-    }
+        // Create publisher for arm collision points in camera optical frame
+        camera_footprint_publisher_ =
+            this->create_publisher<sensor_msgs::msg::PointCloud2>("/footprint/camera_optical", 10);
 
-    // Create a timer based on update_frequency param
-    const auto period = std::chrono::duration<double>(1.0 / update_freq);
-    timer_ = this->create_wall_timer(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(period),
-      std::bind(&DynamicFootprint::timer_callback, this));
-
-    // Get robot_description from parameter server
-    get_robot_description();
-  }
-
-private:
-  static double sign0(double v)
-  {
-    if (v > 0.0) {
-      return 1.0;
-    }
-    if (v < 0.0) {
-      return -1.0;
-    }
-    return 0.0;
-  }
-
-  static void padFootprint(std::vector<geometry_msgs::msg::Point> & footprint, double padding)
-  {
-    // pad footprint in place
-    for (unsigned int i = 0; i < footprint.size(); i++) {
-      geometry_msgs::msg::Point & pt = footprint[i];
-      pt.x += sign0(pt.x) * padding;
-      pt.y += sign0(pt.y) * padding;
-    }
-  }
-
-  struct Point2
-  {
-    double x;
-    double y;
-
-    bool operator<(const Point2 & other) const
-    {
-      if (x < other.x) {
-        return true;
-      }
-      if (x > other.x) {
-        return false;
-      }
-      return y < other.y;
-    }
-
-    bool operator==(const Point2 & other) const
-    {
-      return x == other.x && y == other.y;
-    }
-  };
-
-  static double cross(const Point2 & o, const Point2 & a, const Point2 & b)
-  {
-    return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
-  }
-
-  static std::vector<Point2> convex_hull(std::vector<Point2> pts)
-  {
-    if (pts.size() <= 1) {
-      return pts;
-    }
-
-    std::sort(pts.begin(), pts.end());
-    pts.erase(std::unique(pts.begin(), pts.end()), pts.end());
-
-    if (pts.size() <= 2) {
-      return pts;
-    }
-
-    std::vector<Point2> lower;
-    lower.reserve(pts.size());
-    for (const auto & p : pts) {
-      while (lower.size() >= 2 && cross(lower[lower.size() - 2], lower[lower.size() - 1], p) <= 0.0) {
-        lower.pop_back();
-      }
-      lower.push_back(p);
-    }
-
-    std::vector<Point2> upper;
-    upper.reserve(pts.size());
-    for (auto it = pts.rbegin(); it != pts.rend(); ++it) {
-      const auto & p = *it;
-      while (upper.size() >= 2 && cross(upper[upper.size() - 2], upper[upper.size() - 1], p) <= 0.0) {
-        upper.pop_back();
-      }
-      upper.push_back(p);
-    }
-
-    lower.pop_back();
-    upper.pop_back();
-    lower.insert(lower.end(), upper.begin(), upper.end());
-    return lower;
-  }
-
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
-  rclcpp::Publisher<geometry_msgs::msg::Polygon>::SharedPtr footprint_publisher_;
-  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr height_publisher_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr camera_footprint_publisher_;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr collision_points_publisher_;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr collision_boxes_publisher_;
-  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr robot_hull_publisher_;
-  rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr height_point_publisher_;
-  rclcpp::TimerBase::SharedPtr timer_;
-  std::string robot_description_;
-  std::shared_ptr<urdf::Model> urdf_model_;
-
-  /**
-   * Retrieve robot_description from parameter server
-   */
-  void get_robot_description()
-  {
-    try {
-      auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(this, "robot_state_publisher");
-      
-      while (!parameters_client->wait_for_service(std::chrono::seconds(1))) {
-        if (!rclcpp::ok()) {
-          RCLCPP_WARN(this->get_logger(), "Interrupted while waiting for parameter server");
-          return;
+        // Only create debug publishers if debug mode is enabled
+        if (debug_mode) {
+            collision_points_publisher_ =
+                this->create_publisher<visualization_msgs::msg::MarkerArray>("/footprint/collision_points", 10);
+            collision_boxes_publisher_ =
+                this->create_publisher<visualization_msgs::msg::MarkerArray>("/footprint/collision_boxes", 10);
+            robot_hull_publisher_ =
+                this->create_publisher<visualization_msgs::msg::Marker>("/footprint/robot_convex_hull", 10);
+            height_point_publisher_ =
+                this->create_publisher<geometry_msgs::msg::PointStamped>("/footprint/height_point", 10);
         }
-        RCLCPP_INFO(this->get_logger(), "Waiting for parameter server...");
-      }
 
-      auto params = parameters_client->get_parameters({"robot_description"});
-      if (!params.empty()) {
-        robot_description_ = params[0].as_string();
-        RCLCPP_INFO(this->get_logger(), "Successfully retrieved robot_description (length: %zu bytes)",
-                    robot_description_.length());
-        
-        // Parse URDF
-        parse_urdf();
-      } else {
-        RCLCPP_WARN(this->get_logger(), "robot_description parameter not found");
-      }
-    } catch (const std::exception & e) {
-      RCLCPP_ERROR(this->get_logger(), "Failed to get robot_description: %s", e.what());
+        // Create a timer based on update_frequency param
+        const auto period = std::chrono::duration<double>(1.0 / update_freq);
+        timer_ = this->create_wall_timer(std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+                                         std::bind(&DynamicFootprint::timer_callback, this));
+
+        // Get robot_description from parameter server
+        get_robot_description();
     }
-  }
 
-  /**
-   * Parse URDF and extract robot information
-   */
-  void parse_urdf()
-  {
-    try {
-      urdf_model_ = std::make_shared<urdf::Model>();
-      if (!urdf_model_->initString(robot_description_)) {
-        RCLCPP_ERROR(this->get_logger(), "Failed to parse URDF");
-        urdf_model_ = nullptr;
-        return;
-      }
-      
-      RCLCPP_INFO(this->get_logger(), "Successfully parsed URDF for robot: %s", urdf_model_->getName().c_str());
-      
-      // Log links information
-      RCLCPP_INFO(this->get_logger(), "Number of links: %zu", urdf_model_->links_.size());
-      for (const auto & link_pair : urdf_model_->links_) {
-        const auto & link = link_pair.second;
-        RCLCPP_DEBUG(this->get_logger(), "  Link: %s", link->name.c_str());
-        
-        if (link->inertial) {
-          RCLCPP_DEBUG(this->get_logger(), "    Mass: %f kg", link->inertial->mass);
-          RCLCPP_DEBUG(this->get_logger(), "    Inertia: Ixx=%f, Iyy=%f, Izz=%f",
-                       link->inertial->ixx, link->inertial->iyy, link->inertial->izz);
+   private:
+    static double sign0(double v) {
+        if (v > 0.0) {
+            return 1.0;
         }
-        
-        // Log collision geometry
-        if (!link->collision_array.empty()) {
-          RCLCPP_INFO(this->get_logger(), "  Link '%s' - Collision objects: %zu", 
-                      link->name.c_str(), link->collision_array.size());
-          
-          for (size_t i = 0; i < link->collision_array.size(); ++i) {
-            const auto & collision = link->collision_array[i];
-            RCLCPP_INFO(this->get_logger(), "    Collision [%zu]: name=%s", i, collision->name.c_str());
-            
-            RCLCPP_INFO(this->get_logger(), "      Origin: xyz=(%f, %f, %f)", 
-                        collision->origin.position.x, 
-                        collision->origin.position.y, 
-                        collision->origin.position.z);
-            
-            if (collision->geometry) {
-              const auto & geom = collision->geometry;
-              
-              if (geom->type == urdf::Geometry::BOX) {
-                auto box = std::dynamic_pointer_cast<urdf::Box>(geom);
-                if (box) {
-                  RCLCPP_INFO(this->get_logger(), "      Geometry: BOX - size=(%f, %f, %f)",
-                              box->dim.x, box->dim.y, box->dim.z);
+        if (v < 0.0) {
+            return -1.0;
+        }
+        return 0.0;
+    }
 
-                }
-              } else if (geom->type == urdf::Geometry::CYLINDER) {
-                auto cyl = std::dynamic_pointer_cast<urdf::Cylinder>(geom);
-                if (cyl) {
-                  RCLCPP_INFO(this->get_logger(), "      Geometry: CYLINDER - radius=%f, length=%f",
-                              cyl->radius, cyl->length);
-                }
-              } else if (geom->type == urdf::Geometry::SPHERE) {
-                auto sphere = std::dynamic_pointer_cast<urdf::Sphere>(geom);
-                if (sphere) {
-                  RCLCPP_INFO(this->get_logger(), "      Geometry: SPHERE - radius=%f", sphere->radius);
-                }
-              } else if (geom->type == urdf::Geometry::MESH) {
-                auto mesh = std::dynamic_pointer_cast<urdf::Mesh>(geom);
-                if (mesh) {
-                  RCLCPP_INFO(this->get_logger(), "      Geometry: MESH - filename=%s, scale=(%f, %f, %f)",
-                              mesh->filename.c_str(), mesh->scale.x, mesh->scale.y, mesh->scale.z);
-                }
-              }
+    static void padFootprint(std::vector<geometry_msgs::msg::Point>& footprint, double padding) {
+        // pad footprint in place
+        for (unsigned int i = 0; i < footprint.size(); i++) {
+            geometry_msgs::msg::Point& pt = footprint[i];
+            pt.x += sign0(pt.x) * padding;
+            pt.y += sign0(pt.y) * padding;
+        }
+    }
+
+    struct Point2 {
+        double x;
+        double y;
+
+        bool operator<(const Point2& other) const {
+            if (x < other.x) {
+                return true;
             }
-          }
+            if (x > other.x) {
+                return false;
+            }
+            return y < other.y;
         }
-        
-        if (!link->visual_array.empty()) {
-          RCLCPP_DEBUG(this->get_logger(), "    Visual objects: %zu", link->visual_array.size());
+
+        bool operator==(const Point2& other) const {
+            return x == other.x && y == other.y;
         }
-      }
-      
-      // Log joints information
-      RCLCPP_INFO(this->get_logger(), "Number of joints: %zu", urdf_model_->joints_.size());
-      for (const auto & joint_pair : urdf_model_->joints_) {
-        const auto & joint = joint_pair.second;
-        RCLCPP_DEBUG(this->get_logger(), "  Joint: %s (%s) - %s -> %s",
-                     joint->name.c_str(),
-                     joint->type == urdf::Joint::FIXED ? "FIXED" :
-                     joint->type == urdf::Joint::REVOLUTE ? "REVOLUTE" :
-                     joint->type == urdf::Joint::CONTINUOUS ? "CONTINUOUS" :
-                     joint->type == urdf::Joint::PRISMATIC ? "PRISMATIC" :
-                     joint->type == urdf::Joint::PLANAR ? "PLANAR" : "UNKNOWN",
-                     joint->parent_link_name.c_str(),
-                     joint->child_link_name.c_str());
-      }
-      
-    } catch (const std::exception & e) {
-      RCLCPP_ERROR(this->get_logger(), "Failed to parse URDF: %s", e.what());
-    }
-  }
-
-  /**
-   * Timer callback to publish footprint every 2 seconds
-   */
-  void timer_callback()
-  {
-    if (!urdf_model_) {
-      RCLCPP_WARN_ONCE(this->get_logger(), "URDF model not loaded, skipping footprint publication");
-      return;
-    }
-
-    // Process each link's collision geometry and publish outputs
-    process_collision_boxes();
-  }
-
-  // ===========================================================================
-  // Helper utilities for footprint projection
-  // ===========================================================================
-
-  /**
-   * Check if a link name belongs to the arm kinematic chain.
-   */
-  static bool isArmLink(const std::string & name)
-  {
-    // link1-link5 are arm joints, link61/link62 are gripper fingers
-    static const std::array<std::string, 7> arm_links = {
-      "link1", "link2", "link3", "link4", "link5", "link61", "link62"
     };
-    for (const auto & a : arm_links) {
-      if (name == a) return true;
+
+    static double cross(const Point2& o, const Point2& a, const Point2& b) {
+        return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
     }
-    return false;
-  }
 
-  /**
-   * Apply a pre-looked-up TF transform to a batch of 3D points.
-   */
-  static std::vector<geometry_msgs::msg::Point> applyTransform(
-      const std::vector<geometry_msgs::msg::Point>& points,
-      const geometry_msgs::msg::TransformStamped& tf)
-  {
-    std::vector<geometry_msgs::msg::Point> out;
-    out.reserve(points.size());
-    for (const auto & p : points) {
-      geometry_msgs::msg::PointStamped ps_in, ps_out;
-      ps_in.point = p;
-      tf2::doTransform(ps_in, ps_out, tf);
-      out.push_back(ps_out.point);
-    }
-    return out;
-  }
-
-  /**
-   * Project 3D points onto the XY plane and return the 2D convex hull.
-   */
-  static std::vector<Point2> projectXYConvexHull(
-      const std::vector<geometry_msgs::msg::Point>& pts_3d)
-  {
-    std::vector<Point2> pts_2d;
-    pts_2d.reserve(pts_3d.size());
-    for (const auto & p : pts_3d) {
-      pts_2d.push_back(Point2{p.x, p.y});
-    }
-    return convex_hull(std::move(pts_2d));
-  }
-
-  /**
-   * Build a Polygon message from 2D hull points.
-   */
-  static geometry_msgs::msg::Polygon toPolygonMsg(const std::vector<Point2>& hull)
-  {
-    geometry_msgs::msg::Polygon msg;
-    msg.points.reserve(hull.size());
-    for (const auto & p : hull) {
-      geometry_msgs::msg::Point32 pt;
-      pt.x = static_cast<float>(p.x);
-      pt.y = static_cast<float>(p.y);
-      pt.z = 0.0f;
-      msg.points.push_back(pt);
-    }
-    return msg;
-  }
-
-  /**
-   * Publish arm collision corners as a PointCloud2 in camera_optical_frame.
-   */
-  void publishCameraFootprint(
-      const std::vector<geometry_msgs::msg::Point>& corners_base_link)
-  {
-    if (corners_base_link.empty()) return;
-    try {
-      const auto tf = tf_buffer_.lookupTransform(
-          "camera_optical_frame", "base_link",
-          tf2::TimePointZero, tf2::durationFromSec(0.1));
-
-      const auto cam_pts = applyTransform(corners_base_link, tf);
-
-      auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
-      cloud->header.stamp    = this->get_clock()->now();
-      cloud->header.frame_id = "camera_optical_frame";
-      cloud->height = 1;
-      cloud->width  = static_cast<uint32_t>(cam_pts.size());
-      cloud->is_dense = true;
-      cloud->is_bigendian = false;
-
-      sensor_msgs::PointCloud2Modifier mod(*cloud);
-      mod.setPointCloud2FieldsByString(1, "xyz");
-      mod.resize(cam_pts.size());
-
-      sensor_msgs::PointCloud2Iterator<float> ix(*cloud, "x");
-      sensor_msgs::PointCloud2Iterator<float> iy(*cloud, "y");
-      sensor_msgs::PointCloud2Iterator<float> iz(*cloud, "z");
-
-      for (const auto & p : cam_pts) {
-        *ix = static_cast<float>(p.x);
-        *iy = static_cast<float>(p.y);
-        *iz = static_cast<float>(p.z);
-        ++ix; ++iy; ++iz;
-      }
-
-      camera_footprint_publisher_->publish(std::move(cloud));
-      RCLCPP_DEBUG(this->get_logger(),
-                   "Published /footprint/camera_optical with %zu points",
-                   cam_pts.size());
-    } catch (const tf2::TransformException & ex) {
-      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                           "Camera footprint TF lookup failed: %s", ex.what());
-    }
-  }
-
-  /**
-   * Process collision boxes from each link and transform to base_link frame
-   */
-  void process_collision_boxes()
-  {
-    const bool debug_mode = this->get_parameter("debug").as_bool();
-    const double padding = this->get_parameter("padding").as_double();
-    visualization_msgs::msg::MarkerArray points_array;
-    visualization_msgs::msg::MarkerArray boxes_array;
-    int marker_id = 0;
-
-    std::vector<Point2> all_points_xy;
-    all_points_xy.reserve(512);
-    std::vector<geometry_msgs::msg::Point> all_corners_3d;  // 3D corners (all links)
-    all_corners_3d.reserve(512);
-    std::vector<geometry_msgs::msg::Point> arm_corners_3d;   // 3D corners (arm only) for camera projection
-    arm_corners_3d.reserve(256);
-    double max_z = 0.0;  // Track maximum height of collision geometry
-    geometry_msgs::msg::PointStamped tallest_point;  // Track the tallest point
-    tallest_point.header.frame_id = "base_link";
-
-    for (const auto & link_pair : urdf_model_->links_) {
-      const auto & link = link_pair.second;
-      const std::string & link_name = link->name;
-
-      if (link->collision_array.empty()) {
-        continue;
-      }
-
-      for (size_t i = 0; i < link->collision_array.size(); ++i) {
-        const auto & collision = link->collision_array[i];
-        
-        if (!collision->geometry) {
-          continue;
+    static std::vector<Point2> convex_hull(std::vector<Point2> pts) {
+        if (pts.size() <= 1) {
+            return pts;
         }
 
-        const auto & geom = collision->geometry;
+        std::sort(pts.begin(), pts.end());
+        pts.erase(std::unique(pts.begin(), pts.end()), pts.end());
 
-        // Only process BOX geometry
-        if (geom->type != urdf::Geometry::BOX) {
-          const char* type_str = 
-            geom->type == urdf::Geometry::CYLINDER ? "CYLINDER" :
-            geom->type == urdf::Geometry::SPHERE ? "SPHERE" :
-            geom->type == urdf::Geometry::MESH ? "MESH" : "UNKNOWN";
-          RCLCPP_DEBUG(this->get_logger(), "Link '%s' collision[%zu]: Ignoring geometry type %s",
-                      link_name.c_str(), i, type_str);
-          continue;
+        if (pts.size() <= 2) {
+            return pts;
         }
 
-        auto box = std::dynamic_pointer_cast<urdf::Box>(geom);
-        if (!box) {
-          continue;
+        std::vector<Point2> lower;
+        lower.reserve(pts.size());
+        for (const auto& p : pts) {
+            while (lower.size() >= 2 && cross(lower[lower.size() - 2], lower[lower.size() - 1], p) <= 0.0) {
+                lower.pop_back();
+            }
+            lower.push_back(p);
         }
 
-        // Get half dimensions for local box corners
-        double hx = box->dim.x / 2.0;
-        double hy = box->dim.y / 2.0;
-        double hz = box->dim.z / 2.0;
-
-        // Build collision origin transform (position + rotation)
-        tf2::Transform collision_tf;
-        collision_tf.setOrigin(tf2::Vector3(
-          collision->origin.position.x,
-          collision->origin.position.y,
-          collision->origin.position.z));
-        collision_tf.setRotation(tf2::Quaternion(
-          collision->origin.rotation.x,
-          collision->origin.rotation.y,
-          collision->origin.rotation.z,
-          collision->origin.rotation.w));
-
-        // Compute the 8 corners of the box in the link frame (with rotation applied)
-        std::array<geometry_msgs::msg::PointStamped, 8> corners;
-        const double local_corners[8][3] = {
-          {-hx, -hy, -hz}, {+hx, -hy, -hz}, {-hx, +hy, -hz}, {+hx, +hy, -hz},
-          {-hx, -hy, +hz}, {+hx, -hy, +hz}, {-hx, +hy, +hz}, {+hx, +hy, +hz}
-        };
-        for (size_t c = 0; c < 8; ++c) {
-          tf2::Vector3 local_pt(local_corners[c][0], local_corners[c][1], local_corners[c][2]);
-          tf2::Vector3 link_pt = collision_tf * local_pt;  // Apply collision origin transform
-          corners[c].header.frame_id = link_name;
-          corners[c].header.stamp = rclcpp::Time(0, 0, this->get_clock()->get_clock_type());
-          corners[c].point.x = link_pt.x();
-          corners[c].point.y = link_pt.y();
-          corners[c].point.z = link_pt.z();
+        std::vector<Point2> upper;
+        upper.reserve(pts.size());
+        for (auto it = pts.rbegin(); it != pts.rend(); ++it) {
+            const auto& p = *it;
+            while (upper.size() >= 2 && cross(upper[upper.size() - 2], upper[upper.size() - 1], p) <= 0.0) {
+                upper.pop_back();
+            }
+            upper.push_back(p);
         }
 
+        lower.pop_back();
+        upper.pop_back();
+        lower.insert(lower.end(), upper.begin(), upper.end());
+        return lower;
+    }
+
+    tf2_ros::Buffer tf_buffer_;
+    tf2_ros::TransformListener tf_listener_;
+    rclcpp::Publisher<geometry_msgs::msg::Polygon>::SharedPtr footprint_publisher_;
+    rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr height_publisher_;
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr camera_footprint_publisher_;
+    rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr collision_points_publisher_;
+    rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr collision_boxes_publisher_;
+    rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr robot_hull_publisher_;
+    rclcpp::Publisher<geometry_msgs::msg::PointStamped>::SharedPtr height_point_publisher_;
+    rclcpp::TimerBase::SharedPtr timer_;
+    std::string robot_description_;
+    std::shared_ptr<urdf::Model> urdf_model_;
+
+    /**
+     * Retrieve robot_description from parameter server
+     */
+    void get_robot_description() {
         try {
-          // Transform all corners to base_link
-          for (size_t c = 0; c < 8; ++c) {
-            geometry_msgs::msg::PointStamped transformed;
-            transformed = tf_buffer_.transform(corners[c], "base_link", 
-                                               tf2::durationFromSec(0.1));
-            // Track max Z before projecting to XY plane
-            if (transformed.point.z > max_z) {
-              max_z = transformed.point.z;
-              tallest_point = transformed;
-              tallest_point.header.stamp = this->get_clock()->now();
+            auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(this, "robot_state_publisher");
+
+            while (!parameters_client->wait_for_service(std::chrono::seconds(1))) {
+                if (!rclcpp::ok()) {
+                    RCLCPP_WARN(this->get_logger(), "Interrupted while waiting for parameter server");
+                    return;
+                }
+                RCLCPP_INFO(this->get_logger(), "Waiting for parameter server...");
             }
-            all_corners_3d.push_back(transformed.point);
-            if (isArmLink(link_name)) {
-              arm_corners_3d.push_back(transformed.point);
+
+            auto params = parameters_client->get_parameters({"robot_description"});
+            if (!params.empty()) {
+                robot_description_ = params[0].as_string();
+                RCLCPP_INFO(this->get_logger(), "Successfully retrieved robot_description (length: %zu bytes)",
+                            robot_description_.length());
+
+                // Parse URDF
+                parse_urdf();
+            } else {
+                RCLCPP_WARN(this->get_logger(), "robot_description parameter not found");
             }
-            transformed.point.z = 0.0;
-            all_points_xy.push_back(Point2{transformed.point.x, transformed.point.y});
-          }
-
-          // Only create debug markers if debug mode is enabled
-          if (debug_mode) {
-            visualization_msgs::msg::Marker points_marker;
-            points_marker.header.frame_id = "base_link";
-            points_marker.header.stamp = this->get_clock()->now();
-            points_marker.ns = "collision_points";
-            points_marker.id = marker_id++;
-            points_marker.type = visualization_msgs::msg::Marker::POINTS;
-            points_marker.action = visualization_msgs::msg::Marker::ADD;
-            points_marker.scale.x = 0.02;  // Point size
-            points_marker.scale.y = 0.02;
-            points_marker.scale.z = 0.0;
-            points_marker.color.r = 1.0;
-            points_marker.color.g = 0.0;
-            points_marker.color.b = 0.0;
-            points_marker.color.a = 1.0;
-            points_marker.lifetime = rclcpp::Duration::from_seconds(2.5);
-            visualization_msgs::msg::Marker points_marker_3d = points_marker;
-
-
-            // Re-transform for marker points
-            for (size_t c = 0; c < 8; ++c) {
-              geometry_msgs::msg::PointStamped transformed;
-              transformed = tf_buffer_.transform(corners[c], "base_link", 
-                                                 tf2::durationFromSec(0.1));
-              transformed.point.z = 0.0;
-              points_marker.points.push_back(transformed.point);
-            }
-            boxes_array.markers.push_back(points_marker);
-
-
-            points_marker_3d.scale.z = 0.02;  // Enable 3D visualization
-            // Add 3D points (with actual Z values)
-            for (size_t c = 0; c < 8; ++c) {
-              geometry_msgs::msg::PointStamped transformed;
-              transformed = tf_buffer_.transform(corners[c], "base_link", 
-                                                 tf2::durationFromSec(0.1));
-              points_marker_3d.points.push_back(transformed.point);
-            }
-            points_array.markers.push_back(points_marker_3d);
-
-          }
-
-          RCLCPP_DEBUG(this->get_logger(), 
-                      "Link '%s' collision[%zu] BOX - 8 corners transformed",
-                      link_name.c_str(), i);
-
-        } catch (const tf2::TransformException & ex) {
-          RCLCPP_WARN(this->get_logger(), 
-                      "Could not transform '%s' to base_link: %s",
-                      link_name.c_str(), ex.what());
+        } catch (const std::exception& e) {
+            RCLCPP_ERROR(this->get_logger(), "Failed to get robot_description: %s", e.what());
         }
-      }
     }
 
-    // Publish the debug marker arrays (only if debug mode)
-    if (debug_mode && !points_array.markers.empty()) {
-      collision_points_publisher_->publish(points_array);
-      RCLCPP_DEBUG(this->get_logger(), "Published %zu collision point markers", points_array.markers.size());
-    }
+    /**
+     * Parse URDF and extract robot information
+     */
+    void parse_urdf() {
+        try {
+            urdf_model_ = std::make_shared<urdf::Model>();
+            if (!urdf_model_->initString(robot_description_)) {
+                RCLCPP_ERROR(this->get_logger(), "Failed to parse URDF");
+                urdf_model_ = nullptr;
+                return;
+            }
 
-    if (debug_mode && !boxes_array.markers.empty()) {
-      collision_boxes_publisher_->publish(boxes_array);
-      RCLCPP_DEBUG(this->get_logger(), "Published %zu collision box markers", boxes_array.markers.size());
-    }
+            RCLCPP_INFO(this->get_logger(), "Successfully parsed URDF for robot: %s", urdf_model_->getName().c_str());
 
-    // Publish convex hull over ALL projected points across the robot
-    if (all_points_xy.size() >= 3) {
-      const auto hull = convex_hull(std::move(all_points_xy));
-      if (hull.size() >= 3) {
+            // Log links information
+            RCLCPP_INFO(this->get_logger(), "Number of links: %zu", urdf_model_->links_.size());
+            for (const auto& link_pair : urdf_model_->links_) {
+                const auto& link = link_pair.second;
+                RCLCPP_DEBUG(this->get_logger(), "  Link: %s", link->name.c_str());
 
-        std::vector<geometry_msgs::msg::Point> padded_hull_points;
-        padded_hull_points.reserve(hull.size());
-        for (const auto & p : hull) {
-          geometry_msgs::msg::Point pt;
-          pt.x = p.x;
-          pt.y = p.y;
-          pt.z = 0.0;
-          padded_hull_points.push_back(pt);
+                if (link->inertial) {
+                    RCLCPP_DEBUG(this->get_logger(), "    Mass: %f kg", link->inertial->mass);
+                    RCLCPP_DEBUG(this->get_logger(), "    Inertia: Ixx=%f, Iyy=%f, Izz=%f", link->inertial->ixx,
+                                 link->inertial->iyy, link->inertial->izz);
+                }
+
+                // Log collision geometry
+                if (!link->collision_array.empty()) {
+                    RCLCPP_INFO(this->get_logger(), "  Link '%s' - Collision objects: %zu", link->name.c_str(),
+                                link->collision_array.size());
+
+                    for (size_t i = 0; i < link->collision_array.size(); ++i) {
+                        const auto& collision = link->collision_array[i];
+                        RCLCPP_INFO(this->get_logger(), "    Collision [%zu]: name=%s", i, collision->name.c_str());
+
+                        RCLCPP_INFO(this->get_logger(), "      Origin: xyz=(%f, %f, %f)", collision->origin.position.x,
+                                    collision->origin.position.y, collision->origin.position.z);
+
+                        if (collision->geometry) {
+                            const auto& geom = collision->geometry;
+
+                            if (geom->type == urdf::Geometry::BOX) {
+                                auto box = std::dynamic_pointer_cast<urdf::Box>(geom);
+                                if (box) {
+                                    RCLCPP_INFO(this->get_logger(), "      Geometry: BOX - size=(%f, %f, %f)",
+                                                box->dim.x, box->dim.y, box->dim.z);
+                                }
+                            } else if (geom->type == urdf::Geometry::CYLINDER) {
+                                auto cyl = std::dynamic_pointer_cast<urdf::Cylinder>(geom);
+                                if (cyl) {
+                                    RCLCPP_INFO(this->get_logger(), "      Geometry: CYLINDER - radius=%f, length=%f",
+                                                cyl->radius, cyl->length);
+                                }
+                            } else if (geom->type == urdf::Geometry::SPHERE) {
+                                auto sphere = std::dynamic_pointer_cast<urdf::Sphere>(geom);
+                                if (sphere) {
+                                    RCLCPP_INFO(this->get_logger(), "      Geometry: SPHERE - radius=%f",
+                                                sphere->radius);
+                                }
+                            } else if (geom->type == urdf::Geometry::MESH) {
+                                auto mesh = std::dynamic_pointer_cast<urdf::Mesh>(geom);
+                                if (mesh) {
+                                    RCLCPP_INFO(this->get_logger(),
+                                                "      Geometry: MESH - filename=%s, scale=(%f, %f, %f)",
+                                                mesh->filename.c_str(), mesh->scale.x, mesh->scale.y, mesh->scale.z);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (!link->visual_array.empty()) {
+                    RCLCPP_DEBUG(this->get_logger(), "    Visual objects: %zu", link->visual_array.size());
+                }
+            }
+
+            // Log joints information
+            RCLCPP_INFO(this->get_logger(), "Number of joints: %zu", urdf_model_->joints_.size());
+            for (const auto& joint_pair : urdf_model_->joints_) {
+                const auto& joint = joint_pair.second;
+                RCLCPP_DEBUG(this->get_logger(), "  Joint: %s (%s) - %s -> %s", joint->name.c_str(),
+                             joint->type == urdf::Joint::FIXED        ? "FIXED"
+                             : joint->type == urdf::Joint::REVOLUTE   ? "REVOLUTE"
+                             : joint->type == urdf::Joint::CONTINUOUS ? "CONTINUOUS"
+                             : joint->type == urdf::Joint::PRISMATIC  ? "PRISMATIC"
+                             : joint->type == urdf::Joint::PLANAR     ? "PLANAR"
+                                                                      : "UNKNOWN",
+                             joint->parent_link_name.c_str(), joint->child_link_name.c_str());
+            }
+
+        } catch (const std::exception& e) {
+            RCLCPP_ERROR(this->get_logger(), "Failed to parse URDF: %s", e.what());
         }
-        padFootprint(padded_hull_points, padding);
+    }
 
-        // Publish the hull as the nav2 footprint (Polygon type)
-        {
-          geometry_msgs::msg::Polygon polygon_msg;
-          polygon_msg.points.reserve(padded_hull_points.size());
+    /**
+     * Timer callback to publish footprint every 2 seconds
+     */
+    void timer_callback() {
+        if (!urdf_model_) {
+            RCLCPP_WARN_ONCE(this->get_logger(), "URDF model not loaded, skipping footprint publication");
+            return;
+        }
 
-          for (const auto & p : padded_hull_points) {
+        // Process each link's collision geometry and publish outputs
+        process_collision_boxes();
+    }
+
+    // ===========================================================================
+    // Helper utilities for footprint projection
+    // ===========================================================================
+
+    /**
+     * Check if a link name belongs to the arm kinematic chain.
+     */
+    static bool isArmLink(const std::string& name) {
+        // link1-link5 are arm joints, link61/link62 are gripper fingers
+        static const std::array<std::string, 7> arm_links = {"link1", "link2",  "link3", "link4",
+                                                             "link5", "link61", "link62"};
+        for (const auto& a : arm_links) {
+            if (name == a)
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Apply a pre-looked-up TF transform to a batch of 3D points.
+     */
+    static std::vector<geometry_msgs::msg::Point> applyTransform(const std::vector<geometry_msgs::msg::Point>& points,
+                                                                 const geometry_msgs::msg::TransformStamped& tf) {
+        std::vector<geometry_msgs::msg::Point> out;
+        out.reserve(points.size());
+        for (const auto& p : points) {
+            geometry_msgs::msg::PointStamped ps_in, ps_out;
+            ps_in.point = p;
+            tf2::doTransform(ps_in, ps_out, tf);
+            out.push_back(ps_out.point);
+        }
+        return out;
+    }
+
+    /**
+     * Project 3D points onto the XY plane and return the 2D convex hull.
+     */
+    static std::vector<Point2> projectXYConvexHull(const std::vector<geometry_msgs::msg::Point>& pts_3d) {
+        std::vector<Point2> pts_2d;
+        pts_2d.reserve(pts_3d.size());
+        for (const auto& p : pts_3d) {
+            pts_2d.push_back(Point2{p.x, p.y});
+        }
+        return convex_hull(std::move(pts_2d));
+    }
+
+    /**
+     * Build a Polygon message from 2D hull points.
+     */
+    static geometry_msgs::msg::Polygon toPolygonMsg(const std::vector<Point2>& hull) {
+        geometry_msgs::msg::Polygon msg;
+        msg.points.reserve(hull.size());
+        for (const auto& p : hull) {
             geometry_msgs::msg::Point32 pt;
             pt.x = static_cast<float>(p.x);
             pt.y = static_cast<float>(p.y);
             pt.z = 0.0f;
-            polygon_msg.points.push_back(pt);
-          }
-
-          footprint_publisher_->publish(polygon_msg);
-          RCLCPP_DEBUG(this->get_logger(), "Published /footprint convex hull with %zu vertices", hull.size());
+            msg.points.push_back(pt);
         }
-
-        // Publish arm-only footprint projected into camera optical frame
-        publishCameraFootprint(arm_corners_3d);
-
-        // Publish the max height of the robot collision geometry
-        {
-          std_msgs::msg::Float64 height_msg;
-          height_msg.data = max_z + padding;
-          height_publisher_->publish(height_msg);
-          RCLCPP_DEBUG(this->get_logger(), "Published /footprint/height: %.3f m (max_z=%.3f, padding=%.3f)", 
-                       height_msg.data, max_z, padding);
-        }
-
-        // Only publish hull marker if debug mode
-        if (debug_mode) {
-          visualization_msgs::msg::Marker hull_marker;
-          hull_marker.header.frame_id = "base_link";
-          hull_marker.header.stamp = this->get_clock()->now();
-          hull_marker.ns = "robot_convex_hull";
-          hull_marker.id = 0;
-          hull_marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
-          hull_marker.action = visualization_msgs::msg::Marker::ADD;
-          hull_marker.scale.x = 0.01;  // line width
-          hull_marker.color.r = 1.0;
-          hull_marker.color.g = 1.0;
-          hull_marker.color.b = 0.0;
-          hull_marker.color.a = 1.0;
-          hull_marker.lifetime = rclcpp::Duration::from_seconds(2.5);
-
-          hull_marker.points.reserve(padded_hull_points.size() + 1);
-          for (const auto & p : padded_hull_points) {
-            hull_marker.points.push_back(p);
-          }
-          // Close the loop
-          hull_marker.points.push_back(padded_hull_points.front());
-
-          robot_hull_publisher_->publish(hull_marker);
-          RCLCPP_DEBUG(this->get_logger(), "Published robot convex hull with %zu vertices (padding=%.3f)", hull.size(), padding);
-
-          // Publish the tallest point
-          if (debug_mode && height_point_publisher_ && max_z > 0) {
-            tallest_point.point.z += padding;
-            height_point_publisher_->publish(tallest_point);
-            RCLCPP_DEBUG(this->get_logger(), "Published /footprint/height_point: (%.3f, %.3f, %.3f)", 
-                         tallest_point.point.x, tallest_point.point.y, tallest_point.point.z);
-          }
-        }
-      }
+        return msg;
     }
-  }
+
+    /**
+     * Publish arm collision corners as a PointCloud2 in camera_optical_frame.
+     */
+    void publishCameraFootprint(const std::vector<geometry_msgs::msg::Point>& corners_base_link) {
+        if (corners_base_link.empty())
+            return;
+        try {
+            const auto tf = tf_buffer_.lookupTransform("camera_optical_frame", "base_link", tf2::TimePointZero,
+                                                       tf2::durationFromSec(0.1));
+
+            const auto cam_pts = applyTransform(corners_base_link, tf);
+
+            auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
+            cloud->header.stamp = this->get_clock()->now();
+            cloud->header.frame_id = "camera_optical_frame";
+            cloud->height = 1;
+            cloud->width = static_cast<uint32_t>(cam_pts.size());
+            cloud->is_dense = true;
+            cloud->is_bigendian = false;
+
+            sensor_msgs::PointCloud2Modifier mod(*cloud);
+            mod.setPointCloud2FieldsByString(1, "xyz");
+            mod.resize(cam_pts.size());
+
+            sensor_msgs::PointCloud2Iterator<float> ix(*cloud, "x");
+            sensor_msgs::PointCloud2Iterator<float> iy(*cloud, "y");
+            sensor_msgs::PointCloud2Iterator<float> iz(*cloud, "z");
+
+            for (const auto& p : cam_pts) {
+                *ix = static_cast<float>(p.x);
+                *iy = static_cast<float>(p.y);
+                *iz = static_cast<float>(p.z);
+                ++ix;
+                ++iy;
+                ++iz;
+            }
+
+            camera_footprint_publisher_->publish(std::move(cloud));
+            RCLCPP_DEBUG(this->get_logger(), "Published /footprint/camera_optical with %zu points", cam_pts.size());
+        } catch (const tf2::TransformException& ex) {
+            RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000, "Camera footprint TF lookup failed: %s",
+                                 ex.what());
+        }
+    }
+
+    /**
+     * Process collision boxes from each link and transform to base_link frame
+     */
+    void process_collision_boxes() {
+        const bool debug_mode = this->get_parameter("debug").as_bool();
+        const double padding = this->get_parameter("padding").as_double();
+        visualization_msgs::msg::MarkerArray points_array;
+        visualization_msgs::msg::MarkerArray boxes_array;
+        int marker_id = 0;
+
+        std::vector<Point2> all_points_xy;
+        all_points_xy.reserve(512);
+        std::vector<geometry_msgs::msg::Point> all_corners_3d;  // 3D corners (all links)
+        all_corners_3d.reserve(512);
+        std::vector<geometry_msgs::msg::Point> arm_corners_3d;  // 3D corners (arm only) for camera projection
+        arm_corners_3d.reserve(256);
+        double max_z = 0.0;                              // Track maximum height of collision geometry
+        geometry_msgs::msg::PointStamped tallest_point;  // Track the tallest point
+        tallest_point.header.frame_id = "base_link";
+
+        for (const auto& link_pair : urdf_model_->links_) {
+            const auto& link = link_pair.second;
+            const std::string& link_name = link->name;
+
+            if (link->collision_array.empty()) {
+                continue;
+            }
+
+            for (size_t i = 0; i < link->collision_array.size(); ++i) {
+                const auto& collision = link->collision_array[i];
+
+                if (!collision->geometry) {
+                    continue;
+                }
+
+                const auto& geom = collision->geometry;
+
+                // Only process BOX geometry
+                if (geom->type != urdf::Geometry::BOX) {
+                    const char* type_str = geom->type == urdf::Geometry::CYLINDER ? "CYLINDER"
+                                           : geom->type == urdf::Geometry::SPHERE ? "SPHERE"
+                                           : geom->type == urdf::Geometry::MESH   ? "MESH"
+                                                                                  : "UNKNOWN";
+                    RCLCPP_DEBUG(this->get_logger(), "Link '%s' collision[%zu]: Ignoring geometry type %s",
+                                 link_name.c_str(), i, type_str);
+                    continue;
+                }
+
+                auto box = std::dynamic_pointer_cast<urdf::Box>(geom);
+                if (!box) {
+                    continue;
+                }
+
+                // Get half dimensions for local box corners
+                double hx = box->dim.x / 2.0;
+                double hy = box->dim.y / 2.0;
+                double hz = box->dim.z / 2.0;
+
+                // Build collision origin transform (position + rotation)
+                tf2::Transform collision_tf;
+                collision_tf.setOrigin(tf2::Vector3(collision->origin.position.x, collision->origin.position.y,
+                                                    collision->origin.position.z));
+                collision_tf.setRotation(tf2::Quaternion(collision->origin.rotation.x, collision->origin.rotation.y,
+                                                         collision->origin.rotation.z, collision->origin.rotation.w));
+
+                // Compute the 8 corners of the box in the link frame (with rotation applied)
+                std::array<geometry_msgs::msg::PointStamped, 8> corners;
+                const double local_corners[8][3] = {{-hx, -hy, -hz}, {+hx, -hy, -hz}, {-hx, +hy, -hz}, {+hx, +hy, -hz},
+                                                    {-hx, -hy, +hz}, {+hx, -hy, +hz}, {-hx, +hy, +hz}, {+hx, +hy, +hz}};
+                for (size_t c = 0; c < 8; ++c) {
+                    tf2::Vector3 local_pt(local_corners[c][0], local_corners[c][1], local_corners[c][2]);
+                    tf2::Vector3 link_pt = collision_tf * local_pt;  // Apply collision origin transform
+                    corners[c].header.frame_id = link_name;
+                    corners[c].header.stamp = rclcpp::Time(0, 0, this->get_clock()->get_clock_type());
+                    corners[c].point.x = link_pt.x();
+                    corners[c].point.y = link_pt.y();
+                    corners[c].point.z = link_pt.z();
+                }
+
+                try {
+                    // Transform all corners to base_link
+                    for (size_t c = 0; c < 8; ++c) {
+                        geometry_msgs::msg::PointStamped transformed;
+                        transformed = tf_buffer_.transform(corners[c], "base_link", tf2::durationFromSec(0.1));
+                        // Track max Z before projecting to XY plane
+                        if (transformed.point.z > max_z) {
+                            max_z = transformed.point.z;
+                            tallest_point = transformed;
+                            tallest_point.header.stamp = this->get_clock()->now();
+                        }
+                        all_corners_3d.push_back(transformed.point);
+                        if (isArmLink(link_name)) {
+                            arm_corners_3d.push_back(transformed.point);
+                        }
+                        transformed.point.z = 0.0;
+                        all_points_xy.push_back(Point2{transformed.point.x, transformed.point.y});
+                    }
+
+                    // Only create debug markers if debug mode is enabled
+                    if (debug_mode) {
+                        visualization_msgs::msg::Marker points_marker;
+                        points_marker.header.frame_id = "base_link";
+                        points_marker.header.stamp = this->get_clock()->now();
+                        points_marker.ns = "collision_points";
+                        points_marker.id = marker_id++;
+                        points_marker.type = visualization_msgs::msg::Marker::POINTS;
+                        points_marker.action = visualization_msgs::msg::Marker::ADD;
+                        points_marker.scale.x = 0.02;  // Point size
+                        points_marker.scale.y = 0.02;
+                        points_marker.scale.z = 0.0;
+                        points_marker.color.r = 1.0;
+                        points_marker.color.g = 0.0;
+                        points_marker.color.b = 0.0;
+                        points_marker.color.a = 1.0;
+                        points_marker.lifetime = rclcpp::Duration::from_seconds(2.5);
+                        visualization_msgs::msg::Marker points_marker_3d = points_marker;
+
+                        // Re-transform for marker points
+                        for (size_t c = 0; c < 8; ++c) {
+                            geometry_msgs::msg::PointStamped transformed;
+                            transformed = tf_buffer_.transform(corners[c], "base_link", tf2::durationFromSec(0.1));
+                            transformed.point.z = 0.0;
+                            points_marker.points.push_back(transformed.point);
+                        }
+                        boxes_array.markers.push_back(points_marker);
+
+                        points_marker_3d.scale.z = 0.02;  // Enable 3D visualization
+                        // Add 3D points (with actual Z values)
+                        for (size_t c = 0; c < 8; ++c) {
+                            geometry_msgs::msg::PointStamped transformed;
+                            transformed = tf_buffer_.transform(corners[c], "base_link", tf2::durationFromSec(0.1));
+                            points_marker_3d.points.push_back(transformed.point);
+                        }
+                        points_array.markers.push_back(points_marker_3d);
+                    }
+
+                    RCLCPP_DEBUG(this->get_logger(), "Link '%s' collision[%zu] BOX - 8 corners transformed",
+                                 link_name.c_str(), i);
+
+                } catch (const tf2::TransformException& ex) {
+                    RCLCPP_WARN(this->get_logger(), "Could not transform '%s' to base_link: %s", link_name.c_str(),
+                                ex.what());
+                }
+            }
+        }
+
+        // Publish the debug marker arrays (only if debug mode)
+        if (debug_mode && !points_array.markers.empty()) {
+            collision_points_publisher_->publish(points_array);
+            RCLCPP_DEBUG(this->get_logger(), "Published %zu collision point markers", points_array.markers.size());
+        }
+
+        if (debug_mode && !boxes_array.markers.empty()) {
+            collision_boxes_publisher_->publish(boxes_array);
+            RCLCPP_DEBUG(this->get_logger(), "Published %zu collision box markers", boxes_array.markers.size());
+        }
+
+        // Publish convex hull over ALL projected points across the robot
+        if (all_points_xy.size() >= 3) {
+            const auto hull = convex_hull(std::move(all_points_xy));
+            if (hull.size() >= 3) {
+                std::vector<geometry_msgs::msg::Point> padded_hull_points;
+                padded_hull_points.reserve(hull.size());
+                for (const auto& p : hull) {
+                    geometry_msgs::msg::Point pt;
+                    pt.x = p.x;
+                    pt.y = p.y;
+                    pt.z = 0.0;
+                    padded_hull_points.push_back(pt);
+                }
+                padFootprint(padded_hull_points, padding);
+
+                // Publish the hull as the nav2 footprint (Polygon type)
+                {
+                    geometry_msgs::msg::Polygon polygon_msg;
+                    polygon_msg.points.reserve(padded_hull_points.size());
+
+                    for (const auto& p : padded_hull_points) {
+                        geometry_msgs::msg::Point32 pt;
+                        pt.x = static_cast<float>(p.x);
+                        pt.y = static_cast<float>(p.y);
+                        pt.z = 0.0f;
+                        polygon_msg.points.push_back(pt);
+                    }
+
+                    footprint_publisher_->publish(polygon_msg);
+                    RCLCPP_DEBUG(this->get_logger(), "Published /footprint convex hull with %zu vertices", hull.size());
+                }
+
+                // Publish arm-only footprint projected into camera optical frame
+                publishCameraFootprint(arm_corners_3d);
+
+                // Publish the max height of the robot collision geometry
+                {
+                    std_msgs::msg::Float64 height_msg;
+                    height_msg.data = max_z + padding;
+                    height_publisher_->publish(height_msg);
+                    RCLCPP_DEBUG(this->get_logger(), "Published /footprint/height: %.3f m (max_z=%.3f, padding=%.3f)",
+                                 height_msg.data, max_z, padding);
+                }
+
+                // Only publish hull marker if debug mode
+                if (debug_mode) {
+                    visualization_msgs::msg::Marker hull_marker;
+                    hull_marker.header.frame_id = "base_link";
+                    hull_marker.header.stamp = this->get_clock()->now();
+                    hull_marker.ns = "robot_convex_hull";
+                    hull_marker.id = 0;
+                    hull_marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+                    hull_marker.action = visualization_msgs::msg::Marker::ADD;
+                    hull_marker.scale.x = 0.01;  // line width
+                    hull_marker.color.r = 1.0;
+                    hull_marker.color.g = 1.0;
+                    hull_marker.color.b = 0.0;
+                    hull_marker.color.a = 1.0;
+                    hull_marker.lifetime = rclcpp::Duration::from_seconds(2.5);
+
+                    hull_marker.points.reserve(padded_hull_points.size() + 1);
+                    for (const auto& p : padded_hull_points) {
+                        hull_marker.points.push_back(p);
+                    }
+                    // Close the loop
+                    hull_marker.points.push_back(padded_hull_points.front());
+
+                    robot_hull_publisher_->publish(hull_marker);
+                    RCLCPP_DEBUG(this->get_logger(), "Published robot convex hull with %zu vertices (padding=%.3f)",
+                                 hull.size(), padding);
+
+                    // Publish the tallest point
+                    if (debug_mode && height_point_publisher_ && max_z > 0) {
+                        tallest_point.point.z += padding;
+                        height_point_publisher_->publish(tallest_point);
+                        RCLCPP_DEBUG(this->get_logger(), "Published /footprint/height_point: (%.3f, %.3f, %.3f)",
+                                     tallest_point.point.x, tallest_point.point.y, tallest_point.point.z);
+                    }
+                }
+            }
+        }
+    }
 };
 
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<DynamicFootprint>());
-  rclcpp::shutdown();
-  return 0;
+int main(int argc, char* argv[]) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<DynamicFootprint>());
+    rclcpp::shutdown();
+    return 0;
 }

--- a/ros2_ws/src/maurice_bot/maurice_nav/src/goal_approach_scaler.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_nav/src/goal_approach_scaler.cpp
@@ -16,101 +16,93 @@
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 #include "action_msgs/msg/goal_status_array.hpp"
 
-class GoalApproachScaler : public rclcpp::Node
-{
-public:
-  GoalApproachScaler()
-  : Node("goal_approach_scaler"),
-    distance_remaining_(std::numeric_limits<double>::infinity()),
-    navigating_(false)
-  {
-    // Parameters
-    this->declare_parameter("slowdown_radius", 0.3);
-    this->declare_parameter("min_speed_fraction", 0.3);
+class GoalApproachScaler : public rclcpp::Node {
+   public:
+    GoalApproachScaler()
+        : Node("goal_approach_scaler"),
+          distance_remaining_(std::numeric_limits<double>::infinity()),
+          navigating_(false) {
+        // Parameters
+        this->declare_parameter("slowdown_radius", 0.3);
+        this->declare_parameter("min_speed_fraction", 0.3);
 
-    slowdown_radius_ = this->get_parameter("slowdown_radius").as_double();
-    min_speed_fraction_ = this->get_parameter("min_speed_fraction").as_double();
+        slowdown_radius_ = this->get_parameter("slowdown_radius").as_double();
+        min_speed_fraction_ = this->get_parameter("min_speed_fraction").as_double();
 
-    // Subscribe to NavigateToPose action feedback (published by bt_navigator)
-    using FeedbackMsg = nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage;
-    feedback_sub_ = this->create_subscription<FeedbackMsg>(
-      "/internal_navigate_to_pose/_action/feedback", 10,
-      [this](const FeedbackMsg::SharedPtr msg) {
-        distance_remaining_ = msg->feedback.distance_remaining;
-        navigating_ = true;
-      });
+        // Subscribe to NavigateToPose action feedback (published by bt_navigator)
+        using FeedbackMsg = nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage;
+        feedback_sub_ = this->create_subscription<FeedbackMsg>(
+            "/internal_navigate_to_pose/_action/feedback", 10, [this](const FeedbackMsg::SharedPtr msg) {
+                distance_remaining_ = msg->feedback.distance_remaining;
+                navigating_ = true;
+            });
 
-    // Subscribe to action status to detect when navigation ends
-    status_sub_ = this->create_subscription<action_msgs::msg::GoalStatusArray>(
-      "/internal_navigate_to_pose/_action/status", 10,
-      [this](const action_msgs::msg::GoalStatusArray::SharedPtr msg) {
-        if (msg->status_list.empty()) {
-          navigating_ = false;
-          distance_remaining_ = std::numeric_limits<double>::infinity();
-          return;
-        }
-        // status 2 = EXECUTING, anything else means done/aborted/canceled
-        bool active = false;
-        for (const auto & s : msg->status_list) {
-          if (s.status == 2) {
-            active = true;
-            break;
-          }
-        }
-        if (!active) {
-          navigating_ = false;
-          distance_remaining_ = std::numeric_limits<double>::infinity();
-        }
-      });
+        // Subscribe to action status to detect when navigation ends
+        status_sub_ = this->create_subscription<action_msgs::msg::GoalStatusArray>(
+            "/internal_navigate_to_pose/_action/status", 10,
+            [this](const action_msgs::msg::GoalStatusArray::SharedPtr msg) {
+                if (msg->status_list.empty()) {
+                    navigating_ = false;
+                    distance_remaining_ = std::numeric_limits<double>::infinity();
+                    return;
+                }
+                // status 2 = EXECUTING, anything else means done/aborted/canceled
+                bool active = false;
+                for (const auto& s : msg->status_list) {
+                    if (s.status == 2) {
+                        active = true;
+                        break;
+                    }
+                }
+                if (!active) {
+                    navigating_ = false;
+                    distance_remaining_ = std::numeric_limits<double>::infinity();
+                }
+            });
 
-    // cmd_vel passthrough
-    vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
-      "cmd_vel_in", 10,
-      std::bind(&GoalApproachScaler::vel_cb, this, std::placeholders::_1));
-    vel_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel_out", 10);
+        // cmd_vel passthrough
+        vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+            "cmd_vel_in", 10, std::bind(&GoalApproachScaler::vel_cb, this, std::placeholders::_1));
+        vel_pub_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel_out", 10);
 
-    RCLCPP_INFO(this->get_logger(),
-      "Goal approach scaler: radius=%.2fm, min_fraction=%.2f",
-      slowdown_radius_, min_speed_fraction_);
-  }
-
-private:
-  void vel_cb(const geometry_msgs::msg::Twist::SharedPtr msg)
-  {
-    if (!navigating_ || distance_remaining_ >= slowdown_radius_) {
-      vel_pub_->publish(*msg);
-      return;
+        RCLCPP_INFO(this->get_logger(), "Goal approach scaler: radius=%.2fm, min_fraction=%.2f", slowdown_radius_,
+                    min_speed_fraction_);
     }
 
-    // Linear ramp: at dist==0 -> min_speed_fraction, at dist==radius -> 1.0
-    double fraction = min_speed_fraction_ + (1.0 - min_speed_fraction_) *
-      (distance_remaining_ / slowdown_radius_);
+   private:
+    void vel_cb(const geometry_msgs::msg::Twist::SharedPtr msg) {
+        if (!navigating_ || distance_remaining_ >= slowdown_radius_) {
+            vel_pub_->publish(*msg);
+            return;
+        }
 
-    geometry_msgs::msg::Twist scaled;
-    scaled.linear.x = msg->linear.x * fraction;
-    scaled.linear.y = msg->linear.y;
-    scaled.linear.z = msg->linear.z;
-    scaled.angular.x = msg->angular.x;
-    scaled.angular.y = msg->angular.y;
-    scaled.angular.z = msg->angular.z;
-    vel_pub_->publish(scaled);
-  }
+        // Linear ramp: at dist==0 -> min_speed_fraction, at dist==radius -> 1.0
+        double fraction = min_speed_fraction_ + (1.0 - min_speed_fraction_) * (distance_remaining_ / slowdown_radius_);
 
-  double slowdown_radius_;
-  double min_speed_fraction_;
-  double distance_remaining_;
-  bool navigating_;
+        geometry_msgs::msg::Twist scaled;
+        scaled.linear.x = msg->linear.x * fraction;
+        scaled.linear.y = msg->linear.y;
+        scaled.linear.z = msg->linear.z;
+        scaled.angular.x = msg->angular.x;
+        scaled.angular.y = msg->angular.y;
+        scaled.angular.z = msg->angular.z;
+        vel_pub_->publish(scaled);
+    }
 
-  rclcpp::Subscription<nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage>::SharedPtr feedback_sub_;
-  rclcpp::Subscription<action_msgs::msg::GoalStatusArray>::SharedPtr status_sub_;
-  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr vel_sub_;
-  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr vel_pub_;
+    double slowdown_radius_;
+    double min_speed_fraction_;
+    double distance_remaining_;
+    bool navigating_;
+
+    rclcpp::Subscription<nav2_msgs::action::NavigateToPose::Impl::FeedbackMessage>::SharedPtr feedback_sub_;
+    rclcpp::Subscription<action_msgs::msg::GoalStatusArray>::SharedPtr status_sub_;
+    rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr vel_sub_;
+    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr vel_pub_;
 };
 
-int main(int argc, char ** argv)
-{
-  rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<GoalApproachScaler>());
-  rclcpp::shutdown();
-  return 0;
+int main(int argc, char** argv) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<GoalApproachScaler>());
+    rclcpp::shutdown();
+    return 0;
 }

--- a/ros2_ws/src/maurice_bot/maurice_nav/src/null_map_node.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_nav/src/null_map_node.cpp
@@ -19,220 +19,205 @@ using namespace std::chrono_literals;
  * from map to odom frame. This is useful when a robot doesn't have SLAM
  * and wants to assume the map and odom frames are aligned.
  */
-class NullMapNode : public rclcpp_lifecycle::LifecycleNode
-{
-public:
-  /// NullMapNode constructor
-  /**
-   * The NullMapNode constructor initializes the lifecycle node with
-   * the node name "null_map_node".
-   */
-  explicit NullMapNode(const std::string & node_name = "null_map_node",
-      bool intra_process_comms = false)
-  : rclcpp_lifecycle::LifecycleNode(node_name,
-      rclcpp::NodeOptions().use_intra_process_comms(intra_process_comms))
-  {}
+class NullMapNode : public rclcpp_lifecycle::LifecycleNode {
+   public:
+    /// NullMapNode constructor
+    /**
+     * The NullMapNode constructor initializes the lifecycle node with
+     * the node name "null_map_node".
+     */
+    explicit NullMapNode(const std::string &node_name = "null_map_node", bool intra_process_comms = false)
+        : rclcpp_lifecycle::LifecycleNode(node_name,
+                                          rclcpp::NodeOptions().use_intra_process_comms(intra_process_comms)) {}
 
-  /// Callback for walltimer to publish the identity transform
-  /**
-   * Callback for the wall timer. This function gets invoked periodically
-   * by the timer and publishes an identity transform from map to odom.
-   */
-  void
-  publish_transform()
-  {
-    // Only publish if the node is active
-    if (this->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
-      return;
+    /// Callback for walltimer to publish the identity transform
+    /**
+     * Callback for the wall timer. This function gets invoked periodically
+     * by the timer and publishes an identity transform from map to odom.
+     */
+    void publish_transform() {
+        // Only publish if the node is active
+        if (this->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+            return;
+        }
+
+        geometry_msgs::msg::TransformStamped t;
+
+        // Set header information
+        t.header.stamp = this->get_clock()->now();
+        t.header.frame_id = "map";
+        t.child_frame_id = "odom";
+
+        // Identity transform - no translation
+        t.transform.translation.x = 0.0;
+        t.transform.translation.y = 0.0;
+        t.transform.translation.z = 0.0;
+
+        // Identity rotation (no rotation)
+        tf2::Quaternion q;
+        q.setRPY(0, 0, 0);
+        t.transform.rotation.x = q.x();
+        t.transform.rotation.y = q.y();
+        t.transform.rotation.z = q.z();
+        t.transform.rotation.w = q.w();
+
+        // Send the transformation
+        tf_broadcaster_->sendTransform(t);
+
+        // Publish empty map
+        publish_empty_map();
     }
 
-    geometry_msgs::msg::TransformStamped t;
+    /// Callback to publish an empty occupancy grid
+    /**
+     * Publishes an empty map (0x0 size) to the /map topic.
+     */
+    void publish_empty_map() {
+        if (!map_pub_ || !map_pub_->is_activated()) {
+            return;
+        }
 
-    // Set header information
-    t.header.stamp = this->get_clock()->now();
-    t.header.frame_id = "map";
-    t.child_frame_id = "odom";
+        auto map_msg = std::make_unique<nav_msgs::msg::OccupancyGrid>();
 
-    // Identity transform - no translation
-    t.transform.translation.x = 0.0;
-    t.transform.translation.y = 0.0;
-    t.transform.translation.z = 0.0;
+        // Set header
+        map_msg->header.stamp = this->get_clock()->now();
+        map_msg->header.frame_id = "map";
 
-    // Identity rotation (no rotation)
-    tf2::Quaternion q;
-    q.setRPY(0, 0, 0);
-    t.transform.rotation.x = q.x();
-    t.transform.rotation.y = q.y();
-    t.transform.rotation.z = q.z();
-    t.transform.rotation.w = q.w();
+        // Set minimal map (1x1 size)
+        map_msg->info.resolution = 0.05;  // 5 cm per cell
+        map_msg->info.width = 1;
+        map_msg->info.height = 1;
+        map_msg->info.origin.position.x = 0.0;
+        map_msg->info.origin.position.y = 0.0;
+        map_msg->info.origin.position.z = 0.0;
+        map_msg->info.origin.orientation.x = 0.0;
+        map_msg->info.origin.orientation.y = 0.0;
+        map_msg->info.origin.orientation.z = 0.0;
+        map_msg->info.origin.orientation.w = 1.0;
 
-    // Send the transformation
-    tf_broadcaster_->sendTransform(t);
+        // Single cell data for 1x1 map (0 = free space)
+        map_msg->data = {0};
 
-    // Publish empty map
-    publish_empty_map();
-  }
-
-  /// Callback to publish an empty occupancy grid
-  /**
-   * Publishes an empty map (0x0 size) to the /map topic.
-   */
-  void
-  publish_empty_map()
-  {
-    if (!map_pub_ || !map_pub_->is_activated()) {
-      return;
+        // Publish the empty map
+        map_pub_->publish(std::move(map_msg));
     }
 
-    auto map_msg = std::make_unique<nav_msgs::msg::OccupancyGrid>();
+    /// Transition callback for state configuring
+    /**
+     * on_configure callback is called when the lifecycle node
+     * enters the "configuring" state.
+     * Initialize and configure the transform broadcaster and timer.
+     */
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
+        const rclcpp_lifecycle::State &) {
+        // Initialize the transform broadcaster
+        tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this);
 
-    // Set header
-    map_msg->header.stamp = this->get_clock()->now();
-    map_msg->header.frame_id = "map";
+        // Create a lifecycle publisher for the map
+        map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
+            "/map", rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
 
-    // Set minimal map (1x1 size)
-    map_msg->info.resolution = 0.05;  // 5 cm per cell
-    map_msg->info.width = 1;
-    map_msg->info.height = 1;
-    map_msg->info.origin.position.x = 0.0;
-    map_msg->info.origin.position.y = 0.0;
-    map_msg->info.origin.position.z = 0.0;
-    map_msg->info.origin.orientation.x = 0.0;
-    map_msg->info.origin.orientation.y = 0.0;
-    map_msg->info.origin.orientation.z = 0.0;
-    map_msg->info.origin.orientation.w = 1.0;
+        // Create a wall timer to publish at 10 Hz
+        timer_ = this->create_wall_timer(100ms, [this]() { return this->publish_transform(); });
 
-    // Single cell data for 1x1 map (0 = free space)
-    map_msg->data = {0};
+        RCLCPP_INFO(get_logger(), "on_configure() is called.");
 
-    // Publish the empty map
-    map_pub_->publish(std::move(map_msg));
-  }
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
 
-  /// Transition callback for state configuring
-  /**
-   * on_configure callback is called when the lifecycle node
-   * enters the "configuring" state.
-   * Initialize and configure the transform broadcaster and timer.
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_configure(const rclcpp_lifecycle::State &)
-  {
-    // Initialize the transform broadcaster
-    tf_broadcaster_ =
-      std::make_unique<tf2_ros::TransformBroadcaster>(*this);
+    /// Transition callback for state activating
+    /**
+     * on_activate callback is called when the lifecycle node
+     * enters the "activating" state.
+     */
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(
+        const rclcpp_lifecycle::State &state) {
+        // Activate the lifecycle publisher
+        map_pub_->on_activate();
 
-    // Create a lifecycle publisher for the map
-    map_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
-      "/map", rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+        LifecycleNode::on_activate(state);
 
-    // Create a wall timer to publish at 10 Hz
-    timer_ = this->create_wall_timer(
-      100ms, [this]() {return this->publish_transform();});
+        RCLCPP_INFO(get_logger(), "on_activate() is called.");
 
-    RCLCPP_INFO(get_logger(), "on_configure() is called.");
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
 
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+    /// Transition callback for state deactivating
+    /**
+     * on_deactivate callback is called when the lifecycle node
+     * enters the "deactivating" state.
+     */
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
+        const rclcpp_lifecycle::State &state) {
+        // Deactivate the lifecycle publisher
+        map_pub_->on_deactivate();
 
-  /// Transition callback for state activating
-  /**
-   * on_activate callback is called when the lifecycle node
-   * enters the "activating" state.
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_activate(const rclcpp_lifecycle::State & state)
-  {
-    // Activate the lifecycle publisher
-    map_pub_->on_activate();
-    
-    LifecycleNode::on_activate(state);
+        LifecycleNode::on_deactivate(state);
 
-    RCLCPP_INFO(get_logger(), "on_activate() is called.");
+        RCLCPP_INFO(get_logger(), "on_deactivate() is called.");
 
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
 
-  /// Transition callback for state deactivating
-  /**
-   * on_deactivate callback is called when the lifecycle node
-   * enters the "deactivating" state.
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_deactivate(const rclcpp_lifecycle::State & state)
-  {
-    // Deactivate the lifecycle publisher
-    map_pub_->on_deactivate();
-    
-    LifecycleNode::on_deactivate(state);
+    /// Transition callback for state cleaningup
+    /**
+     * on_cleanup callback is called when the lifecycle node
+     * enters the "cleaningup" state.
+     * Release resources (timer).
+     */
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup(
+        const rclcpp_lifecycle::State &) {
+        // Release the timer and publisher
+        timer_.reset();
+        map_pub_.reset();
 
-    RCLCPP_INFO(get_logger(), "on_deactivate() is called.");
+        RCLCPP_INFO(get_logger(), "on_cleanup() is called.");
 
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
 
-  /// Transition callback for state cleaningup
-  /**
-   * on_cleanup callback is called when the lifecycle node
-   * enters the "cleaningup" state.
-   * Release resources (timer).
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_cleanup(const rclcpp_lifecycle::State &)
-  {
-    // Release the timer and publisher
-    timer_.reset();
-    map_pub_.reset();
+    /// Transition callback for state shutting down
+    /**
+     * on_shutdown callback is called when the lifecycle node
+     * enters the "shuttingdown" state.
+     */
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(
+        const rclcpp_lifecycle::State &state) {
+        // Release the timer and publisher
+        timer_.reset();
+        map_pub_.reset();
 
-    RCLCPP_INFO(get_logger(), "on_cleanup() is called.");
+        RCLCPP_INFO(get_logger(), "on_shutdown() is called from state %s.", state.label().c_str());
 
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+        return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+    }
 
-  /// Transition callback for state shutting down
-  /**
-   * on_shutdown callback is called when the lifecycle node
-   * enters the "shuttingdown" state.
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_shutdown(const rclcpp_lifecycle::State & state)
-  {
-    // Release the timer and publisher
-    timer_.reset();
-    map_pub_.reset();
+   private:
+    // Transform broadcaster for publishing tf transforms
+    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
-    RCLCPP_INFO(get_logger(), "on_shutdown() is called from state %s.", state.label().c_str());
+    // Lifecycle publisher for the empty map
+    std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::OccupancyGrid>> map_pub_;
 
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
-
-private:
-  // Transform broadcaster for publishing tf transforms
-  std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
-
-  // Lifecycle publisher for the empty map
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::OccupancyGrid>> map_pub_;
-
-  // Timer for periodic publishing
-  std::shared_ptr<rclcpp::TimerBase> timer_;
+    // Timer for periodic publishing
+    std::shared_ptr<rclcpp::TimerBase> timer_;
 };
 
-int main(int argc, char * argv[])
-{
-  // Force flush of stdout buffer for correct sync of prints
-  setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+int main(int argc, char *argv[]) {
+    // Force flush of stdout buffer for correct sync of prints
+    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
-  rclcpp::init(argc, argv);
+    rclcpp::init(argc, argv);
 
-  rclcpp::executors::SingleThreadedExecutor exe;
+    rclcpp::executors::SingleThreadedExecutor exe;
 
-  std::shared_ptr<NullMapNode> node = std::make_shared<NullMapNode>();
+    std::shared_ptr<NullMapNode> node = std::make_shared<NullMapNode>();
 
-  exe.add_node(node->get_node_base_interface());
+    exe.add_node(node->get_node_base_interface());
 
-  exe.spin();
+    exe.spin();
 
-  rclcpp::shutdown();
+    rclcpp::shutdown();
 
-  return 0;
+    return 0;
 }

--- a/ros2_ws/src/maurice_bot/maurice_nav/src/plugins/dynamic_goal_checker.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_nav/src/plugins/dynamic_goal_checker.cpp
@@ -25,285 +25,249 @@
 using rcl_interfaces::msg::ParameterType;
 using std::placeholders::_1;
 
-namespace maurice_nav
-{
+namespace maurice_nav {
 
-DynamicGoalChecker::DynamicGoalChecker()
-: current_tier_(0)
-{
-}
+DynamicGoalChecker::DynamicGoalChecker() : current_tier_(0) {}
 
-void DynamicGoalChecker::initialize(
-  const rclcpp_lifecycle::LifecycleNode::WeakPtr & parent,
-  const std::string & plugin_name,
-  const std::shared_ptr<nav2_costmap_2d::Costmap2DROS> /*costmap_ros*/)
-{
-  plugin_name_ = plugin_name;
-  auto node = parent.lock();
+void DynamicGoalChecker::initialize(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent,
+                                    const std::string& plugin_name,
+                                    const std::shared_ptr<nav2_costmap_2d::Costmap2DROS> /*costmap_ros*/) {
+    plugin_name_ = plugin_name;
+    auto node = parent.lock();
 
-  if (!node) {
-    throw std::runtime_error("Failed to lock parent node");
-  }
-
-  logger_ = node->get_logger();
-  clock_ = node->get_clock();
-
-  // Default arrays: single tier - 0.25m/0.25rad for 0 seconds (instant)
-  // Velocity defaults to infinity (no velocity check)
-  std::vector<double> default_times = {0.0};
-  std::vector<double> default_xy = {0.25};
-  std::vector<double> default_yaw = {0.25};
-  std::vector<double> default_linear_vel = {std::numeric_limits<double>::infinity()};
-  std::vector<double> default_angular_vel = {std::numeric_limits<double>::infinity()};
-
-  // Declare parameters with defaults
-  nav2_util::declare_parameter_if_not_declared(
-    node,
-    plugin_name + ".time_thresholds", rclcpp::ParameterValue(default_times));
-  nav2_util::declare_parameter_if_not_declared(
-    node,
-    plugin_name + ".xy_tolerances", rclcpp::ParameterValue(default_xy));
-  nav2_util::declare_parameter_if_not_declared(
-    node,
-    plugin_name + ".yaw_tolerances", rclcpp::ParameterValue(default_yaw));
-  nav2_util::declare_parameter_if_not_declared(
-    node,
-    plugin_name + ".linear_vel_tolerances", rclcpp::ParameterValue(default_linear_vel));
-  nav2_util::declare_parameter_if_not_declared(
-    node,
-    plugin_name + ".angular_vel_tolerances", rclcpp::ParameterValue(default_angular_vel));
-
-  // Get parameter values
-  node->get_parameter(plugin_name + ".time_thresholds", time_thresholds_);
-  node->get_parameter(plugin_name + ".xy_tolerances", xy_tolerances_);
-  node->get_parameter(plugin_name + ".yaw_tolerances", yaw_tolerances_);
-  node->get_parameter(plugin_name + ".linear_vel_tolerances", linear_vel_tolerances_);
-  node->get_parameter(plugin_name + ".angular_vel_tolerances", angular_vel_tolerances_);
-
-  // Validate array sizes match
-  size_t num_tiers = time_thresholds_.size();
-  if (xy_tolerances_.size() != num_tiers ||
-      yaw_tolerances_.size() != num_tiers ||
-      linear_vel_tolerances_.size() != num_tiers ||
-      angular_vel_tolerances_.size() != num_tiers)
-  {
-    RCLCPP_ERROR(
-      logger_,
-      "DynamicGoalChecker: all tolerance arrays must have same size (time=%zu, xy=%zu, yaw=%zu, lin_vel=%zu, ang_vel=%zu)",
-      num_tiers, xy_tolerances_.size(), yaw_tolerances_.size(),
-      linear_vel_tolerances_.size(), angular_vel_tolerances_.size());
-    throw std::runtime_error("Parameter array size mismatch");
-  }
-
-  if (num_tiers == 0) {
-    RCLCPP_ERROR(logger_, "DynamicGoalChecker: parameter arrays cannot be empty");
-    throw std::runtime_error("Parameter arrays empty");
-  }
-
-  // Initialize tier tracking
-  tier_start_times_.resize(time_thresholds_.size());
-  tier_active_.resize(time_thresholds_.size(), false);
-  current_tier_ = 0;
-
-  RCLCPP_INFO(
-    logger_,
-    "DynamicGoalChecker initialized with %zu tolerance tiers",
-    time_thresholds_.size());
-  for (size_t i = 0; i < time_thresholds_.size(); ++i) {
-    RCLCPP_INFO(
-      logger_,
-      "  Tier %zu: xy=%.3fm, yaw=%.3frad, lin_vel=%.3fm/s, ang_vel=%.3frad/s, time=%.2fs",
-      i, xy_tolerances_[i], yaw_tolerances_[i],
-      linear_vel_tolerances_[i], angular_vel_tolerances_[i], time_thresholds_[i]);
-  }
-
-  // Add callback for dynamic parameters
-  dyn_params_handler_ = node->add_on_set_parameters_callback(
-    std::bind(&DynamicGoalChecker::dynamicParametersCallback, this, _1));
-}
-
-void DynamicGoalChecker::reset()
-{
-  // Reset all tier timers
-  for (size_t i = 0; i < tier_active_.size(); ++i) {
-    tier_active_[i] = false;
-  }
-  current_tier_ = 0;
-}
-
-bool DynamicGoalChecker::isGoalReached(
-  const geometry_msgs::msg::Pose & query_pose,
-  const geometry_msgs::msg::Pose & goal_pose,
-  const geometry_msgs::msg::Twist & velocity)
-{
-  // Calculate current distance and yaw error
-  double dx = query_pose.position.x - goal_pose.position.x;
-  double dy = query_pose.position.y - goal_pose.position.y;
-  double dist_sq = dx * dx + dy * dy;
-
-  double dyaw = std::fabs(angles::shortest_angular_distance(
-    tf2::getYaw(query_pose.orientation),
-    tf2::getYaw(goal_pose.orientation)));
-
-  // Calculate current velocities
-  double linear_vel = std::hypot(velocity.linear.x, velocity.linear.y);
-  double angular_vel = std::fabs(velocity.angular.z);
-
-  rclcpp::Time now = clock_->now();
-
-  // Check each tolerance tier
-  for (size_t i = 0; i < time_thresholds_.size(); ++i) {
-    double xy_tol = xy_tolerances_[i];
-    double yaw_tol = yaw_tolerances_[i];
-    double lin_vel_tol = linear_vel_tolerances_[i];
-    double ang_vel_tol = angular_vel_tolerances_[i];
-    double time_thresh = time_thresholds_[i];
-
-    bool in_tolerance = (dist_sq <= xy_tol * xy_tol) &&
-                        (dyaw <= yaw_tol) &&
-                        (linear_vel <= lin_vel_tol) &&
-                        (angular_vel <= ang_vel_tol);
-
-    if (in_tolerance) {
-      if (!tier_active_[i]) {
-        // Just entered this tolerance zone, start timer
-        tier_start_times_[i] = now;
-        tier_active_[i] = true;
-      }
-
-      // Check if we've been in this zone long enough
-      double elapsed = (now - tier_start_times_[i]).seconds();
-      if (elapsed >= time_thresh) {
-        current_tier_ = i;
-        RCLCPP_DEBUG(
-          logger_,
-          "Goal reached via tier %zu (xy=%.3f, yaw=%.3f, time=%.2fs)",
-          i, xy_tol, yaw_tol, elapsed);
-        return true;
-      }
-    } else {
-      // Left this tolerance zone, reset timer
-      tier_active_[i] = false;
-    }
-  }
-
-  return false;
-}
-
-bool DynamicGoalChecker::getTolerances(
-  geometry_msgs::msg::Pose & pose_tolerance,
-  geometry_msgs::msg::Twist & vel_tolerance)
-{
-  double invalid_field = std::numeric_limits<double>::lowest();
-
-  // Report the first tolerance tier
-  double xy_tol = xy_tolerances_.empty() ? 0.25 : xy_tolerances_[0];
-  double yaw_tol = yaw_tolerances_.empty() ? 0.25 : yaw_tolerances_[0];
-  double lin_vel_tol = linear_vel_tolerances_.empty() ?
-    std::numeric_limits<double>::infinity() : linear_vel_tolerances_[0];
-  double ang_vel_tol = angular_vel_tolerances_.empty() ?
-    std::numeric_limits<double>::infinity() : angular_vel_tolerances_[0];
-
-  pose_tolerance.position.x = xy_tol;
-  pose_tolerance.position.y = xy_tol;
-  pose_tolerance.position.z = invalid_field;
-  pose_tolerance.orientation =
-    nav2_util::geometry_utils::orientationAroundZAxis(yaw_tol);
-
-  // Report velocity tolerances (use invalid_field if infinity)
-  vel_tolerance.linear.x = std::isinf(lin_vel_tol) ? invalid_field : lin_vel_tol;
-  vel_tolerance.linear.y = std::isinf(lin_vel_tol) ? invalid_field : lin_vel_tol;
-  vel_tolerance.linear.z = invalid_field;
-
-  vel_tolerance.angular.x = invalid_field;
-  vel_tolerance.angular.y = invalid_field;
-  vel_tolerance.angular.z = std::isinf(ang_vel_tol) ? invalid_field : ang_vel_tol;
-
-  return true;
-}
-
-rcl_interfaces::msg::SetParametersResult
-DynamicGoalChecker::dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters)
-{
-  rcl_interfaces::msg::SetParametersResult result;
-  result.successful = true;
-
-  // Temporary storage for validation
-  std::vector<double> new_time_thresholds = time_thresholds_;
-  std::vector<double> new_xy_tolerances = xy_tolerances_;
-  std::vector<double> new_yaw_tolerances = yaw_tolerances_;
-  std::vector<double> new_linear_vel_tolerances = linear_vel_tolerances_;
-  std::vector<double> new_angular_vel_tolerances = angular_vel_tolerances_;
-  bool arrays_changed = false;
-
-  for (auto & parameter : parameters) {
-    const auto & param_type = parameter.get_type();
-    const auto & param_name = parameter.get_name();
-
-    // Only process parameters for this plugin
-    if (param_name.find(plugin_name_ + ".") != 0) {
-      continue;
+    if (!node) {
+        throw std::runtime_error("Failed to lock parent node");
     }
 
-    if (param_type == ParameterType::PARAMETER_DOUBLE_ARRAY) {
-      if (param_name == plugin_name_ + ".time_thresholds") {
-        new_time_thresholds = parameter.as_double_array();
-        arrays_changed = true;
-      } else if (param_name == plugin_name_ + ".xy_tolerances") {
-        new_xy_tolerances = parameter.as_double_array();
-        arrays_changed = true;
-      } else if (param_name == plugin_name_ + ".yaw_tolerances") {
-        new_yaw_tolerances = parameter.as_double_array();
-        arrays_changed = true;
-      } else if (param_name == plugin_name_ + ".linear_vel_tolerances") {
-        new_linear_vel_tolerances = parameter.as_double_array();
-        arrays_changed = true;
-      } else if (param_name == plugin_name_ + ".angular_vel_tolerances") {
-        new_angular_vel_tolerances = parameter.as_double_array();
-        arrays_changed = true;
-      }
-    }
-  }
+    logger_ = node->get_logger();
+    clock_ = node->get_clock();
 
-  // Validate and apply array changes
-  if (arrays_changed) {
-    size_t num_tiers = new_time_thresholds.size();
-    if (new_xy_tolerances.size() != num_tiers ||
-        new_yaw_tolerances.size() != num_tiers ||
-        new_linear_vel_tolerances.size() != num_tiers ||
-        new_angular_vel_tolerances.size() != num_tiers)
-    {
-      RCLCPP_ERROR(
-        logger_,
-        "Parameter array size mismatch: time=%zu, xy=%zu, yaw=%zu, lin_vel=%zu, ang_vel=%zu",
-        num_tiers, new_xy_tolerances.size(), new_yaw_tolerances.size(),
-        new_linear_vel_tolerances.size(), new_angular_vel_tolerances.size());
-      result.successful = false;
-      result.reason = "Array sizes must match";
-      return result;
+    // Default arrays: single tier - 0.25m/0.25rad for 0 seconds (instant)
+    // Velocity defaults to infinity (no velocity check)
+    std::vector<double> default_times = {0.0};
+    std::vector<double> default_xy = {0.25};
+    std::vector<double> default_yaw = {0.25};
+    std::vector<double> default_linear_vel = {std::numeric_limits<double>::infinity()};
+    std::vector<double> default_angular_vel = {std::numeric_limits<double>::infinity()};
+
+    // Declare parameters with defaults
+    nav2_util::declare_parameter_if_not_declared(node, plugin_name + ".time_thresholds",
+                                                 rclcpp::ParameterValue(default_times));
+    nav2_util::declare_parameter_if_not_declared(node, plugin_name + ".xy_tolerances",
+                                                 rclcpp::ParameterValue(default_xy));
+    nav2_util::declare_parameter_if_not_declared(node, plugin_name + ".yaw_tolerances",
+                                                 rclcpp::ParameterValue(default_yaw));
+    nav2_util::declare_parameter_if_not_declared(node, plugin_name + ".linear_vel_tolerances",
+                                                 rclcpp::ParameterValue(default_linear_vel));
+    nav2_util::declare_parameter_if_not_declared(node, plugin_name + ".angular_vel_tolerances",
+                                                 rclcpp::ParameterValue(default_angular_vel));
+
+    // Get parameter values
+    node->get_parameter(plugin_name + ".time_thresholds", time_thresholds_);
+    node->get_parameter(plugin_name + ".xy_tolerances", xy_tolerances_);
+    node->get_parameter(plugin_name + ".yaw_tolerances", yaw_tolerances_);
+    node->get_parameter(plugin_name + ".linear_vel_tolerances", linear_vel_tolerances_);
+    node->get_parameter(plugin_name + ".angular_vel_tolerances", angular_vel_tolerances_);
+
+    // Validate array sizes match
+    size_t num_tiers = time_thresholds_.size();
+    if (xy_tolerances_.size() != num_tiers || yaw_tolerances_.size() != num_tiers ||
+        linear_vel_tolerances_.size() != num_tiers || angular_vel_tolerances_.size() != num_tiers) {
+        RCLCPP_ERROR(logger_,
+                     "DynamicGoalChecker: all tolerance arrays must have same size (time=%zu, xy=%zu, yaw=%zu, "
+                     "lin_vel=%zu, ang_vel=%zu)",
+                     num_tiers, xy_tolerances_.size(), yaw_tolerances_.size(), linear_vel_tolerances_.size(),
+                     angular_vel_tolerances_.size());
+        throw std::runtime_error("Parameter array size mismatch");
     }
 
     if (num_tiers == 0) {
-      RCLCPP_ERROR(logger_, "Parameter arrays cannot be empty");
-      result.successful = false;
-      result.reason = "Arrays cannot be empty";
-      return result;
+        RCLCPP_ERROR(logger_, "DynamicGoalChecker: parameter arrays cannot be empty");
+        throw std::runtime_error("Parameter arrays empty");
     }
 
-    time_thresholds_ = new_time_thresholds;
-    xy_tolerances_ = new_xy_tolerances;
-    yaw_tolerances_ = new_yaw_tolerances;
-    linear_vel_tolerances_ = new_linear_vel_tolerances;
-    angular_vel_tolerances_ = new_angular_vel_tolerances;
-
-    // Resize tier tracking arrays
+    // Initialize tier tracking
     tier_start_times_.resize(time_thresholds_.size());
     tier_active_.resize(time_thresholds_.size(), false);
+    current_tier_ = 0;
 
-    RCLCPP_INFO(logger_, "Updated tolerance tiers to %zu tiers", time_thresholds_.size());
-  }
+    RCLCPP_INFO(logger_, "DynamicGoalChecker initialized with %zu tolerance tiers", time_thresholds_.size());
+    for (size_t i = 0; i < time_thresholds_.size(); ++i) {
+        RCLCPP_INFO(logger_, "  Tier %zu: xy=%.3fm, yaw=%.3frad, lin_vel=%.3fm/s, ang_vel=%.3frad/s, time=%.2fs", i,
+                    xy_tolerances_[i], yaw_tolerances_[i], linear_vel_tolerances_[i], angular_vel_tolerances_[i],
+                    time_thresholds_[i]);
+    }
 
-  return result;
+    // Add callback for dynamic parameters
+    dyn_params_handler_ =
+        node->add_on_set_parameters_callback(std::bind(&DynamicGoalChecker::dynamicParametersCallback, this, _1));
+}
+
+void DynamicGoalChecker::reset() {
+    // Reset all tier timers
+    for (size_t i = 0; i < tier_active_.size(); ++i) {
+        tier_active_[i] = false;
+    }
+    current_tier_ = 0;
+}
+
+bool DynamicGoalChecker::isGoalReached(const geometry_msgs::msg::Pose& query_pose,
+                                       const geometry_msgs::msg::Pose& goal_pose,
+                                       const geometry_msgs::msg::Twist& velocity) {
+    // Calculate current distance and yaw error
+    double dx = query_pose.position.x - goal_pose.position.x;
+    double dy = query_pose.position.y - goal_pose.position.y;
+    double dist_sq = dx * dx + dy * dy;
+
+    double dyaw = std::fabs(
+        angles::shortest_angular_distance(tf2::getYaw(query_pose.orientation), tf2::getYaw(goal_pose.orientation)));
+
+    // Calculate current velocities
+    double linear_vel = std::hypot(velocity.linear.x, velocity.linear.y);
+    double angular_vel = std::fabs(velocity.angular.z);
+
+    rclcpp::Time now = clock_->now();
+
+    // Check each tolerance tier
+    for (size_t i = 0; i < time_thresholds_.size(); ++i) {
+        double xy_tol = xy_tolerances_[i];
+        double yaw_tol = yaw_tolerances_[i];
+        double lin_vel_tol = linear_vel_tolerances_[i];
+        double ang_vel_tol = angular_vel_tolerances_[i];
+        double time_thresh = time_thresholds_[i];
+
+        bool in_tolerance = (dist_sq <= xy_tol * xy_tol) && (dyaw <= yaw_tol) && (linear_vel <= lin_vel_tol) &&
+                            (angular_vel <= ang_vel_tol);
+
+        if (in_tolerance) {
+            if (!tier_active_[i]) {
+                // Just entered this tolerance zone, start timer
+                tier_start_times_[i] = now;
+                tier_active_[i] = true;
+            }
+
+            // Check if we've been in this zone long enough
+            double elapsed = (now - tier_start_times_[i]).seconds();
+            if (elapsed >= time_thresh) {
+                current_tier_ = i;
+                RCLCPP_DEBUG(logger_, "Goal reached via tier %zu (xy=%.3f, yaw=%.3f, time=%.2fs)", i, xy_tol, yaw_tol,
+                             elapsed);
+                return true;
+            }
+        } else {
+            // Left this tolerance zone, reset timer
+            tier_active_[i] = false;
+        }
+    }
+
+    return false;
+}
+
+bool DynamicGoalChecker::getTolerances(geometry_msgs::msg::Pose& pose_tolerance,
+                                       geometry_msgs::msg::Twist& vel_tolerance) {
+    double invalid_field = std::numeric_limits<double>::lowest();
+
+    // Report the first tolerance tier
+    double xy_tol = xy_tolerances_.empty() ? 0.25 : xy_tolerances_[0];
+    double yaw_tol = yaw_tolerances_.empty() ? 0.25 : yaw_tolerances_[0];
+    double lin_vel_tol =
+        linear_vel_tolerances_.empty() ? std::numeric_limits<double>::infinity() : linear_vel_tolerances_[0];
+    double ang_vel_tol =
+        angular_vel_tolerances_.empty() ? std::numeric_limits<double>::infinity() : angular_vel_tolerances_[0];
+
+    pose_tolerance.position.x = xy_tol;
+    pose_tolerance.position.y = xy_tol;
+    pose_tolerance.position.z = invalid_field;
+    pose_tolerance.orientation = nav2_util::geometry_utils::orientationAroundZAxis(yaw_tol);
+
+    // Report velocity tolerances (use invalid_field if infinity)
+    vel_tolerance.linear.x = std::isinf(lin_vel_tol) ? invalid_field : lin_vel_tol;
+    vel_tolerance.linear.y = std::isinf(lin_vel_tol) ? invalid_field : lin_vel_tol;
+    vel_tolerance.linear.z = invalid_field;
+
+    vel_tolerance.angular.x = invalid_field;
+    vel_tolerance.angular.y = invalid_field;
+    vel_tolerance.angular.z = std::isinf(ang_vel_tol) ? invalid_field : ang_vel_tol;
+
+    return true;
+}
+
+rcl_interfaces::msg::SetParametersResult DynamicGoalChecker::dynamicParametersCallback(
+    std::vector<rclcpp::Parameter> parameters) {
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
+
+    // Temporary storage for validation
+    std::vector<double> new_time_thresholds = time_thresholds_;
+    std::vector<double> new_xy_tolerances = xy_tolerances_;
+    std::vector<double> new_yaw_tolerances = yaw_tolerances_;
+    std::vector<double> new_linear_vel_tolerances = linear_vel_tolerances_;
+    std::vector<double> new_angular_vel_tolerances = angular_vel_tolerances_;
+    bool arrays_changed = false;
+
+    for (auto& parameter : parameters) {
+        const auto& param_type = parameter.get_type();
+        const auto& param_name = parameter.get_name();
+
+        // Only process parameters for this plugin
+        if (param_name.find(plugin_name_ + ".") != 0) {
+            continue;
+        }
+
+        if (param_type == ParameterType::PARAMETER_DOUBLE_ARRAY) {
+            if (param_name == plugin_name_ + ".time_thresholds") {
+                new_time_thresholds = parameter.as_double_array();
+                arrays_changed = true;
+            } else if (param_name == plugin_name_ + ".xy_tolerances") {
+                new_xy_tolerances = parameter.as_double_array();
+                arrays_changed = true;
+            } else if (param_name == plugin_name_ + ".yaw_tolerances") {
+                new_yaw_tolerances = parameter.as_double_array();
+                arrays_changed = true;
+            } else if (param_name == plugin_name_ + ".linear_vel_tolerances") {
+                new_linear_vel_tolerances = parameter.as_double_array();
+                arrays_changed = true;
+            } else if (param_name == plugin_name_ + ".angular_vel_tolerances") {
+                new_angular_vel_tolerances = parameter.as_double_array();
+                arrays_changed = true;
+            }
+        }
+    }
+
+    // Validate and apply array changes
+    if (arrays_changed) {
+        size_t num_tiers = new_time_thresholds.size();
+        if (new_xy_tolerances.size() != num_tiers || new_yaw_tolerances.size() != num_tiers ||
+            new_linear_vel_tolerances.size() != num_tiers || new_angular_vel_tolerances.size() != num_tiers) {
+            RCLCPP_ERROR(logger_, "Parameter array size mismatch: time=%zu, xy=%zu, yaw=%zu, lin_vel=%zu, ang_vel=%zu",
+                         num_tiers, new_xy_tolerances.size(), new_yaw_tolerances.size(),
+                         new_linear_vel_tolerances.size(), new_angular_vel_tolerances.size());
+            result.successful = false;
+            result.reason = "Array sizes must match";
+            return result;
+        }
+
+        if (num_tiers == 0) {
+            RCLCPP_ERROR(logger_, "Parameter arrays cannot be empty");
+            result.successful = false;
+            result.reason = "Arrays cannot be empty";
+            return result;
+        }
+
+        time_thresholds_ = new_time_thresholds;
+        xy_tolerances_ = new_xy_tolerances;
+        yaw_tolerances_ = new_yaw_tolerances;
+        linear_vel_tolerances_ = new_linear_vel_tolerances;
+        angular_vel_tolerances_ = new_angular_vel_tolerances;
+
+        // Resize tier tracking arrays
+        tier_start_times_.resize(time_thresholds_.size());
+        tier_active_.resize(time_thresholds_.size(), false);
+
+        RCLCPP_INFO(logger_, "Updated tolerance tiers to %zu tiers", time_thresholds_.size());
+    }
+
+    return result;
 }
 
 }  // namespace maurice_nav

--- a/ros2_ws/src/maurice_bot/maurice_nav/src/switch_bt_node.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_nav/src/switch_bt_node.cpp
@@ -8,8 +8,7 @@
 #include "behaviortree_cpp_v3/bt_factory.h"
 
 // This is the correct registration function for BT.CPP v3 plugins
-extern "C" void BT_RegisterNodesFromPlugin(BT::BehaviorTreeFactory& factory)
-{
-  factory.registerNodeType<maurice_nav::Switch>("Switch");
-  factory.registerNodeType<maurice_nav::SetHeadPosition>("SetHeadPosition");
+extern "C" void BT_RegisterNodesFromPlugin(BT::BehaviorTreeFactory& factory) {
+    factory.registerNodeType<maurice_nav::Switch>("Switch");
+    factory.registerNodeType<maurice_nav::SetHeadPosition>("SetHeadPosition");
 }


### PR DESCRIPTION
Two parts: format the C++ tree once, then keep it formatted with the same pinned-hook pattern the repo already uses for ruff.

## 1. One-shot reformat
Ran clang-format **18.1.3** (matching CI) over all tracked C++ in `ros2_ws/src` per the repo `.clang-format` (Google base, indent 4, col 120). Pure formatting, 43 files changed, no logic touched.

## 2. Prevent re-rot (mirrors the ruff setup)
- Add the `pre-commit/mirrors-clang-format` hook, **pinned to v18.1.3**, scoped to C/C++. The mirror installs clang-format from pip, so every contributor gets the exact same formatter regardless of their system clang-format.
- Switch the `format` CI job to `pre-commit run --all-files`, so ruff + clang-format run from **one pinned source of truth** locally and in CI.
- **Removes the unpinned `apt-get install clang-format`** in CI, which floated with `ubuntu-latest` and would silently re-break the whole tree on a version bump — the exact drift this PR cleans up.

## Verification
- `pre-commit run --all-files` passes locally: ruff 0.15.15 + clang-format 18.1.3, no diffs.
- Reformat verified with CI’s exact `clang-format --dry-run --Werror` → 0 violations on all 46 files.

## Follow-up (post-merge)
Add this PR’s squashed-merge SHA to `.git-blame-ignore-revs` (as was done for the ruff reformat) so `git blame` skips the formatting churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)