### PR TITLE
Serve & encode datasets from legacy ~/skills locations (no file moves)

### DIFF
--- a/ros2_ws/src/brain/dataset_encoder/dataset_encoder/dataset_encoder_node.py
+++ b/ros2_ws/src/brain/dataset_encoder/dataset_encoder/dataset_encoder_node.py
@@ -58,20 +58,17 @@ class DatasetEncoder(Node):
 
         self.skills_root = os.path.expanduser(self.get_parameter("skills_root").value)
         # Also scan the legacy in-place skill locations the brain still reports
-        # (script_paths.get_skill_directories): $INNATE_OS_ROOT/skills and
-        # ~/skills, used through 0.5.x. Without these a dataset recorded under
-        # ~/skills lists in the app but never gets encoded to MP4 (so it can't
-        # play or be downloaded for training).
-        innate_os_root = os.environ.get(
-            "INNATE_OS_ROOT", os.path.expanduser("~/innate-os")
-        )
+        # ($INNATE_OS_ROOT/skills, ~/skills; used through 0.5.x), else datasets
+        # recorded there never get encoded. realpath (like the media server's
+        # resolve) so symlinked roots dedup correctly.
+        innate_os_root = os.environ.get("INNATE_OS_ROOT", os.path.expanduser("~/innate-os"))
         self.skills_roots = []
         for root in (
             self.skills_root,
             os.path.join(innate_os_root, "skills"),
             os.path.expanduser("~/skills"),
         ):
-            root = os.path.abspath(root)
+            root = os.path.realpath(root)
             if root not in self.skills_roots:
                 self.skills_roots.append(root)
         self.nice_level = int(self.get_parameter("nice_level").value)

--- a/ros2_ws/src/brain/dataset_encoder/dataset_encoder/dataset_encoder_node.py
+++ b/ros2_ws/src/brain/dataset_encoder/dataset_encoder/dataset_encoder_node.py
@@ -57,6 +57,23 @@ class DatasetEncoder(Node):
         self.declare_parameter("scan_period_sec", 60.0)
 
         self.skills_root = os.path.expanduser(self.get_parameter("skills_root").value)
+        # Also scan the legacy in-place skill locations the brain still reports
+        # (script_paths.get_skill_directories): $INNATE_OS_ROOT/skills and
+        # ~/skills, used through 0.5.x. Without these a dataset recorded under
+        # ~/skills lists in the app but never gets encoded to MP4 (so it can't
+        # play or be downloaded for training).
+        innate_os_root = os.environ.get(
+            "INNATE_OS_ROOT", os.path.expanduser("~/innate-os")
+        )
+        self.skills_roots = []
+        for root in (
+            self.skills_root,
+            os.path.join(innate_os_root, "skills"),
+            os.path.expanduser("~/skills"),
+        ):
+            root = os.path.abspath(root)
+            if root not in self.skills_roots:
+                self.skills_roots.append(root)
         self.nice_level = int(self.get_parameter("nice_level").value)
         self.encode_threads = int(self.get_parameter("encode_threads").value)
         self.idle_io = bool(self.get_parameter("idle_io").value)
@@ -92,7 +109,7 @@ class DatasetEncoder(Node):
         self._scan_skills()  # catch up on anything left un-encoded across reboots
         self._publish_idle()
         self.get_logger().info(
-            f"dataset_encoder up; root={self.skills_root}, nice={self.nice_level}, "
+            f"dataset_encoder up; roots={self.skills_roots}, nice={self.nice_level}, "
             f"threads={self.encode_threads}, idle_io={self.idle_io}"
         )
 
@@ -131,13 +148,14 @@ class DatasetEncoder(Node):
         return any(not ep.get("video_files") for ep in episodes if ep.get("file_name"))
 
     def _scan_skills(self):
-        try:
-            entries = sorted(os.scandir(self.skills_root), key=lambda e: e.name)
-        except OSError:
-            return
-        for entry in entries:
-            if entry.is_dir():
-                self._enqueue(entry.path)
+        for root in self.skills_roots:
+            try:
+                entries = sorted(os.scandir(root), key=lambda e: e.name)
+            except OSError:
+                continue
+            for entry in entries:
+                if entry.is_dir():
+                    self._enqueue(entry.path)
 
     # ---- service ---------------------------------------------------------
     def _on_encode_request(self, request, response):

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -48,15 +48,27 @@ ROOT = Path(__file__).resolve().parent.parent
 CERT_DIR = Path.home() / ".innate-webapp-tls"
 ROSBRIDGE_URL = "ws://127.0.0.1:9090"
 
