### PR TITLE
recorder replay: fall back to raw_data/ so episodes stay playable while encoding

### DIFF
--- a/ros2_ws/src/brain/manipulation/src/recorder_node.cpp
+++ b/ros2_ws/src/brain/manipulation/src/recorder_node.cpp
@@ -828,11 +828,34 @@ void RecorderNode::handle_load_episode(const std::shared_ptr<brain_messages::srv
         }
 
         std::string data_dir = request->task_directory + "/data";
-        std::string h5_path = data_dir + "/episode_" + std::to_string(request->episode_id) + ".h5";
+        std::string raw_dir = request->task_directory + "/raw_data";
+        const std::string fname = "/episode_" + std::to_string(request->episode_id) + ".h5";
 
-        if (!fs::exists(h5_path)) {
+        // The replay needs raw images. The MP4 encoder moves the original episode
+        // to raw_data/ and leaves a stripped (image-less) copy in data/, so while
+        // an episode is encoding (and after) the frames live in raw_data/. Prefer
+        // data/, fall back to raw_data/ — otherwise an episode is un-replayable for
+        // the minute-plus it takes to encode, and the app shows a misleading
+        // "Update the OS to play this episode."
+        std::string h5_path;
+        for (const std::string& cand : {data_dir + fname, raw_dir + fname}) {
+            if (!fs::exists(cand)) {
+                continue;
+            }
+            hid_t probe = H5Fopen(cand.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+            if (probe < 0) {
+                continue;
+            }
+            bool has_images = H5Lexists(probe, "/observations/images", H5P_DEFAULT) > 0;
+            H5Fclose(probe);
+            if (has_images) {
+                h5_path = cand;
+                break;
+            }
+        }
+        if (h5_path.empty()) {
             response->success = false;
-            response->message = "Episode file not found: " + h5_path;
+            response->message = "No images found for episode " + std::to_string(request->episode_id);
             response->num_frames = 0;
             response->fps = 0.0;
             response->duration_sec = 0.0;


### PR DESCRIPTION
Follow-up to #450 (pushed just after it merged).

## Problem
`handle_load_episode` (the robot side of WebRTC episode replay) reads only `data/episode_N.h5`. But the MP4 encoder moves the original to `raw_data/` and leaves a **stripped, image-less** copy in `data/`. So for the minute-plus an episode is encoding — and the `dataset_encoder` auto-scans every 60 s after recording — replay finds no images and the app shows a misleading **"Update the OS to play this episode."**

## Fix
Probe `data/episode_N.h5` first, then fall back to `raw_data/episode_N.h5`, using whichever actually has `/observations/images`. `raw_data/` holds the frames from encode-start until the episode is deleted, so replay now works across the whole lifecycle:

- before encode → images in `data/`
- during/after encode (stripped `data/`, `video_files` not yet attached) → images in `raw_data/`
- after encode → MP4 player (`video_files`)

Genuinely image-less old-format episodes (no copy in either dir) still fall through to "No images found" → "Update the OS", which is correct.

## Notes
- Robot-side only, so **already-deployed apps** benefit with no app release (the app calls `LoadEpisode`; the robot does the lookup). Without it, deployed apps would *regress* mid-encode on an updated robot.
- Verified on-device: `raw_data/` h5 files hold full frames (130 MB–1.2 GB, 2 cameras) while `data/` copies are stripped to ~0.1 MB. `colcon build manipulation` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)