### PR TITLE
ci: split test image into a warm base + thin layer for faster CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -48,10 +48,17 @@ jobs:
           if [ -n "${{ vars.GCP_CLOUD_BUILD_WORKER_POOL }}" ]; then
             pool_flag="--worker-pool=${{ vars.GCP_CLOUD_BUILD_WORKER_POOL }}"
           fi
+          # Publish (and push) the warm base image only on main; PRs reuse it.
+          # See ci/cloudbuild.integration-test.yaml for the two-image strategy.
+          publish_base="false"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            publish_base="true"
+          fi
           gcloud builds submit \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --region="${{ vars.GCP_REGION }}" \
             --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \
             --service-account="projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_CLOUD_BUILD_SERVICE_ACCOUNT }}" \
             ${pool_flag} \
+            --substitutions=_PUBLISH_BASE="${publish_base}" \
             --config=ci/cloudbuild.integration-test.yaml

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -1,106 +1,44 @@
 # syntax=docker/dockerfile:1.7
 #
-# ci/Dockerfile.test - Test image for CI on non-Jetson platforms.
-# Skips Jetson-specific packages (nvidia-*, cuda-*, etc.)
+# ci/Dockerfile.test - Thin CI test image (built per PR/commit).
 #
+# Builds on the warm base (ci/Dockerfile.test-base, published as
+# ghcr.io/innate-inc/innate-os-test-base:main): apt/pip deps, rosdep, a full
+# prebuilt ros2_ws (build/ + install/), and a populated ccache are all baked in.
+# This layer overlays the current revision's source and does an INCREMENTAL,
+# ccache-backed colcon build, so only packages that actually changed do real
+# compile work. The whole workspace is still built, so a build error in any
+# package fails CI (the build gate is preserved).
 
-FROM ros:humble-ros-base
-
-ENV DEBIAN_FRONTEND=noninteractive \
-    ROS_DISTRO=humble \
-    INNATE_OS_ROOT=/root/innate-os \
-    UV_SYSTEM_PYTHON=1 \
-    UV_LINK_MODE=copy \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG BASE_IMAGE=ghcr.io/innate-inc/innate-os-test-base:main
+FROM ${BASE_IMAGE}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install base prerequisites + enable universe (for gstreamer, libhdf5-dev, etc.)
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
-        software-properties-common \
-        curl \
-        iputils-ping \
-        gnupg \
-        lsb-release \
-        ca-certificates && \
-    add-apt-repository universe && \
-    apt-get update && apt-get install -y --no-install-recommends \
-        locales \
-        iproute2 \
-        libcairo2-dev \
-        libhdf5-dev \
-        ros-humble-kdl-parser
+# Inherited from the base, re-declared for clarity. The warm ccache lives here.
+ENV CCACHE_DIR=/root/.ccache
 
-# Setup locale
-RUN locale-gen en_US en_US.UTF-8 && \
-    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-
-# Add Innate packages repository (for ros-humble-innate-rws, etc.)
-RUN curl -fsSL https://innate-inc.github.io/innate-packages/pubkey.gpg | \
-    gpg --dearmor -o /usr/share/keyrings/innate-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/innate-archive-keyring.gpg] https://innate-inc.github.io/innate-packages/ $(lsb_release -cs) main" | \
-    tee /etc/apt/sources.list.d/innate.list > /dev/null
-
-# Copy apt dependencies file first (for better layer caching)
-COPY ros2_ws/apt-dependencies.common.txt /tmp/apt-dependencies.txt
-
-# Install apt dependencies from common list
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && \
-    grep -v '^#' /tmp/apt-dependencies.txt | grep -v '^$' | \
-        xargs apt-get install -y --no-install-recommends && \
-    rm /tmp/apt-dependencies.txt
-
-# Install uv for fast, cached Python package installation.
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -sf /root/.local/bin/uv /usr/local/bin/uv
-
-# Install Python deps with uv. Test image is non-Jetson, so we drop Jetson-only
-# entries (cupy, jetson-ai-lab index) and runtime-only packages that don't
-# install on CI runners (pynput, bluezero). google-generativeai is required by
-# skills/scan_for_objects.py in integration tests.
-COPY ros2_ws/pip-requirements.txt /tmp/pip-requirements.txt
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
-    grep -v 'pypi.jetson-ai-lab.io' /tmp/pip-requirements.txt | \
-        grep -v -E '^cupy' | \
-        grep -v -E '^pynput' | \
-        grep -v -E '^bluezero' > /tmp/pip-requirements.filtered.txt && \
-    uv pip install --system meson ninja && \
-    uv pip install --system -r /tmp/pip-requirements.filtered.txt && \
-    uv pip install --system google-generativeai && \
-    rm /tmp/pip-requirements.txt /tmp/pip-requirements.filtered.txt
-
-# Initialize rosdep
-RUN rosdep init || true && rosdep update
-
-# Set up workspace directory
-WORKDIR /root/innate-os
-
-# Copy workspace source
-COPY ros2_ws /root/innate-os/ros2_ws
-
-# Copy additional directories needed at runtime
+# Overlay this revision's first-party source onto the baked workspace. COPY
+# merges (it does not delete), so the vcs-imported externals (rplidar_ros,
+# topic_tools) baked into the base survive; only first-party packages are
+# updated. config/ and workspace/ are runtime inputs for the tests.
+#
+# Caveat: a PR that *deletes* a source file, or *adds* a new external to
+# dependencies.repos, is not reflected until the base is rebuilt on main. Low
+# risk for a build gate; rebuild the base if it matters.
+COPY ros2_ws/src /root/innate-os/ros2_ws/src
 COPY config /root/innate-os/config
 COPY workspace /root/innate-os/workspace
 
