### PR TITLE
Show webapp URI in service banners

### DIFF
--- a/scripts/innate
+++ b/scripts/innate
@@ -644,6 +644,7 @@ ROS_WS = INNATE_OS_ROOT / "ros2_ws"
 LAUNCH_HW = INNATE_OS_ROOT / "scripts" / "launch_ros_in_tmux.sh"
 LAUNCH_SIM = INNATE_OS_ROOT / "scripts" / "launch_sim_in_tmux.zsh"
 DIAGNOSTICS = INNATE_OS_ROOT / "scripts" / "diagnostics.py"
+WEBAPP_URI_SCRIPT = INNATE_OS_ROOT / "scripts" / "webapp_uri.zsh"
 SKILL_CACHE_PATH = Path(os.environ.get("INNATE_SKILL_CACHE", "/tmp/innate_skill_contracts.json"))
 SKILL_SOCKET_PATH = Path(os.environ.get("INNATE_SKILL_SOCKET", "/tmp/innate_skill_cli.sock"))
 
@@ -739,6 +740,34 @@ def run(cmd, **kwargs):
     return subprocess.run(cmd, **kwargs)
 
 
+def get_webapp_uri():
+    zsh = shutil.which("zsh")
+    if zsh is None or not WEBAPP_URI_SCRIPT.exists():
+        return None
+
+    try:
+        result = subprocess.run(
+            [zsh, str(WEBAPP_URI_SCRIPT), "--print"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0:
+        return None
+    uri = result.stdout.strip().splitlines()
+    return uri[0] if uri else None
+
+
+def print_webapp_uri():
+    uri = get_webapp_uri()
+    if uri:
+        print(f"  {C.BOLD}Web app:{C.NC} {uri}")
+
+
 @contextmanager
 def _suppress_process_output():
     sys.stdout.flush()
@@ -828,6 +857,8 @@ def _show_status():
     print(f"  {C.BOLD}Mode:{C.NC}     {mode}")
     print(f"  {C.BOLD}ROS:{C.NC}      {ros_status}")
     print(f"  {C.BOLD}DDS:{C.NC}      {dds_status}")
+    if not is_sim_mode():
+        print_webapp_uri()
     print()
     print(f"  {C.BOLD}innate view{C.NC}         Attach to nodes")
     print(f"  {C.BOLD}innate restart{C.NC}      Restart nodes")
@@ -849,6 +880,7 @@ def _service_start():
     service = SYSTEMD_SERVICE_HW
     if systemd_active(service):
         warn(f"Already running (systemd: {service})")
+        print_webapp_uri()
         return 0
 
     r = run(["sudo", "systemctl", "start", service])
@@ -857,6 +889,7 @@ def _service_start():
         return 1
 
     ok("ROS nodes starting (systemd)")
+    print_webapp_uri()
     return 0
 
 
@@ -917,6 +950,7 @@ def _service_restart():
         return 1
 
     ok("ROS nodes restarting (systemd)")
+    print_webapp_uri()
     return 0
 
 
@@ -1792,6 +1826,9 @@ class _UpdateServiceManager:
     def start(self) -> int:
         if self.is_running():
             self.logger.warning("ROS services already running")
+            uri = get_webapp_uri()
+            if uri:
+                self.logger.info(f"Web app: {uri}")
             return 0
 
         result = self._run(["sudo", "systemctl", "start", self.SYSTEMD_SERVICE], check=False)
@@ -1800,6 +1837,9 @@ class _UpdateServiceManager:
             return 1
 
         self.logger.success("ROS services starting (systemd)")
+        uri = get_webapp_uri()
+        if uri:
+            self.logger.info(f"Web app: {uri}")
         return 0
 
     def status(self) -> dict:

--- a/scripts/launch_ros_in_tmux.sh
+++ b/scripts/launch_ros_in_tmux.sh
@@ -5,6 +5,10 @@ SESSION_NAME="ros_nodes"
 ROS_WS_PATH="$INNATE_OS_ROOT/ros2_ws"
 DDS_SETUP_SCRIPT="$INNATE_OS_ROOT/config/dds/setup_dds.zsh"
 RUNTIME_ENV_EXPORTS=$(python3 "$INNATE_OS_ROOT/scripts/print_runtime_env.py" --shell 2>/dev/null || true)
+WEBAPP_URI_SCRIPT="$INNATE_OS_ROOT/scripts/webapp_uri.zsh"
+if [ -f "$WEBAPP_URI_SCRIPT" ]; then
+    source "$WEBAPP_URI_SCRIPT"
+fi
 
 # Detect a missing service key up front so we can warn loudly once launch is done.
 # Uses the same /etc/innate.env + repo .env merge as the runtime env, so this
@@ -132,6 +136,10 @@ done
 
 tmux select-window -t $SESSION_NAME:"${WINDOW_NAMES[1]}"
 
+WEBAPP_URI=""
+if typeset -f innate_webapp_uri >/dev/null 2>&1; then
+    WEBAPP_URI="$(innate_webapp_uri)"
+fi
 SESSION_FMT=$(printf "%-29s" "$SESSION_NAME")
 WINDOWS_FMT=$(printf "%-29s" "${#WINDOW_NAMES[@]}")
 ATTACH_FMT=$(printf "%-29s" "tmux attach -t $SESSION_NAME")
@@ -146,6 +154,9 @@ echo "  ║  Attach:   ${ATTACH_FMT}║     o  o"
 echo "  ║                                         ║"
 echo "  ║  Run 'innate view' to monitor nodes 👀  ║"
 echo "  ╚═════════════════════════════════════════╝"
+if [ -n "$WEBAPP_URI" ]; then
+    echo "  Web app: $WEBAPP_URI"
+fi
 echo ""
 
 # Loud, hard-to-miss warning when the robot has no service key. Printed last so

--- a/scripts/restart_robot_networking.sh
+++ b/scripts/restart_robot_networking.sh
@@ -19,4 +19,12 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Service restarts requested." >&2
-exit 0 
+INNATE_OS_ROOT="${INNATE_OS_ROOT:-/home/jetson1/innate-os}"
+WEBAPP_URI_SCRIPT="$INNATE_OS_ROOT/scripts/webapp_uri.zsh"
+if command -v zsh >/dev/null 2>&1 && [ -f "$WEBAPP_URI_SCRIPT" ]; then
+  WEBAPP_URI="$(zsh "$WEBAPP_URI_SCRIPT" --print 2>/dev/null || true)"
+  if [ -n "$WEBAPP_URI" ]; then
+    echo "Web app: $WEBAPP_URI" >&2
+  fi
+fi
+exit 0

--- a/scripts/ssh_welcome.zsh
+++ b/scripts/ssh_welcome.zsh
@@ -15,11 +15,16 @@ export INNATE_WELCOME_SHOWN=1
 INNATE_OS_ROOT="${INNATE_OS_ROOT:-$HOME/innate-os}"
 UPDATE_BRANCH="${INNATE_UPDATE_BRANCH:-main}"
 UPDATE_CMD="${INNATE_OS_ROOT}/scripts/update/innate-update"
+WEBAPP_URI_SCRIPT="${INNATE_OS_ROOT}/scripts/webapp_uri.zsh"
 ANIMATE="${INNATE_WELCOME_ANIMATE:-1}"
 ANIMATION_DELAY="${INNATE_WELCOME_DELAY:-0.04}"
 
 if [[ ! -x "$UPDATE_CMD" ]] && command -v innate-update >/dev/null 2>&1; then
     UPDATE_CMD="$(command -v innate-update)"
+fi
+
+if [[ -f "$WEBAPP_URI_SCRIPT" ]]; then
+    source "$WEBAPP_URI_SCRIPT"
 fi
 
 # Colors (safe for plain terminals too).
@@ -64,6 +69,10 @@ if [[ -x "$UPDATE_CMD" ]] && [[ -d "${INNATE_OS_ROOT}/.git" ]]; then
         *) STATUS_MODE="unknown" ;;
     esac
 fi
+WEBAPP_URI=""
+if typeset -f innate_webapp_uri >/dev/null 2>&1; then
+    WEBAPP_URI="$(innate_webapp_uri)"
+fi
 
 echo ""
 for line in "${LOGO_LINES[@]}"; do
@@ -77,6 +86,9 @@ echo ""
 printf "%bCurrent:%b %s\n" "$BOLD" "$NC" "${CURRENT_VERSION:-unknown}"
 if [[ -n "$LATEST_TAG" ]]; then
     printf "%bLatest:%b  %s\n" "$BOLD" "$NC" "$LATEST_TAG"
+fi
+if [[ -n "$WEBAPP_URI" ]]; then
+    printf "%bWeb app:%b %s\n" "$BOLD" "$NC" "$WEBAPP_URI"
 fi
 
 case "$STATUS_MODE" in

--- a/scripts/webapp_uri.zsh
+++ b/scripts/webapp_uri.zsh
@@ -1,0 +1,35 @@
+#!/bin/zsh
+# Shared helper for printing the webapp URL on the robot's current Wi-Fi IP.
+
+innate_current_wifi_ip() {
+    local iface ip
+
+    for iface in $(nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null | awk -F: '$2 == "wifi" && $3 == "connected" { print $1 }'); do
+        ip="$(ip -o -4 addr show dev "$iface" scope global 2>/dev/null | awk '{ split($4, addr, "/"); print addr[1]; exit }')"
+        if [[ -n "$ip" ]]; then
+            print -r -- "$ip"
+            return 0
+        fi
+    done
+
+    for iface in $(iw dev 2>/dev/null | awk '$1 == "Interface" { print $2 }'); do
+        ip="$(ip -o -4 addr show dev "$iface" scope global 2>/dev/null | awk '{ split($4, addr, "/"); print addr[1]; exit }')"
+        if [[ -n "$ip" ]]; then
+            print -r -- "$ip"
+            return 0
+        fi
+    done
+}
+
+innate_webapp_uri() {
+    local ip
+    ip="$(innate_current_wifi_ip)"
+    if [[ -z "$ip" ]]; then
+        return 1
+    fi
+    print -r -- "https://$ip"
+}
+
+if [[ "${ZSH_EVAL_CONTEXT:-}" != *:file && "${1:-}" == "--print" ]]; then
+    innate_webapp_uri
+fi


### PR DESCRIPTION
## Summary
- Add a small shared helper that prints the webapp URL using the robot current Wi-Fi IPv4 address
- Show that URL in SSH welcome, innate status/start/restart, ros-app launch, and network-triggered restart output
- Keep the link simple: `https://<current-wifi-ip>`

## Test plan
- `zsh -n scripts/webapp_uri.zsh scripts/ssh_welcome.zsh scripts/launch_ros_in_tmux.sh`
- `bash -n scripts/restart_robot_networking.sh`
- `python3 -m py_compile scripts/innate`
- `git diff --check`
- Mocked `nmcli`/`iw`/`ip` output to verify `https://<wifi-ip>` generation
- Simulated SSH welcome banner