### PR TITLE
Make camera resolution controllable via settings.yaml (INN-508)

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -66,12 +66,22 @@
 #     max_jerk: 150.0               # rad/s^3 trajectory jerk limit (0 disables)
 #     stress_enabled: false         # motor-protection cooldown
 
-# ── Camera (physical main camera; hardware only) ──────────────────────
+# ── Camera: main (stereo; hardware only) ──────────────────────────────
+# Resolution is staged: the sensor captures the full side-by-side stereo frame at
+# width x height (must be a mode the sensor supports), the GPU downscales it to
+# publish_stereo_*, and each eye (half the stereo width) is resized to
+# publish_left_* — the size every ROS topic carries. Downstream consumers (depth,
+# brain, manipulation) follow the published size automatically; the teleop stream
+# size is separate (see webrtc_streamer below).
 # main_camera_driver:
 #   ros__parameters:
-#     publish_left_width: 640       # streamed main-camera image width (px)
-#     publish_left_height: 480      # streamed main-camera image height (px)
-#     fps: 30.0                     # camera frame rate
+#     width: 2560                   # capture width, both eyes combined (px)
+#     height: 720                   # capture height (px)
+#     publish_stereo_width: 1280    # stereo-frame downscale before the left/right split
+#     publish_stereo_height: 480
+#     publish_left_width: 640       # published per-eye image width (px)
+#     publish_left_height: 480      # published per-eye image height (px)
+#     fps: 15.0                     # camera frame rate
 #     jpeg_quality: 80              # JPEG compression quality (1-100)
 #     auto_exposure_mode: 0         # 0=hardware AE, 1=custom PID, 2=manual
 #     exposure: -1                  # manual exposure time (-1 = keep current; 1-10000)
@@ -79,6 +89,23 @@
 #     default_gain: 110             # gain used in auto-exposure mode (0-255)
 #     target_brightness: 128.0      # auto-exposure target brightness (0-255)
 #     ae_kp: 0.8                    # auto-exposure proportional gain
+
+# ── Camera: arm/wrist (hardware only) ─────────────────────────────────
+# arm_camera_driver:
+#   ros__parameters:
+#     width: 640                    # capture width (must be a mode the sensor supports)
+#     height: 480                   # capture height
+#     fps: 30.0                     # camera frame rate
+
+# ── Camera: teleop stream (WebRTC) ────────────────────────────────────
+# The size each camera is encoded at for the app/teleop video stream — incoming
+# frames are resized to it, independent of the published topic size above.
+# webrtc_streamer:
+#   ros__parameters:
+#     main_width: 640               # main-camera stream size (px)
+#     main_height: 480
+#     arm_width: 640                # arm-camera stream size (px)
+#     arm_height: 480
 
 # ── Manipulation (learned-skill execution) ────────────────────────────
 # chunk_size is fixed by the trained model. These are node-level (restart to apply);

--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -70,7 +70,9 @@
 # Resolution is staged: the sensor captures the full side-by-side stereo frame at
 # width x height (must be a mode the sensor supports), the GPU downscales it to
 # publish_stereo_*, and each eye (half the stereo width) is resized to
