### PR TITLE
fix(brain): stop destroying ROS entities under spinning executors (skills-server cancel crash-loop)

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/core/lifecycle.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/lifecycle.py
@@ -160,6 +160,8 @@ class BrainLifecycle:
         # Re-register after a short delay (lets the server process
         # READY_FOR_CONNECTION) via a one-shot timer, so we don't block the
         # executor thread with a sleep.
+        # Destroying is safe only because brain_client_node is spun
+        # single-threaded, so this runs on the spin thread between callbacks.
         if self._reactivate_timer is not None:
             self._node.destroy_timer(self._reactivate_timer)
         self._reactivate_timer = self._node.create_timer(0.5, self._finish_reactivation)

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -19,6 +19,7 @@ import os
 import queue
 import threading
 import time
+import traceback
 import uuid
 from typing import get_args
 
@@ -28,7 +29,7 @@ from brain_messages.srv import CreatePhysicalSkill, DeleteSkill, ReloadSkillsAge
 from innate.skills import SkillCancelled, SkillFailed, use_invoker
 from rclpy.action import ActionClient, ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
-from rclpy.executors import MultiThreadedExecutor
+from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
 from rclpy.node import Node
 from std_msgs.msg import String
 from std_srvs.srv import Trigger
@@ -719,8 +720,15 @@ def main(args=None):
     executor.add_node(action_server)
     try:
         executor.spin()
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
+    except Exception:
+        # An exception escaping spin() (e.g. InvalidHandle from an entity
+        # destroyed while the executor was using it) must not unwind past the
+        # teardown below: exiting with live zenoh entities panics rmw_zenoh's
+        # Rust runtime (SIGABRT). Log it and exit through the ordered teardown;
+        # launch respawns us either way, but from a clean exit.
+        action_server.get_logger().fatal(f"Executor spin crashed:\n{traceback.format_exc()}")
     action_server.destroy()
     # Guard against double-shutdown: avoids a teardown RCLError that exits 1.
     if rclpy.ok():

--- a/ros2_ws/src/brain/brain_client/brain_client/perception/camera.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/perception/camera.py
@@ -61,6 +61,11 @@ class CameraCapture:
         self._head_sub = self._node.create_subscription(String, "/mars/head/current_position", self._on_head, 10)
 
     def stop(self) -> None:
+        # Destroying here is safe only because brain_client_node is spun
+        # single-threaded and stop() runs on that spin thread (between
+        # callbacks). On a multi-threaded executor this would race the wait
+        # set (InvalidHandle) — flag-gate the callbacks instead, like
+        # skills/robot_state.py.
         for sub in (self._image_sub, self._depth_sub, self._arm_sub, self._head_sub):
             if sub is not None:
                 self._node.destroy_subscription(sub)

--- a/ros2_ws/src/brain/brain_client/brain_client/perception/pose_tracking.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/perception/pose_tracking.py
@@ -68,6 +68,11 @@ class PoseTracker:
         self._transform_timer = self._node.create_timer(1.0 / 30.0, self._fetch_transform)
 
     def stop(self) -> None:
+        # Destroying here is safe only because brain_client_node is spun
+        # single-threaded and stop() runs on that spin thread (between
+        # callbacks). On a multi-threaded executor this would race the wait
+        # set (InvalidHandle) — flag-gate the callbacks instead, like
+        # skills/robot_state.py.
         for sub in (self._odom_sub, self._nav_mode_sub):
             if sub is not None:
                 self._node.destroy_subscription(sub)

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/manipulation.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/manipulation.py
@@ -58,7 +58,11 @@ class ManipulationInterface:
         self._arm_state = None
         self._torque_enabled = None
 
-        # Subscription handles (created in start(), destroyed in stop())
+        # Subscription handles (created once in start(); kept for the node's
+        # lifetime — destroying one while the private executor thread spins
+        # races _take_subscription and crashes the process with InvalidHandle).
+        # stop() instead gates the callbacks via _active.
+        self._active = False
         self._ik_solution_sub = None
         self._ik_solution_fk_sub = None
         self._fk_pose_sub = None
