### PR TITLE
Validate camera resolution settings at launch (follow-up to #498)

### DIFF
--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/config_loader.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/config_loader.py
@@ -198,12 +198,92 @@ def _validate_settings_param_types(data: dict) -> None:
     )
 
 
+# Camera resolution knobs from the template's "Camera" stanzas. A zero/negative or fractional
+# size sails into the GStreamer caps and fails the pipeline build with a cryptic gst error, and
+# a downstream stage set larger than its source silently upscales (no extra detail), so both are
+# rejected up front. Values are the node defaults, used when a key isn't overridden so the
+# cross-stage checks still see both sides of a pair — keep in sync with main_camera_driver.cpp,
+# arm_camera_driver.cpp and webrtc_streamer.cpp declare_parameter defaults.
+_CAMERA_RESOLUTION_DEFAULTS = {
+    "main_camera_driver": {
+        "width": 1280,
+        "height": 480,
+        "publish_stereo_width": 1280,
+        "publish_stereo_height": 480,
+        "publish_left_width": 640,
+        "publish_left_height": 480,
+    },
+    "arm_camera_driver": {"width": 640, "height": 480},
+    "webrtc_streamer": {"main_width": 640, "main_height": 480, "arm_width": 640, "arm_height": 480},
+}
+
+
+def _node_settings_params(data: dict, node_name: str) -> dict:
+    """Flatten one node section of settings.yaml to dotted keys; ``{}`` when absent."""
+    section = data.get(node_name)
+    params = section.get("ros__parameters") if isinstance(section, dict) else None
+    return _flatten_params(params, "") if isinstance(params, dict) else {}
+
+
+def _validate_settings_camera_resolutions(data: dict) -> None:
+    """Fail fast on camera sizes GStreamer would reject or silently upscale.
+
+    Checks each size is a positive whole number, then the main-camera resolution ladder
+    (capture -> publish_stereo -> publish_left): each stage must fit inside the one above,
+    with unset keys resolved from the node defaults so e.g. ``publish_left_width`` raised
+    past the default ``publish_stereo_width / 2`` is still caught."""
+    problems: list[str] = []
+    resolved: dict[str, int] = {}  # main_camera_driver values, for the ladder checks
+    for node_name, defaults in _CAMERA_RESOLUTION_DEFAULTS.items():
+        params = _node_settings_params(data, node_name)
+        for key, default in defaults.items():
+            value = params.get(key, default)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                problems.append(f"  {node_name}: {key}: {value}  ->  must be a positive whole number of pixels")
+                value = default  # keep the ladder checks below from piling on
+            if node_name == "main_camera_driver":
+                resolved[key] = value
+
+    if resolved["publish_stereo_width"] % 2:
+        problems.append(
+            f"  main_camera_driver: publish_stereo_width: {resolved['publish_stereo_width']}  ->  must be even "
+            "(the stereo frame is split into left/right eyes)"
+        )
+    for axis in ("width", "height"):
+        if resolved[f"publish_stereo_{axis}"] > resolved[axis]:
+            problems.append(
+                f"  main_camera_driver: publish_stereo_{axis}: {resolved[f'publish_stereo_{axis}']} is larger than "
+                f"the capture {axis} ({axis}: {resolved[axis]}) — raise {axis} too"
+            )
+    eye_width = resolved["publish_stereo_width"] // 2
+    if resolved["publish_left_width"] > eye_width:
+        problems.append(
+            f"  main_camera_driver: publish_left_width: {resolved['publish_left_width']} is larger than one eye of "
+            f"the stereo frame (publish_stereo_width / 2 = {eye_width}) — that only upscales (no extra detail); "
+            "raise width and publish_stereo_width together instead"
+        )
+    if resolved["publish_left_height"] > resolved["publish_stereo_height"]:
+        problems.append(
+            f"  main_camera_driver: publish_left_height: {resolved['publish_left_height']} is larger than "
+            f"publish_stereo_height ({resolved['publish_stereo_height']}) — that only upscales (no extra detail); "
+            "raise height and publish_stereo_height together instead"
+        )
+
+    if not problems:
+        return
+    raise ValueError(
+        f"{_settings_yaml_path()}: invalid camera resolution settings "
+        f"(values not set in the file are the node defaults):\n" + "\n".join(problems)
+    )
+
+
 def _load_settings_yaml(validate: bool = True) -> dict:
     """Parse config/settings.yaml. Returns ``{}`` when missing, empty, or unreadable
     (unreadable is warned via :func:`_warn_settings_unreadable`, never silent).
 
     With ``validate=True`` an int written for a double-typed key raises (see
-    :func:`_validate_settings_param_types`). Runtime callers that only read the non-ROS
+    :func:`_validate_settings_param_types`), as does a bad camera resolution (see
+    :func:`_validate_settings_camera_resolutions`). Runtime callers that only read the non-ROS
     ``script_paths`` block pass ``validate=False`` so the launch-time guard can't crash a reload."""
     path = _settings_yaml_path()
     if not path.exists():
@@ -217,6 +297,7 @@ def _load_settings_yaml(validate: bool = True) -> dict:
         return {}
     if validate:
         _validate_settings_param_types(data)
