### PR TITLE
feat: persistent robot microphone toggle (INN-485)

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
@@ -139,10 +139,13 @@ class InputDeviceManager:
 
     def set_mic_enabled(self, enabled: bool) -> None:
         """Apply the robot-level microphone toggle."""
-        if enabled == self._mic_enabled:
-            return
+        if enabled != self._mic_enabled:
+            self._logger.info(f"🎙️ Microphone {'enabled' if enabled else 'disabled'}")
+        # Track the user's intent unconditionally (it gates handle_active_inputs
+        # via _is_allowed), and re-apply even when unchanged: _apply is a no-op
+        # when state already matches, so a re-publish of the same value retries
+        # a previously failed open/close instead of being swallowed.
         self._mic_enabled = enabled
-        self._logger.info(f"🎙️ Microphone {'enabled' if enabled else 'disabled'}")
         device = self.input_devices.get(MIC_DEVICE_NAME)
         if device is not None:
             self._apply(MIC_DEVICE_NAME, device, enabled and MIC_DEVICE_NAME in self._requested_inputs)

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
@@ -103,6 +103,10 @@ class InputDeviceManager:
                 self._logger.info(f"💤 Closed input device: {name}")
             return True
         except Exception as e:
+            if should_be_active:
+                # Roll back the flag: a failed open left as "active" would make
+                # every later open attempt a no-op (stuck half-open until restart).
+                device.set_active(False)
             self._logger.error(f"Error {'opening' if should_be_active else 'closing'} input device '{name}': {e}")
             return False
 

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
@@ -20,6 +20,10 @@ from brain_client.common.script_paths import get_input_directories
 from brain_client.inputs.loader import InputLoader
 from brain_client.inputs.types import InputDevice
 
+# Device name of the microphone input (workspace/inputs/micro_input.py), gated
+# by the user-facing microphone toggle persisted in robot_info.json.
+MIC_DEVICE_NAME = "micro"
+
 
 class InputDeviceManager:
     def __init__(self, node, proxy, *, chat_in_pub, custom_pub):
@@ -28,6 +32,8 @@ class InputDeviceManager:
         self._chat_in_pub = chat_in_pub
         self._custom_pub = custom_pub
         self.input_devices: dict[str, InputDevice] = {}
+        self._mic_enabled = True
+        self._requested_inputs: set[str] = set()
         self._load(proxy)
 
     def _load(self, proxy) -> None:
@@ -92,26 +98,43 @@ class InputDeviceManager:
             device.set_active(False)
             self._logger.info(f"💤 Closed input device: {name}")
 
+    def _is_allowed(self, name: str) -> bool:
+        """The mic toggle vetoes the micro device; everything else is always allowed."""
+        return self._mic_enabled or name != MIC_DEVICE_NAME
+
     def handle_active_inputs(self, raw: str) -> None:
         """Open/close devices to match an active-inputs message: {"inputs": [...]}."""
         self._logger.debug(f"📥 Received active_inputs message: {raw}")
         try:
             required_inputs = json.loads(raw).get("inputs", [])
             self._logger.debug(f"🎯 Processing inputs: {required_inputs}")
+            self._requested_inputs = set(required_inputs)
             for name, device in self.input_devices.items():
-                self._apply(name, device, name in required_inputs)
+                self._apply(name, device, name in self._requested_inputs and self._is_allowed(name))
         except Exception as e:
             self._logger.error(f"Error handling active inputs: {e}")
 
     def set_all_active(self, active: bool) -> tuple[bool, str]:
         """Activate or deactivate every device (manual control). Returns (ok, msg)."""
         try:
+            self._requested_inputs = set(self.input_devices) if active else set()
             for name, device in self.input_devices.items():
-                self._apply(name, device, active)
+                self._apply(name, device, active and self._is_allowed(name))
             return True, f"All inputs {'activated' if active else 'deactivated'}"
         except Exception as e:
             self._logger.error(f"Error in set_input_active: {e}")
             return False, str(e)