-# Import external dependencies using vcs
-RUN cd /root/innate-os/ros2_ws/src && \
-    if [ -f dependencies.repos ]; then \
-        echo "Importing external dependencies via vcs..." && \
-        vcs import --input dependencies.repos; \
-    fi
-
-# Install ROS dependencies and build the whole workspace.
-# maurice_cam/nav/control build fine on non-Jetson: cam's VPI stereo component is
-# guarded by if(VPI_FOUND), nav's only Jetson dep (python3-cupy) is runtime-only.
+# Incremental rebuild. ccache (warm from the base) turns unchanged translation
+# units into cache hits; only changed packages truly recompile. --parallel-workers
+# defaults to all cores; cap it if heavy C++ linking OOMs on a small machine.
 WORKDIR /root/innate-os/ros2_ws
 RUN . /opt/ros/humble/setup.sh && \
-    rosdep install --from-paths src --ignore-src -r -y || true && \
-    colcon build --parallel-workers 2 --cmake-args -DCMAKE_BUILD_TYPE=Release
+    colcon build --parallel-workers "$(nproc)" --cmake-args \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
 # Shared test entrypoint script (used by docker-compose.test.yml and Cloud Build).
 # Placed after the build so editing it does not invalidate the colcon build cache.

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -18,31 +18,76 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Inherited from the base, re-declared for clarity. The warm ccache lives here.
 ENV CCACHE_DIR=/root/.ccache
 
-# Overlay this revision's first-party source onto the baked workspace. COPY
-# merges (it does not delete), so the vcs-imported externals (rplidar_ros,
-# topic_tools) baked into the base survive; only first-party packages are
-# updated. config/ and workspace/ are runtime inputs for the tests.
-#
-# Caveat: a PR that *deletes* a source file, or *adds* a new external to
-# dependencies.repos, is not reflected until the base is rebuilt on main. Low
-# risk for a build gate; rebuild the base if it matters.
-COPY ros2_ws/src /root/innate-os/ros2_ws/src
+# If this revision changed the hand-curated dependency lists, apply them on top
+# of the base (which baked the lists as of the last main build) — otherwise a PR
+# adding e.g. a pip package would build against stale deps with no diagnostic.
+# cmp against the copies baked into the base keeps the no-change case free; the
+# baked copies are then updated so the image matches this revision. The pip
+# filter must stay in sync with ci/Dockerfile.test-base.
+COPY ros2_ws/apt-dependencies.common.txt /tmp/pr-apt-deps.txt
+COPY ros2_ws/pip-requirements.txt /tmp/pr-pip-reqs.txt
+RUN if ! cmp -s /tmp/pr-apt-deps.txt /root/innate-os/ros2_ws/apt-dependencies.common.txt; then \
+        echo "apt-dependencies.common.txt changed since the base build; installing..." && \
+        apt-get update && \
+        grep -v '^#' /tmp/pr-apt-deps.txt | grep -v '^$' | \
+            xargs apt-get install -y --no-install-recommends && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi && \
+    if ! cmp -s /tmp/pr-pip-reqs.txt /root/innate-os/ros2_ws/pip-requirements.txt; then \
+        echo "pip-requirements.txt changed since the base build; installing..." && \
+        grep -v 'pypi.jetson-ai-lab.io' /tmp/pr-pip-reqs.txt | \
+            grep -v -E '^cupy' | \
+            grep -v -E '^pynput' | \
+            grep -v -E '^bluezero' > /tmp/pr-pip-reqs.filtered.txt && \
+        uv pip install --system -r /tmp/pr-pip-reqs.filtered.txt && \
+        rm /tmp/pr-pip-reqs.filtered.txt; \
+    fi && \
+    mv /tmp/pr-apt-deps.txt /root/innate-os/ros2_ws/apt-dependencies.common.txt && \
+    mv /tmp/pr-pip-reqs.txt /root/innate-os/ros2_ws/pip-requirements.txt
+
+# REPLACE (not merge) the baked first-party source with this revision's, so file
+# and package deletions take effect instead of leaving stale source behind, then
+# re-import the externals (also picks up changes to dependencies.repos without
+# waiting for a base rebuild). config/ and workspace/ are runtime inputs for the
+# tests; plain COPY-merge is fine there.
+COPY ros2_ws/src /tmp/pr-src
+RUN rm -rf /root/innate-os/ros2_ws/src && \
+    mv /tmp/pr-src /root/innate-os/ros2_ws/src && \
+    cd /root/innate-os/ros2_ws/src && \
+    if [ -f dependencies.repos ]; then \
+        vcs import --input dependencies.repos; \
+    fi
 COPY config /root/innate-os/config
 COPY workspace /root/innate-os/workspace
 
 # Incremental rebuild. ccache (warm from the base) turns unchanged translation
