### PR TITLE
Advertise WebRTC audio capability in robot info

### DIFF
--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -775,6 +775,8 @@ class AppControl : public rclcpp::Node {
             // Include update running status
             data_to_publish_dict["update_running"] = check_update_running();
 
+            data_to_publish_dict["supports_webrtc_audio"] = true;
+
             if (!data_to_publish_dict.empty()) {
                 final_json_string_to_publish = data_to_publish_dict.dump();
             }


### PR DESCRIPTION
## Why

The controller app's manual-control page can request the robot microphone on the WebRTC connection (the `audio` flag on `/webrtc/start`). Robots running **older software** fail that handshake outright — the connection never comes up, the app's watchdog blanks the freeze-frame, and its self-heal keeps retrying the same audio-capable config: the operator gets a permanent black screen.

## What

Adds one field to the `/robot/info` payload published by `app_control`:

```json
"supports_webrtc_audio": true
```

The app (companion change in innate-controller-app) gates its sound button on `supports_webrtc_audio === true`, so:

- robots **with** this software advertise the capability and get the sound button;
- robots **without** it (field absent) never receive an audio-capable handshake request — the app shows an "update your robot" hint instead of a black screen.

A constant `true` is intentional: it advertises that the `/webrtc/start` handler *understands* the audio flag (the streamer already degrades gracefully to video-only when no mic is available or `enable_audio` is off), not that a microphone is currently usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)