### PR TITLE
Migrate ~/skills and ~/agents into workspace/custom_* (fix listed-but-broken datasets)

### DIFF
--- a/scripts/update/migrate_user_data.sh
+++ b/scripts/update/migrate_user_data.sh
@@ -18,10 +18,14 @@
 #   <repo>/maps/*                          -> <repo>/data/maps/
 #   <repo>/.last_mode                      -> <repo>/data/.last_mode
 #   <repo>/.last_map                       -> <repo>/data/.last_map
+#   ~/agents/*                             -> <repo>/workspace/custom_agents/
+#   ~/skills/*                             -> <repo>/workspace/custom_skills/
 #
-# Home-directory skills/agents (~/skills, ~/agents) are NOT handled here; they
-# are migrated at brain startup by
-# brain_client.script_paths.migrate_legacy_home_directories().
+# The home-directory skills/agents (~/skills, ~/agents) are folded in here too.
+# The brain still scans them in place for backwards compatibility, but the
+# dataset media server and encoder only serve workspace/custom_skills, so a
+# ~/skills dataset would otherwise list but be unplayable (no thumbnails/video/
+# joints). Moving them into the workspace keeps both pipelines consistent.
 #
 # Optional env: MIGRATE_CHOWN_USER — when set and running as root, moved files
 # are chowned to this user (best-effort). Unset (e.g. in CI) => no chown.
@@ -100,6 +104,50 @@ _migrate_dir_into_workspace() {
     rmdir "$old_path" 2>/dev/null && _mig_log "Removed empty $old_rel/" || true
 }
 
+# The robot user's home directory — not root's. post_update.sh runs the
+# migration as root, but the legacy ~/skills and ~/agents belong to the login
+# user (MIGRATE_CHOWN_USER), so resolve their home rather than using $HOME.
+_mig_home_dir() {
+    local user="${MIGRATE_CHOWN_USER:-}"
+    local home=""
+    if [ -n "$user" ]; then
+        home=$(getent passwd "$user" 2>/dev/null | cut -d: -f6)
+    fi
+    [ -n "$home" ] || home="$HOME"
+    echo "$home"
+}
+
+# Move every child of an absolute legacy home dir (~/skills, ~/agents) into
+# <repo>/workspace/$new_rel. Same never-clobber/empty-only contract as
+# _migrate_dir_into_workspace; the source just lives outside the repo.
+_migrate_home_dir_into_workspace() {
+    local repo="$1" home_src="$2" new_rel="$3"
+    local new_path="$repo/workspace/$new_rel"
+    [ -d "$home_src" ] || return 0
+    # Never touch a ~/skills that is actually a symlink into the workspace.
+    [ -L "$home_src" ] && return 0
+
+    shopt -s dotglob nullglob
+    local items=("$home_src"/*)
+    shopt -u dotglob nullglob
+
+    if [ ${#items[@]} -gt 0 ]; then
+        _mig_log "Migrating $home_src/ -> workspace/$new_rel/"
+        _mig_mkdir "$new_path"
+        local item name
+        for item in "${items[@]}"; do
+            name=$(basename "$item")
+            if [ "$name" = "__pycache__" ]; then
+                rm -rf "$item"
+                continue
+            fi
+            _mig_move "$item" "$new_path/$name" "$home_src/$name -> workspace/$new_rel/$name"
+        done
+    fi
+
+    rmdir "$home_src" 2>/dev/null && _mig_log "Removed empty $home_src/" || true
+}
+
 # Move trained-model files out of the legacy primitives/ tree into innate_skills,
 # preserving the relative sub-path (e.g. primitives/wave/x.h5 -> innate_skills/wave/x.h5).
 _migrate_primitives_models() {
@@ -167,6 +215,15 @@ run_user_data_migrations() {
     _migrate_dir_into_workspace "$repo" inputs     inputs
     _migrate_primitives_models  "$repo"
     _migrate_nav_state          "$repo"
+
+    # Legacy home-directory locations (~/skills, ~/agents) the brain still scans
+    # in place but the dataset media/encoder pipeline can't serve.
+    local home_dir
+    home_dir="$(_mig_home_dir)"
+    if [ -n "$home_dir" ]; then
+        _migrate_home_dir_into_workspace "$repo" "$home_dir/agents" custom_agents
+        _migrate_home_dir_into_workspace "$repo" "$home_dir/skills" custom_skills
+    fi
 }
 
 # Execute when run directly (not when sourced).

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -234,8 +234,9 @@ fi
 # shipped files; this step preserves any user-created *untracked* content
 # (custom skills/agents/inputs, trained models, SLAM maps, last mode/map).
 # Idempotent, never overwrites, only rmdir's empty dirs.
-# Home-dir ~/agents and ~/skills are migrated separately at brain startup
-# (brain_client.script_paths.migrate_legacy_home_directories).
+# Legacy home-dir ~/agents and ~/skills are folded into workspace/custom_* here
+# too (run_user_data_migrations), so the dataset media server and encoder — which
+# only serve workspace/custom_skills — can reach datasets recorded under ~/skills.
 # -----------------------------------------------------------------------------
 # shellcheck source=scripts/update/migrate_user_data.sh
 source "$SCRIPT_DIR/migrate_user_data.sh"


### PR DESCRIPTION
## Problem
The brain scans `~/skills` and `~/agents` **in place** for backwards compatibility (`get_skill_directories()` in `brain_client/common/script_paths.py`) and reports their **absolute paths** on `/brain/available_skills`. So a dataset recorded under `~/skills/<task>` (older robots, ≤ 0.5.x) appears in the web app's Datasets list and in the controller app.

But the dataset **media server** (`webapp/proxy/https_server.py`, fenced to `SKILLS_ROOT = workspace/custom_skills`) and the **`dataset_encoder`** only ever serve/scan `workspace/custom_skills`. So a `~/skills` dataset is **listed-but-broken**: no thumbnails, episodes won't play, `/episode/joints` 404s, and it can't be encoded or downloaded for training.

The reconciliation these home dirs were supposed to get **never existed** — `migrate_legacy_home_directories()` is referenced only in comments (`migrate_user_data.sh`, `post_update.sh`) and is not implemented anywhere.

(`$INNATE_OS_ROOT/skills` was already migrated by `migrate_user_data.sh`; only the true home dirs were missed.)

## Fix
Fold `~/skills` → `workspace/custom_skills` and `~/agents` → `workspace/custom_agents` in `run_user_data_migrations`, so the brain scan, media server, and encoder all agree on one location. New `_migrate_home_dir_into_workspace` reuses the existing **never-clobber / empty-only / chown-aware** contract; `_mig_home_dir` resolves the login user's home (via `MIGRATE_CHOWN_USER`) since `post_update.sh` runs as root. Symlinked `~/skills` is left untouched. Stale `migrate_legacy_home_directories` comments removed.

This fixes both the web app and the controller app (both consume the same media server) for upgraded robots.

## Testing
Smoke-tested locally:
- happy path: `~/skills/<task>` moves into `workspace/custom_skills/<task>`, empty `~/skills` removed;
- collision: a pre-existing destination is preserved (source kept in place for manual reconciliation);
- `~/agents` migrates to `custom_agents`;
- `bash -n` clean on both scripts.

## Release note
Should ship in **0.6.0** (the controller app now pins `MIN_ROBOT_VERSION = 0.6.0`), so upgraded robots have their `~/skills` datasets served correctly.
