### PR TITLE
chore: disable Claude co-author attribution on commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}


### PR DESCRIPTION
## What

Adds `.claude/settings.json` (checked-in, team-wide) setting `attribution.commit` and `attribution.pr` to empty strings.

## Why

Stops Claude Code from appending the `Co-Authored-By: Claude` trailer and the `Generated with Claude Code` line to commits and PRs it creates. Applies repo-wide for everyone once merged.

## Notes

- Uses the current `attribution` setting (the older `includeCoAuthoredBy` is deprecated).
- `.claude/settings.local.json` (personal) is gitignored and untouched.
- Only affects text Claude Code writes into commit/PR messages — not GitHub's own commit-author display.