-# units into cache hits; only changed packages truly recompile. --parallel-workers
-# defaults to all cores; cap it if heavy C++ linking OOMs on a small machine.
+# units into cache hits; only changed packages truly recompile.
+# --parallel-workers is capped at 4: E2_HIGHCPU_8 has 8 vCPUs but only 8 GB RAM,
+# and >4 concurrent C++ link jobs can OOM with no useful error.
 #
-# rosdep install runs first (as in the base): near-instant when every dep is
-# already satisfied, but if this revision declares a NEW system <depend> it gets
-# installed on top of the base — so such PRs build (and, on a genuinely missing
-# dep, fail with a clear rosdep diagnostic instead of a cryptic compiler error)
-# without waiting for the next base rebuild on main.
+# Before building, prune build/ + install/ dirs of packages that no longer exist
+# in src — otherwise a deleted package's stale artifacts could keep dependents
+# linking and CI would pass while the post-merge main build breaks. Residual
+# caveat: a file deleted from a package that still exists can leave a stale
+# installed copy (cmake install does not prune) until the next base rebuild.
+#
+# rosdep install is best-effort (-r, ||): it exits non-zero for keys with no
+# installable candidate on this non-Jetson image, so we cannot gate on it. Its
+# value: a NEW system <depend> declared by this revision gets installed without
+# waiting for a base rebuild. A truly missing dep still surfaces as a compiler
+# error in the colcon build below — check the rosdep output above it.
 WORKDIR /root/innate-os/ros2_ws
 RUN . /opt/ros/humble/setup.sh && \