-# publish_left_* — the size every ROS topic carries. Downstream consumers (depth,
+# publish_left_* — the size every ROS topic carries. publish_left_* above half the
+# publish_stereo size only upscales (no extra detail): for a sharper image, raise
+# width x height and publish_stereo_* together. Downstream consumers (depth,
 # brain, manipulation) follow the published size automatically; the teleop stream
 # size is separate (see webrtc_streamer below).
 # main_camera_driver:

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -47,7 +47,9 @@ To tune something, **uncomment a whole stanza** (the `node:`, `ros__parameters:`
 | `bringup` `battery` | `warning_percentage` / `critical_percentage` | `20` / `10` |
 | `bringup` `safety` (hard `/cmd_vel` clamp) | `max_speed` / `max_angular_speed` | `0.4` / `2.5` |
 | `mars_arm` | `max_jerk` / `stress_enabled` | `150.0` / `false` |
-| `main_camera_driver` (hardware) | `publish_left_width/height`, `fps`, `jpeg_quality`, `auto_exposure_mode`, `exposure`, `gain`, `default_gain`, `target_brightness`, `ae_kp` | see template |
+| `main_camera_driver` (hardware) | `width/height` (capture), `publish_stereo_width/height`, `publish_left_width/height` (published size — depth/brain/manipulation follow it automatically), `fps`, `jpeg_quality`, `auto_exposure_mode`, `exposure`, `gain`, `default_gain`, `target_brightness`, `ae_kp` | see template |
+| `arm_camera_driver` (hardware) | `width/height` (capture), `fps` | `640/480`, `30.0` |
+| `webrtc_streamer` (teleop stream) | `main_width/main_height`, `arm_width/arm_height` (encode size per camera) | `640/480` each |
 | `manipulation_server` | `inference_hz`, `speed`, `n_action_steps` (0=auto), `temporal_ensemble_coeff` | `25.0`, `1.5`, `0`, `0.0` |
 | `navigation_grid_localizer` | `max_score_threshold`, `max_range`, `auto_localize_timeout` | `0.3`, `12.0`, `30.0` |
 | `brain_client_node` | `cartesia_voice_id` (TTS voice), `vertical_fov`, `pose_image_interval`, `scan_stale_after_sec`, `send_depth`, `send_arm_camera_image`, `log_everything`, STT/transcribe models | see template |

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -47,9 +47,9 @@ To tune something, **uncomment a whole stanza** (the `node:`, `ros__parameters:`
 | `bringup` `battery` | `warning_percentage` / `critical_percentage` | `20` / `10` |
 | `bringup` `safety` (hard `/cmd_vel` clamp) | `max_speed` / `max_angular_speed` | `0.4` / `2.5` |
 | `mars_arm` | `max_jerk` / `stress_enabled` | `150.0` / `false` |
-| `main_camera_driver` (hardware) | `width/height` (capture), `publish_stereo_width/height`, `publish_left_width/height` (published size — depth/brain/manipulation follow it automatically), `fps`, `jpeg_quality`, `auto_exposure_mode`, `exposure`, `gain`, `default_gain`, `target_brightness`, `ae_kp` | see template |
-| `arm_camera_driver` (hardware) | `width/height` (capture), `fps` | `640/480`, `30.0` |
-| `webrtc_streamer` (teleop stream) | `main_width/main_height`, `arm_width/arm_height` (encode size per camera) | `640/480` each |
+| `main_camera_driver` (hardware) | `width/height` (capture), `publish_stereo_width/height`, `publish_left_width/height` (published size; downstream follows it automatically), `fps`, `jpeg_quality`, `auto_exposure_mode`, `exposure`, `gain`, `default_gain`, `target_brightness`, `ae_kp` | see template |
+| `arm_camera_driver` (hardware) | `width/height` (capture), `fps` | see template |
+| `webrtc_streamer` (teleop stream) | `main_width/main_height`, `arm_width/arm_height` (encode size per camera) | see template |
 | `manipulation_server` | `inference_hz`, `speed`, `n_action_steps` (0=auto), `temporal_ensemble_coeff` | `25.0`, `1.5`, `0`, `0.0` |
 | `navigation_grid_localizer` | `max_score_threshold`, `max_range`, `auto_localize_timeout` | `0.3`, `12.0`, `30.0` |
 | `brain_client_node` | `cartesia_voice_id` (TTS voice), `vertical_fov`, `pose_image_interval`, `scan_stale_after_sec`, `send_depth`, `send_arm_camera_image`, `log_everything`, STT/transcribe models | see template |

--- a/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
@@ -51,10 +51,6 @@ arm_camera_driver:
     data_directory: "/home/jetson1/innate-os/data"
     frame_id: "camera_optical_frame"
 
-    # Input image size (single eye, not the combined stereo frame)
-    image_width: 640
-    image_height: 480
-
     # Maximum processing rate (Hz). 0 = unlimited (process every incoming frame).
     max_fps: 8.0
 

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/stereo_depth_estimator.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/stereo_depth_estimator.hpp
@@ -177,9 +177,8 @@ class StereoDepthEstimator : public rclcpp::Node {
     int disparity_border_margin_;
 
     // Image dimensions
-    int image_width_, image_height_;  // input (from camera)
-    int calib_width_, calib_height_;  // calibration (processing)
-    double depth_scale_;
+    int image_width_ = 0, image_height_ = 0;  // input/output — adopted from the incoming images
+    int calib_width_, calib_height_;          // calibration (processing)
 
     // Calibration (from camera_info topics)
     cv::Mat P1_;  // left projection matrix (3×4), for point cloud intrinsics

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/stereo_depth_estimator.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/stereo_depth_estimator.hpp
@@ -178,7 +178,7 @@ class StereoDepthEstimator : public rclcpp::Node {
 
     // Image dimensions
     int image_width_ = 0, image_height_ = 0;  // input/output — adopted from the incoming images
-    int calib_width_, calib_height_;          // calibration (processing)
+    int calib_width_ = 0, calib_height_ = 0;  // calibration (processing)
 
     // Calibration (from camera_info topics)
     cv::Mat P1_;  // left projection matrix (3×4), for point cloud intrinsics

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -44,8 +44,10 @@ class WebRTCStreamer;  // CameraEncoder back-references the node for the static 
 struct CameraEncoder {
     std::string name;
     std::string live_topic, replay_topic;
-    int pt = 96;     // RTP payload type, unique per camera (audio uses 98)
-    int fps = 30;    // encoder framerate (appsrc caps)
+    int pt = 96;       // RTP payload type, unique per camera (audio uses 98)
+    int fps = 30;      // encoder framerate (appsrc caps)
+    int width = 640;   // encode resolution (appsrc caps); incoming frames are resized to it
+    int height = 480;
     guint ssrc = 0;  // fixed SSRC so the SDP offer carries a=ssrc/msid before any RTP has flowed
 
     GstElement* appsrc = nullptr;  // src_<name>, ref'd out of the encode pipeline
@@ -172,7 +174,7 @@ class WebRTCStreamer : public rclcpp::Node {
 
     // ---- Persistent encode pipeline (built once in the constructor) ----
     void configure_cameras();  // read the camera list + per-camera params into cameras_
-    std::string video_encode_branch(const std::string& name, int pt, int fps, guint ssrc) const;
+    std::string video_encode_branch(const CameraEncoder& cam) const;
     bool build_encode_pipeline();
     void attach_playout_delay_extension(const std::string& cam);  // adds the ext to one payloader
     cv::Mat process_raw_image(const sensor_msgs::msg::Image::SharedPtr& msg, int w, int h);

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -44,9 +44,9 @@ class WebRTCStreamer;  // CameraEncoder back-references the node for the static 
 struct CameraEncoder {
     std::string name;
     std::string live_topic, replay_topic;
-    int pt = 96;       // RTP payload type, unique per camera (audio uses 98)
-    int fps = 30;      // encoder framerate (appsrc caps)
-    int width = 640;   // encode resolution (appsrc caps); incoming frames are resized to it
+    int pt = 96;      // RTP payload type, unique per camera (audio uses 98)
+    int fps = 30;     // encoder framerate (appsrc caps)
+    int width = 640;  // encode resolution (appsrc caps); incoming frames are resized to it
     int height = 480;
     guint ssrc = 0;  // fixed SSRC so the SDP offer carries a=ssrc/msid before any RTP has flowed
 

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -110,7 +110,8 @@ def generate_launch_description():
                 # genuinely-dead peer is still caught here and by the ICE DISCONNECTED/FAILED path.
                 # Runtime-tunable via `ros2 param set`.
                 "rtcp_inactivity_timeout_s": 15.0,
-            }
+            },
+            *settings_params(),
         ],
         extra_arguments=[{"use_intra_process_comms": True}],
     )

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/calibration.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/calibration.cpp
@@ -48,7 +48,6 @@ bool StereoDepthEstimator::initCalibrationFromCameraInfo() {
 
     calib_width_ = static_cast<int>(left.width);
     calib_height_ = static_cast<int>(left.height);
-    depth_scale_ = static_cast<double>(calib_width_) / static_cast<double>(image_width_);
 
     // ── Extract matrices from CameraInfo messages ───────────────────────────
     // k/r/p are contiguous row-major doubles — same layout as cv::Mat(CV_64F).
@@ -94,8 +93,6 @@ bool StereoDepthEstimator::initCalibrationFromCameraInfo() {
 
     RCLCPP_INFO(this->get_logger(), "Calibration extracted from camera_info:");
     RCLCPP_INFO(this->get_logger(), "  Resolution: %dx%d", calib_width_, calib_height_);
-    RCLCPP_INFO(this->get_logger(), "  Scale: input %dx%d -> calib %dx%d (scale=%.3f)", image_width_, image_height_,
-                calib_width_, calib_height_, depth_scale_);
     RCLCPP_INFO(this->get_logger(), "  Stereo: focal=%.2f px, baseline=%.4f m (%.1f mm)", focal_length_, baseline_,
                 baseline_ * 1000.0);
 

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/publishing.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/publishing.cpp
@@ -113,7 +113,7 @@ void StereoDepthEstimator::publishDisparityMsg(const cv::Mat& disparity_float, c
     msg->image.data.resize(msg->image.height * msg->image.step);
     memcpy(msg->image.data.data(), disp_full.data, msg->image.data.size());
 
-    const float scale_up = 1.0f / static_cast<float>(depth_scale_);
+    const float scale_up = static_cast<float>(image_width_) / static_cast<float>(calib_width_);
     msg->f = static_cast<float>(focal_length_) * scale_up;
     msg->t = static_cast<float>(baseline_);
     msg->min_disparity = static_cast<float>(min_disparity_);

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_depth_estimator.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_depth_estimator.cpp
@@ -40,8 +40,6 @@ StereoDepthEstimator::StereoDepthEstimator(const rclcpp::NodeOptions& options)
                                          "/mars/main_camera/left/image_rect_color/compressed");
     this->declare_parameter<std::string>("frame_id", "camera_optical_frame");
     this->declare_parameter<int>("jpeg_quality", 80);
-    this->declare_parameter<int>("image_width", 640);
-    this->declare_parameter<int>("image_height", 480);
     this->declare_parameter<double>("max_fps", 10.0);
     this->declare_parameter<std::string>("pointcloud_topic", "/mars/main_camera/points");
     this->declare_parameter<std::string>("pointcloud_color_topic", "/mars/main_camera/points_color");
@@ -77,8 +75,6 @@ StereoDepthEstimator::StereoDepthEstimator(const rclcpp::NodeOptions& options)
     left_rectified_compressed_topic_ = this->get_parameter("left_rectified_compressed_topic").as_string();
     frame_id_ = this->get_parameter("frame_id").as_string();
     jpeg_quality_ = this->get_parameter("jpeg_quality").as_int();
-    image_width_ = this->get_parameter("image_width").as_int();
-    image_height_ = this->get_parameter("image_height").as_int();
     max_fps_ = this->get_parameter("max_fps").as_double();
     if (max_fps_ < 0.0)
         max_fps_ = 0.0;
@@ -123,7 +119,6 @@ StereoDepthEstimator::StereoDepthEstimator(const rclcpp::NodeOptions& options)
     RCLCPP_DEBUG(this->get_logger(), "Left topic: %s", left_topic_.c_str());
     RCLCPP_DEBUG(this->get_logger(), "Right topic: %s", right_topic_.c_str());
     RCLCPP_DEBUG(this->get_logger(), "Depth topic: %s", depth_topic_.c_str());
-    RCLCPP_DEBUG(this->get_logger(), "Input image dimensions: %dx%d", image_width_, image_height_);
     RCLCPP_DEBUG(this->get_logger(), "Max disparity: %d", max_disparity_);
     RCLCPP_DEBUG(this->get_logger(), "SGM params: diagonals=%d, p1=%d, p2=%d, confThreshold=%d, uniqueness=%.2f",
                  include_diagonals_, p1_, p2_, confidence_threshold_, uniqueness_);
@@ -194,8 +189,8 @@ StereoDepthEstimator::StereoDepthEstimator(const rclcpp::NodeOptions& options)
         std::bind(&StereoDepthEstimator::syncCallback, this, std::placeholders::_1, std::placeholders::_2));
 
     last_stats_time_ = this->now();
-    RCLCPP_INFO(this->get_logger(), "Stereo depth estimator running — depth topic: %s (%dx%d, max_disparity=%d)",
-                depth_topic_.c_str(), image_width_, image_height_, max_disparity_);
+    RCLCPP_INFO(this->get_logger(), "Stereo depth estimator running — depth topic: %s (max_disparity=%d)",
+                depth_topic_.c_str(), max_disparity_);
 }
 
 // =============================================================================
@@ -241,18 +236,19 @@ void StereoDepthEstimator::syncCallback(const sensor_msgs::msg::Image::ConstShar
     }
     input_frame_count_++;
 
-    // Validate dimensions
-    if (static_cast<int>(left_msg->width) != image_width_ || static_cast<int>(left_msg->height) != image_height_) {
+    // Adopt the incoming resolution (the camera's publish size is a settings.yaml knob). SGM itself
+    // always runs at calibration resolution; the input size only sets the output size and scale.
+    if (left_msg->width != right_msg->width || left_msg->height != right_msg->height) {
         RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                             "Left image size mismatch: got %dx%d, expected %dx%d", left_msg->width, left_msg->height,
-                             image_width_, image_height_);
+                             "Left/right image size mismatch: %ux%u vs %ux%u", left_msg->width, left_msg->height,
+                             right_msg->width, right_msg->height);
         return;
     }
-    if (static_cast<int>(right_msg->width) != image_width_ || static_cast<int>(right_msg->height) != image_height_) {
-        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                             "Right image size mismatch: got %dx%d, expected %dx%d", right_msg->width,
-                             right_msg->height, image_width_, image_height_);
-        return;
+    if (static_cast<int>(left_msg->width) != image_width_ || static_cast<int>(left_msg->height) != image_height_) {
+        image_width_ = static_cast<int>(left_msg->width);
+        image_height_ = static_cast<int>(left_msg->height);
+        RCLCPP_INFO(this->get_logger(), "Input resolution: %dx%d (SGM runs at calibration %dx%d)", image_width_,
+                    image_height_, calib_width_, calib_height_);
     }
 
     // Decode left image

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -27,22 +27,22 @@ struct FanOutTarget {
 // Persistent encode pipeline
 // =============================================================================
 
-std::string WebRTCStreamer::video_encode_branch(const std::string& name, int pt, int fps, guint ssrc) const {
+std::string WebRTCStreamer::video_encode_branch(const CameraEncoder& cam) const {
     // appsrc -> encoder -> payloader -> appsink. The appsink is the fan-out tap: every connected peer's
     // transport appsrc is fed from here, so each camera is encoded exactly once regardless of peer count.
-    return "appsrc name=src_" + name +
-           " is-live=true format=time caps=video/x-raw,format=BGR,width=640,height=480,framerate=" +
-           std::to_string(fps) +
+    return "appsrc name=src_" + cam.name + " is-live=true format=time caps=video/x-raw,format=BGR,width=" +
+           std::to_string(cam.width) + ",height=" + std::to_string(cam.height) +
+           ",framerate=" + std::to_string(cam.fps) +
            "/1 ! "
            "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
            "videoconvert ! "
            "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=15 "
            "end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
            "rtpvp8pay name=pay_" +
-           name + " pt=" + std::to_string(pt) + " ssrc=" + std::to_string(ssrc) +
+           cam.name + " pt=" + std::to_string(cam.pt) + " ssrc=" + std::to_string(cam.ssrc) +
            " ! "
            "appsink name=sink_" +
-           name + " emit-signals=true sync=false async=false max-buffers=2 drop=true ";
+           cam.name + " emit-signals=true sync=false async=false max-buffers=2 drop=true ";
 }
 
 void WebRTCStreamer::attach_playout_delay_extension(const std::string& cam) {
@@ -64,7 +64,7 @@ void WebRTCStreamer::attach_playout_delay_extension(const std::string& cam) {
 bool WebRTCStreamer::build_encode_pipeline() {
     std::string desc;
     for (const auto& cam : cameras_) {
-        desc += video_encode_branch(cam->name, cam->pt, cam->fps, cam->ssrc);
+        desc += video_encode_branch(*cam);
     }
     GError* error = nullptr;
     encode_pipeline_ = gst_parse_launch(desc.c_str(), &error);
@@ -86,8 +86,8 @@ bool WebRTCStreamer::build_encode_pipeline() {
             return false;
         }
         g_object_set(cam->appsrc, "format", GST_FORMAT_TIME, "do-timestamp", TRUE, "is-live", TRUE, "block", FALSE,
-                     "max-bytes", 2 * 640 * 480 * 3, nullptr);
-        cam->pool = create_frame_pool(640, 480, 3);
+                     "max-bytes", 2 * cam->width * cam->height * 3, nullptr);
+        cam->pool = create_frame_pool(cam->width, cam->height, 3);
         attach_playout_delay_extension(cam->name);
         // user_data = the CameraEncoder* so the one static handler knows which camera fired.
         g_signal_connect(cam->sink, "new-sample", G_CALLBACK(on_sample), cam.get());
@@ -460,7 +460,7 @@ void WebRTCStreamer::on_image_raw(CameraEncoder* cam, const sensor_msgs::msg::Im
     if (cam->want.load(std::memory_order_relaxed) == 0) {
         return;  // no peer wants this camera -> skip all encode work (flat memory, zero idle CPU)
     }
-    cv::Mat img = process_raw_image(msg, 640, 480);
+    cv::Mat img = process_raw_image(msg, cam->width, cam->height);
     if (!img.empty()) {
         push_frame(cam, img);
     }
@@ -470,7 +470,7 @@ void WebRTCStreamer::on_image_compressed(CameraEncoder* cam, const sensor_msgs::
     if (cam->want.load(std::memory_order_relaxed) == 0) {
         return;
     }
-    cv::Mat img = process_compressed_image(msg, 640, 480);
+    cv::Mat img = process_compressed_image(msg, cam->width, cam->height);
     if (!img.empty()) {
         push_frame(cam, img);
     }

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -30,9 +30,9 @@ struct FanOutTarget {
 std::string WebRTCStreamer::video_encode_branch(const CameraEncoder& cam) const {
     // appsrc -> encoder -> payloader -> appsink. The appsink is the fan-out tap: every connected peer's
     // transport appsrc is fed from here, so each camera is encoded exactly once regardless of peer count.
-    return "appsrc name=src_" + cam.name + " is-live=true format=time caps=video/x-raw,format=BGR,width=" +
-           std::to_string(cam.width) + ",height=" + std::to_string(cam.height) +
-           ",framerate=" + std::to_string(cam.fps) +
+    return "appsrc name=src_" + cam.name +
+           " is-live=true format=time caps=video/x-raw,format=BGR,width=" + std::to_string(cam.width) +
+           ",height=" + std::to_string(cam.height) + ",framerate=" + std::to_string(cam.fps) +
            "/1 ! "
            "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
            "videoconvert ! "

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -165,7 +165,7 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
 
 void WebRTCStreamer::configure_cameras() {
     // `cameras` lists the camera names (m-line order). Each gets per-camera params:
-    //   live_<name>_camera_topic, replay_<name>_camera_topic, <name>_fps
+    //   live_<name>_camera_topic, replay_<name>_camera_topic, <name>_fps, <name>_width, <name>_height
     // The built-in `main`/`arm` keep their existing topic/fps defaults (so existing launches are
     // unchanged); any other name must supply its own topics. PT + SSRC are assigned by index.
     static const std::map<std::string, std::tuple<std::string, std::string, int>> kDefaults = {
@@ -184,6 +184,8 @@ void WebRTCStreamer::configure_cameras() {
         cam->live_topic = this->declare_parameter<std::string>("live_" + name + "_camera_topic", def_live);
         cam->replay_topic = this->declare_parameter<std::string>("replay_" + name + "_camera_topic", def_replay);
         cam->fps = static_cast<int>(this->declare_parameter<int>(name + "_fps", def_fps));
+        cam->width = static_cast<int>(this->declare_parameter<int>(name + "_width", 640));
+        cam->height = static_cast<int>(this->declare_parameter<int>(name + "_height", 480));
         cam->pt = cam_pt_for_index(cameras_.size());
         cam->ssrc = cam_ssrc_for_index(cameras_.size());
         cam->owner = this;
@@ -191,8 +193,8 @@ void WebRTCStreamer::configure_cameras() {
             RCLCPP_WARN(this->get_logger(), "Camera '%s' has no live topic configured; skipping it", name.c_str());
             continue;
         }
-        RCLCPP_INFO(this->get_logger(), "  Camera[%zu] '%s': pt=%d ssrc=0x%08X fps=%d live=%s", cameras_.size(),
-                    name.c_str(), cam->pt, cam->ssrc, cam->fps, cam->live_topic.c_str());
+        RCLCPP_INFO(this->get_logger(), "  Camera[%zu] '%s': pt=%d ssrc=0x%08X %dx%d@%dfps live=%s", cameras_.size(),
+                    name.c_str(), cam->pt, cam->ssrc, cam->width, cam->height, cam->fps, cam->live_topic.c_str());
         cameras_.push_back(std::move(cam));
     }
     if (cameras_.empty()) {


### PR DESCRIPTION
## Summary

Participants asked how to change camera resolution via software ([INN-508](https://linear.app/innate/issue/INN-508)). The main/arm camera drivers were already ROS-param driven, but the knobs weren't surfaced in the centralized `config/settings.yaml`, the WebRTC teleop encoder hardcoded 640x480, and the depth estimator dropped every frame that didn't match its own `image_width`/`image_height` params — so changing resolution silently broke depth.

- **settings.yaml template**: camera stanza now exposes the full resolution chain for the main camera (capture `width`/`height` → `publish_stereo_*` → `publish_left_*`), plus new `arm_camera_driver` (capture size/fps) and `webrtc_streamer` (per-camera stream encode size) stanzas. Fixed the stanza's `fps` to match the shipped default (15.0) so uncommenting unedited stays a no-op.
- **WebRTC streamer**: encode resolution is now a per-camera param (`main_width/main_height`, `arm_width/arm_height`, default 640x480); the node now layers `settings_params()` in the composable launch like the other camera nodes.
- **Stereo depth estimator**: drops the redundant `image_width`/`image_height` params and adopts the incoming image size (SGM always runs at calibration resolution; input size only sets output size/scale), so depth follows the camera automatically instead of needing a second config edit. `depth_scale_` state removed — computed at its single use site.
- **docs/PARAMETERS.md**: table updated with the new stanzas.

## Testing (live robot R7-27)

- `innate build mars_cam` clean; all camera nodes healthy at defaults (main left + arm topics at 640x480, WebRTC encoders 640x480, encode pipeline PLAYING).
- Overrode via settings.yaml: `publish_left_* = 320x240`, arm capture `320x240`, `main_width/height = 320x240` → after `innate restart`: main left topic 320x240, arm sensor negotiated + published 320x240, WebRTC main encoder 320x240, compressed (brain) topics flowing, encode pipeline PLAYING, no errors.
- Restored defaults, re-verified 640x480 on all topics.
- Note: this robot has no stereo calibration (`data/` has no `calibration_config`), so depth is gated off here exactly as before the change; the adoption path runs post-calibration and only affects input validation + output sizing.