### PR TITLE
retune(nav): controller 10 Hz, velocity caps at hardware clamp, costmap rates, scan throttle

### DIFF
--- a/ros2_ws/src/mars_bot/mars_bringup/launch/lidar.launch.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/launch/lidar.launch.py
@@ -30,12 +30,17 @@ def generate_launch_description():
     # base_link -> base_laser static TF is now published by
     # robot_state_publisher via the URDF (base_laser_joint).
 
-    # Node to throttle scan_fast into scan
+    # Node to throttle scan_fast into scan.
+    # The lidar actually delivers ~8 Hz (10 Hz nominal); topic_tools throttle
+    # passes a message only when 1/rate has elapsed, so asking for 6.0 from an
+    # 8 Hz stream beat down to every other scan = 4 Hz in practice. 4.0 keeps
+    # the same effective rate every consumer (AMCL, costmaps) was already
+    # getting, but intentionally and without the beat-frequency surprise.
     throttle_node = Node(
         package="topic_tools",
         executable="throttle",
         name="scan_throttle",
-        arguments=["messages", "/scan_fast", "6.0", "/scan"],
+        arguments=["messages", "/scan_fast", "4.0", "/scan"],
         output="screen",
     )
 

--- a/ros2_ws/src/mars_bot/mars_nav/config/behavior.yaml
+++ b/ros2_ws/src/mars_bot/mars_nav/config/behavior.yaml
@@ -22,7 +22,10 @@ behavior_server:
     global_frame: odom
     robot_base_frame: base_link
     transform_tolerance: 0.1
-    simulate_ahead_time: 0.0
+    # Collision-check this far ahead during BackUp/DriveOnHeading. 0.0 made
+    # recovery back-ups reverse completely blind (0.2 m rear overhang, no rear
+    # sensor); this is the one global param the binary does honor.
+    simulate_ahead_time: 1.5
     max_rotational_vel: 1.0
     min_rotational_vel: 0.4
     rotational_acc_lim: 3.2