-    rosdep install --from-paths src --ignore-src -r -y || true && \
-    colcon build --parallel-workers "$(nproc)" --cmake-args \
+    colcon list --names-only --base-paths src > /tmp/current-pkgs.txt && \
+    for d in build/* install/*; do \
+        [ -d "$d" ] || continue; \
+        grep -qx "$(basename "$d")" /tmp/current-pkgs.txt || \
+            { echo "Pruning artifacts of removed package: $d"; rm -rf "$d"; }; \
+    done && \
+    rm /tmp/current-pkgs.txt && \
+    { rosdep install --from-paths src --ignore-src -r -y || \
+        echo "WARNING: rosdep install exited non-zero; if the build below fails on a missing system dep, check the rosdep output above." >&2; } && \
+    colcon build --parallel-workers "$(( $(nproc) < 4 ? $(nproc) : 4 ))" --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -33,8 +33,15 @@ COPY workspace /root/innate-os/workspace
 # Incremental rebuild. ccache (warm from the base) turns unchanged translation
 # units into cache hits; only changed packages truly recompile. --parallel-workers
 # defaults to all cores; cap it if heavy C++ linking OOMs on a small machine.
+#
+# rosdep install runs first (as in the base): near-instant when every dep is
+# already satisfied, but if this revision declares a NEW system <depend> it gets
+# installed on top of the base — so such PRs build (and, on a genuinely missing
+# dep, fail with a clear rosdep diagnostic instead of a cryptic compiler error)
+# without waiting for the next base rebuild on main.
 WORKDIR /root/innate-os/ros2_ws
 RUN . /opt/ros/humble/setup.sh && \
+    rosdep install --from-paths src --ignore-src -r -y || true && \
     colcon build --parallel-workers "$(nproc)" --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/ci/Dockerfile.test-base
+++ b/ci/Dockerfile.test-base
@@ -1,0 +1,121 @@
+# syntax=docker/dockerfile:1.7
+#
+# ci/Dockerfile.test-base - Warm base for the CI test image.
+#
+# Bakes the heavy, slow-changing pieces so PR builds (ci/Dockerfile.test) can be
+# fast: OS/apt deps, Python deps, rosdep, AND a full prebuilt ros2_ws (build/ +
+# install/) with a *populated ccache*. Published to ghcr as
+# innate-os-test-base:{main,buildcache} from main (see
+# ci/cloudbuild.integration-test.yaml). ci/Dockerfile.test does `FROM` this image
+# and only rebuilds what changed.
+#
+# Why a published base (vs. `--cache-from` alone): on ephemeral Cloud Build VMs a
+# cache-missed colcon layer cannot see the ccache it would itself produce, so it
+# would always rebuild from scratch. By baking ccache into this image's
+# filesystem, `FROM`-ing it gives the PR build a warm, content-addressed cache —
+# unchanged translation units become cache hits even after a fresh git checkout.
+#
+# Non-Jetson: skips nvidia-*/cuda-* packages.
+
+FROM ros:humble-ros-base
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    ROS_DISTRO=humble \
+    INNATE_OS_ROOT=/root/innate-os \
+    UV_SYSTEM_PYTHON=1 \
+    UV_LINK_MODE=copy \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    CCACHE_DIR=/root/.ccache
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install base prerequisites + enable universe (for gstreamer, libhdf5-dev, etc.)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        curl \
+        iputils-ping \
+        gnupg \
+        lsb-release \
+        ca-certificates && \
+    add-apt-repository universe && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        locales \
+        iproute2 \
+        libcairo2-dev \
+        libhdf5-dev \
+        ros-humble-kdl-parser
+
+# Setup locale
+RUN locale-gen en_US en_US.UTF-8 && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+# Add Innate packages repository (for ros-humble-innate-rws, etc.)
+RUN curl -fsSL https://innate-inc.github.io/innate-packages/pubkey.gpg | \
+    gpg --dearmor -o /usr/share/keyrings/innate-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/innate-archive-keyring.gpg] https://innate-inc.github.io/innate-packages/ $(lsb_release -cs) main" | \
+    tee /etc/apt/sources.list.d/innate.list > /dev/null
+
+# Copy apt dependencies file first (for better layer caching)
+COPY ros2_ws/apt-dependencies.common.txt /tmp/apt-dependencies.txt
+
+# Install apt dependencies from common list
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    grep -v '^#' /tmp/apt-dependencies.txt | grep -v '^$' | \
+        xargs apt-get install -y --no-install-recommends && \
+    rm /tmp/apt-dependencies.txt
+
+# Install uv for fast, cached Python package installation.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    ln -sf /root/.local/bin/uv /usr/local/bin/uv
+
+# Install Python deps with uv. Test image is non-Jetson, so we drop Jetson-only
+# entries (cupy, jetson-ai-lab index) and runtime-only packages that don't
+# install on CI runners (pynput, bluezero). google-generativeai is required by
+# skills/scan_for_objects.py in integration tests.
+COPY ros2_ws/pip-requirements.txt /tmp/pip-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    grep -v 'pypi.jetson-ai-lab.io' /tmp/pip-requirements.txt | \
+        grep -v -E '^cupy' | \
+        grep -v -E '^pynput' | \
+        grep -v -E '^bluezero' > /tmp/pip-requirements.filtered.txt && \
+    uv pip install --system meson ninja && \
+    uv pip install --system -r /tmp/pip-requirements.filtered.txt && \
+    uv pip install --system google-generativeai && \
+    rm /tmp/pip-requirements.txt /tmp/pip-requirements.filtered.txt
+
+# Initialize rosdep
+RUN rosdep init || true && rosdep update
+
+# Copy the full workspace (+ config/workspace, matching the runtime layout) and
+# import external dependencies (rplidar_ros, topic_tools) so they are baked in.
+WORKDIR /root/innate-os
+COPY ros2_ws /root/innate-os/ros2_ws
+COPY config /root/innate-os/config
+COPY workspace /root/innate-os/workspace
+RUN cd /root/innate-os/ros2_ws/src && \
+    if [ -f dependencies.repos ]; then \
+        echo "Importing external dependencies via vcs..." && \
+        vcs import --input dependencies.repos; \
+    fi
+
+# Full build with ccache. ccache writes to /root/.ccache (a REAL dir, NOT a
+# --mount=type=cache) so the populated cache is baked into the image layer and
+# carried into ci/Dockerfile.test via FROM. --parallel-workers defaults to all
+# cores; cap it if heavy C++ linking OOMs on a small machine.
+# maurice_cam/nav/control build fine on non-Jetson: cam's VPI stereo component is
+# guarded by if(VPI_FOUND), nav's only Jetson dep (python3-cupy) is runtime-only.
+WORKDIR /root/innate-os/ros2_ws
+RUN . /opt/ros/humble/setup.sh && \
+    rosdep install --from-paths src --ignore-src -r -y || true && \
+    colcon build --parallel-workers "$(nproc)" --cmake-args \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+WORKDIR /root/innate-os
+CMD ["bash"]

--- a/ci/Dockerfile.test-base
+++ b/ci/Dockerfile.test-base
@@ -30,6 +30,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install base prerequisites + enable universe (for gstreamer, libhdf5-dev, etc.)
+# ccache is installed explicitly (not only via apt-dependencies.common.txt)
+# because the colcon builds here and in ci/Dockerfile.test hard-depend on it.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -43,6 +45,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
         locales \
         iproute2 \
