### PR TITLE
fix: stop checkpoint-less failed runs from wedging the brain

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/skills/hot_reload.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/hot_reload.py
@@ -24,10 +24,8 @@ from brain_client.skills.hot_reload_watcher import HotReloadWatcher
 from brain_client.skills.registration import AVAILABLE_SKILLS_QOS, registry_from_skills_msg
 from brain_client.skills.registry import SkillRegistry
 
-# A full reload reloads ALL on-disk skills/agents, so one that just ran already
-# reflects requests arriving right after it. Collapse /brain/reload calls within
-# this window so a burst can't each block the executor for the ~30s PEAS reload
-# and overflow the service queue.
+# Collapse /brain/reload bursts: a full reload reloads all on-disk state, so one
+# that just ran already covers requests arriving within this window.
 _RELOAD_COALESCE_SEC = 2.0
 
 
@@ -132,7 +130,7 @@ class ReloadCoordinator:
     def perform_full(self) -> None:
         now = time.monotonic()
         if now - self._last_full_reload < _RELOAD_COALESCE_SEC:
-            self._logger.info("Skipping /brain/reload — a full reload just completed")
+            self._logger.info("Skipping /brain/reload — a full reload ran recently (coalescing)")
             return
         try:
             self._lifecycle.deactivate_brain()

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/hot_reload.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/hot_reload.py
@@ -24,6 +24,12 @@ from brain_client.skills.hot_reload_watcher import HotReloadWatcher
 from brain_client.skills.registration import AVAILABLE_SKILLS_QOS, registry_from_skills_msg
 from brain_client.skills.registry import SkillRegistry
 