+
+    def set_mic_enabled(self, enabled: bool) -> None:
+        """Apply the robot-level microphone toggle: close the mic device when
+        disabled, reopen it when re-enabled if it's currently requested."""
+        if enabled == self._mic_enabled:
+            return
+        self._mic_enabled = enabled
+        self._logger.info(f"🎙️ Microphone {'enabled' if enabled else 'disabled'}")
+        device = self.input_devices.get(MIC_DEVICE_NAME)
+        if device is not None:
+            self._apply(MIC_DEVICE_NAME, device, enabled and MIC_DEVICE_NAME in self._requested_inputs)
 
     def handle_tts_status(self, raw: str) -> None:
         """Notify ducking-capable devices when the robot starts/stops speaking."""

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
@@ -20,8 +20,6 @@ from brain_client.common.script_paths import get_input_directories
 from brain_client.inputs.loader import InputLoader
 from brain_client.inputs.types import InputDevice
 
-# Device name of the microphone input (workspace/inputs/micro_input.py), gated
-# by the user-facing microphone toggle persisted in robot_info.json.
 MIC_DEVICE_NAME = "micro"
 
 
@@ -92,8 +90,7 @@ class InputDeviceManager:
 
     # --- activation ---
     def _apply(self, name: str, device: InputDevice, should_be_active: bool) -> bool:
-        """Open/close one device. Contains device hook failures so one bad device
-        can't abort applying the rest. Returns False if the hook raised."""
+        """Open/close one device. Returns False if its hook raised."""
         try:
             was_active = device.is_active()
             if should_be_active and not was_active:
@@ -110,7 +107,6 @@ class InputDeviceManager:
             return False
 
     def _is_allowed(self, name: str) -> bool:
-        """The mic toggle vetoes the micro device; everything else is always allowed."""
         return self._mic_enabled or name != MIC_DEVICE_NAME
 
     def handle_active_inputs(self, raw: str) -> None:
@@ -138,8 +134,7 @@ class InputDeviceManager:
         return True, f"All inputs {'activated' if active else 'deactivated'}"
 
     def set_mic_enabled(self, enabled: bool) -> None:
-        """Apply the robot-level microphone toggle: close the mic device when
-        disabled, reopen it when re-enabled if it's currently requested."""
+        """Apply the robot-level microphone toggle."""
         if enabled == self._mic_enabled:
             return
         self._mic_enabled = enabled

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
@@ -47,6 +47,10 @@ class InputDeviceManager:
             self._logger.warning("⚠️ No input devices found!")
         else:
             self._logger.info(f"✅ Loaded {len(self.input_devices)} input devices: {list(self.input_devices.keys())}")
+            if MIC_DEVICE_NAME not in self.input_devices:
+                self._logger.warning(
+                    f"⚠️ No input device named '{MIC_DEVICE_NAME}' — the microphone toggle will not gate anything"
+                )
 
         for device in self.input_devices.values():
             device.set_data_callback(self._handle_device_data)
@@ -87,16 +91,23 @@ class InputDeviceManager:
             self._logger.error(f"Error handling data from device '{device_name}': {e}")
 
     # --- activation ---
-    def _apply(self, name: str, device: InputDevice, should_be_active: bool) -> None:
-        was_active = device.is_active()
-        if should_be_active and not was_active:
-            device.set_active(True)
-            device.on_open()
-            self._logger.info(f"🔌 Opened input device: {name}")
-        elif not should_be_active and was_active:
-            device.on_close()
-            device.set_active(False)
-            self._logger.info(f"💤 Closed input device: {name}")
+    def _apply(self, name: str, device: InputDevice, should_be_active: bool) -> bool:
+        """Open/close one device. Contains device hook failures so one bad device
+        can't abort applying the rest. Returns False if the hook raised."""
+        try:
+            was_active = device.is_active()
+            if should_be_active and not was_active:
+                device.set_active(True)
+                device.on_open()
+                self._logger.info(f"🔌 Opened input device: {name}")
+            elif not should_be_active and was_active:
+                device.on_close()
+                device.set_active(False)
+                self._logger.info(f"💤 Closed input device: {name}")
+            return True
+        except Exception as e:
+            self._logger.error(f"Error {'opening' if should_be_active else 'closing'} input device '{name}': {e}")
+            return False
 
     def _is_allowed(self, name: str) -> bool:
         """The mic toggle vetoes the micro device; everything else is always allowed."""