+        _validate_settings_camera_resolutions(data)
     return data
 
 

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/config_loader.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/config_loader.py
@@ -245,22 +245,29 @@ def _validate_settings_camera_resolutions(data: dict) -> None:
                 resolved[key] = value
 
     if resolved["publish_stereo_width"] % 2:
+        # Skip the width ladder checks below: they'd pile on with advice that doesn't
+        # apply when the real fix is simply "make it even".
         problems.append(
             f"  main_camera_driver: publish_stereo_width: {resolved['publish_stereo_width']}  ->  must be even "
             "(the stereo frame is split into left/right eyes)"
         )
-    for axis in ("width", "height"):
-        if resolved[f"publish_stereo_{axis}"] > resolved[axis]:
+    else:
+        if resolved["publish_stereo_width"] > resolved["width"]:
             problems.append(
-                f"  main_camera_driver: publish_stereo_{axis}: {resolved[f'publish_stereo_{axis}']} is larger than "
-                f"the capture {axis} ({axis}: {resolved[axis]}) — raise {axis} too"
+                f"  main_camera_driver: publish_stereo_width: {resolved['publish_stereo_width']} is larger than "
+                f"the capture width (width: {resolved['width']}) — raise width too"
             )
-    eye_width = resolved["publish_stereo_width"] // 2
-    if resolved["publish_left_width"] > eye_width:
+        eye_width = resolved["publish_stereo_width"] // 2
+        if resolved["publish_left_width"] > eye_width:
+            problems.append(
+                f"  main_camera_driver: publish_left_width: {resolved['publish_left_width']} is larger than one eye "
+                f"of the stereo frame (publish_stereo_width / 2 = {eye_width}) — that only upscales (no extra "
+                "detail); raise width and publish_stereo_width together instead"
+            )
+    if resolved["publish_stereo_height"] > resolved["height"]:
         problems.append(
-            f"  main_camera_driver: publish_left_width: {resolved['publish_left_width']} is larger than one eye of "
-            f"the stereo frame (publish_stereo_width / 2 = {eye_width}) — that only upscales (no extra detail); "
-            "raise width and publish_stereo_width together instead"
+            f"  main_camera_driver: publish_stereo_height: {resolved['publish_stereo_height']} is larger than "
+            f"the capture height (height: {resolved['height']}) — raise height too"
         )
     if resolved["publish_left_height"] > resolved["publish_stereo_height"]:
         problems.append(


### PR DESCRIPTION
Follow-up to https://github.com/innate-inc/innate-os/pull/498#discussion_r3538671574 (@vignesh-anand): the camera resolution knobs surfaced in `settings.yaml.template` had no validation — `main_width: 0` under `webrtc_streamer` sailed into the GStreamer appsrc caps and failed the pipeline build with a cryptic gst error, and nothing guarded the cross-param coupling traps discussed on the PR (per-eye/stream size set above what the upstream stage provides → silent upscaling).

**Stacked on #498** (that PR's branch is the base) since it validates the params that PR surfaces; retarget to `main` after #498 merges.

## Approach

Extends the existing launch-time `config_loader` validator, as suggested in the review — it already fails fast on int-vs-double type mistakes, and unlike ROS `ParameterDescriptor` ranges it can express cross-param rules. A new `_validate_settings_camera_resolutions()` runs alongside the type check whenever launch reads `settings.yaml`, and aborts launch with the file, node, key, and fix spelled out.

## Rules

1. **Positive whole numbers** — every size in the `main_camera_driver` / `arm_camera_driver` / `webrtc_streamer` stanzas must be an int ≥ 1 (also catches `640.5`, which ROS would reject later as a type error with no line info).
2. **Even stereo width** — `publish_stereo_width` is split into left/right eyes.
3. **The resolution ladder must narrow** (main camera):
   - `publish_stereo_* ≤ capture width/height` → "raise width too"
   - `publish_left_width ≤ publish_stereo_width / 2` and `publish_left_height ≤ publish_stereo_height` → "only upscales (no extra detail); raise width and publish_stereo_width together instead"

Cross-checks resolve unset keys from the node's `declare_parameter` defaults (mirrored in a keep-in-sync table, same pattern as `_SETTINGS_DOUBLE_KEYS`), so a lone `publish_left_width: 1280` override is still caught against the default stereo size. An all-commented settings.yaml trivially passes; the hot-reload path (`validate=False`) is unaffected.

## Example errors

```
/home/jetson1/innate-os/config/settings.yaml: invalid camera resolution settings (values not set in the file are the node defaults):
  webrtc_streamer: main_width: 0  ->  must be a positive whole number of pixels
```
```
  main_camera_driver: publish_left_width: 1280 is larger than one eye of the stereo frame (publish_stereo_width / 2 = 640) — that only upscales (no extra detail); raise width and publish_stereo_width together instead
```
```
  main_camera_driver: publish_stereo_width: 2560 is larger than the capture width (width: 1280) — raise width too
```

## Verification

Exercised the validator directly against 14 settings.yaml scenarios (empty file, template values, downscale-only `publish_left`, the reviewer's `main_width: 0`, fractional/negative/bool values, each ladder violation with the other side left at defaults, odd stereo width, no cascading errors from a single bad value, and the "raise everything together" recipe) — all pass with the messages above. `ruff check` and `ruff format --check` clean.