### PR TITLE
fix: use perceptual volume scale for speaker volume (INN-467)

### DIFF
--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -918,9 +918,12 @@ class AppControl : public rclcpp::Node {
      * Apply volume to ALSA default playback device.
      * This updates the system volume immediately, affecting any currently
      * playing audio (e.g. TTS via aplay) in real time.
+     * -M maps the percentage on alsamixer's perceptual (dB-normalized)
+     * scale instead of the raw register scale, so e.g. 30% is clearly
+     * audible rather than ~-70dB (INN-467).
      */
     void apply_alsa_volume(int percent) {
-        std::string cmd = "amixer sset Master " + std::to_string(percent) + "% 2>/dev/null";
+        std::string cmd = "amixer -M sset Master " + std::to_string(percent) + "% 2>/dev/null";
         int ret = std::system(cmd.c_str());
         if (ret != 0) {
             RCLCPP_WARN(this->get_logger(), "amixer sset Master failed (rc=%d)", ret);


### PR DESCRIPTION
## Summary

Fixes [INN-467](https://linear.app/innate/issue/INN-467/volume-control-is-not-linear-below-30percent-becomes-inaudible) — volume set below ~30% in the app was inaudible.

`apply_alsa_volume` in `maurice_control/app.cpp` ran `amixer sset Master N%`, which scales the **raw mixer register** linearly. On most codecs the raw register is linear in *decibels* over a huge range (commonly −100 dB to 0 dB), so 30% landed around −70 dB — effectively silence — while everything above ~70% sounded loud.

The fix adds amixer's `-M` flag, which uses the same perceptual (dB-normalized) mapping as `alsamixer`, so the 0–100 percentage tracks perceived loudness.

## Why `-M` instead of a curve in code

A hand-rolled log/exponential curve would have to guess the hardware's dB range; `-M` reads the actual dB range from the driver, so it's correct on any codec. It's also a one-word change at the single choke point both callers go through — the `/set_volume` service from the app and the startup sync from `robot_info.json` — so the app keeps sending plain 0–100 with no protocol changes.

## Testing

- clang-format (CI pre-commit) passes.
- On-robot check: `ros2 service call /set_volume maurice_msgs/srv/SetVolume "{volume_percent: 30}"` then trigger TTS — should now be quiet but clearly audible, with a smooth ramp to 100%.

Note: stored values now map to a somewhat lower raw mixer level than before (perceptual 80% ≈ −10 dB vs. raw 80%), so robots may sound slightly quieter at their old settings until users adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)