### PR TITLE
innate update status: warn when installed systemd units drift from the checkout

### DIFF
--- a/scripts/innate
+++ b/scripts/innate
@@ -3,6 +3,7 @@
 
 import json
 import os
+import pwd
 import re
 import shlex
 import shutil
@@ -2358,7 +2359,14 @@ class _UpdateManager:
             return []
 
         user = os.environ.get("USER") or os.environ.get("LOGNAME") or "jetson1"
-        home = str(Path.home())
+        # Resolve home from passwd, matching post_update.sh's `eval echo
+        # ~$ACTUAL_USER` — Path.home() prefers $HOME, which a container or
+        # custom SSH environment can point elsewhere and false-positive
+        # every unit.
+        try:
+            home = pwd.getpwnam(user).pw_dir
+        except KeyError:
+            home = str(Path.home())
         drifted = []
         for unit in sorted(repo_units.glob("*.service")):
             installed = Path("/etc/systemd/system") / unit.name

--- a/scripts/innate
+++ b/scripts/innate
@@ -2371,11 +2371,7 @@ class _UpdateManager:
         for unit in sorted(repo_units.glob("*.service")):
             installed = Path("/etc/systemd/system") / unit.name
             try:
-                rendered = (
-                    unit.read_text()
-                    .replace("User=jetson1", f"User={user}")
-                    .replace("/home/jetson1", home)
-                )
+                rendered = unit.read_text().replace("User=jetson1", f"User={user}").replace("/home/jetson1", home)
                 if not installed.exists() or installed.read_text() != rendered:
                     drifted.append(unit.name)
             except OSError:
@@ -2423,9 +2419,7 @@ class _UpdateManager:
 
         drifted = self._systemd_unit_drift()
         if drifted:
-            self.logger.warning(
-                f"Installed systemd units differ from this checkout: {', '.join(drifted)}"
-            )
+            self.logger.warning(f"Installed systemd units differ from this checkout: {', '.join(drifted)}")
             print("  Services may be running stale paths (a manual `git pull` skips")
             print("  unit installation). Run 'innate update reinstall' to fix.")
             print()

--- a/scripts/innate
+++ b/scripts/innate
@@ -2343,6 +2343,37 @@ class _UpdateManager:
 
     # -- status ---------------------------------------------------------------
 
+    def _systemd_unit_drift(self) -> list:
+        """Unit files in config/systemd that differ from what's installed.
+
+        A manual `git pull` updates the checkout without re-running
+        post_update.sh, so /etc/systemd/system keeps serving stale unit files
+        — after a path rename that means a service silently crash-looping
+        (e.g. ble-provisioner pointing at a script that no longer exists).
+        Compares each repo unit, rendered with the same user/home templating
+        post_update.sh applies, against the installed copy.
+        """
+        repo_units = self.config.repo_dir / "config" / "systemd"
+        if not repo_units.is_dir():
+            return []
+
+        user = os.environ.get("USER") or os.environ.get("LOGNAME") or "jetson1"
+        home = str(Path.home())
+        drifted = []
+        for unit in sorted(repo_units.glob("*.service")):
+            installed = Path("/etc/systemd/system") / unit.name
+            try:
+                rendered = (
+                    unit.read_text()
+                    .replace("User=jetson1", f"User={user}")
+                    .replace("/home/jetson1", home)
+                )
+                if not installed.exists() or installed.read_text() != rendered:
+                    drifted.append(unit.name)
+            except OSError:
+                drifted.append(unit.name)
+        return drifted
+
     def status(self) -> int:
         self._check_repo()
 
@@ -2381,6 +2412,15 @@ class _UpdateManager:
         if svc_status["update_running"]:
             print(f"  {C.YELLOW}●{C.NC} Update: in progress (lock: {self.config.update_lock})")
         print()
+
+        drifted = self._systemd_unit_drift()
+        if drifted:
+            self.logger.warning(
+                f"Installed systemd units differ from this checkout: {', '.join(drifted)}"
+            )
+            print("  Services may be running stale paths (a manual `git pull` skips")
+            print("  unit installation). Run 'innate update reinstall' to fix.")
+            print()
 
         cached = self._read_cache()
         if cached:


### PR DESCRIPTION
## Problem

`innate update apply` re-installs systemd units via `post_update.sh`, but a manual `git pull` on a robot bypasses that — the checkout moves, `/etc/systemd/system` doesn't. Found in the field: a robot whose checkout had been manually merged onto the maurice→mars rename had its **ble-provisioner crash-looping ~4,000 times** (installed unit still ran `maurice_bot/.../simple_bt_service.py`, which no longer exists). The only symptom was the robot silently vanishing from the controller app's BLE scanner; `systemctl is-active` even reported `active` between restarts.

## Fix

`innate update status` now renders each `config/systemd/*.service` with the same `User=`/home templating `post_update.sh` applies and compares it against the installed copy. On any mismatch or missing unit it prints:

```
⚠ Installed systemd units differ from this checkout: ble-provisioner.service
  Services may be running stale paths (a manual `git pull` skips
  unit installation). Run 'innate update reinstall' to fix.
```

Detection only — nothing is changed automatically; the remedy remains the existing `innate update reinstall`.

## Validation

- `python3 -m py_compile scripts/innate` clean
- Helper smoke-tested in isolation: on a machine with no installed units it lists every repo unit as drifted; identical rendered content reports clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)