### PR TITLE
chore: rename basic_agent → default_agent (remove BASIC naming)

### DIFF
--- a/workspace/innate_agents/default_agent.py
+++ b/workspace/innate_agents/default_agent.py
@@ -1,15 +1,15 @@
 from brain_client.agents.types import Agent
 
 
-class BasicAgent(Agent):
+class DefaultAgent(Agent):
     """
     Default directive for the robot.
-    Provides a basic professional personality and enables navigation primitives.
+    Provides a simple professional personality and enables navigation primitives.
     """
 
     @property
     def id(self) -> str:
-        return "basic_agent"
+        return "default_agent"
 
     @property
     def display_name(self) -> str:


### PR DESCRIPTION
## Summary
Part of the BASIC → Innate agent rebrand (companion to the docs PR innate-inc/docs#10).

- Renames the shipped no-prompt agent: `workspace/innate_agents/basic_agent.py` → `default_agent.py`
- `BasicAgent` → `DefaultAgent`, agent id `basic_agent` → `default_agent`
- Docstring wording updated ("basic" → "simple")

No other code in the repo references the old id (agents are discovered dynamically; the default-agent fallback in `initializer.py` looks for `empty_directive`, not `basic_agent`). Remaining lowercase "basic" occurrences in the repo are generic technical terms (nav2 `BasicNavigator`, THREE.js `LineBasicMaterial`, comments) and were left untouched.

## Note for reviewers
If the cloud/app persists the selected agent id per robot, a robot with `basic_agent` currently selected will fall back to the default after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)