### PR TITLE
manipulation: default temporal ensembling off; fix base-speed comment

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -86,9 +86,9 @@
 #     inference_hz: 25.0            # policy inference loop rate (Hz)
 #     speed: 1.5                    # action execution speed multiplier
 #     replay_base_speed_scale: 1.0  # base-speed scale for replay; 1.0 = play base back at full recorded speed
-#     learned_base_speed_scale: 0.5 # base-speed de-rate for the learned policy; 1.0 = full predicted speed
+#     learned_base_speed_scale: 1.0 # base-speed scale for the learned policy; 1.0 = full predicted speed
 #     n_action_steps: 0            # replan horizon; 0 = auto (min(40, chunk_size)), clamped to chunk_size
-#     temporal_ensemble_coeff: 0.01  # ACT action smoothing; 0 = disabled (0.01 default enables it, pinning n_action_steps to 1)
+#     temporal_ensemble_coeff: 0.0   # ACT action smoothing; 0 = disabled (default). 0.01 is a good value to enable it (pins n_action_steps to 1)
 
 # ── Localization (grid localizer) ─────────────────────────────────────
 # navigation_grid_localizer:

--- a/ros2_ws/src/brain/manipulation/config/manipulation_server.yaml
+++ b/ros2_ws/src/brain/manipulation/config/manipulation_server.yaml
@@ -16,4 +16,5 @@ manipulation_server:
     #   > 0 : weight OLDER predictions more (smoother; can over-commit to stale far-horizon steps)
     #   < 0 : weight the LATEST chunk more (reactive/closed-loop; noisier)
     #   = 0 : disabled -- fall back to the chunked-queue path (replan every n_action_steps)
-    temporal_ensemble_coeff: 0.01
+    # Disabled by default; 0.01 is a good starting value to enable smoothing (pins n_action_steps=1).
+    temporal_ensemble_coeff: 0.0

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -90,13 +90,13 @@ class ManipulationServer(Node):
         # ensembling (see manipulation_server.yaml for the behavior of each sign). Resolve and
         # validate it once here, normalizing 0 -> None ("disabled"), so the same value drives
         # both create_act_config (which pins n_action_steps=1 when ensembling) and TRTACTPolicy.
-        self.declare_parameter("temporal_ensemble_coeff", 0.01)
+        self.declare_parameter("temporal_ensemble_coeff", 0.0)
         coeff = self.get_parameter("temporal_ensemble_coeff").value
         if not math.isfinite(coeff):
             # nan/inf pass the float param but poison the ensemble weights (exp(-nan*i)=nan),
             # which would publish NaN joint commands. Reject like a malformed value.
-            self.get_logger().warn(f"Invalid temporal_ensemble_coeff ({coeff}); using default 0.01")
-            coeff = 0.01
+            self.get_logger().warn(f"Invalid temporal_ensemble_coeff ({coeff}); disabling ensembling")
+            coeff = 0.0
         self.temporal_ensemble_coeff = coeff if coeff != 0 else None
 
         # Image size for policy inference (matches checkpoint training)

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -16,7 +16,7 @@
 // code default AND from settings.yaml.template's comments (e.g. the launch sets
 // vertical_fov=80, send_depth=false, log_everything=true — overriding config.py;
 // both nodes' TTS voice default to the same env-backed id; temporal_ensemble_coeff
-// is 0.01 and consecutive_stops_to_complete is 30 per the loaded YAMLs). Add knobs
+// is 0.0 and consecutive_stops_to_complete is 30 per the loaded YAMLs). Add knobs
 // here to expose more; nothing else changes.
 // (Note: `inflation_layer` is intentionally omitted — its default differs per
 //  costmap (0.25/0.3/0.35), so there's no honest single default to show.)
@@ -103,7 +103,7 @@ export const CATALOG = [
       { path: ["manipulation_server", P, "replay_base_speed_scale"], label: "Replay base speed", default: 1.0, type: "float", unit: "×", doc: "Base-speed scale for replay (1.0 = recorded speed)" },
       { path: ["manipulation_server", P, "learned_base_speed_scale"], label: "Learned base speed", default: 1.0, type: "float", unit: "×", doc: "Base-speed scale for the learned policy (1.0 = full predicted speed)" },
       { path: ["manipulation_server", P, "n_action_steps"], label: "Replan horizon", default: 0, type: "int", doc: "Replan horizon; 0 = auto (min(40, chunk_size))" },
-      { path: ["manipulation_server", P, "temporal_ensemble_coeff"], label: "Action smoothing", default: 0.01, type: "float", doc: "ACT temporal-ensemble coefficient; 0 = disabled" },
+      { path: ["manipulation_server", P, "temporal_ensemble_coeff"], label: "Action smoothing", default: 0.0, type: "float", doc: "ACT temporal-ensemble coefficient; 0 = disabled (default). 0.01 is a good value to enable it" },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- **Disable ACT temporal-ensemble smoothing by default** — `temporal_ensemble_coeff` goes `0.01 → 0.0`. Temporal ensembling is a post-hoc smoothing layer that existing learned policies were **not** trained with, so applying it to every policy by default silently changes behavior. It is now opt-in; `0.01` is documented inline as a good value to enable it (it pins `n_action_steps=1`).
- **Invalid coeff now falls back to disabled** — a non-finite (`nan`/`inf`) `temporal_ensemble_coeff` previously fell back to `0.01`; it now falls back to `0.0`. A malformed config should not turn on a feature that is off by default.
- **Fix stale `settings.yaml.template` comment** — it showed `learned_base_speed_scale: 0.5`, but the actual node default is `1.0`. Updated to match (no behavior change; comment only).

Kept all four default sites in sync so they no longer contradict each other:
- `ros2_ws/src/brain/manipulation/config/manipulation_server.yaml` (node default)
- `ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py` (ROS param declaration + invalid-value fallback)
- `config/settings.yaml.template` (commented override example)
- `webapp/js/settings/catalog.js` (default shown in the Settings UI + header comment)

`docs/PARAMETERS.md` already listed `0.0`, so the YAML now matches the docs rather than contradicting them. The consuming code (`ACT.py` / `act_config.py` / `act_trt.py`) already treats `0`/`None` as disabled — no logic change needed there.

### Reviewer notes
- This is the **node-level** default. A robot that has explicitly set `temporal_ensemble_coeff` in its `settings.yaml` override keeps its value; only robots relying on the default are affected.
- These are restart-to-apply params, not per-skill behavior_config overrides.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped. (`ruff check` passes on the touched Python file; changes are config defaults + comments only.)
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate sim up`. — N/A (no simulator behavior/asset changes).
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)