@@ -87,7 +91,8 @@ class ManipulationInterface:
             self.logger.error(f"[ManipulationInterface] Executor stopped unexpectedly: {e}")
 
     def start(self):
-        """Create all subscriptions. Safe to call multiple times."""
+        """Enable arm-state feeds (subscriptions are created once). Safe to call multiple times."""
+        self._active = True
         if self._arm_state_sub is not None:
             return
         self._ik_solution_sub = self.node.create_subscription(
@@ -100,14 +105,12 @@ class ManipulationInterface:
         self._arm_state_sub = self.node.create_subscription(JointState, "/mars/arm/state", self._arm_state_callback, 10)
 
     def stop(self):
-        """Destroy all subscriptions and clear cached state."""
-        for sub in (self._ik_solution_sub, self._ik_solution_fk_sub, self._fk_pose_sub, self._arm_state_sub):
-            if sub is not None:
-                self.node.destroy_subscription(sub)
-        self._ik_solution_sub = None
-        self._ik_solution_fk_sub = None
-        self._fk_pose_sub = None
-        self._arm_state_sub = None
+        """Deactivate arm-state feeds and clear cached state.
+
+        Subscriptions are deliberately kept alive (see __init__); the callbacks
+        early-return while inactive.
+        """
+        self._active = False
         self._ik_solution = None
         self._ik_solution_fk = None
         self._fk_pose = None

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/manipulation.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/manipulation.py
@@ -42,10 +42,14 @@ class ManipulationInterface:
         """
         self.node = rclpy.create_node(f"{node.get_name()}_manipulation_interface")
         self.logger = logger
-        self._executor = rclpy.executors.SingleThreadedExecutor()
-        self._executor.add_node(self.node)
-        self._executor_thread = threading.Thread(target=self._spin_executor, daemon=True)
-        self._executor_thread.start()
+        # The private executor spins only while a skill is active
+        # (start()..stop()). While parked, messages arriving on the
+        # always-alive subscriptions just rotate in the bounded rmw queues at
+        # no Python cost — dispatching them through an executor costs ~half a
+        # Jetson core at the ~600 msgs/s these feeds add up to.
+        self._executor = None
+        self._executor_thread = None
+        self._lifecycle_lock = threading.Lock()
         self._ik_lock = threading.Lock()
 
         # Publishers
@@ -61,7 +65,8 @@ class ManipulationInterface:
         # Subscription handles (created once in start(); kept for the node's
         # lifetime — destroying one while the private executor thread spins
         # races _take_subscription and crashes the process with InvalidHandle).
-        # stop() instead gates the callbacks via _active.
+        # stop() instead gates the callbacks via _active and parks the
+        # executor.
         self._active = False
         self._ik_solution_sub = None
         self._ik_solution_fk_sub = None
@@ -84,33 +89,51 @@ class ManipulationInterface:
 
         self.logger.info("ManipulationInterface initialized")
 
-    def _spin_executor(self):
+    def _spin_executor(self, executor):
         try:
-            self._executor.spin()
+            executor.spin()
         except Exception as e:
             self.logger.error(f"[ManipulationInterface] Executor stopped unexpectedly: {e}")
 
     def start(self):
-        """Enable arm-state feeds (subscriptions are created once). Safe to call multiple times."""
-        self._active = True
-        if self._arm_state_sub is not None:
-            return
-        self._ik_solution_sub = self.node.create_subscription(
-            JointState, "/ik_solution", self._ik_solution_callback, 10
-        )
-        self._ik_solution_fk_sub = self.node.create_subscription(
-            PoseStamped, "/ik_solution_fk", self._ik_solution_fk_callback, 10
-        )
-        self._fk_pose_sub = self.node.create_subscription(PoseStamped, "/fk_pose", self._fk_pose_callback, 10)
-        self._arm_state_sub = self.node.create_subscription(JointState, "/mars/arm/state", self._arm_state_callback, 10)
+        """Enable arm-state feeds: spin up the private executor and create the
+        subscriptions once. Safe to call multiple times."""
+        with self._lifecycle_lock:
+            self._active = True
+            if self._executor is None:
+                self._executor = rclpy.executors.SingleThreadedExecutor()
+                self._executor.add_node(self.node)
+                self._executor_thread = threading.Thread(
+                    target=self._spin_executor, args=(self._executor,), daemon=True
+                )
+                self._executor_thread.start()
+            if self._arm_state_sub is not None:
+                return
+            self._ik_solution_sub = self.node.create_subscription(
+                JointState, "/ik_solution", self._ik_solution_callback, 10
+            )
+            self._ik_solution_fk_sub = self.node.create_subscription(
+                PoseStamped, "/ik_solution_fk", self._ik_solution_fk_callback, 10
+            )
+            self._fk_pose_sub = self.node.create_subscription(PoseStamped, "/fk_pose", self._fk_pose_callback, 10)
+            self._arm_state_sub = self.node.create_subscription(
+                JointState, "/mars/arm/state", self._arm_state_callback, 10
+            )
 
     def stop(self):
-        """Deactivate arm-state feeds and clear cached state.
+        """Deactivate arm-state feeds, park the private executor and clear cached state.
 
         Subscriptions are deliberately kept alive (see __init__); the callbacks
-        early-return while inactive.
+        early-return while inactive, and with the executor parked they are not
+        invoked at all between skills.
         """
-        self._active = False
+        with self._lifecycle_lock:
+            self._active = False
+            if self._executor is not None:
+                self._executor.shutdown()
+                self._executor_thread.join(timeout=2.0)
+                self._executor = None
+                self._executor_thread = None
         self._ik_solution = None
         self._ik_solution_fk = None
         self._fk_pose = None
@@ -119,8 +142,6 @@ class ManipulationInterface:
     def shutdown(self):
         """Stop the manipulation helper node and its private executor."""
         self.stop()
-        self._executor.shutdown()
-        self._executor_thread.join(timeout=2.0)
         self.node.destroy_node()
 
     def spin_node_to_refresh_topics(self, count: int = 10, timeout_sec: float = 0.001):
@@ -139,20 +160,24 @@ class ManipulationInterface:
 
     def _ik_solution_callback(self, msg: JointState):
         """Store the latest IK solution."""
-        self.logger.debug(f"IK solution received: {msg}")
-        self._ik_solution = msg
+        if self._active:
+            self.logger.debug(f"IK solution received: {msg}")
+            self._ik_solution = msg
 
     def _ik_solution_fk_callback(self, msg: PoseStamped):
         """Store the FK of the latest IK solution (what commanded joints map to)."""
-        self._ik_solution_fk = msg
+        if self._active:
+            self._ik_solution_fk = msg
 
     def _fk_pose_callback(self, msg: PoseStamped):
         """Store the latest FK pose."""
-        self._fk_pose = msg
+        if self._active:
+            self._fk_pose = msg
 
     def _arm_state_callback(self, msg: JointState):
         """Store the latest arm state (includes effort/load)."""
-        self._arm_state = msg
+        if self._active:
+            self._arm_state = msg
 
     def get_current_end_effector_pose(self) -> dict | None:
         """

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/mobility.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/mobility.py
@@ -83,6 +83,10 @@ class MobilityInterface:
 
         if duration is not None and duration > 0.0:
             self._schedule_stop(duration)
+        elif self._stop_timer is not None:
+            # Continuous motion requested: disarm any stop still pending from
+            # an earlier timed command so it doesn't cut this one short.
+            self._stop_timer.cancel()
 
     def rotate_in_place(self, angular_speed: float, duration: float) -> None:
         """Rotate in place with specified angular speed for a duration (non-blocking).

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/mobility.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/mobility.py
@@ -40,30 +40,23 @@ class MobilityInterface:
         self.logger.info(f"MobilityInterface initialized with cmd_vel topic: {self.cmd_vel_topic}")
 
     def _schedule_stop(self, duration: float):
+        # One timer, created once and retargeted per command. Destroying a
+        # timer on a node a live executor is spinning races the executor's
+        # wait set (InvalidHandle -> crash), and creating a fresh one per
+        # deadman refresh (10-20/s) would leak cancelled timers in the node's
+        # timer list — reset/cancel on a single timer avoids both.
         if duration is None or duration <= 0.0:
             return
+        if self._stop_timer is None:
+            self._stop_timer = self.node.create_timer(duration, self._on_stop_timer)
+            return
+        self._stop_timer.timer_period_ns = int(duration * 1e9)
+        self._stop_timer.reset()
 
-        self._destroy_stop_timer()
-
-        def _stop_callback():
-            try:
-                stop_cmd = Twist()
-                self._cmd_vel_pub.publish(stop_cmd)
-                self.logger.debug("MobilityInterface: stop command published")
-            finally:
-                self._destroy_stop_timer()
-
-        self._stop_timer = self.node.create_timer(duration, _stop_callback)
-
-    def _destroy_stop_timer(self):
-        # destroy, don't just cancel: a cancelled timer stays in the node's
-        # timer list forever, which leaks at deadman rates (10-20 timers/s)
-        timer, self._stop_timer = self._stop_timer, None
-        if timer is not None:
-            try:
-                self.node.destroy_timer(timer)
-            except Exception:
-                pass
+    def _on_stop_timer(self):
+        self._stop_timer.cancel()  # one-shot: stays cancelled until the next _schedule_stop
+        self._cmd_vel_pub.publish(Twist())
+        self.logger.debug("MobilityInterface: stop command published")
 
     def send_cmd_vel(
         self,

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
@@ -45,6 +45,12 @@ class RobotStateProvider:
         self._head_position_sub = None
         self._joint_states_sub = None
         self._battery_sub = None
+        # Feeds are gated by this flag instead of destroying the subscriptions:
+        # destroying a subscription the spinning MultiThreadedExecutor has
+        # already selected as "ready" races _take_subscription and crashes the
+        # process (InvalidHandle -> rmw_zenoh Rust panic -> SIGABRT), easiest
+        # to hit right after a skill cancellation.
+        self._active = False
         # warn once per missing state, not at 50 Hz while a slow topic
         # (battery publishes at 0.2 Hz) sends its first message
         self._warned_missing = set()
@@ -69,7 +75,10 @@ class RobotStateProvider:
 
     # --- subscriptions ---
     def start_subscriptions(self) -> None:
-        """Create robot-state subscriptions needed during skill execution."""
+        """Enable robot-state feeds for skill execution (subscriptions are created once)."""
+        self._warned_missing.clear()
+        self._manipulation.start()
+        self._active = True
         if self._odom_sub is not None:
             return
         self._odom_sub = self._node.create_subscription(Odometry, "/odom", self._on_odom, 10)
@@ -79,19 +88,15 @@ class RobotStateProvider:
         )
         self._joint_states_sub = self._node.create_subscription(JointState, "/joint_states", self._on_joint_states, 10)
         self._battery_sub = self._node.create_subscription(BatteryState, "/battery_state", self._on_battery, 10)
-        self._warned_missing.clear()
-        self._manipulation.start()
 
     def stop_subscriptions(self) -> None:
-        """Destroy robot-state subscriptions when no skill is running."""
-        for sub in (self._odom_sub, self._map_sub, self._head_position_sub, self._joint_states_sub, self._battery_sub):
-            if sub is not None:
-                self._node.destroy_subscription(sub)
-        self._odom_sub = None
-        self._map_sub = None
-        self._head_position_sub = None
-        self._joint_states_sub = None
-        self._battery_sub = None
+        """Deactivate robot-state feeds when no skill is running.
+
+        The subscriptions are deliberately NOT destroyed (see __init__); the
+        callbacks early-return while inactive, so the idle cost is bounded by
+        message deserialization.
+        """
+        self._active = False
         self._manipulation.stop()
         self.last_odom = None
         self.last_map = None
@@ -100,18 +105,24 @@ class RobotStateProvider:
         self.last_battery = None
 
     def _on_odom(self, msg: Odometry) -> None:
-        self.last_odom = msg
+        if self._active:
+            self.last_odom = msg
 
     def _on_map(self, msg: OccupancyGrid) -> None:
-        self.last_map = msg
+        if self._active:
+            self.last_map = msg
 
     def _on_joint_states(self, msg: JointState) -> None:
-        self.last_joint_states = msg
+        if self._active:
+            self.last_joint_states = msg
 
     def _on_battery(self, msg: BatteryState) -> None:
-        self.last_battery = msg
+        if self._active:
+            self.last_battery = msg
 
     def _on_head_position(self, msg: String) -> None:
+        if not self._active:
+            return
         try:
             self.last_head_position = json.loads(msg.data)
         except Exception as e:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
@@ -46,10 +46,14 @@ class RobotStateProvider:
         self._joint_states_sub = None
         self._battery_sub = None
         # Feeds are gated by this flag instead of destroying the subscriptions:
-        # destroying a subscription the spinning MultiThreadedExecutor has
-        # already selected as "ready" races _take_subscription and crashes the
-        # process (InvalidHandle -> rmw_zenoh Rust panic -> SIGABRT), easiest
-        # to hit right after a skill cancellation.
+        # destroying a subscription an executor has already selected as
+        # "ready" races _take_subscription and crashes the process
+        # (InvalidHandle -> rmw_zenoh Rust panic -> SIGABRT), easiest to hit
+        # right after a skill cancellation. The subscriptions live on the
+        # manipulation interface's private node, whose executor is parked
+        # between skills — always-alive high-rate feeds (/joint_states + head
+        # position alone are ~400 msgs/s) would otherwise cost ~half a Jetson
+        # core in executor dispatch even while idle.
         self._active = False
         # warn once per missing state, not at 50 Hz while a slow topic
         # (battery publishes at 0.2 Hz) sends its first message
@@ -77,24 +81,27 @@ class RobotStateProvider:
     def start_subscriptions(self) -> None:
         """Enable robot-state feeds for skill execution (subscriptions are created once)."""
         self._warned_missing.clear()
+        # start() first: it spins up the private executor that also dispatches
+        # the robot-state subscriptions below
         self._manipulation.start()
         self._active = True
         if self._odom_sub is not None:
             return
-        self._odom_sub = self._node.create_subscription(Odometry, "/odom", self._on_odom, 10)
-        self._map_sub = self._node.create_subscription(OccupancyGrid, "/map", self._on_map, 1)
-        self._head_position_sub = self._node.create_subscription(
+        feed_node = self._manipulation.node
+        self._odom_sub = feed_node.create_subscription(Odometry, "/odom", self._on_odom, 10)
+        self._map_sub = feed_node.create_subscription(OccupancyGrid, "/map", self._on_map, 1)
+        self._head_position_sub = feed_node.create_subscription(
             String, self._head_current_position_topic, self._on_head_position, 10
         )
-        self._joint_states_sub = self._node.create_subscription(JointState, "/joint_states", self._on_joint_states, 10)
-        self._battery_sub = self._node.create_subscription(BatteryState, "/battery_state", self._on_battery, 10)
+        self._joint_states_sub = feed_node.create_subscription(JointState, "/joint_states", self._on_joint_states, 10)
+        self._battery_sub = feed_node.create_subscription(BatteryState, "/battery_state", self._on_battery, 10)
 
     def stop_subscriptions(self) -> None:
         """Deactivate robot-state feeds when no skill is running.
 
         The subscriptions are deliberately NOT destroyed (see __init__); the
-        callbacks early-return while inactive, so the idle cost is bounded by
-        message deserialization.
+        callbacks early-return while inactive, and parking the private
+        executor (manipulation.stop()) stops them being invoked at all.
         """
         self._active = False
         self._manipulation.stop()


### PR DESCRIPTION
## Problem

While testing #484 on-robot, @DavidDobas hit a reproducible skills-server crash-loop immediately after skill cancellations ([report](https://github.com/innate-inc/innate-os/pull/484#discussion_r3533659358)): rclpy `InvalidHandle` → rmw_zenoh Rust panic → SIGABRT, respawned by launch, with every `/brain` service timing out for ~2 minutes. The Profiling page's run → Stop → run-again rollout loop (and #484's auto-stop, which ends every rollout in a cancel) hits it constantly.

## Root cause

The trigger is our own teardown, not just the upstream races. At the end of **every** skill, `execute_callback`'s `finally` destroyed nine subscriptions while executors were spinning the nodes that own them:

- `RobotStateProvider.stop_subscriptions()` — five subs (`/odom`, `/map`, `/joint_states`, head, battery) on the skills-server node, which spins on a `MultiThreadedExecutor`
- `ManipulationInterface.stop()` — four subs on its private node, spun by its own executor thread

Destroying a subscription the executor has already selected as ready races `Executor._take_subscription` (`with sub.handle:` → `InvalidHandle: cannot use Destroyable because destruction was requested`). The exception re-raises in the spin thread (`_spin_once_impl` → `future.result()`), `main()` only caught `KeyboardInterrupt`, so the process unwound past `destroy()`/`shutdown()` — and exiting with live zenoh entities is what panics rmw_zenoh's Rust runtime into SIGABRT.

`manipulation_server.py` already diagnosed and fixed this exact race for its own sensor subscriptions (2d188b64, "deliberately NEVER destroyed"); the skills server kept the racy pattern.

**Repro** (CI image, Humble + rmw_zenoh): a worker thread cycling create/destroy of 5 subs under 500 Hz traffic on a `MultiThreadedExecutor` node crashed with the exact field signature **within 6 cycles**. The flag-gated pattern below survived 483 cycles / 60k messages clean.

## Fix

Same pattern as `manipulation_server.py`: **create subscriptions once, keep them for the node's lifetime, gate the callbacks with an `_active` flag** (`robot_state.py`, `manipulation.py`). Cached state is still cleared on stop, so skills never read stale data; idle cost is bounded by message deserialization.

Also in this PR:

- `skills_server.py` `main()` — belt-and-braces guard: exceptions escaping `spin()` are logged FATAL and the node exits through the ordered teardown, so any residual race of this class becomes a clean 2 s respawn instead of a SIGABRT cascade (this is also the upstream-recommended mitigation, see ros2/rclpy#1385).
- `mobility.py` — the cmd_vel deadman destroyed/recreated its stop timer at 10–20/s on the same spinning nodes (same race class, reachable from skills driving the base). Replaced with one persistent timer retargeted via `timer_period_ns` + `reset()`, cancelled in its callback for one-shot semantics — which also removes the cancelled-timer leak the destroy approach existed to avoid. Verified live on Humble/rmw_zenoh: refreshes suppress firing, exactly one stop per deadman window, retargets across durations.
- `camera.py` / `pose_tracking.py` / `lifecycle.py` — their runtime destroys are **safe** (brain_client_node is spun single-threaded via `spin_once`, WS handlers run on the spin thread, so destroys happen between callbacks); added a comment at each site stating that constraint so a future executor change doesn't silently reintroduce the crash.

## Upstream context

- The `InvalidHandle` executor races are known and fixed only in **rolling** (ros2/rclpy#1668 registry locking, ros2/rclpy#1385 waitable iteration) — no Humble backports.
- Robots run the apt binary `ros-humble-rmw-zenoh-cpp` ≤ 0.1.8 (zenoh 1.5.0), which lacks the zenoh 1.8.0 "undeclare blocks until callbacks finish" fix (rmw_zenoh `humble` source branch since 2026-04, never binary-released). Building that branch from source would add fleet-wide hardening independent of this fix.
- Unrelated to this repro but worth knowing: rcl expires goal handles `result_timeout` (900 s) after goal *creation*, not completion (ros2/rcl#970), so cancelling a goal that ran > 15 min destroys its handle at the cancel instant — a ceiling on safe skill runtimes under Humble.

## Verification

- Repro script (destroy pattern): `InvalidHandle` within 6 cycles; fixed pattern: clean over 483 cycles / 60k msgs (CI image, zenoh router, 500 Hz × 5 topics)
- Live deadman-timer test on Humble/rmw_zenoh: 20 Hz refresh suppresses firing, one fire per window at the right delay, reusable across durations
- `ruff check` / `ruff format` / `pre-commit` (`.config/pre-commit-config.yaml`): pass on all 7 files
- Import smoke tests of all changed modules in the ROS 2 Humble image: pass
- CI no-ROS pytest bucket (`test_fake_cloud_selftest.py`, `test_backwards_compat.py`): 19 passed

Repro: run a learned skill from the Profiling page, hit Stop, immediately run again, repeat — previously crash-looped the skills server within a few cycles; with this fix the loop runs clean.