### PR TITLE
fix(recorder): 14-wide /action episodes from rollout capture on a fresh boot

### DIFF
--- a/ros2_ws/src/brain/manipulation/src/recorder_node.cpp
+++ b/ros2_ws/src/brain/manipulation/src/recorder_node.cpp
@@ -310,13 +310,21 @@ void RecorderNode::timer_callback() {
         return;
     }
 
-    // Build action data
-    std::vector<double> action_data;
-    if (latest_leader_command_) {
-        action_data = std::vector<double>(latest_leader_command_->data.begin(), latest_leader_command_->data.end());
-    } else {
-        action_data.resize(10, 0.0);
+    if (!latest_leader_command_) {
+        // No arm command has arrived since the node started. Expected briefly at
+        // the start of a policy-rollout capture (the episode opens before the
+        // policy's first inference step), hence throttled. The old fallback
+        // fabricated 10 zeros here — with cmd_vel and the trailing termination
+        // columns that made a 14-wide /action, and the first row latches the
+        // episode's width, so one such row corrupted the whole file against the
+        // normal 10-wide layout (train-time collate can't stack mixed widths).
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                             "No leader/policy arm command received yet. Skipping timestep.");
+        return;
     }
+
+    // Build action data
+    std::vector<double> action_data(latest_leader_command_->data.begin(), latest_leader_command_->data.end());
 
     // Add forward speed and yaw rate
     if (latest_cmd_vel_) {


### PR DESCRIPTION
## The bug (root cause of the mixed-width training crash)

The recorder's action builder had a fabrication fallback: if no `/mars/arm/commands` message had arrived since the node booted, it invented **10 zeros**, then appended 2 cmd_vel values — and the episode file adds 2 trailing termination columns, so `/action` came out **14 wide** instead of the normal **10** (6 arm + 2 base + 2 trailing). `action_dim_` latches from the first row, so a single command-less first tick poisoned the entire episode's width.

**The Profiling page's rollout capture is the reliable trigger** (#484 flow): `capture.start()` opens the episode *before* the skill goal is sent, and the policy only starts publishing arm commands once its inference loop spins up — seconds of model-load/goto-start during which the recorder ticks with `latest_leader_command_ == null`. On a fresh boot (or after the brain respawns) with no prior teleop, that means a 14-wide episode. Teleop demos never hit it because the leader arm is already streaming — which is exactly why the field dataset that died at collate ("stack expects each tensor to be equal size, but got [30, 10] ... and [30, 14]") mixed 10-wide demos with 14-wide rollout captures.

## The fix

Treat a missing arm command like the missing-image / arm-state / odom cases directly above it: **skip the timestep** (throttled warn — the gap is *expected* for a few seconds at every rollout start). Episodes now begin at the policy's first real command. The dropped rows were fabricated zero-action labels anyway — worse than no data.

The `copy_episode` action-width guard (1c29140c) already prevents such episodes from spreading into training datasets; this removes the source.

## Verification

- Compiled clean (`brain_messages` + `manipulation`) in the CI image.
- clang-format via pre-commit passes; `RCLCPP_WARN_THROTTLE` usage matches existing call sites (mars_cam).
- Behavior note: an episode where *no* arm command ever arrives (e.g. policy fails to load) now records zero timesteps rather than a file of zero-action rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)