### PR TITLE
Enable disk-backed swap file in post_update (INN-530)

### DIFF
--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -230,38 +230,44 @@ SWAP_FILE="/swapfile"
 SWAP_SIZE_GB=8
 
 setup_swap() {
-    # Already active? Nothing to do (the common case on every update after the first).
     if swapon --show=NAME --noheadings 2>/dev/null | grep -qx "$SWAP_FILE"; then
+        # Already active (the common case on every update after the first).
+        # Still fall through to the fstab check below: an earlier run interrupted
+        # between swapon and the fstab append leaves swap active but unpersisted.
         log "  Swap file already active ($SWAP_FILE)"
-        return 0
-    fi
-
-    # Not active. Any existing file may be a partial leftover from an interrupted
-    # run (power loss, disk-full, OOM-killed dd); a truncated file would make
-    # mkswap fail on every future update. So never trust an existing file:
-    # rebuild from scratch, and remove it on any failure so a botched run can't
-    # permanently block swap setup on later updates.
-    rm -f "$SWAP_FILE"
-    log "  Creating ${SWAP_SIZE_GB}G swap file at $SWAP_FILE..."
-
-    # Create with mode 600 up front (never world-readable), then allocate.
-    # fallocate works on the ext4 NVMe root; fall back to dd where unsupported.
-    install -m 600 /dev/null "$SWAP_FILE" || return 1
-    if ! fallocate -l "${SWAP_SIZE_GB}G" "$SWAP_FILE"; then
-        log "  fallocate unavailable; falling back to dd"
-        dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$((SWAP_SIZE_GB * 1024)) status=none \
-            || { rm -f "$SWAP_FILE"; return 1; }
-    fi
-
-    if ! mkswap "$SWAP_FILE" >/dev/null || ! swapon "$SWAP_FILE"; then
+    else
+        # Not active. Any existing file may be a partial leftover from an
+        # interrupted run (power loss, disk-full, OOM-killed dd); a truncated
+        # file would make mkswap fail on every future update. So never trust an
+        # existing file: rebuild from scratch, and remove it on any failure so a
+        # botched run can't permanently block swap setup on later updates.
         rm -f "$SWAP_FILE"
-        return 1
-    fi
-    log "  Swap enabled ($SWAP_FILE)"
+        log "  Creating ${SWAP_SIZE_GB}G swap file at $SWAP_FILE..."
 
-    # Persist across reboots.
+        # Create with mode 600 up front (never world-readable), then allocate.
+        # fallocate works on the ext4 NVMe root; fall back to dd where unsupported.
+        install -m 600 /dev/null "$SWAP_FILE" || return 1
+        if ! fallocate -l "${SWAP_SIZE_GB}G" "$SWAP_FILE"; then
+            log "  fallocate unavailable; falling back to dd"
+            dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$((SWAP_SIZE_GB * 1024)) status=none \
+                || { rm -f "$SWAP_FILE"; return 1; }
+        fi
+
+        if ! mkswap "$SWAP_FILE" >/dev/null || ! swapon "$SWAP_FILE"; then
+            rm -f "$SWAP_FILE"
+            return 1
+        fi
+        log "  Swap enabled ($SWAP_FILE)"
+    fi
+
+    # Persist across reboots. nofail keeps boot clean if the file is ever
+    # missing (e.g. removed by a failed re-setup); the entry then just waits
+    # for the next successful run instead of producing a degraded swap unit.
     if ! grep -qE "^${SWAP_FILE}[[:space:]]" /etc/fstab; then
-        echo "$SWAP_FILE none swap sw 0 0" >> /etc/fstab
+        # Guard against an fstab without a trailing newline: a bare append
+        # would glue the swap entry onto the previous mount line.
+        [ -n "$(tail -c1 /etc/fstab)" ] && echo >> /etc/fstab
+        echo "$SWAP_FILE none swap sw,nofail 0 0" >> /etc/fstab
         log "  Added $SWAP_FILE to /etc/fstab"
     fi
     return 0

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -7,6 +7,7 @@
 #
 # This script handles:
 #   0a. Migrate root-level agents/, inputs/, skills/ into workspace/
+#   0b. Enable a disk-backed swap file (INN-530)
 #   1. Systemd service files
 #   2. Helper scripts in /usr/local/bin
 #   3. Udev rules
@@ -214,6 +215,56 @@ fi
 # shellcheck source=scripts/update/migrate_user_data.sh
 source "$SCRIPT_DIR/migrate_user_data.sh"
 MIGRATE_CHOWN_USER="$ACTUAL_USER" run_user_data_migrations "$REPO_DIR"
+
+# -----------------------------------------------------------------------------
+# 0b. Enable a disk-backed swap file (INN-530)
+# Jetson ships only zram (compressed RAM swap), which adds no real headroom once
+# physical RAM is exhausted — the cause of OOM kills during memory-heavy work
+# like the colcon rebuild further down. A small NVMe-backed swap file adds a
+# genuine overflow tier; the kernel fills high-priority zram first, then spills
+# here. Enabled before the build so this very update run already benefits.
+# Idempotent: created/enabled once, then persisted in /etc/fstab.
+# Non-fatal: swap must never block an update, so failures only warn.
+# -----------------------------------------------------------------------------
+SWAP_FILE="/swapfile"
+SWAP_SIZE_GB=8
+
+setup_swap() {
+    # Already active? Nothing to do (the common case on every update after the first).
+    if swapon --show=NAME --noheadings 2>/dev/null | grep -qx "$SWAP_FILE"; then
+        log "  Swap file already active ($SWAP_FILE)"
+        return 0
+    fi
+
+    # Create the backing file if missing. fallocate works on the ext4 NVMe root;
+    # fall back to dd for filesystems where it produces a sparse file.
+    if [ ! -f "$SWAP_FILE" ]; then
+        log "  Creating ${SWAP_SIZE_GB}G swap file at $SWAP_FILE..."
+        if ! fallocate -l "${SWAP_SIZE_GB}G" "$SWAP_FILE"; then
+            log "  fallocate unavailable; falling back to dd"
+            dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$((SWAP_SIZE_GB * 1024)) status=none || return 1
+        fi
+    fi
+
+    chmod 600 "$SWAP_FILE"
+    mkswap "$SWAP_FILE" >/dev/null || return 1
+    swapon "$SWAP_FILE" || return 1
+    log "  Swap enabled ($SWAP_FILE)"
+
+    # Persist across reboots.
+    if ! grep -qE "^${SWAP_FILE}[[:space:]]" /etc/fstab; then
+        echo "$SWAP_FILE none swap sw 0 0" >> /etc/fstab
+        log "  Added $SWAP_FILE to /etc/fstab"
+    fi
+    return 0
+}
+
+log "Configuring swap..."
+if setup_swap; then
+    log "  Swap configuration complete"
+else
+    log "  WARNING: swap configuration failed (continuing without disk swap)"
+fi
 
 # Stop running services before updating (keep app.cpp alive during build)
 log "Stopping services to begin update..."

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -236,19 +236,27 @@ setup_swap() {
         return 0
     fi
 
-    # Create the backing file if missing. fallocate works on the ext4 NVMe root;
-    # fall back to dd for filesystems where it produces a sparse file.
-    if [ ! -f "$SWAP_FILE" ]; then
-        log "  Creating ${SWAP_SIZE_GB}G swap file at $SWAP_FILE..."
-        if ! fallocate -l "${SWAP_SIZE_GB}G" "$SWAP_FILE"; then
-            log "  fallocate unavailable; falling back to dd"
-            dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$((SWAP_SIZE_GB * 1024)) status=none || return 1
-        fi
+    # Not active. Any existing file may be a partial leftover from an interrupted
+    # run (power loss, disk-full, OOM-killed dd); a truncated file would make
+    # mkswap fail on every future update. So never trust an existing file:
+    # rebuild from scratch, and remove it on any failure so a botched run can't
+    # permanently block swap setup on later updates.
+    rm -f "$SWAP_FILE"
+    log "  Creating ${SWAP_SIZE_GB}G swap file at $SWAP_FILE..."
+
+    # Create with mode 600 up front (never world-readable), then allocate.
+    # fallocate works on the ext4 NVMe root; fall back to dd where unsupported.
+    install -m 600 /dev/null "$SWAP_FILE" || return 1
+    if ! fallocate -l "${SWAP_SIZE_GB}G" "$SWAP_FILE"; then
+        log "  fallocate unavailable; falling back to dd"
+        dd if=/dev/zero of="$SWAP_FILE" bs=1M count=$((SWAP_SIZE_GB * 1024)) status=none \
+            || { rm -f "$SWAP_FILE"; return 1; }
     fi
 
-    chmod 600 "$SWAP_FILE"
-    mkswap "$SWAP_FILE" >/dev/null || return 1
-    swapon "$SWAP_FILE" || return 1
+    if ! mkswap "$SWAP_FILE" >/dev/null || ! swapon "$SWAP_FILE"; then
+        rm -f "$SWAP_FILE"
+        return 1
+    fi
     log "  Swap enabled ($SWAP_FILE)"
 
     # Persist across reboots.


### PR DESCRIPTION
## What

Adds an idempotent step to `scripts/update/post_update.sh` that creates an **8 GB NVMe-backed swap file** (`/swapfile`), enables it, and persists it in `/etc/fstab`.

Because `post_update.sh` runs after every OTA, **all robots gain swap on their next update with no manual action** — which is the point of [INN-530](https://linear.app/innate/issue/INN-530/enable-swap).

## Why

Jetson ships only **zram** (compressed *RAM*-backed swap). zram adds no real capacity once physical RAM is exhausted — it just compresses pages in the same 7.4 GB. That's the cause of the OOM kills seen during the hackathon (INN-515, duplicated into this ticket) and during the memory-heavy `colcon` rebuild that runs later in this same script.

A disk-backed swap file adds a genuine overflow tier. The kernel fills high-priority zram first (prio 5), then spills to the lower-priority disk swap.

## Details

- **Placement:** runs before the ROS workspace rebuild, so the *same* update run that ships this already benefits from the extra headroom.
- **Idempotent:** detects already-active swap and an existing fstab entry; safe to run on every update.
- **Non-fatal:** swap setup must never block an update, so any failure only logs a warning and the update continues. `fallocate` falls back to `dd` on filesystems that would produce a sparse file.

## Testing

- `bash -n` syntax check passes.
- Isolated harness with stubbed `swapon`/`mkswap`/`fallocate` verified: fresh setup, idempotent re-run (exactly one fstab line, no duplicates), and the failure path (warns + continues, exit 0).

Note: not yet exercised on a live robot through a full `innate update apply` — worth a smoke test on one device before broad rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)