### PR TITLE
fix(profiling): read the picked skill once per rollout

### DIFF
--- a/webapp/js/profiling/rolloutControl.js
+++ b/webapp/js/profiling/rolloutControl.js
@@ -193,11 +193,15 @@ export function buildRolloutControl(chartWindow, session) {
   async function runRollout(m) {
     mode = m;
     hideError();
+    // Read the picked skill once: the skills-topic handler rebuilds the select
+    // (and can clear its value) at any time, so a second read after the await
+    // below could stamp the episode with one id and run a different skill.
+    const skillId = select.value;
     if (mode === "eval") {
       state = "starting";
       sync();
       // Stamp the episode with the evaluated skill's id as its driving policy.
-      await capture.start(select.value);
+      await capture.start(skillId);
       if (destroyed) {
         // Torn down while start was in flight: destroy()'s discard may have
         // raced the episode-open service call, so discard again now that the
@@ -209,7 +213,7 @@ export function buildRolloutControl(chartWindow, session) {
     chartWindow.begin();
     runStartedAt = performance.now();
     const { promise, cancel } = ros.sendActionGoal(EXECUTE_SKILL_ACTION, EXECUTE_SKILL_ACTION_TYPE, {
-      skill_type: select.value,
+      skill_type: skillId,
       inputs: "{}",
     });
     cancelSkill = cancel;


### PR DESCRIPTION
Rescues a fix that was pushed to the #484 branch minutes after that PR merged, so it never landed: `runRollout` read `select.value` twice around the `capture.start()` await. The skills topic rebuilds the select (and can clear its value) at any time, so the episode's policy provenance and the executed `skill_type` could diverge — worst case an empty `skill_type` goal after the roster changed mid-start. The picked skill is now read once up front and feeds both.

(Flagged by Greptile's final pass on #484; cherry-pick of 3e3118e0.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)