### PR TITLE
fix: brain resilience — bad chat JSON + detached HEAD version check (INN-490, INN-496)

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -234,7 +234,11 @@ class BrainClientNode(Node):
 
     # ================= always-on subscription callbacks =================
     def _on_chat_in(self, msg: String) -> None:
-        data = json.loads(msg.data)
+        try:
+            data = json.loads(msg.data)
+        except (json.JSONDecodeError, TypeError):
+            self.get_logger().warn("[BrainClient] Ignoring /brain/chat_in: invalid JSON payload.")
+            return
         if not self.state.is_brain_active:
             self.get_logger().warn("[BrainClient] Brain is not active. Skipping chat_in message.")
             return

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -239,6 +239,11 @@ class BrainClientNode(Node):
         except (json.JSONDecodeError, TypeError):
             self.get_logger().warn("[BrainClient] Ignoring /brain/chat_in: invalid JSON payload.")
             return
+        if not isinstance(data, dict) or "text" not in data:
+            self.get_logger().warn(
+                "[BrainClient] Ignoring /brain/chat_in: payload must be a JSON object with a 'text' field."
+            )
+            return
         if not self.state.is_brain_active:
             self.get_logger().warn("[BrainClient] Brain is not active. Skipping chat_in message.")
             return

--- a/ros2_ws/src/maurice_bot/maurice_control/maurice_control/app.cpp
+++ b/ros2_ws/src/maurice_bot/maurice_control/maurice_control/app.cpp
@@ -178,15 +178,11 @@ std::string get_tag_body(const std::string& maurice_root) {
 
 /**
  * Get the current robot version.
- * - If on main branch and there are tags, returns the latest tag
- * - If in development (not on main), returns dev version using latest tag
+ * - If HEAD is exactly on a tag (branch or detached), returns that tag
+ * - Otherwise (development or detached HEAD), returns latest tag + "-dev"
  * - Throws runtime_error if no tags exist (this should not happen)
  */
 std::string get_robot_version(const std::string& maurice_root) {
-    // Get current branch (empty if detached HEAD, e.g. tag checkout)
-    std::string branch_cmd = "cd \"" + maurice_root + "\" && git branch --show-current 2>/dev/null";
-    std::string current_branch = exec_command(branch_cmd);
-
     // Check if we're exactly on a tag (works for both branch and detached HEAD)
     std::string exact_cmd = "cd \"" + maurice_root + "\" && git describe --exact-match --tags HEAD 2>/dev/null";
     std::string exact_tag = exec_command(exact_cmd);
@@ -196,10 +192,9 @@ std::string get_robot_version(const std::string& maurice_root) {
         return exact_tag;
     }
 
-    // If not on a branch and not on a tag, we're in an unknown state
-    if (current_branch.empty()) {
-        throw std::runtime_error("Detached HEAD but not on a tag - checkout a branch or tag");
-    }
+    // Detached HEAD not exactly on a tag (e.g. interrupted update or manual
+    // checkout) is treated like any development state: fall through to the
+    // latest-tag "-dev" fallback instead of failing the version check.
 
     // Get all tags sorted by version
     std::string tags_cmd = "cd \"" + maurice_root + "\" && git tag --list --sort=-version:refname 2>/dev/null";


### PR DESCRIPTION
Two small guards so the brain survives bad inputs ("the brain can be chill about it"):

- **INN-490:** `brain_client` no longer crashes on malformed JSON published to `/brain/chat_in` — invalid payloads are logged and ignored, and the payload shape is validated before use.
- **INN-496:** `get_robot_version()` in `maurice_control/app.cpp` no longer throws on a detached HEAD that isn't exactly on a tag (e.g. after an interrupted update). It now falls back to the existing `latest tag + "-dev"` path, so `/robot/info` keeps publishing a version. The "no tags exist" error is unchanged.

## Testing

Ran the real `get_robot_version()` against scratch git repos via a temporary harness (removed before merge):

| Scenario | Old code | New code |
|---|---|---|
| On branch, ahead of tag | `1.2.3-dev` | `1.2.3-dev` |
| Detached HEAD exactly on tag | `1.2.3` | `1.2.3` |
| Detached HEAD past tag | **throws** `Detached HEAD but not on a tag` | `1.2.3-dev` |
| No tags at all | throws | throws (unchanged) |

`maurice_control` builds clean on the robot.

Fixes INN-490, INN-496

🤖 Generated with [Claude Code](https://claude.com/claude-code)