### PR TITLE
Switch TTS to Cartesia Sonic 3.5

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/transport/tts.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/tts.py
@@ -171,7 +171,7 @@ class TTSHandler:
 
                 t_api = time.perf_counter()
                 for chunk in self._cartesia_client.tts.bytes_stream(
-                    model_id="sonic-3",
+                    model_id="sonic-3.5",
                     transcript=text,
                     voice=voice,
                     output_format={


### PR DESCRIPTION
## What

Switches the brain_client TTS from Cartesia `sonic-3` to `sonic-3.5` — a one-line change in `tts.py`.

## Why

Sonic 3.5 is a drop-in replacement for Sonic 3: identical request shape, same `output_format`, and existing voice IDs work as-is — including our **instant-cloned voice** (Katie, `9fdaae0b-…`). No re-cloning needed.

## Testing

Verified end-to-end against the **live production path** (`ProxyClient` → cloud proxy → Cartesia) using the real cloned voice, on the Jetson:

- Probed candidate model IDs empirically — `sonic-3.5` accepted; `sonic-3-5` / `sonic-3.5-2025` / `sonic-turbo-3.5` all 404 (confirms the correct string).
- Generated audio is well-formed: `RIFF/WAVE, 16-bit mono PCM, 44100 Hz`.
- Played successfully through `aplay`.

## Note

Only the source tree is changed. `colcon build` (or a brain_client restart) is needed for the robot to pick it up, since `ros2_ws/build` and `ros2_ws/install` hold regenerated copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)