### PR TITLE
webapp: nav rail expands on hover with text labels

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -84,12 +84,23 @@ button {
 .rail {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   padding: 14px 0 12px;
   border-right: 1px solid var(--hairline);
   background: var(--bg);
   user-select: none;
   -webkit-user-select: none;
+  /* Overlay-expand on hover: the body grid reserves 64px; the rail widens on top
+     of the content (no reflow) and fades in text labels. */
+  position: relative;
+  z-index: 40;
+  width: 64px;
+  overflow: hidden;
+  transition: width 160ms ease;
+}
+.rail:hover {
+  width: 200px;
+  box-shadow: 2px 0 18px rgb(0 0 0 / 45%);
 }
 
 .rail-mark {
@@ -110,12 +121,14 @@ button {
 
 .rail-link {
   position: relative;
-  display: grid;
-  place-items: center;
-  width: 38px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   height: 38px;
+  margin: 0 8px;           /* 48px content + 2×8 = the 64px collapsed rail, icon stays centered */
   border-radius: 9px;
   color: var(--muted);
+  text-decoration: none;   /* it's an <a> — no link underline under the label */
   transition: color 120ms ease;
 }
 
@@ -125,6 +138,25 @@ button {
 
 .rail-link.active {
   color: var(--text);
+}
+
+.rail-ico {
+  flex: none;
+  width: 48px;             /* centers the icon within the 64px collapsed rail */
+  display: grid;
+  place-items: center;
+}
+
+.rail-label {
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 11px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.rail:hover .rail-label {
+  opacity: 1;
 }
 
 .rail-link.active::before {

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -71,7 +71,9 @@ export function initShell(activeKey, root) {
     a.title = section.label;
     a.setAttribute("aria-label", section.label);
     if (section.key === activeKey) a.setAttribute("aria-current", "page");
-    a.innerHTML = `<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${section.icon}</svg>`;
+    a.innerHTML =
+      `<span class="rail-ico"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${section.icon}</svg></span>` +
+      `<span class="rail-label">${section.label}</span>`;
     nav.appendChild(a);
   }
   rail.appendChild(nav);


### PR DESCRIPTION
Small UX polish for the operator webapp's left nav rail.

The 64px icon rail now **widens to 200px on hover** and fades in an uppercase text label beside each icon (Teleop, Debugging, Datasets, Collect, Training, Settings) — glanceable as icons, legible as labels.

- **Overlay, no reflow**: the body grid still reserves 64px; the rail expands on top of the content (position + z-index) with a soft drop shadow, so the page never shifts.
- **No icon jump**: each icon stays centered in a fixed 48px zone (= the 64px collapsed rail), so it holds position as the rail grows.
- **Label style** matches the in-app `.microlabel` section headers (UI font, uppercase, 0.14em tracking, normal weight); labels inherit the link color so they stay muted and brighten on the active/hovered item.

CSS + one `shell.js` markup tweak (wrap the icon, add a label span). Tunable: the 200px width and 160ms speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)