### PR TITLE
chore: remove .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,0 @@
-# Reformat / lint commits to skip in git blame (git config blame.ignoreRevsFile .git-blame-ignore-revs)
-# style: adopt ruff repo-wide and reformat
-0c5898daffaceb62b9ee840bae7b069d8686a80c


### PR DESCRIPTION
Removes `.git-blame-ignore-revs` from the repo.

No `blame.ignoreRevsFile` git config points at it, so nothing references the file. Note: removing it means `git blame` will no longer skip the bulk ruff reformat commit (`0c5898da`) — reformatted lines will be attributed to that style commit rather than the original author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)