--- a/ros2_ws/src/mars_bot/mars_nav/config/controller.yaml
+++ b/ros2_ws/src/mars_bot/mars_nav/config/controller.yaml
@@ -1,7 +1,13 @@
 /**:
   ros__parameters:
     use_sim_time: false
-    controller_frequency: 20.0
+    # 10 Hz: 20 Hz MPPI was not achievable on this CPU (constant "Control loop
+    # missed its desired rate" spam), and every overrun past the velocity
+    # smoother's timeout zeroed cmd_vel -> stop-start stutter.
+    controller_frequency: 10.0
+    # Tolerate brief controller hiccups instead of aborting the whole goal on
+    # the first missed cycle (seconds; 0.0 = abort immediately).
+    failure_tolerance: 1.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5         # Differential drive: no lateral motion
     min_theta_velocity_threshold: 0.001
@@ -32,14 +38,15 @@
       
       # Motion model and basic parameters
       motion_model: "DiffDrive"
-      time_steps: 50                    # 50 steps * 0.05s = 2.5s prediction horizon (matches old sim_time)
-      model_dt: 0.05                    # 1/controller_frequency = 1/20 = 0.05s
-      batch_size: 2000                  # Number of trajectory samples
+      time_steps: 25                    # 25 steps * 0.1s = same 2.5s prediction horizon at half the compute
+      model_dt: 0.1                     # 1/controller_frequency = 1/10 = 0.1s
+      batch_size: 1500                  # Number of trajectory samples
       iteration_count: 1
-      
+
       # Velocity limits (from existing DWB config)
       vx_min: -0.2                      # matches min_vel_x
-      vx_max: 0.45                       # matches max_vel_x
+      vx_max: 0.4                       # bringup hard-clamps at safety.max_speed 0.4 — commanding above it
+                                        # makes MPPI's model assume speed the motors never deliver
       vy_max: 0.0                       # differential drive - no lateral motion
       wz_max: 0.6                       # matches velocity_smoother max
       

--- a/ros2_ws/src/mars_bot/mars_nav/config/costmap.yaml
+++ b/ros2_ws/src/mars_bot/mars_nav/config/costmap.yaml
@@ -2,8 +2,10 @@ navigation:
   global_costmap:
     global_costmap:
       ros__parameters:
-        update_frequency: 5.0
-        publish_frequency: 5.0
+        # 2 Hz is plenty for a static-map costmap: the BT replans at 1 Hz and
+        # the only dynamic input (/scan) arrives at 4 Hz. Was 5 Hz of pure CPU.
+        update_frequency: 2.0
+        publish_frequency: 2.0
         global_frame: map
         robot_base_frame: base_link
         use_sim_time: false
@@ -135,8 +137,12 @@ mapfree:
   global_costmap:
     global_costmap:
       ros__parameters:
-        update_frequency: 5.0
-        publish_frequency: 5.0
+        # 2 Hz: the planner replans at 1 Hz and /scan arrives at 4 Hz; this
+        # rolling costmap only feeds path planning (the controller avoids
+        # obstacles via the 5 Hz local costmap). This stack runs even while in
+        # navigation mode (local_frame goals use it), so its idle cost matters.
+        update_frequency: 2.0
+        publish_frequency: 2.0
         global_frame: odom
         robot_base_frame: base_link
         use_sim_time: false

--- a/ros2_ws/src/mars_bot/mars_nav/config/velocity_smoother.yaml
+++ b/ros2_ws/src/mars_bot/mars_nav/config/velocity_smoother.yaml
@@ -1,13 +1,15 @@
 velocity_smoother:
   ros__parameters:
     # General settings
-    smoothing_frequency: 40.0       # Hz, Match controller_frequency from controller.yaml
+    smoothing_frequency: 20.0       # Hz, 2x controller_frequency (10 Hz) from controller.yaml
     scale_velocities: false         # Clamp velocities instead of scaling
     feedback: "OPEN_LOOP"           # Options: OPEN_LOOP, CLOSED_LOOP (requires odometry)
-    velocity_timeout: 0.2           # Seconds. If no commands received for this duration, output zero velocity.
+    # 0.5s: with a 10 Hz controller on a loaded CPU, a 0.2s timeout zeroed
+    # cmd_vel on every missed control cycle -> visible stop-start stutter.
+    velocity_timeout: 0.5
 
     # Limits using flat list structure [x, y, theta]
-    max_velocity: [0.45, 0.0, 0.6]   # Based on controller max_vel_x, max_vel_y, max_vel_theta
+    max_velocity: [0.4, 0.0, 0.6]    # x capped at bringup's hardware clamp (safety.max_speed 0.4)
     min_velocity: [-0.2, 0.0, -0.6]  # Based on controller min_vel_x, min_vel_y, symmetric min_vel_theta
     
     max_accel: [0.3, 0.0, 0.5]


### PR DESCRIPTION
Split out of #508 per review (karmanyaahm): #508 keeps code fixes, BT correctness, and dead-config cleanup; this PR carries **only the nav parameter retunes** so their effects can be tested and reverted independently. Stacked on `theo/nav-perf-robustness` — merge #508 first, then this retargets to main.

## Changes and evidence (all verified live on mars-the-44th, full production stack, load ~10-12)

- **controller_frequency 20 → 10 Hz** with the same 2.5 s MPPI horizon (`time_steps` 25 × `model_dt` 0.1), `batch_size` 1500, `failure_tolerance: 1.0`. At 20 Hz under today's concurrent workload the loop missed its rate continuously, and each overrun past the smoother's 0.2 s `velocity_timeout` zeroed cmd_vel → visible stop-start stutter. After: missed-rate warnings from continuous to ~14 across two full goal runs, zero aborts. (It may well have run fine at 20 Hz on a lighter stack historically.)
- **smoother `velocity_timeout` 0.2 → 0.5, `smoothing_frequency` 40 → 20 Hz** (2× the new controller rate).
- **`vx_max`/`max_velocity` 0.45 → 0.4** — bringup hard-clamps every cmd_vel at `safety.max_speed: 0.4`, so 0.45 only made MPPI's motion model assume speed the motors never deliver. Zero physical behavior change.
- **static + mapfree global costmaps 5 → 2 Hz** update/publish — the BT replans at 1 Hz and `/scan` arrives at 4 Hz; the controller's 5 Hz **local** costmap is untouched.
- **scan throttle 6.0 → 4.0** — the lidar delivers ~8 Hz; topic_tools' 6.0 throttle beat that down to every-other-scan = 4 Hz anyway. Same effective rate, now intentional and documented.
- **behavior `simulate_ahead_time` 0.0 → 1.5** — recovery BackUps were reversing with collision checking disabled (0.2 m rear overhang, no rear sensor).

Each bullet is independent; happy to drop any line item or split further if you want per-subsystem PRs.