### PR TITLE
fix(scripts): show webapp URL as mDNS hostname instead of Wi-Fi IP

### DIFF
--- a/scripts/webapp_uri.zsh
+++ b/scripts/webapp_uri.zsh
@@ -24,6 +24,27 @@ innate_current_wifi_ip() {
     done
 }
 
+# Resolve the mDNS name actually advertised for the given IP (avahi can
+# publish e.g. mars-the-27th-2.local on a name conflict, diverging from the
+# system hostname). Mirrors mars_control's get_hostname() in app.cpp.
+innate_mdns_name() {
+    local ip="$1" name
+
+    name="$(avahi-resolve -a "$ip" 2>/dev/null | awk '{ print $2; exit }')"
+    if [[ -n "$name" ]]; then
+        print -r -- "$name"
+        return 0
+    fi
+
+    name="$(hostname -s 2>/dev/null)"
+    if [[ -n "$name" ]]; then
+        print -r -- "${name}.local"
+        return 0
+    fi
+
+    return 1
+}
+
 innate_webapp_uri() {
     local ip host
     ip="$(innate_current_wifi_ip)"
@@ -31,9 +52,9 @@ innate_webapp_uri() {
         return 1
     fi
 
-    host="$(hostname -s 2>/dev/null)"
+    host="$(innate_mdns_name "$ip")"
     if [[ -n "$host" ]]; then
-        print -r -- "https://${host}.local"
+        print -r -- "https://$host"
     else
         print -r -- "https://$ip"
     fi

--- a/scripts/webapp_uri.zsh
+++ b/scripts/webapp_uri.zsh
@@ -1,5 +1,8 @@
 #!/bin/zsh
-# Shared helper for printing the webapp URL on the robot's current Wi-Fi IP.
+# Shared helper for printing the webapp URL as the robot's mDNS hostname
+# (e.g. https://mars-the-27th.local), falling back to the Wi-Fi IP when no
+# hostname is available. Wi-Fi connectivity is still required either way so
+# the URL is only shown when the webapp is actually reachable.
 
 innate_current_wifi_ip() {
     local iface ip
@@ -22,12 +25,18 @@ innate_current_wifi_ip() {
 }
 
 innate_webapp_uri() {
-    local ip
+    local ip host
     ip="$(innate_current_wifi_ip)"
     if [[ -z "$ip" ]]; then
         return 1
     fi
-    print -r -- "https://$ip"
+
+    host="$(hostname -s 2>/dev/null)"
+    if [[ -n "$host" ]]; then
+        print -r -- "https://${host}.local"
+    else
+        print -r -- "https://$ip"
+    fi
 }
 
 if [[ "${ZSH_EVAL_CONTEXT:-}" != *:file && "${1:-}" == "--print" ]]; then

--- a/scripts/webapp_uri.zsh
+++ b/scripts/webapp_uri.zsh
@@ -1,8 +1,8 @@
 #!/bin/zsh
-# Shared helper for printing the webapp URL as the robot's mDNS hostname
-# (e.g. https://mars-the-27th.local), falling back to the Wi-Fi IP when no
-# hostname is available. Wi-Fi connectivity is still required either way so
-# the URL is only shown when the webapp is actually reachable.
+# Shared helper for printing the webapp URL as the robot's advertised mDNS
+# name (e.g. https://mars-the-27th.local), falling back to the Wi-Fi IP when
+# the name can't be reverse-resolved. Wi-Fi connectivity is still required
+# either way so the URL is only shown when the webapp is actually reachable.
 
 innate_current_wifi_ip() {
     local iface ip
@@ -26,23 +26,15 @@ innate_current_wifi_ip() {
 
 # Resolve the mDNS name actually advertised for the given IP (avahi can
 # publish e.g. mars-the-27th-2.local on a name conflict, diverging from the
-# system hostname). Mirrors mars_control's get_hostname() in app.cpp.
+# system hostname). Only the reverse-resolved name is guaranteed reachable,
+# so on failure return nothing and let the caller fall back to the IP.
 innate_mdns_name() {
-    local ip="$1" name
-
-    name="$(avahi-resolve -a "$ip" 2>/dev/null | awk '{ print $2; exit }')"
-    if [[ -n "$name" ]]; then
-        print -r -- "$name"
-        return 0
+    local name
+    name="$(avahi-resolve -a "$1" 2>/dev/null | awk '{ print $2; exit }')"
+    if [[ -z "$name" ]]; then
+        return 1
     fi
-
-    name="$(hostname -s 2>/dev/null)"
-    if [[ -n "$name" ]]; then
-        print -r -- "${name}.local"
-        return 0
-    fi
-
-    return 1
+    print -r -- "$name"
 }
 
 innate_webapp_uri() {


### PR DESCRIPTION
## Summary
- The `Web app:` link shown in the tmux launch banner, SSH welcome, networking restart script, and the `innate` CLI printed `https://<wifi-ip>` (e.g. `https://192.168.0.71`).
- All of these go through the shared helper `scripts/webapp_uri.zsh`, so this changes just that helper to print `https://<hostname>.local` instead (e.g. `https://mars-the-27th.local`).
- The Wi-Fi connectivity check is unchanged, so the URL still only appears when the robot is online; if `hostname` fails we fall back to the IP URL.

## Testing
- `zsh -n` syntax check passes.
- Sourced the helper with a stubbed Wi-Fi IP: prints `https://<host>.local`; with `hostname` stubbed to fail, falls back to `https://192.168.0.71`.