### PR TITLE
Make innate diag offer to stop running ROS nodes (INN-469)

### DIFF
--- a/scripts/diagnostics.py
+++ b/scripts/diagnostics.py
@@ -80,7 +80,11 @@ def stop_innate_service():
         if subprocess.run(["sudo", "systemctl", "stop", SYSTEMD_SERVICE]).returncode != 0:
             return False
     if is_innate_service_running():
-        subprocess.run(["tmux", "kill-session", "-t", TMUX_SESSION], capture_output=True)
+        r = subprocess.run(["tmux", "kill-session", "-t", TMUX_SESSION], capture_output=True)
+        # Non-zero can also mean the session died on its own between the check
+        # and the kill, so only fail if it is actually still alive
+        if r.returncode != 0 and is_innate_service_running():
+            return False
 
     for _ in range(20):
         if not is_innate_service_running():

--- a/scripts/diagnostics.py
+++ b/scripts/diagnostics.py
@@ -16,6 +16,7 @@ import glob
 import os
 import subprocess
 import sys
+import time
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CONFIGURATION
@@ -72,8 +73,6 @@ def is_innate_service_running():
 
 def stop_innate_service():
     """Stop the ROS nodes (systemd service and/or bare tmux session)."""
-    import time
-
     r = subprocess.run(["systemctl", "is-active", "--quiet", SYSTEMD_SERVICE])
     if r.returncode == 0:
         # Inherit stdio so a sudo password prompt (if any) reaches the user
@@ -192,8 +191,6 @@ def check_servos():
         return False
 
     ok(f"Serial port opened at {DYNAMIXEL_BAUDRATE} baud")
-
-    import time
 
     detected = []
     missing = []
@@ -414,8 +411,6 @@ def check_pcb():
 
     try:
         bus.write_i2c_block_data(I2C_ADDRESS, 0x00, message)
-        import time
-
         time.sleep(0.01)
         response = bus.read_i2c_block_data(I2C_ADDRESS, 0x00, 8)
         bus.close()

--- a/scripts/diagnostics.py
+++ b/scripts/diagnostics.py
@@ -32,6 +32,9 @@ I2C_BUS = 1
 I2C_ADDRESS = 0x42
 SPEAKER_SOUND = "/usr/share/sounds/sound-icons/electric-piano-3.wav"
 
+TMUX_SESSION = "ros_nodes"
+SYSTEMD_SERVICE = "ros-app.service"
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # OUTPUT FORMATTING
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -63,8 +66,67 @@ def header(msg):
 
 
 def is_innate_service_running():
-    r = subprocess.run(["tmux", "has-session", "-t", "ros_nodes"], capture_output=True)
+    r = subprocess.run(["tmux", "has-session", "-t", TMUX_SESSION], capture_output=True)
     return r.returncode == 0
+
+
+def stop_innate_service():
+    """Stop the ROS nodes (systemd service and/or bare tmux session)."""
+    import time
+
+    r = subprocess.run(["systemctl", "is-active", "--quiet", SYSTEMD_SERVICE])
+    if r.returncode == 0:
+        # Inherit stdio so a sudo password prompt (if any) reaches the user
+        if subprocess.run(["sudo", "systemctl", "stop", SYSTEMD_SERVICE]).returncode != 0:
+            return False
+    if is_innate_service_running():
+        subprocess.run(["tmux", "kill-session", "-t", TMUX_SESSION], capture_output=True)
+
+    for _ in range(20):
+        if not is_innate_service_running():
+            break
+        time.sleep(0.5)
+    else:
+        return False
+
+    # Give the dying nodes a moment to release the serial port and cameras
+    time.sleep(2.0)
+    return True
+
+
+def ensure_services_stopped():
+    """Offer to stop running ROS nodes — diagnostics needs exclusive hardware access.
+
+    Returns True if the nodes were stopped here, False if they were not running.
+    Exits if the user declines or the nodes cannot be stopped.
+    """
+    if not is_innate_service_running():
+        return False
+
+    warn("ROS nodes are running — diagnostics needs exclusive access to the")
+    warn("hardware (serial port, cameras), so most checks would fail.")
+
+    if not sys.stdin.isatty():
+        fail("Stop the nodes first:  innate service stop")
+        sys.exit(1)
+
+    try:
+        answer = input("\n  Stop all ROS nodes and run diagnostics? [Y/n] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        sys.exit(1)
+
+    if answer not in ("", "y", "yes"):
+        fail("Aborted — stop the nodes first:  innate service stop")
+        sys.exit(1)
+
+    print("  Stopping ROS nodes...")
+    if not stop_innate_service():
+        fail("Failed to stop the ROS nodes — try manually:  innate service stop")
+        sys.exit(1)
+
+    ok("ROS nodes stopped")
+    return True
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -407,6 +469,8 @@ def main():
     print("║              MARS SYSTEM CHECK                           ║")
     print(f"╚══════════════════════════════════════════════════════════╝{Colors.END}")
 
+    nodes_stopped = ensure_services_stopped()
+
     results = {}
 
     # Wrap check_servos to catch any unhandled exceptions from SDK
@@ -453,6 +517,10 @@ def main():
         print(f"\n{Colors.GREEN}{Colors.BOLD}All systems detected! ✓{Colors.END}\n")
     else:
         print(f"\n{Colors.RED}{Colors.BOLD}Some components missing.{Colors.END}\n")
+
+    if nodes_stopped:
+        warn("ROS nodes were stopped for diagnostics — restart them with:  innate service start")
+        print()
 
     return 0 if all_ok else 1
 


### PR DESCRIPTION
## Summary

Fixes [INN-469](https://linear.app/innate/issue/INN-469/innate-diag-should-be-more-assertive-about-stopping-services): running `innate diag` while the ROS nodes were up just failed a bunch of checks (the service holds the serial port and cameras), with only a buried hint to run `innate service stop` manually.

Now `diag` is assertive about it:

- Detects running nodes **before** any check and prompts: `Stop all ROS nodes and run diagnostics? [Y/n]` (default yes — just press Enter).
- On confirm, stops them via `sudo systemctl stop ros-app.service` when the unit is active (NOPASSWD in sudoers, same as `innate service stop`), with a `tmux kill-session -t ros_nodes` fallback for a bare tmux session, then waits for the session to die plus a short grace period so the serial port/cameras are actually released.
- On decline, aborts immediately with the manual command instead of spewing spurious failures.
- Non-interactive runs (no TTY) fail fast with a clear message rather than hanging on a prompt.
- After the summary, reminds the user the nodes were stopped and how to restart them (`innate service start`).

## Test plan

All tested live on mars-the-44th with nodes running:

- [x] Non-TTY (`< /dev/null`): early exit 1 with "Stop the nodes first" message, nodes untouched
- [x] Decline (`n` via pty): aborts with exit 1, nodes untouched
- [x] Confirm (bare Enter via pty): nodes stopped, **all checks pass** (servos previously failed in this exact situation), restart hint printed, exit 0
- [x] `sudo systemctl stop ros-app.service` confirmed NOPASSWD in sudoers — no password prompt
- [x] Nodes restarted cleanly afterwards with `systemctl start ros-app.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<img width="1712" height="780" alt="image" src="https://github.com/user-attachments/assets/7e097810-22f9-47c2-ad9b-85470ca539b1" />