-# Recorded episodes live here (mirrors the recorder's data_directory). The
-# /episode* routes only ever serve files resolved under this root.
-SKILLS_ROOT = Path(
-    os.path.join(
-        os.environ.get("INNATE_OS_ROOT", os.path.expanduser("~/innate-os")),
-        "workspace",
-        "custom_skills",
+# Recorded episodes live here. The /episode* routes only ever serve files
+# resolved under one of these roots. Besides workspace/custom_skills we also
+# allow the legacy in-place locations the brain still scans for skills
+# (script_paths.get_skill_directories): $INNATE_OS_ROOT/skills and ~/skills,
+# used through 0.5.x. Without them a dataset recorded under ~/skills lists in the
+# app (the brain reports its absolute path) but its media would 404 here.
+_INNATE_OS_ROOT = os.environ.get("INNATE_OS_ROOT", os.path.expanduser("~/innate-os"))
+SKILLS_ROOTS = tuple(
+    p.resolve()
+    for p in (
+        Path(_INNATE_OS_ROOT) / "workspace" / "custom_skills",
+        Path(_INNATE_OS_ROOT) / "skills",
+        Path(os.path.expanduser("~")) / "skills",
     )
-).resolve()
+)
+
+
+def _under_skills_root(p: Path) -> bool:
+    """True if p resolves inside one of the allowed skill roots (the media
+    path-traversal fence)."""
+    return any(p.is_relative_to(root) for root in SKILLS_ROOTS)
 
 
 def _quiet_benign_disconnects() -> None:
@@ -160,7 +172,7 @@ def _resolve_under_root(rel: str):
         p = Path(rel).resolve()
     except (OSError, ValueError):
         return None
-    return p if p.is_relative_to(SKILLS_ROOT) else None
+    return p if _under_skills_root(p) else None
 
 
 def _safe_resolve(p: Path):
@@ -225,7 +237,7 @@ def episode_response(request, qs: dict) -> Response:
     if base is None or not eid or not cam:
         return _plain(404, "Not Found", "not found")
     mp4 = _safe_resolve(base / "data" / f"episode_{eid}_{cam}.mp4")
-    if mp4 is None or not mp4.is_relative_to(SKILLS_ROOT) or mp4.suffix != ".mp4" or not mp4.is_file():
+    if mp4 is None or not _under_skills_root(mp4) or mp4.suffix != ".mp4" or not mp4.is_file():
         return _plain(404, "Not Found", "no such episode video")
     return _serve_file_with_range(request, mp4, "video/mp4")
 
@@ -276,7 +288,7 @@ async def thumb_response(qs: dict) -> Response:
     if base is None or not eid:
         return _plain(404, "Not Found", "not found")
     mp4 = _safe_resolve(base / "data" / f"episode_{eid}_{cam}.mp4")
-    if mp4 is None or not mp4.is_relative_to(SKILLS_ROOT) or not mp4.is_file():
+    if mp4 is None or not _under_skills_root(mp4) or not mp4.is_file():
         return _plain(404, "Not Found", "no such episode video")
     # Cache beside data/ (not inside it) so thumbnails are never uploaded to the cloud.
     cache = base / "thumbs" / f"episode_{eid}_{cam}.jpg"
@@ -309,7 +321,7 @@ def joints_response(qs: dict) -> Response:
     if base is None or not eid:
         return _plain(404, "Not Found", "not found")
     h5 = _safe_resolve(base / "data" / f"episode_{eid}.h5")
-    if h5 is None or not h5.is_relative_to(SKILLS_ROOT) or h5.suffix != ".h5" or not h5.is_file():
+    if h5 is None or not _under_skills_root(h5) or h5.suffix != ".h5" or not h5.is_file():
         return _plain(404, "Not Found", "no such episode")
     try:
         import h5py  # available in the robot's system python
@@ -345,7 +357,7 @@ def run_info_response(qs: dict) -> Response:
     if base is None or not rid:
         return _plain(404, "Not Found", "not found")
     run_dir = _safe_resolve(base / rid)
-    if run_dir is None or not run_dir.is_relative_to(SKILLS_ROOT) or not run_dir.is_dir():
+    if run_dir is None or not _under_skills_root(run_dir) or not run_dir.is_dir():
         # Not downloaded yet (or never will be).
         body = json.dumps({"downloaded": False, "has_checkpoint": False, "files": []}).encode()
         return Response(
@@ -389,7 +401,7 @@ def run_log_response(qs: dict) -> Response:
     if (
         run_dir is None
         or target is None
-        or not run_dir.is_relative_to(SKILLS_ROOT)
+        or not _under_skills_root(run_dir)
         or not target.is_relative_to(run_dir)
         or not target.is_file()
     ):

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -48,26 +48,25 @@ ROOT = Path(__file__).resolve().parent.parent
 CERT_DIR = Path.home() / ".innate-webapp-tls"
 ROSBRIDGE_URL = "ws://127.0.0.1:9090"
 
-# Recorded episodes live here. The /episode* routes only ever serve files
-# resolved under one of these roots. Besides workspace/custom_skills we also
-# allow the legacy in-place locations the brain still scans for skills
-# (script_paths.get_skill_directories): $INNATE_OS_ROOT/skills and ~/skills,
-# used through 0.5.x. Without them a dataset recorded under ~/skills lists in the
-# app (the brain reports its absolute path) but its media would 404 here.
+# Roots the /episode* routes may serve from: workspace/custom_skills plus the
+# legacy in-place locations the brain still scans ($INNATE_OS_ROOT/skills,
+# ~/skills; used through 0.5.x). Deduped after resolve so INNATE_OS_ROOT=~ (which
+# collapses two of them) doesn't double-check.
 _INNATE_OS_ROOT = os.environ.get("INNATE_OS_ROOT", os.path.expanduser("~/innate-os"))
 SKILLS_ROOTS = tuple(
-    p.resolve()
-    for p in (
-        Path(_INNATE_OS_ROOT) / "workspace" / "custom_skills",
-        Path(_INNATE_OS_ROOT) / "skills",
-        Path(os.path.expanduser("~")) / "skills",
+    dict.fromkeys(
+        p.resolve()
+        for p in (
+            Path(_INNATE_OS_ROOT) / "workspace" / "custom_skills",
+            Path(_INNATE_OS_ROOT) / "skills",
+            Path(os.path.expanduser("~")) / "skills",
+        )
     )
 )
 
 
 def _under_skills_root(p: Path) -> bool:
-    """True if p resolves inside one of the allowed skill roots (the media
-    path-traversal fence)."""
+    """True if p is inside an allowed skill root (path-traversal fence)."""
     return any(p.is_relative_to(root) for root in SKILLS_ROOTS)
 
 


### PR DESCRIPTION
## Problem
The brain scans `~/skills` and `$INNATE_OS_ROOT/skills` **in place** for backwards compatibility (`script_paths.get_skill_directories`) and reports their **absolute paths** on `/brain/available_skills`. So a dataset recorded under `~/skills/<task>` (robots from ≤ 0.5.x) appears in the web app's Datasets list and in the controller app.

But the dataset **media server** (`webapp/proxy/https_server.py`) and the **`dataset_encoder`** only ever served/scanned `workspace/custom_skills`. So a `~/skills` dataset was **listed-but-broken**: no thumbnails, episodes won't play, `/episode/joints` 404s, and it never gets encoded or downloaded for training.

## Fix
Make the media server and encoder read the same legacy locations the brain already scans — **without moving any user files** (per discussion, we don't want to relocate users' data):

- **`https_server.py`**: replaced the single `SKILLS_ROOT` with `SKILLS_ROOTS = (workspace/custom_skills, $INNATE_OS_ROOT/skills, ~/skills)` and a `_under_skills_root(p)` membership helper used by every `/episode*` fence. The path-traversal guard is unchanged in spirit — a resolved path must still sit under one of the allowed roots.
- **`dataset_encoder_node.py`**: scans all three roots (deduped) instead of only the configurable `custom_skills` root. The `skills_root` parameter still works as the primary/default.

This earlier had a [migration PR (#461)] that *moved* `~/skills` into the workspace; that was scrapped in favor of this read-in-place approach.

## Testing
- `python3 -m py_compile` clean on both files.
- Validated the fence logic standalone: paths under each of the three roots resolve allowed; shipped `workspace/innate_skills`, `/etc/passwd`, and `../../etc` traversal all correctly rejected; encoder dedup yields 3 distinct roots.

## Note
This covers the standard legacy locations. Config-driven `extra_skill_dirs` (a newer `script_paths` feature) are not mirrored here; if datasets in a configured extra dir need media too, we can fold those in as a follow-up. Should ship in **0.6.0** alongside the controller-app MP4 replay.
