### PR TITLE
Sim: host world server + ground-truth observer stream -- smooth, low-latency 3D view

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py
@@ -811,6 +811,8 @@ class SkillRepository:
         for param_name, param in signature.parameters.items():
             if param_name == "self":
                 continue
+            if param.kind in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL):
+                continue  # *args/**kwargs are compat plumbing, not inputs
             param_type = "any"
             enum_values = None
             try:

--- a/ros2_ws/src/mars_bot/mars_sim_driver/launch/sim_driver.launch.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/launch/sim_driver.launch.py
@@ -34,6 +34,13 @@ def generate_launch_description():
         [
             # Software GL for the in-container world server (no GPU in Docker).
             SetEnvironmentVariable("MUJOCO_GL", os.environ.get("MUJOCO_GL", "osmesa")),
+            # rosidl's generated setters assert-validate EVERY byte of a
+            # message in pure Python under __debug__: one 640x480 Image is
+            # 921K iterations, and with raw camera + depth + points
+            # subscribed the driver burned ~1.5 cores on asserts alone
+            # (measured via py-spy), starving its executor -- /cmd_vel and
+            # /mars/arm/commands callbacks dropped to ~5Hz. -O strips them.
+            SetEnvironmentVariable("PYTHONOPTIMIZE", "1"),
             *world_actions,
             Node(
                 package="robot_state_publisher",

--- a/ros2_ws/src/mars_bot/mars_sim_driver/launch/sim_driver.launch.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/launch/sim_driver.launch.py
@@ -1,24 +1,40 @@
 """Virtual MARS: the MuJoCo sim driver + robot_state_publisher fed the same
 mars.urdf the real bringup uses (static frames: base_footprint, base_laser,
 camera_optical_frame, arm links). AMCL owns map->odom; the driver broadcasts
-odom->base_link itself, like the real base driver."""
+odom->base_link itself, like the real base driver.
+
+The world (physics + rendering) always runs in the world server; the driver
+node is a thin client. When VIRTUAL_MARS_REMOTE is set (the launcher's host
+world server -- native GL), only the client side starts here. When unset,
+a server is started next to the node in-container, at --render-scale 2
+because software GL pays per pixel."""
 
 import os
 from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import SetEnvironmentVariable
+from launch.actions import ExecuteProcess, SetEnvironmentVariable
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     urdf = Path(get_package_share_directory("mars_sim")) / "urdf" / "mars.urdf"
 
+    world_actions = []
+    if not os.environ.get("VIRTUAL_MARS_REMOTE", "").strip():
+        world_actions.append(
+            ExecuteProcess(
+                cmd=["ros2", "run", "mars_sim_driver", "world_server", "--render-scale", "2"],
+                output="screen",
+            )
+        )
+
     return LaunchDescription(
         [
-            # Software GL: the sim container has no GPU.
+            # Software GL for the in-container world server (no GPU in Docker).
             SetEnvironmentVariable("MUJOCO_GL", os.environ.get("MUJOCO_GL", "osmesa")),
+            *world_actions,
             Node(
                 package="robot_state_publisher",
                 executable="robot_state_publisher",

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
@@ -25,17 +25,20 @@ The URDF's static frames (base_footprint, base_laser, camera_optical_frame,
 arm links) come from robot_state_publisher fed by /joint_states -- launch it
 alongside this node with the same mars.urdf. AMCL owns map->odom.
 
-Needs a ROS 2 environment (rclpy comes from the distro, not pip):
-  source /opt/ros/<distro>/setup.bash   # plus ros2_ws for mars_msgs services
-  python3 virtual_mars_node.py
-The mujoco/trimesh/pillow deps must be importable from that python.
+The world itself (physics + rendering) runs in the world server (see
+world_server.py) -- this node is a thin RPC client publishing the topic
+surface. Needs a ROS 2 environment; VIRTUAL_MARS_REMOTE picks the server
+endpoint (default 127.0.0.1:8799, started by sim_driver.launch.py).
 """
 
 import contextlib
+import io
 import json
 import math
+import os
 import threading
 import time
+from functools import lru_cache
 from types import SimpleNamespace
 
 import numpy as np
@@ -52,7 +55,8 @@ from std_msgs.msg import Empty, Float64MultiArray, Int32, String
 from std_srvs.srv import Trigger
 from tf2_ros import TransformBroadcaster
 
-from .core import CAMERA_FOVY, CAMERA_HEIGHT, CAMERA_WIDTH, VirtualMars, encode_jpeg
+from .core import CAMERA_FOVY, CAMERA_HEIGHT, CAMERA_WIDTH
+from .remote_world import RemoteWorld
 
 try:
     from mars_msgs.srv import GotoJS, GotoJSTrajectory
@@ -67,7 +71,6 @@ SCAN_HZ = 6.0  # lidar.launch.py throttle
 JOINT_STATE_HZ = 30.0
 ARM_STATE_HZ = 20.0
 HEAD_POSITION_HZ = 10.0
-PHYSICS_CHUNK_S = 0.01
 
 LIDAR_N_RAYS = 360
 LIDAR_RANGE_MIN = 0.15  # rplidar A-series
@@ -87,38 +90,50 @@ ARM_JOINTS = ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"]
 FOCAL = CAMERA_HEIGHT / (2 * math.tan(math.radians(CAMERA_FOVY) / 2))
 CX, CY = CAMERA_WIDTH / 2, CAMERA_HEIGHT / 2
 
-# Software-GL render cost scales with fill rate, and one thread does every
-# render: at 640x480 a single OSMesa frame costs ~105ms and the camera/depth
-# rates collapse far below their targets (measured 2 / 0.85 Hz vs 7.5 / 8 Hz
-# in the container). Render RGB at half res, and depth at the pointcloud's
-# native res (the cloud was a 4x subsample anyway, so nothing is lost), then
-# upscale at the wire: published topics keep the hardware contract (640x480,
-# camera_info intrinsics unchanged).
-RENDER_SCALE = 2
-RENDER_WH = (CAMERA_WIDTH // RENDER_SCALE, CAMERA_HEIGHT // RENDER_SCALE)
-DEPTH_SCALE = POINTS_SUBSAMPLE  # depth render == pointcloud grid, 1:1
-DEPTH_WH = (CAMERA_WIDTH // DEPTH_SCALE, CAMERA_HEIGHT // DEPTH_SCALE)
-# Pointcloud pixel grid, precomputed once, 1:1 with the depth render.
-POINTS_VS, POINTS_US = np.mgrid[0 : DEPTH_WH[1], 0 : DEPTH_WH[0]].astype(np.float32)
-DFOCAL, DCX, DCY = FOCAL / DEPTH_SCALE, CX / DEPTH_SCALE, CY / DEPTH_SCALE
+# In-container rendering is software GL (no GPU in Docker on macOS/Windows):
+# The world (physics + rendering) always runs in the world server (see
+# world_server.py); this node is a thin RPC client. VIRTUAL_MARS_REMOTE
+# selects the endpoint: the launcher points it at the host world server
+# (native GL, full-res renders), and when unset the launch file starts a
+# server next to this node in the container (software GL, scaled renders).
+# Either way the wire contract is identical: 640x480 topics, camera_info
+# intrinsics unchanged, ~160x120 pointcloud.
+WORLD_DEFAULT_ENDPOINT = "127.0.0.1:8799"
+
+
+@lru_cache(maxsize=4)
+def _points_grid(h: int, w: int, step: int) -> tuple[np.ndarray, np.ndarray]:
+    vs, us = np.mgrid[0:h:step, 0:w:step]
+    return vs.astype(np.float32), us.astype(np.float32)
 
 
 class VirtualMarsNode(Node):
     def __init__(self) -> None:
         super().__init__("virtual_mars")
-        self.sim = VirtualMars(render_wh=RENDER_WH, depth_render_wh=DEPTH_WH)
+        endpoint = os.environ.get("VIRTUAL_MARS_REMOTE", "").strip() or WORLD_DEFAULT_ENDPOINT
+        host, _, port = endpoint.partition(":")
+        self.sim = RemoteWorld(host, int(port or "8799"))
+        self.get_logger().info(f"waiting for the world server at {endpoint}...")
+        self.sim.wait_ready(timeout=180.0)
+        self.get_logger().info(f"world server connected at {endpoint}")
         self._lock = threading.Lock()
         # Active joint-space trajectory: list of (from, to, duration) dicts
-        # consumed by the physics loop. _traj_req is the waiting goto_js*
+        # consumed by the trajectory loop. _traj_req is the waiting goto_js*
         # call's completion token (done event + ok flag) -- per-request, not
         # shared state, so concurrent service calls can't race each other's
         # preemption result (the services run in a reentrant group).
         self._segments: list[tuple[dict, dict, float]] = []
         self._segment_started: float | None = None
         self._traj_req: SimpleNamespace | None = None
+        self._last_stream_at = 0.0  # /mars/arm/commands ramp pacing
 
         self._tf = TransformBroadcaster(self)
-        self._odom_pub = self.create_publisher(Odometry, "/odom", 10)
+        # State topics publish with history depth 1 (latest-wins): pose is
+        # state, not a stream, and any hop that buffers more than the newest
+        # sample converts a slow consumer (rws under container CPU pressure)
+        # into permanent, accumulating display lag. With KEEP_LAST(1) a slow
+        # subscriber just skips to the newest sample instead.
+        self._odom_pub = self.create_publisher(Odometry, "/odom", 1)
         self._scan_pub = self.create_publisher(LaserScan, "/scan", qos_profile_sensor_data)
         self._main_pub = self.create_publisher(
             CompressedImage, "/mars/main_camera/left/image_raw/compressed", qos_profile_sensor_data
@@ -134,9 +149,9 @@ class VirtualMarsNode(Node):
         )
         self._points_pub = self.create_publisher(PointCloud2, "/mars/main_camera/points", qos_profile_sensor_data)
         self._caminfo_pub = self.create_publisher(CameraInfo, "/mars/main_camera/left/camera_info", 10)
-        self._arm_state_pub = self.create_publisher(JointState, "/mars/arm/state", 10)
-        self._joint_states_pub = self.create_publisher(JointState, "/joint_states", 10)
-        self._head_pub = self.create_publisher(String, "/mars/head/current_position", 10)
+        self._arm_state_pub = self.create_publisher(JointState, "/mars/arm/state", 1)
+        self._joint_states_pub = self.create_publisher(JointState, "/joint_states", 1)
+        self._head_pub = self.create_publisher(String, "/mars/head/current_position", 1)
 
         # Latched robot identity: clients (webapp) pick their camera view
         # implementation from this -- rendered view for sim, WebRTC for real.
@@ -153,7 +168,9 @@ class VirtualMarsNode(Node):
         self._streams_pub = self.create_publisher(String, "/webrtc/active_streams", 10)
         self.create_timer(2.0, self._publish_active_streams)
 
-        self.create_subscription(Twist, "/cmd_vel", self._on_cmd_vel, 10)
+        # Depth 1: a stale Twist is worthless, and a deep queue here turns an
+        # executor hiccup into seconds of the base replaying old commands.
+        self.create_subscription(Twist, "/cmd_vel", self._on_cmd_vel, 1)
         self.create_subscription(
             Float64MultiArray, "/mars/arm/commands", self._on_arm_commands, qos_profile_sensor_data
         )
@@ -182,7 +199,9 @@ class VirtualMarsNode(Node):
         self.create_timer(1.0 / ARM_STATE_HZ, self._publish_arm_state)
         self.create_timer(1.0 / HEAD_POSITION_HZ, self._publish_head)
 
-        threading.Thread(target=self._physics_loop, daemon=True).start()
+        # The server steps physics; this node only drives the goto_js
+        # trajectory interpolation on the server's clock.
+        threading.Thread(target=self._trajectory_loop, daemon=True).start()
         # Rendering runs on its own thread, NOT executor timers: a software-GL
         # render takes ~100ms+, and doing it under the physics lock (or on the
         # mutually-exclusive callback group) starves physics and /cmd_vel.
@@ -192,9 +211,18 @@ class VirtualMarsNode(Node):
 
     # --- inputs ---
 
+    def _rpc_safe(self, what: str, fn) -> None:
+        """Run an RPC-backed command, tolerating a briefly-away world server
+        (restart window): the command is dropped with a throttled warning
+        instead of the callback exception killing the executor."""
+        try:
+            fn()
+        except (OSError, RuntimeError) as exc:
+            self.get_logger().warning(f"{what} dropped: world server unavailable ({exc})", throttle_duration_sec=5.0)
+
     def _on_cmd_vel(self, msg: Twist) -> None:
         with self._lock:
-            self.sim.set_cmd_vel(msg.linear.x, msg.angular.z)
+            self._rpc_safe("cmd_vel", lambda: self.sim.set_cmd_vel(msg.linear.x, msg.angular.z))
 
     def _fail_active_traj(self) -> None:
         """Preempt the queued trajectory: wake its waiting goto_js* call with
@@ -208,10 +236,23 @@ class VirtualMarsNode(Node):
 
     def _on_arm_commands(self, msg: Float64MultiArray) -> None:
         values = list(msg.data)[: len(ARM_JOINTS)]
+        now = time.monotonic()
         with self._lock:
             self._fail_active_traj()  # streaming preempts trajectories
+            # Ramp to each streamed target over the stream interval instead of
+            # stepping: replay skills stream at ~12Hz, and a stiff PD snapping
+            # to each point reads as a staircase. Real Dynamixels velocity-
+            # profile between points; the 50Hz trajectory interpolator is our
+            # equivalent. Interval is measured (clamped) so any stream rate
+            # plays back smoothly.
+            interval = 0.1 if self._last_stream_at == 0.0 else min(0.25, max(0.05, now - self._last_stream_at))
+            self._last_stream_at = now
+            current = self.sim.joint_targets()
+            start = {k: current[k] for k in ARM_JOINTS}
+            target = dict(start)
             for name, value in zip(ARM_JOINTS, values, strict=False):
-                self.sim.set_joint_target(name, float(value))
+                target[name] = float(value)
+            self._segments.append((start, target, interval))
 
     def _on_reset(self, _msg: Empty) -> None:
         with self._lock:
@@ -278,37 +319,35 @@ class VirtualMarsNode(Node):
         response.success = True
         return response
 
-    # --- physics ---
+    # --- trajectory servo (physics itself runs in the world server) ---
 
-    def _physics_loop(self) -> None:
-        start_wall = time.perf_counter()
-        start_sim = self.sim.data.time
+    def _trajectory_loop(self) -> None:
+        """Interpolate queued goto segments at ~50Hz on the server's clock."""
         while rclpy.ok():
-            target = start_sim + (time.perf_counter() - start_wall)
             try:
                 with self._lock:
                     self._advance_trajectory()
-                    behind = target - self.sim.data.time
-                    if behind > 0:
-                        self.sim.step(min(behind, 0.1))  # cap catch-up after stalls
             except Exception as exc:  # noqa: BLE001 -- this thread must never die
-                self.get_logger().error(f"physics step failed ({exc!r}); dropping active trajectory")
+                self.get_logger().error(f"trajectory tick failed ({exc!r}); dropping active trajectory")
                 with self._lock:
                     self._fail_active_traj()
-            time.sleep(PHYSICS_CHUNK_S)
+            time.sleep(0.02)
+
+    def _sim_now(self) -> float:
+        return self.sim.time
 
     def _advance_trajectory(self) -> None:
         """Linear joint-space interpolation of the queued goto segments
         (called with the lock held, sim time as the clock)."""
         if not self._segments:
             return
-        now = self.sim.data.time
+        now = self._sim_now()
         if self._segment_started is None:
             self._segment_started = now
         start, end, duration = self._segments[0]
         alpha = min(1.0, (now - self._segment_started) / duration)
-        for name in ARM_JOINTS:
-            self.sim.set_joint_target(name, start[name] + alpha * (end[name] - start[name]))
+        # One batched RPC per tick, not one per joint (7x fewer round-trips).
+        self.sim.set_joint_targets({name: start[name] + alpha * (end[name] - start[name]) for name in ARM_JOINTS})
         if alpha >= 1.0:
             self._segments.pop(0)
             self._segment_started = None
@@ -349,8 +388,11 @@ class VirtualMarsNode(Node):
         self._tf.sendTransform(tf)
 
     def _publish_scan(self) -> None:
-        with self._lock:
-            ranges = self.sim.lidar_scan(LIDAR_N_RAYS, LIDAR_RANGE_MAX)
+        try:
+            with self._lock:
+                ranges = self.sim.lidar_scan(LIDAR_N_RAYS, LIDAR_RANGE_MAX)
+        except (OSError, RuntimeError):
+            return  # server briefly away; skip this scan
         msg = LaserScan()
         msg.header.stamp = self._stamp()
         msg.header.frame_id = "base_laser"
@@ -408,9 +450,11 @@ class VirtualMarsNode(Node):
                 last["depth"] = now
                 rendered = True
                 t0 = time.perf_counter()
-                with self._lock:
-                    self.sim.update_depth("main")
-                depth = self.sim.read_depth()
+                try:
+                    depth = self.sim.render_depth("main")
+                except (OSError, RuntimeError) as exc:
+                    self.get_logger().warning(f"depth render unavailable ({exc}); skipping frame")
+                    continue
                 cost["depth"] = 0.8 * cost["depth"] + 0.2 * (time.perf_counter() - t0)
                 self._publish_depth_and_points(depth)
             for camera, pub, raw_pub in (
@@ -422,29 +466,31 @@ class VirtualMarsNode(Node):
                 last[camera] = now
                 rendered = True
                 t0 = time.perf_counter()
-                with self._lock:
-                    self.sim.update_camera(camera)
-                rgb = self.sim.read_rgb()
+                try:
+                    jpeg = self.sim.render_jpeg(camera)
+                except (OSError, RuntimeError) as exc:
+                    self.get_logger().warning(f"{camera} render unavailable ({exc}); skipping frame")
+                    continue
                 cost[camera] = 0.8 * cost[camera] + 0.2 * (time.perf_counter() - t0)
-                self._publish_camera_frames(pub, raw_pub, camera, rgb)
+                self._publish_camera_frames(pub, raw_pub, camera, jpeg)
             if not rendered:
                 time.sleep(0.02)
 
-    def _publish_camera_frames(self, pub, raw_pub, camera: str, rgb) -> None:
+    def _publish_camera_frames(self, pub, raw_pub, camera: str, jpeg: bytes) -> None:
+        """Publish one camera frame; the server hands us a wire-res JPEG."""
         stamp = self._stamp()
         frame_id = "camera_optical_frame" if camera == "main" else "arm_camera_link"
-        # Upscale the half-res render to the wire resolution (bilinear).
-        rgb = np.asarray(PILImage.fromarray(rgb).resize((CAMERA_WIDTH, CAMERA_HEIGHT), PILImage.BILINEAR))
 
         if pub.get_subscription_count() > 0:
             msg = CompressedImage()
             msg.header.stamp = stamp
             msg.header.frame_id = frame_id
             msg.format = "jpeg"
-            msg.data = encode_jpeg(rgb)
+            msg.data = jpeg
             pub.publish(msg)
 
         if raw_pub.get_subscription_count() > 0:
+            rgb = np.asarray(PILImage.open(io.BytesIO(jpeg)).convert("RGB"))
             msg = Image()
             msg.header.stamp = stamp
             msg.header.frame_id = frame_id
@@ -456,18 +502,23 @@ class VirtualMarsNode(Node):
             raw_pub.publish(msg)
 
     def _publish_depth_and_points(self, depth) -> None:
+        """Works at any render scale: full-res 640x480 from the host world
+        server, or the pointcloud-native 160x120 of the local renderer. The
+        wire depth image is always 640x480; the cloud always ~160x120."""
         want_depth = self._depth_pub.get_subscription_count() > 0
         want_points = self._points_pub.get_subscription_count() > 0
         stamp = self._stamp()
         invalid = (depth < DEPTH_MIN_M) | (depth > DEPTH_MAX_M)
+        img_scale = CAMERA_HEIGHT // depth.shape[0]
 
         if want_depth:
             # 16SC1 millimeters, invalid = 0 -- publishing.cpp's convention.
-            # Nearest-neighbor upscale of the half-res render to the wire
-            # resolution (depth must not be interpolated across edges).
+            # Nearest-neighbor upscale to the wire resolution when the render
+            # is smaller (depth must not be interpolated across edges).
             mm = np.where(invalid, 0, depth * 1000.0)
             mm = np.clip(mm, 0, np.iinfo(np.int16).max).astype(np.int16)
-            mm = np.repeat(np.repeat(mm, DEPTH_SCALE, axis=0), DEPTH_SCALE, axis=1)
+            if img_scale > 1:
+                mm = np.repeat(np.repeat(mm, img_scale, axis=0), img_scale, axis=1)
             msg = Image()
             msg.header.stamp = stamp
             msg.header.frame_id = "camera_optical_frame"
@@ -479,9 +530,12 @@ class VirtualMarsNode(Node):
             self._depth_pub.publish(msg)
 
         if want_points:
-            z = np.where(invalid, np.nan, depth).astype(np.float32)
-            x = (POINTS_US - DCX) / DFOCAL * z
-            y = (POINTS_VS - DCY) / DFOCAL * z
+            step = max(1, POINTS_SUBSAMPLE // img_scale)
+            vs, us = _points_grid(depth.shape[0], depth.shape[1], step)
+            f, cx, cy = FOCAL / img_scale, CX / img_scale, CY / img_scale
+            z = np.where(invalid, np.nan, depth)[::step, ::step].astype(np.float32)
+            x = (us - cx) / f * z
+            y = (vs - cy) / f * z
             cloud = np.stack([x, y, z], axis=-1)
 
             msg = PointCloud2()

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
@@ -126,6 +126,7 @@ class VirtualMarsNode(Node):
         self._segment_started: float | None = None
         self._traj_req: SimpleNamespace | None = None
         self._last_stream_at = 0.0  # /mars/arm/commands ramp pacing
+        self._stream_interval = 0.1  # EMA of the stream's cadence (see _on_arm_commands)
 
         self._tf = TransformBroadcaster(self)
         # State topics publish with history depth 1 (latest-wins): pose is
@@ -234,25 +235,48 @@ class VirtualMarsNode(Node):
         self._segments.clear()
         self._segment_started = None
 
+    # Streamed setpoints buffered beyond this are dropped from the front:
+    # bounds added playback latency when delivery falls behind for a while.
+    STREAM_QUEUE_CAP_S = 0.3
+
     def _on_arm_commands(self, msg: Float64MultiArray) -> None:
         values = list(msg.data)[: len(ARM_JOINTS)]
         now = time.monotonic()
         with self._lock:
-            self._fail_active_traj()  # streaming preempts trajectories
-            # Ramp to each streamed target over the stream interval instead of
-            # stepping: replay skills stream at ~12Hz, and a stiff PD snapping
-            # to each point reads as a staircase. Real Dynamixels velocity-
-            # profile between points; the 50Hz trajectory interpolator is our
-            # equivalent. Interval is measured (clamped) so any stream rate
-            # plays back smoothly.
-            interval = 0.1 if self._last_stream_at == 0.0 else min(0.25, max(0.05, now - self._last_stream_at))
+            gap = now - self._last_stream_at
+            new_stream = self._last_stream_at == 0.0 or gap > 0.5
             self._last_stream_at = now
-            current = self.sim.joint_targets()
-            start = {k: current[k] for k in ARM_JOINTS}
+            # A goto trajectory, or a stale leftover from a stream that ended,
+            # is preempted; within a live stream the queue is NOT cleared --
+            # zenoh delivers the 50Hz command stream in ~100ms clumps when the
+            # session also carries bulk camera/depth traffic, and clearing per
+            # message collapses each clump into one PD teleport (measured:
+            # stop-go wave with 3x overspeed bursts). Appending replays the
+            # stream on its own timeline, one segment per setpoint.
+            if self._traj_req is not None or new_stream:
+                self._fail_active_traj()
+            # Segment duration is the stream's CADENCE, not the raw delivery
+            # gap: an EMA over gaps recovers the true rate even under clumped
+            # delivery (the mean of [~0,~0,~0,~0, 120ms] is the 24ms truth),
+            # where using the clump leader's 120ms gap would overfill the
+            # queue and replay the stream slower than commanded.
+            if new_stream:
+                self._stream_interval = 0.1  # bootstrap: first segment ramps gently
+            else:
+                self._stream_interval = 0.8 * self._stream_interval + 0.2 * gap
+            interval = min(0.25, max(0.02, self._stream_interval))
+            if self._segments:
+                start = dict(self._segments[-1][1])
+            else:
+                current = self.sim.joint_targets()
+                start = {k: current[k] for k in ARM_JOINTS}
             target = dict(start)
             for name, value in zip(ARM_JOINTS, values, strict=False):
                 target[name] = float(value)
             self._segments.append((start, target, interval))
+            while sum(d for _, _, d in self._segments) > self.STREAM_QUEUE_CAP_S:
+                self._segments.pop(0)
+                self._segment_started = None
 
     def _on_reset(self, _msg: Empty) -> None:
         with self._lock:
@@ -334,27 +358,38 @@ class VirtualMarsNode(Node):
             time.sleep(0.02)
 
     def _sim_now(self) -> float:
-        return self.sim.time
+        # The world server steps physics against the wall clock, so local
+        # monotonic time IS the sim clock -- without an RPC per tick, and
+        # without the state cache's 15ms quantization jittering the
+        # interpolation alpha of 20ms stream segments.
+        return time.monotonic()
 
     def _advance_trajectory(self) -> None:
-        """Linear joint-space interpolation of the queued goto segments
-        (called with the lock held, sim time as the clock)."""
+        """Linear joint-space interpolation of the queued segments (called
+        with the lock held, sim time as the clock). Completed segments roll
+        the clock forward within one tick -- a segment shorter than the 20ms
+        tick must not cost a whole tick, or a 50Hz setpoint stream plays back
+        at a fraction of its commanded speed."""
         if not self._segments:
             return
         now = self._sim_now()
         if self._segment_started is None:
             self._segment_started = now
+        while self._segments and now - self._segment_started >= self._segments[0][2]:
+            _start, end, duration = self._segments.pop(0)
+            self._segment_started += duration
+            if not self._segments:
+                self.sim.set_joint_targets(dict(end))  # land exactly on the final pose
+                self._segment_started = None
+                if self._traj_req is not None:
+                    self._traj_req.ok = True
+                    self._traj_req.done.set()
+                    self._traj_req = None
+                return
         start, end, duration = self._segments[0]
-        alpha = min(1.0, (now - self._segment_started) / duration)
+        alpha = min(1.0, max(0.0, (now - self._segment_started) / duration))
         # One batched RPC per tick, not one per joint (7x fewer round-trips).
         self.sim.set_joint_targets({name: start[name] + alpha * (end[name] - start[name]) for name in ARM_JOINTS})
-        if alpha >= 1.0:
-            self._segments.pop(0)
-            self._segment_started = None
-            if not self._segments and self._traj_req is not None:
-                self._traj_req.ok = True
-                self._traj_req.done.set()
-                self._traj_req = None
 
     # --- outputs ---
 

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/remote_world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/remote_world.py
@@ -1,0 +1,170 @@
+"""Client for the host world server (world_server.py).
+
+Exposes the slice of VirtualMars' surface the driver node uses, over the
+localhost RPC. Two connections: a "state" channel for the small, frequent
+calls (pose/joints/lidar/commands) and a "render" channel so a 15ms render
+never delays a 30Hz odom read. State reads are coalesced: /odom,
+/joint_states, /mars/arm/state and the head publisher all tick within a few
+ms of each other, so one `state` RPC serves them all via a short-lived cache.
+"""
+
+import json
+import math
+import socket
+import struct
+import threading
+import time
+
+import numpy as np
+
+STATE_CACHE_S = 0.015  # coalesce the 30/30/20/10Hz state publishers into one RPC
+
+
+class _Channel:
+    """One socket to the server. Connects lazily and reconnects once per
+    call on a dropped connection -- the server is load-bearing for the whole
+    driver, so a restart must not permanently kill the node."""
+
+    def __init__(self, host: str, port: int):
+        self._addr = (host, port)
+        self._sock: socket.socket | None = None
+        self._lock = threading.Lock()
+
+    def _connect(self) -> None:
+        self._sock = socket.create_connection(self._addr, timeout=10.0)
+        self._sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+    def _read_frame(self) -> bytes:
+        header = b""
+        while len(header) < 4:
+            chunk = self._sock.recv(4 - len(header))
+            if not chunk:
+                raise ConnectionError("world server closed the connection")
+            header += chunk
+        (length,) = struct.unpack(">I", header)
+        payload = bytearray()
+        while len(payload) < length:
+            chunk = self._sock.recv(min(1 << 16, length - len(payload)))
+            if not chunk:
+                raise ConnectionError("world server closed the connection")
+            payload += chunk
+        return bytes(payload)
+
+    def _call_once(self, req: dict, timeout: float) -> tuple[dict, bytes | None]:
+        if self._sock is None:
+            self._connect()
+        self._sock.settimeout(timeout)
+        payload = json.dumps(req).encode()
+        self._sock.sendall(struct.pack(">I", len(payload)) + payload)
+        meta = json.loads(self._read_frame())
+        blob = self._read_frame() if meta.get("blob") is not None else None
+        return meta, blob
+
+    def call(self, req: dict, timeout: float = 10.0) -> tuple[dict, bytes | None]:
+        with self._lock:
+            try:
+                meta, blob = self._call_once(req, timeout)
+            except (OSError, ConnectionError):
+                # Dropped/never-up connection: reconnect and retry once.
+                if self._sock is not None:
+                    self._sock.close()
+                self._sock = None
+                meta, blob = self._call_once(req, timeout)
+        if not meta.get("ok"):
+            raise RuntimeError(f"world server error for {req.get('op')}: {meta.get('error')}")
+        return meta, blob
+
+
+class RemoteWorld:
+    """VirtualMars-shaped proxy; see world_server.py for the other side."""
+
+    def __init__(self, host: str, port: int):
+        self._state_ch = _Channel(host, port)
+        self._render_ch = _Channel(host, port)
+        self._state: dict | None = None
+        self._state_at = 0.0
+        self._state_lock = threading.Lock()
+
+    def ping(self) -> None:
+        self._state_ch.call({"op": "ping"}, timeout=3.0)
+
+    def wait_ready(self, timeout: float = 60.0) -> None:
+        """Block until the server answers a ping (it builds the MuJoCo model
+        before listening, so first contact can take a while)."""
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                self.ping()
+                return
+            except (OSError, ConnectionError, RuntimeError):
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(1.0)
+
+    # --- coalesced state ---
+
+    def _fresh_state(self) -> dict:
+        with self._state_lock:
+            now = time.monotonic()
+            if self._state is None or now - self._state_at > STATE_CACHE_S:
+                try:
+                    self._state, _ = self._state_ch.call({"op": "state"})
+                    self._state_at = now
+                except (OSError, RuntimeError):
+                    if self._state is None:
+                        raise
+                    # Server briefly away (restart): a stale snapshot beats
+                    # crashing the publishers; reconnect happens per call.
+            return self._state
+
+    @property
+    def time(self) -> float:
+        return float(self._fresh_state()["time"])
+
+    def pose(self) -> tuple[float, float, float]:
+        return tuple(self._fresh_state()["pose"])
+
+    def velocity(self) -> tuple[float, float, float]:
+        return tuple(self._fresh_state()["vel"])
+
+    def joint_positions(self) -> dict[str, float]:
+        return dict(self._fresh_state()["joints"])
+
+    def joint_targets(self) -> dict[str, float]:
+        return dict(self._fresh_state()["targets"])
+
+    # --- commands ---
+
+    def set_cmd_vel(self, vx: float, wz: float) -> None:
+        self._state_ch.call({"op": "cmd_vel", "vx": vx, "wz": wz})
+
+    def set_joint_targets(self, targets: dict[str, float]) -> None:
+        self._state_ch.call({"op": "joint_targets", "targets": targets})
+        with self._state_lock:
+            self._state_at = 0.0  # targets changed; drop the cached snapshot
+
+    def set_joint_target(self, name: str, value: float) -> None:
+        self.set_joint_targets({name: value})
+
+    def head_pitch_deg(self) -> float:
+        return math.degrees(self._fresh_state()["joints"].get("joint_head", 0.0))
+
+    def reset(self) -> None:
+        self._state_ch.call({"op": "reset"})
+        with self._state_lock:
+            self._state_at = 0.0
+
+    # --- sensors ---
+
+    def lidar_scan(self, n_rays: int, max_range: float) -> np.ndarray:
+        _meta, blob = self._state_ch.call({"op": "lidar", "n_rays": n_rays, "max_range": max_range})
+        return np.frombuffer(blob, dtype=np.float32)
+
+    def render_jpeg(self, camera: str) -> bytes:
+        _meta, blob = self._render_ch.call({"op": "render_jpeg", "camera": camera})
+        return blob
+
+    def render_depth(self, camera: str) -> np.ndarray:
+        meta, blob = self._render_ch.call({"op": "render_depth", "camera": camera})
+        h, w = meta["shape"]
+        return np.frombuffer(blob, dtype=np.float32).reshape(h, w)

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -1,0 +1,274 @@
+"""The world server: VirtualMars behind a tiny localhost RPC.
+
+The ONLY way the driver node runs the sim -- there is no embedded mode. The
+world (physics + sensor rendering) needs no ROS, so it runs wherever the
+best GL lives, and only the endpoint changes:
+
+- host placement (default via ./innate-sim up): native GL, ~15ms full-res
+  renders on an M1 vs ~105ms software GL in Docker. Docker has no GPU on
+  macOS/Windows.
+- container placement (CI, no-uv hosts): sim_driver.launch.py starts this
+  same server next to the node with --render-scale 2 (software-GL fill-rate
+  mitigation); the node can't tell the difference.
+
+Either way the node (a thin client, see remote_world.py) publishes the same
+hardware topic contract: RGB is upscaled to the 640x480 wire here before
+JPEG encoding, and depth always renders at the pointcloud's native 160x120
+(the cloud was a 4x subsample anyway; the node upscales the wire image).
+
+No ROS, no third-party deps beyond VirtualMars' own (mujoco/numpy/PIL).
+Framing: 4-byte big-endian length | JSON request; responses are one JSON
+frame, followed by one binary frame iff the JSON says "blob": <nbytes>.
+
+Binds 127.0.0.1 only. GL contexts are macOS-main-thread-sensitive, so all
+render work runs on the main thread via a job queue; state reads/writes
+take the physics lock directly from connection threads.
+"""
+
+import argparse
+import json
+import socket
+import struct
+import threading
+import time
+
+import numpy as np
+from PIL import Image as PILImage
+
+from .core import CAMERA_HEIGHT, CAMERA_WIDTH, VirtualMars, encode_jpeg
+
+# Depth renders at the pointcloud grid (640/4 x 480/4): the published cloud
+# is identical, and the fill cost is 16x less -- see node.py's publish path.
+DEPTH_WH = (CAMERA_WIDTH // 4, CAMERA_HEIGHT // 4)
+
+
+def _read_frame(conn: socket.socket) -> bytes | None:
+    header = b""
+    while len(header) < 4:
+        chunk = conn.recv(4 - len(header))
+        if not chunk:
+            return None
+        header += chunk
+    (length,) = struct.unpack(">I", header)
+    payload = bytearray()
+    while len(payload) < length:
+        chunk = conn.recv(min(1 << 16, length - len(payload)))
+        if not chunk:
+            return None
+        payload += chunk
+    return bytes(payload)
+
+
+def _send_frame(conn: socket.socket, payload: bytes) -> None:
+    conn.sendall(struct.pack(">I", len(payload)) + payload)
+
+
+# A camera/depth product keeps rendering this long after its last request,
+# so the pump stays lazy (unwatched cameras cost nothing).
+PRODUCT_TTL_S = 3.0
+PRODUCTS = ("jpeg:main", "jpeg:wrist", "depth:main")
+
+
+class WorldServer:
+    def __init__(self, sim: VirtualMars):
+        self.sim = sim
+        self.lock = threading.Lock()
+        # Latest rendered frame per product + when it was last requested.
+        # RPCs return the freshest frame instead of triggering a render:
+        # sporadic offscreen GL from a background process can stall for
+        # minutes on macOS under GPU load (browser contention), while a
+        # continuously rendering context stays healthy -- so the pump
+        # free-runs and a GL stall degrades freshness, never liveness.
+        self.latest: dict[str, tuple[dict, bytes]] = {}
+        self.requested_at: dict[str, float] = {}
+        self.frame_ready = threading.Condition()
+
+    # --- physics (side thread; MuJoCo stepping is pure CPU) ---
+
+    def physics_loop(self) -> None:
+        start_wall = time.perf_counter()
+        start_sim = self.sim.data.time
+        while True:
+            target = start_sim + (time.perf_counter() - start_wall)
+            with self.lock:
+                behind = target - self.sim.data.time
+                if behind > 0.5:
+                    # A long stall (App Nap, machine sleep, CPU squeeze) left a
+                    # big backlog. Catching up would monopolize the lock for
+                    # minutes and starve every render; drop the lost time.
+                    print(f"[world-server] dropping {behind:.1f}s of physics backlog after a stall", flush=True)
+                    start_wall = time.perf_counter()
+                    start_sim = self.sim.data.time
+                elif behind > 0:
+                    self.sim.step(min(behind, 0.1))
+            time.sleep(0.01)
+
+    # --- renders (main thread only: macOS GL is main-thread-sensitive) ---
+
+    def _render_product(self, product: str) -> None:
+        kind, camera = product.split(":")
+        if kind == "jpeg":
+            with self.lock:
+                self.sim.update_camera(camera)
+            rgb = self.sim.read_rgb()
+            if rgb.shape[0] != CAMERA_HEIGHT:  # scaled render -> wire res
+                rgb = np.asarray(PILImage.fromarray(rgb).resize((CAMERA_WIDTH, CAMERA_HEIGHT), PILImage.BILINEAR))
+            frame = ({"ok": True}, encode_jpeg(rgb))
+        else:  # depth
+            with self.lock:
+                self.sim.update_depth(camera)
+            depth = self.sim.read_depth().astype(np.float32)
+            frame = ({"ok": True, "shape": list(depth.shape), "dtype": "float32"}, depth.tobytes())
+        with self.frame_ready:
+            self.latest[product] = frame
+            self.frame_ready.notify_all()
+
+    def render_loop(self) -> None:
+        """Free-running frame pump: renders every recently-requested product
+        round-robin, as fast as the GPU allows (idle-capped)."""
+        while True:
+            now = time.monotonic()
+            active = [p for p in PRODUCTS if now - self.requested_at.get(p, -1e9) < PRODUCT_TTL_S]
+            if not active:
+                # Keep the GL channel warm even with no clients: macOS parks
+                # an idle offscreen context of a background process, and
+                # re-acquiring the GPU under load (busy browser) can stall
+                # for minutes with the GIL held. A 5Hz heartbeat render
+                # prevents the parking outright.
+                try:
+                    self._render_product("jpeg:main")
+                except Exception:  # noqa: BLE001,S110 -- heartbeat is best-effort
+                    pass
+                time.sleep(0.2)
+                continue
+            for product in active:
+                try:
+                    self._render_product(product)
+                except Exception as exc:  # noqa: BLE001 -- the pump must never die
+                    with self.frame_ready:
+                        self.latest[product] = ({"ok": False, "error": repr(exc)}, None)
+                        self.frame_ready.notify_all()
+            time.sleep(0.02)  # idle cap; under load the renders self-pace
+
+    def render(self, camera: str, kind: str) -> tuple[dict, bytes | None]:
+        """Return the freshest frame for this product (waits only for the
+        very first one after activation)."""
+        product = f"{kind}:{camera}"
+        self.requested_at[product] = time.monotonic()
+        with self.frame_ready:
+            if product not in self.latest:
+                self.frame_ready.wait_for(lambda: product in self.latest, timeout=10.0)
+            if product not in self.latest:
+                return {"ok": False, "error": "render timeout (no frame produced)"}, None
+            meta, blob = self.latest[product]
+        return meta, blob
+
+    # --- request handling (one thread per connection) ---
+
+    def handle(self, req: dict) -> tuple[dict, bytes | None]:
+        op = req.get("op")
+        if op == "ping":
+            return {"ok": True}, None
+        if op == "state":
+            with self.lock:
+                x, y, yaw = self.sim.pose()
+                vx, vy, wz = self.sim.velocity()
+                joints = self.sim.joint_positions()
+                targets = self.sim.joint_targets()
+                sim_time = float(self.sim.data.time)
+            return {
+                "ok": True,
+                "time": sim_time,
+                "pose": [x, y, yaw],
+                "vel": [vx, vy, wz],
+                "joints": joints,
+                "targets": targets,
+            }, None
+        if op == "cmd_vel":
+            with self.lock:
+                self.sim.set_cmd_vel(float(req["vx"]), float(req["wz"]))
+            return {"ok": True}, None
+        if op == "joint_targets":
+            with self.lock:
+                for name, value in req["targets"].items():
+                    self.sim.set_joint_target(name, float(value))
+            return {"ok": True}, None
+        if op == "reset":
+            with self.lock:
+                self.sim.reset()
+            return {"ok": True}, None
+        if op == "lidar":
+            with self.lock:
+                ranges = self.sim.lidar_scan(int(req["n_rays"]), float(req["max_range"]))
+            blob = np.asarray(ranges, dtype=np.float32).tobytes()
+            return {"ok": True, "dtype": "float32"}, blob
+        if op == "render_jpeg":
+            return self.render(str(req["camera"]), "jpeg")
+        if op == "render_depth":
+            return self.render(str(req["camera"]), "depth")
+        if op == "shutdown":  # used by the launcher for a clean stop
+            return {"ok": True}, None
+        return {"ok": False, "error": f"unknown op {op!r}"}, None
+
+    def serve_connection(self, conn: socket.socket) -> None:
+        try:
+            conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            while True:
+                payload = _read_frame(conn)
+                if payload is None:
+                    return
+                try:
+                    meta, blob = self.handle(json.loads(payload))
+                except Exception as exc:  # noqa: BLE001 -- bad request must not kill the server
+                    meta, blob = {"ok": False, "error": repr(exc)}, None
+                if blob is not None:
+                    meta["blob"] = len(blob)
+                _send_frame(conn, json.dumps(meta).encode())
+                if blob is not None:
+                    _send_frame(conn, blob)
+        finally:
+            conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8799)
+    parser.add_argument(
+        "--render-scale",
+        type=int,
+        default=1,
+        help="Divide the RGB render resolution by N (software-GL mitigation; the wire stays 640x480)",
+    )
+    args = parser.parse_args()
+
+    print(f"[world-server] loading VirtualMars (render scale {args.render_scale})...", flush=True)
+    render_wh = (CAMERA_WIDTH // args.render_scale, CAMERA_HEIGHT // args.render_scale)
+    server = WorldServer(VirtualMars(render_wh=render_wh, depth_render_wh=DEPTH_WH))
+    server.sim.step(0.5)  # settle from the spawn drop before clients look
+
+    # Boot self-test: prove GL works before accepting clients, and report the
+    # per-frame cost so placement decisions are visible in the log.
+    t0 = time.perf_counter()
+    server.sim.render_rgb("main")
+    first_ms = (time.perf_counter() - t0) * 1000
+    t1 = time.perf_counter()
+    server.sim.render_rgb("main")
+    steady_ms = (time.perf_counter() - t1) * 1000
+    print(f"[world-server] GL self-test: {steady_ms:.0f} ms/frame (first frame {first_ms:.0f} ms)", flush=True)
+
+    listener = socket.create_server(("127.0.0.1", args.port))
+    print(f"[world-server] ready on 127.0.0.1:{args.port}", flush=True)
+
+    threading.Thread(target=server.physics_loop, daemon=True).start()
+
+    def accept_loop() -> None:
+        while True:
+            conn, _addr = listener.accept()
+            threading.Thread(target=server.serve_connection, args=(conn,), daemon=True).start()
+
+    threading.Thread(target=accept_loop, daemon=True).start()
+    server.render_loop()  # main thread owns the GL context
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -16,9 +16,21 @@ hardware topic contract: RGB is upscaled to the 640x480 wire here before
 JPEG encoding, and depth always renders at the pointcloud's native 160x120
 (the cloud was a 4x subsample anyway; the node upscales the wire image).
 
-No ROS, no third-party deps beyond VirtualMars' own (mujoco/numpy/PIL).
-Framing: 4-byte big-endian length | JSON request; responses are one JSON
-frame, followed by one binary frame iff the JSON says "blob": <nbytes>.
+Two interfaces, two kinds of consumers:
+
+- driver RPC (--port): sensing/actuation for the robot adapter (node.py),
+  robot-shaped and rate-limited like real hardware. Framing: 4-byte
+  big-endian length | JSON request; responses are one JSON frame, followed
+  by one binary frame iff the JSON says "blob": <nbytes>.
+- observer state stream (--state-port): a WebSocket broadcasting ground
+  truth ({t, wall, pose, joints}) after every physics slice, for things
+  that WATCH the world rather than run in it -- the webapp's 3D view
+  (proxied at /worldstate), future challenge UIs/graders. Robot software
+  must never consume this; fidelity lives on the RPC/topic path.
+
+No ROS. Beyond VirtualMars' own deps (mujoco/numpy/PIL) only `websockets`
+(already a sim-project and webapp-proxy dependency); if it's missing the
+stream is disabled and everything else still runs.
 
 Binds 127.0.0.1 only. GL contexts are macOS-main-thread-sensitive, so all
 render work runs on the main thread via a job queue; state reads/writes
@@ -34,6 +46,11 @@ import time
 
 import numpy as np
 from PIL import Image as PILImage
+
+try:
+    from websockets.sync.server import serve as ws_serve
+except ImportError:  # view-only feature; the sim must not die without it
+    ws_serve = None
 
 from .core import CAMERA_HEIGHT, CAMERA_WIDTH, VirtualMars, encode_jpeg
 
@@ -82,6 +99,11 @@ class WorldServer:
         self.latest: dict[str, tuple[dict, bytes]] = {}
         self.requested_at: dict[str, float] = {}
         self.frame_ready = threading.Condition()
+        # Observer state stream: newest ground-truth snapshot + a seq,
+        # broadcast to every connected WebSocket (see serve_state).
+        self.state_payload = "{}"
+        self.state_seq = 0
+        self.state_cond = threading.Condition()
 
     # --- physics (side thread; MuJoCo stepping is pure CPU) ---
 
@@ -90,6 +112,7 @@ class WorldServer:
         start_sim = self.sim.data.time
         while True:
             target = start_sim + (time.perf_counter() - start_wall)
+            stepped = False
             with self.lock:
                 behind = target - self.sim.data.time
                 if behind > 0.5:
@@ -101,7 +124,39 @@ class WorldServer:
                     start_sim = self.sim.data.time
                 elif behind > 0:
                     self.sim.step(min(behind, 0.1))
+                    stepped = True
+            if stepped:
+                self.publish_state()
             time.sleep(0.01)
+
+    # --- observer state stream (ground truth for viewers, never for robot code) ---
+
+    def publish_state(self) -> None:
+        with self.lock:
+            x, y, yaw = self.sim.pose()
+            joints = self.sim.joint_positions()
+            sim_time = float(self.sim.data.time)
+        # `wall` shares the browser's physical clock, so viewers can measure
+        # true delivery lag; `t` is the sim clock the playback interpolates on.
+        payload = json.dumps({"t": sim_time, "wall": time.time(), "pose": [x, y, yaw], "joints": joints})
+        with self.state_cond:
+            self.state_payload = payload
+            self.state_seq += 1
+            self.state_cond.notify_all()
+
+    def serve_state(self, ws) -> None:
+        """One observer connection: push each new state as it is produced,
+        latest-wins -- a slow client skips intermediate states instead of
+        queueing them (pose is state, not a stream)."""
+        last_seq = -1
+        try:
+            while True:
+                with self.state_cond:
+                    self.state_cond.wait_for(lambda: self.state_seq != last_seq)
+                    payload, last_seq = self.state_payload, self.state_seq
+                ws.send(payload)
+        except Exception:  # noqa: BLE001,S110 -- client gone; the stream just ends
+            pass
 
     # --- renders (main thread only: macOS GL is main-thread-sensitive) ---
 
@@ -234,6 +289,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--port", type=int, default=8799)
     parser.add_argument(
+        "--state-port",
+        type=int,
+        default=8800,
+        help="Observer state-stream WebSocket port (the webapp proxy's /worldstate assumes this default)",
+    )
+    parser.add_argument(
         "--render-scale",
         type=int,
         default=1,
@@ -258,6 +319,14 @@ def main() -> None:
 
     listener = socket.create_server(("127.0.0.1", args.port))
     print(f"[world-server] ready on 127.0.0.1:{args.port}", flush=True)
+
+    server.publish_state()  # observers get a frame before the first physics slice
+    if ws_serve is None:
+        print("[world-server] `websockets` not installed -- observer state stream disabled", flush=True)
+    else:
+        state_server = ws_serve(server.serve_state, "127.0.0.1", args.state_port)
+        threading.Thread(target=state_server.serve_forever, daemon=True).start()
+        print(f"[world-server] observer state stream on ws://127.0.0.1:{args.state_port}", flush=True)
 
     threading.Thread(target=server.physics_loop, daemon=True).start()
 

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -104,6 +104,12 @@ class WorldServer:
         self.latest: dict[str, tuple[dict, bytes]] = {}
         self.requested_at: dict[str, float] = {}
         self.frame_ready = threading.Condition()
+        # Demand pacing: a product renders when a client has asked since its
+        # last render, so the pump tracks consumer rates (~8Hz) instead of
+        # free-running at GPU speed (~30-60Hz, half a core of pure waste that
+        # jitters every sleep on the machine, including our own physics).
+        self.wanted: set[str] = set()
+        self.render_demand = threading.Event()
         # Observer state stream: newest ground-truth snapshot + a seq,
         # broadcast to every connected WebSocket (see serve_state).
         self.state_payload = "{}"
@@ -111,6 +117,12 @@ class WorldServer:
         self.state_cond = threading.Condition()
 
     # --- physics (side thread; MuJoCo stepping is pure CPU) ---
+
+    # Longest single step slice: bounds both the lock hold and the sim-time
+    # jump between two published states, so a scheduling stall (loaded
+    # machine stretches every sleep) replays as several small, smooth slices
+    # instead of one 100ms teleport in the 3D view.
+    MAX_SLICE_S = 0.025
 
     def physics_loop(self) -> None:
         start_wall = time.perf_counter()
@@ -128,11 +140,14 @@ class WorldServer:
                     start_wall = time.perf_counter()
                     start_sim = self.sim.data.time
                 elif behind > 0:
-                    self.sim.step(min(behind, 0.1))
+                    self.sim.step(min(behind, self.MAX_SLICE_S))
                     stepped = True
+                    behind -= self.MAX_SLICE_S
             if stepped:
                 self.publish_state()
-            time.sleep(0.01)
+            # Catch up through a backlog in quick small slices (publishing
+            # each), then settle back to the 10ms cadence.
+            time.sleep(0.001 if behind > self.MAX_SLICE_S else 0.01)
 
     # --- observer state stream (ground truth for viewers, never for robot code) ---
 
@@ -184,8 +199,11 @@ class WorldServer:
             self.frame_ready.notify_all()
 
     def render_loop(self) -> None:
-        """Free-running frame pump: renders every recently-requested product
-        round-robin, as fast as the GPU allows (idle-capped)."""
+        """Demand-paced frame pump: renders a product once per client request
+        (the node pulls at its publish rates, so render work tracks consumer
+        demand -- ~8Hz per product -- rather than free-running at GPU speed).
+        The context never idles long: demand keeps it busy with clients, and
+        a heartbeat covers the clientless case."""
         while True:
             now = time.monotonic()
             active = [p for p in PRODUCTS if now - self.requested_at.get(p, -1e9) < PRODUCT_TTL_S]
@@ -201,20 +219,27 @@ class WorldServer:
                     pass
                 time.sleep(0.2)
                 continue
-            for product in active:
+            todo = [p for p in active if p in self.wanted]
+            if not todo:
+                self.render_demand.wait(timeout=0.2)
+                self.render_demand.clear()
+                continue
+            for product in todo:
+                self.wanted.discard(product)
                 try:
                     self._render_product(product)
                 except Exception as exc:  # noqa: BLE001 -- the pump must never die
                     with self.frame_ready:
                         self.latest[product] = ({"ok": False, "error": repr(exc)}, None)
                         self.frame_ready.notify_all()
-            time.sleep(0.02)  # idle cap; under load the renders self-pace
 
     def render(self, camera: str, kind: str) -> tuple[dict, bytes | None]:
         """Return the freshest frame for this product (waits only for the
-        very first one after activation)."""
+        very first one after activation) and queue the next render."""
         product = f"{kind}:{camera}"
         self.requested_at[product] = time.monotonic()
+        self.wanted.add(product)
+        self.render_demand.set()
         with self.frame_ready:
             if product not in self.latest:
                 self.frame_ready.wait_for(lambda: product in self.latest, timeout=10.0)

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -90,6 +90,11 @@ class WorldServer:
     def __init__(self, sim: VirtualMars):
         self.sim = sim
         self.lock = threading.Lock()
+        # Advertised in ping replies once the observer stream is listening,
+        # so the launcher can tell a current server from a stale one (a
+        # pre-stream process would otherwise be reused and the 3D view
+        # starves with no diagnosis).
+        self.state_port: int | None = None
         # Latest rendered frame per product + when it was last requested.
         # RPCs return the freshest frame instead of triggering a render:
         # sporadic offscreen GL from a background process can stall for
@@ -223,7 +228,7 @@ class WorldServer:
     def handle(self, req: dict) -> tuple[dict, bytes | None]:
         op = req.get("op")
         if op == "ping":
-            return {"ok": True}, None
+            return {"ok": True, "state_port": self.state_port}, None
         if op == "state":
             with self.lock:
                 x, y, yaw = self.sim.pose()
@@ -326,6 +331,7 @@ def main() -> None:
     else:
         state_server = ws_serve(server.serve_state, "127.0.0.1", args.state_port)
         threading.Thread(target=state_server.serve_forever, daemon=True).start()
+        server.state_port = args.state_port
         print(f"[world-server] observer state stream on ws://127.0.0.1:{args.state_port}", flush=True)
 
     threading.Thread(target=server.physics_loop, daemon=True).start()

--- a/ros2_ws/src/mars_bot/mars_sim_driver/setup.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/setup.py
@@ -20,6 +20,7 @@ setup(
     entry_points={
         "console_scripts": [
             "sim_driver = mars_sim_driver.node:main",
+            "world_server = mars_sim_driver.world_server:main",
             "grid_localizer_sim = mars_sim_driver.grid_localizer_sim:main",
         ],
     },

--- a/sim/README.md
+++ b/sim/README.md
@@ -124,6 +124,16 @@ walks through them.
 ./innate-sim down        # stop
 ```
 
+The world itself (physics + sensor rendering) always runs in the **world
+server** (`mars_sim_driver/world_server.py`); the driver node is a thin RPC
+client, so there is exactly one render path. Only the server's *placement*
+varies: on macOS `up` runs it natively on the host (Docker has no GPU there
+-- host GL renders ~7x faster, full resolution), elsewhere/in CI the launch
+file starts the same server inside the container (software GL, scaled
+renders, identical wire contract). `INNATE_SIM_HOST_WORLD=1/0` forces host
+placement on/off; without `uv` on the host it falls back to in-container
+with a warning. `./innate-sim logs world-server` shows the host server log.
+
 The generated geometry (driver meshes in `sim/assets/`, the viewer's hulls,
 GLB, and robot meshes) is not in git: `./innate-sim up` downloads the bundle
 pinned by `sim/sim-assets.lock` from a GitHub release and extracts it in

--- a/sim/README.md
+++ b/sim/README.md
@@ -23,10 +23,15 @@ of the MARS robot in an apartment. Local code edits + `innate build`
   `sim-driver`). Readiness = `/odom` publishing.
 - **Viewing** -- the operator webapp at `https://localhost` IS the sim UI:
   in sim mode its camera panel is a SimSession (built from `viewer/`) that
-  renders the live simulation with Three.js from rosbridge state -- main
-  and wrist robot-camera views plus a sim-only orbit chase view, all at
-  render rate, no video streaming. (The standalone browser sim with WASM
-  physics lives in the separate innate-sim-demo repo.)
+  renders the live simulation with Three.js -- main and wrist robot-camera
+  views plus a sim-only orbit chase view, all at render rate, no video
+  streaming. State comes from the world server's ground-truth observer
+  stream (`/worldstate`, ~100Hz pose + joints), NOT from robot telemetry:
+  the robot's topics stay hardware-shaped (30Hz odom) for the software
+  under test, while things that merely watch the world get it fresh. Only
+  the lidar debug overlay reads a robot topic (`/scan` over rosbridge),
+  because it deliberately shows what the robot senses. (The standalone
+  browser sim with WASM physics lives in the separate innate-sim-demo repo.)
 - **Dev tooling** -- `sandbox/` (native MuJoCo viewers + physics stress
   gates, see its README), `tools/` (apartment asset pipeline -> `assets/`,
   gitignored), `viewer/` (the Three.js renderer package).
@@ -133,6 +138,14 @@ file starts the same server inside the container (software GL, scaled
 renders, identical wire contract). `INNATE_SIM_HOST_WORLD=1/0` forces host
 placement on/off; without `uv` on the host it falls back to in-container
 with a warning. `./innate-sim logs world-server` shows the host server log.
+
+The server exposes two interfaces because it has two kinds of consumers:
+the driver RPC (port 8799) serves the robot adapter, robot-shaped and
+rate-limited like real hardware; the observer state stream (WebSocket,
+port 8800, proxied by the webapp at `/worldstate`) broadcasts ground truth
+after every physics slice for things that watch the world -- the webapp's
+3D view today, challenge UIs/graders tomorrow. Robot software must never
+consume the observer stream; fidelity lives on the RPC/topic path.
 
 The generated geometry (driver meshes in `sim/assets/`, the viewer's hulls,
 GLB, and robot meshes) is not in git: `./innate-sim up` downloads the bundle

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -38,6 +38,10 @@ services:
       # Zenoh SHM needs realtime thread priorities Docker won't grant; without
       # them it stalls service/action traffic under load (see setup_dds.zsh).
       - INNATE_ZENOH_DISABLE_SHM=1
+      # Set by the launcher when the host world server runs (native GL
+      # rendering outside Docker, see mars_sim_driver/world_server.py);
+      # empty = simulate in-container on software GL.
+      - VIRTUAL_MARS_REMOTE=${VIRTUAL_MARS_REMOTE:-}
       # Brain ("agent") websocket the robot connects to. With
       # COMPOSE_PROFILES=local-brain the in-compose cloud-agent service starts and
       # the brain client is pointed at it over the shared x11 network. With no

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -38,6 +38,9 @@ CLOUD_AGENT_LOG_PATH = LOG_DIR / "cloud-agent.log"
 COMPOSE_LOG_PATH = LOG_DIR / "compose.log"
 OS_BUILD_LOG_PATH = LOG_DIR / "os-build.log"
 VIEWER_BUILD_LOG_PATH = LOG_DIR / "viewer-build.log"
+WORLD_SERVER_LOG_PATH = LOG_DIR / "world-server.log"
+WORLD_SERVER_PID_PATH = STATE_DIR / "world-server.pid"
+WORLD_SERVER_PORT = 8799
 OS_SESSION_LOG_PATH = LOG_DIR / "os-session.log"
 DOWN_LOG_PATH = LOG_DIR / "down.log"
 ROS_INSTALL_STATE_PATH = STATE_DIR / "ros-install.inputs.sha256"
@@ -92,6 +95,7 @@ LOG_TARGETS = {
     "compose": COMPOSE_LOG_PATH,
     "os-build": OS_BUILD_LOG_PATH,
     "viewer-build": VIEWER_BUILD_LOG_PATH,
+    "world-server": WORLD_SERVER_LOG_PATH,
     "os-session": OS_SESSION_LOG_PATH,
     "down": DOWN_LOG_PATH,
 }

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -52,10 +52,12 @@ from runtime import (
     ensure_sim_assets,
     ensure_sim_viewer_bundle,
     ensure_skill_assets,
+    ensure_world_server,
     open_os_container_shell,
     print_startup_checks,
     runtime_already_running,
     start_cloud_agent,
+    stop_world_server,
     tail_file,
     wait_for_os_runtime_ready,
     wait_for_virtual_mars,
@@ -126,6 +128,7 @@ def cmd_up(
                     f"`{CLI_SIM} up --offline` to start with whatever is already downloaded."
                 ) from exc
         ensure_sim_viewer_bundle(config, offline=offline)
+        config["world_endpoint"] = ensure_world_server(config)
 
         started = True
         try:
@@ -187,6 +190,7 @@ def cmd_up(
 def cmd_down(config: dict[str, object]) -> None:
     down_cloud_agent()
     down_os(config)
+    stop_world_server()
     log("Innate sim runtime is down.")
 
 
@@ -206,6 +210,7 @@ def cmd_clean(config: dict[str, object], *, assume_yes: bool = False) -> None:
         warn("Aborted. Nothing was deleted.")
         return
 
+    stop_world_server()
     clean_runtime(config)
     success("Innate sim runtime cleaned (containers and volumes removed).")
 

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -109,6 +109,10 @@ def cmd_up(
         print_banner()
         report_configured_keys(config)
         if runtime_already_running(config):
+            # Still verify the host world server: after a code update the
+            # running runtime may be talking to a stale server (no observer
+            # state stream -> frozen 3D view), and only a restart fixes it.
+            ensure_world_server(config)
             log("Innate sim runtime is already running. Opening dashboard...")
             show_runtime_dashboard(config, watch=watch)
             return

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -2,13 +2,16 @@
 # Copyright (c) 2026 Innate Inc
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
 import shlex
 import shutil
+import signal
 import socket
 import subprocess
+import sys
 import tarfile
 import time
 from pathlib import Path
@@ -37,6 +40,9 @@ from config import (
     TMUX_SESSION_NAME,
     VIEWER_BUILD_LOG_PATH,
     WORKSPACE_ROOT,
+    WORLD_SERVER_LOG_PATH,
+    WORLD_SERVER_PID_PATH,
+    WORLD_SERVER_PORT,
     StackError,
     compute_ros_install_validation_hash,
     ensure_state_dir,
@@ -302,6 +308,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         compose_values = {"INNATE_OS_ENV_FILE": str(os_env_file)}
         if os_image:
             compose_values["INNATE_OS_IMAGE"] = os_image
+        compose_values["VIRTUAL_MARS_REMOTE"] = str(config.get("world_endpoint", "") or "")
         compose_env = os_compose_env(compose_values, env_file=os_env_file)
         log("Starting Innate OS dev container...")
         run_logged_with_heartbeat(
@@ -318,6 +325,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
     compose_values = {"INNATE_OS_ENV_FILE": str(os_env_file)}
     if os_image:
         compose_values["INNATE_OS_IMAGE"] = os_image
+    compose_values["VIRTUAL_MARS_REMOTE"] = str(config.get("world_endpoint", "") or "")
     compose_env = os_compose_env(compose_values, env_file=os_env_file)
     host_repo_id = hashlib.sha256(str(os_repo.resolve()).encode("utf-8")).hexdigest()[:16]
 
@@ -969,6 +977,92 @@ def ensure_sim_viewer_bundle(config: dict[str, object], *, offline: bool = False
         log_path=VIEWER_BUILD_LOG_PATH,
         failure_message="Sim viewer bundle build failed (npm run build:lib).",
     )
+
+
+def _world_server_ping(port: int, timeout: float = 2.0) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout) as conn:
+            payload = json.dumps({"op": "ping"}).encode()
+            conn.sendall(len(payload).to_bytes(4, "big") + payload)
+            header = conn.recv(4)
+            if len(header) < 4:
+                return False
+            reply = conn.recv(int.from_bytes(header, "big"))
+            return json.loads(reply).get("ok") is True
+    except OSError:
+        return False
+
+
+def ensure_world_server(config: dict[str, object]) -> str:
+    """Start the host world server (physics + native-GL rendering outside
+    Docker -- see mars_sim_driver/world_server.py) and return the endpoint
+    the container should use, or "" for in-container rendering.
+
+    Docker has no GPU on macOS/Windows, so in-container renders run on
+    software GL at ~105ms/frame; the host renders the same frame in ~15ms.
+    Default: on for macOS, off elsewhere; INNATE_SIM_HOST_WORLD=1/0 overrides.
+    Requires uv on the host (for the mujoco environment); falls back to
+    in-container rendering with a warning when unavailable.
+    """
+    override = os.environ.get("INNATE_SIM_HOST_WORLD", "").strip()
+    enabled = override == "1" if override else sys.platform == "darwin"
+    if not enabled:
+        return ""
+    if shutil.which("uv") is None:
+        warn("uv not found -- running the sim world in-container (software GL). Install uv for native-speed rendering.")
+        return ""
+
+    sim_repo: Path = config["sim_repo"]  # type: ignore[assignment]
+    endpoint = f"host.docker.internal:{WORLD_SERVER_PORT}"
+    if _world_server_ping(WORLD_SERVER_PORT):
+        log("Host world server already running.")
+        return endpoint
+
+    log("Starting host world server (native GL rendering)...")
+    ensure_state_dir()
+    bootstrap = (
+        "import sys; sys.path.insert(0, 'ros2_ws/src/mars_bot/mars_sim_driver'); "
+        "from mars_sim_driver.world_server import main; main()"
+    )
+    env = os.environ.copy()
+    env["VIRTUAL_MARS_ASSETS"] = str(sim_repo / "assets")
+    with WORLD_SERVER_LOG_PATH.open("a", encoding="utf-8") as log_file:
+        proc = subprocess.Popen(
+            ["uv", "run", "--project", str(sim_repo), "python", "-c", bootstrap],
+            cwd=sim_repo.parent,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+    WORLD_SERVER_PID_PATH.write_text(f"{proc.pid}\n", encoding="utf-8")
+    for _ in range(60):  # model build takes a few seconds
+        if _world_server_ping(WORLD_SERVER_PORT):
+            log("Host world server ready.")
+            return endpoint
+        if proc.poll() is not None:
+            break
+        time.sleep(0.5)
+    warn(
+        "Host world server failed to start -- running the sim world in-container instead. "
+        f"Details: {WORLD_SERVER_LOG_PATH}"
+    )
+    with contextlib.suppress(ProcessLookupError, OSError):
+        proc.kill()
+    WORLD_SERVER_PID_PATH.unlink(missing_ok=True)
+    return ""
+
+
+def stop_world_server() -> None:
+    if not WORLD_SERVER_PID_PATH.exists():
+        return
+    try:
+        pid = int(WORLD_SERVER_PID_PATH.read_text().strip())
+        os.kill(pid, signal.SIGTERM)
+        log("Stopped host world server.")
+    except (ValueError, ProcessLookupError, PermissionError):
+        pass
+    WORLD_SERVER_PID_PATH.unlink(missing_ok=True)
 
 
 def ensure_skill_assets(config: dict[str, object]) -> None:

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -979,18 +979,43 @@ def ensure_sim_viewer_bundle(config: dict[str, object], *, offline: bool = False
     )
 
 
-def _world_server_ping(port: int, timeout: float = 2.0) -> bool:
+def _world_server_ping_reply(port: int, timeout: float = 2.0) -> dict | None:
+    """The server's ping reply, or None when nothing healthy answers. The
+    reply advertises capabilities (state_port) -- how ensure_world_server
+    tells a current server from a stale pre-update process."""
     try:
         with socket.create_connection(("127.0.0.1", port), timeout=timeout) as conn:
             payload = json.dumps({"op": "ping"}).encode()
             conn.sendall(len(payload).to_bytes(4, "big") + payload)
             header = conn.recv(4)
             if len(header) < 4:
-                return False
-            reply = conn.recv(int.from_bytes(header, "big"))
-            return json.loads(reply).get("ok") is True
-    except OSError:
-        return False
+                return None
+            reply = json.loads(conn.recv(int.from_bytes(header, "big")))
+            return reply if reply.get("ok") is True else None
+    except (OSError, ValueError):
+        return None
+
+
+def _world_server_ping(port: int, timeout: float = 2.0) -> bool:
+    return _world_server_ping_reply(port, timeout) is not None
+
+
+def _stop_stale_world_server() -> None:
+    """SIGTERM whatever owns the RPC port. The PID file only covers servers
+    THIS checkout started; a stale server may belong to another checkout or
+    an older build, so fall back to the port's listener."""
+    stop_world_server()
+    out = subprocess.run(
+        ["lsof", "-ti", f"tcp:{WORLD_SERVER_PORT}", "-sTCP:LISTEN"], capture_output=True, text=True, check=False
+    )
+    for pid in out.stdout.split():
+        with contextlib.suppress(ProcessLookupError, OSError, ValueError):
+            os.kill(int(pid), signal.SIGTERM)
+    for _ in range(20):
+        if not _world_server_ping(WORLD_SERVER_PORT, timeout=0.5):
+            return
+        time.sleep(0.25)
+    warn("A previous world server is still holding the port; the new one may fail to bind.")
 
 
 def ensure_world_server(config: dict[str, object]) -> str:
@@ -1014,9 +1039,15 @@ def ensure_world_server(config: dict[str, object]) -> str:
 
     sim_repo: Path = config["sim_repo"]  # type: ignore[assignment]
     endpoint = f"host.docker.internal:{WORLD_SERVER_PORT}"
-    if _world_server_ping(WORLD_SERVER_PORT):
-        log("Host world server already running.")
-        return endpoint
+    reply = _world_server_ping_reply(WORLD_SERVER_PORT)
+    if reply is not None:
+        if reply.get("state_port"):
+            log("Host world server already running.")
+            return endpoint
+        # Alive but from before the observer state stream: reusing it would
+        # leave the webapp's 3D view with no state and no diagnosis.
+        log("Host world server is outdated (no observer state stream) -- restarting it...")
+        _stop_stale_world_server()
 
     log("Starting host world server (native GL rendering)...")
     ensure_state_dir()

--- a/sim/sim-assets.lock
+++ b/sim/sim-assets.lock
@@ -1,5 +1,5 @@
 {
-  "tag": "sim-assets-258343f422b5",
-  "url": "https://github.com/innate-inc/innate-os/releases/download/sim-assets-258343f422b5/innate-sim-assets-258343f422b5.tar.gz",
-  "sha256": "258343f422b58500a7b282449c862afa0df6f9be909000ba5322966c5ce9dedf"
+  "tag": "sim-assets-e9f733ac9862",
+  "url": "https://github.com/innate-inc/innate-sim-assets/releases/download/sim-assets-e9f733ac9862/innate-sim-assets-e9f733ac9862.tar.gz",
+  "sha256": "e9f733ac986286b1f7aa44baa5a6148bda3838f1fb017ec422bc7160f487fb64"
 }

--- a/sim/tools/publish_assets.py
+++ b/sim/tools/publish_assets.py
@@ -33,7 +33,9 @@ ASSETS = SIM / "assets"
 VIEWER = SIM / "viewer"
 LOCK_FILE = SIM / "sim-assets.lock"
 MARKER = ASSETS / ".assets-tag"
-REPO = "innate-inc/innate-os"
+REPO = (
+    "innate-inc/innate-sim-assets"  # dedicated repo: keeps asset tags out of innate-os (robots version-check its tags)
+)
 
 WORK_DIRS = ["apartment_split", "apartment_split_v2", "apartment_visual", "sdf_shells", "map"]
 VIEWER_CARRYOVER = ["public/models", "public/robot", "assets/apartment_obj"]
@@ -53,7 +55,12 @@ def stage(root: Path) -> None:
         shutil.copy2(obj, hulls_dir / obj.name)
         names.append(obj.name)
     (hulls_dir / "manifest.json").write_text(json.dumps(names, indent=1) + "\n")
-    print(f"  apartment_collisions_v2: {len(names)} hulls")
+    # One binary triangle soup of ALL hulls (float32 xyz per vertex, 3 verts
+    # per tri): the browser overlay loads this in one fetch + zero parsing,
+    # vs ~30s for 1300 individual OBJ fetches through the TLS proxy.
+    soup = _hull_soup(hulls_dir, names)
+    (hulls_dir / "hulls.f32").write_bytes(soup.tobytes())
+    print(f"  apartment_collisions_v2: {len(names)} hulls, soup {soup.shape[0] // 3} tris")
 
     sdf_dir = root / "viewer" / "public" / "physics" / "apartment_sdf"
     sdf_dir.mkdir(parents=True)
@@ -65,6 +72,23 @@ def stage(root: Path) -> None:
         if not src.is_dir():
             sys.exit(f"missing {src} -- need a full asset checkout to publish")
         shutil.copytree(src, root / "viewer" / rel, ignore=shutil.ignore_patterns(".DS_Store"))
+
+
+def _hull_soup(hulls_dir: Path, names: list[str]):
+    """Concatenate every hull OBJ into one (N*3, 3) float32 triangle soup."""
+    import numpy as np
+
+    chunks = []
+    for name in names:
+        verts, faces = [], []
+        for line in (hulls_dir / name).read_text().splitlines():
+            if line.startswith("v "):
+                verts.append([float(v) for v in line.split()[1:4]])
+            elif line.startswith("f "):
+                faces.append([int(t.split("/")[0]) - 1 for t in line.split()[1:4]])
+        v = np.asarray(verts, dtype=np.float32)
+        chunks.append(v[np.asarray(faces, dtype=np.int32)].reshape(-1, 3))
+    return np.concatenate(chunks)
 
 
 def deterministic_targz(root: Path, out: Path) -> str:

--- a/sim/viewer/src/physics/rosbridgeController.ts
+++ b/sim/viewer/src/physics/rosbridgeController.ts
@@ -11,7 +11,15 @@
 const LASER_OFFSET = { x: -0.0764, z: 0.17165 };
 
 export class RosbridgePhysicsController {
-  onPose?: (pose: { x: number; y: number; z: number; yaw: number; joints: Record<string, number> }) => void;
+  /** stampS is the driver's wall-clock publish time (header.stamp) -- same
+   * physical clock as the browser's, so Date.now()/1000 - stampS measures
+   * true delivery lag through rws/proxy (see SimSession's lag HUD).
+   *
+   * Pose and joints emit separately (one callback per source topic): merging
+   * them into one stream stamps stale poses with fresh joint_states times,
+   * which the interpolator then renders as stop-go motion. */
+  onPose?: (pose: { x: number; y: number; z: number; yaw: number; stampS: number }) => void;
+  onJoints?: (state: { joints: Record<string, number>; stampS: number }) => void;
   /** World-frame lidar hit points [x0,y0,z0, x1,...], null-range rays skipped. */
   onScan?: (points: Float32Array) => void;
 
@@ -44,9 +52,15 @@ export class RosbridgePhysicsController {
     ws.onopen = () => {
       this.#everOpened = true;
       this.#retryMs = 500;
-      this.#send({ op: "subscribe", topic: "/odom", type: "nav_msgs/msg/Odometry", throttle_rate: 33 });
-      this.#send({ op: "subscribe", topic: "/joint_states", type: "sensor_msgs/msg/JointState", throttle_rate: 33 });
-      this.#send({ op: "subscribe", topic: "/scan", type: "sensor_msgs/msg/LaserScan", throttle_rate: 150 });
+      // No throttle on the state topics: rws throttling quantizes -- a 33ms
+      // throttle on a 33ms-period topic drops every other sample (measured
+      // 30Hz -> 15Hz with doubled jitter), which is exactly the rubber-band
+      // feel in the 3D view. Full rate is ~40KB/s; the browser can take it.
+      // queue_length 1: pose is state, not a stream -- any hop buffering more
+      // than the newest sample converts load hiccups into permanent lag.
+      this.#send({ op: "subscribe", topic: "/odom", type: "nav_msgs/msg/Odometry", queue_length: 1 });
+      this.#send({ op: "subscribe", topic: "/joint_states", type: "sensor_msgs/msg/JointState", queue_length: 1 });
+      this.#send({ op: "subscribe", topic: "/scan", type: "sensor_msgs/msg/LaserScan", throttle_rate: 150, queue_length: 1 });
       this.#resolveOpen();
     };
     ws.onerror = () => {
@@ -74,17 +88,22 @@ export class RosbridgePhysicsController {
   #onMessage(msg: { op: string; topic?: string; msg?: unknown }): void {
     if (msg.op !== "publish") return;
     if (msg.topic === "/odom") {
-      const odom = msg.msg as { pose: { pose: { position: { x: number; y: number }; orientation: { z: number; w: number } } } };
+      const odom = msg.msg as {
+        header: { stamp: { sec: number; nanosec: number } };
+        pose: { pose: { position: { x: number; y: number }; orientation: { z: number; w: number } } };
+      };
       const { position, orientation } = odom.pose.pose;
       this.#pose = { x: position.x, y: position.y, yaw: 2 * Math.atan2(orientation.z, orientation.w) };
-      this.#emit();
+      const stamp = odom.header.stamp;
+      this.onPose?.({ ...this.#pose, z: 0, stampS: stamp.sec + stamp.nanosec * 1e-9 });
     } else if (msg.topic === "/joint_states") {
-      const js = msg.msg as { name: string[]; position: number[] };
+      const js = msg.msg as { header: { stamp: { sec: number; nanosec: number } }; name: string[]; position: number[] };
       js.name.forEach((name, i) => (this.#joints[name] = js.position[i]));
       // joint6M is the gripper's mirrored finger (URDF mimic of joint6,
       // multiplier -1) -- the driver doesn't publish it, so derive it here.
       this.#joints["joint6M"] = -(this.#joints["joint6"] ?? 0);
-      this.#emit();
+      const stamp = js.header.stamp;
+      this.onJoints?.({ joints: { ...this.#joints }, stampS: stamp.sec + stamp.nanosec * 1e-9 });
     } else if (msg.topic === "/scan" && this.onScan) {
       const scan = msg.msg as { angle_min: number; angle_increment: number; range_max: number; ranges: number[] };
       const { x, y, yaw } = this.#pose;
@@ -100,10 +119,6 @@ export class RosbridgePhysicsController {
       });
       this.onScan(new Float32Array(points));
     }
-  }
-
-  #emit(): void {
-    this.onPose?.({ x: this.#pose.x, y: this.#pose.y, z: 0, yaw: this.#pose.yaw, joints: this.#joints });
   }
 
   #send(payload: object): void {

--- a/sim/viewer/src/physics/rosbridgeController.ts
+++ b/sim/viewer/src/physics/rosbridgeController.ts
@@ -1,8 +1,9 @@
-// Connected-mode state source for the webapp's SimSession: subscribe to the
-// real innate-os ROS graph over rosbridge and mirror the virtual MARS
-// driver's pose + joint state. Read-only -- teleop/commands go through the
-// webapp's own rosbridge client, and physics lives in the mars_sim_driver
-// container.
+// /scan overlay source for the webapp's SimSession: subscribe to the robot's
+// lidar over rosbridge and emit world-frame hit points. Pose/joints for the
+// 3D view come from the world server's observer stream (worldStateController)
+// -- lidar stays here deliberately: it is a robot sensor, so the robot's own
+// pipeline is the honest source for the debug overlay. Read-only --
+// teleop/commands go through the webapp's own rosbridge client.
 //
 // Speaks the rosbridge JSON protocol directly (subscribe/publish) -- no
 // roslib dependency for two message types.
@@ -11,15 +12,6 @@
 const LASER_OFFSET = { x: -0.0764, z: 0.17165 };
 
 export class RosbridgePhysicsController {
-  /** stampS is the driver's wall-clock publish time (header.stamp) -- same
-   * physical clock as the browser's, so Date.now()/1000 - stampS measures
-   * true delivery lag through rws/proxy (see SimSession's lag HUD).
-   *
-   * Pose and joints emit separately (one callback per source topic): merging
-   * them into one stream stamps stale poses with fresh joint_states times,
-   * which the interpolator then renders as stop-go motion. */
-  onPose?: (pose: { x: number; y: number; z: number; yaw: number; stampS: number }) => void;
-  onJoints?: (state: { joints: Record<string, number>; stampS: number }) => void;
   /** World-frame lidar hit points [x0,y0,z0, x1,...], null-range rays skipped. */
   onScan?: (points: Float32Array) => void;
 
@@ -31,8 +23,8 @@ export class RosbridgePhysicsController {
   #everOpened = false;
   #disposed = false;
   #retryMs = 500;
+  // Latest driver pose -- only anchors scan points in the world frame.
   #pose = { x: 0, y: 0, yaw: 0 };
-  #joints: Record<string, number> = {};
 
   constructor(url: string) {
     this.#url = url;
@@ -52,14 +44,11 @@ export class RosbridgePhysicsController {
     ws.onopen = () => {
       this.#everOpened = true;
       this.#retryMs = 500;
-      // No throttle on the state topics: rws throttling quantizes -- a 33ms
-      // throttle on a 33ms-period topic drops every other sample (measured
-      // 30Hz -> 15Hz with doubled jitter), which is exactly the rubber-band
-      // feel in the 3D view. Full rate is ~40KB/s; the browser can take it.
-      // queue_length 1: pose is state, not a stream -- any hop buffering more
-      // than the newest sample converts load hiccups into permanent lag.
-      this.#send({ op: "subscribe", topic: "/odom", type: "nav_msgs/msg/Odometry", queue_length: 1 });
-      this.#send({ op: "subscribe", topic: "/joint_states", type: "sensor_msgs/msg/JointState", queue_length: 1 });
+      // /odom only anchors the scan overlay, so a mild throttle is fine here
+      // (the 3D view's pose comes from the world state stream, not rosbridge).
+      // queue_length 1: latest-wins -- a hop buffering more than the newest
+      // sample converts load hiccups into permanent lag.
+      this.#send({ op: "subscribe", topic: "/odom", type: "nav_msgs/msg/Odometry", throttle_rate: 100, queue_length: 1 });
       this.#send({ op: "subscribe", topic: "/scan", type: "sensor_msgs/msg/LaserScan", throttle_rate: 150, queue_length: 1 });
       this.#resolveOpen();
     };
@@ -89,21 +78,10 @@ export class RosbridgePhysicsController {
     if (msg.op !== "publish") return;
     if (msg.topic === "/odom") {
       const odom = msg.msg as {
-        header: { stamp: { sec: number; nanosec: number } };
         pose: { pose: { position: { x: number; y: number }; orientation: { z: number; w: number } } };
       };
       const { position, orientation } = odom.pose.pose;
       this.#pose = { x: position.x, y: position.y, yaw: 2 * Math.atan2(orientation.z, orientation.w) };
-      const stamp = odom.header.stamp;
-      this.onPose?.({ ...this.#pose, z: 0, stampS: stamp.sec + stamp.nanosec * 1e-9 });
-    } else if (msg.topic === "/joint_states") {
-      const js = msg.msg as { header: { stamp: { sec: number; nanosec: number } }; name: string[]; position: number[] };
-      js.name.forEach((name, i) => (this.#joints[name] = js.position[i]));
-      // joint6M is the gripper's mirrored finger (URDF mimic of joint6,
-      // multiplier -1) -- the driver doesn't publish it, so derive it here.
-      this.#joints["joint6M"] = -(this.#joints["joint6"] ?? 0);
-      const stamp = js.header.stamp;
-      this.onJoints?.({ joints: { ...this.#joints }, stampS: stamp.sec + stamp.nanosec * 1e-9 });
     } else if (msg.topic === "/scan" && this.onScan) {
       const scan = msg.msg as { angle_min: number; angle_increment: number; range_max: number; ranges: number[] };
       const { x, y, yaw } = this.#pose;

--- a/sim/viewer/src/physics/worldStateController.ts
+++ b/sim/viewer/src/physics/worldStateController.ts
@@ -1,0 +1,88 @@
+// Ground-truth state feed for the sim viewer: the world server broadcasts
+// {t, wall, pose, joints} after every physics slice (~100Hz) on its observer
+// WebSocket, which the webapp front door proxies at /worldstate. This is the
+// 3D view's only state source -- robot telemetry (/odom, /joint_states) is
+// for robot software, and watching the world through the robot's own sensor
+// pipeline is exactly the lag the observer stream exists to remove (see
+// world_server.py "two interfaces").
+
+export interface WorldState {
+  /** Sim clock (s) -- the playback timeline samples interpolate on. */
+  t: number;
+  /** Server wall clock (s), same physical clock as the browser: Date.now()/1000 - wall
+   * is the true server->browser delivery lag (SimSession's lag HUD). */
+  wall: number;
+  x: number;
+  y: number;
+  yaw: number;
+  joints: Record<string, number>;
+}
+
+export class WorldStateController {
+  onState?: (state: WorldState) => void;
+
+  #url: string;
+  #ws!: WebSocket;
+  #open: Promise<void>;
+  #resolveOpen!: () => void;
+  #rejectOpen!: (err: Error) => void;
+  #everOpened = false;
+  #disposed = false;
+  #retryMs = 500;
+
+  constructor(url: string) {
+    this.#url = url;
+    this.#open = new Promise((resolve, reject) => {
+      this.#resolveOpen = resolve;
+      this.#rejectOpen = reject;
+    });
+    this.#connect();
+  }
+
+  /** (Re)open the socket; the server needs no subscription handshake -- it
+   * pushes state from the first frame. On drop we retry with backoff until
+   * dispose(), so a world-server restart doesn't kill the view. */
+  #connect(): void {
+    const ws = new WebSocket(this.#url);
+    this.#ws = ws;
+    ws.onopen = () => {
+      this.#everOpened = true;
+      this.#retryMs = 500;
+      this.#resolveOpen();
+    };
+    ws.onerror = () => {
+      // Settle init()'s await on a failed FIRST attempt (later errors are
+      // no-ops on the settled promise); reconnection continues regardless.
+      if (!this.#everOpened) this.#rejectOpen(new Error(`world state connection failed: ${this.#url}`));
+    };
+    ws.onclose = () => {
+      if (this.#disposed) return;
+      setTimeout(() => this.#connect(), this.#retryMs);
+      this.#retryMs = Math.min(this.#retryMs * 2, 5000);
+    };
+    ws.onmessage = (ev) => this.#onMessage(ev.data as string);
+  }
+
+  async init(): Promise<void> {
+    await this.#open;
+  }
+
+  dispose(): void {
+    this.#disposed = true;
+    this.#ws.close();
+  }
+
+  #onMessage(raw: string): void {
+    const msg = JSON.parse(raw) as {
+      t: number;
+      wall: number;
+      pose: [number, number, number];
+      joints: Record<string, number>;
+    };
+    const joints = msg.joints;
+    // joint6M is the gripper's mirrored finger (URDF mimic of joint6,
+    // multiplier -1) -- the world exposes real joints only, so derive it here.
+    joints["joint6M"] = -(joints["joint6"] ?? 0);
+    this.onState?.({ t: msg.t, wall: msg.wall, x: msg.pose[0], y: msg.pose[1], yaw: msg.pose[2], joints });
+  }
+}

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -178,7 +178,14 @@ export class SimScene {
    */
   setCollisionHullsVisible(visible: boolean): void {
     this.hullsVisible = visible;
-    if (visible && !this.hullsPromise) this.hullsPromise = this.loadCollisionHulls();
+    if (visible && !this.hullsPromise) {
+      // ~1300 OBJ fetches; takes seconds on first show. A failure resets the
+      // promise so toggling again retries instead of staying dead forever.
+      this.hullsPromise = this.loadCollisionHulls().catch((err) => {
+        console.error("[sim-viewer] collision hulls failed to load:", err);
+        this.hullsPromise = undefined;
+      });
+    }
     if (this.hullsGroup) this.hullsGroup.visible = visible;
   }
 
@@ -186,18 +193,30 @@ export class SimScene {
     const group = new THREE.Group();
     group.rotation.x = Math.PI / 2;
     const baseUrl = "/physics/apartment_collisions_v2/";
-    const manifest: string[] = await (await fetch(`${baseUrl}manifest.json`)).json();
-    const loader = new OBJLoader();
     const material = new THREE.MeshBasicMaterial({ color: 0x00ff88, wireframe: true });
-    await Promise.all(
-      manifest.map(async (filename) => {
-        const obj = await loader.loadAsync(`${baseUrl}${filename}`);
-        obj.traverse((child) => {
-          if (child instanceof THREE.Mesh) child.material = material;
-        });
-        group.add(obj);
-      }),
-    );
+
+    // Fast path: one binary triangle soup (float32 xyz), one fetch, no
+    // parsing -- publish_assets writes it next to the per-hull OBJs.
+    const bin = await fetch(`${baseUrl}hulls.f32`);
+    if (bin.ok) {
+      const positions = new Float32Array(await bin.arrayBuffer());
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+      group.add(new THREE.Mesh(geometry, material));
+    } else {
+      // Older bundles: fetch + parse every hull OBJ individually (slow).
+      const manifest: string[] = await (await fetch(`${baseUrl}manifest.json`)).json();
+      const loader = new OBJLoader();
+      await Promise.all(
+        manifest.map(async (filename) => {
+          const obj = await loader.loadAsync(`${baseUrl}${filename}`);
+          obj.traverse((child) => {
+            if (child instanceof THREE.Mesh) child.material = material;
+          });
+          group.add(obj);
+        }),
+      );
+    }
     group.visible = this.hullsVisible; // honor toggles made while loading
     this.hullsGroup = group;
     this.scene.add(group);

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -57,6 +57,9 @@ export class SimScene {
 
   followCamera = true;
 
+  // Hidden until the first real pose (spawnAt): a robot at the world origin
+  // before state arrives reads as "spawned in the wrong place" when the true
+  // failure is "no state yet".
   private robotRoot = new THREE.Group();
   private robot?: URDFRobot;
   private followPrevXY: [number, number] = [0, 0];
@@ -102,6 +105,7 @@ export class SimScene {
 
     this.addLights();
     this.addGround();
+    this.robotRoot.visible = false;
     this.scene.add(this.robotRoot);
 
     if (!this.fixedSize) window.addEventListener("resize", () => this.onResize());
@@ -378,6 +382,7 @@ export class SimScene {
    * by setPose. Use once — e.g. on spawn or reset — before driving resumes.
    */
   spawnAt(x: number, y: number, yaw: number): void {
+    this.robotRoot.visible = true;
     this.robotRoot.position.set(x, y, 0);
     this.robotRoot.rotation.set(0, 0, yaw);
 

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -5,12 +5,17 @@
 // resolution, drag-to-orbit), and only the small PiP thumbnails are
 // captureStream canvases the stage blits into.
 //
-// The session owns the rosbridge state feed (/odom + /joint_states, from the
-// virtual driver) and the pose-smoothing applied per rendered frame; the
-// stage owns the GL context and calls tick()/liveThumbnails()/blitThumbnail.
+// State comes from the world server's ground-truth observer stream
+// (/worldstate -> world_server.py), NOT from robot telemetry: one message
+// per physics slice (~100Hz) carrying pose + joints on the sim clock, so
+// playback is a short clamped interpolation with no wall-clock mapping and
+// no extrapolation. The rosbridge connection remains only for the /scan
+// debug overlay -- lidar is a robot sensor, so the robot's pipeline is the
+// honest source for it.
 
 import type { SimScene } from "./scene";
 import { RosbridgePhysicsController } from "./physics/rosbridgeController";
+import { WorldStateController } from "./physics/worldStateController";
 
 /** Thumbnail (PiP tile) render size, shared with createSimStage's scissor
  * pass. Square, matching the webapp's square .cam-tile (--pip-w/h), so
@@ -18,22 +23,11 @@ import { RosbridgePhysicsController } from "./physics/rosbridgeController";
 export const THUMB_W = 240;
 export const THUMB_H = 240;
 
-/** Playback delay behind the driver's (offset-mapped) clock: sized for
- * typical delivery jitter around its mean, so a bracketing sample has
- * usually arrived when playback needs it. Deliberately NOT worst-case --
- * rare longer gaps are dead-reckoned through instead (see tick), keeping
- * the scene close to the map widget, which draws raw samples on arrival. */
-const INTERP_DELAY_S = 0.05;
-
-/** Longest gap the pose stream extrapolates through before holding. The
- * base accelerates at ~1 m/s^2, so 150ms of dead reckoning mis-predicts by
- * ~1cm worst-case -- invisible, unlike a fatter interpolation delay. */
-const MAX_EXTRAP_S = 0.15;
-
-/** EMA weight per sample for the browser-to-driver clock offset (~1s time
- * constant at 30Hz): fast enough to absorb the container clock's drift and
- * step corrections, slow enough that delivery jitter averages out. */
-const OFFSET_EMA_ALPHA = 0.03;
+/** Playback delay bounds (see #delayS): the floor covers one ~100Hz stream
+ * interval plus a frame; the ceiling keeps a terrible connection watchable
+ * rather than minutes behind. */
+const DELAY_MIN_S = 0.015;
+const DELAY_MAX_S = 0.25;
 
 /** Advance `samples` past renderT and return the bracketing pair plus the
  * clamped interpolation factor (holds the last sample during a gap instead
@@ -76,37 +70,33 @@ export class SimSession {
   #primaryIndex = 0;
   #primaryName = "main";
 
-  #controller: RosbridgePhysicsController | null = null;
+  #controller: WorldStateController | null = null;
+  #scanFeed: RosbridgePhysicsController | null = null;
   #thumbCanvases: HTMLCanvasElement[] = [];
   #thumbContexts: (CanvasRenderingContext2D | null)[] = [];
   #started = false;
   #gotPose = false;
   #stageReady = false;
 
-  // Snapshot buffers for interpolated playback, keyed by the driver's own
-  // stamps: rws delivery is bursty (median 32ms gaps, p90 ~70ms), and
-  // arrival-time playback replays every burst as uneven motion, while the
-  // stamps are an evenly spaced 30Hz timer. Playback maps the local clock
-  // onto the stamp clock through #offsetS and renders INTERP_DELAY_S behind.
-  // Pose and joints are separate streams: /odom and /joint_states interleave,
-  // and a merged buffer stamps stale poses with fresh joint times, rendering
-  // 30Hz pose data as 60Hz stop-go stutter.
-  #poseSamples: { t: number; x: number; y: number; yaw: number }[] = [];
-  #jointSamples: { t: number; joints: Record<string, number> }[] = [];
-  // EMA of (local arrival - stamp). An AVERAGE is the whole trick: it is
-  // bounded by construction (a min-ratchet integrates clock steps forever;
-  // an incrementally built timeline ratchets on every hiccup -- both were
-  // tried, both accumulated visible delay), it absorbs the container
-  // clock's drift within ~1s, and jitter cancels out of it.
-  #offsetS: number | null = null;
+  // Ground-truth snapshots on the sim clock (one stream: pose and joints
+  // arrive in the same message, so no cross-stream stamp mixing to avoid).
+  #samples: { t: number; x: number; y: number; yaw: number; joints: Record<string, number> }[] = [];
+  // Recent inter-arrival gaps (s) -- sizes the playback delay to measured
+  // delivery jitter instead of a hand-tuned constant.
+  #gaps: number[] = [];
+  #lastArrival = 0;
+  // Playback position on the sim clock: advanced by the frame clock and
+  // softly steered toward (newest - delay), so delivery jitter is absorbed
+  // instead of replayed 1:1 into the scene.
+  #playT: number | null = null;
   #live = false;
   #spawned = false;
 
-  // Delivery-lag tracking: the driver stamps state with the same physical
-  // wall clock the browser reads, so Date.now()/1000 - stampS is the true
-  // driver->browser pipeline delay. The session minimum is the fixed cost
+  // Delivery-lag tracking: the server stamps state with the same physical
+  // wall clock the browser reads, so Date.now()/1000 - wall is the true
+  // server->browser pipeline delay. The session minimum is the fixed cost
   // of the pipeline; current-minus-min growing while driving means a queue
-  // is filling at some hop (rws, DDS, proxy). Shown by the ?simperf HUD.
+  // is filling at some hop. Shown by the ?simperf HUD.
   #lagRecent: number[] = [];
   #lagMinS = Infinity;
 
@@ -117,10 +107,12 @@ export class SimSession {
   #hullsOn = false;
   #overlaysDirty = false;
 
+  #stateUrl: string;
   #rosUrl: string;
 
-  constructor(opts: { rosUrl?: string } = {}) {
+  constructor(opts: { stateUrl?: string; rosUrl?: string } = {}) {
     const scheme = location.protocol === "https:" ? "wss" : "ws";
+    this.#stateUrl = opts.stateUrl ?? `${scheme}://${location.host}/worldstate`;
     this.#rosUrl = opts.rosUrl ?? `${scheme}://${location.host}/ws`;
   }
 
@@ -156,22 +148,28 @@ export class SimSession {
     // (thumbnailCanvas below); a 2D canvas in the DOM repaints only when
     // drawn into -- no media pipeline at all.
 
-    this.#controller = new RosbridgePhysicsController(this.#rosUrl);
-    this.#controller.onScan = (points) => {
-      this.#scan = points;
-      this.#scanDirty = true;
-    };
-    this.#controller.onPose = ({ x, y, yaw, stampS }) => {
-      const lag = Date.now() / 1000 - stampS;
+    this.#controller = new WorldStateController(this.#stateUrl);
+    this.#controller.onState = (s) => {
+      const lag = Date.now() / 1000 - s.wall;
       if (lag < this.#lagMinS) this.#lagMinS = lag;
       this.#lagRecent.push(lag);
       if (this.#lagRecent.length > 60) this.#lagRecent.shift();
-      const off = performance.now() / 1000 - stampS;
-      this.#offsetS = this.#offsetS === null ? off : this.#offsetS + OFFSET_EMA_ALPHA * (off - this.#offsetS);
-      const last = this.#poseSamples[this.#poseSamples.length - 1];
-      if (last === undefined || stampS > last.t) {
-        this.#poseSamples.push({ t: stampS, x, y, yaw });
-        if (this.#poseSamples.length > 40) this.#poseSamples.shift();
+
+      const now = performance.now() / 1000;
+      if (this.#lastArrival > 0) {
+        this.#gaps.push(Math.min(now - this.#lastArrival, 0.5));
+        if (this.#gaps.length > 60) this.#gaps.shift();
+      }
+      this.#lastArrival = now;
+
+      const last = this.#samples[this.#samples.length - 1];
+      if (last === undefined || s.t > last.t) {
+        this.#samples.push({ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints });
+        if (this.#samples.length > 60) this.#samples.shift();
+      } else if (s.t < last.t - 0.5) {
+        // Sim clock jumped backwards (world-server restart): restart playback.
+        this.#samples = [{ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints }];
+        this.#playT = null;
       }
       this.#live = true;
       if (!this.#gotPose) {
@@ -179,15 +177,8 @@ export class SimSession {
         this.#maybeStreaming();
       }
     };
-    this.#controller.onJoints = ({ joints, stampS }) => {
-      const last = this.#jointSamples[this.#jointSamples.length - 1];
-      if (last === undefined || stampS > last.t) {
-        this.#jointSamples.push({ t: stampS, joints });
-        if (this.#jointSamples.length > 40) this.#jointSamples.shift();
-      }
-    };
     this.#controller.init().catch((err) => {
-      console.error("[sim-session] rosbridge init failed:", err);
+      console.error("[sim-session] world state feed failed:", err);
       this.#patch({ status: "error" });
     });
   }
@@ -195,6 +186,8 @@ export class SimSession {
   stop(): void {
     this.#controller?.dispose();
     this.#controller = null;
+    this.#scanFeed?.dispose();
+    this.#scanFeed = null;
     this.#started = false;
     this.#gotPose = false;
     this.#patch({ status: "idle", videoStream: null });
@@ -205,10 +198,20 @@ export class SimSession {
     this.#listeners.clear();
   }
 
-  /** Toggle the /scan hit-point overlay (stage "lidar" chip). */
+  /** Toggle the /scan hit-point overlay (stage "lidar" chip). The rosbridge
+   * connection is opened on first use -- the 3D view itself never consumes
+   * robot telemetry. */
   setLidarVisible(on: boolean): void {
     this.#lidarOn = on;
     this.#overlaysDirty = true;
+    if (on && this.#scanFeed === null) {
+      this.#scanFeed = new RosbridgePhysicsController(this.#rosUrl);
+      this.#scanFeed.onScan = (points) => {
+        this.#scan = points;
+        this.#scanDirty = true;
+      };
+      this.#scanFeed.init().catch((err) => console.warn("[sim-session] scan overlay unavailable:", err));
+    }
   }
 
   /** Toggle the collision-hull wireframe overlay (stage "collisions" chip). */
@@ -253,43 +256,48 @@ export class SimSession {
     this.#patch({ status: "error" });
   }
 
-  /** Per-frame: interpolated playback INTERP_DELAY_S behind the driver's
-   * stamp clock, mapped onto the local clock via #offsetS. */
-  tick(scene: SimScene, _dt: number): void {
-    if (!this.#live || this.#poseSamples.length === 0 || this.#offsetS === null) return;
-    const first = this.#poseSamples[0];
+  /** Playback delay behind the newest sample: 1.5x the p90 inter-arrival gap
+   * (clamped), so a bracketing sample has usually arrived when playback needs
+   * it. Resolves to ~20ms on a localhost stream and grows only as much as the
+   * actual transport demands. */
+  #delayS(): number {
+    if (this.#gaps.length < 5) return 0.05; // conservative until measured
+    const sorted = [...this.#gaps].sort((a, b) => a - b);
+    const p90 = sorted[Math.floor(sorted.length * 0.9)];
+    return Math.min(DELAY_MAX_S, Math.max(DELAY_MIN_S, p90 * 1.5));
+  }
+
+  /** Per-frame: clamped interpolation on the sim clock, #delayS behind the
+   * newest sample. A delivery gap holds the last pose -- never extrapolates;
+   * delayed-but-coherent beats optimistic-and-wrong. */
+  tick(scene: SimScene, dt: number): void {
+    if (!this.#live || this.#samples.length === 0) return;
+    const first = this.#samples[0];
     if (!this.#spawned) {
       this.#spawned = true;
       scene.spawnAt(first.x, first.y, first.yaw);
     }
 
-    const renderT = performance.now() / 1000 - this.#offsetS - INTERP_DELAY_S;
-    const [a, b, u] = bracket(this.#poseSamples, renderT);
-    let x = a.x + (b.x - a.x) * u;
-    let y = a.y + (b.y - a.y) * u;
-    const dyaw = Math.atan2(Math.sin(b.yaw - a.yaw), Math.cos(b.yaw - a.yaw));
-    let yaw = a.yaw + dyaw * u;
-    // Playback caught up with the newest sample (delivery gap): dead-reckon
-    // from the last two samples' velocity instead of visibly freezing. The
-    // span guard skips degenerate pairs whose velocity would be noise.
-    const span = b.t - a.t;
-    if (renderT > b.t && span > 0.005) {
-      const dt = Math.min(renderT - b.t, MAX_EXTRAP_S);
-      x = b.x + ((b.x - a.x) / span) * dt;
-      y = b.y + ((b.y - a.y) / span) * dt;
-      yaw = b.yaw + (dyaw / span) * dt;
-    }
-    scene.setPose(x, y, yaw);
+    // Advance the playback clock with the frame clock, softly steered toward
+    // the stream (hard-locking to `target` would replay delivery jitter 1:1;
+    // the ~250ms steering constant absorbs it). A large error -- tab was
+    // hidden, server restarted -- snaps instead of chasing for seconds.
+    const target = this.#samples[this.#samples.length - 1].t - this.#delayS();
+    if (this.#playT === null || Math.abs(target - this.#playT) > 0.3) this.#playT = target;
+    else this.#playT += dt + (target - this.#playT) * Math.min(1, dt * 4);
 
-    if (this.#jointSamples.length > 0) {
-      const [ja, jb, ju] = bracket(this.#jointSamples, renderT);
-      const joints: Record<string, number> = {};
-      for (const [name, va] of Object.entries(ja.joints)) {
-        const vb = jb.joints[name] ?? va;
-        joints[name] = va + (vb - va) * ju;
-      }
-      scene.setJointAngles(joints);
+    const [a, b, u] = bracket(this.#samples, this.#playT);
+    const x = a.x + (b.x - a.x) * u;
+    const y = a.y + (b.y - a.y) * u;
+    const dyaw = Math.atan2(Math.sin(b.yaw - a.yaw), Math.cos(b.yaw - a.yaw));
+    scene.setPose(x, y, a.yaw + dyaw * u);
+
+    const joints: Record<string, number> = {};
+    for (const [name, va] of Object.entries(a.joints)) {
+      const vb = b.joints[name] ?? va;
+      joints[name] = va + (vb - va) * u;
     }
+    scene.setJointAngles(joints);
 
     if (this.#overlaysDirty) {
       this.#overlaysDirty = false;
@@ -335,7 +343,7 @@ export class SimSession {
     return this.#thumbCanvases[index] ?? null;
   }
 
-  /** Driver->browser state delivery lag: cur is the median of the last ~2s,
+  /** Server->browser state delivery lag: cur is the median of the last ~2s,
    * min is the session floor (the pipeline's fixed cost). cur >> min means
    * a queue is filling upstream. Null until state has arrived. */
   get pipelineLag(): { curMs: number; minMs: number } | null {
@@ -351,7 +359,7 @@ export class SimSession {
   }
 }
 
-export function createSimSession(opts: { rosUrl?: string } = {}): SimSession {
+export function createSimSession(opts: { stateUrl?: string; rosUrl?: string } = {}): SimSession {
   return new SimSession(opts);
 }
 

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -23,10 +23,10 @@ import { WorldStateController } from "./physics/worldStateController";
 export const THUMB_W = 240;
 export const THUMB_H = 240;
 
-/** Playback delay bounds (see #delayS): the floor covers one ~100Hz stream
+/** Playback delay bounds (see #delayS): the floor covers one ~75Hz stream
  * interval plus a frame; the ceiling keeps a terrible connection watchable
  * rather than minutes behind. */
-const DELAY_MIN_S = 0.015;
+const DELAY_MIN_S = 0.025;
 const DELAY_MAX_S = 0.25;
 
 /** Advance `samples` past renderT and return the bracketing pair plus the
@@ -107,12 +107,23 @@ export class SimSession {
   #hullsOn = false;
   #overlaysDirty = false;
 
-  #stateUrl: string;
+  #stateUrls: string[];
   #rosUrl: string;
 
   constructor(opts: { stateUrl?: string; rosUrl?: string } = {}) {
     const scheme = location.protocol === "https:" ? "wss" : "ws";
-    this.#stateUrl = opts.stateUrl ?? `${scheme}://${location.host}/worldstate`;
+    const proxied = `${scheme}://${location.host}/worldstate`;
+    // A local browser connects straight to the world server: loopback is
+    // exempt from mixed-content blocking in Chrome/Firefox, and skipping the
+    // container relay removes its occasional 100-400ms delivery tail
+    // (measured under load). Safari blocks loopback from a secure page, and
+    // remote browsers can't reach it -- both fall back to the same-origin
+    // proxied route automatically when the direct connection fails.
+    this.#stateUrls = opts.stateUrl
+      ? [opts.stateUrl]
+      : ["localhost", "127.0.0.1"].includes(location.hostname)
+        ? ["ws://127.0.0.1:8800", proxied]
+        : [proxied];
     this.#rosUrl = opts.rosUrl ?? `${scheme}://${location.host}/ws`;
   }
 
@@ -148,7 +159,14 @@ export class SimSession {
     // (thumbnailCanvas below); a 2D canvas in the DOM repaints only when
     // drawn into -- no media pipeline at all.
 
-    this.#controller = new WorldStateController(this.#stateUrl);
+    this.#connectState(0);
+  }
+
+  /** Connect the state feed, falling through the URL candidates (direct
+   * loopback first when local, then the proxied route). */
+  #connectState(i: number): void {
+    const url = this.#stateUrls[i];
+    this.#controller = new WorldStateController(url);
     this.#controller.onState = (s) => {
       const lag = Date.now() / 1000 - s.wall;
       if (lag < this.#lagMinS) this.#lagMinS = lag;
@@ -178,6 +196,12 @@ export class SimSession {
       }
     };
     this.#controller.init().catch((err) => {
+      this.#controller?.dispose();
+      if (i + 1 < this.#stateUrls.length) {
+        console.warn(`[sim-session] ${url} unavailable, falling back:`, err);
+        this.#connectState(i + 1);
+        return;
+      }
       console.error("[sim-session] world state feed failed:", err);
       this.#patch({ status: "error" });
     });
@@ -256,15 +280,16 @@ export class SimSession {
     this.#patch({ status: "error" });
   }
 
-  /** Playback delay behind the newest sample: 1.5x the p90 inter-arrival gap
+  /** Playback delay behind the newest sample: 2x the p90 inter-arrival gap
    * (clamped), so a bracketing sample has usually arrived when playback needs
-   * it. Resolves to ~20ms on a localhost stream and grows only as much as the
-   * actual transport demands. */
+   * it -- p90-based with margin rather than p99, which one outlier in the
+   * window would own. Resolves to ~30ms on a localhost stream and grows only
+   * as much as the actual transport demands. */
   #delayS(): number {
     if (this.#gaps.length < 5) return 0.05; // conservative until measured
     const sorted = [...this.#gaps].sort((a, b) => a - b);
     const p90 = sorted[Math.floor(sorted.length * 0.9)];
-    return Math.min(DELAY_MAX_S, Math.max(DELAY_MIN_S, p90 * 1.5));
+    return Math.min(DELAY_MAX_S, Math.max(DELAY_MIN_S, p90 * 2.0));
   }
 
   /** Per-frame: clamped interpolation on the sim clock, #delayS behind the

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -12,9 +12,40 @@
 import type { SimScene } from "./scene";
 import { RosbridgePhysicsController } from "./physics/rosbridgeController";
 
-/** Thumbnail (PiP tile) render size, shared with createSimStage's scissor pass. */
-export const THUMB_W = 320;
-export const THUMB_H = 180;
+/** Thumbnail (PiP tile) render size, shared with createSimStage's scissor
+ * pass. Square, matching the webapp's square .cam-tile (--pip-w/h), so
+ * object-fit doesn't crop the view. */
+export const THUMB_W = 240;
+export const THUMB_H = 240;
+
+/** Playback delay behind the driver's (offset-mapped) clock: sized for
+ * typical delivery jitter around its mean, so a bracketing sample has
+ * usually arrived when playback needs it. Deliberately NOT worst-case --
+ * rare longer gaps are dead-reckoned through instead (see tick), keeping
+ * the scene close to the map widget, which draws raw samples on arrival. */
+const INTERP_DELAY_S = 0.05;
+
+/** Longest gap the pose stream extrapolates through before holding. The
+ * base accelerates at ~1 m/s^2, so 150ms of dead reckoning mis-predicts by
+ * ~1cm worst-case -- invisible, unlike a fatter interpolation delay. */
+const MAX_EXTRAP_S = 0.15;
+
+/** EMA weight per sample for the browser-to-driver clock offset (~1s time
+ * constant at 30Hz): fast enough to absorb the container clock's drift and
+ * step corrections, slow enough that delivery jitter averages out. */
+const OFFSET_EMA_ALPHA = 0.03;
+
+/** Advance `samples` past renderT and return the bracketing pair plus the
+ * clamped interpolation factor (holds the last sample during a gap instead
+ * of extrapolating past it). Mutates the array (drops consumed history). */
+function bracket<T extends { t: number }>(samples: T[], renderT: number): [T, T, number] {
+  while (samples.length > 2 && samples[1].t <= renderT) samples.shift();
+  const a = samples[0];
+  const b = samples.length > 1 ? samples[1] : a;
+  const span = b.t - a.t;
+  const u = span > 1e-4 ? Math.min(1, Math.max(0, (renderT - a.t) / span)) : 1;
+  return [a, b, u];
+}
 
 export interface SimSessionState {
   status: "idle" | "connecting" | "streaming" | "error";
@@ -48,16 +79,36 @@ export class SimSession {
   #controller: RosbridgePhysicsController | null = null;
   #thumbCanvases: HTMLCanvasElement[] = [];
   #thumbContexts: (CanvasRenderingContext2D | null)[] = [];
-  #streams: (MediaStream | null)[] = [];
   #started = false;
   #gotPose = false;
   #stageReady = false;
 
-  // Smoothing target; applied by tick() every rendered frame.
-  #target = { x: 0, y: 0, yaw: 0, joints: {} as Record<string, number>, live: false };
-  #pose = { x: 0, y: 0, yaw: 0 };
-  #shownJoints: Record<string, number> = {};
+  // Snapshot buffers for interpolated playback, keyed by the driver's own
+  // stamps: rws delivery is bursty (median 32ms gaps, p90 ~70ms), and
+  // arrival-time playback replays every burst as uneven motion, while the
+  // stamps are an evenly spaced 30Hz timer. Playback maps the local clock
+  // onto the stamp clock through #offsetS and renders INTERP_DELAY_S behind.
+  // Pose and joints are separate streams: /odom and /joint_states interleave,
+  // and a merged buffer stamps stale poses with fresh joint times, rendering
+  // 30Hz pose data as 60Hz stop-go stutter.
+  #poseSamples: { t: number; x: number; y: number; yaw: number }[] = [];
+  #jointSamples: { t: number; joints: Record<string, number> }[] = [];
+  // EMA of (local arrival - stamp). An AVERAGE is the whole trick: it is
+  // bounded by construction (a min-ratchet integrates clock steps forever;
+  // an incrementally built timeline ratchets on every hiccup -- both were
+  // tried, both accumulated visible delay), it absorbs the container
+  // clock's drift within ~1s, and jitter cancels out of it.
+  #offsetS: number | null = null;
+  #live = false;
   #spawned = false;
+
+  // Delivery-lag tracking: the driver stamps state with the same physical
+  // wall clock the browser reads, so Date.now()/1000 - stampS is the true
+  // driver->browser pipeline delay. The session minimum is the fixed cost
+  // of the pipeline; current-minus-min growing while driving means a queue
+  // is filling at some hop (rws, DDS, proxy). Shown by the ?simperf HUD.
+  #lagRecent: number[] = [];
+  #lagMinS = Infinity;
 
   // Debug overlays (stage toggle chips); applied to the scene in tick().
   #scan: Float32Array | null = null;
@@ -99,21 +150,40 @@ export class SimSession {
       return c;
     });
     this.#thumbContexts = this.#thumbCanvases.map((c) => c.getContext("2d"));
-    this.#streams = this.#thumbCanvases.map((c) => c.captureStream(15));
+    // No captureStream: an active canvas-capture pipeline pinned the whole
+    // page's composition to its 15fps tick (measured: 16fps with capture,
+    // 120fps without). The webapp mounts these canvases directly instead
+    // (thumbnailCanvas below); a 2D canvas in the DOM repaints only when
+    // drawn into -- no media pipeline at all.
 
     this.#controller = new RosbridgePhysicsController(this.#rosUrl);
     this.#controller.onScan = (points) => {
       this.#scan = points;
       this.#scanDirty = true;
     };
-    this.#controller.onPose = ({ x, y, yaw, joints }) => {
-      Object.assign(this.#target, { x, y, yaw, live: true });
-      Object.assign(this.#target.joints, joints);
+    this.#controller.onPose = ({ x, y, yaw, stampS }) => {
+      const lag = Date.now() / 1000 - stampS;
+      if (lag < this.#lagMinS) this.#lagMinS = lag;
+      this.#lagRecent.push(lag);
+      if (this.#lagRecent.length > 60) this.#lagRecent.shift();
+      const off = performance.now() / 1000 - stampS;
+      this.#offsetS = this.#offsetS === null ? off : this.#offsetS + OFFSET_EMA_ALPHA * (off - this.#offsetS);
+      const last = this.#poseSamples[this.#poseSamples.length - 1];
+      if (last === undefined || stampS > last.t) {
+        this.#poseSamples.push({ t: stampS, x, y, yaw });
+        if (this.#poseSamples.length > 40) this.#poseSamples.shift();
+      }
+      this.#live = true;
       if (!this.#gotPose) {
         this.#gotPose = true;
-        this.#pose = { x, y, yaw };
-        Object.assign(this.#shownJoints, joints);
         this.#maybeStreaming();
+      }
+    };
+    this.#controller.onJoints = ({ joints, stampS }) => {
+      const last = this.#jointSamples[this.#jointSamples.length - 1];
+      if (last === undefined || stampS > last.t) {
+        this.#jointSamples.push({ t: stampS, joints });
+        if (this.#jointSamples.length > 40) this.#jointSamples.shift();
       }
     };
     this.#controller.init().catch((err) => {
@@ -183,23 +253,43 @@ export class SimSession {
     this.#patch({ status: "error" });
   }
 
-  /** Per-frame: smooth the scene toward the latest network sample. */
-  tick(scene: SimScene, dt: number): void {
-    if (!this.#target.live) return;
+  /** Per-frame: interpolated playback INTERP_DELAY_S behind the driver's
+   * stamp clock, mapped onto the local clock via #offsetS. */
+  tick(scene: SimScene, _dt: number): void {
+    if (!this.#live || this.#poseSamples.length === 0 || this.#offsetS === null) return;
+    const first = this.#poseSamples[0];
     if (!this.#spawned) {
       this.#spawned = true;
-      scene.spawnAt(this.#pose.x, this.#pose.y, this.#pose.yaw);
+      scene.spawnAt(first.x, first.y, first.yaw);
     }
-    const alpha = 1 - Math.exp(-dt * 15);
-    this.#pose.x += (this.#target.x - this.#pose.x) * alpha;
-    this.#pose.y += (this.#target.y - this.#pose.y) * alpha;
-    const dyaw = Math.atan2(Math.sin(this.#target.yaw - this.#pose.yaw), Math.cos(this.#target.yaw - this.#pose.yaw));
-    this.#pose.yaw += dyaw * alpha;
-    for (const [name, target] of Object.entries(this.#target.joints)) {
-      this.#shownJoints[name] = (this.#shownJoints[name] ?? target) + (target - (this.#shownJoints[name] ?? target)) * alpha;
+
+    const renderT = performance.now() / 1000 - this.#offsetS - INTERP_DELAY_S;
+    const [a, b, u] = bracket(this.#poseSamples, renderT);
+    let x = a.x + (b.x - a.x) * u;
+    let y = a.y + (b.y - a.y) * u;
+    const dyaw = Math.atan2(Math.sin(b.yaw - a.yaw), Math.cos(b.yaw - a.yaw));
+    let yaw = a.yaw + dyaw * u;
+    // Playback caught up with the newest sample (delivery gap): dead-reckon
+    // from the last two samples' velocity instead of visibly freezing. The
+    // span guard skips degenerate pairs whose velocity would be noise.
+    const span = b.t - a.t;
+    if (renderT > b.t && span > 0.005) {
+      const dt = Math.min(renderT - b.t, MAX_EXTRAP_S);
+      x = b.x + ((b.x - a.x) / span) * dt;
+      y = b.y + ((b.y - a.y) / span) * dt;
+      yaw = b.yaw + (dyaw / span) * dt;
     }
-    scene.setPose(this.#pose.x, this.#pose.y, this.#pose.yaw);
-    scene.setJointAngles(this.#shownJoints);
+    scene.setPose(x, y, yaw);
+
+    if (this.#jointSamples.length > 0) {
+      const [ja, jb, ju] = bracket(this.#jointSamples, renderT);
+      const joints: Record<string, number> = {};
+      for (const [name, va] of Object.entries(ja.joints)) {
+        const vb = jb.joints[name] ?? va;
+        joints[name] = va + (vb - va) * ju;
+      }
+      scene.setJointAngles(joints);
+    }
 
     if (this.#overlaysDirty) {
       this.#overlaysDirty = false;
@@ -234,11 +324,24 @@ export class SimSession {
 
   #videoArrays() {
     return {
-      // The primary view is the live stage canvas, not a stream -- but tiles
-      // only display non-primary entries, so streams exist for all actives.
-      videoStreams: this.#roster.map((name, i) => (this.#activeCams.includes(name) ? this.#streams[i] : null)),
+      // No MediaStreams in sim: tiles mount thumbnailCanvas() nodes instead.
+      videoStreams: this.#roster.map(() => null),
       videoLive: this.#roster.map((name) => this.#gotPose && this.#stageReady && this.#activeCams.includes(name)),
     };
+  }
+
+  /** The live 2D canvas behind a PiP tile; the webapp mounts it directly. */
+  thumbnailCanvas(index: number): HTMLCanvasElement | null {
+    return this.#thumbCanvases[index] ?? null;
+  }
+
+  /** Driver->browser state delivery lag: cur is the median of the last ~2s,
+   * min is the session floor (the pipeline's fixed cost). cur >> min means
+   * a queue is filling upstream. Null until state has arrived. */
+  get pipelineLag(): { curMs: number; minMs: number } | null {
+    if (this.#lagRecent.length === 0) return null;
+    const sorted = [...this.#lagRecent].sort((a, b) => a - b);
+    return { curMs: sorted[sorted.length >> 1] * 1000, minMs: this.#lagMinS * 1000 };
   }
 
   #patch(partial: Partial<SimSessionState>): void {

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -13,12 +13,19 @@
 import { SimScene, type CameraView } from "./scene";
 import { THUMB_H, THUMB_W, type SimSession } from "./simSession";
 
-// One PiP tile refresh per N rAF frames, round-robin: each refresh is an
+// One PiP tile refresh per N rendered frames, round-robin: each refresh is an
 // extra scene render + a canvas-to-canvas composite (cheap now that the
 // captureStream pipeline is gone -- THAT was what pinned the page to 15fps).
-// N=2 with two live tiles gives each ~30fps at a 120Hz display while
-// costing at most half an extra scene render per frame.
+// N=2 with two live tiles gives each ~30fps while costing at most half an
+// extra scene render per frame.
 const THUMB_FRAME_DIV = 2;
+
+// Render cap: on a 120Hz display an uncapped rAF loop doubles the GPU/CPU
+// cost of the page for no visible gain (state arrives at ~75Hz and is
+// interpolated), and on a loaded machine that pressure comes straight back
+// as scheduling jitter everywhere -- including the world server's physics
+// cadence. 60fps is indistinguishable here and halves the load.
+const MIN_FRAME_MS = 1000 / 62;
 
 const VIEW_FOR: Record<string, CameraView> = { main: "main", arm: "arm", orbit: "orbit" };
 
@@ -102,6 +109,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
 
   const loop = (now: number) => {
     raf = requestAnimationFrame(loop);
+    if (now - lastTime < MIN_FRAME_MS - 1) return; // 120Hz display -> render every other vsync
     const dt = Math.min((now - lastTime) / 1000, 0.1);
     lastTime = now;
     session.tick(scene, dt);

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -13,7 +13,12 @@
 import { SimScene, type CameraView } from "./scene";
 import { THUMB_H, THUMB_W, type SimSession } from "./simSession";
 
-const THUMB_FRAME_DIV = 3;
+// One PiP tile refresh per N rAF frames, round-robin: each refresh is an
+// extra scene render + a canvas-to-canvas composite (cheap now that the
+// captureStream pipeline is gone -- THAT was what pinned the page to 15fps).
+// N=2 with two live tiles gives each ~30fps at a 120Hz display while
+// costing at most half an extra scene render per frame.
+const THUMB_FRAME_DIV = 2;
 
 const VIEW_FOR: Record<string, CameraView> = { main: "main", arm: "arm", orbit: "orbit" };
 
@@ -38,8 +43,10 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
     b.type = "button";
     b.textContent = label;
     b.style.cssText =
+      // No backdrop-filter: blurring over an animated canvas forces a
+      // re-blur pass every frame the canvas changes (fps drops while moving).
       `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
-      "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;backdrop-filter:blur(6px);";
+      "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
     let on = false;
     b.onclick = () => {
       on = !on;
@@ -52,6 +59,28 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   addChip("lidar", (on) => session.setLidarVisible(on));
   addChip("collisions", (on) => session.setCollisionHullsVisible(on));
   wrap.appendChild(chips);
+
+  // Tiny frame-time readout (?simperf in the URL): median/p95 of the last
+  // second, so render regressions are measurable instead of guessed at.
+  let perfEl: HTMLElement | null = null;
+  let frameTimes: number[] = [];
+  let perfNextAt = 0;
+  let longTaskMs = 0;
+  const bare = new URLSearchParams(location.search).has("simbare");
+  try {
+    new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) longTaskMs += e.duration;
+    }).observe({ type: "longtask", buffered: false });
+  } catch {
+    /* longtask unsupported -- HUD just shows 0 */
+  }
+  if (new URLSearchParams(location.search).has("simperf")) {
+    perfEl = document.createElement("div");
+    perfEl.style.cssText =
+      "position:absolute;right:10px;bottom:10px;z-index:5;padding:3px 8px;border-radius:6px;" +
+      "background:rgba(0,0,0,.6);color:#9f9;font:11px ui-monospace,monospace;pointer-events:none;";
+    wrap.appendChild(perfEl);
+  }
 
   const scene = new SimScene(canvas, { fixedSize: { width: parent.clientWidth || 1280, height: parent.clientHeight || 720 } });
   scene.followCamera = true;
@@ -67,6 +96,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
 
   let raf = 0;
   let frame = 0;
+  let thumbCursor = 0;
   let lastTime = performance.now();
   let disposed = false;
 
@@ -76,18 +106,40 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
     lastTime = now;
     session.tick(scene, dt);
 
-    // Thumbnails first (scissor corner renders, blitted out)...
-    if (frame % THUMB_FRAME_DIV === 0) {
-      for (const { index, name } of session.liveThumbnails()) {
+    // Thumbnails first (scissor corner renders, blitted out), one tile per
+    // slot -- see THUMB_FRAME_DIV.
+    if (!bare && frame % THUMB_FRAME_DIV === 0) {
+      const live = session.liveThumbnails();
+      if (live.length) {
+        const { index, name } = live[thumbCursor++ % live.length];
         scene.setView(VIEW_FOR[name] ?? "orbit");
         scene.renderRegion(0, 0, THUMB_W, THUMB_H);
-        session.blitThumbnail(index, canvas, THUMB_W, THUMB_H);
+        // renderRegion speaks logical px; the canvas backing store is
+        // scaled by the pixel ratio -- blit the full physical region or
+        // the tile shows a zoomed-in crop.
+        const ratio = scene.renderer.getPixelRatio();
+        session.blitThumbnail(index, canvas, THUMB_W * ratio, THUMB_H * ratio);
       }
     }
     // ...then the primary view full-frame on top.
     scene.setView(VIEW_FOR[session.primaryCamera] ?? "orbit");
     scene.render();
     frame++;
+
+    if (perfEl) {
+      frameTimes.push(performance.now() - now);
+      if (now >= perfNextAt) {
+        perfNextAt = now + 1000;
+        const sorted = [...frameTimes].sort((x, y) => x - y);
+        const med = sorted[sorted.length >> 1] ?? 0;
+        const p95 = sorted[Math.floor(sorted.length * 0.95)] ?? 0;
+        const lag = session.pipelineLag;
+        const lagTxt = lag ? `  lag ${lag.curMs.toFixed(0)}ms (min ${lag.minMs.toFixed(0)})` : "";
+        perfEl.textContent = `js ${med.toFixed(1)}/${p95.toFixed(1)}ms  lt ${longTaskMs.toFixed(0)}ms  ${frameTimes.length}fps${lagTxt}`;
+        frameTimes = [];
+        longTaskMs = 0;
+      }
+    }
   };
 
   (async () => {

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -194,6 +194,16 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     if (!enabledCams.has(name)) return offTile(name, name, `Turn on ${name} camera`);
     // alwaysOn cameras are never turned off, so they carry no close affordance.
     const tile = liveTile(name, name, `Make ${name} the main view`, !alwaysOn);
+    // Sim sessions expose live canvases (no MediaStream pipeline -- canvas
+    // capture pinned page composition to its capture rate); mount those
+    // directly. Real robots keep the <video> + WebRTC stream path.
+    const thumbCanvas = session.thumbnailCanvas?.(index) ?? null;
+    if (thumbCanvas) {
+      thumbCanvas.style.cssText = "width:100%;height:100%;object-fit:cover;display:block;";
+      tile.prepend(thumbCanvas);
+      tiles.set(name, { tile, video: null, index });
+      return tile;
+    }
     const video = document.createElement("video");
     video.autoplay = true;
     video.muted = true;
@@ -251,10 +261,12 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   /** @param {WebRtcState} state */
   function syncStreams(state) {
     for (const { tile, video, index } of tiles.values()) {
-      const stream = state.videoStreams[index] ?? null;
-      if (video.srcObject !== stream) {
-        video.srcObject = stream;
-        video.play().catch(() => {});
+      if (video) {
+        const stream = state.videoStreams[index] ?? null;
+        if (video.srcObject !== stream) {
+          video.srcObject = stream;
+          video.play().catch(() => {});
+        }
       }
       tile.classList.toggle("connecting", !state.videoLive[index]);
     }

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -68,6 +68,14 @@ WEBAPP_SIM_CONTROLS = os.environ.get("WEBAPP_SIM_CONTROLS", "").strip().lower() 
 CERT_DIR = Path.home() / ".innate-webapp-tls"
 ROSBRIDGE_URL = "ws://127.0.0.1:9090"
 
+# /worldstate -> the sim world server's ground-truth observer stream (see
+# mars_sim_driver/world_server.py). The server lives wherever the world runs:
+# on the host when the launcher started it there (VIRTUAL_MARS_REMOTE, e.g.
+# "host.docker.internal:8799"), else next to us in the container. Its state
+# stream is always on port 8800 (world_server.py --state-port default).
+_WORLD_HOST = os.environ.get("VIRTUAL_MARS_REMOTE", "").strip().partition(":")[0] or "127.0.0.1"
+WORLD_STATE_URL = f"ws://{_WORLD_HOST}:8800"
+
 
 def _quiet_benign_disconnects() -> None:
     """Stop the websockets library from logging a full traceback every time a
@@ -262,7 +270,7 @@ def restart_response() -> Response:
 
 
 async def _dispatch_request(connection, request):
-    if request.path == "/ws":
+    if request.path in ("/ws", "/worldstate"):
         return None  # proceed with the WebSocket handshake
     if request.path.split("?", 1)[0] == "/config.json":
         return await asyncio.to_thread(config_response)
@@ -306,12 +314,14 @@ async def relay(source, sink):
 
 
 async def ws_handler(connection):
-    """Bidirectional /ws <-> rosbridge relay (or the /settings write channel)."""
+    """Bidirectional relay: /ws <-> rosbridge, /worldstate <-> the sim world
+    server's observer stream (or the /settings write channel)."""
     if connection.request.path == "/settings":
         await settings_ws(connection)
         return
+    upstream_url = WORLD_STATE_URL if connection.request.path == "/worldstate" else ROSBRIDGE_URL
     try:
-        async with ws_connect(ROSBRIDGE_URL, max_size=None) as upstream:
+        async with ws_connect(upstream_url, max_size=None) as upstream:
             done, pending = await asyncio.wait(
                 [
                     asyncio.ensure_future(relay(connection, upstream)),
@@ -340,7 +350,10 @@ async def main():
         await stack.enter_async_context(
             serve(ws_handler, "0.0.0.0", HTTPS_PORT, ssl=ctx, process_request=_dispatch_request, max_size=None)
         )
-        print(f"https front door on https://0.0.0.0:{HTTPS_PORT} (app + /ws -> {ROSBRIDGE_URL})")
+        print(
+            f"https front door on https://0.0.0.0:{HTTPS_PORT} "
+            f"(app + /ws -> {ROSBRIDGE_URL} + /worldstate -> {WORLD_STATE_URL})"
+        )
         if HTTP_PORT:
             # Same app over cleartext — no auto-upgrade; the arm panel offers a manual HTTPS switch.
             await stack.enter_async_context(

--- a/workspace/innate_skills/navigate_to_position.py
+++ b/workspace/innate_skills/navigate_to_position.py
@@ -237,11 +237,13 @@ class NavigateToPosition(Skill):
             "If local_frame is set to true, it navigates locally, where the robot is currently (0,0)"
         )
 
-    def execute(self, x: float, y: float, theta_degrees: float = 0.0, local_frame: bool = False, theta: float = None):
+    def execute(self, x: float, y: float, theta_degrees: float = 0.0, local_frame: bool = False, **legacy):
         # The tool schema speaks theta_degrees, but the cloud agent and the
         # pose-adjustment pipeline speak `theta` in radians (the same keys the
-        # robot's pose payload uses). Accept both; radians win when present.
-        if theta is not None:
+        # robot's pose payload uses). The alias lives in **legacy so schema
+        # introspection doesn't surface it as a second UI field.
+        if legacy.get("theta") is not None:
+            theta = float(legacy["theta"])
             theta_degrees = math.degrees(theta)
         else:
             theta = math.radians(theta_degrees)


### PR DESCRIPTION
The world moves out of Docker and the 3D view stops watching robot telemetry. Result, measured on an M1 Pro with the full stack and webapp running: the view's state is ~20-30ms old (was 100-150ms with bursts), zero sim-time jumps above 26ms, and the 50Hz wave replay renders with a continuous velocity profile (was stop-go with 3x overspeed bursts).

## Architecture

Four layers, one invariant: **robot software sees the world only through the robot adapter; humans and tools see it only through the observer stream.**

```
1. World          VirtualMars (core.py)     physics + sensors, pure Python, no ROS, no network
2. World host     world_server.py           owns the clock; TWO interfaces:
                                              a. driver RPC (8799)       sensing/actuation, robot-shaped
                                              b. observer stream (8800)  ground-truth WebSocket, ~75Hz
3. Robot adapter  mars_sim_driver node      consumes 2a, impersonates the hardware topic contract
4. Observers      webapp SimSession          consume 2b; never touch ROS
```

- **Placement**: the world server runs natively on the host on macOS (native GL: ~15ms full-res renders vs ~105ms software GL in Docker); in CI the same server starts next to the node in-container. The node can't tell the difference. The launcher refuses to reuse a running server that doesn't advertise the observer stream (version handshake in `ping`).
- **Observer stream**: `{t, wall, pose, joints}` pushed after every physics slice, latest-wins per client. The webapp front door proxies it at `/worldstate`; a local browser connects straight to loopback (mixed-content-exempt) and falls back to the proxied route automatically. The viewer plays it back with clamped interpolation sized to measured jitter (~30ms) -- no extrapolation, no wall-clock mapping, net deletion of the old smoothing machinery.
- **Commands stay on the robot path** (webapp → rosbridge → `/cmd_vel` → driver RPC): command latency is part of what the twin simulates. With a uniformly fresh view it reads as the robot's response time, as on hardware.
- **Why this is the challenge substrate**: movable objects, scoring, and spectators need ground truth that robot topics can never carry. Object poses become one more field in the stream message; graders are RPC clients of the ROS-free world host.

## Performance work (each item measured before/after)

- Demand-paced rendering: products render once per client pull (~8Hz) instead of free-running at GPU speed. World server 56% → 26% CPU.
- Physics steps in ≤25ms slices, publishing per slice: a scheduling stall replays as smooth slices, never a 100ms teleport.
- `PYTHONOPTIMIZE=1` for the driver: rosidl setters assert-validate every message byte in pure Python -- raw camera + depth + points burned ~1.5 cores of asserts (py-spy), starving the executor to ~5Hz command callbacks. Driver 94% → 26% CPU, callbacks back to 50Hz.
- Arm setpoint streams replay on their own timeline (cadence-EMA segments, roll-over interpolation, 300ms cap): zenoh clumps the 50Hz stream under bulk camera traffic, and per-message queue clearing collapsed each clump into a PD teleport. Wave ground truth: 31% exact stalls → 0%.
- Viewer render capped at 60fps (halves Chrome's load; data is ~75Hz interpolated), playback delay 2x p90 inter-arrival.

## Verification

Measured with the full stack under load (`?simperf` HUD shows the same live): stream 72Hz with arrival gaps p50/p90/p99 = 14/17/26ms; simulated 60fps playback over recorded arrivals: 0.8% frozen frames, visual age p50 18ms; wave replay 0.0% ground-truth stalls; base driving 0 pose stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