@@ -116,14 +127,15 @@ class InputDeviceManager:
 
     def set_all_active(self, active: bool) -> tuple[bool, str]:
         """Activate or deactivate every device (manual control). Returns (ok, msg)."""
-        try:
-            self._requested_inputs = set(self.input_devices) if active else set()
-            for name, device in self.input_devices.items():
-                self._apply(name, device, active and self._is_allowed(name))
-            return True, f"All inputs {'activated' if active else 'deactivated'}"
-        except Exception as e:
-            self._logger.error(f"Error in set_input_active: {e}")
-            return False, str(e)
+        self._requested_inputs = set(self.input_devices) if active else set()
+        failed = [
+            name
+            for name, device in self.input_devices.items()
+            if not self._apply(name, device, active and self._is_allowed(name))
+        ]
+        if failed:
+            return False, f"Failed to {'activate' if active else 'deactivate'} inputs: {', '.join(failed)}"
+        return True, f"All inputs {'activated' if active else 'deactivated'}"
 
     def set_mic_enabled(self, enabled: bool) -> None:
         """Apply the robot-level microphone toggle: close the mic device when

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
@@ -35,7 +35,6 @@ class InputManagerNode(Node):
         self.create_subscription(String, "/tts/is_playing", self._on_tts_status, 10)
         self.create_service(SetBool, "/input_manager/set_input_active", self._svc_set_input_active)
 
-        # Latched mic toggle published by app_control (persisted in robot_info.json)
         mic_state_qos = QoSProfile(depth=1, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
         self.create_subscription(Bool, "/microphone_enabled", self._on_mic_enabled, mic_state_qos)
 

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import rclpy
 from innate_proxy import ProxyClient
 from rclpy.node import Node
-from std_msgs.msg import String
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile
+from std_msgs.msg import Bool, String
 from std_srvs.srv import SetBool
 
 from brain_client.common.logging import UniversalLogger
@@ -33,6 +34,10 @@ class InputManagerNode(Node):
         self.create_subscription(String, "/input_manager/active_inputs", self._on_active_inputs, 10)
         self.create_subscription(String, "/tts/is_playing", self._on_tts_status, 10)
         self.create_service(SetBool, "/input_manager/set_input_active", self._svc_set_input_active)
+
+        # Latched mic toggle published by app_control (persisted in robot_info.json)
+        mic_state_qos = QoSProfile(depth=1, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
+        self.create_subscription(Bool, "/microphone_enabled", self._on_mic_enabled, mic_state_qos)
 
         self.logger.info("✅ Input Manager Node started successfully")
 
@@ -63,6 +68,9 @@ class InputManagerNode(Node):
 
     def _on_tts_status(self, msg: String) -> None:
         self.manager.handle_tts_status(msg.data)
+
+    def _on_mic_enabled(self, msg: Bool) -> None:
+        self.manager.set_mic_enabled(msg.data)
 
     def _svc_set_input_active(self, request, response):
         response.success, response.message = self.manager.set_all_active(request.data)

--- a/ros2_ws/src/mars_bot/mars_control/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_control/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(ament_cmake_python REQUIRED)
 find_package(mars_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
@@ -34,14 +35,13 @@ ament_target_dependencies(app.cpp
   rclcpp
   geometry_msgs
   std_msgs
+  std_srvs
   mars_msgs
 )
 
 # ============================================================================
 # C++ Executable: udp_leader_receiver.cpp
 # ============================================================================
-find_package(std_srvs REQUIRED)
-
 add_executable(udp_leader_receiver mars_control/udp_leader_receiver.cpp)
 
 ament_target_dependencies(udp_leader_receiver

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -430,14 +430,11 @@ class AppControl : public rclcpp::Node {
             "/set_microphone",
             std::bind(&AppControl::set_microphone_callback, this, std::placeholders::_1, std::placeholders::_2));
 
-        // Latched microphone state so the input manager picks it up at startup
-        // and reacts immediately when it changes
+        // Latched publisher for microphone state
         mic_enabled_pub_ =
             this->create_publisher<std_msgs::msg::Bool>("/microphone_enabled", rclcpp::QoS(1).transient_local());
 
-        // Sync mic state and ALSA volume from robot_info.json on startup. Mic
-        // state is published first so a volume-sync failure can't leave a muted
-        // robot listening (the input manager defaults to mic enabled).
+        // Sync mic state and ALSA volume from robot_info.json on startup
         try {
             json robot_info = get_robot_info();
             publish_mic_enabled(robot_info.value("microphone_enabled", true));

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -13,6 +13,8 @@
 #include <mars_msgs/srv/trigger_update.hpp>
 #include <mars_msgs/srv/shutdown.hpp>
 #include <mars_msgs/srv/set_volume.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <std_srvs/srv/set_bool.hpp>
 
 #include <nlohmann/json.hpp>
 #include <yaml-cpp/yaml.h>
@@ -423,12 +425,23 @@ class AppControl : public rclcpp::Node {
             "/set_volume",
             std::bind(&AppControl::set_volume_callback, this, std::placeholders::_1, std::placeholders::_2));
 
+        // Service for enabling/disabling the robot microphone
+        set_microphone_srv_ = this->create_service<std_srvs::srv::SetBool>(
+            "/set_microphone",
+            std::bind(&AppControl::set_microphone_callback, this, std::placeholders::_1, std::placeholders::_2));
+
+        // Latched microphone state so the input manager picks it up at startup
+        // and reacts immediately when it changes
+        mic_enabled_pub_ =
+            this->create_publisher<std_msgs::msg::Bool>("/microphone_enabled", rclcpp::QoS(1).transient_local());
+
         // Sync ALSA volume from robot_info.json on startup
         try {
             json robot_info = get_robot_info();
             int startup_vol = robot_info.value("volume_percent", 80);
             apply_alsa_volume(startup_vol);
             RCLCPP_INFO(this->get_logger(), "ALSA volume synced to %d%%", startup_vol);
+            publish_mic_enabled(robot_info.value("microphone_enabled", true));
         } catch (const std::exception& e) {
             RCLCPP_WARN(this->get_logger(), "Failed to sync startup volume: %s", e.what());
         }
@@ -499,11 +512,9 @@ class AppControl : public rclcpp::Node {
 
         // Define default robot info values
         std::string default_hw_rev = this->get_parameter("default_hardware_revision").as_string();
-        json default_robot_info = {{"robot_name", "MARS"},
-                                   {"robot_id", nullptr},
-                                   {"hardware_revision", default_hw_rev},
-                                   {"color_variant", "black"},
-                                   {"volume_percent", 80}};
+        json default_robot_info = {
+            {"robot_name", "MARS"},     {"robot_id", nullptr},  {"hardware_revision", default_hw_rev},
+            {"color_variant", "black"}, {"volume_percent", 80}, {"microphone_enabled", true}};
 
         json robot_info;
 
@@ -725,6 +736,7 @@ class AppControl : public rclcpp::Node {
             data_to_publish_dict["hardware_revision"] = robot_info.value("hardware_revision", default_hw_rev);
             data_to_publish_dict["color_variant"] = robot_info.value("color_variant", "black");
             data_to_publish_dict["volume_percent"] = robot_info.value("volume_percent", 80);
+            data_to_publish_dict["microphone_enabled"] = robot_info.value("microphone_enabled", true);
 
             // Read minimum_app_version from os_config.json
             if (app_config_.contains("minimum_app_version")) {
@@ -967,6 +979,42 @@ class AppControl : public rclcpp::Node {
         }
     }
 
+    void publish_mic_enabled(bool enabled) {
+        std_msgs::msg::Bool msg;
+        msg.data = enabled;
+        mic_enabled_pub_->publish(msg);
+    }
+
+    /**
+     * Service callback to enable/disable the robot microphone.
+     * Stores microphone_enabled in robot_info.json and broadcasts the new
+     * state on the latched /microphone_enabled topic; the input manager
+     * closes/reopens the mic input device accordingly.
+     */
+    void set_microphone_callback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                 std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+        try {
+            json robot_info = get_robot_info();
+            robot_info["microphone_enabled"] = request->data;
+
+            if (!set_robot_info(robot_info)) {
+                response->success = false;
+                response->message = "Failed to save robot_info.json";
+                return;
+            }
+
+            publish_mic_enabled(request->data);
+
+            response->success = true;
+            response->message = std::string("Microphone ") + (request->data ? "enabled" : "disabled");
+            RCLCPP_INFO(this->get_logger(), "%s", response->message.c_str());
+        } catch (const std::exception& e) {
+            response->success = false;
+            response->message = std::string("Failed to set microphone: ") + e.what();
+            RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
+        }
+    }
+
     // Member variables
     json app_config_;
 
@@ -988,6 +1036,7 @@ class AppControl : public rclcpp::Node {
     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub_;
     rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr cmd_pub_;
     rclcpp::Publisher<std_msgs::msg::String>::SharedPtr robot_info_pub_;
+    rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr mic_enabled_pub_;
 
     // Timers
     rclcpp::TimerBase::SharedPtr robot_info_timer_;
@@ -998,6 +1047,7 @@ class AppControl : public rclcpp::Node {
     rclcpp::Service<mars_msgs::srv::TriggerUpdate>::SharedPtr trigger_update_srv_;
     rclcpp::Service<mars_msgs::srv::Shutdown>::SharedPtr shutdown_srv_;
     rclcpp::Service<mars_msgs::srv::SetVolume>::SharedPtr set_volume_srv_;
+    rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_microphone_srv_;
 };
 
 }  // namespace mars_control

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -435,15 +435,17 @@ class AppControl : public rclcpp::Node {
         mic_enabled_pub_ =
             this->create_publisher<std_msgs::msg::Bool>("/microphone_enabled", rclcpp::QoS(1).transient_local());
 
-        // Sync ALSA volume from robot_info.json on startup
+        // Sync mic state and ALSA volume from robot_info.json on startup. Mic
+        // state is published first so a volume-sync failure can't leave a muted
+        // robot listening (the input manager defaults to mic enabled).
         try {
             json robot_info = get_robot_info();
+            publish_mic_enabled(robot_info.value("microphone_enabled", true));
             int startup_vol = robot_info.value("volume_percent", 80);
             apply_alsa_volume(startup_vol);
             RCLCPP_INFO(this->get_logger(), "ALSA volume synced to %d%%", startup_vol);
-            publish_mic_enabled(robot_info.value("microphone_enabled", true));
         } catch (const std::exception& e) {
-            RCLCPP_WARN(this->get_logger(), "Failed to sync startup volume: %s", e.what());
+            RCLCPP_WARN(this->get_logger(), "Failed to sync startup volume/mic state: %s", e.what());
         }
 
         RCLCPP_INFO(this->get_logger(), "AppControl node started. [C++]");


### PR DESCRIPTION
## Summary

There was no easy way to disable the robot's microphone ([INN-485](https://linear.app/innate/issue/INN-485/robot-microphone-should-be-easily-deactivatable)). This adds a robot-side mute that is the source of truth — it survives robot reboots and works regardless of app state — following the same pattern as the speaker volume setting (INN-467).

- **`app_control`** (`mars_control/app.cpp`): new `/set_microphone` service (`std_srvs/SetBool`) persists `microphone_enabled` in `robot_info.json`, mirrors it in `/robot/info`, and broadcasts it on a latched `/microphone_enabled` Bool topic (also published at startup so the setting is re-applied after reboot).
- **Input manager** (`brain_client`): subscribes to `/microphone_enabled` (TRANSIENT_LOCAL QoS) and gates the `micro` input device. Disabling closes the device immediately — the arecord stream and the OpenAI Realtime connection are torn down, so the robot truly stops listening, not just ignoring transcripts. Re-enabling reopens the mic if the active directive requests it (requested inputs are now tracked across toggles).
- TTS output is unaffected: the robot can still speak while muted.

Companion app PR adds a discrete mute button on the agent screen that calls the service and reflects `robot_info.microphone_enabled`.

## Test plan
- [x] `pre-commit` (ruff + clang-format, `.config/pre-commit-config.yaml`) passes on changed files
- [x] `mars_control` compiles in the CI test image (`colcon build --packages-select mars_msgs mars_control`)
- [x] `brain_client.inputs.manager` / `brain_client.nodes.input_manager` import cleanly in a ROS2 Humble env
- [ ] On robot: `ros2 service call /set_microphone std_srvs/srv/SetBool '{data: false}'` → mic device closes (input_manager logs "💤 Closed input device: micro"), `robot_info.json` gains `"microphone_enabled": false`, state persists across reboot, re-enable reopens mic while a directive is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)