### PR TITLE
fix(webapp): stop training dashboard from storming /brain/reload (key collision)

### DIFF
--- a/webapp/js/training/runDashboard.js
+++ b/webapp/js/training/runDashboard.js
@@ -124,6 +124,10 @@ export function createRunDashboard(parent, ros, store, opts) {
 
   // Reload-the-brain-on-download: only when a run transitions to DOWNLOADED
   // *this session* (existing downloads seen on first render don't trigger it).
+  // Keyed by training_skill_id, NOT skill_dir: every skill without a local dir
+  // shares skill_dir "", so their runs collided on one key and a mix of
+  // statuses read as a fresh DOWNLOADED transition on every tick — hammering
+  // /brain/reload once per second for as long as the page stayed open.
   /** @type {Map<string, number>} run key → last status */
   const prevStatus = new Map();
   let primed = false;
@@ -131,8 +135,9 @@ export function createRunDashboard(parent, ros, store, opts) {
   function reloadOnDownloads() {
     const skills = store.jobList?.skills || [];
     for (const sk of skills) {
+      if (!sk.skill_dir) continue; // not on this robot: nothing downloads here
       for (const run of sk.runs || []) {
-        const key = `${sk.skill_dir}#${run.run_id}`;
+        const key = `${sk.training_skill_id}#${run.run_id}`;
         const was = prevStatus.get(key);
         if (primed && was !== undefined && was !== STATUS.DOWNLOADED && run.status === STATUS.DOWNLOADED) {
           ros.callService(BRAIN_RELOAD_SERVICE, {}).catch((e) => console.error("[training] reload failed:", e));


### PR DESCRIPTION
## Problem

On MARS, the `brain_client_node` log showed **2,223 `/brain/reload` requests in 30 minutes**, forcing **83 back-to-back full skill reloads** (~30 s each — every reload re-instantiates every skill on the skills_action_server). The storm started ~1 s after an rws websocket client connected and stopped exactly when that client vanished (rws "Pong timeout"): the caller was the webapp's Training tab.

## Root cause

`reloadOnDownloads()` in `webapp/js/training/runDashboard.js` fires `/brain/reload` when a run *transitions* to `DOWNLOADED`, tracking previous statuses in a map keyed by `` `${skill_dir}#${run_id}` `` — and it iterates **all** skills in the account's job list, not just ones on this robot.

Every cloud skill with no local directory has `skill_dir: ""`, so all their runs collide on keys like `#1`. On the affected robot, nine dir-less skills collide on `#1` alone, with statuses mixing `DONE`/`REJECTED`/`DOWNLOADED`. Walking that mix in order makes every `≠DOWNLOADED → DOWNLOADED` adjacency read as a fresh "just finished downloading" — on **every** 1 Hz `job_statuses` tick, for as long as the tab is open.

(The ~10 ms spacing between log entries was an artifact: requests queue while each ~30 s reload blocks the executor, then drain in a burst. The actual send rate was ~1/s.)

## Fix

- Skip skills without a local `skill_dir` — nothing can download to this robot for them, so they can never legitimately trigger a reload.
- Key the transition map by `training_skill_id` (unique per cloud skill, and immune to two skill entries mapping to one dir after a resubmission).

A genuine `DONE → DOWNLOADED` transition still fires exactly once.

## Verification

Replayed the robot's **live** `/innate_training/job_statuses` snapshot (11 skills / 26 runs, captured via rclpy) through both versions of the gate logic:

| | spurious reloads per tick |
|---|---|
| before | **6, every tick, forever** |
| after | 0 (and exactly 1 on a real `DONE→DOWNLOADED` transition) |

Without this fix the storm resumes the moment anyone opens the Training tab against this account's job list.