### PR TITLE
Fix simulator skill failure handling

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -11,6 +11,7 @@ the action server.
 
 from __future__ import annotations
 
+import inspect
 import json
 import queue
 import threading
@@ -31,7 +32,7 @@ from brain_client.robot.mobility import MobilityInterface
 from brain_client.skills.catalog import SkillRepository
 from brain_client.skills.cli_bridge import SkillCliBridge, SkillCliGoalHandle
 from brain_client.skills.robot_state import RobotStateProvider
-from brain_client.skills.types import RobotStateType, SkillResult
+from brain_client.skills.types import InterfaceType, RobotStateType, SkillResult
 
 
 class SkillsActionServer(Node):
@@ -183,6 +184,7 @@ class SkillsActionServer(Node):
 
     def execute_callback(self, goal_handle):
         self.get_logger().debug(f"[SAS] execute_callback ENTER for skill: '{goal_handle.request.skill_type}'")
+        skill_type = goal_handle.request.skill_type
         try:
             inputs = json.loads(goal_handle.request.inputs)
         except Exception as e:
@@ -192,11 +194,30 @@ class SkillsActionServer(Node):
                 success=False, message="Invalid inputs JSON", success_type=SkillResult.FAILURE.value
             )
 
-        skill_type = goal_handle.request.skill_type
+        if not isinstance(inputs, dict):
+            goal_handle.abort()
+            return ExecuteSkill.Result(
+                success=False,
+                message="Skill inputs must be a JSON object.",
+                skill_type=skill_type,
+                success_type=SkillResult.FAILURE.value,
+            )
+
         if self.catalog.get_code_skill(skill_type) is not None:
             return self._execute_code_skill(goal_handle, skill_type, inputs)
         if self.catalog.get_physical_skill(skill_type) is not None:
             return self._execute_physical_skill(goal_handle, skill_type, inputs)
+        if self.catalog.get_in_training_skill(skill_type) is not None:
+            goal_handle.abort()
+            return ExecuteSkill.Result(
+                success=False,
+                message=(
+                    f"Skill '{skill_type}' is not executable yet because it is still in training "
+                    "or missing required runtime artifacts."
+                ),
+                skill_type=skill_type,
+                success_type=SkillResult.FAILURE.value,
+            )
 
         self.get_logger().error(f"Skill '{skill_type}' not available")
         self.get_logger().error(f"Available skills: {self.catalog.all_skill_ids()}")
@@ -227,6 +248,28 @@ class SkillsActionServer(Node):
             self.get_logger().debug(f"Published feedback for '{skill_type}': {update_message}")
 
         skill.set_feedback_callback(_publish_feedback)
