### PR TITLE
fix: bump web teleop shift-slow speed to 75% (INN-624)

### DIFF
--- a/webapp/js/teleop/keyboardDrive.js
+++ b/webapp/js/teleop/keyboardDrive.js
@@ -2,7 +2,7 @@
 // Keyboard drive: WASD/arrows with ramping, so taps nudge and holds glide.
 //
 // W/↑ = forward, S/↓ = back, A/← = left, D/→ = right. Opposing keys cancel,
-// the combined vector is clamped to unit magnitude, Shift scales to 0.4 for
+// the combined vector is clamped to unit magnitude, Shift scales to 0.75 for
 // precision work. A 50 ms tick ramps toward the target (~350 ms up, ~150 ms
 // down); when no keys are held and the vector decays below epsilon the loop
 // stops and the source disengages (DriveController emits the single zero).
@@ -15,7 +15,7 @@
 const TICK_MS = 50;
 const RAMP_UP_MS = 350;
 const RAMP_DOWN_MS = 150;
-const PRECISION_SCALE = 0.4;
+const PRECISION_SCALE = 0.75;
 const EPSILON = 0.02;
 
 /** @type {Map<string, "up" | "down" | "left" | "right">} */


### PR DESCRIPTION
## What
Bumps the web app's keyboard shift-to-slow teleop speed from **40% → 75%** (`PRECISION_SCALE` in `webapp/js/teleop/keyboardDrive.js`).

## Why
Feature request from Axel (hackathon chat): the "shift = slow" precision speed felt too slow to be useful. INN-624 suggested ~75%. This is the web-app keyboard slow modifier (the robot-side gamepad `slow_mode_factor` is a separate path and is unchanged).

## Scope
One constant + its header comment. No UI/behavior changes otherwise.

Closes INN-624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)