### PR TITLE
fix: camera container leak/laziness + nav-stack lethal-start & dead-config fixes

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/stereo_depth_estimator.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/stereo_depth_estimator.hpp
@@ -85,6 +85,7 @@ class StereoDepthEstimator : public rclcpp::Node {
     void syncCallback(const sensor_msgs::msg::Image::ConstSharedPtr& left_msg,
                       const sensor_msgs::msg::Image::ConstSharedPtr& right_msg);
     void processFrame(const cv::Mat& left_img, const cv::Mat& right_img, const rclcpp::Time& timestamp);
+    bool anyOutputSubscribed() const;
 
     // ── Camera Info Calibration ────────────────────────────────────────────
     void leftCameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
@@ -209,6 +210,7 @@ class StereoDepthEstimator : public rclcpp::Node {
 
     bool vpi_initialized_{false};
     bool calibration_loaded_{false};
+    bool pipeline_active_{true};  // lazy gate: false while no output has subscribers
     int frame_count_{0};
     int input_frame_count_{0};
     rclcpp::Time last_stats_time_;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/rectification.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/rectification.cpp
@@ -14,6 +14,12 @@ namespace mars_cam {
 // =============================================================================
 void StereoDepthEstimator::scaleToCalibRes(const cv::Mat& left_in, const cv::Mat& right_in, cv::Mat& left_out,
                                            cv::Mat& right_out) {
+    if (left_in.cols == calib_width_ && left_in.rows == calib_height_) {
+        // Already at calibration resolution: shallow copy (downstream only reads).
+        left_out = left_in;
+        right_out = right_in;
+        return;
+    }
     cv::resize(left_in, left_out, cv::Size(calib_width_, calib_height_), 0, 0, cv::INTER_LINEAR);
     cv::resize(right_in, right_out, cv::Size(calib_width_, calib_height_), 0, 0, cv::INTER_LINEAR);
 }

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_depth_estimator.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_depth_estimator.cpp
@@ -204,6 +204,19 @@ StereoDepthEstimator::~StereoDepthEstimator() {
 }
 
 // =============================================================================
+// Lazy gate — true if any of the node's outputs currently has a subscriber
+// =============================================================================
+bool StereoDepthEstimator::anyOutputSubscribed() const {
+    return left_rectified_pub_->get_subscription_count() > 0 || right_rectified_pub_->get_subscription_count() > 0 ||
+           left_rectified_color_pub_->get_subscription_count() > 0 ||
+           left_rectified_compressed_pub_->get_subscription_count() > 0 ||
+           pointcloud_pub_->get_subscription_count() > 0 || pointcloud_color_pub_->get_subscription_count() > 0 ||
+           disparity_unfiltered_pub_->get_subscription_count() > 0 || disparity_pub_->get_subscription_count() > 0 ||
+           depth_pub_->get_subscription_count() > 0 || footprint_overlay_pub_->get_subscription_count() > 0 ||
+           footprint_mask_pub_->get_subscription_count() > 0 || footprint_cutout_pub_->get_subscription_count() > 0;
+}
+
+// =============================================================================
 // Synchronized callback — decode ROS images, gate frame rate, call pipeline
 // =============================================================================
 void StereoDepthEstimator::syncCallback(const sensor_msgs::msg::Image::ConstSharedPtr& left_msg,
@@ -222,6 +235,21 @@ void StereoDepthEstimator::syncCallback(const sensor_msgs::msg::Image::ConstShar
     // state is always distinguishable (disabled-once vs. enabled-once), rather
     // than going silent after the first boot warning.
     RCLCPP_INFO_ONCE(this->get_logger(), "Depth enabled: stereo calibration loaded, publishing depth");
+
+    // Lazy pipeline: with no subscriber on any output, skip decode and compute
+    // entirely. (In normal nav operation the costmaps' pointcloud subscription
+    // keeps the pipeline on; this gate matters when nav is down or idle.)
+    if (!anyOutputSubscribed()) {
+        if (pipeline_active_) {
+            pipeline_active_ = false;
+            RCLCPP_INFO(this->get_logger(), "Depth pipeline idle: no output has subscribers");
+        }
+        return;
+    }
+    if (!pipeline_active_) {
+        pipeline_active_ = true;
+        RCLCPP_INFO(this->get_logger(), "Depth pipeline resumed: output subscribed");
+    }
 
     // Frame rate control — advance deadline by interval (not snap to now)
     // so leftover time carries forward for accurate average rate.
@@ -332,19 +360,27 @@ void StereoDepthEstimator::processFrame(const cv::Mat& left_input, const cv::Mat
     const bool has_color = left_input.channels() == 3;
     const bool need_color_rect = has_color && (pub_left_color || pub_left_compressed || pub_pointcloud_color ||
                                                pub_footprint_overlay || pub_footprint_cutout);
+    // Which compute stages the subscribed outputs actually need. SGM (and the
+    // filter chain downstream) only for disparity/depth/pointcloud consumers;
+    // mono rectification also feeds SGM and the color publishers' mono fallback.
+    const bool need_sgm = pub_pointcloud || pub_pointcloud_color || pub_unfiltered || pub_disparity || pub_depth;
+    const bool need_mono_rect = need_sgm || pub_left_rect || pub_right_rect || pub_left_color || pub_left_compressed;
+    const bool need_mask = need_sgm || pub_footprint_overlay || pub_footprint_mask || pub_footprint_cutout;
 
     // ── Scale to calibration resolution ────────────────────────────────────
     cv::Mat left_scaled, right_scaled;
-    scaleToCalibRes(left_input, right_input, left_scaled, right_scaled);
+    if (need_mono_rect || need_color_rect)
+        scaleToCalibRes(left_input, right_input, left_scaled, right_scaled);
     const auto t_scale = clock::now();
 
     // ── Rectify mono (gray + remap) ────────────────────────────────────────
     cv::Mat left_rect, right_rect;
-    rectifyMono(left_scaled, right_scaled, left_rect, right_rect);
+    if (need_mono_rect)
+        rectifyMono(left_scaled, right_scaled, left_rect, right_rect);
     const auto t_rect = clock::now();
 
     // ── Submit SGM to GPU (async) ──────────────────────────────────────────
-    if (!submitSGM(left_rect, right_rect))
+    if (need_sgm && !submitSGM(left_rect, right_rect))
         return;
     const auto t_submit = clock::now();
 
@@ -362,8 +398,9 @@ void StereoDepthEstimator::processFrame(const cv::Mat& left_input, const cv::Mat
         publishColorRectified(left_color_rect, left_rect, has_color, timestamp, pub_left_color, pub_left_compressed);
     const auto t_color_pub = clock::now();
 
-    // ── Footprint mask (always computed — filter chain needs it) ───────
-    computeFootprintMaskCalib();
+    // ── Footprint mask (needed by the filter chain and the mask topics) ──
+    if (need_mask)
+        computeFootprintMaskCalib();
     if (pub_footprint_overlay)
         publishFootprintOverlay(left_color_rect, timestamp);
     if (pub_footprint_mask)
@@ -373,14 +410,18 @@ void StereoDepthEstimator::processFrame(const cv::Mat& left_input, const cv::Mat
     const auto t_footprint = clock::now();
 
     // ── Sync GPU ───────────────────────────────────────────────────────────
-    syncSGM();
+    if (need_sgm)
+        syncSGM();
     const auto t_sgm = clock::now();
 
     // ── Extract disparity from VPI ─────────────────────────────────────────
-    cv::Mat disparity_float = extractDisparity();
-    if (disparity_float.empty()) {
-        cleanupSGMWraps();
-        return;
+    cv::Mat disparity_float;
+    if (need_sgm) {
+        disparity_float = extractDisparity();
+        if (disparity_float.empty()) {
+            cleanupSGMWraps();
+            return;
+        }
     }
     const auto t_extract = clock::now();
 
@@ -389,18 +430,18 @@ void StereoDepthEstimator::processFrame(const cv::Mat& left_input, const cv::Mat
         publishDisparityMsg(disparity_float, timestamp, disparity_unfiltered_pub_);
     const auto t_unfilt = clock::now();
 
-    // ── Footprint mask on disparity (always, before filter chain) ────────
+    // ── Footprint mask on disparity + filter chain (SGM consumers only) ──
     cv::Mat disparity_lowres;
     FilterTimings ft;
-    {
-        const auto t_fp0 = clock::now();
-        applyFootprintMask(disparity_float);
-        ft.footprint_mask_ms = std::chrono::duration<double, std::milli>(clock::now() - t_fp0).count();
+    if (need_sgm) {
+        {
+            const auto t_fp0 = clock::now();
+            applyFootprintMask(disparity_float);
+            ft.footprint_mask_ms = std::chrono::duration<double, std::milli>(clock::now() - t_fp0).count();
+        }
+        applyFilterChain(disparity_float, disparity_lowres, ft, static_cast<float>(focal_length_),
+                         static_cast<float>(baseline_));
     }
-
-    // ── Filter chain ───────────────────────────────────────────────────────
-    applyFilterChain(disparity_float, disparity_lowres, ft, static_cast<float>(focal_length_),
-                     static_cast<float>(baseline_));
     const auto t_filter = clock::now();
 
     // ── Publish filtered disparity ─────────────────────────────────────────

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -179,7 +179,11 @@ void WebRTCStreamer::fan_out(GstElement* appsink, const std::function<GstElement
             GST_BUFFER_PTS(out) = GST_CLOCK_TIME_NONE;
             GST_BUFFER_DTS(out) = GST_CLOCK_TIME_NONE;
             GstFlowReturn ret;
-            g_signal_emit_by_name(target.src, "push-buffer", out, &ret);  // takes ownership of the copy
+            // The "push-buffer" action signal does NOT take ownership (transfer-none),
+            // unlike gst_app_src_push_buffer(); the copy must be unreffed or it leaks
+            // one RTP packet per push (~1 GB/h per viewing peer at 2 Mbps).
+            g_signal_emit_by_name(target.src, "push-buffer", out, &ret);
+            gst_buffer_unref(out);
             {
                 std::lock_guard<std::mutex> lock(peers_mutex_);
                 auto it = peers_.find(target.client_id);


### PR DESCRIPTION
## Summary

Robot-reliability fixes from a live debugging session on mars-the-44th, in two commits. Everything below was root-caused and verified on the running robot.

## Commit 1 — mars_cam

### WebRTC streamer: one GstBuffer leaked per RTP packet per viewer (~1.7 GB/h)

`fan_out()` pushes a `gst_buffer_copy` to each peer's appsrc via the `"push-buffer"` **action signal** with a comment claiming the signal takes ownership. It does not — the action signal is transfer-none; only `gst_app_src_push_buffer()` is transfer-full. `push_frame()` in the same file already unrefs after the identical emit. Every encoded RTP packet copy leaked while anyone watched a camera. This grew the container to 2.2 GB and got `ros-app.service` OOM-killed (Jul 7 18:31 — a peer had been streaming since 15:41), taking every skill down.

**Verification** (headless `webrtcbin` peer over the `/webrtc/*` topics, identical ~67k-packet 6-min streams): before +168 MB linear; after flat, full release on teardown. Refcount semantics confirmed against the installed GStreamer 1.20.3.

### Depth estimator: "lazy publishing" was only lazy about messages

Scale/rectify/SGM/footprint/filter ran unconditionally regardless of subscribers. Now: `syncCallback` early-outs before decode when no output is subscribed (`Depth pipeline idle/resumed` logs), `processFrame` gates each stage on what subscribed outputs need, `scaleToCalibRes` passes through at calibration resolution. Verified with a private estimator instance on synthetic stereo: idle = zero compute; mask-only = 0.3 ms/frame vs 14–48 ms with SGM; no happy-path regression (costmaps' pointcloud subscription keeps SGM on exactly as before).

## Commit 2 — mars_nav

Map-frame navigation failed deterministically with `GridBased: Starting point in lethal space!` — **0/2 before, 2/2 after** these fixes (same robot, same speckled map):

- **`amcl.yaml` was never applied.** The launch renames the node `navigation_amcl`; the file was keyed `amcl:`, so every value was silently ignored (verified live: 2000 particles, divergence recovery off, `always_reset_initial_pose` off). Re-keyed with `/**:` and retuned the values that would be harmful once actually applied (`update_min_d/a` 0→0.15/0.2, `resample_interval` 1→2, 6000→3000 particles).
- **Planner: SmacPlanner2D → NavFn + `allow_unknown`.** NavFn clears the robot's start cell, so localization drift into inflated map speckle degrades instead of instantly aborting (Smac2D has no start tolerance).
- **Localization handoff fixed.** grid_localizer's "latched" `/initialpose` never reached a late-activating AMCL (VOLATILE subscription). It now also seeds AMCL via `/set_initial_pose` with retry; mode_manager triggers `/localize` after every map switch and logs the outcome. Verified live: `Seeded AMCL via /set_initial_pose`, `Re-localized on new map: ... score=0.689`.
- **Spin recovery** added to both BTs — costmap clears can't fix a bad pose (static layer repaints speckle immediately); spinning feeds AMCL fresh scan matches.
- **`nav_through_poses.xml` was `<AlwaysSuccess/>`** — every NavigateThroughPoses goal fake-succeeded instantly without moving (Humble has no `navigators` param to disable that server). Replaced with a real tree mirroring nav_to_pose.xml.
- **Dead/ignored config removed**: unused voxel block in the navigation global costmap, Jazzy-era params in bt_navigator.yaml/planner.yaml, ignored topic params in behavior.yaml. `simulate_ahead_time` 0.0→1.5 so recovery BackUps stop reversing blind (0.2 m rear overhang, no rear sensor).
- **Lidar-only operation is now visible**: mode_manager warns once when `/mars/main_camera/points` never publishes (camera voxel layer silently inert without stereo calibration). `expected_update_rate` deliberately stays 0 — nonzero marks the costmap not-current and blocks all planning when the camera is down.

## Not addressed here (known follow-ups)

The map itself is still speckle garbage and should be re-recorded; stereo calibration is missing on this robot (camera obstacle layer inert); MPPI 20 Hz + `velocity_timeout: 0.2` stutter under load; mapfree stack stays active in navigation mode; `/scan` throttle beats 8 Hz lidar down to 4 Hz.