### PR TITLE
feat(manipulation): record policy rollouts as labeled eval episodes

### DIFF
--- a/ros2_ws/src/brain/manipulation/config/recorder.yaml
+++ b/ros2_ws/src/brain/manipulation/config/recorder.yaml
@@ -12,3 +12,13 @@
     odom_topic: "/odom"                    # Topic for odometry data (used to verify robot is alive)
     image_size: [640, 480]
     max_timesteps: 1800                    # Maximum number of timesteps before automatically stopping episode
+    # Policy-rollout capture (evaluation datasets). Off for teleop demos: the
+    # trailing two /action columns are then synthesized training labels
+    # (progress ramp + termination flag) written at save time. When true at
+    # episode start, those columns instead record the policy's live
+    # [progress, termination] head from policy_head_topic (NaN on steps with no
+    # fresh sample), and the episode is tagged action_head_source: "policy" in
+    # dataset_metadata.json. Flip at runtime with:
+    #   ros2 param set /recorder_node capture_policy_head true
+    capture_policy_head: false
+    policy_head_topic: "/brain/manipulation/policy_head"

--- a/ros2_ws/src/brain/manipulation/include/manipulation/episode_data.hpp
+++ b/ros2_ws/src/brain/manipulation/include/manipulation/episode_data.hpp
@@ -39,6 +39,17 @@ class EpisodeData {
     // Set the output path. Does not touch disk yet.
     void open_file(const std::string& path);
 
+    // Record the policy's own progress/termination head into the trailing two
+    // /action columns instead of synthesizing them at finalize(). For teleop
+    // demos (default off) there is no real head, so finalize() writes the
+    // linear-ramp training labels; for a policy rollout the live head values
+    // are the data under evaluation and must not be overwritten. Call before
+    // the first add_timestep(); the choice holds for the whole episode so a
+    // column can never mix real and synthesized values.
+    void enable_policy_head() {
+        policy_head_enabled_ = true;
+    }
+
     // Append one timestep to the file. On the first call we create the
     // HDF5 file and all chunked extendable datasets sized from the inputs.
     //
@@ -46,14 +57,23 @@ class EpisodeData {
     // /head_command dataset — kept out of /action so the learned-policy action
     // space is unaffected. Pass NaN (the default) to omit head recording; if it
     // is NaN on the first timestep the dataset is never created.
+    //
+    // policy_progress / policy_termination are only consumed when
+    // enable_policy_head() was called: they land in the trailing two /action
+    // columns. NaN marks a step with no fresh head sample (policy not running
+    // or stale) — deliberately not zero-filled so gaps stay visible.
     void add_timestep(const std::vector<double>& action, const std::vector<double>& qpos,
                       const std::vector<double>& qvel, const std::vector<cv::Mat>& images, double arm_timestamp = -1.0,
                       const std::vector<double>& image_timestamps = {},
-                      double head_command = std::numeric_limits<double>::quiet_NaN());
+                      double head_command = std::numeric_limits<double>::quiet_NaN(),
+                      double policy_progress = std::numeric_limits<double>::quiet_NaN(),
+                      double policy_termination = std::numeric_limits<double>::quiet_NaN());
 
-    // Write the termination columns of /action, then close the file.
-    // Safe to call when no timesteps were written; in that case behaves
-    // like cancel() (since an empty file is useless).
+    // Write the termination columns of /action (skipped when
+    // enable_policy_head() was called — the real head was streamed per
+    // timestep), then close the file. Safe to call when no timesteps were
+    // written; in that case behaves like cancel() (since an empty file is
+    // useless).
     void finalize();
 
     // Close any open handles and delete the file on disk.
@@ -82,6 +102,10 @@ class EpisodeData {
     std::string file_path_;
     bool file_created_;
     size_t timestep_count_;
+    // When true, the trailing two /action columns carry the policy's live
+    // progress/termination head (written per timestep) and finalize() must not
+    // overwrite them with synthesized training labels.
+    bool policy_head_enabled_ = false;
 
     std::vector<std::string> camera_names_;
     bool camera_names_set_;

--- a/ros2_ws/src/brain/manipulation/include/manipulation/recorder_node.hpp
+++ b/ros2_ws/src/brain/manipulation/include/manipulation/recorder_node.hpp
@@ -53,6 +53,7 @@ class RecorderNode : public rclcpp::Node {
     void head_position_callback(const std_msgs::msg::String::SharedPtr msg);
     void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
     void odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg);
+    void policy_head_callback(const std_msgs::msg::Float64MultiArray::SharedPtr msg);
     void timer_callback();
 
     // Service handlers
@@ -108,6 +109,7 @@ class RecorderNode : public rclcpp::Node {
     std::string head_position_topic_;
     std::string velocity_topic_;
     std::string odom_topic_;
+    std::string policy_head_topic_;
     std::vector<int64_t> image_size_;
     int max_timesteps_;
 
@@ -131,6 +133,18 @@ class RecorderNode : public rclcpp::Node {
     // for replay skills only. head_received_ stays false until the first reading.
     double latest_head_position_ = 0.0;
     bool head_received_ = false;
+    // Policy progress/termination head, published by the inference server while
+    // a learned behavior runs. Only recorded when the capture_policy_head param
+    // was true at episode start (snapshotted into episode_policy_head_ so the
+    // semantics can't flip mid-episode). Receipt time gates staleness: a value
+    // older than kPolicyHeadStaleSec is recorded as NaN rather than reusing the
+    // last sample after the policy stopped.
+    double latest_policy_progress_ = 0.0;
+    double latest_policy_termination_ = 0.0;
+    std::chrono::steady_clock::time_point latest_policy_head_time_;
+    bool policy_head_received_ = false;
+    bool episode_policy_head_ = false;
+    static constexpr double kPolicyHeadStaleSec = 0.5;
 
     // Topic tracking
     std::map<std::string, bool> topics_received_;
@@ -143,6 +157,7 @@ class RecorderNode : public rclcpp::Node {
     rclcpp::Subscription<std_msgs::msg::String>::SharedPtr head_position_sub_;
     rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
     rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
+    rclcpp::Subscription<std_msgs::msg::Float64MultiArray>::SharedPtr policy_head_sub_;
 
     // Publishers
     rclcpp::Publisher<brain_messages::msg::RecorderStatus>::SharedPtr status_pub_;

--- a/ros2_ws/src/brain/manipulation/include/manipulation/task_manager.hpp
+++ b/ros2_ws/src/brain/manipulation/include/manipulation/task_manager.hpp
@@ -28,8 +28,14 @@ class TaskManager {
 
     // Rename the already-finalized streaming file at `temp_file_path` to its
     // final episode slot and update the dataset metadata.
+    //
+    // action_head_source records what the trailing two /action columns contain:
+    // "synthesized" (teleop demo: linear-ramp training labels written at
+    // finalize) or "policy" (rollout: the policy's live progress/termination
+    // head). It describes the data, not who drove the robot — consumers (e.g.
+    // training uploads) must not treat "policy" episodes as demo labels.
     void add_episode(const std::string& temp_file_path, const std::string& start_timestamp,
-                     const std::string& end_timestamp);
+                     const std::string& end_timestamp, const std::string& action_head_source = "synthesized");
 
     void end_task();
 

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -150,6 +150,11 @@ class ManipulationServer(Node):
         # Per-step inference timing breakdown (JSON String), for the webapp Profiling page.
         # Only published while a learned behavior is executing, so it's free when idle.
         self.inference_profile_pub = self.create_publisher(String, "/brain/manipulation/inference_profile", 10)
+        # The policy's [progress, termination] head, one message per inference step
+        # (only when the action head is wide enough to carry it). The recorder
+        # subscribes to this during policy-rollout capture so evaluation episodes
+        # store the real head instead of synthesized training labels.
+        self.policy_head_pub = self.create_publisher(Float64MultiArray, "/brain/manipulation/policy_head", 10)
         self._inference_seq = 0
         # Previous emitted action, for the per-step command-jerk (smoothness) metric.
         self._prev_action_np = None
@@ -925,10 +930,16 @@ class ManipulationServer(Node):
                 )
                 return None
 
-            # Action layout: [0:6] arm joint targets, [6] linear.x, [7] angular.z, [8] progress.
+            # Action layout: [0:6] arm joint targets, [6] linear.x, [7] angular.z,
+            # [8] progress, [9] termination.
             self._publish_base(float(action_np[6]), float(action_np[7]), self.learned_base_speed_scale)
             self._publish_arm(action_np[:6])
             t3 = time.perf_counter()
+
+            if self.current_action_dim >= 10:
+                head_msg = Float64MultiArray()
+                head_msg.data = [float(action_np[8]), float(action_np[9])]
+                self.policy_head_pub.publish(head_msg)
 
             if profiling:
                 quality = {}

--- a/ros2_ws/src/brain/manipulation/manipulation/rollout_eval.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/rollout_eval.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Operator-in-the-loop rollout evaluation for learned skills.
+
+Runs a learned skill N times, recording every rollout as a labeled episode in
+an evaluation task directory. Each trial:
+
+1. prompts the operator to reset the scene,
+2. starts a recorder episode with policy-head capture on (the trailing two
+   /action columns hold the policy's live progress/termination head, and the
+   episode is tagged ``action_head_source: "policy"``),
+3. executes the skill via the /behavior/execute action,
+4. saves the episode and asks the operator for a success/failure label
+   (stored via /brain/recorder/set_episode_outcome) plus an optional
+   free-text failure note (stored in ``eval_log.jsonl`` in the eval dir).
+
+The result is an ordinary recorder dataset — episode_N.h5 + auto-encoded MP4s +
+dataset_metadata.json — whose outcome labels give task success rate and whose
+real head columns feed offline auto-stop evaluation.
+
+Usage (on the robot, with recorder_node and manipulation_server running)::
+
+    python3 -m manipulation.rollout_eval \
+        --skill-dir ~/innate-os/workspace/custom_skills/pick-up-socks \
+        --eval-name pick-up-socks-eval \
+        --trials 10 [--checkpoint act_policy_step_135000.pth]
+
+``--eval-dir`` reuses an existing eval task directory instead of creating one;
+``--checkpoint`` overrides ``execution.checkpoint`` for A/B between training
+steps without editing the skill's metadata.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import rclpy
+from brain_messages.action import ExecuteBehavior
+from brain_messages.srv import ActivateManipulationTask, CreatePhysicalSkill, GetTaskMetadata, SetEpisodeOutcome
+from rcl_interfaces.msg import Parameter, ParameterType, ParameterValue
+from rcl_interfaces.srv import SetParameters
+from rclpy.action import ActionClient
+from rclpy.node import Node
+from std_srvs.srv import Trigger
+
+RECORDER = "/brain/recorder"
+
+
+class RolloutEval(Node):
+    def __init__(self):
+        super().__init__("rollout_eval")
+        self._behavior_client = ActionClient(self, ExecuteBehavior, "/behavior/execute")
+
+    # --- service plumbing ----------------------------------------------------
+
+    def call(self, srv_type, name, request, timeout=10.0):
+        client = self.create_client(srv_type, name)
+        try:
+            if not client.wait_for_service(timeout_sec=timeout):
+                raise RuntimeError(f"service {name} not available")
+            future = client.call_async(request)
+            rclpy.spin_until_future_complete(self, future, timeout_sec=timeout)
+            if not future.done():
+                raise RuntimeError(f"service {name} timed out")
+            return future.result()
+        finally:
+            self.destroy_client(client)
+
+    def trigger(self, name):
+        result = self.call(Trigger, name, Trigger.Request())
+        if not result.success:
+            raise RuntimeError(f"{name}: {result.message}")
+        return result
+
+    def set_recorder_capture(self, enabled: bool):
+        param = Parameter(
+            name="capture_policy_head",
+            value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=enabled),
+        )
+        result = self.call(SetParameters, "/recorder_node/set_parameters", SetParameters.Request(parameters=[param]))
+        if not result.results[0].successful:
+            raise RuntimeError(f"failed to set capture_policy_head={enabled}: {result.results[0].reason}")
+
+    # --- eval steps -----------------------------------------------------------
+
+    def resolve_eval_dir(self, eval_dir: str | None, eval_name: str | None) -> str:
+        if eval_dir:
+            if not os.path.isfile(os.path.join(eval_dir, "metadata.json")):
+                raise RuntimeError(f"{eval_dir} has no metadata.json; create it with /brain/create_physical_skill")
+            return eval_dir
+        result = self.call(
+            CreatePhysicalSkill, "/brain/create_physical_skill", CreatePhysicalSkill.Request(name=eval_name, kind="")
+        )
+        if not result.success:
+            raise RuntimeError(f"create_physical_skill: {result.message}")
+        return result.skill_directory
+
+    def execute_behavior(self, skill_dir: str, behavior_config: str) -> tuple[bool, str]:
+        """Send the skill to the behavior server and wait for it to finish."""
+        if not self._behavior_client.wait_for_server(timeout_sec=10.0):
+            raise RuntimeError("behavior server (/behavior/execute) not available")
+        goal = ExecuteBehavior.Goal(skill_dir=skill_dir, behavior_config=behavior_config)
+        send_future = self._behavior_client.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self, send_future, timeout_sec=10.0)
+        handle = send_future.result()
+        if handle is None or not handle.accepted:
+            raise RuntimeError("behavior goal rejected")
+        result_future = handle.get_result_async()
+        try:
+            rclpy.spin_until_future_complete(self, result_future)  # bounded by the skill's own duration cap
+        except KeyboardInterrupt:
+            # Don't leave the policy driving the robot after the operator bails.
+            cancel_future = handle.cancel_goal_async()
+            rclpy.spin_until_future_complete(self, cancel_future, timeout_sec=5.0)
+            raise
+        result = result_future.result().result
+        return result.success, result.message
+
+    def last_episode_id(self, eval_dir: str) -> int:
+        result = self.call(
+            GetTaskMetadata, f"{RECORDER}/get_task_metadata", GetTaskMetadata.Request(task_directory=eval_dir)
+        )
+        if not result.success:
+            raise RuntimeError(f"get_task_metadata: {result.message}")
+        episodes = json.loads(result.json_metadata).get("episodes", [])
+        if not episodes:
+            raise RuntimeError("no episodes in eval task metadata after save")
+        return int(episodes[-1]["episode_id"])
+
+    def label_episode(self, eval_dir: str, episode_id: int, outcome: str):
+        result = self.call(
+            SetEpisodeOutcome,
+            f"{RECORDER}/set_episode_outcome",
+            SetEpisodeOutcome.Request(task_directory=eval_dir, episode_id=episode_id, outcome=outcome),
+        )
+        if not result.success:
+            raise RuntimeError(f"set_episode_outcome: {result.message}")
+
+
+def ask(prompt: str) -> str:
+    return input(prompt).strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--skill-dir", required=True, help="Skill directory of the learned skill under test")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--eval-dir", help="Existing eval task directory to record into")
+    group.add_argument("--eval-name", help="Create a new eval task directory with this name")
+    parser.add_argument("--trials", type=int, default=10)
+    parser.add_argument("--checkpoint", help="Override execution.checkpoint (A/B between training steps)")
+    args = parser.parse_args()
+
+    skill_dir = os.path.abspath(os.path.expanduser(args.skill_dir))
+    with open(os.path.join(skill_dir, "metadata.json")) as f:
+        metadata = json.load(f)
+    if metadata.get("type") != "learned":
+        sys.exit(f"--skill-dir must be a learned skill, got type={metadata.get('type')!r}")
+    if args.checkpoint:
+        metadata["execution"]["checkpoint"] = args.checkpoint
+    behavior_config = json.dumps(metadata)
+    checkpoint = metadata["execution"].get("checkpoint")
+
+    rclpy.init()
+    node = RolloutEval()
+    results = []
+    eval_dir = None
+    try:
+        eval_dir = node.resolve_eval_dir(
+            os.path.abspath(os.path.expanduser(args.eval_dir)) if args.eval_dir else None, args.eval_name
+        )
+        log_path = os.path.join(eval_dir, "eval_log.jsonl")
+        print(f"Recording rollouts into {eval_dir} (labels also in {log_path})")
+
+        node.set_recorder_capture(True)
+        activate = node.call(
+            ActivateManipulationTask,
+            f"{RECORDER}/activate_physical_primitive",
+            ActivateManipulationTask.Request(task_directory=eval_dir),
+        )
+        if not activate.success:
+            raise RuntimeError("activate_physical_primitive failed")
+
+        for trial in range(1, args.trials + 1):
+            ask(f"\n[trial {trial}/{args.trials}] Reset the scene, then press Enter (Ctrl-C to finish early)... ")
+            node.trigger(f"{RECORDER}/new_episode")
+            try:
+                ok, message = node.execute_behavior(skill_dir, behavior_config)
+            except (Exception, KeyboardInterrupt):
+                node.trigger(f"{RECORDER}/cancel_episode")
+                raise
+            if not ok:
+                # The behavior itself failed to run (sensors, config) — not a
+                # policy failure. Discard the episode so it can't skew the eval.
+                print(f"  behavior errored ({message}); episode discarded, not counted")
+                node.trigger(f"{RECORDER}/cancel_episode")
+                continue
+            node.trigger(f"{RECORDER}/save_episode")
+            episode_id = node.last_episode_id(eval_dir)
+
+            success = ask("  task successful? [y/n] ").lower().startswith("y")
+            note = "" if success else ask("  failure note (optional): ")
+            node.label_episode(eval_dir, episode_id, "success" if success else "failure")
+
+            record = {
+                "episode_id": episode_id,
+                "outcome": "success" if success else "failure",
+                "note": note,
+                "skill_dir": skill_dir,
+                "checkpoint": checkpoint,
+                "behavior_message": message,
+                "t": time.time(),
+            }
+            with open(log_path, "a") as f:
+                f.write(json.dumps(record) + "\n")
+            results.append(record)
+            print(f"  episode {episode_id}: {record['outcome']}")
+    except KeyboardInterrupt:
+        print("\nInterrupted; finishing up.")
+    finally:
+        for cleanup in (lambda: node.trigger(f"{RECORDER}/end_task"), lambda: node.set_recorder_capture(False)):
+            try:
+                cleanup()
+            except Exception as e:  # noqa: BLE001 - best-effort teardown, report and continue
+                print(f"cleanup warning: {e}")
+        node.destroy_node()
+        rclpy.shutdown()
+
+    if results:
+        wins = sum(r["outcome"] == "success" for r in results)
+        print(f"\n=== {wins}/{len(results)} successful ({100.0 * wins / len(results):.0f}%) ===")
+        print(f"checkpoint: {checkpoint}")
+        for r in results:
+            tag = f"  ({r['note']})" if r["note"] else ""
+            print(f"  episode {r['episode_id']}: {r['outcome']}{tag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/brain/manipulation/src/episode_data.cpp
+++ b/ros2_ws/src/brain/manipulation/src/episode_data.cpp
@@ -74,6 +74,7 @@ void EpisodeData::steal_from(EpisodeData& other) noexcept {
     file_path_ = std::move(other.file_path_);
     file_created_ = other.file_created_;
     timestep_count_ = other.timestep_count_;
+    policy_head_enabled_ = other.policy_head_enabled_;
     camera_names_ = std::move(other.camera_names_);
     camera_names_set_ = other.camera_names_set_;
     img_h_ = other.img_h_;
@@ -263,7 +264,8 @@ void EpisodeData::create_file_and_datasets(const std::vector<double>& action, co
 
 void EpisodeData::add_timestep(const std::vector<double>& action, const std::vector<double>& qpos,
                                const std::vector<double>& qvel, const std::vector<cv::Mat>& images,
-                               double arm_timestamp, const std::vector<double>& image_timestamps, double head_command) {
+                               double arm_timestamp, const std::vector<double>& image_timestamps, double head_command,
+                               double policy_progress, double policy_termination) {
     if (!file_created_) {
         create_file_and_datasets(action, qpos, qvel, images, head_command);
     } else if (images.size() != camera_names_.size()) {
@@ -315,12 +317,17 @@ void EpisodeData::add_timestep(const std::vector<double>& action, const std::vec
     };
 
     try {
-        // /action: write the first action_dim_ columns; trailing termination
-        // columns stay 0 until finalize() rewrites them.
+        // /action: write the first action_dim_ columns. The trailing two
+        // columns carry the policy's live head when enabled; otherwise they
+        // stay 0 until finalize() rewrites them with synthesized labels.
         {
             std::vector<double> row(action_dim_ + 2, 0.0);
             const size_t copy_n = std::min(action.size(), action_dim_);
             std::copy(action.begin(), action.begin() + copy_n, row.begin());
+            if (policy_head_enabled_) {
+                row[action_dim_] = policy_progress;
+                row[action_dim_ + 1] = policy_termination;
+            }
             write_2d_row(action_dset_, action_dim_ + 2, row.data(), "/action");
         }
 
@@ -430,6 +437,14 @@ void EpisodeData::finalize() {
     if (!file_created_ || timestep_count_ == 0) {
         // Nothing useful was written; treat as cancel.
         cancel();
+        return;
+    }
+
+    // Policy rollout: the trailing columns already hold the policy's real
+    // head, streamed per timestep. Overwriting them with the synthesized
+    // teleop-demo ramp would destroy the data under evaluation.
+    if (policy_head_enabled_) {
+        close_handles();
         return;
     }
 

--- a/ros2_ws/src/brain/manipulation/src/recorder_node.cpp
+++ b/ros2_ws/src/brain/manipulation/src/recorder_node.cpp
@@ -36,6 +36,13 @@ RecorderNode::RecorderNode()
     this->declare_parameter("odom_topic", "/odom");
     this->declare_parameter("image_size", std::vector<int64_t>{640, 480});
     this->declare_parameter("max_timesteps", 1800);
+    // Policy-rollout capture: when capture_policy_head is true at episode
+    // start, the trailing two /action columns record the policy's live
+    // progress/termination head (from policy_head_topic) instead of the
+    // synthesized training-label ramp. Settable at runtime via `ros2 param set`
+    // so an eval orchestrator can flip it without restarting the recorder.
+    this->declare_parameter("capture_policy_head", false);
+    this->declare_parameter("policy_head_topic", "/brain/manipulation/policy_head");
 
     // Get parameter values
     std::string data_dir_param = this->get_parameter("data_directory").as_string();
@@ -60,6 +67,7 @@ RecorderNode::RecorderNode()
     odom_topic_ = this->get_parameter("odom_topic").as_string();
     image_size_ = this->get_parameter("image_size").as_integer_array();
     max_timesteps_ = this->get_parameter("max_timesteps").as_int();
+    policy_head_topic_ = this->get_parameter("policy_head_topic").as_string();
 
     // Initialize TaskManager
     task_manager_ = std::make_unique<TaskManager>(data_directory_);
@@ -101,6 +109,9 @@ RecorderNode::RecorderNode()
 
     odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
         odom_topic_, 10, std::bind(&RecorderNode::odom_callback, this, std::placeholders::_1));
+
+    policy_head_sub_ = this->create_subscription<std_msgs::msg::Float64MultiArray>(
+        policy_head_topic_, 10, std::bind(&RecorderNode::policy_head_callback, this, std::placeholders::_1));
 
     // Log subscriptions (debug — detail; the "initialized" line below is the summary)
     RCLCPP_DEBUG(this->get_logger(), "Subscribing to image topics:");
@@ -282,6 +293,21 @@ void RecorderNode::odom_callback(const nav_msgs::msg::Odometry::SharedPtr msg) {
     latest_odom_ = msg;
 }
 
+void RecorderNode::policy_head_callback(const std_msgs::msg::Float64MultiArray::SharedPtr msg) {
+    // [progress, termination] from the inference server, emitted per inference
+    // step while a learned behavior runs. Never a required topic: absence just
+    // means NaN head columns when capture is enabled.
+    if (msg->data.size() < 2) {
+        RCLCPP_WARN_ONCE(this->get_logger(), "Policy head message on %s has %zu values, expected 2; ignoring.",
+                         policy_head_topic_.c_str(), msg->data.size());
+        return;
+    }
+    latest_policy_progress_ = msg->data[0];
+    latest_policy_termination_ = msg->data[1];
+    latest_policy_head_time_ = std::chrono::steady_clock::now();
+    policy_head_received_ = true;
+}
+
 void RecorderNode::timer_callback() {
     if (state_ != State::EPISODE_ACTIVE || !current_episode_) {
         return;
@@ -358,10 +384,25 @@ void RecorderNode::timer_callback() {
         }
     }
 
+    // Policy head values for this tick (NaN unless capture is on for this
+    // episode AND a fresh sample exists — reusing the last sample after the
+    // policy stopped would fabricate a head that was never emitted).
+    double policy_progress = std::numeric_limits<double>::quiet_NaN();
+    double policy_termination = std::numeric_limits<double>::quiet_NaN();
+    if (episode_policy_head_ && policy_head_received_) {
+        const double age =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() - latest_policy_head_time_).count();
+        if (age <= kPolicyHeadStaleSec) {
+            policy_progress = latest_policy_progress_;
+            policy_termination = latest_policy_termination_;
+        }
+    }
+
     try {
         current_episode_->add_timestep(
             action_data, qpos, qvel, images_converted, arm_timestamp, image_timestamps,
-            head_received_ ? latest_head_position_ : std::numeric_limits<double>::quiet_NaN());
+            head_received_ ? latest_head_position_ : std::numeric_limits<double>::quiet_NaN(), policy_progress,
+            policy_termination);
         size_t timestep_count = current_episode_->get_episode_length();
 
         // Check if timestep limit reached
@@ -537,6 +578,18 @@ void RecorderNode::handle_new_episode(const std::shared_ptr<std_srvs::srv::Trigg
     }
 
     current_episode_ = std::make_unique<EpisodeData>();
+    // Snapshot the capture mode for the whole episode so a runtime param flip
+    // can't mix real and synthesized values within one file.
+    episode_policy_head_ = this->get_parameter("capture_policy_head").as_bool();
+    if (episode_policy_head_) {
+        current_episode_->enable_policy_head();
+        // Forget any head sample from a previous behavior run; only samples
+        // received during this episode may be recorded.
+        policy_head_received_ = false;
+        RCLCPP_INFO(this->get_logger(),
+                    "Policy-head capture enabled: /action[-2:] will hold the live policy head from %s.",
+                    policy_head_topic_.c_str());
+    }
     try {
         current_episode_->open_file(task_manager_->get_streaming_episode_path());
     } catch (const std::exception& e) {
@@ -641,7 +694,7 @@ void RecorderNode::handle_save_episode(const std::shared_ptr<std_srvs::srv::Trig
     }
 
     try {
-        task_manager_->add_episode(temp_path, start_ts, end_ts);
+        task_manager_->add_episode(temp_path, start_ts, end_ts, episode_policy_head_ ? "policy" : "synthesized");
     } catch (const std::exception& e) {
         // The file is already finalized but couldn't be moved into the slot;
         // remove it so we don't leak a stranded file.

--- a/ros2_ws/src/brain/manipulation/src/task_manager.cpp
+++ b/ros2_ws/src/brain/manipulation/src/task_manager.cpp
@@ -209,7 +209,7 @@ void TaskManager::cleanup_stale_streaming_files() {
 }
 
 void TaskManager::add_episode(const std::string& temp_file_path, const std::string& start_timestamp,
-                              const std::string& end_timestamp) {
+                              const std::string& end_timestamp, const std::string& action_head_source) {
     std::string data_dir = current_task_dir_ + "/data";
     fs::create_directories(data_dir);
 
@@ -242,7 +242,8 @@ void TaskManager::add_episode(const std::string& temp_file_path, const std::stri
     nlohmann::json episode_info = {{"episode_id", episode_id},
                                    {"file_name", file_name},
                                    {"start_timestamp", start_timestamp},
-                                   {"end_timestamp", end_timestamp}};
+                                   {"end_timestamp", end_timestamp},
+                                   {"action_head_source", action_head_source}};
     metadata_["episodes"].push_back(episode_info);
     metadata_["number_of_episodes"] = episode_id + 1;
     save_metadata();


### PR DESCRIPTION
## What

Makes the recorder **oracle-agnostic**: it already captures a policy rollout unchanged (during inference the arm/base commands flow on the same `/mars/arm/commands` + `/cmd_vel` topics it records for teleop) — the only teleop-specific piece was the trailing two `/action` columns, which were always **synthesized** training labels (linear progress ramp + last-10-steps termination flag). For a policy rollout those columns should hold the policy's **real** progress/termination head — that's the data under evaluation.

## How

- **`manipulation_server`** publishes the live `[progress, termination]` head on `/brain/manipulation/policy_head` each inference step (only when `action_dim >= 10`). Two doubles at 25 Hz.
- **Recorder param `capture_policy_head`** (default `false`, runtime-settable via `ros2 param set`): snapshotted at episode start so semantics can't flip mid-file. When on, the trailing `/action` columns stream the real head per timestep; steps with no fresh sample (policy not running, or stale > 0.5 s) record **NaN** — never zero-filled, never mixed with synthesized values. `finalize()` skips the ramp.
- **Provenance:** each episode entry in `dataset_metadata.json` gets `action_head_source: "policy" | "synthesized"` — it describes *what the columns contain* (the recorder can't vouch for who drove the robot), so a rollout episode can't be mistaken for a demo with training labels and silently trained on.
- **`rollout_eval.py`** — operator-in-the-loop harness: reset prompt → `new_episode` → `/behavior/execute` → `save_episode` → y/n outcome (`set_episode_outcome`) + optional failure note (`eval_log.jsonl`), `--checkpoint` override for A/B between training steps. Behavior errors discard the episode (not a policy failure); Ctrl-C cancels the running goal + episode and restores the param.

## Why this shape

One rollout trial yields **both** evaluations from one ordinary recorder artifact (`episode_N.h5` + auto-encoded MP4s + labeled metadata):
- **task success rate** — `outcome` labels + videos, per checkpoint / per condition;
- **auto-stop tuning** — the real `action[8:9]` trace replays offline through `LearnedStopDetector` (#484), including the trained-but-never-captured `termination` head, which this records for the first time.

Default-off: teleop demo recording is byte-for-byte unchanged.

## Testing

- `manipulation` + `brain_messages` compile clean in the CI test image (colcon, Release).
- `rollout_eval` import-smoked inside the ROS container.
- ruff + `pre-commit` (ruff-format, clang-format) pass on all touched files.
- Not yet run on hardware — needs a live rollout to verify the head lands in the columns end-to-end.

## Notes for reviewers

- NaN in `/action[-2:]` is deliberate (visible gaps > fabricated values); downstream consumers verified unaffected: `episode_converter` strips images only, `replay_conversion` slices `[:, :6]` and `[:, -4:-2]` (cmd_vel), MP4 encoder doesn't read `/action`.
- The synthesized-path default keeps `add_episode()`'s old signature semantics (`action_head_source` defaults to `"synthesized"`).
- Known pre-existing quirk (unchanged): if an episode starts before any arm command has ever arrived, the recorder falls back to a 10-wide zero action which locks the column count — the eval harness sidesteps it by starting the episode right before `ExecuteBehavior`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)