### PR TITLE
ci: tighten colcon worker cap to 3 to avoid OOM

### DIFF
--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -62,8 +62,8 @@ COPY workspace /root/innate-os/workspace
 
 # Incremental rebuild. ccache (warm from the base) turns unchanged translation
 # units into cache hits; only changed packages truly recompile.
-# --parallel-workers is capped at 4: E2_HIGHCPU_8 has 8 vCPUs but only 8 GB RAM,
-# and >4 concurrent C++ link jobs can OOM with no useful error.
+# --parallel-workers is capped at 3: E2_HIGHCPU_8 has 8 vCPUs but only 8 GB RAM,
+# and >3 concurrent C++ link jobs can OOM with no useful error.
 #
 # Before building, prune build/ + install/ dirs of packages that no longer exist
 # in src — otherwise a deleted package's stale artifacts could keep dependents
@@ -87,7 +87,7 @@ RUN . /opt/ros/humble/setup.sh && \
     rm /tmp/current-pkgs.txt && \
     { rosdep install --from-paths src --ignore-src -r -y || \
         echo "WARNING: rosdep install exited non-zero; if the build below fails on a missing system dep, check the rosdep output above." >&2; } && \
-    colcon build --parallel-workers "$(( $(nproc) < 4 ? $(nproc) : 4 ))" --cmake-args \
+    colcon build --parallel-workers "$(( $(nproc) < 3 ? $(nproc) : 3 ))" --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/ci/Dockerfile.test-base
+++ b/ci/Dockerfile.test-base
@@ -108,15 +108,15 @@ RUN cd /root/innate-os/ros2_ws/src && \
 
 # Full build with ccache. ccache writes to /root/.ccache (a REAL dir, NOT a
 # --mount=type=cache) so the populated cache is baked into the image layer and
-# carried into ci/Dockerfile.test via FROM. --parallel-workers is capped at 4:
-# E2_HIGHCPU_8 has 8 vCPUs but only 8 GB RAM, and >4 concurrent C++ link jobs
+# carried into ci/Dockerfile.test via FROM. --parallel-workers is capped at 3:
+# E2_HIGHCPU_8 has 8 vCPUs but only 8 GB RAM, and >3 concurrent C++ link jobs
 # (mars_cam etc.) can OOM with no useful error.
 # mars_cam/nav/control build fine on non-Jetson: cam's VPI stereo component is
 # guarded by if(VPI_FOUND), nav's only Jetson dep (python3-cupy) is runtime-only.
 WORKDIR /root/innate-os/ros2_ws
 RUN . /opt/ros/humble/setup.sh && \
     rosdep install --from-paths src --ignore-src -r -y || true && \
-    colcon build --parallel-workers "$(( $(nproc) < 4 ? $(nproc) : 4 ))" --cmake-args \
+    colcon build --parallel-workers "$(( $(nproc) < 3 ? $(nproc) : 3 ))" --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/ci/run_integration_tests.sh
+++ b/ci/run_integration_tests.sh
@@ -123,7 +123,7 @@ echo "=== integration tests: --symlink-install ==="
 python3 -m pip install --quiet 'setuptools<80'
 rm -rf build install log
 colcon build --symlink-install \
-  --parallel-workers "$(( $(nproc) < 4 ? $(nproc) : 4 ))" --cmake-args \
+  --parallel-workers "$(( $(nproc) < 3 ? $(nproc) : 3 ))" --cmake-args \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache


### PR DESCRIPTION
## Summary

Tightens the colcon `--parallel-workers` cap from **4 → 3** to stop OOM failures on the CI build machine.

Cloud Build's `E2_HIGHCPU_8` has 8 vCPUs but only **8 GB RAM**. The existing 4-worker cap still allowed enough concurrent C++ link jobs (`mars_cam` etc.) to exhaust memory and die with no useful error. Capping at 3 keeps peak memory well under the limit.

> Note: `E2_STANDARD_8` (more RAM) isn't available — Cloud Build's default pool only offers `e2-highcpu-{8,32}`, `e2-medium`, `n1-highcpu-{8,32}`. Getting a true standard machine would require a private worker pool, which is out of scope here.

## Changes
- `ci/Dockerfile.test`, `ci/Dockerfile.test-base`, `ci/run_integration_tests.sh` — `--parallel-workers` `min(nproc, 4)` → `min(nproc, 3)`
- Updated the two comments that document the cap rationale

## Validation
- [x] CI-config only; the base/test image build and integration-test run on this PR exercise the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
