### PR TITLE
Drop datachannel + increment webrtc timestamps properly

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_internal.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_internal.hpp
@@ -107,7 +107,6 @@ struct OfferContext {
     std::string client_id;
     guint expected_videos = 0;
     bool expected_audio = false;
-    bool expected_data = false;
 };
 
 inline void offer_context_free(gpointer data) {

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -71,9 +71,8 @@ struct CameraEncoder {
 struct Peer {
     std::string client_id;
     GstElement* pipeline = nullptr;                // transport pipeline (owns webrtcbin + rtp appsrcs)
-    GstElement* webrtc = nullptr;                  // ref'd from pipeline
-    GstWebRTCDataChannel* diag_channel = nullptr;  // robot-created SCTP probe channel
-    std::map<std::string, GstElement*> rtp;        // camera name -> ref'd transport appsrc (the negotiated set)
+    GstElement* webrtc = nullptr;            // ref'd from pipeline
+    std::map<std::string, GstElement*> rtp;  // camera name -> ref'd transport appsrc (the negotiated set)
     std::vector<std::string> videos;               // NEGOTIATED video streams (transceivers), in m-line order
     std::vector<std::string> active;               // currently PUSHED streams (subset of videos); toggled live on a
                                                    // stream switch without renegotiating, so switches are instant
@@ -114,12 +113,8 @@ struct Peer {
     ~Peer() {
         if (pipeline)
             gst_element_set_state(pipeline, GST_STATE_NULL);
-        if (diag_channel)
-            gst_webrtc_data_channel_close(diag_channel);
         for (auto& kv : rtp)
             gst_object_unref(kv.second);
-        if (diag_channel)
-            gst_object_unref(diag_channel);
         if (webrtc)
             gst_object_unref(webrtc);
         if (pipeline)
@@ -151,9 +146,6 @@ class WebRTCStreamer : public rclcpp::Node {
     static void on_connection_state_changed(GstElement* webrtc, GParamSpec* pspec, gpointer user_data);
     static void on_negotiation_needed(GstElement* webrtc, gpointer user_data);
     static void on_offer_created(GstPromise* promise, gpointer user_data);
-    static void on_diag_channel_open(GstWebRTCDataChannel* channel, gpointer user_data);
-    static void on_diag_channel_message(GstWebRTCDataChannel* channel, gchar* data, gpointer user_data);
-    static void on_diag_channel_close(GstWebRTCDataChannel* channel, gpointer user_data);
     // appsink new-sample (user_data = the CameraEncoder*): pull the encoded RTP buffer and fan it out to
     // every peer with this camera active.
     static GstFlowReturn on_sample(GstElement* appsink, gpointer user_data);

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -60,8 +60,11 @@ struct CameraEncoder {
     uint64_t prev_input_frames = 0;    // publish_status fps sampling
     uint64_t prev_encoded_frames = 0;  // publish_status fps sampling
     std::atomic<int> input_flow_code{GST_FLOW_OK};
-    rclcpp::SubscriptionBase::SharedPtr sub;  // lazy raw|compressed image subscription
-    WebRTCStreamer* owner = nullptr;          // for the static appsink new-sample callback
+    GstClockTime pts_base_ns = GST_CLOCK_TIME_NONE;  // capture-stamp anchor; PTS = frame stamp - this
+    GstClockTime last_pts_ns = 0;                    // last emitted PTS (monotonic guard / unstamped tick)
+    GstClockTime last_stamp_ns = 0;                  // last capture stamp seen (0 = none); backward step re-anchors
+    rclcpp::SubscriptionBase::SharedPtr sub;         // lazy raw|compressed image subscription
+    WebRTCStreamer* owner = nullptr;                 // for the static appsink new-sample callback
 };
 
 // One connected WebRTC peer. The cameras are encoded ONCE in a persistent pipeline; each peer owns a
@@ -70,14 +73,14 @@ struct CameraEncoder {
 // can't take the cameras down with it.
 struct Peer {
     std::string client_id;
-    GstElement* pipeline = nullptr;                // transport pipeline (owns webrtcbin + rtp appsrcs)
+    GstElement* pipeline = nullptr;          // transport pipeline (owns webrtcbin + rtp appsrcs)
     GstElement* webrtc = nullptr;            // ref'd from pipeline
     std::map<std::string, GstElement*> rtp;  // camera name -> ref'd transport appsrc (the negotiated set)
-    std::vector<std::string> videos;               // NEGOTIATED video streams (transceivers), in m-line order
-    std::vector<std::string> active;               // currently PUSHED streams (subset of videos); toggled live on a
-                                                   // stream switch without renegotiating, so switches are instant
-    bool with_audio = false;                       // audio m-line NEGOTIATED (an opus transceiver exists)
-    bool audio_active = false;  // audio currently being SENT — toggled live like the cameras (no reneg)
+    std::vector<std::string> videos;         // NEGOTIATED video streams (transceivers), in m-line order
+    std::vector<std::string> active;         // currently PUSHED streams (subset of videos); toggled live on a
+                                             // stream switch without renegotiating, so switches are instant
+    bool with_audio = false;                 // audio m-line NEGOTIATED (an opus transceiver exists)
+    bool audio_active = false;               // audio currently being SENT — toggled live like the cameras (no reneg)
     // True only after webrtcbin CONNECTED; gates RTP fan-out into webrtcbin. Shared + atomic because it
     // is written from webrtcbin's PC thread (the connection-state callback, via a copy tagged on the
     // element) — that callback must NOT take peers_mutex_: ~Peer runs set_state(NULL) under the mutex,
@@ -171,7 +174,7 @@ class WebRTCStreamer : public rclcpp::Node {
     void attach_playout_delay_extension(const std::string& cam);  // adds the ext to one payloader
     cv::Mat process_raw_image(const sensor_msgs::msg::Image::SharedPtr& msg, int w, int h);
     cv::Mat process_compressed_image(const sensor_msgs::msg::CompressedImage::SharedPtr& msg, int w, int h);
-    void push_frame(CameraEncoder* cam, const cv::Mat& frame);
+    void push_frame(CameraEncoder* cam, const cv::Mat& frame, const rclcpp::Time& stamp);
     GstBufferPool* create_frame_pool(int width, int height, int channels);
     void force_keyframe(const std::string& cam);          // request an IDR so a fresh/resumed peer can decode
     CameraEncoder* find_camera(const std::string& name);  // configured camera by name, or nullptr

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -85,7 +85,9 @@ bool WebRTCStreamer::build_encode_pipeline() {
             RCLCPP_ERROR(this->get_logger(), "Encode pipeline missing elements for camera '%s'", cam->name.c_str());
             return false;
         }
-        g_object_set(cam->appsrc, "format", GST_FORMAT_TIME, "do-timestamp", TRUE, "is-live", TRUE, "block", FALSE,
+        // do-timestamp=FALSE: push_frame stamps each buffer's PTS explicitly from a monotonic clock. Left to
+        // do-timestamp, rtpvp8pay was emitting RTP header timestamps stuck at 0, which iOS/Safari WebRTC drops.
+        g_object_set(cam->appsrc, "format", GST_FORMAT_TIME, "do-timestamp", FALSE, "is-live", TRUE, "block", FALSE,
                      "max-bytes", 2 * cam->width * cam->height * 3, nullptr);
         cam->pool = create_frame_pool(cam->width, cam->height, 3);
         attach_playout_delay_extension(cam->name);
@@ -430,7 +432,7 @@ GstBufferPool* WebRTCStreamer::create_frame_pool(int width, int height, int chan
     return pool;
 }
 
-void WebRTCStreamer::push_frame(CameraEncoder* cam, const cv::Mat& frame) {
+void WebRTCStreamer::push_frame(CameraEncoder* cam, const cv::Mat& frame, const rclcpp::Time& stamp) {
     if (!cam->appsrc || frame.empty() || !cam->pool) {
         return;
     }
@@ -442,6 +444,29 @@ void WebRTCStreamer::push_frame(CameraEncoder* cam, const cv::Mat& frame) {
     gst_buffer_map(buffer, &map, GST_MAP_WRITE);
     memcpy(map.data, frame.data, frame.total() * frame.elemSize());
     gst_buffer_unmap(buffer, &map);
+
+    // PTS from the frame's capture stamp, so inter-frame timing reflects true capture cadence. rtpvp8pay
+    // turns this into the 90kHz RTP timestamp; a non-advancing one makes iOS/Safari drop the stream. The
+    // stamp is untrusted: anchor on the first frame and re-anchor on any backward step (NTP correction,
+    // replay loop) so PTS stays monotonic, and synthesize an fps-paced tick for an unstamped frame.
+    const int64_t stamp_ns = stamp.nanoseconds();
+    const GstClockTime tick = GST_SECOND / static_cast<GstClockTime>(std::max(cam->fps, 1));  // nominal frame step
+    GstClockTime pts;
+    if (stamp_ns > 0) {
+        const GstClockTime s = static_cast<GstClockTime>(stamp_ns);
+        if (cam->pts_base_ns == GST_CLOCK_TIME_NONE || s < cam->last_stamp_ns) {
+            // Anchor one tick PAST the last PTS, not on it: s - (last_pts + tick) makes this frame's PTS
+            // resume at last_pts + tick, so a re-anchor never repeats the previous frame's RTP timestamp.
+            cam->pts_base_ns = s - (cam->last_pts_ns + tick);
+        }
+        cam->last_stamp_ns = s;
+        pts = s - cam->pts_base_ns;
+    } else {
+        pts = cam->last_pts_ns + tick;
+    }
+    cam->last_pts_ns = pts;
+    GST_BUFFER_PTS(buffer) = pts;
+    GST_BUFFER_DTS(buffer) = pts;
 
     GstFlowReturn ret;
     g_signal_emit_by_name(cam->appsrc, "push-buffer", buffer, &ret);
@@ -462,7 +487,7 @@ void WebRTCStreamer::on_image_raw(CameraEncoder* cam, const sensor_msgs::msg::Im
     }
     cv::Mat img = process_raw_image(msg, cam->width, cam->height);
     if (!img.empty()) {
-        push_frame(cam, img);
+        push_frame(cam, img, rclcpp::Time(msg->header.stamp));
     }
 }
 
@@ -472,7 +497,7 @@ void WebRTCStreamer::on_image_compressed(CameraEncoder* cam, const sensor_msgs::
     }
     cv::Mat img = process_compressed_image(msg, cam->width, cam->height);
     if (!img.empty()) {
-        push_frame(cam, img);
+        push_frame(cam, img, rclcpp::Time(msg->header.stamp));
     }
 }
 

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_signaling.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_signaling.cpp
@@ -242,16 +242,14 @@ void WebRTCStreamer::on_offer_created(GstPromise* promise, gpointer user_data) {
     const SdpMediaCounts counts = count_sdp_media(offer->sdp);
     const bool missing_video = counts.video < ctx->expected_videos;
     const bool missing_audio = ctx->expected_audio && counts.audio == 0;
-    const bool missing_data = ctx->expected_data && counts.application == 0;
-    if (missing_video || missing_audio || missing_data) {
-        RCLCPP_WARN(self->get_logger(), "Dropping incomplete offer for '%s' (video=%u/%u audio=%u%s data=%u%s)",
+    if (missing_video || missing_audio) {
+        RCLCPP_WARN(self->get_logger(), "Dropping incomplete offer for '%s' (video=%u/%u audio=%u%s)",
                     peer_label(ctx->client_id), counts.video, ctx->expected_videos, counts.audio,
-                    ctx->expected_audio ? " required" : "", counts.application, ctx->expected_data ? " required" : "");
-        // Do not retry create-offer on this same webrtcbin. GStreamer 1.20 can assert in
-        // _add_data_channel_offer() if an incomplete offer is followed by an immediate second offer on the
-        // same element. The client offer watchdog will send a renegotiate START, which creates a fresh
-        // transport; until then the connect timeout releases this peer. The offer-once latch (set when this
-        // offer was kicked off) stays latched, so this webrtcbin never re-offers.
+                    ctx->expected_audio ? " required" : "");
+        // Do not retry create-offer on this same webrtcbin; an immediate second offer can disrupt it. The
+        // client offer watchdog will send a renegotiate START, which creates a fresh transport; until then
+        // the connect timeout releases this peer. The offer-once latch (set when this offer was kicked off)
+        // stays latched, so this webrtcbin never re-offers.
         gst_webrtc_session_description_free(offer);
         gst_promise_unref(promise);
         return;
@@ -283,11 +281,10 @@ void WebRTCStreamer::apply_answer(Peer* peer, const std::string& sdp) {
     const SdpMediaCounts counts = count_sdp_media(sdp_msg);
     const bool missing_video = counts.video < peer->videos.size();
     const bool missing_audio = peer->with_audio && counts.audio == 0;
-    const bool missing_data = counts.application == 0;
-    if (missing_video || missing_audio || missing_data) {
-        RCLCPP_WARN(this->get_logger(), "Ignoring incomplete SDP answer for '%s' (video=%u/%zu audio=%u%s data=%u)",
+    if (missing_video || missing_audio) {
+        RCLCPP_WARN(this->get_logger(), "Ignoring incomplete SDP answer for '%s' (video=%u/%zu audio=%u%s)",
                     peer_label(peer->client_id), counts.video, peer->videos.size(), counts.audio,
-                    peer->with_audio ? " required" : "", counts.application);
+                    peer->with_audio ? " required" : "");
         gst_sdp_message_free(sdp_msg);
         return;
     }
@@ -342,8 +339,7 @@ void WebRTCStreamer::deliver_ice(const std::string& client_id, const std::string
     auto it = peers_.find(client_id);
     if (it != peers_.end()) {
         Peer* peer = it->second.get();
-        const int max_mline =
-            static_cast<int>(peer->videos.size()) + (peer->with_audio ? 1 : 0) + 1;  // + diagnostics data channel
+        const int max_mline = static_cast<int>(peer->videos.size()) + (peer->with_audio ? 1 : 0);
         if (mline >= max_mline) {
             RCLCPP_WARN(this->get_logger(), "Ignoring ICE for '%s': m-line %d outside negotiated range [0,%d)",
                         client_id.c_str(), mline, max_mline - 1);
@@ -468,40 +464,6 @@ void WebRTCStreamer::on_connection_state_changed(GstElement* webrtc, GParamSpec*
     }
     RCLCPP_INFO(self->get_logger(), "Peer '%s' connection state: %s", (cid && *cid) ? cid : "(default)",
                 conn_state_name(state));
-}
-
-void WebRTCStreamer::on_diag_channel_open(GstWebRTCDataChannel* channel, gpointer user_data) {
-    auto* self = static_cast<WebRTCStreamer*>(user_data);
-    const char* cid = static_cast<const char*>(g_object_get_data(G_OBJECT(channel), "client_id"));
-    const char* label = nullptr;
-    g_object_get(channel, "label", &label, nullptr);
-    RCLCPP_INFO(self->get_logger(), "Peer '%s' data channel '%s' open", (cid && *cid) ? cid : "(default)",
-                label ? label : "?");
-
-    nlohmann::json hello;
-    hello["type"] = "robot-hello";
-    hello["client_id"] = cid ? cid : "";
-    hello["steady_ns"] = std::chrono::steady_clock::now().time_since_epoch().count();
-    gst_webrtc_data_channel_send_string(channel, hello.dump().c_str());
-    if (label)
-        g_free(const_cast<char*>(label));
-}
-
-void WebRTCStreamer::on_diag_channel_message(GstWebRTCDataChannel* channel, gchar* data, gpointer user_data) {
-    auto* self = static_cast<WebRTCStreamer*>(user_data);
-    const char* cid = static_cast<const char*>(g_object_get_data(G_OBJECT(channel), "client_id"));
-    if (data && std::string(data).find("\"type\":\"browser-ping\"") != std::string::npos) {
-        RCLCPP_DEBUG(self->get_logger(), "Peer '%s' data channel browser-ping", (cid && *cid) ? cid : "(default)");
-        return;
-    }
-    RCLCPP_INFO(self->get_logger(), "Peer '%s' data channel <- %s", (cid && *cid) ? cid : "(default)",
-                data ? data : "(null)");
-}
-
-void WebRTCStreamer::on_diag_channel_close(GstWebRTCDataChannel* channel, gpointer user_data) {
-    auto* self = static_cast<WebRTCStreamer*>(user_data);
-    const char* cid = static_cast<const char*>(g_object_get_data(G_OBJECT(channel), "client_id"));
-    RCLCPP_INFO(self->get_logger(), "Peer '%s' data channel closed", (cid && *cid) ? cid : "(default)");
 }
 
 }  // namespace mars_cam

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -158,10 +158,9 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
     g_object_set_data(G_OBJECT(peer->webrtc), "mars_expected_videos",
                       GUINT_TO_POINTER(static_cast<guint>(negotiated.size())));
     g_object_set_data(G_OBJECT(peer->webrtc), "mars_expected_audio", GINT_TO_POINTER(peer->with_audio ? 1 : 0));
-    g_object_set_data(G_OBJECT(peer->webrtc), "mars_expected_data", GINT_TO_POINTER(1));
     // Offer-once latch: CAS'd 0->1 by whichever of the racing negotiation-needed callers wins (the explicit
     // one below on the executor thread vs. webrtcbin's queued signal on the GLib thread). A second create-offer
-    // on a webrtcbin that holds a data channel asserts in _add_data_channel_offer; the atomic prevents it.
+    // would renegotiate and disrupt the live connection; the atomic prevents it.
     g_object_set_data_full(G_OBJECT(peer->webrtc), "mars_offer_latch", new std::atomic<int>(0),
                            [](gpointer p) { delete static_cast<std::atomic<int>*>(p); });
     g_signal_connect(peer->webrtc, "on-ice-candidate", G_CALLBACK(on_ice_candidate), this);
@@ -189,19 +188,8 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         return nullptr;  // ~Peer() tears down the pipeline
     }
 
-    // Diagnostic SCTP data channel. GStreamer 1.20 may return null if this is created before the transport
-    // pipeline reaches PLAYING, so create it here and then trigger the initial offer deterministically below.
-    g_signal_emit_by_name(peer->webrtc, "create-data-channel", "mars-diagnostics", nullptr, &peer->diag_channel);
-    if (peer->diag_channel) {
-        g_object_set_data_full(G_OBJECT(peer->diag_channel), "client_id", g_strdup(client_id.c_str()), g_free);
-        g_signal_connect(peer->diag_channel, "on-open", G_CALLBACK(on_diag_channel_open), this);
-        g_signal_connect(peer->diag_channel, "on-message-string", G_CALLBACK(on_diag_channel_message), this);
-        g_signal_connect(peer->diag_channel, "on-close", G_CALLBACK(on_diag_channel_close), this);
-    } else {
-        RCLCPP_WARN(this->get_logger(), "Failed to create diagnostics data channel for '%s'", client_id.c_str());
-    }
     // Keep listening for future negotiation-needed signals, but create the first offer explicitly after all
-    // media/data transceivers are in place so the SDP includes the diagnostics m=application section.
+    // media transceivers are in place.
     g_signal_connect(peer->webrtc, "on-negotiation-needed", G_CALLBACK(on_negotiation_needed), this);
 
     Peer* raw = peer.get();
@@ -302,8 +290,7 @@ void WebRTCStreamer::on_negotiation_needed(GstElement* webrtc, gpointer user_dat
         (*genp)->load(),
         client_id,
         static_cast<guint>(GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(webrtc), "mars_expected_videos"))),
-        static_cast<bool>(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(webrtc), "mars_expected_audio"))),
-        static_cast<bool>(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(webrtc), "mars_expected_data")))};
+        static_cast<bool>(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(webrtc), "mars_expected_audio")))};
     GstPromise* promise = gst_promise_new_with_change_func(on_offer_created, ctx, offer_context_free);
     g_signal_emit_by_name(webrtc, "create-offer", nullptr, promise);
     RCLCPP_INFO(self->get_logger(), "Negotiation needed for '%s'; offering...", client_id.c_str());


### PR DESCRIPTION
## Summary

- remove unnecessary datachannel in webrtc
- increment timestamps properly, otherwise ios doesn't work

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`.
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`.
