### PR TITLE
fix: serialize episode conversion so the encoder and training upload don't race

### DIFF
--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/episode_converter.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/episode_converter.py
@@ -105,16 +105,6 @@ def convert_episodes_to_h264(
                 )
                 continue
 
-            if not raw_path.exists():
-                if not h5_path.exists():
-                    # Source vanished mid-pass — the episode was deleted while we
-                    # were encoding this skill. Skip it instead of crashing the
-                    # whole pass; _update_metadata re-reads fresh and drops it.
-                    logger.info("Source for %s gone — skipping (deleted?)", item["filename"])
-                    continue
-                shutil.move(str(h5_path), str(raw_path))
-                logger.info("Moved %s -> raw_data/%s", h5_path.name, raw_path.name)
-
             yield ProgressUpdate(
                 stage=ProgressStage.COMPRESSING,
                 message=f"[{idx}/{total}] Encoding {item['filename']}…",
@@ -122,15 +112,24 @@ def convert_episodes_to_h264(
             )
 
             try:
-                _encode_camera_to_mp4(
-                    raw_path,
-                    cam_name,
-                    mp4_path,
-                    fps,
-                    nice_level=nice_level,
-                    threads=threads,
-                    idle_io=idle_io,
-                )
+                with _convert_lock(data_dir):
+                    if mp4_path.exists():
+                        continue  # another converter finished it first
+                    if not raw_path.exists():
+                        if not h5_path.exists():
+                            # deleted mid-pass — _update_metadata drops it
+                            logger.info("Source for %s gone — skipping", item["filename"])
+                            continue
+                        shutil.move(str(h5_path), str(raw_path))
+                    _encode_camera_to_mp4(
+                        raw_path,
+                        cam_name,
+                        mp4_path,
+                        fps,
+                        nice_level=nice_level,
+                        threads=threads,
+                        idle_io=idle_io,
+                    )
             except Exception as e:
                 yield ProgressUpdate(
                     stage=ProgressStage.ERROR,
@@ -161,7 +160,8 @@ def convert_episodes_to_h264(
             )
 
             try:
-                _strip_images_from_h5(raw_path, h5_path)
+                with _convert_lock(data_dir):
+                    _strip_images_from_h5(raw_path, h5_path)
             except Exception as e:
                 yield ProgressUpdate(
                     stage=ProgressStage.ERROR,
@@ -190,13 +190,14 @@ def convert_episodes_to_h264(
             )
 
             try:
-                _transcode_mp4_to_420(
-                    mp4_path,
-                    fps,
-                    nice_level=nice_level,
-                    threads=threads,
-                    idle_io=idle_io,
-                )
+                with _convert_lock(data_dir):
+                    _transcode_mp4_to_420(
+                        mp4_path,
+                        fps,
+                        nice_level=nice_level,
+                        threads=threads,
+                        idle_io=idle_io,
+                    )
             except Exception as e:
                 yield ProgressUpdate(
                     stage=ProgressStage.ERROR,
@@ -532,6 +533,18 @@ def _metadata_lock(data_dir: Path):
         yield
     finally:
         os.close(fd)  # closing the fd releases the flock
+
+
+@contextlib.contextmanager
+def _convert_lock(data_dir: Path):
+    """Exclusive lock so the background encoder and a training upload can't
+    convert the same item at once. Held only around one item's move/encode."""
+    fd = os.open(str(data_dir / ".convert.lock"), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(fd)
 
 
 def _update_metadata(data_dir: Path) -> None:

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/episode_converter.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/episode_converter.py
@@ -161,6 +161,8 @@ def convert_episodes_to_h264(
 
             try:
                 with _convert_lock(data_dir):
+                    if h5_path.exists():
+                        continue  # another converter already stripped it
                     _strip_images_from_h5(raw_path, h5_path)
             except Exception as e:
                 yield ProgressUpdate(


### PR DESCRIPTION
## Problem
The background `dataset_encoder` node and the training upload both run the **same** `convert_episodes_to_h264` on a dataset's `data/` dir (one converter, two triggers). If they run at once — e.g. you start training right after recording, before the eager encode finishes — their per-episode steps interleave:

- **Pass-aborting crash:** both see `raw_data/episode_N.h5` missing and both call `shutil.move(h5 → raw_data)`; the loser hits `FileNotFoundError`. That move is outside the encode `try`, so it propagates and aborts the whole pass — i.e. the training upload fails (run never created) or the encoder errors the dataset.
- **Wasted work:** both gst-encode the same MP4 (the atomic rename keeps the result correct, just doubles the CPU).

## Fix
Guard each item's mutating work (move/encode, strip, transcode) with an exclusive `flock` on `data/.convert.lock`, mirroring the existing `_metadata_lock` right beside it (which the C++ recorder already shares for metadata edits). The lock is held only around a single item — never across a `yield` — so the encoder still releases between its timer ticks. An under-lock re-check (`if mp4_path.exists(): continue`) lets a converter skip an item a peer just finished, so the two cooperate instead of colliding.

Deliberately keeps both triggers: training stays self-sufficient (it still converts inline), so a crashed/disabled encoder never blocks a run — `flock` also auto-releases on process death. No behavior change when only one converter runs.

## Testing
- `ruff format` / `ruff check` clean; `py_compile` clean.
- Reviewed the contended path: P1 moves+encodes under the lock; P2 blocks, then its under-lock `mp4_path.exists()` re-check is true → it skips. No double move, no double encode, no abort.
