### PR TITLE
feat(webapp): prompt mobile visitors to get the native app

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -3402,3 +3402,94 @@ button {
     grid-template-columns: 1fr;
   }
 }
+
+/* ---- mobile app promo ----------------------------------------------------- */
+/* Shown only on phones/tablets (appPromo.js). Fixed over everything, including
+   the rail (z 40), so it reads as a true interstitial. */
+
+.app-promo-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgb(0 0 0 / 62%);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.app-promo {
+  position: relative;
+  width: 320px;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  padding: 30px 26px 24px;
+  background: var(--panel);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 14px;
+}
+
+.app-promo-close {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.app-promo-close:hover {
+  color: var(--text);
+}
+
+.app-promo-logo {
+  height: 40px;
+  width: auto;
+}
+
+.app-promo-title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.app-promo-blurb {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+.app-promo-cta {
+  width: 100%;
+  margin-top: 4px;
+  padding: 12px 0;
+  border: 1px solid var(--accent-dim);
+  border-radius: 9px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-decoration: none;
+  transition: background 150ms ease;
+}
+
+.app-promo-cta:hover {
+  background: var(--accent-faint);
+}
+
+.app-promo-stay {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  transition: color 150ms ease;
+}
+
+.app-promo-stay:hover {
+  color: var(--text);
+}

--- a/webapp/js/appPromo.js
+++ b/webapp/js/appPromo.js
@@ -20,6 +20,9 @@ export function maybeShowAppPromo(root) {
   const platform = detectMobilePlatform();
   if (!platform || storageGet(DISMISS_KEY)) return;
 
+  // Remember what had focus so we can hand it back when the dialog closes.
+  const prevFocus = document.activeElement;
+
   const backdrop = document.createElement("div");
   backdrop.className = "app-promo-backdrop";
   backdrop.addEventListener("click", dismiss); // tap outside the card to dismiss
@@ -29,6 +32,7 @@ export function maybeShowAppPromo(root) {
   card.setAttribute("role", "dialog");
   card.setAttribute("aria-modal", "true");
   card.setAttribute("aria-label", "Get the Innate app");
+  card.tabIndex = -1; // focusable target so the dialog can be announced on open
   card.addEventListener("click", (e) => e.stopPropagation());
 
   const close = document.createElement("button");
@@ -70,6 +74,8 @@ export function maybeShowAppPromo(root) {
   backdrop.appendChild(card);
   document.body.appendChild(backdrop);
   document.addEventListener("keydown", onKey);
+  // Move focus into the dialog so screen-reader / keyboard users land on it.
+  card.focus();
 
   /** @param {KeyboardEvent} e */
   function onKey(e) {
@@ -80,6 +86,8 @@ export function maybeShowAppPromo(root) {
     storageSet(DISMISS_KEY, "1");
     document.removeEventListener("keydown", onKey);
     backdrop.remove();
+    // Hand focus back to wherever it was before the dialog opened.
+    if (prevFocus instanceof HTMLElement) prevFocus.focus();
   }
 }
 
@@ -90,11 +98,12 @@ export function maybeShowAppPromo(root) {
 export function detectMobilePlatform() {
   const ua = navigator.userAgent || "";
   if (/android/i.test(ua)) return "android";
-  // iPhone/iPod/iPad, plus iPadOS which reports itself as desktop Safari on a
-  // Mac — distinguished from an actual Mac by the touch screen.
+  // iPhone/iPod/iPad, plus iPadOS 13+ which reports itself as desktop Safari
+  // ("Macintosh" UA) — distinguished from an actual Mac by the touch screen.
+  // (navigator.platform would work too but is deprecated.)
   const isIOS =
     /iphone|ipad|ipod/i.test(ua) ||
-    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+    (/macintosh/i.test(ua) && navigator.maxTouchPoints > 1);
   return isIOS ? "ios" : null;
 }
 

--- a/webapp/js/appPromo.js
+++ b/webapp/js/appPromo.js
@@ -59,8 +59,12 @@ export function maybeShowAppPromo(root) {
   const cta = document.createElement("a");
   cta.className = "app-promo-cta";
   cta.href = platform === "ios" ? IOS_APP_URL : ANDROID_APP_URL;
-  cta.target = "_blank";
-  cta.rel = "noopener noreferrer";
+  // iOS TestFlight opens in a new tab; the Android .apk should download in place.
+  // A _blank to a downloadable file leaves an empty lingering tab on Chrome for Android.
+  if (platform === "ios") {
+    cta.target = "_blank";
+    cta.rel = "noopener noreferrer";
+  }
   cta.textContent = platform === "ios" ? "Download for iOS" : "Download for Android";
   cta.addEventListener("click", dismiss); // they've got the message — don't ask again
 

--- a/webapp/js/appPromo.js
+++ b/webapp/js/appPromo.js
@@ -1,0 +1,118 @@
+// @ts-check
+// Mobile "get the app" prompt — shown once when the browser cockpit is opened
+// on a phone or tablet. The web app is tuned for a laptop; on the go the native
+// app is the better surface (leader-arm teleop in the field), so nudge mobile
+// visitors toward it with a platform-correct store link. Dismissal is
+// remembered so it never nags across page switches or repeat visits.
+
+const IOS_APP_URL = "https://testflight.apple.com/join/YeChe4A7";
+const ANDROID_APP_URL = "https://cdn.innate.bot/innate-app-latest.apk";
+const DISMISS_KEY = "innate.appPromoDismissed";
+
+/** @typedef {"ios" | "android"} MobilePlatform */
+
+/**
+ * Show the app-download prompt if the visitor is on mobile and hasn't dismissed
+ * it before. No-op on desktop. Safe to call on every page mount.
+ * @param {string} root Relative prefix to the site root ("" or "../"), for the logo asset.
+ */
+export function maybeShowAppPromo(root) {
+  const platform = detectMobilePlatform();
+  if (!platform || storageGet(DISMISS_KEY)) return;
+
+  const backdrop = document.createElement("div");
+  backdrop.className = "app-promo-backdrop";
+  backdrop.addEventListener("click", dismiss); // tap outside the card to dismiss
+
+  const card = document.createElement("div");
+  card.className = "app-promo";
+  card.setAttribute("role", "dialog");
+  card.setAttribute("aria-modal", "true");
+  card.setAttribute("aria-label", "Get the Innate app");
+  card.addEventListener("click", (e) => e.stopPropagation());
+
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "app-promo-close";
+  close.textContent = "✕";
+  close.setAttribute("aria-label", "Dismiss");
+  close.addEventListener("click", dismiss);
+
+  const logo = document.createElement("img");
+  logo.className = "app-promo-logo";
+  logo.src = root + "public/innate-logo.avif";
+  logo.alt = "";
+
+  const title = document.createElement("h2");
+  title.className = "app-promo-title";
+  title.textContent = "Get the Innate app";
+
+  const blurb = document.createElement("p");
+  blurb.className = "app-promo-blurb";
+  blurb.textContent =
+    "The web app is built for a laptop. On your phone, the Innate app is the better way to drive — including leader-arm teleoperation in the field.";
+
+  const cta = document.createElement("a");
+  cta.className = "app-promo-cta";
+  cta.href = platform === "ios" ? IOS_APP_URL : ANDROID_APP_URL;
+  cta.target = "_blank";
+  cta.rel = "noopener noreferrer";
+  cta.textContent = platform === "ios" ? "Download for iOS" : "Download for Android";
+  cta.addEventListener("click", dismiss); // they've got the message — don't ask again
+
+  const stay = document.createElement("button");
+  stay.type = "button";
+  stay.className = "app-promo-stay";
+  stay.textContent = "Continue in browser";
+  stay.addEventListener("click", dismiss);
+
+  card.append(close, logo, title, blurb, cta, stay);
+  backdrop.appendChild(card);
+  document.body.appendChild(backdrop);
+  document.addEventListener("keydown", onKey);
+
+  /** @param {KeyboardEvent} e */
+  function onKey(e) {
+    if (e.key === "Escape") dismiss();
+  }
+
+  function dismiss() {
+    storageSet(DISMISS_KEY, "1");
+    document.removeEventListener("keydown", onKey);
+    backdrop.remove();
+  }
+}
+
+/**
+ * Detect whether we're on a phone/tablet that can run the native app.
+ * Exported for unit testing the gating logic. @returns {MobilePlatform | null} null on desktop / unknown.
+ */
+export function detectMobilePlatform() {
+  const ua = navigator.userAgent || "";
+  if (/android/i.test(ua)) return "android";
+  // iPhone/iPod/iPad, plus iPadOS which reports itself as desktop Safari on a
+  // Mac — distinguished from an actual Mac by the touch screen.
+  const isIOS =
+    /iphone|ipad|ipod/i.test(ua) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+  return isIOS ? "ios" : null;
+}
+
+/** localStorage can throw (private mode / disabled) — never let it break a page. */
+/** @param {string} key @returns {string | null} */
+function storageGet(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** @param {string} key @param {string} value */
+function storageSet(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* ignore — a non-persisted dismissal still hides it for this page view */
+  }
+}

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -3,6 +3,7 @@
 // and the placeholder renderer for not-yet-built sections.
 
 import { ros } from "./rosClient.js";
+import { maybeShowAppPromo } from "./appPromo.js";
 
 /** @typedef {{ key: string, label: string, icon: string }} Section */
 
@@ -86,6 +87,9 @@ export function initShell(activeKey, root) {
 
   rail.appendChild(createBadge());
   document.body.prepend(rail);
+
+  // On a phone/tablet, nudge toward the native app (shown once, then remembered).
+  maybeShowAppPromo(root);
 }
 
 /**

--- a/webapp/tests/appPromo.test.js
+++ b/webapp/tests/appPromo.test.js
@@ -15,9 +15,9 @@ function test(name, fn) {
 }
 
 /** Stub the bits of navigator the detector reads (the global is read-only in Node). */
-function setNavigator(ua, platform = "", maxTouchPoints = 0) {
+function setNavigator(ua, maxTouchPoints = 0) {
   Object.defineProperty(globalThis, "navigator", {
-    value: { userAgent: ua, platform, maxTouchPoints },
+    value: { userAgent: ua, maxTouchPoints },
     configurable: true,
   });
 }
@@ -40,13 +40,13 @@ test("Android phone → android", () => {
 });
 
 test("desktop Mac → null (no prompt)", () => {
-  setNavigator(MAC, "MacIntel", 0);
+  setNavigator(MAC, 0);
   assert.equal(detectMobilePlatform(), null);
 });
 
 test("iPadOS (Mac UA + touch) → ios", () => {
   // iPadOS Safari masquerades as a Mac; the touch screen is the tell.
-  setNavigator(MAC, "MacIntel", 5);
+  setNavigator(MAC, 5);
   assert.equal(detectMobilePlatform(), "ios");
 });
 

--- a/webapp/tests/appPromo.test.js
+++ b/webapp/tests/appPromo.test.js
@@ -1,0 +1,53 @@
+// Gating-logic tests for js/appPromo.js — zero dependencies, plain node:
+//   node tests/appPromo.test.js
+// Only detectMobilePlatform() is exercised here: it's pure (reads navigator)
+// and is what decides whether the prompt ever appears.
+
+import assert from "node:assert/strict";
+import { detectMobilePlatform } from "../js/appPromo.js";
+
+let passed = 0;
+/** @param {string} name @param {() => void} fn */
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+/** Stub the bits of navigator the detector reads (the global is read-only in Node). */
+function setNavigator(ua, platform = "", maxTouchPoints = 0) {
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: ua, platform, maxTouchPoints },
+    configurable: true,
+  });
+}
+
+const IPHONE =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1";
+const ANDROID =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Mobile Safari/537.36";
+const MAC =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15";
+
+test("iPhone → ios", () => {
+  setNavigator(IPHONE);
+  assert.equal(detectMobilePlatform(), "ios");
+});
+
+test("Android phone → android", () => {
+  setNavigator(ANDROID);
+  assert.equal(detectMobilePlatform(), "android");
+});
+
+test("desktop Mac → null (no prompt)", () => {
+  setNavigator(MAC, "MacIntel", 0);
+  assert.equal(detectMobilePlatform(), null);
+});
+
+test("iPadOS (Mac UA + touch) → ios", () => {
+  // iPadOS Safari masquerades as a Mac; the touch screen is the tell.
+  setNavigator(MAC, "MacIntel", 5);
+  assert.equal(detectMobilePlatform(), "ios");
+});
+
+console.log(`\n${passed} passed`);


### PR DESCRIPTION
## What

When the robot's web cockpit (`webapp/`) is opened on a **phone or tablet**, show a dismissible popup nudging the visitor to download the native app, with a platform-correct link:

- **iOS** → TestFlight (`testflight.apple.com/join/YeChe4A7`)
- **Android** → APK (`cdn.innate.bot/innate-app-latest.apk`)

The links match what the docs hand out (`get-started/mars-quick-start.mdx`, `hackathon/robohacks.mdx`). The web app is built for a laptop; on the go the native app is the better surface (leader-arm teleop in the field), so this points mobile users there.

## How

- **`js/appPromo.js`** (new) — `maybeShowAppPromo(root)`: detects the platform from the user agent (including the iPadOS-as-Mac case via touch points), builds the popup, and gates on a `localStorage` flag so it shows once and never nags across page switches or repeat visits. No-op on desktop.
- **`js/shell.js`** — invoked from `initShell()`, the one hook every page already runs, so it covers all pages with the correct asset root.
- **`css/app.css`** — `.app-promo*` styles reusing the existing design tokens (panel / hairline / amber accent), fixed above the icon rail.
- **`tests/appPromo.test.js`** (new) — zero-dep node test for the detection logic (iPhone / Android / desktop-Mac / iPad), following the repo's `tests/` convention.

## Notes

- Dismissal is **permanent** (localStorage), not per-session — easy to switch to `sessionStorage` if we'd rather re-prompt each visit.
- The two URLs are hardcoded constants at the top of `appPromo.js`; update them there if the TestFlight/APK links change.

## Verification

- `node --check` clean; `tsc` reports no errors in the new/changed files.
- `node tests/appPromo.test.js` → 4 passed; existing `dynamixel.test.js` still green.
- Rendered both variants in a browser at phone size and confirmed the iOS/Android labels + correct hrefs, on-brand styling, and that "Continue in browser" removes the overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)