### PR TITLE
ACT improvements

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -79,7 +79,8 @@
 #     ae_kp: 0.8                    # auto-exposure proportional gain
 
 # ── Manipulation (learned-skill execution) ────────────────────────────
-# chunk_size is fixed by the trained model; a per-skill behavior_config still wins over these.
+# chunk_size is fixed by the trained model. These are node-level (restart to apply);
+# only n_action_steps accepts a per-skill behavior_config override.
 # manipulation_server:
 #   ros__parameters:
 #     inference_hz: 25.0            # policy inference loop rate (Hz)

--- a/ros2_ws/src/brain/manipulation/config/manipulation_server.yaml
+++ b/ros2_ws/src/brain/manipulation/config/manipulation_server.yaml
@@ -9,7 +9,7 @@ manipulation_server:
     inference_hz: 25.0                      # policy inference loop rate (Hz)
     speed: 1.5                             # action execution speed multiplier
     replay_base_speed_scale: 1.0            # scale on replayed base cmd_vel; 1.0 = full recorded speed
-    learned_base_speed_scale: 1.0           # de-rate on learned-policy predicted base cmd_vel; 1.0 = full predicted speed
+    learned_base_speed_scale: 1.0           # scale on learned-policy predicted base cmd_vel; 1.0 = full predicted speed
     n_action_steps: 0                      # replan horizon; 0 = auto (min(40, chunk_size)), per-skill config wins
     # ACT temporal-ensemble smoothing. Runs the TRT engine every step and exponentially blends
     # overlapping chunk predictions to remove the per-replan motion discontinuity.

--- a/ros2_ws/src/brain/manipulation/config/manipulation_server.yaml
+++ b/ros2_ws/src/brain/manipulation/config/manipulation_server.yaml
@@ -9,7 +9,7 @@ manipulation_server:
     inference_hz: 25.0                      # policy inference loop rate (Hz)
     speed: 1.5                             # action execution speed multiplier
     replay_base_speed_scale: 1.0            # scale on replayed base cmd_vel; 1.0 = full recorded speed
-    learned_base_speed_scale: 0.5           # de-rate on learned-policy predicted base cmd_vel; 1.0 = full predicted speed
+    learned_base_speed_scale: 1.0           # de-rate on learned-policy predicted base cmd_vel; 1.0 = full predicted speed
     n_action_steps: 0                      # replan horizon; 0 = auto (min(40, chunk_size)), per-skill config wins
     # ACT temporal-ensemble smoothing. Runs the TRT engine every step and exponentially blends
     # overlapping chunk predictions to remove the per-replan motion discontinuity.

--- a/ros2_ws/src/brain/manipulation/manipulation/ACT.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/ACT.py
@@ -641,8 +641,13 @@ class ACTTemporalEnsembler:
     def reset(self):
         """Resets the online computation variables."""
         self.ensembled_actions = None
+        # Online weighted mean of squares, mirroring ensembled_actions; together they give the
+        # weighted variance of the chunk predictions voting on each step (the ensemble's
+        # disagreement / uncertainty). last_disagreement is the std of the emitted action.
+        self.ensembled_actions_sq = None
         # (chunk_size,) count of how many actions are in the ensemble for each time step
         self.ensembled_actions_count = None
+        self.last_disagreement = None
 
     def update(self, actions: Tensor) -> Tensor:
         """
@@ -651,25 +656,37 @@ class ACTTemporalEnsembler:
         """
         self.ensemble_weights = self.ensemble_weights.to(device=actions.device)
         self.ensemble_weights_cumsum = self.ensemble_weights_cumsum.to(device=actions.device)
+        actions_sq = actions * actions
 
         if self.ensembled_actions is None:
             # Initialize with the first sequence of actions
             self.ensembled_actions = actions.clone()
+            self.ensembled_actions_sq = actions_sq.clone()
             self.ensembled_actions_count = torch.ones(
                 (self.chunk_size, 1), dtype=torch.long, device=self.ensembled_actions.device
             )
         else:
-            # Update existing ensemble
-            self.ensembled_actions *= self.ensemble_weights_cumsum[self.ensembled_actions_count - 1]
-            self.ensembled_actions += actions[:, :-1] * self.ensemble_weights[self.ensembled_actions_count]
-            self.ensembled_actions /= self.ensemble_weights_cumsum[self.ensembled_actions_count]
+            # Update existing ensemble. Capture the weights once and apply the same online-mean
+            # recurrence to both the actions and their squares (for the variance).
+            prev_w = self.ensemble_weights_cumsum[self.ensembled_actions_count - 1]
+            add_w = self.ensemble_weights[self.ensembled_actions_count]
+            new_w = self.ensemble_weights_cumsum[self.ensembled_actions_count]
+            self.ensembled_actions = (self.ensembled_actions * prev_w + actions[:, :-1] * add_w) / new_w
+            self.ensembled_actions_sq = (self.ensembled_actions_sq * prev_w + actions_sq[:, :-1] * add_w) / new_w
             self.ensembled_actions_count = torch.clamp(self.ensembled_actions_count + 1, max=self.chunk_size)
 
             # Add the last action which has no prior online average
             self.ensembled_actions = torch.cat([self.ensembled_actions, actions[:, -1:]], dim=1)
+            self.ensembled_actions_sq = torch.cat([self.ensembled_actions_sq, actions_sq[:, -1:]], dim=1)
             self.ensembled_actions_count = torch.cat(
                 [self.ensembled_actions_count, torch.ones_like(self.ensembled_actions_count[-1:])]
             )
+
+        # Ensemble disagreement for the action about to be emitted: weighted std across the
+        # chunk predictions that voted on slot 0, averaged over action dims. Kept on-device
+        # (no host sync); the caller reads it only when profiling.
+        var0 = (self.ensembled_actions_sq[:, 0] - self.ensembled_actions[:, 0] ** 2).clamp_min(0)
+        self.last_disagreement = var0.sqrt().mean()
 
         # Return the first action and update the queue
         action, self.ensembled_actions, self.ensembled_actions_count = (
@@ -677,6 +694,7 @@ class ACTTemporalEnsembler:
             self.ensembled_actions[:, 1:],
             self.ensembled_actions_count[1:],
         )
+        self.ensembled_actions_sq = self.ensembled_actions_sq[:, 1:]
         return action
 
 

--- a/ros2_ws/src/brain/manipulation/manipulation/act_trt.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/act_trt.py
@@ -236,10 +236,9 @@ class TRTACTPolicy:
             )
         self._context = self._engine.create_execution_context()
         self._stream = torch.cuda.Stream()
-        # CUDA events bracketing execute only (no H2D copies / host sync), for the profiler.
+        # CUDA events bracket execute only (no H2D copies / host sync).
         self._ev_start = torch.cuda.Event(enable_timing=True)
         self._ev_end = torch.cuda.Event(enable_timing=True)
-        # Per-step timing the profiler reads; cleared on cached dequeue steps (see select_action).
         self.last_engine_ms = 0.0
         self.engine_ran = False
 
@@ -340,7 +339,7 @@ class TRTACTPolicy:
                 actions_to_queue = self._resample_actions(actions_to_queue, self.config.speed)
             self._action_queue.extend(actions_to_queue.transpose(0, 1))
         else:
-            # Cached dequeue step -- no GPU forward, so clear the timing the profiler reads.
+            # Cached dequeue: no engine ran this step.
             self.engine_ran = False
             self.last_engine_ms = 0.0
         return self._action_queue.popleft()

--- a/ros2_ws/src/brain/manipulation/manipulation/act_trt.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/act_trt.py
@@ -236,12 +236,12 @@ class TRTACTPolicy:
             )
         self._context = self._engine.create_execution_context()
         self._stream = torch.cuda.Stream()
-        # Pure-GPU forward timing (CUDA events around execute only, excluding the H2D
-        # copies and the host-side sync wait). Read by the profiler to separate the raw
-        # engine cost from the Python/transfer overhead in select_action.
+        # CUDA events bracketing execute only (no H2D copies / host sync), for the profiler.
         self._ev_start = torch.cuda.Event(enable_timing=True)
         self._ev_end = torch.cuda.Event(enable_timing=True)
+        # Per-step timing the profiler reads; cleared on cached dequeue steps (see select_action).
         self.last_engine_ms = 0.0
+        self.engine_ran = False
 
         # Persistent I/O buffers (fixed batch size 1); engine addresses bound once.
         self._buffers = {
@@ -299,11 +299,8 @@ class TRTACTPolicy:
     def _run_engine(self, batch):
         """Run the engine for the current observation; returns the full unnormalized
         action chunk (1, chunk_size, action_dim), cloned out of the persistent buffer."""
-        # Run the input copies AND the engine launch on self._stream, after waiting for the
-        # caller's stream (where the input tensors were produced). Without this, the copies
-        # would run on the default stream while the engine ran on self._stream with no
-        # ordering between them -- the engine could read the input buffers before the copies
-        # land, yielding actions computed from stale/partial data.
+        # Wait for the caller's stream (where the inputs were produced) before copying and
+        # launching, so the engine can't read the buffers before the copies land.
         self._stream.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(self._stream):
             self._buffers["image_camera_1"].copy_(batch["observation.image_camera_1"])
@@ -314,6 +311,7 @@ class TRTACTPolicy:
             self._ev_end.record(self._stream)
         self._stream.synchronize()
         self.last_engine_ms = self._ev_start.elapsed_time(self._ev_end)
+        self.engine_ran = True
         if not ok:
             # A failed launch (CUDA OOM, driver fault, unbound tensor) leaves stale data in
             # action_chunk; raise so the caller skips this step instead of acting on it.
@@ -322,8 +320,7 @@ class TRTACTPolicy:
 
     @property
     def last_disagreement(self):
-        """Ensemble disagreement (uncertainty) of the last emitted action, or None when not
-        ensembling. On-device scalar tensor; the caller converts it only when profiling."""
+        """Ensemble disagreement of the last action (on-device scalar), or None when not ensembling."""
         return self._ensembler.last_disagreement if self._ensembler is not None else None
 
     @torch.no_grad()
@@ -342,6 +339,10 @@ class TRTACTPolicy:
             if self.config.speed != 1:
                 actions_to_queue = self._resample_actions(actions_to_queue, self.config.speed)
             self._action_queue.extend(actions_to_queue.transpose(0, 1))
+        else:
+            # Cached dequeue step -- no GPU forward, so clear the timing the profiler reads.
+            self.engine_ran = False
+            self.last_engine_ms = 0.0
         return self._action_queue.popleft()
 
     def __del__(self):

--- a/ros2_ws/src/brain/manipulation/manipulation/act_trt.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/act_trt.py
@@ -236,6 +236,12 @@ class TRTACTPolicy:
             )
         self._context = self._engine.create_execution_context()
         self._stream = torch.cuda.Stream()
+        # Pure-GPU forward timing (CUDA events around execute only, excluding the H2D
+        # copies and the host-side sync wait). Read by the profiler to separate the raw
+        # engine cost from the Python/transfer overhead in select_action.
+        self._ev_start = torch.cuda.Event(enable_timing=True)
+        self._ev_end = torch.cuda.Event(enable_timing=True)
+        self.last_engine_ms = 0.0
 
         # Persistent I/O buffers (fixed batch size 1); engine addresses bound once.
         self._buffers = {
@@ -303,8 +309,11 @@ class TRTACTPolicy:
             self._buffers["image_camera_1"].copy_(batch["observation.image_camera_1"])
             self._buffers["image_camera_2"].copy_(batch["observation.image_camera_2"])
             self._buffers["state"].copy_(batch["observation.state"])
+            self._ev_start.record(self._stream)
             ok = self._context.execute_async_v3(self._stream.cuda_stream)
+            self._ev_end.record(self._stream)
         self._stream.synchronize()
+        self.last_engine_ms = self._ev_start.elapsed_time(self._ev_end)
         if not ok:
             # A failed launch (CUDA OOM, driver fault, unbound tensor) leaves stale data in
             # action_chunk; raise so the caller skips this step instead of acting on it.

--- a/ros2_ws/src/brain/manipulation/manipulation/act_trt.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/act_trt.py
@@ -320,6 +320,12 @@ class TRTACTPolicy:
             raise RuntimeError("TensorRT execute_async_v3 failed (engine execution did not launch)")
         return self._buffers["action_chunk"].clone()
 
+    @property
+    def last_disagreement(self):
+        """Ensemble disagreement (uncertainty) of the last emitted action, or None when not
+        ensembling. On-device scalar tensor; the caller converts it only when profiling."""
+        return self._ensembler.last_disagreement if self._ensembler is not None else None
+
     @torch.no_grad()
     def select_action(self, batch):
         if self._ensembler is not None:

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -77,10 +77,9 @@ class ManipulationServer(Node):
         self.inference_hz = inference_hz
         self.policy_speed = self.get_parameter("speed").value
         # De-rate applied to the recorded/predicted base velocity at execution time. Replay and
-        # learned inference are tuned independently: replay plays back recorded cmd_vel 1:1 by
-        # default, the learned path de-rates the policy's predicted cmd_vel to half speed.
+        # learned inference are tuned independently; both play back base cmd_vel 1:1 by default.
         self.declare_parameter("replay_base_speed_scale", 1.0)
-        self.declare_parameter("learned_base_speed_scale", 0.5)
+        self.declare_parameter("learned_base_speed_scale", 1.0)
         self.replay_base_speed_scale = self.get_parameter("replay_base_speed_scale").value
         self.learned_base_speed_scale = self.get_parameter("learned_base_speed_scale").value
         # n_action_steps=0 means "auto" (min(40, chunk_size)); a per-skill value still wins.

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -381,56 +381,66 @@ class ManipulationServer(Node):
                 f"Starting policy inference for {duration} seconds at {inference_hz} Hz (progress threshold: {progress_threshold})"
             )
 
-            while rclpy.ok():
-                loop_start = time.time()
-                elapsed_time = loop_start - start_time
-                iteration_count += 1
+            # Disable automatic GC for the run. Per-step allocations (tensors, numpy,
+            # feedback msgs) are freed by refcounting, but periodic gen-2 collections
+            # cause pauses that show up as latency spikes in the 25 Hz loop. freeze()
+            # moves already-live objects out of the scan set; gc is re-enabled in the
+            # finally so every exit path (return/break/raise) restores it.
+            gc.freeze()
+            gc.disable()
+            try:
+                while rclpy.ok():
+                    loop_start = time.time()
+                    elapsed_time = loop_start - start_time
+                    iteration_count += 1
 
-                # Check for cancellation
-                if self._cancel_requested.is_set():
-                    self.get_logger().info("Behavior execution canceled")
-                    self._stop_robot()
-                    if end_pose:
-                        self.call_arm_goto_service(end_pose, end_pose_time)
-                    return "CANCELLED", "User requested cancellation"
-
-                # Check if duration completed (moved earlier to prevent infinite loop)
-                if elapsed_time >= duration:
-                    self.get_logger().info(f"Behavior timeout reached after {elapsed_time:.2f} seconds")
-                    break
-
-                progress = self._run_inference_once()
-
-                # Check if inference failed due to missing sensor data
-                if progress is None:
-                    # Check if it's due to missing sensors
-                    if not self._check_sensor_availability():
-                        self.get_logger().error("Required sensors became unavailable during execution")
+                    # Check for cancellation
+                    if self._cancel_requested.is_set():
+                        self.get_logger().info("Behavior execution canceled")
                         self._stop_robot()