+
+        validation_error = self._validate_skill_inputs(skill_type, skill, inputs)
+        if validation_error:
+            self.get_logger().info(f"Skill '{skill_type}' rejected invalid inputs: {validation_error}")
+            goal_handle.abort()
+            return ExecuteSkill.Result(
+                success=False,
+                message=validation_error,
+                skill_type=skill_type,
+                success_type=SkillResult.FAILURE.value,
+            )
+
+        manipulation_error = self._sim_manipulation_unavailable_reason(skill)
+        if manipulation_error:
+            self.get_logger().info(f"Skill '{skill_type}' skipped in simulator mode: {manipulation_error}")
+            goal_handle.abort()
+            return ExecuteSkill.Result(
+                success=False,
+                message=manipulation_error,
+                skill_type=skill_type,
+                success_type=SkillResult.FAILURE.value,
+            )
 
         required_states = skill.get_required_robot_states()
         needs_camera = required_states and (
@@ -277,6 +320,63 @@ class SkillsActionServer(Node):
             if needs_camera:
                 self._camera_node.stop()
             self.robot_state.stop_subscriptions()
+
+    def _validate_skill_inputs(self, skill_id: str, skill, inputs) -> str | None:
+        """Return a basic call-shape validation error, or None if inputs are usable."""
+        if not isinstance(inputs, dict):
+            return "Skill inputs must be a JSON object."
+
+        try:
+            signature = inspect.signature(skill.execute)
+        except (TypeError, ValueError):
+            return None
+
+        parameters = {
+            name: param
+            for name, param in signature.parameters.items()
+            if name != "self" and param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        }
+        accepts_extra_kwargs = any(
+            param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()
+        )
+
+        if not accepts_extra_kwargs:
+            unexpected = sorted(set(inputs) - set(parameters))
+            if unexpected:
+                accepted = ", ".join(parameters) if parameters else "none"
+                return (
+                    f"Skill '{skill_id}' got unsupported input(s): {', '.join(unexpected)}. "
+                    f"Accepted inputs: {accepted}."
+                )
+
+        missing = [
+            name
+            for name, param in parameters.items()
+            if param.default == inspect.Parameter.empty
+            and param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+            and name not in inputs
+        ]
+        if missing:
+            return f"Skill '{skill_id}' is missing required input(s): {', '.join(missing)}."
+
+        return None
+
+    def _sim_manipulation_unavailable_reason(self, skill) -> str | None:
+        """Explain why a manipulation skill cannot run in the current sim session."""
+        if not self.simulator_mode:
+            return None
+        if InterfaceType.MANIPULATION not in skill.get_required_interfaces():
+            return None
+
+        topic_names = {name for name, _types in self.get_topic_names_and_types()}
+        missing_topics = [name for name in ("/fk_pose", "/ik_solution") if name not in topic_names]
+        if missing_topics:
+            return (
+                "Arm manipulation skills are not available in this simulator session "
+                f"(missing {', '.join(missing_topics)}). The skill was not run."
+            )
+
+        return None
 
     def _execute_physical_skill(self, goal_handle, skill_type, inputs):
         self.get_logger().info(f"Delegating physical skill '{skill_type}' to behavior_server")

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py
@@ -82,9 +82,17 @@ class SkillRepository:
         with self._skills_lock:
             return self._physical_skills.get(skill_id)
 
+    def get_in_training_skill(self, skill_id: str):
+        with self._skills_lock:
+            return self._in_training_skills.get(skill_id)
+
     def all_skill_ids(self) -> list[str]:
         with self._skills_lock:
-            return list(self._code_skills.keys()) + list(self._physical_skills.keys())
+            return (
+                list(self._code_skills.keys())
+                + list(self._physical_skills.keys())
+                + list(self._in_training_skills.keys())
+            )
 
     def all_code_skills(self) -> list[tuple[str, tuple[str, Skill]]]:
         with self._skills_lock:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/loader.py
@@ -77,7 +77,7 @@ class SkillLoader(DynamicLoader):
         Returns:
             tuple: (is_valid: bool, is_in_training: bool, episode_count: int)
                 - is_valid: True if the skill can be loaded (either ready or in training)
-                - is_in_training: True if the skill is a learned type missing its checkpoint
+                - is_in_training: True if the skill is missing required runtime artifacts
                 - episode_count: Number of recorded episodes (0 if not applicable or not found)
         """
         skill_type = metadata.get("type", "").lower()
@@ -88,12 +88,20 @@ class SkillLoader(DynamicLoader):
             episode_count = self._get_episode_count(skill_dir)
             return (is_valid, is_in_training, episode_count)
         elif skill_type == "replay":
+            replay_file = execution.get("replay_file")
+            if not replay_file:
+                self.logger.warning(f"Replay skill in {skill_dir} missing replay_file - marked as in_training")
+                return (True, True, 0)
+            replay_path = os.path.join(skill_dir, replay_file)
+            if not os.path.exists(replay_path):
+                self.logger.warning(f"Replay skill file not found: {replay_path} - marked as in_training")
+                return (True, True, 0)
             is_valid = self._validate_replay_skill(skill_dir, execution)
             return (
                 is_valid,
                 False,
                 0,
-            )  # Replay skills are never "in training", no episodes
+            )  # Ready replay skills have no training episodes.
         else:
             self.logger.warning(f"Unknown skill type '{skill_type}' in {skill_dir}")
             return (True, False, 0)  # Allow unknown types but log warning

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -61,6 +61,8 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
         cartesia \
         einops \
         python-dotenv \
+        python-chess \
+        google-genai \
         websocket-client && \
     uv pip install --system \
         --index-url https://download.pytorch.org/whl/cpu \

--- a/workspace/innate_agents/security_guard_agent.py
+++ b/workspace/innate_agents/security_guard_agent.py
@@ -36,8 +36,7 @@ class SecurityGuardAgent(Agent):
 Your patrol route should follow this specific order:
 1. First, navigate to the laundry room with squares on the floor.
 2. Then, navigate to the bedroom, close to the black bed.
-3. Once in the bedroom, look on the right, there is a backdoor unsafe there.
-4. When you reach the backdoor, inspect it closely — a backdoor that has been left open is a security concern.
+3. Once in the bedroom, look on the right and inspect the backdoor area.
 
 You can navigate from memory to the laundry room and the bedroom. Inside the bedroom, use turn_and_move to see if someone is here. Never use navigation_in_sight.
 

--- a/workspace/innate_skills/scan_for_objects.py
+++ b/workspace/innate_skills/scan_for_objects.py
@@ -3,12 +3,14 @@
 Skill that rotates the robot 360 degrees while scanning for objects using Gemini.
 """
 
+import base64
 import json
 import math
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-import google.generativeai as genai
+from google import genai
+from google.genai import types
 
 from brain_client.skills.types import Interface, InterfaceType, RobotState, RobotStateType, Skill, SkillResult
 
@@ -44,11 +46,12 @@ class ScanForObjects(Skill):
 
         self.api_key = env_vars.get("GEMINI_API_KEY", "")
         if self.api_key and self.api_key != "your_gemini_api_key_here":
-            genai.configure(api_key=self.api_key)
-            self.model = genai.GenerativeModel("gemini-2.0-flash")
+            self.client = genai.Client(api_key=self.api_key)
+            self.model_name = "gemini-2.0-flash"
             self.logger.info("[ScanForObjects] Gemini configured")
         else:
-            self.model = None
+            self.client = None
+            self.model_name = None
             self.logger.warn(f"[ScanForObjects] GEMINI_API_KEY not set in {env_path}")
 
         # Scan parameters
@@ -76,7 +79,7 @@ class ScanForObjects(Skill):
         Returns:
             tuple: (result_message, result_status)
         """
-        if not self.model:
+        if not self.client:
             self.logger.error("[ScanForObjects] GEMINI_API_KEY not set")
             return "Gemini API key not configured", SkillResult.FAILURE
 
@@ -177,7 +180,7 @@ class ScanForObjects(Skill):
 
     def _detect_objects(self, image_b64: str, target_object: str = None) -> list:
         """Send image to Gemini and return detected objects."""
-        if not self.model:
+        if not self.client:
             return []
 
         try:
@@ -201,12 +204,16 @@ Respond with ONLY a JSON array. Each object should have:
 Example: [{"class": "laptop", "confidence": 0.95, "position": "center"}, {"class": "coffee mug", "confidence": 0.8, "position": "right"}]"""  # noqa: W291
 
             # Create image part for Gemini
-            image_part = {"mime_type": "image/jpeg", "data": image_b64}
+            image_part = types.Part.from_bytes(
+                data=base64.b64decode(image_b64),
+                mime_type="image/jpeg",
+            )
 
             # Call Gemini
-            response = self.model.generate_content(
-                [prompt, image_part],
-                generation_config=genai.GenerationConfig(
+            response = self.client.models.generate_content(
+                model=self.model_name,
+                contents=[prompt, image_part],
+                config=types.GenerateContentConfig(
                     response_mime_type="application/json",
                 ),
             )


### PR DESCRIPTION
## Summary
- supersedes #414 by porting the still-needed simulator skill failure handling onto the current brain_client layout
- validate code-skill inputs before execution so malformed, missing, or unsupported params return clean failure messages instead of raw Python exceptions
- return an explicit unavailable/in-training message for physical skills that are advertised but missing runtime artifacts
- mark replay skills with missing replay artifacts as in-training instead of silently hiding them as invalid
- install the shipped chess/Gemini runtime dependencies in the sim image and migrate scan_for_objects to the current google-genai client
- clean the security guard prompt so it no longer implies an unavailable door-opening primitive

## Validation
- `python3 -m py_compile ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py ros2_ws/src/brain/brain_client/brain_client/skills/loader.py workspace/innate_agents/security_guard_agent.py workspace/innate_skills/scan_for_objects.py`
- `/opt/homebrew/bin/ruff check ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py ros2_ws/src/brain/brain_client/brain_client/skills/loader.py workspace/innate_agents/security_guard_agent.py workspace/innate_skills/scan_for_objects.py`
- `git diff --check`
- `rg -n "open_door|open door" workspace/innate_agents workspace/innate_skills ros2_ws/src/brain -S` returns no matches
