### PR TITLE
Reduce WebRTC stream latency

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_cam/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(OpenCV REQUIRED)
 # Find GStreamer (for webrtc_streamer)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(TURBOJPEG REQUIRED libturbojpeg)
-pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 gstreamer-webrtc-1.0 gstreamer-sdp-1.0)
+pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 gstreamer-webrtc-1.0 gstreamer-sdp-1.0 gstreamer-rtp-1.0)
 
 # Find nlohmann_json (for webrtc_streamer and stereo_depth_estimator)
 find_package(nlohmann_json QUIET)

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -62,6 +62,9 @@ class WebRTCStreamer : public rclcpp::Node {
     // with_audio is updated to reflect whether audio actually made it into the pipeline.
     bool start_pipeline_locked(bool& with_audio);
     void teardown_pipeline_locked();
+
+    // Adds the playout-delay RTP header extension to both video tracks (caller holds the mutex).
+    void attach_playout_delay_extension();
     cv::Mat process_raw_image(const sensor_msgs::msg::Image::SharedPtr& msg, int target_width, int target_height);
     cv::Mat process_compressed_image(const sensor_msgs::msg::CompressedImage::SharedPtr& msg, int target_width,
                                      int target_height);
@@ -117,6 +120,10 @@ class WebRTCStreamer : public rclcpp::Node {
     bool enable_audio_;
     std::string audio_source_element_;
     std::string audio_capture_device_;
+
+    // Receiver de-jitter buffer bounds (ms) signalled via the playout-delay header extension.
+    guint playout_min_delay_ms_ = 0;
+    guint playout_max_delay_ms_ = 40;
 };
 
 }  // namespace mars_cam

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -85,6 +85,15 @@ def generate_launch_description():
                 "enable_audio": True,
                 "audio_source_element": "alsasrc",
                 "audio_capture_device": "sysdefault:CARD=Light",