+        ccache \
         libcairo2-dev \
         libhdf5-dev \
         ros-humble-kdl-parser
@@ -105,14 +108,15 @@ RUN cd /root/innate-os/ros2_ws/src && \
 
 # Full build with ccache. ccache writes to /root/.ccache (a REAL dir, NOT a
 # --mount=type=cache) so the populated cache is baked into the image layer and
-# carried into ci/Dockerfile.test via FROM. --parallel-workers defaults to all
-# cores; cap it if heavy C++ linking OOMs on a small machine.
+# carried into ci/Dockerfile.test via FROM. --parallel-workers is capped at 4:
+# E2_HIGHCPU_8 has 8 vCPUs but only 8 GB RAM, and >4 concurrent C++ link jobs
+# (maurice_cam etc.) can OOM with no useful error.
 # maurice_cam/nav/control build fine on non-Jetson: cam's VPI stereo component is
 # guarded by if(VPI_FOUND), nav's only Jetson dep (python3-cupy) is runtime-only.
 WORKDIR /root/innate-os/ros2_ws
 RUN . /opt/ros/humble/setup.sh && \
     rosdep install --from-paths src --ignore-src -r -y || true && \
-    colcon build --parallel-workers "$(nproc)" --cmake-args \
+    colcon build --parallel-workers "$(( $(nproc) < 4 ? $(nproc) : 4 ))" --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/ci/Dockerfile.test-base.dockerignore
+++ b/ci/Dockerfile.test-base.dockerignore
@@ -1,0 +1,12 @@
+# CI base image bakes deps + a full prebuilt ros2_ws (incl. vcs-imported
+# externals), config, and workspace at build time. Allow what
+# Dockerfile.test-base COPYs from; without this file BuildKit would fall back to
+# the restrictive root .dockerignore and the build would have no source.
+**
+
+!ros2_ws/
+!ros2_ws/**
+!config/
+!config/**
+!workspace/
+!workspace/**

--- a/ci/README.md
+++ b/ci/README.md
@@ -7,8 +7,9 @@ gate-by-gate breakdown of what runs, see [`../docs/TESTING.md`](../docs/TESTING.
 
 | File | Role |
 |---|---|
-| `Dockerfile.test` | The CI image: builds the whole `ros2_ws` (all packages) + bakes in `config/`, `workspace/`, and the test script. |
-| `Dockerfile.test.dockerignore` | Build context for the above (allowlist of what the image COPYs). |
+| `Dockerfile.test-base` | **Warm base** (published to ghcr from main): apt/pip deps, rosdep, a full prebuilt `ros2_ws` (`build/`+`install/`), and a *populated ccache*. Changes rarely. |
+| `Dockerfile.test` | Thin CI image, `FROM` the warm base: overlays this revision's source + `config/`/`workspace/` and does an **incremental, ccache-backed** `colcon build` (only changed packages recompile; the whole tree is still built). |
+| `Dockerfile.test-base.dockerignore` / `Dockerfile.test.dockerignore` | Build contexts for the two images (allowlist of what each COPYs). Each Dockerfile needs its own — BuildKit otherwise falls back to the restrictive root `.dockerignore`. |
 | `run_integration_tests.sh` | **Single source of truth for "the tests."** Runs unit (pytest) + integration (`colcon test`) inside the image. |
 | `docker-compose.test.yml` | Runs `run_integration_tests.sh` locally / on a self-hosted box. |
 | `cloudbuild.integration-test.yaml` | Runs the *same* script on Google Cloud Build. |
@@ -47,15 +48,36 @@ suspenders: they only matter if SHM is ever re-enabled in CI.
 
 ## Why the build covers every package
 
-`Dockerfile.test` builds **all** packages (no `--packages-skip`). `maurice_cam`/
-`nav`/`control` were once skipped as "Jetson-only", but they compile fine off
-Jetson (cam's VPI stereo is `if(VPI_FOUND)`-guarded; nav's `cupy` is runtime-only).
+The build covers **all** packages (no `--packages-skip`). `maurice_cam`/`nav`/
+`control` were once skipped as "Jetson-only", but they compile fine off Jetson
+(cam's VPI stereo is `if(VPI_FOUND)`-guarded; nav's `cupy` is runtime-only).
 Building everything makes the build the broad safety net for structural refactors.
+
+## Why the image is split into a base + thin layer
+
+Cloud Build VMs are ephemeral, so without help every run paid ~180s to apt/pip
+install ~1000 packages **and** a full `colcon build` from scratch. The split fixes
+both while still building the whole tree:
+
+- `Dockerfile.test-base` bakes the deps + a full prebuilt `ros2_ws` + a populated
+  ccache, and is pushed to `ghcr.io/innate-inc/innate-os-test-base:{main,buildcache}`
+  **only on main** (`_PUBLISH_BASE=true`).
+- PR builds `FROM` that base, so they skip apt/pip entirely and the ccache (which
+  is content-addressed, so it survives a fresh checkout) turns unchanged
+  translation units into hits — only changed packages do real compile work.
+
+A cache-missed `colcon` layer can never see the ccache it would itself produce, so
+`--cache-from` alone can't make it incremental — the *published* base is the load-
+bearing piece. See `cloudbuild.integration-test.yaml` for the main-vs-PR flow.
 
 ## Running it locally
 
 ```bash
+# Build the warm base once (deps + full prebuilt ros2_ws + ccache), then the thin
+# image on top. CI publishes the base from main; locally you build it yourself.
+docker build -t ghcr.io/innate-inc/innate-os-test-base:main -f ci/Dockerfile.test-base .
+docker build -t innate-os-test:latest -f ci/Dockerfile.test .
+
 INNATE_TEST_IMAGE=innate-os-test:latest docker compose -f ci/docker-compose.test.yml up \
   --abort-on-container-exit --exit-code-from integration-test
-# (build the image first: docker build -f ci/Dockerfile.test -t innate-os-test:latest .)
 ```

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -72,14 +72,18 @@ steps:
         }
 
         if [[ "${_PUBLISH_BASE}" == "true" ]]; then
-          # main: (re)build and publish the warm base.
-          build_base
-          if [[ "$logged_in" == "true" ]]; then
-            docker push "$base_image:main"
-            docker push "$base_image:buildcache"
-          else
-            echo "WARNING: not logged in to ghcr; base built but not pushed."
+          # main: (re)build and publish the warm base. Publishing IS the job on
+          # main, so fail fast if we can't push — a silent "built but not pushed"
+          # would leave a stale base on ghcr that quietly degrades every later PR
+          # build (and the thin layer's `rosdep ... || true` would hide the
+          # resulting missing deps). Check before the expensive build_base.
+          if [[ "$logged_in" != "true" ]]; then
+            echo "ERROR: _PUBLISH_BASE=true but ghcr login failed; cannot publish the base." >&2
+            exit 1
           fi
+          build_base
+          docker push "$base_image:main"
+          docker push "$base_image:buildcache"
         else
           # PR: reuse the published warm base; only the thin layer rebuilds.
           # Fall back to an inline base build if it has never been published yet

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -16,6 +16,9 @@
 # NOTE: this build runs on a private worker pool (see the GitHub workflow). The
 # pool must have egress to ghcr.io (external IP or Cloud NAT) for the base
 # pull/push, and the build service account needs read access to the GHCR secrets.
+# The GHCR token (reused from the sim-image secrets) must also be authorized to
+# push the ${_BASE_IMAGE_NAME} package — a token fine-grained to the sim repos
+# only will make the first main build fail at `docker push`.
 timeout: 3600s
 
 substitutions:
@@ -32,7 +35,11 @@ options:
   logging: CLOUD_LOGGING_ONLY
 
 steps:
-  - id: build-test-image
+  # Make the warm base available in the local docker daemon: pull it on PRs
+  # (building it inline if it was never published), rebuild + push it on main.
+  # Kept as its own step so the per-step status distinguishes "base
+  # provisioning broke" from "this revision's build broke".
+  - id: prepare-base-image
     name: gcr.io/cloud-builders/docker
     entrypoint: bash
     secretEnv:
@@ -75,7 +82,7 @@ steps:
           # main: (re)build and publish the warm base. Publishing IS the job on
           # main, so fail fast if we can't push — a silent "built but not pushed"
           # would leave a stale base on ghcr that quietly degrades every later PR
-          # build (and the thin layer's `rosdep ... || true` would hide the
+          # build (and the thin layer's `rosdep ... || ...` would hide the
           # resulting missing deps). Check before the expensive build_base.
           if [[ "$logged_in" != "true" ]]; then
             echo "ERROR: _PUBLISH_BASE=true but ghcr login failed; cannot publish the base." >&2
@@ -94,14 +101,23 @@ steps:
           fi
         fi
 
-        # Thin layer: overlay this revision's source onto the warm base and do an
-        # incremental, ccache-backed colcon build.
-        docker build \
-          --progress=plain \
-          --build-arg "BASE_IMAGE=$base_image:main" \
-          -t innate-os-test:latest \
-          -f ci/Dockerfile.test \
-          .
+  # Thin layer: overlay this revision's source onto the warm base and do an
+  # incremental, ccache-backed colcon build. The base tag is in the local daemon
+  # from the previous step (Cloud Build steps share the docker daemon).
+  - id: build-test-image
+    name: gcr.io/cloud-builders/docker
+    env:
+      - DOCKER_BUILDKIT=1
+    args:
+      - build
+      - --progress=plain
+      - --build-arg
+      - BASE_IMAGE=${_IMAGE_PREFIX}/${_BASE_IMAGE_NAME}:main
+      - -t
+      - innate-os-test:latest
+      - -f
+      - ci/Dockerfile.test
+      - .
 
   - id: run-tests
     name: gcr.io/cloud-builders/docker

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -3,10 +3,28 @@
 # `gcloud builds submit` (GitHub Actions authenticates with Workload Identity
 # Federation — same setup as ci/cloudbuild.sim-images.yaml).
 #
-# It builds ci/Dockerfile.test and then runs the *same* test flow as a local
-# `docker compose -f ci/docker-compose.test.yml up`, so there is a single source
-# of truth for what "the tests" are.
+# Two-image strategy for speed (mirrors the sim deps/ros-prebuilt split):
+#   - ci/Dockerfile.test-base  -> a "warm" base (apt+pip deps, rosdep, a full
+#     prebuilt ros2_ws, and a populated ccache). Rebuilt + pushed to ghcr only on
+#     main (_PUBLISH_BASE=true), so it changes rarely.
+#   - ci/Dockerfile.test       -> a thin layer FROM the warm base that overlays
+#     this revision's source and does an INCREMENTAL, ccache-backed colcon build.
+# On a PR this skips the ~180s apt/pip install entirely and only recompiles the
+# packages that actually changed, while still building the whole workspace (so a
+# build error in any package fails CI).
+#
+# NOTE: this build runs on a private worker pool (see the GitHub workflow). The
+# pool must have egress to ghcr.io (external IP or Cloud NAT) for the base
+# pull/push, and the build service account needs read access to the GHCR secrets.
 timeout: 3600s
+
+substitutions:
+  _IMAGE_PREFIX: ghcr.io/innate-inc
+  _BASE_IMAGE_NAME: innate-os-test-base
+  _GHCR_TOKEN_SECRET: innate-os-sim-ghcr-token
+  _GHCR_USERNAME_SECRET: innate-os-sim-ghcr-username
+  # Set to "true" by the GitHub workflow on pushes to main; "false" for PRs.
+  _PUBLISH_BASE: "false"
 
 options:
   machineType: E2_HIGHCPU_8
@@ -16,16 +34,65 @@ options:
 steps:
   - id: build-test-image
     name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    secretEnv:
+      - GHCR_TOKEN
+      - GHCR_USERNAME
     env:
       - DOCKER_BUILDKIT=1
     args:
-      - build
-      - --progress=plain
-      - -t
-      - innate-os-test:latest
-      - -f
-      - ci/Dockerfile.test
-      - .
+      - -ceu
+      - |
+        base_image="${_IMAGE_PREFIX}/${_BASE_IMAGE_NAME}"
+
+        # ghcr login is best-effort: if it fails we simply build the base inline.
+        logged_in="false"
+        if echo "$$GHCR_TOKEN" | docker login ghcr.io -u "$$GHCR_USERNAME" --password-stdin; then
+          logged_in="true"
+        fi
+
+        build_base() {
+          # Full deps + prebuilt workspace + warm ccache. --cache-from reuses the
+          # deps layers; the colcon layer is a full build whenever ros2_ws/src
+          # changed (acceptable on main's cadence).
+          docker pull "$base_image:buildcache" || true
+          docker build \
+            --progress=plain \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --cache-from "$base_image:buildcache" \
+            -t "$base_image:main" \
+            -t "$base_image:buildcache" \
+            -f ci/Dockerfile.test-base \
+            .
+        }
+
+        if [[ "${_PUBLISH_BASE}" == "true" ]]; then
+          # main: (re)build and publish the warm base.
+          build_base
+          if [[ "$logged_in" == "true" ]]; then
+            docker push "$base_image:main"
+            docker push "$base_image:buildcache"
+          else
+            echo "WARNING: not logged in to ghcr; base built but not pushed."
+          fi
+        else
+          # PR: reuse the published warm base; only the thin layer rebuilds.
+          # Fall back to an inline base build if it has never been published yet
+          # (e.g. before the first main build after this change).
+          if ! docker pull "$base_image:main"; then
+            echo "Base image $base_image:main unavailable; building it inline."
+            build_base
+          fi
+        fi
+
+        # Thin layer: overlay this revision's source onto the warm base and do an
+        # incremental, ccache-backed colcon build.
+        docker build \
+          --progress=plain \
+          --build-arg "BASE_IMAGE=$base_image:main" \
+          -t innate-os-test:latest \
+          -f ci/Dockerfile.test \
+          .
 
   - id: run-tests
     name: gcr.io/cloud-builders/docker
@@ -43,3 +110,10 @@ steps:
       - SKIP_UPDATE_CHECK=1
       - innate-os-test:latest
       - run_integration_tests.sh
+
+availableSecrets:
+  secretManager:
+    - env: GHCR_USERNAME
+      versionName: projects/$PROJECT_ID/secrets/${_GHCR_USERNAME_SECRET}/versions/latest
+    - env: GHCR_TOKEN
+      versionName: projects/$PROJECT_ID/secrets/${_GHCR_TOKEN_SECRET}/versions/latest

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -45,7 +45,12 @@ steps:
       - |
         base_image="${_IMAGE_PREFIX}/${_BASE_IMAGE_NAME}"
 
-        # ghcr login is best-effort: if it fails we simply build the base inline.
+        # The GHCR secrets themselves are a hard prerequisite: Cloud Build
+        # resolves secretEnv before this step runs, so a missing secret or a
+        # service account without secretmanager.versions.access fails the build up
+        # front (see the header note). What we guard here is the docker login
+        # *call* (expired token, network blip): on failure we fall back to
+        # building the base inline instead of pulling it.
         logged_in="false"
         if echo "$$GHCR_TOKEN" | docker login ghcr.io -u "$$GHCR_USERNAME" --password-stdin; then
           logged_in="true"

--- a/ci/run_integration_tests.sh
+++ b/ci/run_integration_tests.sh
@@ -33,8 +33,9 @@ export ZENOH_SESSION_CONFIG_OVERRIDE="transport/shared_memory/enabled=false"
 export ZENOH_ROUTER_CONFIG_OVERRIDE="transport/shared_memory/enabled=false"
 export ZENOH_CONFIG_OVERRIDE="transport/shared_memory/enabled=false"
 
+# The test image already built the workspace at image-build time
+# (ci/Dockerfile.test does an incremental colcon build), so just source it.
 cd /root/innate-os/ros2_ws
-colcon build
 source install/setup.bash
 
 echo "=== unit tests (fast, no ROS) ==="

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -23,7 +23,10 @@ Build is the broad safety net for refactors (all 19 packages). Tests are the beh
 ## Run it locally
 
 ```bash
-# Build the test image
+# Build the test image. It's split in two: a "warm" base (deps + a full prebuilt
+# ros2_ws + ccache) and a thin layer on top that rebuilds only what changed.
+# CI publishes the base to ghcr from main; locally, build it once yourself first.
+docker build -t ghcr.io/innate-inc/innate-os-test-base:main -f ci/Dockerfile.test-base .
 docker build -t innate-os-test:latest -f ci/Dockerfile.test .
 
 # Run all of Gate 3 exactly as CI does


### PR DESCRIPTION
## What
Speeds up the `integration-test` CI (GitHub Actions → Cloud Build) from ~6 min toward ~1–2 min on a typical PR, **without** reducing build coverage.

## Why
Every run rebuilt the whole image from scratch: ~180s to apt/pip-install ~1000 ROS packages **and** a full `colcon build`. The `build-test-image` step had no `--cache-from`, and Cloud Build VMs are ephemeral, so the BuildKit `--mount=type=cache` mounts don't persist between runs.

## How
Mirrors the existing `sim/Dockerfile` + `Dockerfile.ros-prebuilt` + `cloudbuild.sim-images.yaml` pattern:

- **`ci/Dockerfile.test-base`** (new) — warm base: apt/pip deps, rosdep, a full prebuilt `ros2_ws` (`build/`+`install/`), and a populated **ccache**. Pushed to `ghcr.io/innate-inc/innate-os-test-base:{main,buildcache}` **only on main** (`_PUBLISH_BASE=true`).
- **`ci/Dockerfile.test`** — now a thin `FROM`-the-base layer: overlays this revision's source and does an **incremental, ccache-backed** `colcon build`. Only changed packages recompile; the whole tree still builds, so a build error anywhere fails CI.
- **`ci/cloudbuild.integration-test.yaml`** — bash step that logs into ghcr, publishes the base on main / reuses it on PRs (with an inline-build fallback for cold start), then builds the thin image and runs the tests. Reuses the existing `innate-os-sim-ghcr-*` secrets. `colcon` parallelism `2 → $(nproc)`.
- **`ci/run_integration_tests.sh`** — dropped the redundant second `colcon build` (the image already built the workspace).
- Docs (`ci/README.md`, `docs/TESTING.md`) updated for the two-step local build.

Why a *published* base (not just `--cache-from`): on ephemeral VMs a cache-missed `colcon` layer can never see the ccache it would itself produce, so only a base used as `FROM` carries a warm cache across runs.

## Repo size
Unaffected — nothing built is committed. `build/`/`install/`/ccache live only in Docker and ghcr (already covered by `.gitignore`); this PR adds two small text files.

## Rollout / prerequisites
- The base doesn't exist until the **first push to main** after merge; until then PRs build it inline (no slower than today).
- The Cloud Build service account needs **read access to the `innate-os-sim-ghcr-*` secrets**, and the private worker pool needs **egress to ghcr.io**.

## Verification
Real end-to-end needs a Cloud Build run. Locally (linux/amd64): build the base, build the thin against unchanged src and confirm `ccache -s` shows ~100% hits; touch one `.cpp` → only that package recompiles; introduce a deliberate error in `maurice_cam` → image build still **fails** (gate preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)