### PR TITLE
Show digital skill output in the app response popup (INN-455)

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -176,7 +176,8 @@ class PrimitiveRunner:
         self._state.primitive_running = None
         self._on_task_finished()
 
-        outgoing_msg, local_status, local_reason = self._classify_result(result, primitive_name, primitive_id)
+        is_code = self._is_code_skill(skill_id)
+        outgoing_msg, local_status, local_reason = self._classify_result(result, primitive_name, primitive_id, is_code)
         if outgoing_msg:
             self._ws.send_message(outgoing_msg)
             self._logger.info(f"Sent primitive status message: {outgoing_msg.type.name}")
@@ -189,27 +190,25 @@ class PrimitiveRunner:
                 reason=local_reason,
             )
 
-        self._emit_skill_output(result, skill_id)
+        self._emit_skill_output(result, is_code)
         self._maybe_run_pending(result)
 
-    def _emit_skill_output(self, result, skill_id: str) -> None:
-        """Surface a successful code skill's output in the chat (never spoken)."""
+    def _is_code_skill(self, skill_id: str) -> bool:
         stub = self._state.registry.primitives.get(skill_id)
-        is_code = stub is not None and stub.metadata.get("type") == "code"
+        return stub is not None and stub.metadata.get("type") == "code"
+
+    def _emit_skill_output(self, result, is_code: bool) -> None:
+        """Surface a successful code skill's output in the chat (never spoken)."""
         if is_code and result.success and result.success_type == SkillResult.SUCCESS.value and result.message.strip():
             self._chat.emit("skill_output", result.message, speak=False)
 
-    def _classify_result(self, result, primitive_name, primitive_id):
+    def _classify_result(self, result, primitive_name, primitive_id, is_code):
         """Map an action result to (ws message, local status, reason)."""
         if result.success and result.success_type == SkillResult.SUCCESS.value:
-            msg = MessageIn(
-                type=MessageInType.PRIMITIVE_COMPLETED,
-                payload={
-                    "primitive_name": primitive_name,
-                    "primitive_id": primitive_id,
-                    "output": result.message,
-                },
-            )
+            payload = {"primitive_name": primitive_name, "primitive_id": primitive_id}
+            if is_code and result.message.strip():
+                payload["output"] = result.message
+            msg = MessageIn(type=MessageInType.PRIMITIVE_COMPLETED, payload=payload)
             return msg, "completed", None
         if result.success_type == SkillResult.CANCELLED.value:
             msg = MessageIn(

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -196,12 +196,7 @@ class PrimitiveRunner:
         """Surface a successful code skill's output in the chat (never spoken)."""
         stub = self._state.registry.primitives.get(skill_id)
         is_code = stub is not None and stub.metadata.get("type") == "code"
-        if (
-            is_code
-            and result.success
-            and result.success_type == SkillResult.SUCCESS.value
-            and result.message.strip()
-        ):
+        if is_code and result.success and result.success_type == SkillResult.SUCCESS.value and result.message.strip():
             self._chat.emit("skill_output", result.message, speak=False)
 
     def _classify_result(self, result, primitive_name, primitive_id):

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -189,14 +189,31 @@ class PrimitiveRunner:
                 reason=local_reason,
             )
 
+        self._emit_skill_output(result, skill_id)
         self._maybe_run_pending(result)
+
+    def _emit_skill_output(self, result, skill_id: str) -> None:
+        """Surface a successful code skill's output in the chat (never spoken)."""
+        stub = self._state.registry.primitives.get(skill_id)
+        is_code = stub is not None and stub.metadata.get("type") == "code"
+        if (
+            is_code
+            and result.success
+            and result.success_type == SkillResult.SUCCESS.value
+            and result.message.strip()
+        ):
+            self._chat.emit("skill_output", result.message, speak=False)
 
     def _classify_result(self, result, primitive_name, primitive_id):
         """Map an action result to (ws message, local status, reason)."""
         if result.success and result.success_type == SkillResult.SUCCESS.value:
             msg = MessageIn(
                 type=MessageInType.PRIMITIVE_COMPLETED,
-                payload={"primitive_name": primitive_name, "primitive_id": primitive_id},
+                payload={
+                    "primitive_name": primitive_name,
+                    "primitive_id": primitive_id,
+                    "output": result.message,
+                },
             )
             return msg, "completed", None
         if result.success_type == SkillResult.CANCELLED.value:


### PR DESCRIPTION
## Context

[INN-455](https://linear.app/innate/issue/INN-455/digital-skills-should-show-output-in-the-response-popup): when a digital (code) skill runs, its text output was invisible in the controller app. The output (`result_message`) was captured in the `ExecuteSkill` action result but dropped before reaching the app or the cloud agent.

This is the **robot-side** half of the change.

## What changed

`brain_client/skills/runner.py`:
- `_on_result` → new `_emit_skill_output`: on a successful **code** skill completion with non-empty output, publish it to `/brain/chat_out` with sender `skill_output`. Emitted via `ChatManager.emit(..., speak=False)` so it is never spoken by TTS, and gated to `type == "code"` skills so physical-skill status strings stay out of the chat.
- `_classify_result`: the `PRIMITIVE_COMPLETED` websocket payload now also carries an `output` field so the cloud agent can reference skill results when it talks.

## Companion PRs

- **innate-controller-app** — renders the new `skill_output` sender in the chat popup + shows output in the manual `DigitalSkillScreen` alert.
- **innate-cloud-agent** — appends the `output` to agent history.

## Compatibility

- Old app + new robot: unknown `skill_output` sender is dropped by the app's chat filter — safe.
- Old cloud agent + new robot: the extra `output` payload key is ignored (`Dict[str, Any]` payload) — safe. No protocol version bump.

## Verification

- Robot-side runner logic covered by an offline harness (7 cases): success payload includes `output`; failure payload unchanged; emit gated on code-type + success + non-empty message; registry miss doesn't crash.
- Not yet smoke-tested on the live Docker sim stack — quickest check is `ros2 topic echo /brain/chat_out` while the agent runs a code skill, expecting one `{"sender":"skill_output", ...}` message after completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)