+                # Bound the teleop receiver's de-jitter buffer (ms) via the playout-delay RTP
+                # extension. Measured effect on the LAN: once this extension advertises playout-delay
+                # support, Chrome (which already pins jitterBufferTarget=0) drops the buffer from
+                # ~75 ms to ~2 ms with no added loss. max is the effective lever — it caps how far the
+                # buffer may grow during jitter spikes, bounding worst-case latency below the 75 ms
+                # default. min is inert while the client pins target=0 (kept at 0). Raise max for
+                # smoother playout under jitter, lower it for tighter latency. Retunable via restart.
+                "playout_min_delay_ms": 0,
+                "playout_max_delay_ms": 40,
             }
         ],
         extra_arguments=[{"use_intra_process_comms": True}],

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -522,7 +522,11 @@ std::string WebRTCStreamer::build_pipeline_description(bool& with_audio) const {
         "caps=video/x-raw,format=BGR,width=640,height=480,framerate=30/1 ! "
         "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
         "videoconvert ! "
-        "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=30 ! "
+        // CBR with a small rate-control buffer stops the encoder from holding frames to
+        // smooth out the bitrate (the VBR default buffers ~6 s). ~0.5 s of buffering trades
+        // a little bitrate stability for lower glass-to-glass latency on the live link.
+        "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=30 "
+        "end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
         "rtpvp8pay pt=96 ! "
         "application/x-rtp,media=video,encoding-name=VP8,clock-rate=90000,payload=96 ! "
         "webrtc.sink_0 "
@@ -531,7 +535,11 @@ std::string WebRTCStreamer::build_pipeline_description(bool& with_audio) const {
         "caps=video/x-raw,format=BGR,width=640,height=480,framerate=15/1 ! "
         "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
         "videoconvert ! "
-        "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=30 ! "
+        // CBR with a small rate-control buffer stops the encoder from holding frames to
+        // smooth out the bitrate (the VBR default buffers ~6 s). ~0.5 s of buffering trades
+        // a little bitrate stability for lower glass-to-glass latency on the live link.
+        "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=30 "
+        "end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
         "rtpvp8pay pt=97 ! "
         "application/x-rtp,media=video,encoding-name=VP8,clock-rate=90000,payload=97 ! "
         "webrtc.sink_1";

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -522,9 +522,6 @@ std::string WebRTCStreamer::build_pipeline_description(bool& with_audio) const {
         "caps=video/x-raw,format=BGR,width=640,height=480,framerate=30/1 ! "
         "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
         "videoconvert ! "
-        // CBR with a small rate-control buffer stops the encoder from holding frames to
-        // smooth out the bitrate (the VBR default buffers ~6 s). ~0.5 s of buffering trades
-        // a little bitrate stability for lower glass-to-glass latency on the live link.
         "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=30 "
         "end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
         "rtpvp8pay pt=96 ! "
@@ -535,9 +532,6 @@ std::string WebRTCStreamer::build_pipeline_description(bool& with_audio) const {
         "caps=video/x-raw,format=BGR,width=640,height=480,framerate=15/1 ! "
         "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
         "videoconvert ! "
-        // CBR with a small rate-control buffer stops the encoder from holding frames to
-        // smooth out the bitrate (the VBR default buffers ~6 s). ~0.5 s of buffering trades
-        // a little bitrate stability for lower glass-to-glass latency on the live link.
         "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=30 "
         "end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
         "rtpvp8pay pt=97 ! "

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -1,5 +1,7 @@
 #include "mars_cam/webrtc_streamer.hpp"
 
+#include <gst/rtp/rtp.h>
+
 #include <sstream>
 #include <algorithm>
 #include <cctype>
@@ -17,6 +19,81 @@ GstWebRTCPeerConnectionState peer_connection_state(GstElement* webrtc) {
 // has stayed down this many consecutive polls (~15 s) — long enough for webrtcbin to recover a
 // transient blip via ICE restart, short enough to free the video encoders + mic on a dead session.
 constexpr int kTeardownGracePolls = 75;
+
+// ---- WebRTC "playout-delay" RTP header extension -----------------------------------------------
+// Caps the receiver's de-jitter buffer. On a clean LAN libwebrtc's adaptive estimator sits on a
+// conservative buffer (~75 ms measured) even when the client asks for minimal delay via
+// jitterBufferTarget=0 — that only lowers the floor, not the ceiling. This extension's max bound is
+// a hard upper clamp libwebrtc honors, so it's the lever that actually pulls the delay down.
+// GStreamer < 1.24 ships no built-in element for this URI, so we implement it as a minimal
+// GstRTPHeaderExtension subclass and add it to each payloader; webrtcbin then emits the matching
+// a=extmap line and the payloader writes the bytes into every RTP packet.
+//
+// Wire format (WebRTC experiment): 3 bytes = MIN delay (12 bits) | MAX delay (12 bits), 10 ms units.
+#define MARS_PLAYOUT_DELAY_URI "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay"
+
+// One-byte extmap id, kept at the top of the 1..14 range so it does not clash with the low ids
+// webrtcbin auto-assigns to the extensions it manages itself (mid, transport-cc, ...).
+constexpr guint kPlayoutDelayExtId = 14;
+
+struct MarsPlayoutDelayExt {
+    GstRTPHeaderExtension parent;
+    guint min_delay_ms;
+    guint max_delay_ms;
+};
+struct MarsPlayoutDelayExtClass {
+    GstRTPHeaderExtensionClass parent_class;
+};
+
+G_DEFINE_TYPE(MarsPlayoutDelayExt, mars_playout_delay_ext, GST_TYPE_RTP_HEADER_EXTENSION)
+
+GstRTPHeaderExtensionFlags mars_playout_delay_supported_flags(GstRTPHeaderExtension*) {
+    return static_cast<GstRTPHeaderExtensionFlags>(GST_RTP_HEADER_EXTENSION_ONE_BYTE |
+                                                   GST_RTP_HEADER_EXTENSION_TWO_BYTE);
+}
+
+gsize mars_playout_delay_max_size(GstRTPHeaderExtension*, const GstBuffer*) {
+    return 3;
+}
+
+gssize mars_playout_delay_write(GstRTPHeaderExtension* ext, const GstBuffer* /*input_meta*/,
+                                GstRTPHeaderExtensionFlags /*write_flags*/, GstBuffer* /*output*/, guint8* data,
+                                gsize size) {
+    if (size < 3) {
+        return -1;
+    }
+    auto* self = reinterpret_cast<MarsPlayoutDelayExt*>(ext);
+    const guint min_units = (self->min_delay_ms / 10) & 0xFFF;  // 12-bit, 10 ms units
+    const guint max_units = (self->max_delay_ms / 10) & 0xFFF;
+    data[0] = static_cast<guint8>(min_units >> 4);
+    data[1] = static_cast<guint8>(((min_units & 0xF) << 4) | ((max_units >> 8) & 0xF));
+    data[2] = static_cast<guint8>(max_units & 0xFF);
+    return 3;
+}
+
+void mars_playout_delay_ext_class_init(MarsPlayoutDelayExtClass* klass) {
+    GstRTPHeaderExtensionClass* ext_class = GST_RTP_HEADER_EXTENSION_CLASS(klass);
+    ext_class->get_supported_flags = mars_playout_delay_supported_flags;
+    ext_class->get_max_size = mars_playout_delay_max_size;
+    ext_class->write = mars_playout_delay_write;
+    gst_rtp_header_extension_class_set_uri(ext_class, MARS_PLAYOUT_DELAY_URI);
+    gst_element_class_set_metadata(GST_ELEMENT_CLASS(klass), "Playout delay RTP header extension",
+                                   GST_RTP_HDREXT_ELEMENT_CLASS, "WebRTC playout-delay header extension", "mars_cam");
+}
+
+void mars_playout_delay_ext_init(MarsPlayoutDelayExt* self) {
+    self->min_delay_ms = 0;
+    self->max_delay_ms = 0;
+}
+
+// Returns a floating ref; the payloader's "add-extension" (transfer full) takes ownership.
+GstRTPHeaderExtension* make_playout_delay_ext(guint ext_id, guint min_ms, guint max_ms) {
+    auto* self = static_cast<MarsPlayoutDelayExt*>(g_object_new(mars_playout_delay_ext_get_type(), nullptr));
+    self->min_delay_ms = min_ms;
+    self->max_delay_ms = max_ms;
+    gst_rtp_header_extension_set_id(GST_RTP_HEADER_EXTENSION(self), ext_id);
+    return GST_RTP_HEADER_EXTENSION(self);
+}
 }  // namespace
 
 WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
@@ -48,6 +125,12 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     this->declare_parameter("audio_source_element", "alsasrc");
     this->declare_parameter("audio_capture_device", "");
 
+    // Receiver de-jitter buffer bounds (ms) signalled via the playout-delay RTP header extension.
+    // max caps libwebrtc's conservative buffer; min lets it go as low as the cap allows. Tunable
+    // from the launch file so the latency/jitter tradeoff can be retuned with a restart (no rebuild).
+    this->declare_parameter("playout_min_delay_ms", 0);
+    this->declare_parameter("playout_max_delay_ms", 40);
+
     // Get parameters
     use_compressed_images_ = this->get_parameter("use_compressed_images").as_bool();
     live_main_topic_ = this->get_parameter("live_main_camera_topic").as_string();
@@ -57,6 +140,8 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     enable_audio_ = this->get_parameter("enable_audio").as_bool();
     audio_source_element_ = this->get_parameter("audio_source_element").as_string();
     audio_capture_device_ = this->get_parameter("audio_capture_device").as_string();
+    playout_min_delay_ms_ = static_cast<guint>(this->get_parameter("playout_min_delay_ms").as_int());
+    playout_max_delay_ms_ = static_cast<guint>(this->get_parameter("playout_max_delay_ms").as_int());
 
     // Create publishers
     offer_pub_ = this->create_publisher<std_msgs::msg::String>("/webrtc/offer", 10);
@@ -524,8 +609,10 @@ std::string WebRTCStreamer::build_pipeline_description(bool& with_audio) const {
         "videoconvert ! "
         "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=30 "
         "end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
-        "rtpvp8pay pt=96 ! "
-        "application/x-rtp,media=video,encoding-name=VP8,clock-rate=90000,payload=96 ! "
+        "rtpvp8pay name=pay_main pt=96 ! "
+        // Named so attach_playout_delay_extension() can add the playout-delay extmap field to the
+        // caps webrtcbin reads when building the offer. Base RTP caps are set there too.
+        "capsfilter name=rtpcaps_main ! "
         "webrtc.sink_0 "
 
         "appsrc name=src_arm is-live=true format=time "
@@ -534,8 +621,8 @@ std::string WebRTCStreamer::build_pipeline_description(bool& with_audio) const {
         "videoconvert ! "
         "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=30 "
         "end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
-        "rtpvp8pay pt=97 ! "
-        "application/x-rtp,media=video,encoding-name=VP8,clock-rate=90000,payload=97 ! "
+        "rtpvp8pay name=pay_arm pt=97 ! "
+        "capsfilter name=rtpcaps_arm ! "
         "webrtc.sink_1";
 
     if (with_audio) {
@@ -590,6 +677,50 @@ std::string WebRTCStreamer::build_pipeline_description(bool& with_audio) const {
     return desc;
 }
 
+void WebRTCStreamer::attach_playout_delay_extension() {
+    // Apply the playout-delay header extension to both video tracks. Two pieces, agreeing on the
+    // extmap id: (1) the extmap field in the RTP caps webrtcbin reads -> emits the SDP a=extmap
+    // line, and (2) the extension object added to the payloader -> writes the 3 bytes into every
+    // RTP packet (GStreamer < 1.24 has no built-in writer for this URI).
+    const std::string extmap_field = "extmap-" + std::to_string(kPlayoutDelayExtId);
+
+    struct VideoTrack {
+        const char* payloader;
+        const char* capsfilter;
+        int payload;
+    };
+    for (const VideoTrack& track :
+         {VideoTrack{"pay_main", "rtpcaps_main", 96}, VideoTrack{"pay_arm", "rtpcaps_arm", 97}}) {
+        GstElement* pay = gst_bin_get_by_name(GST_BIN(pipeline_), track.payloader);
+        GstElement* caps_elem = gst_bin_get_by_name(GST_BIN(pipeline_), track.capsfilter);
+        if (!pay || !caps_elem) {
+            RCLCPP_WARN(this->get_logger(), "Missing %s/%s; playout-delay extension not applied to that track",
+                        track.payloader, track.capsfilter);
+            if (pay)
+                gst_object_unref(pay);
+            if (caps_elem)
+                gst_object_unref(caps_elem);
+            continue;
+        }
+
+        GstCaps* caps =
+            gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, "video", "encoding-name", G_TYPE_STRING,
+                                "VP8", "clock-rate", G_TYPE_INT, 90000, "payload", G_TYPE_INT, track.payload, nullptr);
+        gst_caps_set_simple(caps, extmap_field.c_str(), G_TYPE_STRING, MARS_PLAYOUT_DELAY_URI, nullptr);
+        g_object_set(caps_elem, "caps", caps, nullptr);
+        gst_caps_unref(caps);
+
+        GstRTPHeaderExtension* ext =
+            make_playout_delay_ext(kPlayoutDelayExtId, playout_min_delay_ms_, playout_max_delay_ms_);
+        g_signal_emit_by_name(pay, "add-extension", ext);  // transfer full: payloader owns ext now
+
+        gst_object_unref(pay);
+        gst_object_unref(caps_elem);
+    }
+    RCLCPP_INFO(this->get_logger(), "Playout-delay extension applied (id=%u, min=%u ms, max=%u ms)", kPlayoutDelayExtId,
+                playout_min_delay_ms_, playout_max_delay_ms_);
+}
+
 bool WebRTCStreamer::start_pipeline_locked(bool& with_audio) {
     GError* error = nullptr;
     std::string desc = build_pipeline_description(with_audio);
@@ -629,6 +760,8 @@ bool WebRTCStreamer::start_pipeline_locked(bool& with_audio) {
                  "max-bytes", 2 * 640 * 480 * 3, nullptr);
     g_object_set(appsrc_arm_, "format", GST_FORMAT_TIME, "do-timestamp", TRUE, "is-live", TRUE, "block", FALSE,
                  "max-bytes", 2 * 640 * 480 * 3, nullptr);
+
+    attach_playout_delay_extension();
 
     // Connect signals
     g_signal_connect(webrtc_, "on-ice-candidate", G_CALLBACK(on_ice_candidate), this);

--- a/sim/frontend/src/hooks/useRobotWebRTC.ts
+++ b/sim/frontend/src/hooks/useRobotWebRTC.ts
@@ -139,10 +139,6 @@ export function useRobotWebRTC({
           return;
         }
 
-        // Minimize the receive jitter buffer: this is a live teleop feed, so
-        // freshness beats smoothness. The browser otherwise buffers 100s of ms
-        // to absorb jitter. jitterBufferTarget is the standardized knob;
-        // playoutDelayHint is the older Chrome equivalent — set both, guarded.
         const receiver = event.receiver as RTCRtpReceiver & {
           jitterBufferTarget?: number | null;
           playoutDelayHint?: number | null;
@@ -151,7 +147,7 @@ export function useRobotWebRTC({
           if ("jitterBufferTarget" in receiver) receiver.jitterBufferTarget = 0;
           if ("playoutDelayHint" in receiver) receiver.playoutDelayHint = 0;
         } catch {
-          // Older browsers reject the assignment; the default buffer still works.
+          // unsupported; default buffer applies
         }
 
         const stream = new MediaStream([event.track]);

--- a/sim/frontend/src/hooks/useRobotWebRTC.ts
+++ b/sim/frontend/src/hooks/useRobotWebRTC.ts
@@ -139,6 +139,21 @@ export function useRobotWebRTC({
           return;
         }
 
+        // Minimize the receive jitter buffer: this is a live teleop feed, so
+        // freshness beats smoothness. The browser otherwise buffers 100s of ms
+        // to absorb jitter. jitterBufferTarget is the standardized knob;
+        // playoutDelayHint is the older Chrome equivalent — set both, guarded.
+        const receiver = event.receiver as RTCRtpReceiver & {
+          jitterBufferTarget?: number | null;
+          playoutDelayHint?: number | null;
+        };
+        try {
+          if ("jitterBufferTarget" in receiver) receiver.jitterBufferTarget = 0;
+          if ("playoutDelayHint" in receiver) receiver.playoutDelayHint = 0;
+        } catch {
+          // Older browsers reject the assignment; the default buffer still works.
+        }
+
         const stream = new MediaStream([event.track]);
         const mid = event.transceiver?.mid;
         const isMainMid = mid === "0" || mid === "video0";

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -418,6 +418,110 @@ button {
   border-radius: 999px;
 }
 
+/* ---- profiling panel (Teleop) ------------------------------------------- */
+
+/* Discrete toggle: a small glass pulse button, top-right corner. */
+.profiling-toggle {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: var(--glass);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid var(--hairline);
+  border-radius: 9px;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.profiling-toggle:hover {
+  color: var(--text);
+  border-color: var(--hairline-strong);
+}
+
+.profiling-toggle.active {
+  color: var(--accent);
+  border-color: var(--accent-dim);
+}
+
+/* Panel sits just below the toggle; denser glass since it's over the feed. */
+.profiling {
+  position: absolute;
+  top: 54px;
+  right: 14px;
+  width: 232px;
+  padding: 11px 14px;
+  background: rgb(0 0 0 / 66%);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--hairline);
+  border-radius: 11px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.profiling-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.profiling-hint {
+  font-size: 10px;
+  color: var(--muted);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 4px;
+  padding: 0 5px;
+  line-height: 1.5;
+}
+
+.profiling-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 11px 10px;
+}
+
+.profiling-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.profiling-row {
+  display: flex;
+  align-items: baseline;
+  gap: 3px;
+}
+
+.profiling-value {
+  font-size: 14px;
+  color: var(--text);
+}
+
+.profiling-unit {
+  font-size: 10px;
+  color: var(--muted);
+}
+
+/* The jitter buffer delay is the headline metric — span the row and accent it. */
+.profiling-item.headline {
+  grid-column: 1 / -1;
+}
+
+.profiling-item.headline .profiling-value {
+  font-size: 20px;
+  color: var(--accent);
+}
+
 /* ---- record HUD (Collect page) ------------------------------------------ */
 
 .overlay-record {

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -20,6 +20,7 @@ import { createHeadTilt } from "./headTilt.js";
 import { createTtsBar } from "./ttsBar.js";
 import { createTelemetry } from "./telemetry.js";
 import { createArmPanel } from "./armPanel.js";
+import { createProfilingPanel } from "./profilingPanel.js";
 
 initShell("teleop", "");
 
@@ -67,6 +68,7 @@ function buildCockpit(root) {
     createJoystick(stickOverlay, drive),
     createTtsBar(ttsOverlay, ros),
     createArmPanel(armOverlay, ros),
+    createProfilingPanel(root, session),
     keyboard,
   ];
 

--- a/webapp/js/teleop/profilingPanel.js
+++ b/webapp/js/teleop/profilingPanel.js
@@ -1,0 +1,240 @@
+// @ts-check
+// Profiling panel — a live read-out of the WebRTC receive side, for tuning
+// glass-to-glass latency. A discrete pulse button (top-right) toggles it; "p"
+// does too. Hidden by default so the cockpit stays clean for operators.
+//
+// The headline is the jitter buffer delay: the receiver's de-jitter buffer is
+// the dominant tunable latency on a clean LAN. RTT, bitrate, loss, and freezes
+// give the context to judge whether a tighter buffer is safe.
+//
+// Rates (bitrate, loss) are deltas between polls; jitter buffer delay is the
+// delta of cumulative hold-time over the delta of frames emitted, i.e. the
+// average delay of the frames played out since the last poll.
+
+const POLL_MS = 1000;
+const TOGGLE_KEY = "KeyP";
+
+/**
+ * @typedef {object} Sample
+ * @property {number} t           performance.now() at capture (ms)
+ * @property {number} jbDelay     jitterBufferDelay, cumulative seconds
+ * @property {number} jbEmitted   jitterBufferEmittedCount, cumulative frames
+ * @property {number} bytes       bytesReceived, cumulative
+ * @property {number} packets     packetsReceived, cumulative
+ * @property {number} lost        packetsLost, cumulative
+ */
+
+/**
+ * @param {HTMLElement} parent cockpit root — owns the toggle button + panel.
+ * @param {import("../webrtcSession.js").WebRtcSession} session
+ * @returns {{ destroy: () => void }}
+ */
+export function createProfilingPanel(parent, session) {
+  // Discrete toggle: a small glass pulse button, top-right.
+  const toggleBtn = document.createElement("button");
+  toggleBtn.type = "button";
+  toggleBtn.className = "profiling-toggle";
+  toggleBtn.title = "Profiling (p)";
+  toggleBtn.setAttribute("aria-label", "Toggle profiling panel");
+  toggleBtn.innerHTML =
+    '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" ' +
+    'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M3 12h4l2 6 4-14 2 8h6"/></svg>';
+
+  // The panel itself — its own glass box, sits just under the button.
+  const wrap = document.createElement("div");
+  wrap.className = "profiling";
+  wrap.hidden = true;
+
+  const head = document.createElement("div");
+  head.className = "profiling-head";
+  const title = document.createElement("span");
+  title.className = "microlabel";
+  title.textContent = "profiling";
+  const hint = document.createElement("span");
+  hint.className = "profiling-hint mono";
+  hint.textContent = "p";
+  head.append(title, hint);
+
+  const grid = document.createElement("div");
+  grid.className = "profiling-grid";
+
+  const jitterBuffer = metric("jitter buf", "ms", true);
+  const rtt = metric("rtt", "ms");
+  const jitter = metric("jitter", "ms");
+  const fps = metric("fps", "");
+  const resolution = metric("res", "");
+  const bitrate = metric("bitrate", "kb/s");
+  const loss = metric("loss", "%");
+  const dropped = metric("dropped", "");
+  const freezes = metric("freezes", "");
+  const all = [jitterBuffer, rtt, jitter, fps, resolution, bitrate, loss, dropped, freezes];
+  for (const m of all) grid.append(m.el);
+
+  wrap.append(head, grid);
+  parent.append(toggleBtn, wrap);
+
+  /** @type {Sample | null} */
+  let prev = null;
+  /** @type {number | null} */
+  let timer = null;
+
+  /**
+   * @param {string} labelText
+   * @param {string} unit
+   * @param {boolean} [headline]
+   */
+  function metric(labelText, unit, headline = false) {
+    const el = document.createElement("div");
+    el.className = headline ? "profiling-item headline" : "profiling-item";
+    const label = document.createElement("span");
+    label.className = "microlabel";
+    label.textContent = labelText;
+    const value = document.createElement("span");
+    value.className = "profiling-value mono";
+    value.textContent = "—";
+    const unitEl = document.createElement("span");
+    unitEl.className = "profiling-unit";
+    unitEl.textContent = unit;
+    const row = document.createElement("div");
+    row.className = "profiling-row";
+    row.append(value, unitEl);
+    el.append(label, row);
+    return { el, value };
+  }
+
+  /**
+   * @param {number | undefined | null} n
+   * @param {number} [digits]
+   */
+  function fmt(n, digits = 0) {
+    return typeof n === "number" && Number.isFinite(n) ? n.toFixed(digits) : "—";
+  }
+
+  function clearValues() {
+    for (const m of all) m.value.textContent = "—";
+    prev = null;
+  }
+
+  async function poll() {
+    /** @type {RTCStatsReport | null} */
+    let report;
+    try {
+      report = await session.getStats();
+    } catch {
+      report = null;
+    }
+    if (!report) {
+      clearValues();
+      return;
+    }
+
+    /** @type {any} */ let vid = null;
+    /** @type {any} */ let selectedPair = null;
+    /** @type {string | undefined} */ let selectedPairId;
+
+    report.forEach((/** @type {any} */ s) => {
+      if (s.type === "inbound-rtp" && s.kind === "video") vid = s;
+      else if (s.type === "transport" && s.selectedCandidatePairId) selectedPairId = s.selectedCandidatePairId;
+    });
+    report.forEach((/** @type {any} */ s) => {
+      if (s.type !== "candidate-pair") return;
+      if (s.id === selectedPairId) selectedPair = s;
+      else if (!selectedPair && (s.nominated || s.selected)) selectedPair = s;
+    });
+
+    if (!vid) {
+      clearValues();
+      return;
+    }
+
+    rtt.value.textContent = fmt(selectedPair?.currentRoundTripTime * 1000, 1);
+    jitter.value.textContent = fmt(vid.jitter * 1000, 1);
+    fps.value.textContent = fmt(vid.framesPerSecond, 0);
+    resolution.value.textContent =
+      vid.frameWidth && vid.frameHeight ? `${vid.frameWidth}×${vid.frameHeight}` : "—";
+    dropped.value.textContent = fmt(vid.framesDropped, 0);
+    freezes.value.textContent = fmt(vid.freezeCount, 0);
+
+    /** @type {Sample} */
+    const now = {
+      t: performance.now(),
+      jbDelay: vid.jitterBufferDelay ?? 0,
+      jbEmitted: vid.jitterBufferEmittedCount ?? 0,
+      bytes: vid.bytesReceived ?? 0,
+      packets: vid.packetsReceived ?? 0,
+      lost: vid.packetsLost ?? 0,
+    };
+
+    if (prev) {
+      const dt = (now.t - prev.t) / 1000;
+      const dEmitted = now.jbEmitted - prev.jbEmitted;
+      const dDelay = now.jbDelay - prev.jbDelay;
+      jitterBuffer.value.textContent = dEmitted > 0 ? fmt((dDelay / dEmitted) * 1000, 0) : "—";
+
+      if (dt > 0) bitrate.value.textContent = fmt(((now.bytes - prev.bytes) * 8) / dt / 1000, 0);
+
+      const dRecv = now.packets - prev.packets;
+      const dLost = now.lost - prev.lost;
+      const denom = dRecv + dLost;
+      loss.value.textContent = denom > 0 ? fmt((dLost / denom) * 100, 1) : "0.0";
+    } else if (now.jbEmitted > 0) {
+      // First poll: show the session-cumulative average so the panel isn't blank.
+      jitterBuffer.value.textContent = fmt((now.jbDelay / now.jbEmitted) * 1000, 0);
+    }
+    prev = now;
+  }
+
+  function start() {
+    if (timer !== null) return;
+    void poll();
+    timer = window.setInterval(() => void poll(), POLL_MS);
+  }
+
+  function stop() {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  /** @param {boolean} open */
+  function setOpen(open) {
+    wrap.hidden = !open;
+    toggleBtn.classList.toggle("active", open);
+    toggleBtn.setAttribute("aria-pressed", String(open));
+    if (open) {
+      start();
+    } else {
+      stop();
+      clearValues();
+    }
+  }
+
+  function toggle() {
+    setOpen(Boolean(wrap.hidden));
+  }
+
+  toggleBtn.addEventListener("click", toggle);
+
+  /** @param {KeyboardEvent} e */
+  function onKeyDown(e) {
+    if (e.code !== TOGGLE_KEY || e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
+    const el = document.activeElement;
+    if (el instanceof HTMLElement && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable)) {
+      return;
+    }
+    toggle();
+  }
+
+  window.addEventListener("keydown", onKeyDown);
+
+  return {
+    destroy() {
+      stop();
+      window.removeEventListener("keydown", onKeyDown);
+      toggleBtn.remove();
+      wrap.remove();
+    },
+  };
+}

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -211,17 +211,13 @@ export class WebRtcSession {
    */
   #onTrack(event, pc) {
     const track = event.track;
-    // Minimize the receive jitter buffer: this is a live teleop feed, so freshness
-    // beats smoothness. The browser otherwise buffers 100s of ms to absorb jitter.
-    // jitterBufferTarget is the standardized knob; playoutDelayHint is the older
-    // Chrome equivalent — set both for coverage, guarded since support varies.
     const receiver = event.receiver;
     if (receiver) {
       try {
         if ("jitterBufferTarget" in receiver) receiver.jitterBufferTarget = 0;
         if ("playoutDelayHint" in receiver) receiver.playoutDelayHint = 0;
       } catch {
-        // Older browsers reject the assignment; the default buffer still works.
+        // unsupported; default buffer applies
       }
     }
     if (track.kind === "audio") {

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -219,6 +219,22 @@ export class WebRtcSession {
    */
   #onTrack(event, pc) {
     const track = event.track;
+    if (track.kind === "audio") {
+      // Start in the operator's chosen state; never audible by default.
+      // NB: deliberately not tuned below — zeroing the audio receiver's NetEq
+      // buffer starves mic audio under jitter, and the latency win is video-only.
+      track.enabled = this.#state.audioRequested;
+      this.#patch({ audioStream: new MediaStream([track]) });
+      return;
+    }
+
+    // Minimize the receive-side jitter buffer on the video receiver. The
+    // playout-delay extension caps the ceiling; these pin the floor.
+    // Units differ: jitterBufferTarget is in milliseconds, playoutDelayHint in
+    // seconds. Both 0 here means "minimal delay". Modern Chrome honors
+    // jitterBufferTarget and ignores the hint (not a strict fallback — both are
+    // set whenever present). To match the robot-side max=40, the values diverge:
+    // jitterBufferTarget = 40, playoutDelayHint = 0.04.
     const receiver = event.receiver;
     if (receiver) {
       try {
@@ -227,12 +243,6 @@ export class WebRtcSession {
       } catch {
         // unsupported; default buffer applies
       }
-    }
-    if (track.kind === "audio") {
-      // Start in the operator's chosen state; never audible by default.
-      track.enabled = this.#state.audioRequested;
-      this.#patch({ audioStream: new MediaStream([track]) });
-      return;
     }
 
     const stream = new MediaStream([track]);

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -211,6 +211,19 @@ export class WebRtcSession {
    */
   #onTrack(event, pc) {
     const track = event.track;
+    // Minimize the receive jitter buffer: this is a live teleop feed, so freshness
+    // beats smoothness. The browser otherwise buffers 100s of ms to absorb jitter.
+    // jitterBufferTarget is the standardized knob; playoutDelayHint is the older
+    // Chrome equivalent — set both for coverage, guarded since support varies.
+    const receiver = event.receiver;
+    if (receiver) {
+      try {
+        if ("jitterBufferTarget" in receiver) receiver.jitterBufferTarget = 0;
+        if ("playoutDelayHint" in receiver) receiver.playoutDelayHint = 0;
+      } catch {
+        // Older browsers reject the assignment; the default buffer still works.
+      }
+    }
     if (track.kind === "audio") {
       // Start in the operator's chosen state; never audible by default.
       track.enabled = this.#state.audioRequested;

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -97,6 +97,14 @@ export class WebRtcSession {
   }
 
   /**
+   * Live RTCStatsReport for the profiling panel, or null when no pc is up.
+   * @returns {Promise<RTCStatsReport | null>}
+   */
+  getStats() {
+    return this.#pc ? this.#pc.getStats() : Promise.resolve(null);
+  }
+
+  /**
    * @param {(state: WebRtcState) => void} cb Fires immediately, then on change.
    * @returns {() => void} unsubscribe
    */


### PR DESCRIPTION
## What

Reduces glass-to-glass latency on the live WebRTC teleop feed. The sender pipeline was already well-tuned (`vp8enc deadline=1`, single-buffer leaky queues, non-blocking live `appsrc`), so this PR goes after the remaining buffering sources — and adds a profiling panel that measured the win on-device.

**Headline result (measured on the webapp, 30 fps):** receiver de-jitter buffer **75 ms → ~1 ms**, with **0% packet loss, 0 dropped frames, 0 freezes** — ~74 ms of receive-side latency removed. RTT held at 4–8 ms throughout.

## Changes

### 1. Sender-side playout-delay RTP header extension — the main lever
`ros2_ws/src/mars_bot/mars_cam/...` (`webrtc_streamer.cpp/.hpp`, `CMakeLists.txt`, `camera_composable.launch.py`)

The receiver's de-jitter buffer was the dominant remaining latency: libwebrtc sat on a ~75 ms buffer on a clean LAN (RTT ~6 ms, jitter ~10 ms, 0% loss). Setting `jitterBufferTarget = 0` on the browser (below) only lowers the *floor* — the adaptive estimator still picked 75 ms because nothing capped the *ceiling*.

Send the WebRTC **playout-delay** RTP header extension from `webrtcbin` so the receiver's libwebrtc clamps its buffer to `[min, max]`. GStreamer 1.20.3 ships no element for this URI, so it's implemented as a minimal `GstRTPHeaderExtension` subclass added to each VP8 payloader; `webrtcbin` then emits the `a=extmap` line and the payloader writes the 3-byte field into every RTP packet.

`min`/`max` are launch params (`playout_min_delay_ms` / `playout_max_delay_ms`, default **0 / 40**), so the latency/smoothness tradeoff is retunable with an `innate restart` — no rebuild.

**Note on `min` vs `max`:** measurement showed the browser's `jitterBufferTarget = 0` pins the buffer near the floor, so the extension's **`max` is the effective lever** (the cap is what tamed the 75 ms); `min` is largely inert on the webapp and kept at 0. Documented in the launch file.

### 2. Browser receivers — minimize the receive-side jitter buffer
`webapp/js/webrtcSession.js` and `sim/frontend/src/hooks/useRobotWebRTC.ts`

On each incoming video track, set `jitterBufferTarget = 0` (standardized `RTCRtpReceiver` knob) and `playoutDelayHint = 0` (legacy Chrome knob); both are set when present — modern Chrome honors `jitterBufferTarget` and ignores the hint. Video receivers only — the audio receiver is left untouched so robot-mic NetEq isn't starved. Feature-guarded + try/catch. This unlocks the low-latency path that the playout-delay extension then bounds.

### 3. GStreamer sender — CBR with a small rate-control buffer
`webrtc_streamer.cpp`

Switch both VP8 encoders from default VBR (~6 s rate buffer) to `end-usage=cbr` with a ~0.5 s buffer, so the encoder stops holding frames to smooth bitrate.

### 4. WebRTC profiling panel (Teleop cockpit)
`webapp/js/teleop/profilingPanel.js` (+ `main.js`, `webrtcSession.js`, `app.css`)

A discrete toggle (top-right pulse button, or `p`) opens a live read-out of the receive side: **jitter buffer delay** (headline), RTT, jitter, fps, resolution, bitrate, loss, dropped frames, freezes. Rates are deltas between 1 s polls. Hidden by default; exposes `WebRtcSession.getStats()`. This is what was used to tune and validate the numbers above.

## Tradeoffs

The buffer changes trade a little tolerance for network/bitrate jitter (possible micro-stutter under load) for lower latency — the right call for teleop, and confirmed loss-free on this LAN at 30 fps.

## Mobile app

The extension is sender-side and receiver-agnostic, so the native libwebrtc in the phone app honors it too. But the app has no `jitterBufferTarget`, so its buffer sits at its adaptive estimate **clamped to ≤ `max`** (lands near 40 ms, not ~1 ms). Lowering `max` pulls the app's buffer down directly without affecting the webapp — to be tuned/verified on-device.

## Testing

- **On-device:** built with `innate build mars_cam` and validated live via the profiling panel — jitter buffer 75 → ~1 ms, 30 fps, 0 loss / 0 drops / 0 freezes. The brief 30 → 14 fps dip seen mid-tuning was camera auto-exposure (dim scene), not this change (`framesReceived == framesDecoded`, 0 drops).
- **Frontend:** `tsc --noEmit` clean on changed files (other errors are pre-existing).
- **Not yet measured:** true motion-to-photon (glass-to-glass) — receive-side stats are now near-optimal, so remaining latency is upstream (software VP8 encode), which is the case for hardware H.264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

