### PR TITLE
fix: only list learned skills in the Train-a-skill selector

### DIFF
--- a/webapp/js/training/configurePanel.js
+++ b/webapp/js/training/configurePanel.js
@@ -52,11 +52,12 @@ export function createConfigurePanel(parent, ros, store, opts) {
   const formEl = document.createElement("div");
   formEl.className = "modal-body";
 
-  // skill selector
+  // skill selector — only learned skills are trainable (not replay/code/poses)
   const skillRow = field("Skill");
   const skillSel = document.createElement("select");
   skillSel.className = "modal-select";
   for (const s of store.skills) {
+    if (s.type !== "learned") continue;
     const o = document.createElement("option");
     o.value = s.directory || "";
     o.textContent = s.name;


### PR DESCRIPTION
## Problem
The **Train a skill** configure panel built its skill dropdown by iterating `store.skills` with no type filter (`configurePanel.js`), so **replay** skills (and any `code`/`poses` skills) showed up as trainable alongside the learned ones. Only learned skills have a trainable dataset.

## Fix
Skip non-`learned` skills when populating the selector:

```js
for (const s of store.skills) {
  if (s.type !== "learned") continue;
  ...
}
```

`store.skills` is left intact (the dashboard's find-by-directory lookup still works); only the picker is filtered. `Skill.type` is `"code" | "learned" | "replay" | "poses"` per `types.d.ts`.

## Testing
`node --check` clean. No JS formatter in pre-commit (clang-format hook is C/C++ only).