+# A full reload reloads ALL on-disk skills/agents, so one that just ran already
+# reflects requests arriving right after it. Collapse /brain/reload calls within
+# this window so a burst can't each block the executor for the ~30s PEAS reload
+# and overflow the service queue.
+_RELOAD_COALESCE_SEC = 2.0
+
 
 class ReloadCoordinator:
     def __init__(
@@ -42,6 +48,7 @@ class ReloadCoordinator:
         self._lock = threading.Lock()
         self._watcher = None
         self._timer = None
+        self._last_full_reload = 0.0  # monotonic time of the last perform_full
 
     # --- watcher lifecycle ---
     def start_watcher(self) -> None:
@@ -123,6 +130,10 @@ class ReloadCoordinator:
         return reloaded_skills, reloaded_agents
 
     def perform_full(self) -> None:
+        now = time.monotonic()
+        if now - self._last_full_reload < _RELOAD_COALESCE_SEC:
+            self._logger.info("Skipping /brain/reload — a full reload just completed")
+            return
         try:
             self._lifecycle.deactivate_brain()
             self._state.directives = {}
@@ -163,6 +174,9 @@ class ReloadCoordinator:
                 self._lifecycle.reactivate_brain()
             except Exception:
                 pass
+        finally:
+            # Record even on failure so a persistent error can't drive a reload storm.
+            self._last_full_reload = time.monotonic()
 
     def _await_available_skills(self, timeout_sec: float):
         """Wait for the latched /brain/available_skills sample after a reload.

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/workers.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/workers.py
@@ -10,6 +10,7 @@ Downloads automatically activate the run (set checkpoint + stats in
 
 from __future__ import annotations
 
+import glob
 import json
 import os
 import subprocess
@@ -331,11 +332,21 @@ def do_download(
                 f"Activated run {sid}/{run_id}: checkpoint={result['checkpoint']} stats_file={result['stats_file']}"
             )
         except Exception as e:
-            # Activation failed: files are on disk but execution.checkpoint was
-            # never written, so the skill is un-runnable and the startup sweep
-            # can't recover it. Clear the download mark so a later poll retries.
-            _ros.error(f"Download OK but activation failed for {sid}/{run_id}: {e}")
-            store.unmark_download(skill_id, run_id)
+            run_dir = os.path.join(dest_dir, str(run_id))
+            if not glob.glob(os.path.join(run_dir, "*_step_*.pth")):
+                # No model checkpoint => training failed; this run can never be
+                # activated. Don't re-arm the download — retrying re-downloads and
+                # re-triggers brain reloads forever. The dataset + metadata stay on
+                # disk so the skill can be re-trained.
+                _ros.warning(
+                    f"Run {sid}/{run_id} has no checkpoint (training failed) — "
+                    f"not retrying activation; dataset left in place"
+                )
+            else:
+                # Checkpoint present but activation hit a transient error — clear
+                # the download mark so a later poll retries.
+                _ros.error(f"Download OK but activation failed for {sid}/{run_id}: {e}")
+                store.unmark_download(skill_id, run_id)
 
         # Pre-build the TensorRT inference engine so the first execution is fast
         # (the engine is otherwise built lazily on first run, costing ~1 min).

--- a/ros2_ws/src/cloud/innate_training_node/innate_training_node/workers.py
+++ b/ros2_ws/src/cloud/innate_training_node/innate_training_node/workers.py
@@ -334,17 +334,14 @@ def do_download(
         except Exception as e:
             run_dir = os.path.join(dest_dir, str(run_id))
             if not glob.glob(os.path.join(run_dir, "*_step_*.pth")):
-                # No model checkpoint => training failed; this run can never be
-                # activated. Don't re-arm the download — retrying re-downloads and
-                # re-triggers brain reloads forever. The dataset + metadata stay on
-                # disk so the skill can be re-trained.
+                # No checkpoint => training failed; don't retry (it would loop
+                # re-downloading + reloading). Dataset stays for re-training.
                 _ros.warning(
                     f"Run {sid}/{run_id} has no checkpoint (training failed) — "
-                    f"not retrying activation; dataset left in place"
+                    f"not retrying activation; dataset left in place. Error: {e}"
                 )
             else:
-                # Checkpoint present but activation hit a transient error — clear
-                # the download mark so a later poll retries.
+                # Checkpoint present — transient error; retry on a later poll.
                 _ros.error(f"Download OK but activation failed for {sid}/{run_id}: {e}")
                 store.unmark_download(skill_id, run_id)
 


### PR DESCRIPTION
## Problem
A training run that **failed before producing a model checkpoint** (no `*_step_*.pth`) turned a single failed run into a continuous, brain-wide outage:

1. Robot auto-downloads the run, `activate_run()` fails (no checkpoint), and `workers.py` calls `unmark_download()` to "retry later" → the run is **re-downloaded and re-activated forever**, re-triggering `/brain/reload` each cycle.
2. `/brain/reload` runs `perform_full()` on the brain_client's **single-threaded executor** and blocks it for the ~30s PEAS reload (`call_service_sync`, 30s timeout). A burst of reloads overflows the Zenoh query queue (`Query queue depth of 10 reached, discarding oldest Query for '/brain/reload'`) and the brain stays deactivated — never self-recovers.

(The brain catalog already does the right thing for the *listing* side: checkpoint-less learned skills load as `in_training` and are never handed to PEAS to run — see `loader._validate_learned_skill` / `catalog._load_physical_skills`. This PR fixes the two paths that actually loop/wedge.)

## Fix — two minimal, independent guards
- **`workers.py` (activation path):** if a downloaded run has no `*_step_*.pth`, it's a failed run that can never activate — log it and **don't re-arm the download** (no retry loop). The dataset + `metadata.json` (`type: learned`) stay on disk so it can be re-trained. Transient activation errors *with* a checkpoint present still retry as before.
- **`hot_reload.py` (resilience):** coalesce `/brain/reload` calls within a short window (`_RELOAD_COALESCE_SEC = 2.0`). A full reload reloads *all* on-disk state, so one that just ran already reflects a request arriving right after it — collapsing the burst stops them from each blocking the executor ~30s and overflowing the queue. The completion time is recorded even on failure, so a persistent error can't drive a reload storm either.

These are defense-in-depth behind the cloud-side fix (separate PR) that marks a crashed run **failed** instead of `done`, so the robot never enters the download/activate loop in the first place.

## Testing
`py_compile` + `ruff format`/`check` (v0.15.15) clean on both files. No behavior change for the normal success path or for transient activation retries when a checkpoint exists.

## Notes / not in scope
The deeper resilience option — running `perform_full` off the executor so a single reload never blocks the main thread for 30s — is left out to keep this minimal; the coalescing guard plus removing the retry source addresses the observed wedge. Happy to follow up with the non-blocking executor change if desired.
