### PR TITLE
webapp/debugging: retry console history request so backfill reliably shows

### DIFF
--- a/webapp/js/debugging/consoleSource.js
+++ b/webapp/js/debugging/consoleSource.js
@@ -22,6 +22,7 @@ export function createConsoleSource(ros) {
   /** @type {Set<() => void>} */
   const readyCbs = new Set();
   let backfilled = false;
+  let readyFired = false;
   let retryTimer = 0;
 
   /** @param {any} rec @param {boolean} isBackfill */
@@ -31,6 +32,17 @@ export function createConsoleSource(ros) {
     if (rec && typeof rec.node === "string") rec.node = normNode(rec.node);
     for (const cb of [...recordCbs]) {
       try { cb(rec, isBackfill); } catch (err) { console.error("[console] consumer threw:", err); }
+    }
+  }
+
+  // Fire the ready callbacks exactly once — on the first backfill batch, or when
+  // we give up retrying — so consumers always finalize their initial render
+  // instead of waiting forever when no history ever arrives.
+  function signalReady() {
+    if (readyFired) return;
+    readyFired = true;
+    for (const cb of [...readyCbs]) {
+      try { cb(); } catch (err) { console.error("[console] ready cb threw:", err); }
     }
   }
 
@@ -45,9 +57,7 @@ export function createConsoleSource(ros) {
     try {
       for (const rec of JSON.parse(m.data).entries || []) emit(rec, true);
     } catch { /* ignore */ }
-    for (const cb of [...readyCbs]) {
-      try { cb(); } catch (err) { console.error("[console] ready cb threw:", err); }
-    }
+    signalReady();
   });
 
   // Ask for history. The reply comes over a volatile topic, and on a fresh page
@@ -63,6 +73,7 @@ export function createConsoleSource(ros) {
     if (backfilled || ++tries >= 8) {
       clearInterval(retryTimer);
       retryTimer = 0;
+      signalReady(); // done or gave up — let consumers finalize (a late reply still populates)
       return;
     }
     ros.publish(CONSOLE_REQUEST_TOPIC, reqMsg);
@@ -72,7 +83,7 @@ export function createConsoleSource(ros) {
     onRecord(cb) { recordCbs.add(cb); return () => recordCbs.delete(cb); },
     onReady(cb) { readyCbs.add(cb); return () => readyCbs.delete(cb); },
     destroy() {
-      if (retryTimer) clearInterval(retryTimer);
+      if (retryTimer) { clearInterval(retryTimer); retryTimer = 0; }
       unsubLive();
       unsubBackfill();
       recordCbs.clear();

--- a/webapp/js/debugging/consoleSource.js
+++ b/webapp/js/debugging/consoleSource.js
@@ -22,6 +22,7 @@ export function createConsoleSource(ros) {
   /** @type {Set<() => void>} */
   const readyCbs = new Set();
   let backfilled = false;
+  let retryTimer = 0;
 
   /** @param {any} rec @param {boolean} isBackfill */
   function emit(rec, isBackfill) {
@@ -40,6 +41,7 @@ export function createConsoleSource(ros) {
   const unsubBackfill = ros.subscribe(CONSOLE_BACKFILL_TOPIC, (m) => {
     if (backfilled) return; // one batch only
     backfilled = true;
+    if (retryTimer) { clearInterval(retryTimer); retryTimer = 0; }
     try {
       for (const rec of JSON.parse(m.data).entries || []) emit(rec, true);
     } catch { /* ignore */ }
@@ -48,13 +50,29 @@ export function createConsoleSource(ros) {
     }
   });
 
-  // Ask for history once subscriptions are registered.
-  ros.publish(CONSOLE_REQUEST_TOPIC, { data: JSON.stringify({ max_lines: BACKFILL_LINES }) });
+  // Ask for history. The reply comes over a volatile topic, and on a fresh page
+  // load it can be published before this subscription has finished matching
+  // (rosbridge discovery lag) — then it's missed and the page shows nothing. So
+  // re-issue the request until the first batch lands (or we give up): that lets
+  // the subscription settle so the reply gets through. `backfilled` keeps us to
+  // a single batch even if several replies arrive.
+  const reqMsg = { data: JSON.stringify({ max_lines: BACKFILL_LINES }) };
+  let tries = 0;
+  ros.publish(CONSOLE_REQUEST_TOPIC, reqMsg);
+  retryTimer = setInterval(() => {
+    if (backfilled || ++tries >= 8) {
+      clearInterval(retryTimer);
+      retryTimer = 0;
+      return;
+    }
+    ros.publish(CONSOLE_REQUEST_TOPIC, reqMsg);
+  }, 500);
 
   return {
     onRecord(cb) { recordCbs.add(cb); return () => recordCbs.delete(cb); },
     onReady(cb) { readyCbs.add(cb); return () => readyCbs.delete(cb); },
     destroy() {
+      if (retryTimer) clearInterval(retryTimer);
       unsubLive();
       unsubBackfill();
       recordCbs.clear();


### PR DESCRIPTION
## Problem
The Debugging page often showed **no history** — and "starts from zero on every refresh" long after a restart.

The page requests its backfill once, over a **volatile, one-shot** topic (`/innate/console/backfill`, depth 1). On a fresh page load it subscribes and *immediately* publishes the request, but the ROS-side `/backfill` subscription hasn't finished matching yet (rosbridge discovery lag), so `console_node`'s single reply is published into the void and dropped. Early after boot the **live** stream (startup chatter) masks this; long after boot the robot is quiet, so backfill is the only source — and with it dropped, the page is blank. Each refresh is a new connection that re-loses the same race.

## Fix
Front-end only: re-issue the history request every **500 ms until the first batch arrives** (max 8 tries, ~4 s), then stop — cleared on success and on teardown. That lets the subscription settle so the reply gets through. The existing `backfilled` guard keeps it to a single batch even if several replies land.

**No caps changed** — backfill is still the existing ring tail (120 lines/node, 200 buckets; page buffers 6000 / renders 1500). This just makes that history *show up* reliably. If the amount then feels short, the follow-up is to serve history from the bridge's per-pane capture files (bigger history, same UI) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)