-                        return "FAILURE", "Required sensors became unavailable during execution"
-                    # If sensors are available but inference still failed, continue
-                    # but still check timeout and send feedback
-                else:
-                    # Check for early termination based on progress metric
-                    if progress > progress_threshold:
-                        early_termination = True
-                        self.get_logger().info(
-                            f"Early termination triggered! Progress: {progress:.4f} > {progress_threshold}"
-                        )
+                        if end_pose:
+                            self.call_arm_goto_service(end_pose, end_pose_time)
+                        return "CANCELLED", "User requested cancellation"
+
+                    # Check if duration completed (moved earlier to prevent infinite loop)
+                    if elapsed_time >= duration:
+                        self.get_logger().info(f"Behavior timeout reached after {elapsed_time:.2f} seconds")
                         break
 
-                # Send feedback
-                remaining_time = max(0.0, duration - elapsed_time)
-                feedback_msg = ExecuteBehavior.Feedback()
-                feedback_msg.elapsed_time = float(elapsed_time)
-                feedback_msg.remaining_time = float(remaining_time)
-                feedback_msg.status = f"Executing {behavior_name} ({skill_dir})"
-                goal_handle.publish_feedback(feedback_msg)
+                    progress = self._run_inference_once()
 
-                # Maintain loop rate
-                sleep_time = period - (time.time() - loop_start)
-                if sleep_time > 0:
-                    time.sleep(sleep_time)
+                    # Check if inference failed due to missing sensor data
+                    if progress is None:
+                        # Check if it's due to missing sensors
+                        if not self._check_sensor_availability():
+                            self.get_logger().error("Required sensors became unavailable during execution")
+                            self._stop_robot()
+                            return "FAILURE", "Required sensors became unavailable during execution"
+                        # If sensors are available but inference still failed, continue
+                        # but still check timeout and send feedback
+                    else:
+                        # Check for early termination based on progress metric
+                        if progress > progress_threshold:
+                            early_termination = True
+                            self.get_logger().info(
+                                f"Early termination triggered! Progress: {progress:.4f} > {progress_threshold}"
+                            )
+                            break
+
+                    # Send feedback
+                    remaining_time = max(0.0, duration - elapsed_time)
+                    feedback_msg = ExecuteBehavior.Feedback()
+                    feedback_msg.elapsed_time = float(elapsed_time)
+                    feedback_msg.remaining_time = float(remaining_time)
+                    feedback_msg.status = f"Executing {behavior_name} ({skill_dir})"
+                    goal_handle.publish_feedback(feedback_msg)
+
+                    # Maintain loop rate
+                    sleep_time = period - (time.time() - loop_start)
+                    if sleep_time > 0:
+                        time.sleep(sleep_time)
+            finally:
+                gc.enable()
 
             # Stop robot and move to end pose
             self._stop_robot()

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -307,6 +307,9 @@ class ManipulationServer(Node):
             self._stop_sensor_subscriptions()
             self.execution_running = False
             self.current_goal_handle = None
+            # Drop the jerk reference so the next behavior's first step isn't compared
+            # against this one's final action.
+            self._prev_action_np = None
             self._release_policy()
 
     def _release_policy(self):

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -896,6 +896,10 @@ class ManipulationServer(Node):
                 "observation.image_camera_2": img2,
                 "observation.state": torch.tensor(qpos, device=self.device).unsqueeze(0),
             }
+            # The GPU resize is async; the engine waits on it anyway, so sync here (no net
+            # latency cost) to attribute its compute to preprocess instead of inference.
+            if self.device.type == "cuda":
+                torch.cuda.current_stream().synchronize()
             t1 = time.perf_counter()
 
             # Chunked policies only run the model when their action queue drains; the other
@@ -906,8 +910,12 @@ class ManipulationServer(Node):
 
             with torch.no_grad():
                 action = self.current_policy.select_action(batch)
-            action_np = action.cpu().numpy().squeeze(0)  # .cpu() blocks until inference is done
+            t_sel = time.perf_counter()  # select_action returns once the engine has synced
+            action_np = action.cpu().numpy().squeeze(0)  # .cpu() blocks on the remaining GPU work
             t2 = time.perf_counter()
