### PR TITLE
Point arm-sensor failure messages at the USB-C cable

### DIFF
--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -359,7 +359,11 @@ class ManipulationServer(Node):
             while not self._check_sensor_availability():
                 if time.time() > sensor_wait_deadline:
                     self.get_logger().error("Required sensors not available after 2s. Cannot execute learned behavior.")
-                    return "FAILURE", "Required sensors not available (cameras or joint state)"
+                    return (
+                        "FAILURE",
+                        "Required sensors not available (cameras or joint state). "
+                        "If the arm joint state is missing, please check that the arm's USB-C cable is plugged in.",
+                    )
                 time.sleep(0.1)
             self.get_logger().info("All sensors available")
 
@@ -1035,7 +1039,10 @@ class ManipulationServer(Node):
             return False
 
         if self.latest_joint_state is None:
-            self.get_logger().warn("Joint state (/mars/arm/state) has never received data")
+            self.get_logger().warn(
+                "Joint state (/mars/arm/state) has never received data "
+                "- please check that the arm's USB-C cable is plugged in"
+            )
             return False
 
         # Check if data is recent (within timeout threshold)


### PR DESCRIPTION
## What
When a learned behavior can't start because `/mars/arm/state` never publishes, the manipulation server fails with a generic _"Required sensors not available"_ message and logs _"Joint state has never received data"_ — with no hint about the actual fix.

The common root cause is that the arm driver (`mars_arm`) can't reach the Dynamixel servos over the USB-C serial link, most often because **the arm's USB-C cable isn't plugged in**. (Hit exactly this on `mars-the-27th`: cameras were publishing fine, only the arm joint state was missing.)

## Change
Surface the USB-C hint in the two messages that fire when joint state is missing, in [`manipulation_server.py`](ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py):

- Joint-state warning → `... has never received data - please check that the arm's USB-C cable is plugged in`
- Failure reason returned to the caller → appends `If the arm joint state is missing, please check that the arm's USB-C cable is plugged in.`

Scoped to the joint-state path only; the camera messages are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)