+            # Pure GPU forward (CUDA-event measured inside the engine), to compare against
+            # the ~6 ms fp32 spec and separate it from copy/ensemble/transfer overhead.
+            engine_ms = float(getattr(self.current_policy, "last_engine_ms", 0.0))
 
             if action_np.shape[0] < self.current_action_dim:
                 self.get_logger().error(
@@ -920,7 +928,7 @@ class ManipulationServer(Node):
             self._publish_arm(action_np[:6])
             t3 = time.perf_counter()
 
-            self._publish_inference_profile(t0, t1, t2, t3, engine_ran)
+            self._publish_inference_profile(t0, t1, t_sel, t2, t3, engine_ran, engine_ms)
 
             return float(action_np[8]) if self.current_action_dim >= 10 else None
 
@@ -928,12 +936,14 @@ class ManipulationServer(Node):
             self.get_logger().error(f"Error during inference: {e}")
             return None
 
-    def _publish_inference_profile(self, t0, t1, t2, t3, engine_ran):
+    def _publish_inference_profile(self, t0, t1, t_sel, t2, t3, engine_ran, engine_ms):
         """Publish one inference step's timing breakdown as JSON for the Profiling page.
 
         Sections (ms): preprocess (resize/normalize/to-GPU), inference (select_action +
-        GPU->CPU sync), postprocess (command publishing). period_ms is the 25 Hz budget
-        so the page can show headroom.
+        GPU->CPU sync), postprocess (command publishing). inference is further split into
+        engine (pure GPU forward, CUDA-event measured) and transfer (the final .cpu()
+        copy); the remainder is input copies + temporal-ensemble + Python overhead.
+        period_ms is the 25 Hz budget so the page can show headroom.
         """
         self._inference_seq += 1
         payload = {
@@ -941,6 +951,8 @@ class ManipulationServer(Node):
             "t": time.time(),
             "preprocess_ms": (t1 - t0) * 1000.0,
             "inference_ms": (t2 - t1) * 1000.0,
+            "engine_ms": engine_ms,
+            "transfer_ms": (t2 - t_sel) * 1000.0,
             "postprocess_ms": (t3 - t2) * 1000.0,
             "total_ms": (t3 - t0) * 1000.0,
             "engine_ran": bool(engine_ran),

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -843,17 +843,14 @@ class ManipulationServer(Node):
         self.latest_joint_timestamp = rclpy.time.Time.from_msg(msg.header.stamp)
 
     def _resize_matrices(self, h, w):
-        """Return cached (row, col) GPU matrices that replicate cv2.INTER_AREA for an
-        (h, w) -> image_size resize. INTER_AREA is a separable, content-independent
-        linear filter, so its weights can be recovered exactly from identity inputs and
-        applied as two matmuls. Built once per source resolution."""
+        """Cached (row, col) GPU matrices replicating cv2.INTER_AREA for an (h, w) ->
+        image_size resize. INTER_AREA is separable, so its weights recover exactly from
+        identity inputs and apply as two matmuls."""
         key = (h, w)
         mats = self._resize_mats.get(key)
         if mats is None:
             out_h, out_w = self.image_size[1], self.image_size[0]
-            # row[i, j]: weight of src row j in dst row i (out_h x h)
             row = cv2.resize(np.eye(h, dtype=np.float32), (h, out_h), interpolation=cv2.INTER_AREA)
-            # col[k, l]: weight of src col k in dst col l (w x out_w)
             col = cv2.resize(np.eye(w, dtype=np.float32), (out_w, w), interpolation=cv2.INTER_AREA)
             mats = (
                 torch.from_numpy(row).to(self.device),
@@ -868,7 +865,10 @@ class ManipulationServer(Node):
         h, w = img_bgr.shape[:2]
         row, col = self._resize_matrices(h, w)
         src = torch.from_numpy(np.ascontiguousarray(img_bgr)).to(self.device, non_blocking=True).float()
-        resized = torch.einsum("ij,jkc,kl->ilc", row, src, col)  # (out_h, out_w, 3)
+        # Contract columns first: the (h, out_w, 3) intermediate is the cheaper order for a
+        # landscape frame (torch.einsum has no per-call optimize flag).
+        cols = torch.einsum("jkc,kl->jlc", src, col)
+        resized = torch.einsum("ij,jlc->ilc", row, cols)
         return resized.permute(2, 0, 1) / 255.0
 
     def _run_inference_once(self):
@@ -886,14 +886,11 @@ class ManipulationServer(Node):
             return None
 
         try:
-            # Only do the profiling work (stream sync for attribution + JSON publish) when
-            # someone is actually subscribed, so it costs literally nothing when idle.
+            # Profiling work (stream sync + JSON publish) only runs when someone's subscribed.
             profiling = self.inference_profile_pub.get_subscription_count() > 0
 
             t0 = time.perf_counter()
-            # Keep BGR + INTER_AREA to match the training pipeline (recorder -> H5 -> webdataset).
-            # Resize on-GPU via precomputed INTER_AREA matrices to keep the CPU off the
-            # hot path; output is (1, 3, 224, 224) float32 in [0, 1], CHW, BGR.
+            # On-GPU resize keeps the CPU off the hot path; BGR + INTER_AREA matches training.
             img1 = self._resize_normalize_gpu(self.latest_image1).unsqueeze(0)
             img2 = self._resize_normalize_gpu(self.latest_image2).unsqueeze(0)
             qpos = np.asarray(self.latest_joint_state.position, dtype=np.float32)
@@ -902,26 +899,19 @@ class ManipulationServer(Node):
                 "observation.image_camera_2": img2,
                 "observation.state": torch.tensor(qpos, device=self.device).unsqueeze(0),
             }
-            # The GPU resize is async; the engine waits on it anyway, so syncing here has no
-            # net latency cost but attributes its compute to preprocess instead of inference.
-            # Only worth it when profiling — otherwise let it overlap freely.
+            # Sync so the GPU resize is attributed to preprocess, not inference; no net cost
+            # since the engine waits on it anyway. Only when profiling.
             if profiling and self.device.type == "cuda":
                 torch.cuda.current_stream().synchronize()
             t1 = time.perf_counter()
 
-            # Chunked policies only run the model when their action queue drains; the other
-            # steps just dequeue a cached action. Flag which kind of step this is so the
-            # profiler can separate true model latency from cheap dequeues.
-            queue = getattr(self.current_policy, "_action_queue", None)
-            engine_ran = queue is None or len(queue) == 0
-
             with torch.no_grad():
                 action = self.current_policy.select_action(batch)
-            t_sel = time.perf_counter()  # select_action returns once the engine has synced
+            t_sel = time.perf_counter()  # returns once the engine has synced
             action_np = action.cpu().numpy().squeeze(0)  # .cpu() blocks on the remaining GPU work
             t2 = time.perf_counter()
-            # Pure GPU forward (CUDA-event measured inside the engine), to compare against
-            # the ~6 ms fp32 spec and separate it from copy/ensemble/transfer overhead.
+            # Whether the model ran this step (vs. a cached dequeue) and its GPU-forward time.
+            engine_ran = bool(getattr(self.current_policy, "engine_ran", True))
             engine_ms = float(getattr(self.current_policy, "last_engine_ms", 0.0))
 
             if action_np.shape[0] < self.current_action_dim:
@@ -936,9 +926,7 @@ class ManipulationServer(Node):
             t3 = time.perf_counter()
 
             if profiling:
-                # Behavior-quality signals (cheap; only when someone's recording): the policy's
-                # progress head, command smoothness (jerk = ||Δaction||), and ensemble
-                # disagreement (uncertainty). float() on the disagreement is post-sync, so free.
+                # Behavior signals: progress head, command jerk (||Δaction||), ensemble disagreement.
                 quality = {}
                 if self.current_action_dim >= 10:
                     quality["progress"] = float(action_np[8])
@@ -953,7 +941,6 @@ class ManipulationServer(Node):
                 disagreement = getattr(self.current_policy, "last_disagreement", None)
                 if disagreement is not None:
                     quality["disagreement"] = float(disagreement)
-                self._prev_action_np = action_np
                 self._publish_inference_profile(t0, t1, t_sel, t2, t3, engine_ran, engine_ms, quality)
 
             return float(action_np[8]) if self.current_action_dim >= 10 else None
@@ -963,15 +950,7 @@ class ManipulationServer(Node):
             return None
 
     def _publish_inference_profile(self, t0, t1, t_sel, t2, t3, engine_ran, engine_ms, quality=None):
-        """Publish one inference step's timing breakdown as JSON for the Profiling page.
-
-        Sections (ms): preprocess (resize/normalize/to-GPU), inference (select_action +
-        GPU->CPU sync), postprocess (command publishing). inference is further split into
-        engine (pure GPU forward, CUDA-event measured) and transfer (the final .cpu()
-        copy); the remainder is input copies + temporal-ensemble + Python overhead.
-        period_ms is the 25 Hz budget so the page can show headroom. quality carries the
-        optional behavior signals (progress, arm/base jerk, ensemble disagreement).
-        """
+        """Publish one inference step's timing breakdown (ms) as JSON for the Profiling page."""
         self._inference_seq += 1
         payload = {
             "seq": self._inference_seq,

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -884,6 +884,10 @@ class ManipulationServer(Node):
             return None
 
         try:
+            # Only do the profiling work (stream sync for attribution + JSON publish) when
+            # someone is actually subscribed, so it costs literally nothing when idle.
+            profiling = self.inference_profile_pub.get_subscription_count() > 0
+
             t0 = time.perf_counter()
             # Keep BGR + INTER_AREA to match the training pipeline (recorder -> H5 -> webdataset).
             # Resize on-GPU via precomputed INTER_AREA matrices to keep the CPU off the
@@ -896,9 +900,10 @@ class ManipulationServer(Node):
                 "observation.image_camera_2": img2,
                 "observation.state": torch.tensor(qpos, device=self.device).unsqueeze(0),
             }
-            # The GPU resize is async; the engine waits on it anyway, so sync here (no net
-            # latency cost) to attribute its compute to preprocess instead of inference.
-            if self.device.type == "cuda":
+            # The GPU resize is async; the engine waits on it anyway, so syncing here has no
+            # net latency cost but attributes its compute to preprocess instead of inference.
+            # Only worth it when profiling — otherwise let it overlap freely.
+            if profiling and self.device.type == "cuda":
                 torch.cuda.current_stream().synchronize()
             t1 = time.perf_counter()
 
@@ -928,7 +933,8 @@ class ManipulationServer(Node):
             self._publish_arm(action_np[:6])
             t3 = time.perf_counter()
 
-            self._publish_inference_profile(t0, t1, t_sel, t2, t3, engine_ran, engine_ms)
+            if profiling:
+                self._publish_inference_profile(t0, t1, t_sel, t2, t3, engine_ran, engine_ms)
 
             return float(action_np[8]) if self.current_action_dim >= 10 else None
 

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -942,9 +942,14 @@ class ManipulationServer(Node):
                 quality = {}
                 if self.current_action_dim >= 10:
                     quality["progress"] = float(action_np[8])
-                if self._prev_action_np is not None:
-                    quality["arm_jerk"] = float(np.linalg.norm(action_np[:6] - self._prev_action_np[:6]))
-                    quality["base_jerk"] = float(np.linalg.norm(action_np[6:8] - self._prev_action_np[6:8]))
+                # Update prev first so a failure below can't stall it, and guard on matching
+                # shape: switching to a behavior with a different action_dim leaves a stale
+                # prev whose slices won't broadcast.
+                prev = self._prev_action_np
+                self._prev_action_np = action_np
+                if prev is not None and prev.shape == action_np.shape:
+                    quality["arm_jerk"] = float(np.linalg.norm(action_np[:6] - prev[:6]))
+                    quality["base_jerk"] = float(np.linalg.norm(action_np[6:8] - prev[6:8]))
                 disagreement = getattr(self.current_policy, "last_disagreement", None)
                 if disagreement is not None:
                     quality["disagreement"] = float(disagreement)

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -886,11 +886,10 @@ class ManipulationServer(Node):
             return None
 
         try:
-            # Profiling work (stream sync + JSON publish) only runs when someone's subscribed.
             profiling = self.inference_profile_pub.get_subscription_count() > 0
 
             t0 = time.perf_counter()
-            # On-GPU resize keeps the CPU off the hot path; BGR + INTER_AREA matches training.
+            # BGR + INTER_AREA matches the training pipeline.
             img1 = self._resize_normalize_gpu(self.latest_image1).unsqueeze(0)
             img2 = self._resize_normalize_gpu(self.latest_image2).unsqueeze(0)
             qpos = np.asarray(self.latest_joint_state.position, dtype=np.float32)
@@ -907,10 +906,9 @@ class ManipulationServer(Node):
 
             with torch.no_grad():
                 action = self.current_policy.select_action(batch)
-            t_sel = time.perf_counter()  # returns once the engine has synced
+            t_sel = time.perf_counter()
             action_np = action.cpu().numpy().squeeze(0)  # .cpu() blocks on the remaining GPU work
             t2 = time.perf_counter()
-            # Whether the model ran this step (vs. a cached dequeue) and its GPU-forward time.
             engine_ran = bool(getattr(self.current_policy, "engine_ran", True))
             engine_ms = float(getattr(self.current_policy, "last_engine_ms", 0.0))
 
@@ -926,7 +924,6 @@ class ManipulationServer(Node):
             t3 = time.perf_counter()
 
             if profiling:
-                # Behavior signals: progress head, command jerk (||Δaction||), ensemble disagreement.
                 quality = {}
                 if self.current_action_dim >= 10:
                     quality["progress"] = float(action_np[8])

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -149,6 +149,8 @@ class ManipulationServer(Node):
         # Only published while a learned behavior is executing, so it's free when idle.
         self.inference_profile_pub = self.create_publisher(String, "/brain/manipulation/inference_profile", 10)
         self._inference_seq = 0
+        # Previous emitted action, for the per-step command-jerk (smoothness) metric.
+        self._prev_action_np = None
         # Service clients
         self.head_ai_position_client = self.create_client(Trigger, "/mars/head/set_ai_position")
         self.arm_goto_client = self.create_client(GotoJS, "/mars/arm/goto_js")
@@ -934,7 +936,20 @@ class ManipulationServer(Node):
             t3 = time.perf_counter()
 
             if profiling:
-                self._publish_inference_profile(t0, t1, t_sel, t2, t3, engine_ran, engine_ms)
+                # Behavior-quality signals (cheap; only when someone's recording): the policy's
+                # progress head, command smoothness (jerk = ||Δaction||), and ensemble
+                # disagreement (uncertainty). float() on the disagreement is post-sync, so free.
+                quality = {}
+                if self.current_action_dim >= 10:
+                    quality["progress"] = float(action_np[8])
+                if self._prev_action_np is not None:
+                    quality["arm_jerk"] = float(np.linalg.norm(action_np[:6] - self._prev_action_np[:6]))
+                    quality["base_jerk"] = float(np.linalg.norm(action_np[6:8] - self._prev_action_np[6:8]))
+                disagreement = getattr(self.current_policy, "last_disagreement", None)
+                if disagreement is not None:
+                    quality["disagreement"] = float(disagreement)
+                self._prev_action_np = action_np
+                self._publish_inference_profile(t0, t1, t_sel, t2, t3, engine_ran, engine_ms, quality)
 
             return float(action_np[8]) if self.current_action_dim >= 10 else None
 
@@ -942,14 +957,15 @@ class ManipulationServer(Node):
             self.get_logger().error(f"Error during inference: {e}")
             return None
 
-    def _publish_inference_profile(self, t0, t1, t_sel, t2, t3, engine_ran, engine_ms):
+    def _publish_inference_profile(self, t0, t1, t_sel, t2, t3, engine_ran, engine_ms, quality=None):
         """Publish one inference step's timing breakdown as JSON for the Profiling page.
 
         Sections (ms): preprocess (resize/normalize/to-GPU), inference (select_action +
         GPU->CPU sync), postprocess (command publishing). inference is further split into
         engine (pure GPU forward, CUDA-event measured) and transfer (the final .cpu()
         copy); the remainder is input copies + temporal-ensemble + Python overhead.
-        period_ms is the 25 Hz budget so the page can show headroom.
+        period_ms is the 25 Hz budget so the page can show headroom. quality carries the
+        optional behavior signals (progress, arm/base jerk, ensemble disagreement).
         """
         self._inference_seq += 1
         payload = {
@@ -964,6 +980,8 @@ class ManipulationServer(Node):
             "engine_ran": bool(engine_ran),
             "period_ms": 1000.0 / self.inference_hz,
         }
+        if quality:
+            payload.update(quality)
         msg = String()
         msg.data = json.dumps(payload)
         self.inference_profile_pub.publish(msg)

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import gc
+import json
 import math
 import os
 import threading
@@ -19,7 +20,7 @@ from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import Image, JointState
-from std_msgs.msg import Float64MultiArray, Int32
+from std_msgs.msg import Float64MultiArray, Int32, String
 from std_srvs.srv import Trigger
 
 # Import your policy class and trajectory generator
@@ -139,6 +140,10 @@ class ManipulationServer(Node):
         self.arm_state_pub = self.create_publisher(Float64MultiArray, "/mars/arm/commands", 10)
         # Head position command (degrees) — only published for head-enabled replay skills.
         self.head_set_position_pub = self.create_publisher(Int32, "/mars/head/set_position", 10)
+        # Per-step inference timing breakdown (JSON String), for the webapp Profiling page.
+        # Only published while a learned behavior is executing, so it's free when idle.
+        self.inference_profile_pub = self.create_publisher(String, "/brain/manipulation/inference_profile", 10)
+        self._inference_seq = 0
         # Service clients
         self.head_ai_position_client = self.create_client(Trigger, "/mars/head/set_ai_position")
         self.arm_goto_client = self.create_client(GotoJS, "/mars/arm/goto_js")
@@ -845,6 +850,7 @@ class ManipulationServer(Node):
             return None
 
         try:
+            t0 = time.perf_counter()
             # Keep BGR + INTER_AREA to match the training pipeline (recorder -> H5 -> webdataset).
             img1 = cv2.resize(self.latest_image1, self.image_size, interpolation=cv2.INTER_AREA)
             img2 = cv2.resize(self.latest_image2, self.image_size, interpolation=cv2.INTER_AREA)
@@ -856,10 +862,18 @@ class ManipulationServer(Node):
                 "observation.image_camera_2": torch.tensor(img2, device=self.device).unsqueeze(0),
                 "observation.state": torch.tensor(qpos, device=self.device).unsqueeze(0),
             }
+            t1 = time.perf_counter()
+
+            # Chunked policies only run the model when their action queue drains; the other
+            # steps just dequeue a cached action. Flag which kind of step this is so the
+            # profiler can separate true model latency from cheap dequeues.
+            queue = getattr(self.current_policy, "_action_queue", None)
+            engine_ran = queue is None or len(queue) == 0
 
             with torch.no_grad():
                 action = self.current_policy.select_action(batch)
             action_np = action.cpu().numpy().squeeze(0)  # .cpu() blocks until inference is done
+            t2 = time.perf_counter()
 
             if action_np.shape[0] < self.current_action_dim:
                 self.get_logger().error(
@@ -870,12 +884,37 @@ class ManipulationServer(Node):
             # Action layout: [0:6] arm joint targets, [6] linear.x, [7] angular.z, [8] progress.
             self._publish_base(float(action_np[6]), float(action_np[7]), self.learned_base_speed_scale)
             self._publish_arm(action_np[:6])
+            t3 = time.perf_counter()
+
+            self._publish_inference_profile(t0, t1, t2, t3, engine_ran)
 
             return float(action_np[8]) if self.current_action_dim >= 10 else None
 
         except Exception as e:
             self.get_logger().error(f"Error during inference: {e}")
             return None
+
+    def _publish_inference_profile(self, t0, t1, t2, t3, engine_ran):
+        """Publish one inference step's timing breakdown as JSON for the Profiling page.
+
+        Sections (ms): preprocess (resize/normalize/to-GPU), inference (select_action +
+        GPU->CPU sync), postprocess (command publishing). period_ms is the 25 Hz budget
+        so the page can show headroom.
+        """
+        self._inference_seq += 1
+        payload = {
+            "seq": self._inference_seq,
+            "t": time.time(),
+            "preprocess_ms": (t1 - t0) * 1000.0,
+            "inference_ms": (t2 - t1) * 1000.0,
+            "postprocess_ms": (t3 - t2) * 1000.0,
+            "total_ms": (t3 - t0) * 1000.0,
+            "engine_ran": bool(engine_ran),
+            "period_ms": 1000.0 / self.inference_hz,
+        }
+        msg = String()
+        msg.data = json.dumps(payload)
+        self.inference_profile_pub.publish(msg)
 
     def _publish_arm(self, positions):
         """Publish a single absolute joint-position command (first 6 joints)."""

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -103,6 +103,11 @@ class ManipulationServer(Node):
         self.bridge = CvBridge()
         self.image_size = (224, 224)  # Resize to match checkpoint expectations
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        # Cache of GPU resampling matrices keyed by source (h, w). INTER_AREA is a
+        # separable linear filter, so resize == two matmuls with content-independent
+        # weights; precomputing them lets the whole resize run on-GPU, bit-exact to
+        # cv2.INTER_AREA (up to uint8 rounding), instead of on the contended CPU.
+        self._resize_mats = {}
 
         if torch.cuda.is_available():
             props = torch.cuda.get_device_properties(0)
@@ -835,6 +840,35 @@ class ManipulationServer(Node):
         self.latest_joint_state = msg
         self.latest_joint_timestamp = rclpy.time.Time.from_msg(msg.header.stamp)
 
+    def _resize_matrices(self, h, w):
+        """Return cached (row, col) GPU matrices that replicate cv2.INTER_AREA for an
+        (h, w) -> image_size resize. INTER_AREA is a separable, content-independent
+        linear filter, so its weights can be recovered exactly from identity inputs and
+        applied as two matmuls. Built once per source resolution."""
+        key = (h, w)
+        mats = self._resize_mats.get(key)
+        if mats is None:
+            out_h, out_w = self.image_size[1], self.image_size[0]
+            # row[i, j]: weight of src row j in dst row i (out_h x h)
+            row = cv2.resize(np.eye(h, dtype=np.float32), (h, out_h), interpolation=cv2.INTER_AREA)
+            # col[k, l]: weight of src col k in dst col l (w x out_w)
+            col = cv2.resize(np.eye(w, dtype=np.float32), (out_w, w), interpolation=cv2.INTER_AREA)
+            mats = (
+                torch.from_numpy(row).to(self.device),
+                torch.from_numpy(col).to(self.device),
+            )
+            self._resize_mats[key] = mats
+        return mats
+
+    def _resize_normalize_gpu(self, img_bgr):
+        """Resize a HWC uint8 BGR frame to (3, image_size) float32 in [0, 1] on the GPU,
+        matching the cv2.INTER_AREA + /255 + CHW transpose the model was trained on."""
+        h, w = img_bgr.shape[:2]
+        row, col = self._resize_matrices(h, w)
+        src = torch.from_numpy(np.ascontiguousarray(img_bgr)).to(self.device, non_blocking=True).float()
+        resized = torch.einsum("ij,jkc,kl->ilc", row, src, col)  # (out_h, out_w, 3)
+        return resized.permute(2, 0, 1) / 255.0
+
     def _run_inference_once(self):
         """Run one inference step and publish its commands.
 
@@ -852,14 +886,14 @@ class ManipulationServer(Node):
         try:
             t0 = time.perf_counter()
             # Keep BGR + INTER_AREA to match the training pipeline (recorder -> H5 -> webdataset).
-            img1 = cv2.resize(self.latest_image1, self.image_size, interpolation=cv2.INTER_AREA)
-            img2 = cv2.resize(self.latest_image2, self.image_size, interpolation=cv2.INTER_AREA)
-            img1 = np.transpose(img1.astype(np.float32) / 255.0, (2, 0, 1))
-            img2 = np.transpose(img2.astype(np.float32) / 255.0, (2, 0, 1))
+            # Resize on-GPU via precomputed INTER_AREA matrices to keep the CPU off the
+            # hot path; output is (1, 3, 224, 224) float32 in [0, 1], CHW, BGR.
+            img1 = self._resize_normalize_gpu(self.latest_image1).unsqueeze(0)
+            img2 = self._resize_normalize_gpu(self.latest_image2).unsqueeze(0)
             qpos = np.asarray(self.latest_joint_state.position, dtype=np.float32)
             batch = {
-                "observation.image_camera_1": torch.tensor(img1, device=self.device).unsqueeze(0),
-                "observation.image_camera_2": torch.tensor(img2, device=self.device).unsqueeze(0),
+                "observation.image_camera_1": img1,
+                "observation.image_camera_2": img2,
                 "observation.state": torch.tensor(qpos, device=self.device).unsqueeze(0),
             }
             t1 = time.perf_counter()

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -381,66 +381,56 @@ class ManipulationServer(Node):
                 f"Starting policy inference for {duration} seconds at {inference_hz} Hz (progress threshold: {progress_threshold})"
             )
 
-            # Disable automatic GC for the run. Per-step allocations (tensors, numpy,
-            # feedback msgs) are freed by refcounting, but periodic gen-2 collections
-            # cause pauses that show up as latency spikes in the 25 Hz loop. freeze()
-            # moves already-live objects out of the scan set; gc is re-enabled in the
-            # finally so every exit path (return/break/raise) restores it.
-            gc.freeze()
-            gc.disable()
-            try:
-                while rclpy.ok():
-                    loop_start = time.time()
-                    elapsed_time = loop_start - start_time
-                    iteration_count += 1
+            while rclpy.ok():
+                loop_start = time.time()
+                elapsed_time = loop_start - start_time
+                iteration_count += 1
 
-                    # Check for cancellation
-                    if self._cancel_requested.is_set():
-                        self.get_logger().info("Behavior execution canceled")
+                # Check for cancellation
+                if self._cancel_requested.is_set():
+                    self.get_logger().info("Behavior execution canceled")
+                    self._stop_robot()
+                    if end_pose:
+                        self.call_arm_goto_service(end_pose, end_pose_time)
+                    return "CANCELLED", "User requested cancellation"
+
+                # Check if duration completed (moved earlier to prevent infinite loop)
+                if elapsed_time >= duration:
+                    self.get_logger().info(f"Behavior timeout reached after {elapsed_time:.2f} seconds")
+                    break
+
+                progress = self._run_inference_once()
+
+                # Check if inference failed due to missing sensor data
+                if progress is None:
+                    # Check if it's due to missing sensors
+                    if not self._check_sensor_availability():
+                        self.get_logger().error("Required sensors became unavailable during execution")
                         self._stop_robot()
-                        if end_pose:
-                            self.call_arm_goto_service(end_pose, end_pose_time)
-                        return "CANCELLED", "User requested cancellation"
-
-                    # Check if duration completed (moved earlier to prevent infinite loop)
-                    if elapsed_time >= duration:
-                        self.get_logger().info(f"Behavior timeout reached after {elapsed_time:.2f} seconds")
+                        return "FAILURE", "Required sensors became unavailable during execution"
+                    # If sensors are available but inference still failed, continue
+                    # but still check timeout and send feedback
+                else:
+                    # Check for early termination based on progress metric
+                    if progress > progress_threshold:
+                        early_termination = True
+                        self.get_logger().info(
+                            f"Early termination triggered! Progress: {progress:.4f} > {progress_threshold}"
+                        )
                         break
 
-                    progress = self._run_inference_once()
+                # Send feedback
+                remaining_time = max(0.0, duration - elapsed_time)
+                feedback_msg = ExecuteBehavior.Feedback()
+                feedback_msg.elapsed_time = float(elapsed_time)
+                feedback_msg.remaining_time = float(remaining_time)
+                feedback_msg.status = f"Executing {behavior_name} ({skill_dir})"
+                goal_handle.publish_feedback(feedback_msg)
 
-                    # Check if inference failed due to missing sensor data
-                    if progress is None:
-                        # Check if it's due to missing sensors
-                        if not self._check_sensor_availability():
-                            self.get_logger().error("Required sensors became unavailable during execution")
-                            self._stop_robot()
-                            return "FAILURE", "Required sensors became unavailable during execution"
-                        # If sensors are available but inference still failed, continue
-                        # but still check timeout and send feedback
-                    else:
-                        # Check for early termination based on progress metric
-                        if progress > progress_threshold:
-                            early_termination = True
-                            self.get_logger().info(
-                                f"Early termination triggered! Progress: {progress:.4f} > {progress_threshold}"
-                            )
-                            break
-
-                    # Send feedback
-                    remaining_time = max(0.0, duration - elapsed_time)
-                    feedback_msg = ExecuteBehavior.Feedback()
-                    feedback_msg.elapsed_time = float(elapsed_time)
-                    feedback_msg.remaining_time = float(remaining_time)
-                    feedback_msg.status = f"Executing {behavior_name} ({skill_dir})"
-                    goal_handle.publish_feedback(feedback_msg)
-
-                    # Maintain loop rate
-                    sleep_time = period - (time.time() - loop_start)
-                    if sleep_time > 0:
-                        time.sleep(sleep_time)
-            finally:
-                gc.enable()
+                # Maintain loop rate
+                sleep_time = period - (time.time() - loop_start)
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
 
             # Stop robot and move to end pose
             self._stop_robot()

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -872,7 +872,9 @@ class ManipulationServer(Node):
         # landscape frame (torch.einsum has no per-call optimize flag).
         cols = torch.einsum("jkc,kl->jlc", src, col)
         resized = torch.einsum("ij,jlc->ilc", row, cols)
-        return resized.permute(2, 0, 1) / 255.0
+        # Round to uint8 before normalizing: cv2.resize returns a uint8 image, so training
+        # saw integer-quantized pixels. Matmuls stay in float, so round here to match.
+        return resized.round().permute(2, 0, 1) / 255.0
 
     def _run_inference_once(self):
         """Run one inference step and publish its commands.

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -950,25 +950,40 @@ class ManipulationServer(Node):
             return None
 
     def _publish_inference_profile(self, t0, t1, t_sel, t2, t3, engine_ran, engine_ms, quality=None):
-        """Publish one inference step's timing breakdown (ms) as JSON for the Profiling page."""
+        """Publish one inference step's timing breakdown (ms) as JSON for the Profiling page.
+
+        Non-finite values are coerced to null: a diverging policy emits NaN/Inf actions,
+        which turn the derived jerk/progress fields non-finite. json.dumps would then write
+        a bare `NaN` token (invalid JSON), and the page's JSON.parse would reject the whole
+        sample — blanking the profiler exactly when divergence is most worth seeing.
+        allow_nan=False is a tripwire for any field we missed; the publish is isolated so a
+        serialization error can never break the live inference path.
+        """
         self._inference_seq += 1
+
+        def fin(v):
+            return v if math.isfinite(v) else None
+
         payload = {
             "seq": self._inference_seq,
             "t": time.time(),
-            "preprocess_ms": (t1 - t0) * 1000.0,
-            "inference_ms": (t2 - t1) * 1000.0,
-            "engine_ms": engine_ms,
-            "transfer_ms": (t2 - t_sel) * 1000.0,
-            "postprocess_ms": (t3 - t2) * 1000.0,
-            "total_ms": (t3 - t0) * 1000.0,
+            "preprocess_ms": fin((t1 - t0) * 1000.0),
+            "inference_ms": fin((t2 - t1) * 1000.0),
+            "engine_ms": fin(engine_ms),
+            "transfer_ms": fin((t2 - t_sel) * 1000.0),
+            "postprocess_ms": fin((t3 - t2) * 1000.0),
+            "total_ms": fin((t3 - t0) * 1000.0),
             "engine_ran": bool(engine_ran),
-            "period_ms": 1000.0 / self.inference_hz,
+            "period_ms": fin(1000.0 / self.inference_hz),
         }
         if quality:
-            payload.update(quality)
-        msg = String()
-        msg.data = json.dumps(payload)
-        self.inference_profile_pub.publish(msg)
+            payload.update({k: fin(v) for k, v in quality.items()})
+        try:
+            msg = String()
+            msg.data = json.dumps(payload, allow_nan=False)
+            self.inference_profile_pub.publish(msg)
+        except (ValueError, TypeError) as e:
+            self.get_logger().warning(f"Skipping inference profile sample: {e}")
 
     def _publish_arm(self, positions):
         """Publish a single absolute joint-position command (first 6 joints)."""

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -3092,3 +3092,207 @@ button {
     transition: none !important;
   }
 }
+
+/* ---- profiling page ----------------------------------------------------- */
+/* Record-and-graph view for ACT inference timing. Inherits .page-head /
+   .page-title from the shared header. */
+
+.profiling {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+.prof-sub {
+  align-self: center;
+}
+
+.prof-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.prof-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+.prof-live[data-state="live"] .prof-live-dot {
+  background: var(--ok);
+}
+.prof-live[data-state="rec"] .prof-live-dot {
+  background: var(--danger);
+  animation: prof-pulse 1.2s ease-in-out infinite;
+}
+@keyframes prof-pulse {
+  50% { opacity: 0.25; }
+}
+
+.prof-btn {
+  padding: 7px 14px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 8px;
+  color: var(--text);
+  background: var(--panel);
+  font-size: 12px;
+}
+.prof-btn:hover {
+  border-color: var(--accent-dim);
+}
+.prof-btn-rec.active {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.prof-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px 20px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.prof-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 10px;
+}
+.prof-stat {
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: var(--panel);
+}
+.prof-stat.warn {
+  border-color: var(--danger);
+}
+.prof-stat-label {
+  margin-bottom: 6px;
+}
+.prof-stat-value {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.1;
+}
+.prof-stat.warn .prof-stat-value {
+  color: var(--danger);
+}
+.prof-stat-foot {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.prof-charts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.prof-chart-card {
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  padding: 14px 16px 16px;
+  background: var(--panel);
+  min-width: 0;
+}
+.prof-chart-card:first-child {
+  grid-column: 1 / -1;
+}
+.prof-chart-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.prof-chart-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+.prof-chart-body {
+  min-height: 120px;
+}
+
+.prof-svg {
+  width: 100%;
+  height: 200px;
+  display: block;
+  border-bottom: 1px solid var(--hairline);
+}
+.prof-axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-size: 10px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+}
+.prof-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.prof-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.prof-legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.prof-bar-row {
+  display: grid;
+  grid-template-columns: 120px 1fr 70px;
+  align-items: center;
+  gap: 12px;
+  margin: 10px 0;
+}
+.prof-bar-name {
+  font-size: 12px;
+  color: var(--text);
+}
+.prof-bar-track {
+  height: 14px;
+  border-radius: 4px;
+  background: var(--hairline);
+  overflow: hidden;
+}
+.prof-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.2s ease;
+}
+.prof-bar-val {
+  text-align: right;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.prof-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  color: var(--muted);
+}
+.prof-hint {
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .prof-charts {
+    grid-template-columns: 1fr;
+  }
+}

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -15,6 +15,10 @@ export const HEAD_CURRENT_POSITION_TOPIC = "/mars/head/current_position";
 
 export const TTS_TOPIC = "/brain/tts";
 
+// Per-step ACT inference timing breakdown (std_msgs/String carrying JSON), published
+// by the manipulation server while a learned behavior runs. Drives the Profiling page.
+export const INFERENCE_PROFILE_TOPIC = "/brain/manipulation/inference_profile";
+
 export const BATTERY_STATE_TOPIC = "/battery_state";
 // std_msgs/String carrying JSON (RobotInfo).
 export const ROBOT_INFO_TOPIC = "/robot/info";

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -56,11 +56,14 @@ function buildView(root) {
 
   const recordBtn = document.createElement("button");
   recordBtn.className = "prof-btn prof-btn-rec";
+  const exportBtn = document.createElement("button");
+  exportBtn.className = "prof-btn";
+  exportBtn.textContent = "Export JSON";
   const clearBtn = document.createElement("button");
   clearBtn.className = "prof-btn";
   clearBtn.textContent = "Clear";
 
-  head.append(title, sub, live, spacer, recordBtn, clearBtn);
+  head.append(title, sub, live, spacer, recordBtn, exportBtn, clearBtn);
 
   // ---- body ---------------------------------------------------------------
   const body = document.createElement("div");
@@ -98,6 +101,7 @@ function buildView(root) {
     samples = [];
     dirty = true;
   });
+  exportBtn.addEventListener("click", () => exportJson(samples, exportBtn));
   syncRecordBtn();
 
   // ---- subscription -------------------------------------------------------
@@ -156,6 +160,80 @@ function setLive(live, flowing, recording) {
   text.textContent = state === "idle" ? "no signal" : state === "rec" ? "recording" : "receiving";
 }
 
+// ---- export ---------------------------------------------------------------
+
+/**
+ * Build a self-describing JSON profile and hand it off — copied to the clipboard
+ * for pasting into an LLM, with a file download as fallback. All times in ms.
+ * @param {Sample[]} samples
+ * @param {HTMLButtonElement} btn
+ */
+async function exportJson(samples, btn) {
+  if (!samples.length) return flashBtn(btn, "No data", "Export JSON");
+  const st = computeStats(samples);
+  const r = (x, d = 2) => Math.round(x * 10 ** d) / 10 ** d;
+  const profile = {
+    generated_at: new Date().toISOString(),
+    source: "Innate webapp · ACT inference profiler",
+    topic: INFERENCE_PROFILE_TOPIC,
+    schema:
+      "ACT policy inference timing. All values in milliseconds unless noted. " +
+      "budget_ms is the inference period target (1000/target_hz). breakdown_ms holds " +
+      "per-step means: preprocess (image resize/normalize/to-GPU), inference " +
+      "(model forward + GPU→CPU sync), postprocess (command publish). model_inference_ms " +
+      "covers only steps where the policy actually ran the engine (others reuse a queued " +
+      "action chunk). samples is the raw per-step record.",
+    sample_count: st.sampleCount,
+    budget_ms: r(st.budgetMs),
+    summary: {
+      effective_hz: r(st.effectiveHz),
+      over_budget_pct: r(st.overBudgetPct, 1),
+      headroom_ms: r(st.headroomMs),
+      total_ms: { mean: r(st.total.mean), p50: r(st.total.p50), p95: r(st.total.p95), p99: r(st.total.p99), max: r(st.total.max) },
+      model_inference_ms: { count: st.model.count, mean: r(st.model.mean), p95: r(st.model.p95) },
+      breakdown_ms: { preprocess: r(st.breakdown.preprocess), inference: r(st.breakdown.inference), postprocess: r(st.breakdown.postprocess) },
+    },
+    samples: samples.map((s) => ({
+      seq: s.seq,
+      t: s.t,
+      preprocess_ms: r(s.preprocess_ms, 3),
+      inference_ms: r(s.inference_ms, 3),
+      postprocess_ms: r(s.postprocess_ms, 3),
+      total_ms: r(s.total_ms, 3),
+      engine_ran: s.engine_ran,
+    })),
+  };
+
+  const text = JSON.stringify(profile, null, 2);
+  try {
+    await navigator.clipboard.writeText(text);
+    flashBtn(btn, "Copied ✓", "Export JSON");
+  } catch {
+    downloadText(text, `act-profile-${st.sampleCount}steps.json`);
+    flashBtn(btn, "Downloaded", "Export JSON");
+  }
+}
+
+/** @param {HTMLButtonElement} btn @param {string} msg @param {string} restore */
+function flashBtn(btn, msg, restore) {
+  btn.textContent = msg;
+  btn.disabled = true;
+  setTimeout(() => {
+    btn.textContent = restore;
+    btn.disabled = false;
+  }, 1400);
+}
+
+/** @param {string} text @param {string} filename */
+function downloadText(text, filename) {
+  const url = URL.createObjectURL(new Blob([text], { type: "application/json" }));
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 // ---- rendering ------------------------------------------------------------
 
 /**
@@ -172,27 +250,53 @@ function render(samples, statsRow, tsCard, histCard, breakdownCard) {
   renderBreakdown(samples, breakdownCard.body);
 }
 
-/** @param {Sample[]} samples @param {HTMLElement} host */
-function renderStats(samples, host) {
-  host.replaceChildren();
+/**
+ * Aggregate the recorded samples into the numbers the page shows and exports.
+ * @param {Sample[]} samples
+ */
+function computeStats(samples) {
   const n = samples.length;
   const total = samples.map((s) => s.total_ms);
   const engine = samples.filter((s) => s.engine_ran).map((s) => s.inference_ms);
   const period = n ? samples[n - 1].period_ms : 40;
-
   const overBudget = total.filter((v) => v > period).length;
-  const hz = effectiveHz(samples);
   const p95 = percentile(total, 95);
+  return {
+    sampleCount: n,
+    budgetMs: period,
+    effectiveHz: effectiveHz(samples),
+    overBudgetPct: n ? (100 * overBudget) / n : 0,
+    headroomMs: period - p95,
+    total: {
+      mean: mean(total),
+      p50: percentile(total, 50),
+      p95,
+      p99: percentile(total, 99),
+      max: total.length ? Math.max(...total) : 0,
+    },
+    model: { count: engine.length, mean: mean(engine), p95: percentile(engine, 95) },
+    breakdown: {
+      preprocess: mean(samples.map((s) => s.preprocess_ms)),
+      inference: mean(samples.map((s) => s.inference_ms)),
+      postprocess: mean(samples.map((s) => s.postprocess_ms)),
+    },
+  };
+}
 
+/** @param {Sample[]} samples @param {HTMLElement} host */
+function renderStats(samples, host) {
+  host.replaceChildren();
+  const n = samples.length;
+  const st = computeStats(samples);
   const cards = [
     stat("samples", n ? String(n) : "—", "recorded steps"),
-    stat("effective rate", n ? `${hz.toFixed(1)} Hz` : "—", `budget ${period.toFixed(0)} ms`),
-    stat("total p50", fmtMs(percentile(total, 50)), "median step"),
-    stat("total p95", fmtMs(p95), "95th pct"),
-    stat("total p99", fmtMs(percentile(total, 99)), "99th pct"),
-    stat("model p95", fmtMs(percentile(engine, 95)), `${engine.length} engine runs`),
-    stat("over budget", n ? `${((100 * overBudget) / n).toFixed(0)}%` : "—", `> ${period.toFixed(0)} ms`),
-    stat("headroom", n ? fmtMs(period - p95) : "—", "budget − p95", period - p95 < 0),
+    stat("effective rate", n ? `${st.effectiveHz.toFixed(1)} Hz` : "—", `budget ${st.budgetMs.toFixed(0)} ms`),
+    stat("total p50", fmtMs(st.total.p50), "median step"),
+    stat("total p95", fmtMs(st.total.p95), "95th pct"),
+    stat("total p99", fmtMs(st.total.p99), "99th pct"),
+    stat("model p95", fmtMs(st.model.p95), `${st.model.count} engine runs`),
+    stat("over budget", n ? `${st.overBudgetPct.toFixed(0)}%` : "—", `> ${st.budgetMs.toFixed(0)} ms`),
+    stat("headroom", n ? fmtMs(st.headroomMs) : "—", "budget − p95", st.headroomMs < 0),
   ];
   host.append(...cards);
 }

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -23,7 +23,8 @@ const MAX_PLOT_POINTS = 400; // timeseries window; stats use the full record
 /**
  * @typedef {{ seq:number, t:number, preprocess_ms:number, inference_ms:number,
  *   engine_ms:number, transfer_ms:number, postprocess_ms:number, total_ms:number,
- *   engine_ran:boolean, period_ms:number }} Sample
+ *   engine_ran:boolean, period_ms:number, progress?:number, disagreement?:number,
+ *   arm_jerk?:number, base_jerk?:number }} Sample
  */
 
 /**
@@ -78,7 +79,16 @@ function buildView(root) {
   const tsCard = chartCard("Total step latency vs 25 Hz budget", "ms over recorded steps");
   const histCard = chartCard("Model inference time", "engine-run steps only");
   const breakdownCard = chartCard("Average per-step breakdown", "where each step spends time");
-  charts.append(tsCard.card, histCard.card, breakdownCard.card);
+  // Behavior quality: how well / how confident the policy is, vs just how fast.
+  const progressCard = chartCard("Progress", "policy's learned progress head (action[8])");
+  const disagreementCard = chartCard("Ensemble disagreement", "uncertainty — spikes precede failures");
+  charts.append(
+    tsCard.card,
+    histCard.card,
+    breakdownCard.card,
+    progressCard.card,
+    disagreementCard.card,
+  );
 
   const hint = document.createElement("p");
   hint.className = "prof-hint microlabel";
@@ -124,12 +134,12 @@ function buildView(root) {
     const flowing = lastMsgAt > 0 && sinceMsg < 500;
     setLive(live, flowing, recording);
     if (dirty) {
-      render(samples, statsRow, tsCard, histCard, breakdownCard);
+      render(samples, statsRow, tsCard, histCard, breakdownCard, progressCard, disagreementCard);
       dirty = false;
     }
   }, 140);
 
-  render(samples, statsRow, tsCard, histCard, breakdownCard);
+  render(samples, statsRow, tsCard, histCard, breakdownCard, progressCard, disagreementCard);
 
   return {
     destroy() {
@@ -173,6 +183,7 @@ async function exportJson(samples, btn) {
   if (!samples.length) return flashBtn(btn, "No data", "Export JSON");
   const st = computeStats(samples);
   const r = (x, d = 2) => Math.round(x * 10 ** d) / 10 ** d;
+  const rn = (x, d = 2) => (x == null ? null : r(x, d)); // null-safe (quality may be absent)
   const profile = {
     generated_at: new Date().toISOString(),
     source: "Innate webapp · ACT inference profiler",
@@ -184,7 +195,10 @@ async function exportJson(samples, btn) {
       "engine (pure GPU model forward, CUDA-event measured), overhead (input copies + " +
       "temporal-ensemble + Python, = inference − engine − transfer), transfer (final GPU→CPU " +
       "copy), postprocess (command publish). model_inference_ms is the full select_action+copy " +
-      "for engine-run steps; engine_forward_ms is just the GPU forward. samples is the raw record.",
+      "for engine-run steps; engine_forward_ms is just the GPU forward. behavior_quality holds " +
+      "policy signals (not timing): progress (learned progress head action[8]), disagreement " +
+      "(ensemble uncertainty — weighted std across overlapping chunk predictions; spikes precede " +
+      "failures/OOD), arm_jerk/base_jerk (per-step ‖Δcommand‖, lower=smoother). samples is the raw record.",
     sample_count: st.sampleCount,
     budget_ms: r(st.budgetMs),
     summary: {
@@ -201,6 +215,13 @@ async function exportJson(samples, btn) {
         transfer: r(st.breakdown.transfer),
         postprocess: r(st.breakdown.postprocess),
       },
+      behavior_quality: {
+        progress_last: rn(st.quality.progressLast, 4),
+        disagreement_mean: rn(st.quality.disagreementMean, 4),
+        disagreement_p95: rn(st.quality.disagreementP95, 4),
+        arm_jerk_mean: rn(st.quality.armJerkMean, 4),
+        base_jerk_mean: rn(st.quality.baseJerkMean, 4),
+      },
     },
     samples: samples.map((s) => ({
       seq: s.seq,
@@ -212,6 +233,10 @@ async function exportJson(samples, btn) {
       postprocess_ms: r(s.postprocess_ms, 3),
       total_ms: r(s.total_ms, 3),
       engine_ran: s.engine_ran,
+      ...(s.progress != null ? { progress: r(s.progress, 4) } : {}),
+      ...(s.disagreement != null ? { disagreement: r(s.disagreement, 4) } : {}),
+      ...(s.arm_jerk != null ? { arm_jerk: r(s.arm_jerk, 4) } : {}),
+      ...(s.base_jerk != null ? { base_jerk: r(s.base_jerk, 4) } : {}),
     })),
   };
 
@@ -253,12 +278,56 @@ function downloadText(text, filename) {
  * @param {ReturnType<typeof chartCard>} tsCard
  * @param {ReturnType<typeof chartCard>} histCard
  * @param {ReturnType<typeof chartCard>} breakdownCard
+ * @param {ReturnType<typeof chartCard>} progressCard
+ * @param {ReturnType<typeof chartCard>} disagreementCard
  */
-function render(samples, statsRow, tsCard, histCard, breakdownCard) {
+function render(samples, statsRow, tsCard, histCard, breakdownCard, progressCard, disagreementCard) {
   renderStats(samples, statsRow);
   renderTimeseries(samples, tsCard.body);
   renderHistogram(samples, histCard.body);
   renderBreakdown(samples, breakdownCard.body);
+  renderLine(samples, progressCard.body, (s) => s.progress, "var(--ok)", { lo: 0, hi: 1 });
+  renderLine(samples, disagreementCard.body, (s) => s.disagreement, "var(--blue)", {});
+}
+
+/**
+ * Generic line chart over the recorded window for an optional per-sample scalar.
+ * @param {Sample[]} samples
+ * @param {HTMLElement} host
+ * @param {(s: Sample) => number|undefined} accessor
+ * @param {string} color
+ * @param {{lo?: number, hi?: number}} fixed  optional fixed y-range (else auto)
+ */
+function renderLine(samples, host, accessor, color, fixed) {
+  host.replaceChildren();
+  const pts = samples.slice(-MAX_PLOT_POINTS).map(accessor).filter((v) => typeof v === "number");
+  if (!pts.length) return placeholder(host, "no signal in this recording");
+
+  const lo = fixed.lo ?? Math.min(...pts);
+  const hi = fixed.hi ?? Math.max(...pts);
+  const span = hi - lo || 1;
+  const W = 1000;
+  const H = 240;
+  const svg = makeSvg(W, H);
+  svg.setAttribute("preserveAspectRatio", "none");
+
+  let d = "";
+  pts.forEach((v, i) => {
+    const x = (i / Math.max(1, pts.length - 1)) * W;
+    const y = H - ((v - lo) / span) * H;
+    d += `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)} `;
+  });
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute("d", d.trim());
+  path.setAttribute("fill", "none");
+  path.setAttribute("stroke", color);
+  path.setAttribute("stroke-width", "1.5");
+  path.setAttribute("vector-effect", "non-scaling-stroke");
+  svg.appendChild(path);
+
+  host.appendChild(svg);
+  const last = pts[pts.length - 1];
+  host.appendChild(axisLabels([hi.toFixed(2), `now ${last.toFixed(2)}`, lo.toFixed(2)]));
 }
 
 /**
@@ -279,6 +348,13 @@ function computeStats(samples) {
   const meanInfer = mean(samples.map((s) => s.inference_ms));
   const meanEngine = mean(samples.map((s) => s.engine_ms || 0));
   const meanTransfer = mean(samples.map((s) => s.transfer_ms || 0));
+  // Behavior-quality signals (present only when recorded against an ensembling policy
+  // with a progress head). num() drops missing values so stats stay meaningful.
+  const num = (key) => samples.map((s) => s[key]).filter((v) => typeof v === "number");
+  const progress = num("progress");
+  const disagree = num("disagreement");
+  const armJerk = num("arm_jerk");
+  const baseJerk = num("base_jerk");
   return {
     sampleCount: n,
     budgetMs: period,
@@ -301,6 +377,13 @@ function computeStats(samples) {
       transfer: meanTransfer,
       postprocess: mean(samples.map((s) => s.postprocess_ms)),
     },
+    quality: {
+      progressLast: progress.length ? progress[progress.length - 1] : null,
+      disagreementMean: disagree.length ? mean(disagree) : null,
+      disagreementP95: disagree.length ? percentile(disagree, 95) : null,
+      armJerkMean: armJerk.length ? mean(armJerk) : null,
+      baseJerkMean: baseJerk.length ? mean(baseJerk) : null,
+    },
   };
 }
 
@@ -320,6 +403,10 @@ function renderStats(samples, host) {
     stat("over budget", n ? `${st.overBudgetPct.toFixed(0)}%` : "—", `> ${st.budgetMs.toFixed(0)} ms`),
     stat("headroom", n ? fmtMs(st.headroomMs) : "—", "budget − p95", st.headroomMs < 0),
   ];
+  const q = st.quality;
+  const fmt = (v, d = 3) => (v == null ? "—" : v.toFixed(d));
+  if (q.armJerkMean != null) cards.push(stat("arm jerk", `${fmt(q.armJerkMean)} rad`, "mean ‖Δcmd‖ — smoothness"));
+  if (q.disagreementMean != null) cards.push(stat("uncertainty", fmt(q.disagreementMean), "mean ensemble disagreement"));
   host.append(...cards);
 }
 

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -22,7 +22,8 @@ const MAX_PLOT_POINTS = 400; // timeseries window; stats use the full record
 
 /**
  * @typedef {{ seq:number, t:number, preprocess_ms:number, inference_ms:number,
- *   postprocess_ms:number, total_ms:number, engine_ran:boolean, period_ms:number }} Sample
+ *   engine_ms:number, transfer_ms:number, postprocess_ms:number, total_ms:number,
+ *   engine_ran:boolean, period_ms:number }} Sample
  */
 
 /**
@@ -179,10 +180,11 @@ async function exportJson(samples, btn) {
     schema:
       "ACT policy inference timing. All values in milliseconds unless noted. " +
       "budget_ms is the inference period target (1000/target_hz). breakdown_ms holds " +
-      "per-step means: preprocess (image resize/normalize/to-GPU), inference " +
-      "(model forward + GPU→CPU sync), postprocess (command publish). model_inference_ms " +
-      "covers only steps where the policy actually ran the engine (others reuse a queued " +
-      "action chunk). samples is the raw per-step record.",
+      "per-step means for the pipeline stages: preprocess (image resize/normalize/to-GPU), " +
+      "engine (pure GPU model forward, CUDA-event measured), overhead (input copies + " +
+      "temporal-ensemble + Python, = inference − engine − transfer), transfer (final GPU→CPU " +
+      "copy), postprocess (command publish). model_inference_ms is the full select_action+copy " +
+      "for engine-run steps; engine_forward_ms is just the GPU forward. samples is the raw record.",
     sample_count: st.sampleCount,
     budget_ms: r(st.budgetMs),
     summary: {
@@ -191,13 +193,22 @@ async function exportJson(samples, btn) {
       headroom_ms: r(st.headroomMs),
       total_ms: { mean: r(st.total.mean), p50: r(st.total.p50), p95: r(st.total.p95), p99: r(st.total.p99), max: r(st.total.max) },
       model_inference_ms: { count: st.model.count, mean: r(st.model.mean), p95: r(st.model.p95) },
-      breakdown_ms: { preprocess: r(st.breakdown.preprocess), inference: r(st.breakdown.inference), postprocess: r(st.breakdown.postprocess) },
+      engine_forward_ms: { mean: r(st.engine.mean), p50: r(st.engine.p50), p95: r(st.engine.p95) },
+      breakdown_ms: {
+        preprocess: r(st.breakdown.preprocess),
+        engine: r(st.breakdown.engine),
+        overhead: r(st.breakdown.overhead),
+        transfer: r(st.breakdown.transfer),
+        postprocess: r(st.breakdown.postprocess),
+      },
     },
     samples: samples.map((s) => ({
       seq: s.seq,
       t: s.t,
       preprocess_ms: r(s.preprocess_ms, 3),
       inference_ms: r(s.inference_ms, 3),
+      engine_ms: r(s.engine_ms, 3),
+      transfer_ms: r(s.transfer_ms, 3),
       postprocess_ms: r(s.postprocess_ms, 3),
       total_ms: r(s.total_ms, 3),
       engine_ran: s.engine_ran,
@@ -257,10 +268,17 @@ function render(samples, statsRow, tsCard, histCard, breakdownCard) {
 function computeStats(samples) {
   const n = samples.length;
   const total = samples.map((s) => s.total_ms);
-  const engine = samples.filter((s) => s.engine_ran).map((s) => s.inference_ms);
+  const run = samples.filter((s) => s.engine_ran);
+  const inference = run.map((s) => s.inference_ms);
+  const engineFwd = run.map((s) => s.engine_ms || 0);
   const period = n ? samples[n - 1].period_ms : 40;
   const overBudget = total.filter((v) => v > period).length;
   const p95 = percentile(total, 95);
+  // Mean per-step inference splits into the pure GPU forward, the final D2H copy,
+  // and the remainder (input copies + temporal-ensemble + Python).
+  const meanInfer = mean(samples.map((s) => s.inference_ms));
+  const meanEngine = mean(samples.map((s) => s.engine_ms || 0));
+  const meanTransfer = mean(samples.map((s) => s.transfer_ms || 0));
   return {
     sampleCount: n,
     budgetMs: period,
@@ -274,10 +292,13 @@ function computeStats(samples) {
       p99: percentile(total, 99),
       max: total.length ? Math.max(...total) : 0,
     },
-    model: { count: engine.length, mean: mean(engine), p95: percentile(engine, 95) },
+    model: { count: run.length, mean: mean(inference), p95: percentile(inference, 95) },
+    engine: { mean: mean(engineFwd), p50: percentile(engineFwd, 50), p95: percentile(engineFwd, 95) },
     breakdown: {
       preprocess: mean(samples.map((s) => s.preprocess_ms)),
-      inference: mean(samples.map((s) => s.inference_ms)),
+      engine: meanEngine,
+      overhead: Math.max(0, meanInfer - meanEngine - meanTransfer),
+      transfer: meanTransfer,
       postprocess: mean(samples.map((s) => s.postprocess_ms)),
     },
   };
@@ -294,6 +315,7 @@ function renderStats(samples, host) {
     stat("total p50", fmtMs(st.total.p50), "median step"),
     stat("total p95", fmtMs(st.total.p95), "95th pct"),
     stat("total p99", fmtMs(st.total.p99), "99th pct"),
+    stat("engine p50", fmtMs(st.engine.p50), "pure GPU forward"),
     stat("model p95", fmtMs(st.model.p95), `${st.model.count} engine runs`),
     stat("over budget", n ? `${st.overBudgetPct.toFixed(0)}%` : "—", `> ${st.budgetMs.toFixed(0)} ms`),
     stat("headroom", n ? fmtMs(st.headroomMs) : "—", "budget − p95", st.headroomMs < 0),
@@ -413,15 +435,15 @@ function renderBreakdown(samples, host) {
   host.replaceChildren();
   if (!samples.length) return placeholder(host);
 
-  const pre = mean(samples.map((s) => s.preprocess_ms));
-  const inf = mean(samples.map((s) => s.inference_ms));
-  const post = mean(samples.map((s) => s.postprocess_ms));
-  const sum = pre + inf + post || 1;
+  const b = computeStats(samples).breakdown;
+  const sum = b.preprocess + b.engine + b.overhead + b.transfer + b.postprocess || 1;
 
   const rows = [
-    ["Preprocess", pre, "var(--blue)"],
-    ["Model inference", inf, "var(--accent)"],
-    ["Postprocess", post, "var(--ok)"],
+    ["Preprocess", b.preprocess, "var(--blue)"],
+    ["Model fwd (GPU)", b.engine, "var(--accent)"],
+    ["Copy + ensemble", b.overhead, "var(--accent-dim)"],
+    ["GPU → CPU copy", b.transfer, "var(--muted)"],
+    ["Postprocess", b.postprocess, "var(--ok)"],
   ];
 
   for (const [label, val, color] of rows) {

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -155,16 +155,30 @@ function buildView(root) {
   };
 }
 
+// Timing fields the page reads unguarded in computeStats; a dropped or renamed one
+// would propagate undefined/NaN into mean/percentile. Quality fields are optional and
+// filtered downstream, so they're not required here.
+const REQUIRED_NUMERIC = [
+  "seq", "t", "preprocess_ms", "inference_ms", "engine_ms",
+  "transfer_ms", "postprocess_ms", "total_ms", "period_ms",
+];
+
 /** @param {any} data @returns {Sample | null} */
 function parseSample(data) {
   if (typeof data !== "string") return null;
+  let s;
   try {
-    const s = JSON.parse(data);
-    if (typeof s.total_ms !== "number") return null;
-    return s;
+    s = JSON.parse(data);
   } catch {
     return null;
   }
+  // Reject the whole sample unless every required field is present and the right type,
+  // rather than letting a missing value silently become NaN in the stats.
+  if (typeof s.engine_ran !== "boolean") return null;
+  for (const f of REQUIRED_NUMERIC) {
+    if (typeof s[f] !== "number" || !isFinite(s[f])) return null;
+  }
+  return s;
 }
 
 /** @param {HTMLElement} live @param {boolean} flowing @param {boolean} recording */

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -12,13 +12,13 @@ import { initShell } from "../shell.js";
 import { mountPage } from "../pageMount.js";
 import { INFERENCE_PROFILE_TOPIC } from "../constants.js";
 
+const SVG_NS = "http://www.w3.org/2000/svg";
+const MAX_PLOT_POINTS = 400; // timeseries window; stats use the full record
+
 initShell("profiling", "../");
 
 const stage = /** @type {HTMLElement} */ (document.getElementById("stage"));
 mountPage(stage, "profiling", buildView);
-
-const SVG_NS = "http://www.w3.org/2000/svg";
-const MAX_PLOT_POINTS = 400; // timeseries window; stats use the full record
 
 /**
  * @typedef {{ seq:number, t:number, preprocess_ms:number, inference_ms:number,

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -13,7 +13,12 @@ import { mountPage } from "../pageMount.js";
 import { INFERENCE_PROFILE_TOPIC } from "../constants.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
-const MAX_PLOT_POINTS = 400; // timeseries window; stats use the full record
+const MAX_PLOT_POINTS = 400; // timeseries window; stats use the full retained record
+// Cap the retained record so an unattended recording can't grow without bound. At the
+// 25 Hz inference rate this is ~20 min of history — well past any real profiling session —
+// and it bounds the per-tick computeStats/histogram sort cost, not just memory. Older
+// samples roll off; stats and the export reflect the most recent MAX_SAMPLES.
+const MAX_SAMPLES = 30000;
 
 initShell("profiling", "../");
 
@@ -122,6 +127,7 @@ function buildView(root) {
     const s = parseSample(msg?.data);
     if (s) {
       samples.push(s);
+      if (samples.length > MAX_SAMPLES) samples.shift();
       dirty = true;
     }
   });
@@ -282,7 +288,7 @@ function downloadText(text, filename) {
  * @param {ReturnType<typeof chartCard>} disagreementCard
  */
 function render(samples, statsRow, tsCard, histCard, breakdownCard, progressCard, disagreementCard) {
-  // computeStats sorts the (growing) record for percentiles, so do it once per tick and
+  // computeStats sorts the retained record for percentiles, so do it once per tick and
   // share it with the views that need aggregates.
   const st = computeStats(samples);
   renderStats(st, statsRow);

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -282,12 +282,35 @@ function downloadText(text, filename) {
  * @param {ReturnType<typeof chartCard>} disagreementCard
  */
 function render(samples, statsRow, tsCard, histCard, breakdownCard, progressCard, disagreementCard) {
-  renderStats(samples, statsRow);
+  // computeStats sorts the (growing) record for percentiles, so do it once per tick and
+  // share it with the views that need aggregates.
+  const st = computeStats(samples);
+  renderStats(st, statsRow);
   renderTimeseries(samples, tsCard.body);
   renderHistogram(samples, histCard.body);
-  renderBreakdown(samples, breakdownCard.body);
+  renderBreakdown(st, breakdownCard.body);
   renderLine(samples, progressCard.body, (s) => s.progress, "var(--ok)", { lo: 0, hi: 1 });
   renderLine(samples, disagreementCard.body, (s) => s.disagreement, "var(--blue)", {});
+}
+
+/**
+ * Lazily attach a persistent scaffold to a host and reuse it across ticks, rebuilding only
+ * when `key` changes (e.g. empty <-> populated). Returns whatever `build` produced so the
+ * caller can update its nodes in place instead of recreating the subtree every render.
+ * @template T
+ * @param {HTMLElement} host
+ * @param {string} key
+ * @param {(host: HTMLElement) => T} build
+ * @returns {T}
+ */
+function scaffold(host, key, build) {
+  const h = /** @type {any} */ (host);
+  if (h.__key !== key) {
+    host.replaceChildren();
+    h.__ui = build(host);
+    h.__key = key;
+  }
+  return h.__ui;
 }
 
 /**
@@ -299,17 +322,32 @@ function render(samples, statsRow, tsCard, histCard, breakdownCard, progressCard
  * @param {{lo?: number, hi?: number}} fixed  optional fixed y-range (else auto)
  */
 function renderLine(samples, host, accessor, color, fixed) {
-  host.replaceChildren();
   const pts = samples.slice(-MAX_PLOT_POINTS).map(accessor).filter((v) => typeof v === "number");
-  if (!pts.length) return placeholder(host, "no signal in this recording");
+  if (!pts.length) {
+    scaffold(host, "empty", (h) => placeholder(h, "no signal in this recording"));
+    return;
+  }
 
   const lo = fixed.lo ?? Math.min(...pts);
   const hi = fixed.hi ?? Math.max(...pts);
   const span = hi - lo || 1;
   const W = 1000;
   const H = 240;
-  const svg = makeSvg(W, H);
-  svg.setAttribute("preserveAspectRatio", "none");
+  // Persist the svg + path + axis; only the path's `d` and the axis labels change each tick.
+  const { path, axis } = scaffold(host, "data", (h) => {
+    const svg = makeSvg(W, H);
+    svg.setAttribute("preserveAspectRatio", "none");
+    const p = document.createElementNS(SVG_NS, "path");
+    p.setAttribute("fill", "none");
+    p.setAttribute("stroke", color);
+    p.setAttribute("stroke-width", "1.5");
+    p.setAttribute("vector-effect", "non-scaling-stroke");
+    svg.appendChild(p);
+    h.appendChild(svg);
+    const ax = axisLabels(["", "", ""]);
+    h.appendChild(ax);
+    return { path: p, axis: ax };
+  });
 
   let d = "";
   pts.forEach((v, i) => {
@@ -317,17 +355,9 @@ function renderLine(samples, host, accessor, color, fixed) {
     const y = H - ((v - lo) / span) * H;
     d += `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)} `;
   });
-  const path = document.createElementNS(SVG_NS, "path");
   path.setAttribute("d", d.trim());
-  path.setAttribute("fill", "none");
-  path.setAttribute("stroke", color);
-  path.setAttribute("stroke-width", "1.5");
-  path.setAttribute("vector-effect", "non-scaling-stroke");
-  svg.appendChild(path);
-
-  host.appendChild(svg);
   const last = pts[pts.length - 1];
-  host.appendChild(axisLabels([hi.toFixed(2), `now ${last.toFixed(2)}`, lo.toFixed(2)]));
+  setAxis(axis, [hi.toFixed(2), `now ${last.toFixed(2)}`, lo.toFixed(2)]);
 }
 
 /**
@@ -387,75 +417,89 @@ function computeStats(samples) {
   };
 }
 
-/** @param {Sample[]} samples @param {HTMLElement} host */
-function renderStats(samples, host) {
-  host.replaceChildren();
-  const n = samples.length;
-  const st = computeStats(samples);
-  const cards = [
-    stat("samples", n ? String(n) : "—", "recorded steps"),
-    stat("effective rate", n ? `${st.effectiveHz.toFixed(1)} Hz` : "—", `budget ${st.budgetMs.toFixed(0)} ms`),
-    stat("total p50", fmtMs(st.total.p50), "median step"),
-    stat("total p95", fmtMs(st.total.p95), "95th pct"),
-    stat("total p99", fmtMs(st.total.p99), "99th pct"),
-    stat("engine p50", fmtMs(st.engine.p50), "pure GPU forward"),
-    stat("model p95", fmtMs(st.model.p95), `${st.model.count} engine runs`),
-    stat("over budget", n ? `${st.overBudgetPct.toFixed(0)}%` : "—", `> ${st.budgetMs.toFixed(0)} ms`),
-    stat("headroom", n ? fmtMs(st.headroomMs) : "—", "budget − p95", st.headroomMs < 0),
-  ];
+/** @param {ReturnType<typeof computeStats>} st @param {HTMLElement} host */
+function renderStats(st, host) {
+  const n = st.sampleCount;
   const q = st.quality;
   const fmt = (v, d = 3) => (v == null ? "—" : v.toFixed(d));
-  if (q.armJerkMean != null) cards.push(stat("arm jerk", `${fmt(q.armJerkMean)} rad`, "mean ‖Δcmd‖ — smoothness"));
-  if (q.disagreementMean != null) cards.push(stat("uncertainty", fmt(q.disagreementMean), "mean ensemble disagreement"));
-  host.append(...cards);
+  // Fixed-order rows; labels are stable, so build the cards once and update value/foot/warn
+  // in place each tick. The two quality cards are always present but hidden until recorded.
+  const rows = [
+    ["samples", n ? String(n) : "—", "recorded steps", false, true],
+    ["effective rate", n ? `${st.effectiveHz.toFixed(1)} Hz` : "—", `budget ${st.budgetMs.toFixed(0)} ms`, false, true],
+    ["total p50", fmtMs(st.total.p50), "median step", false, true],
+    ["total p95", fmtMs(st.total.p95), "95th pct", false, true],
+    ["total p99", fmtMs(st.total.p99), "99th pct", false, true],
+    ["engine p50", fmtMs(st.engine.p50), "pure GPU forward", false, true],
+    ["model p95", fmtMs(st.model.p95), `${st.model.count} engine runs`, false, true],
+    ["over budget", n ? `${st.overBudgetPct.toFixed(0)}%` : "—", `> ${st.budgetMs.toFixed(0)} ms`, false, true],
+    ["headroom", n ? fmtMs(st.headroomMs) : "—", "budget − p95", st.headroomMs < 0, true],
+    ["arm jerk", `${fmt(q.armJerkMean)} rad`, "mean ‖Δcmd‖ — smoothness", false, q.armJerkMean != null],
+    ["uncertainty", fmt(q.disagreementMean), "mean ensemble disagreement", false, q.disagreementMean != null],
+  ];
+  const cards = scaffold(host, "stats", (h) => rows.map((r) => stat(/** @type {string} */ (r[0]), h)));
+  rows.forEach((r, i) => {
+    const c = cards[i];
+    c.value.textContent = /** @type {string} */ (r[1]);
+    c.foot.textContent = /** @type {string} */ (r[2]);
+    c.card.classList.toggle("warn", !!r[3]);
+    c.card.hidden = !r[4];
+  });
 }
 
 /**
- * @param {string} label @param {string} value @param {string} foot @param {boolean} [warn]
+ * Build one stat card with a fixed label; value/foot are filled in by the caller each tick.
+ * @param {string} label @param {HTMLElement} host
  */
-function stat(label, value, foot, warn = false) {
+function stat(label, host) {
   const card = document.createElement("div");
-  card.className = "prof-stat" + (warn ? " warn" : "");
+  card.className = "prof-stat";
   const l = document.createElement("div");
   l.className = "prof-stat-label microlabel";
   l.textContent = label;
-  const v = document.createElement("div");
-  v.className = "prof-stat-value mono";
-  v.textContent = value;
-  const f = document.createElement("div");
-  f.className = "prof-stat-foot";
-  f.textContent = foot;
-  card.append(l, v, f);
-  return card;
+  const value = document.createElement("div");
+  value.className = "prof-stat-value mono";
+  const foot = document.createElement("div");
+  foot.className = "prof-stat-foot";
+  card.append(l, value, foot);
+  host.appendChild(card);
+  return { card, value, foot };
 }
 
 /** @param {Sample[]} samples @param {HTMLElement} host */
 function renderTimeseries(samples, host) {
-  host.replaceChildren();
-  if (!samples.length) return placeholder(host);
+  if (!samples.length) {
+    scaffold(host, "empty", (h) => placeholder(h));
+    return;
+  }
 
   const pts = samples.slice(-MAX_PLOT_POINTS);
   const period = pts[pts.length - 1].period_ms;
   const totals = pts.map((s) => s.total_ms);
   const max = Math.max(period, ...totals) * 1.1;
-
   const W = 1000;
   const H = 240;
-  const svg = makeSvg(W, H);
-  svg.setAttribute("preserveAspectRatio", "none");
 
-  // budget line
+  const { svg, axis } = scaffold(host, "data", (h) => {
+    const el = makeSvg(W, H);
+    el.setAttribute("preserveAspectRatio", "none");
+    h.appendChild(el);
+    const ax = axisLabels(["", "", ""]);
+    h.appendChild(ax);
+    h.appendChild(legend([["var(--accent)", "total step"], ["var(--danger)", "budget"], ["var(--accent-dim)", "model ran"]]));
+    return { svg: el, axis: ax };
+  });
+
+  // The plotted geometry changes every tick (window scrolls, model-ran marker count varies),
+  // so redraw the svg's interior; the card, axis, and legend persist across ticks.
+  svg.replaceChildren();
   const by = H - (period / max) * H;
-  svg.appendChild(hline(by, W, "var(--danger)", "4 4"));
-
-  // model-ran markers (faint) so the chunk cadence is visible
+  svg.appendChild(hline(by, W, "var(--danger)", "4 4")); // budget line
   pts.forEach((s, i) => {
-    if (!s.engine_ran) return;
+    if (!s.engine_ran) return; // model-ran markers (faint) so the chunk cadence is visible
     const x = (i / Math.max(1, pts.length - 1)) * W;
     svg.appendChild(vline(x, H, "var(--accent-faint)"));
   });
-
-  // total line
   let d = "";
   pts.forEach((s, i) => {
     const x = (i / Math.max(1, pts.length - 1)) * W;
@@ -470,16 +514,16 @@ function renderTimeseries(samples, host) {
   path.setAttribute("vector-effect", "non-scaling-stroke");
   svg.appendChild(path);
 
-  host.appendChild(svg);
-  host.appendChild(axisLabels([fmtMs(max, 0), `budget ${period.toFixed(0)} ms`, "0"]));
-  host.appendChild(legend([["var(--accent)", "total step"], ["var(--danger)", "budget"], ["var(--accent-dim)", "model ran"]]));
+  setAxis(axis, [fmtMs(max, 0), `budget ${period.toFixed(0)} ms`, "0"]);
 }
 
 /** @param {Sample[]} samples @param {HTMLElement} host */
 function renderHistogram(samples, host) {
-  host.replaceChildren();
   const vals = samples.filter((s) => s.engine_ran).map((s) => s.inference_ms);
-  if (!vals.length) return placeholder(host, "no engine-run steps yet");
+  if (!vals.length) {
+    scaffold(host, "empty", (h) => placeholder(h, "no engine-run steps yet"));
+    return;
+  }
 
   const min = Math.min(...vals);
   const max = Math.max(...vals);
@@ -494,64 +538,83 @@ function renderHistogram(samples, host) {
 
   const W = 1000;
   const H = 240;
-  const svg = makeSvg(W, H);
-  const bw = W / bins;
-  counts.forEach((c, i) => {
-    const h = (c / peak) * (H - 4);
-    const rect = document.createElementNS(SVG_NS, "rect");
-    rect.setAttribute("x", (i * bw + 1).toFixed(1));
-    rect.setAttribute("y", (H - h).toFixed(1));
-    rect.setAttribute("width", (bw - 2).toFixed(1));
-    rect.setAttribute("height", h.toFixed(1));
-    rect.setAttribute("fill", "var(--accent)");
-    rect.setAttribute("opacity", "0.85");
-    svg.appendChild(rect);
+  // bin count and x/width are fixed, so build the bars + median marker once and only update
+  // each bar's height and the median's x-position per tick.
+  const { rects, median, axis } = scaffold(host, "data", (h) => {
+    const svg = makeSvg(W, H);
+    const bw = W / bins;
+    const bars = counts.map((_, i) => {
+      const rect = document.createElementNS(SVG_NS, "rect");
+      rect.setAttribute("x", (i * bw + 1).toFixed(1));
+      rect.setAttribute("width", (bw - 2).toFixed(1));
+      rect.setAttribute("fill", "var(--accent)");
+      rect.setAttribute("opacity", "0.85");
+      svg.appendChild(rect);
+      return rect;
+    });
+    const med = vline(0, H, "var(--text)", "1.5");
+    svg.appendChild(med);
+    h.appendChild(svg);
+    const ax = axisLabels(["", "", ""]);
+    h.appendChild(ax);
+    return { rects: bars, median: med, axis: ax };
   });
 
-  // median marker
+  rects.forEach((rect, i) => {
+    const h = (counts[i] / peak) * (H - 4);
+    rect.setAttribute("y", (H - h).toFixed(1));
+    rect.setAttribute("height", h.toFixed(1));
+  });
   const med = percentile(vals, 50);
-  const mx = ((med - min) / span) * W;
-  svg.appendChild(vline(mx, H, "var(--text)", "1.5"));
-
-  host.appendChild(svg);
-  host.appendChild(axisLabels([`${min.toFixed(1)} ms`, `median ${med.toFixed(1)} ms`, `${max.toFixed(1)} ms`]));
+  const mx = (((med - min) / span) * W).toFixed(1);
+  median.setAttribute("x1", mx);
+  median.setAttribute("x2", mx);
+  setAxis(axis, [`${min.toFixed(1)} ms`, `median ${med.toFixed(1)} ms`, `${max.toFixed(1)} ms`]);
 }
 
-/** @param {Sample[]} samples @param {HTMLElement} host */
-function renderBreakdown(samples, host) {
-  host.replaceChildren();
-  if (!samples.length) return placeholder(host);
+const BREAKDOWN_ROWS = [
+  ["Preprocess", "var(--blue)"],
+  ["Model fwd (GPU)", "var(--accent)"],
+  ["Copy + ensemble", "var(--accent-dim)"],
+  ["GPU → CPU copy", "var(--muted)"],
+  ["Postprocess", "var(--ok)"],
+];
 
-  const b = computeStats(samples).breakdown;
-  const sum = b.preprocess + b.engine + b.overhead + b.transfer + b.postprocess || 1;
-
-  const rows = [
-    ["Preprocess", b.preprocess, "var(--blue)"],
-    ["Model fwd (GPU)", b.engine, "var(--accent)"],
-    ["Copy + ensemble", b.overhead, "var(--accent-dim)"],
-    ["GPU → CPU copy", b.transfer, "var(--muted)"],
-    ["Postprocess", b.postprocess, "var(--ok)"],
-  ];
-
-  for (const [label, val, color] of rows) {
-    const row = document.createElement("div");
-    row.className = "prof-bar-row";
-    const name = document.createElement("span");
-    name.className = "prof-bar-name";
-    name.textContent = /** @type {string} */ (label);
-    const track = document.createElement("div");
-    track.className = "prof-bar-track";
-    const fill = document.createElement("div");
-    fill.className = "prof-bar-fill";
-    fill.style.width = `${(/** @type {number} */ (val) / sum) * 100}%`;
-    fill.style.background = /** @type {string} */ (color);
-    track.appendChild(fill);
-    const v = document.createElement("span");
-    v.className = "prof-bar-val mono";
-    v.textContent = fmtMs(/** @type {number} */ (val));
-    row.append(name, track, v);
-    host.appendChild(row);
+/** @param {ReturnType<typeof computeStats>} st @param {HTMLElement} host */
+function renderBreakdown(st, host) {
+  if (!st.sampleCount) {
+    scaffold(host, "empty", (h) => placeholder(h));
+    return;
   }
+  const b = st.breakdown;
+  const vals = [b.preprocess, b.engine, b.overhead, b.transfer, b.postprocess];
+  const sum = vals.reduce((a, v) => a + v, 0) || 1;
+  // Fixed label/colour rows, so build them once and only nudge the fill width + value text.
+  const bars = scaffold(host, "data", (h) => BREAKDOWN_ROWS.map(([label, color]) => breakdownBar(label, color, h)));
+  bars.forEach((bar, i) => {
+    bar.fill.style.width = `${(vals[i] / sum) * 100}%`;
+    bar.val.textContent = fmtMs(vals[i]);
+  });
+}
+
+/** @param {string} label @param {string} color @param {HTMLElement} host */
+function breakdownBar(label, color, host) {
+  const row = document.createElement("div");
+  row.className = "prof-bar-row";
+  const name = document.createElement("span");
+  name.className = "prof-bar-name";
+  name.textContent = label;
+  const track = document.createElement("div");
+  track.className = "prof-bar-track";
+  const fill = document.createElement("div");
+  fill.className = "prof-bar-fill";
+  fill.style.background = color;
+  track.appendChild(fill);
+  const val = document.createElement("span");
+  val.className = "prof-bar-val mono";
+  row.append(name, track, val);
+  host.appendChild(row);
+  return { fill, val };
 }
 
 // ---- small DOM/SVG helpers ------------------------------------------------
@@ -620,6 +683,13 @@ function axisLabels(labels) {
     wrap.appendChild(span);
   }
   return wrap;
+}
+
+/** Update an existing axisLabels row in place. @param {HTMLElement} wrap @param {string[]} labels */
+function setAxis(wrap, labels) {
+  wrap.querySelectorAll("span").forEach((span, i) => {
+    span.textContent = labels[i] ?? "";
+  });
 }
 
 /** @param {Array<[string,string]>} items color,label */

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -1,0 +1,460 @@
+// @ts-check
+// Profiling page entry — record and visualize ACT policy inference timing.
+//
+// The manipulation server publishes a per-step timing breakdown on
+// INFERENCE_PROFILE_TOPIC (std_msgs/String → JSON) while a learned behavior
+// runs. This page subscribes, lets the operator Record / Stop / Clear a window
+// of those samples, and renders live latency graphs so we can see where the
+// 25 Hz inference budget goes and whether there's headroom to improve.
+
+import { ros } from "../rosClient.js";
+import { initShell } from "../shell.js";
+import { mountPage } from "../pageMount.js";
+import { INFERENCE_PROFILE_TOPIC } from "../constants.js";
+
+initShell("profiling", "../");
+
+const stage = /** @type {HTMLElement} */ (document.getElementById("stage"));
+mountPage(stage, "profiling", buildView);
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const MAX_PLOT_POINTS = 400; // timeseries window; stats use the full record
+
+/**
+ * @typedef {{ seq:number, t:number, preprocess_ms:number, inference_ms:number,
+ *   postprocess_ms:number, total_ms:number, engine_ran:boolean, period_ms:number }} Sample
+ */
+
+/**
+ * @param {HTMLElement} root
+ * @returns {{ destroy: () => void }}
+ */
+function buildView(root) {
+  /** @type {Sample[]} */
+  let samples = [];
+  let recording = false;
+  let lastMsgAt = 0; // wall-clock of last received message, for the live dot
+  let dirty = false;
+
+  // ---- header -------------------------------------------------------------
+  const head = document.createElement("div");
+  head.className = "page-head";
+  const title = document.createElement("h1");
+  title.className = "page-title";
+  title.textContent = "Profiling";
+
+  const sub = document.createElement("span");
+  sub.className = "prof-sub microlabel";
+  sub.textContent = "ACT inference";
+
+  const live = document.createElement("span");
+  live.className = "prof-live";
+  live.innerHTML = '<span class="prof-live-dot"></span><span class="prof-live-text">no signal</span>';
+
+  const spacer = document.createElement("div");
+  spacer.style.flex = "1";
+
+  const recordBtn = document.createElement("button");
+  recordBtn.className = "prof-btn prof-btn-rec";
+  const clearBtn = document.createElement("button");
+  clearBtn.className = "prof-btn";
+  clearBtn.textContent = "Clear";
+
+  head.append(title, sub, live, spacer, recordBtn, clearBtn);
+
+  // ---- body ---------------------------------------------------------------
+  const body = document.createElement("div");
+  body.className = "prof-body";
+
+  const statsRow = document.createElement("div");
+  statsRow.className = "prof-stats";
+
+  const charts = document.createElement("div");
+  charts.className = "prof-charts";
+  const tsCard = chartCard("Total step latency vs 25 Hz budget", "ms over recorded steps");
+  const histCard = chartCard("Model inference time", "engine-run steps only");
+  const breakdownCard = chartCard("Average per-step breakdown", "where each step spends time");
+  charts.append(tsCard.card, histCard.card, breakdownCard.card);
+
+  const hint = document.createElement("p");
+  hint.className = "prof-hint microlabel";
+  hint.textContent =
+    "Run a learned behavior, then press Record. Data only flows while a policy is executing.";
+
+  body.append(statsRow, charts, hint);
+  root.append(head, body);
+
+  // ---- controls -----------------------------------------------------------
+  function syncRecordBtn() {
+    recordBtn.textContent = recording ? "■ Stop" : "● Record";
+    recordBtn.classList.toggle("active", recording);
+  }
+  recordBtn.addEventListener("click", () => {
+    recording = !recording;
+    syncRecordBtn();
+    dirty = true;
+  });
+  clearBtn.addEventListener("click", () => {
+    samples = [];
+    dirty = true;
+  });
+  syncRecordBtn();
+
+  // ---- subscription -------------------------------------------------------
+  const unsubscribe = ros.subscribe(INFERENCE_PROFILE_TOPIC, (msg) => {
+    lastMsgAt = performance.now();
+    if (!recording) return;
+    const s = parseSample(msg?.data);
+    if (s) {
+      samples.push(s);
+      dirty = true;
+    }
+  });
+
+  // ---- render loop --------------------------------------------------------
+  // Throttle to ~7 Hz: SVG re-render on every 25 Hz sample is wasteful and the
+  // eye can't read faster anyway. The live dot updates on the same tick.
+  const timer = setInterval(() => {
+    const sinceMsg = performance.now() - lastMsgAt;
+    const flowing = lastMsgAt > 0 && sinceMsg < 500;
+    setLive(live, flowing, recording);
+    if (dirty) {
+      render(samples, statsRow, tsCard, histCard, breakdownCard);
+      dirty = false;
+    }
+  }, 140);
+
+  render(samples, statsRow, tsCard, histCard, breakdownCard);
+
+  return {
+    destroy() {
+      clearInterval(timer);
+      unsubscribe();
+    },
+  };
+}
+
+/** @param {any} data @returns {Sample | null} */
+function parseSample(data) {
+  if (typeof data !== "string") return null;
+  try {
+    const s = JSON.parse(data);
+    if (typeof s.total_ms !== "number") return null;
+    return s;
+  } catch {
+    return null;
+  }
+}
+
+/** @param {HTMLElement} live @param {boolean} flowing @param {boolean} recording */
+function setLive(live, flowing, recording) {
+  const dot = live.querySelector(".prof-live-dot");
+  const text = live.querySelector(".prof-live-text");
+  if (!dot || !text) return;
+  const state = !flowing ? "idle" : recording ? "rec" : "live";
+  live.dataset.state = state;
+  text.textContent = state === "idle" ? "no signal" : state === "rec" ? "recording" : "receiving";
+}
+
+// ---- rendering ------------------------------------------------------------
+
+/**
+ * @param {Sample[]} samples
+ * @param {HTMLElement} statsRow
+ * @param {ReturnType<typeof chartCard>} tsCard
+ * @param {ReturnType<typeof chartCard>} histCard
+ * @param {ReturnType<typeof chartCard>} breakdownCard
+ */
+function render(samples, statsRow, tsCard, histCard, breakdownCard) {
+  renderStats(samples, statsRow);
+  renderTimeseries(samples, tsCard.body);
+  renderHistogram(samples, histCard.body);
+  renderBreakdown(samples, breakdownCard.body);
+}
+
+/** @param {Sample[]} samples @param {HTMLElement} host */
+function renderStats(samples, host) {
+  host.replaceChildren();
+  const n = samples.length;
+  const total = samples.map((s) => s.total_ms);
+  const engine = samples.filter((s) => s.engine_ran).map((s) => s.inference_ms);
+  const period = n ? samples[n - 1].period_ms : 40;
+
+  const overBudget = total.filter((v) => v > period).length;
+  const hz = effectiveHz(samples);
+  const p95 = percentile(total, 95);
+
+  const cards = [
+    stat("samples", n ? String(n) : "—", "recorded steps"),
+    stat("effective rate", n ? `${hz.toFixed(1)} Hz` : "—", `budget ${period.toFixed(0)} ms`),
+    stat("total p50", fmtMs(percentile(total, 50)), "median step"),
+    stat("total p95", fmtMs(p95), "95th pct"),
+    stat("total p99", fmtMs(percentile(total, 99)), "99th pct"),
+    stat("model p95", fmtMs(percentile(engine, 95)), `${engine.length} engine runs`),
+    stat("over budget", n ? `${((100 * overBudget) / n).toFixed(0)}%` : "—", `> ${period.toFixed(0)} ms`),
+    stat("headroom", n ? fmtMs(period - p95) : "—", "budget − p95", period - p95 < 0),
+  ];
+  host.append(...cards);
+}
+
+/**
+ * @param {string} label @param {string} value @param {string} foot @param {boolean} [warn]
+ */
+function stat(label, value, foot, warn = false) {
+  const card = document.createElement("div");
+  card.className = "prof-stat" + (warn ? " warn" : "");
+  const l = document.createElement("div");
+  l.className = "prof-stat-label microlabel";
+  l.textContent = label;
+  const v = document.createElement("div");
+  v.className = "prof-stat-value mono";
+  v.textContent = value;
+  const f = document.createElement("div");
+  f.className = "prof-stat-foot";
+  f.textContent = foot;
+  card.append(l, v, f);
+  return card;
+}
+
+/** @param {Sample[]} samples @param {HTMLElement} host */
+function renderTimeseries(samples, host) {
+  host.replaceChildren();
+  if (!samples.length) return placeholder(host);
+
+  const pts = samples.slice(-MAX_PLOT_POINTS);
+  const period = pts[pts.length - 1].period_ms;
+  const totals = pts.map((s) => s.total_ms);
+  const max = Math.max(period, ...totals) * 1.1;
+
+  const W = 1000;
+  const H = 240;
+  const svg = makeSvg(W, H);
+  svg.setAttribute("preserveAspectRatio", "none");
+
+  // budget line
+  const by = H - (period / max) * H;
+  svg.appendChild(hline(by, W, "var(--danger)", "4 4"));
+
+  // model-ran markers (faint) so the chunk cadence is visible
+  pts.forEach((s, i) => {
+    if (!s.engine_ran) return;
+    const x = (i / Math.max(1, pts.length - 1)) * W;
+    svg.appendChild(vline(x, H, "var(--accent-faint)"));
+  });
+
+  // total line
+  let d = "";
+  pts.forEach((s, i) => {
+    const x = (i / Math.max(1, pts.length - 1)) * W;
+    const y = H - (s.total_ms / max) * H;
+    d += `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)} `;
+  });
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute("d", d.trim());
+  path.setAttribute("fill", "none");
+  path.setAttribute("stroke", "var(--accent)");
+  path.setAttribute("stroke-width", "1.5");
+  path.setAttribute("vector-effect", "non-scaling-stroke");
+  svg.appendChild(path);
+
+  host.appendChild(svg);
+  host.appendChild(axisLabels([fmtMs(max, 0), `budget ${period.toFixed(0)} ms`, "0"]));
+  host.appendChild(legend([["var(--accent)", "total step"], ["var(--danger)", "budget"], ["var(--accent-dim)", "model ran"]]));
+}
+
+/** @param {Sample[]} samples @param {HTMLElement} host */
+function renderHistogram(samples, host) {
+  host.replaceChildren();
+  const vals = samples.filter((s) => s.engine_ran).map((s) => s.inference_ms);
+  if (!vals.length) return placeholder(host, "no engine-run steps yet");
+
+  const min = Math.min(...vals);
+  const max = Math.max(...vals);
+  const span = max - min || 1;
+  const bins = 24;
+  const counts = new Array(bins).fill(0);
+  for (const v of vals) {
+    const b = Math.min(bins - 1, Math.floor(((v - min) / span) * bins));
+    counts[b]++;
+  }
+  const peak = Math.max(...counts);
+
+  const W = 1000;
+  const H = 240;
+  const svg = makeSvg(W, H);
+  const bw = W / bins;
+  counts.forEach((c, i) => {
+    const h = (c / peak) * (H - 4);
+    const rect = document.createElementNS(SVG_NS, "rect");
+    rect.setAttribute("x", (i * bw + 1).toFixed(1));
+    rect.setAttribute("y", (H - h).toFixed(1));
+    rect.setAttribute("width", (bw - 2).toFixed(1));
+    rect.setAttribute("height", h.toFixed(1));
+    rect.setAttribute("fill", "var(--accent)");
+    rect.setAttribute("opacity", "0.85");
+    svg.appendChild(rect);
+  });
+
+  // median marker
+  const med = percentile(vals, 50);
+  const mx = ((med - min) / span) * W;
+  svg.appendChild(vline(mx, H, "var(--text)", "1.5"));
+
+  host.appendChild(svg);
+  host.appendChild(axisLabels([`${min.toFixed(1)} ms`, `median ${med.toFixed(1)} ms`, `${max.toFixed(1)} ms`]));
+}
+
+/** @param {Sample[]} samples @param {HTMLElement} host */
+function renderBreakdown(samples, host) {
+  host.replaceChildren();
+  if (!samples.length) return placeholder(host);
+
+  const pre = mean(samples.map((s) => s.preprocess_ms));
+  const inf = mean(samples.map((s) => s.inference_ms));
+  const post = mean(samples.map((s) => s.postprocess_ms));
+  const sum = pre + inf + post || 1;
+
+  const rows = [
+    ["Preprocess", pre, "var(--blue)"],
+    ["Model inference", inf, "var(--accent)"],
+    ["Postprocess", post, "var(--ok)"],
+  ];
+
+  for (const [label, val, color] of rows) {
+    const row = document.createElement("div");
+    row.className = "prof-bar-row";
+    const name = document.createElement("span");
+    name.className = "prof-bar-name";
+    name.textContent = /** @type {string} */ (label);
+    const track = document.createElement("div");
+    track.className = "prof-bar-track";
+    const fill = document.createElement("div");
+    fill.className = "prof-bar-fill";
+    fill.style.width = `${(/** @type {number} */ (val) / sum) * 100}%`;
+    fill.style.background = /** @type {string} */ (color);
+    track.appendChild(fill);
+    const v = document.createElement("span");
+    v.className = "prof-bar-val mono";
+    v.textContent = fmtMs(/** @type {number} */ (val));
+    row.append(name, track, v);
+    host.appendChild(row);
+  }
+}
+
+// ---- small DOM/SVG helpers ------------------------------------------------
+
+/** @param {string} title @param {string} foot */
+function chartCard(title, foot) {
+  const card = document.createElement("div");
+  card.className = "prof-chart-card";
+  const h = document.createElement("div");
+  h.className = "prof-chart-head";
+  const t = document.createElement("span");
+  t.className = "prof-chart-title";
+  t.textContent = title;
+  const f = document.createElement("span");
+  f.className = "prof-chart-foot microlabel";
+  f.textContent = foot;
+  h.append(t, f);
+  const bodyEl = document.createElement("div");
+  bodyEl.className = "prof-chart-body";
+  card.append(h, bodyEl);
+  return { card, body: bodyEl };
+}
+
+/** @param {number} w @param {number} h */
+function makeSvg(w, h) {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", `0 0 ${w} ${h}`);
+  svg.setAttribute("class", "prof-svg");
+  return svg;
+}
+
+/** @param {number} y @param {number} w @param {string} color @param {string} dash */
+function hline(y, w, color, dash) {
+  const l = document.createElementNS(SVG_NS, "line");
+  l.setAttribute("x1", "0");
+  l.setAttribute("x2", String(w));
+  l.setAttribute("y1", y.toFixed(1));
+  l.setAttribute("y2", y.toFixed(1));
+  l.setAttribute("stroke", color);
+  l.setAttribute("stroke-width", "1");
+  l.setAttribute("stroke-dasharray", dash);
+  l.setAttribute("vector-effect", "non-scaling-stroke");
+  return l;
+}
+
+/** @param {number} x @param {number} h @param {string} color @param {string} [w] */
+function vline(x, h, color, w = "1") {
+  const l = document.createElementNS(SVG_NS, "line");
+  l.setAttribute("x1", x.toFixed(1));
+  l.setAttribute("x2", x.toFixed(1));
+  l.setAttribute("y1", "0");
+  l.setAttribute("y2", String(h));
+  l.setAttribute("stroke", color);
+  l.setAttribute("stroke-width", w);
+  l.setAttribute("vector-effect", "non-scaling-stroke");
+  return l;
+}
+
+/** @param {string[]} labels top/mid/bottom */
+function axisLabels(labels) {
+  const wrap = document.createElement("div");
+  wrap.className = "prof-axis";
+  for (const text of labels) {
+    const span = document.createElement("span");
+    span.textContent = text;
+    wrap.appendChild(span);
+  }
+  return wrap;
+}
+
+/** @param {Array<[string,string]>} items color,label */
+function legend(items) {
+  const wrap = document.createElement("div");
+  wrap.className = "prof-legend";
+  for (const [color, label] of items) {
+    const item = document.createElement("span");
+    item.className = "prof-legend-item";
+    item.innerHTML = `<span class="prof-legend-swatch" style="background:${color}"></span>${label}`;
+    wrap.appendChild(item);
+  }
+  return wrap;
+}
+
+/** @param {HTMLElement} host @param {string} [text] */
+function placeholder(host, text = "no data — press Record while a behavior runs") {
+  const p = document.createElement("p");
+  p.className = "prof-empty microlabel";
+  p.textContent = text;
+  host.appendChild(p);
+}
+
+// ---- math -----------------------------------------------------------------
+
+/** @param {number[]} arr */
+function mean(arr) {
+  if (!arr.length) return 0;
+  return arr.reduce((a, b) => a + b, 0) / arr.length;
+}
+
+/** @param {number[]} arr @param {number} p 0-100 */
+function percentile(arr, p) {
+  if (!arr.length) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+/** @param {Sample[]} samples → steps/sec from message timestamps */
+function effectiveHz(samples) {
+  if (samples.length < 2) return 0;
+  const span = samples[samples.length - 1].t - samples[0].t;
+  return span > 0 ? (samples.length - 1) / span : 0;
+}
+
+/** @param {number} ms @param {number} [digits] */
+function fmtMs(ms, digits = 1) {
+  if (!isFinite(ms)) return "—";
+  return `${ms.toFixed(digits)} ms`;
+}

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -101,7 +101,7 @@ export const CATALOG = [
       { path: ["manipulation_server", P, "inference_hz"], label: "Inference rate", default: 25.0, type: "float", unit: "Hz", doc: "Policy inference loop rate" },
       { path: ["manipulation_server", P, "speed"], label: "Execution speed", default: 1.5, type: "float", unit: "×", doc: "Action execution speed multiplier" },
       { path: ["manipulation_server", P, "replay_base_speed_scale"], label: "Replay base speed", default: 1.0, type: "float", unit: "×", doc: "Base-speed scale for replay (1.0 = recorded speed)" },
-      { path: ["manipulation_server", P, "learned_base_speed_scale"], label: "Learned base speed", default: 1.0, type: "float", unit: "×", doc: "Base-speed de-rate for the learned policy (1.0 = full predicted speed)" },
+      { path: ["manipulation_server", P, "learned_base_speed_scale"], label: "Learned base speed", default: 1.0, type: "float", unit: "×", doc: "Base-speed scale for the learned policy (1.0 = full predicted speed)" },
       { path: ["manipulation_server", P, "n_action_steps"], label: "Replan horizon", default: 0, type: "int", doc: "Replan horizon; 0 = auto (min(40, chunk_size))" },
       { path: ["manipulation_server", P, "temporal_ensemble_coeff"], label: "Action smoothing", default: 0.01, type: "float", doc: "ACT temporal-ensemble coefficient; 0 = disabled" },
     ],

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -101,7 +101,7 @@ export const CATALOG = [
       { path: ["manipulation_server", P, "inference_hz"], label: "Inference rate", default: 25.0, type: "float", unit: "Hz", doc: "Policy inference loop rate" },
       { path: ["manipulation_server", P, "speed"], label: "Execution speed", default: 1.5, type: "float", unit: "×", doc: "Action execution speed multiplier" },
       { path: ["manipulation_server", P, "replay_base_speed_scale"], label: "Replay base speed", default: 1.0, type: "float", unit: "×", doc: "Base-speed scale for replay (1.0 = recorded speed)" },
-      { path: ["manipulation_server", P, "learned_base_speed_scale"], label: "Learned base speed", default: 0.5, type: "float", unit: "×", doc: "Base-speed de-rate for the learned policy (1.0 = full predicted speed)" },
+      { path: ["manipulation_server", P, "learned_base_speed_scale"], label: "Learned base speed", default: 1.0, type: "float", unit: "×", doc: "Base-speed de-rate for the learned policy (1.0 = full predicted speed)" },
       { path: ["manipulation_server", P, "n_action_steps"], label: "Replan horizon", default: 0, type: "int", doc: "Replan horizon; 0 = auto (min(40, chunk_size))" },
       { path: ["manipulation_server", P, "temporal_ensemble_coeff"], label: "Action smoothing", default: 0.01, type: "float", doc: "ACT temporal-ensemble coefficient; 0 = disabled" },
     ],

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -96,7 +96,7 @@ export const CATALOG = [
   },
   {
     section: "Manipulation",
-    note: "Learned-skill execution. A per-skill behavior_config still overrides these.",
+    note: "Learned-skill execution. Node-level, applied at startup (restart to apply); only n_action_steps accepts a per-skill behavior_config override.",
     knobs: [
       { path: ["manipulation_server", P, "inference_hz"], label: "Inference rate", default: 25.0, type: "float", unit: "Hz", doc: "Policy inference loop rate" },
       { path: ["manipulation_server", P, "speed"], label: "Execution speed", default: 1.5, type: "float", unit: "×", doc: "Action execution speed multiplier" },

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -35,6 +35,12 @@ const SECTIONS = [
     icon: '<polyline points="4,17.5 9.5,11.5 13.5,15 20,7"/><polyline points="15.5,7 20,7 20,11.5"/>',
   },
   {
+    key: "profiling",
+    label: "Profiling",
+    // Stopwatch motif: dial, crown, and a sweeping hand.
+    icon: '<circle cx="12" cy="13" r="7.5"/><line x1="12" y1="13" x2="15" y2="10"/><line x1="12" y1="2.5" x2="12" y2="5" /><line x1="9.5" y1="2.5" x2="14.5" y2="2.5"/>',
+  },
+  {
     key: "settings",
     label: "Settings",
     // Sliders motif: two tracks, each with a knob.

--- a/webapp/profiling/index.html
+++ b/webapp/profiling/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
+    <title>Innate · Profiling</title>
+    <link rel="icon" type="image/avif" href="../public/innate-logo.avif" />
+    <link rel="stylesheet" href="../css/app.css" />
+  </head>
+  <body>
+    <main id="stage" class="stage"></main>
+    <script type="module" src="../js/profiling/main.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Change the default **Learned base speed** scale from `0.5` to `1.0` so the learned ACT policy plays back its predicted base `cmd_vel` at full speed by default (matching the replay path).

Updated in all three places that carry the default:
- `ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py` — `declare_parameter` default (and refreshed the now-stale "half speed" comment)
- `ros2_ws/src/brain/manipulation/config/manipulation_server.yaml` — config default
- `webapp/js/settings/catalog.js` — settings UI default

A per-skill `behavior_config` still overrides this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)