### PR TITLE
feat(power): light-sleep mode with idle timeout, app/skill triggers, and head-boop wake

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -60,6 +60,16 @@
 #       max_speed: 0.4              # m/s, hard /cmd_vel linear ceiling at the motors
 #       max_angular_speed: 2.5      # rad/s, hard /cmd_vel angular ceiling at the motors
 
+# ── Sleep mode (power_manager) ────────────────────────────────────────
+# Light sleep powers down lidar, cameras, nav and arm torque after the robot
+# has been idle for N minutes. Active SSH sessions, teleop, skills and camera
+# viewers all count as activity. Wake via the app, a chat message, joystick
+# input, or a boop on the head.
+# power_manager:
+#   ros__parameters:
+#     sleep_after_idle_minutes: 0     # auto-sleep after N idle minutes (0 = never)
+#     boop_wake_threshold_degrees: 4  # head movement that counts as a wake-up boop
+
 # ── Arm ───────────────────────────────────────────────────────────────
 # mars_arm:
 #   ros__parameters:

--- a/ros2_ws/src/mars_bot/mars_bringup/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_bringup/CMakeLists.txt
@@ -40,6 +40,7 @@ ament_python_install_package(${PROJECT_NAME}
 install(PROGRAMS
   mars_bringup/bringup.py
   mars_bringup/rosbag.py
+  mars_bringup/power_manager.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros2_ws/src/mars_bot/mars_bringup/launch/bringup_core.launch.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/launch/bringup_core.launch.py
@@ -23,11 +23,21 @@ def generate_launch_description():
         output="screen",
     )
 
+    # Sleep/wake orchestration (light sleep) — see mars_bringup/power_manager.py
+    power_manager_node = Node(
+        package="mars_bringup",
+        executable="power_manager.py",
+        name="power_manager",
+        parameters=[*settings_params()],
+        output="screen",
+    )
+
     # base_link -> base_footprint static TF is now published by
     # robot_state_publisher via the URDF (base_footprint_joint).
 
     return LaunchDescription(
         [
             bringup_node,
+            power_manager_node,
         ]
     )

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Light-sleep power manager.
+
+Owns the robot's AWAKE <-> SLEEPING state. Sleep powers down the big
+consumers (lidar motor, cameras, nav2 stack, arm/head torque, Jetson clocks)
+while keeping the network path (zenoh, rosbridge) and this node alive, so the
+robot stays remotely wakeable in seconds.
+
+Triggers:
+  - /power/sleep, /power/wake (std_srvs/Trigger) — apps, skills, CLI
+  - auto-sleep after `sleep_after_idle_minutes` of inactivity (0 = never);
+    active SSH connections count as activity
+  - wake on joystick input, chat message, or a head boop (head torque is off
+    during sleep, but mars_arm keeps publishing the head position, so pushing
+    the head is detectable)
+
+State is broadcast on /power/state ("awake" / "going_to_sleep" / "sleeping" /
+"waking"), latched + 1 Hz heartbeat, mirroring /brain/agent_status delivery.
+"""
+
+import json
+import subprocess
+import threading
+import time
+
+import rclpy
+from brain_messages.srv import ChangeNavigationMode
+from geometry_msgs.msg import Vector3
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+from std_msgs.msg import Int32, String
+from std_srvs.srv import Empty, SetBool, Trigger
+
+STATE_AWAKE = "awake"
+STATE_GOING_TO_SLEEP = "going_to_sleep"
+STATE_SLEEPING = "sleeping"
+STATE_WAKING = "waking"
+
+# tmux layout from scripts/launch_ros_in_tmux.sh — the camera container runs in
+# the first pane of this window, and its shell keeps the sourced ROS env, so we
+# can Ctrl-C the launch to sleep and re-send the command to wake.
+TMUX_SESSION = "ros_nodes"
+CAMERA_WINDOW = "cam-leader"
+CAMERA_LAUNCH_CMD = "ros2 launch mars_cam camera_composable.launch.py"
+
+# Terminal statuses from skills_server._publish_skill_status; anything else
+# (i.e. "running") means a skill is in flight.
+_SKILL_TERMINAL_STATUSES = {"completed", "interrupted", "failed"}
+
+_SS_ESTABLISHED_SSH = ["ss", "-tnH", "state", "established", "( sport = :22 )"]
+
+
+class PowerManager(Node):
+    def __init__(self):
+        super().__init__("power_manager")
+
+        self.declare_parameter("sleep_after_idle_minutes", 0)
+        self.declare_parameter("boop_wake_threshold_degrees", 4)
+
+        self._state = STATE_AWAKE
+        self._state_lock = threading.Lock()
+        self._transition_lock = threading.Lock()
+
+        self._last_activity = time.monotonic()
+        self._skill_in_flight = False
+        self._nav_mode = "none"  # live value from /nav/current_mode
+        self._nav_mode_before_sleep = "none"
+        self._brain_active = False  # live value from /brain/agent_status
+        self._brain_active_before_sleep = False
+        self._camera_pane_id: str | None = None
+
+        # Head-boop detection (armed while sleeping)
+        self._head_baseline_deg: float | None = None
+        self._boop_arm_time = 0.0
+        self._boop_hits = 0
+        self._last_boop_sample = 0.0
+
+        latched = QoSProfile(
+            depth=1,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+        )
+        self._state_pub = self.create_publisher(String, "/power/state", latched)
+        self._head_position_pub = self.create_publisher(Int32, "/mars/head/set_position", 10)
+
+        self.create_service(Trigger, "/power/sleep", self._on_sleep_request)
+        self.create_service(Trigger, "/power/wake", self._on_wake_request)
+
+        # Downstream controls
+        self._brain_active_client = self.create_client(SetBool, "/brain/set_brain_active")
+        self._nav_mode_client = self.create_client(ChangeNavigationMode, "/nav/change_mode")
+        self._lidar_stop_client = self.create_client(Empty, "/stop_motor")
+        self._lidar_start_client = self.create_client(Empty, "/start_motor")
+        self._arm_torque_off_client = self.create_client(Trigger, "/mars/arm/torque_off")
+        self._arm_torque_on_client = self.create_client(Trigger, "/mars/arm/torque_on")
+        self._head_servo_client = self.create_client(SetBool, "/mars/head/enable_servo")
+
+        # Activity signals
+        self.create_subscription(Vector3, "/joystick", self._on_joystick, 10)
+        self.create_subscription(String, "/brain/chat_in", self._on_chat_in, 10)
+        self.create_subscription(String, "/webrtc/active_streams", self._on_webrtc_streams, 10)
+        self.create_subscription(String, "/brain/skill_status_update", self._on_skill_status, 10)
+        self.create_subscription(String, "/nav/current_mode", self._on_nav_mode, 10)
+        self.create_subscription(String, "/brain/agent_status", self._on_agent_status, latched)
+        self.create_subscription(String, "/mars/head/current_position", self._on_head_position, 10)
+
+        self.create_timer(1.0, self._publish_state)
+        self.create_timer(10.0, self._idle_tick)
+
+        self.get_logger().info("Power manager ready (state: awake)")
+
+    # ------------------------------------------------------------------ state
+
+    @property
+    def state(self) -> str:
+        with self._state_lock:
+            return self._state
+
+    def _set_state(self, state: str) -> None:
+        with self._state_lock:
+            self._state = state
+        self._state_pub.publish(String(data=state))
+        self.get_logger().info(f"Power state: {state}")
+
+    def _publish_state(self) -> None:
+        self._state_pub.publish(String(data=self.state))
+
+    # -------------------------------------------------------------- services
+
+    def _on_sleep_request(self, request, response):
+        del request
+        started = self._start_transition(self._sleep_sequence, from_state=STATE_AWAKE)
+        response.success = started
+        response.message = "Going to sleep" if started else f"Cannot sleep from state '{self.state}'"
+        return response
+
+    def _on_wake_request(self, request, response):
+        del request
+        started = self._start_transition(self._wake_sequence, from_state=STATE_SLEEPING, reason="wake service")
+        response.success = started
+        response.message = "Waking up" if started else f"Cannot wake from state '{self.state}'"
+        return response
+
+    def _start_transition(self, sequence, from_state: str, reason: str = "") -> bool:
+        """Kick off a sleep/wake sequence in a worker thread (service callbacks
+        must not block the executor — the sequences themselves call services)."""
+        with self._state_lock:
+            if self._state != from_state:
+                return False
+            self._state = STATE_GOING_TO_SLEEP if sequence is self._sleep_sequence else STATE_WAKING
+        self._state_pub.publish(String(data=self.state))
+        self.get_logger().info(f"Power state: {self.state}" + (f" ({reason})" if reason else ""))
+        threading.Thread(target=self._run_transition, args=(sequence,), daemon=True).start()
+        return True
+
+    def _run_transition(self, sequence) -> None:
+        with self._transition_lock:
+            try:
+                sequence()
+            except Exception as e:  # a half-finished transition is recoverable via the other service
+                self.get_logger().error(f"Power transition failed: {e}")
+                self._set_state(STATE_AWAKE if sequence is self._wake_sequence else STATE_SLEEPING)
+
+    # ------------------------------------------------------------- activity
+
+    def _touch_activity(self) -> None:
+        self._last_activity = time.monotonic()
+
+    def _on_joystick(self, msg: Vector3) -> None:
+        # driveController publishes a zero vector on release/pagehide — only
+        # real input counts as activity (and wakes the robot).
+        if abs(msg.x) < 1e-3 and abs(msg.y) < 1e-3 and abs(msg.z) < 1e-3:
+            return
+        self._touch_activity()
+        self._wake_if_sleeping("joystick input")
+
+    def _on_chat_in(self, msg: String) -> None:
+        del msg
+        self._touch_activity()
+        self._wake_if_sleeping("chat message")
+
+    def _on_webrtc_streams(self, msg: String) -> None:
+        try:
+            count = json.loads(msg.data).get("count", 0)
+        except (json.JSONDecodeError, AttributeError):
+            return
+        if count > 0:
+            self._touch_activity()
+
+    def _on_skill_status(self, msg: String) -> None:
+        self._touch_activity()
+        try:
+            status = json.loads(msg.data).get("status", "")
+        except json.JSONDecodeError:
+            return
+        self._skill_in_flight = status not in _SKILL_TERMINAL_STATUSES
+
+    def _on_nav_mode(self, msg: String) -> None:
+        self._nav_mode = msg.data
+
+    def _on_agent_status(self, msg: String) -> None:
+        try:
+            self._brain_active = bool(json.loads(msg.data).get("brain_active", False))
+        except json.JSONDecodeError:
+            pass
+
+    def _ssh_session_active(self) -> bool:
+        try:
+            out = subprocess.run(_SS_ESTABLISHED_SSH, capture_output=True, text=True, timeout=5)
+            return bool(out.stdout.strip())
+        except (OSError, subprocess.SubprocessError) as e:
+            self.get_logger().warning(f"SSH activity check failed: {e}")
+            return False
+
+    def _idle_tick(self) -> None:
+        if self.state != STATE_AWAKE:
+            return
+        idle_minutes = self.get_parameter("sleep_after_idle_minutes").value
+        if idle_minutes <= 0:
+            return
+        if self._skill_in_flight or self._nav_mode in ("mapping", "switching"):
+            self._touch_activity()
+            return
+        if self._ssh_session_active():
+            self._touch_activity()
+            return
+        if time.monotonic() - self._last_activity >= idle_minutes * 60:
+            self.get_logger().info(f"Idle for {idle_minutes} minutes — going to sleep")
+            self._start_transition(self._sleep_sequence, from_state=STATE_AWAKE, reason="idle timeout")
+
+    # ------------------------------------------------------------- head boop
+
+    def _on_head_position(self, msg: String) -> None:
+        if self.state != STATE_SLEEPING or time.monotonic() < self._boop_arm_time:
+            return
+        # The arm node streams this at its control-loop rate; sample at 10 Hz.
+        if time.monotonic() - self._last_boop_sample < 0.1:
+            return
+        self._last_boop_sample = time.monotonic()
+        try:
+            position = float(json.loads(msg.data).get("current_position"))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return
+        if self._head_baseline_deg is None:
+            self._head_baseline_deg = position
+            return
+        threshold = self.get_parameter("boop_wake_threshold_degrees").value
+        delta = position - self._head_baseline_deg
+        if abs(delta) >= threshold:
+            self._boop_hits += 1
+            # two consecutive readings past the threshold, so a single glitched
+            # sample or a floor vibration doesn't wake the robot
+            if self._boop_hits >= 2:
+                self._wake_if_sleeping("head boop")
+        else:
+            self._boop_hits = 0
+            # Creep-track the baseline (≤0.5°/s): a torque-less head can sag
+            # slowly under gravity, and untracked sag would eventually read as
+            # a boop. A real boop is a fast >threshold push the creep can't absorb.
+            self._head_baseline_deg += max(-0.05, min(0.05, delta))
+
+    def _wake_if_sleeping(self, reason: str) -> None:
+        if self.state == STATE_SLEEPING:
+            self._start_transition(self._wake_sequence, from_state=STATE_SLEEPING, reason=reason)
+
+    # ------------------------------------------------------------- sequences
+
+    def _sleep_sequence(self) -> None:
+        # Let whatever triggered us (e.g. the go_to_sleep skill) finish its
+        # goodbye before we start tearing subsystems down.
+        time.sleep(2.0)
+
+        self._nav_mode_before_sleep = self._nav_mode
+        self._brain_active_before_sleep = self._brain_active
+
+        self._droop_head()
+        self._call(self._brain_active_client, SetBool.Request(data=False), "brain off")
+        self._call(
+            self._nav_mode_client,
+            ChangeNavigationMode.Request(mode="off"),
+            "nav stack off",
+            timeout=45.0,
+        )
+        self._call(self._lidar_stop_client, Empty.Request(), "lidar motor off")
+        self._call(self._arm_torque_off_client, Trigger.Request(), "arm torque off")
+        self._call(self._head_servo_client, SetBool.Request(data=False), "head torque off")
+        self._stop_camera_container()
+        self._run_privileged(["systemctl", "stop", "speaker-keepalive.service"])
+        self._run_privileged(["systemctl", "stop", "jetson-perf.service"])
+        self._run_privileged(["/usr/sbin/nvpmodel", "-m", "3"])  # 7W profile
+
+        # Arm the boop detector: give the torque-less head a moment to settle,
+        # then take the first reading after that as the baseline.
+        self._head_baseline_deg = None
+        self._boop_hits = 0
+        self._boop_arm_time = time.monotonic() + 2.0
+
+        self._set_state(STATE_SLEEPING)
+
+    def _wake_sequence(self) -> None:
+        # Compute first so the robot feels responsive from the very first second.
+        self._run_privileged(["systemctl", "start", "jetson-perf.service"])
+        self._start_camera_container()
+        self._call(self._lidar_start_client, Empty.Request(), "lidar motor on")
+        self._call(self._head_servo_client, SetBool.Request(data=True), "head torque on")
+        self._call(self._arm_torque_on_client, Trigger.Request(), "arm torque on")
+        self._run_privileged(["systemctl", "start", "speaker-keepalive.service"])
+
+        if self._nav_mode_before_sleep in ("navigation", "mapping", "mapfree"):
+            self._call(
+                self._nav_mode_client,
+                ChangeNavigationMode.Request(mode=self._nav_mode_before_sleep),
+                f"nav stack -> {self._nav_mode_before_sleep}",
+                timeout=60.0,
+            )
+        if self._brain_active_before_sleep:
+            self._call(self._brain_active_client, SetBool.Request(data=True), "brain on")
+
+        self._head_position_pub.publish(Int32(data=0))
+        self._touch_activity()
+        self._set_state(STATE_AWAKE)
+
+    def _droop_head(self) -> None:
+        """Slow droop to the head's lower limit — the visible 'falling asleep' cue."""
+        for angle in (-5, -12, -20, -25):
+            self._head_position_pub.publish(Int32(data=angle))
+            time.sleep(0.35)
+
+    # -------------------------------------------------------------- helpers
+
+    def _call(self, client, request, label: str, timeout: float = 10.0) -> None:
+        """Fire a service call from the transition thread and wait for it.
+
+        Failures are logged and skipped: a missing subsystem (e.g. lidar
+        unplugged on a dev bench) must not abort the whole transition."""
+        if not client.wait_for_service(timeout_sec=3.0):
+            self.get_logger().warning(f"[{label}] service {client.srv_name} unavailable, skipping")
+            return
+        future = client.call_async(request)
+        deadline = time.monotonic() + timeout
+        while not future.done():
+            if time.monotonic() > deadline:
+                self.get_logger().warning(f"[{label}] timed out after {timeout}s")
+                return
+            time.sleep(0.05)
+        self.get_logger().info(f"[{label}] done")
+
+    def _run_privileged(self, cmd: list[str]) -> None:
+        """Run a whitelisted root command (sudoers entries installed by
+        scripts/update/post_update.sh). Degrades to a warning if not granted."""
+        try:
+            result = subprocess.run(
+                ["sudo", "-n", *cmd],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                stdin=subprocess.DEVNULL,
+            )
+            if result.returncode != 0:
+                self.get_logger().warning(
+                    f"'{' '.join(cmd)}' failed (rc={result.returncode}): "
+                    f"{result.stderr.strip() or result.stdout.strip()} — "
+                    "run scripts/update/post_update.sh to install the sudoers entries"
+                )
+        except (OSError, subprocess.SubprocessError) as e:
+            self.get_logger().warning(f"'{' '.join(cmd)}' failed: {e}")
+
+    def _tmux(self, *args: str) -> subprocess.CompletedProcess | None:
+        try:
+            return subprocess.run(["tmux", *args], capture_output=True, text=True, timeout=10)
+        except (OSError, subprocess.SubprocessError) as e:
+            self.get_logger().warning(f"tmux {' '.join(args)} failed: {e}")
+            return None
+
+    def _find_camera_pane(self) -> str | None:
+        """The pane in cam-leader whose shell has the camera launch as a child."""
+        listing = self._tmux(
+            "list-panes", "-t", f"{TMUX_SESSION}:{CAMERA_WINDOW}", "-F", "#{pane_id} #{pane_pid}"
+        )
+        if listing is None or listing.returncode != 0:
+            return None
+        for line in listing.stdout.splitlines():
+            pane_id, _, pane_pid = line.partition(" ")
+            try:
+                children = subprocess.run(
+                    ["ps", "--ppid", pane_pid.strip(), "-o", "args="],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                ).stdout
+            except (OSError, subprocess.SubprocessError):
+                continue
+            if "camera_composable" in children:
+                return pane_id
+        return None
+
+    def _stop_camera_container(self) -> None:
+        pane = self._find_camera_pane()
+        if pane is None:
+            self.get_logger().warning("Camera launch pane not found — cameras may already be down")
+            return
+        self._camera_pane_id = pane
+        self._tmux("send-keys", "-t", pane, "C-c")
+        time.sleep(5.0)  # ros2 launch tears the container down gracefully on SIGINT
+        self.get_logger().info("[cameras off] done")
+
+    def _start_camera_container(self) -> None:
+        # Fall back to the window's first pane — the launcher always puts the
+        # camera command there (see scripts/launch_ros_in_tmux.sh).
+        pane = self._camera_pane_id or f"{TMUX_SESSION}:{CAMERA_WINDOW}.0"
+        if self._find_camera_pane() is not None:
+            self.get_logger().info("[cameras on] already running")
+            return
+        self._tmux("send-keys", "-t", pane, CAMERA_LAUNCH_CMD, "Enter")
+        self.get_logger().info("[cameras on] launch sent")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = PowerManager()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/mars_bot/mars_bringup/package.xml
+++ b/ros2_ws/src/mars_bot/mars_bringup/package.xml
@@ -30,6 +30,7 @@
   <depend>tf2_geometry_msgs</depend>
 
   <!-- Internal package dependencies -->
+  <exec_depend>brain_messages</exec_depend>
   <exec_depend>mars_msgs</exec_depend>
   <exec_depend>mars_sim</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -909,13 +909,28 @@ class ModeManager(Node):
 
         try:
             target_mode = request.mode.strip().lower()
+
+            # "off" tears the whole nav stack down (used by the power manager's
+            # sleep mode). Deliberately not persisted: .last_mode keeps the
+            # pre-sleep mode so boot and wake restore it.
+            if target_mode == "off":
+                self.current_mode = "switching"
+                self.publish_status()
+                for mode in NavigationMode:
+                    self.shutdown_mode(mode.value)
+                self.current_mode = "none"
+                response.success = True
+                response.message = "Navigation stack off"
+                self.get_logger().info(response.message)
+                return response
+
             if self.current_map is None:
                 target_mode = "mapping"
 
             # Validate mode
             if target_mode not in ["navigation", "mapping", "mapfree"]:
                 response.success = False
-                response.message = f"Invalid mode '{target_mode}'. Use 'navigation', 'mapping', or 'mapfree'"
+                response.message = f"Invalid mode '{target_mode}'. Use 'navigation', 'mapping', 'mapfree', or 'off'"
                 self.get_logger().error(response.message)
                 return response
 

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -842,6 +842,13 @@ $ACTUAL_USER ALL=(ALL) NOPASSWD: /bin/nmcli
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start ros-app.service
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop ros-app.service
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart ros-app.service
+
+# Sleep mode (called by the power_manager node)
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start jetson-perf.service
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop jetson-perf.service
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start speaker-keepalive.service
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop speaker-keepalive.service
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/sbin/nvpmodel -m 0, /usr/sbin/nvpmodel -m 1, /usr/sbin/nvpmodel -m 2, /usr/sbin/nvpmodel -m 3
 EOF
 chmod 440 "$SUDOERS_FILE"
 log "  Sudoers configured for $ACTUAL_USER"

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -81,6 +81,13 @@ export const ROBOT_INFO_TOPIC = "/robot/info";
 // mobile app's volume slider calls; current value rides on /robot/info.
 export const SET_VOLUME_SERVICE = "/set_volume";
 
+// Light sleep (power_manager). State is a plain std_msgs/String:
+// "awake" | "going_to_sleep" | "sleeping" | "waking" (latched + 1 Hz heartbeat).
+// Sleep/wake are std_srvs/Trigger. Same services the mobile app should call.
+export const POWER_STATE_TOPIC = "/power/state";
+export const POWER_SLEEP_SERVICE = "/power/sleep";
+export const POWER_WAKE_SERVICE = "/power/wake";
+
 // WebRTC signaling over rosbridge. START is a std_msgs/String JSON payload that
 // carries our client_id: {"source":"live","audio":bool,"client_id":"...","video":[...]}.
 // The robot routes offer/answer/ICE on the *_id topics, each enveloped as {client_id, ...}

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -90,6 +90,14 @@ export const CATALOG = [
     ],
   },
   {
+    section: "Sleep mode",
+    note: "Light sleep powers down lidar, cameras, nav and arm torque. SSH sessions, teleop, skills and camera viewers count as activity. Wake from the app or boop the head.",
+    knobs: [
+      { path: ["power_manager", P, "sleep_after_idle_minutes"], label: "Auto-sleep after idle", default: 0, type: "int", unit: "min", doc: "Enter sleep after this many idle minutes (0 = never)", min: 0, max: 1440 },
+      { path: ["power_manager", P, "boop_wake_threshold_degrees"], label: "Boop sensitivity", default: 4, type: "int", unit: "°", doc: "Head movement that counts as a wake-up boop", min: 2, max: 20 },
+    ],
+  },
+  {
     section: "Arm",
     knobs: [
       { path: ["mars_arm", P, "max_jerk"], label: "Max jerk", default: 150.0, type: "float", unit: "rad/s³", doc: "Trajectory jerk limit (0 disables)" },

--- a/webapp/js/teleop/telemetry.js
+++ b/webapp/js/teleop/telemetry.js
@@ -5,7 +5,14 @@
 // sensor_msgs/BatteryState at 0.2 Hz; name/version ride /robot/info's
 // JSON-in-String payload.
 
-import { BATTERY_STATE_TOPIC, ROBOT_INFO_TOPIC, WEBSOCKET_STATUS_TOPIC } from "../constants.js";
+import {
+  BATTERY_STATE_TOPIC,
+  POWER_SLEEP_SERVICE,
+  POWER_STATE_TOPIC,
+  POWER_WAKE_SERVICE,
+  ROBOT_INFO_TOPIC,
+  WEBSOCKET_STATUS_TOPIC,
+} from "../constants.js";
 
 /**
  * @param {HTMLElement} parent
@@ -21,12 +28,28 @@ export function createTelemetry(parent, rosClient, opts = {}) {
 
   const name = item("robot", "—");
   const battery = showBattery ? item("batt", "—") : null;
+  // Sleep/wake state; click toggles it (sleep when awake, wake when asleep).
+  const power = item("power", "—");
   const link = item("link", "—");
   // Cloud/local agent backend connection (the brain's websocket to its agent
   // backend) — distinct from the rosbridge LINK above.
   const agent = item("agent", "—");
-  wrap.append(name.el, ...(battery ? [battery.el] : []), link.el, agent.el);
+  wrap.append(name.el, ...(battery ? [battery.el] : []), power.el, link.el, agent.el);
   parent.appendChild(wrap);
+
+  let powerState = "";
+  power.el.style.cursor = "pointer";
+  power.el.title = "Click to put the robot to sleep / wake it up";
+  power.el.addEventListener("click", async () => {
+    // Ignore clicks mid-transition; the state heartbeat will flip the label.
+    if (powerState !== "awake" && powerState !== "sleeping") return;
+    const service = powerState === "sleeping" ? POWER_WAKE_SERVICE : POWER_SLEEP_SERVICE;
+    try {
+      await rosClient.callService(service, {});
+    } catch (e) {
+      console.warn("power toggle failed", e);
+    }
+  });
 
   /**
    * @param {string} labelText
@@ -46,6 +69,19 @@ export function createTelemetry(parent, rosClient, opts = {}) {
   }
 
   const unsubs = [
+    rosClient.subscribe(POWER_STATE_TOPIC, (payload) => {
+      if (typeof payload?.data !== "string") return;
+      powerState = payload.data;
+      const labels = {
+        awake: "awake",
+        going_to_sleep: "sleeping…",
+        sleeping: "asleep",
+        waking: "waking…",
+      };
+      power.value.textContent = labels[powerState] ?? powerState;
+      power.el.classList.toggle("live", powerState === "awake");
+      power.el.classList.toggle("warn", powerState === "sleeping");
+    }),
     rosClient.subscribe(ROBOT_INFO_TOPIC, (payload) => {
       if (typeof payload?.data !== "string") return;
       /** @type {RobotInfo} */

--- a/workspace/innate_agents/basic_agent.py
+++ b/workspace/innate_agents/basic_agent.py
@@ -19,7 +19,7 @@ class BasicAgent(Agent):
 
     def get_skills(self) -> list[str]:
         """Return the list of skill IDs this directive can use"""
-        return ["innate-os/navigate_to_position", "innate-os/navigate_with_vision"]
+        return ["innate-os/navigate_to_position", "innate-os/navigate_with_vision", "innate-os/go_to_sleep"]
 
     def get_inputs(self) -> list[str]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_skills/go_to_sleep.py
+++ b/workspace/innate_skills/go_to_sleep.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""
+Go To Sleep Skill - Put the robot into low-power sleep mode.
+"""
+
+import time
+
+from brain_client.skills.types import Skill, SkillResult
+from std_srvs.srv import Trigger
+
+
+class GoToSleep(Skill):
+    """Ask the power manager to enter light sleep."""
+
+    def __init__(self, logger):
+        super().__init__(logger)
+        self._sleep_client = None
+
+    @property
+    def name(self):
+        return "go_to_sleep"
+
+    def guidelines(self):
+        return (
+            "Put the robot into low-power sleep mode (lidar, cameras, navigation and "
+            "arm power down; the agent goes offline until wake-up). Use when asked to "
+            "sleep, rest, nap, or power down. The robot wakes from the app, joystick "
+            "or chat input, or a gentle push on its head."
+        )
+
+    def execute(self):
+        if self.node is None:
+            return "Robot node not available", SkillResult.FAILURE
+
+        if self._sleep_client is None:
+            self._sleep_client = self.node.create_client(Trigger, "/power/sleep")
+
+        if not self._sleep_client.wait_for_service(timeout_sec=5.0):
+            return "Power manager is not available", SkillResult.FAILURE
+
+        # Speak first: the power manager deactivates the brain (and with it TTS)
+        # a couple of seconds after accepting the sleep request.
+        self.say("Going to sleep. Boop my head or use the app to wake me up.", wait=True)
+
+        future = self._sleep_client.call_async(Trigger.Request())
+        deadline = time.time() + 10.0
+        while not future.done():
+            if time.time() > deadline:
+                return "Power manager did not answer in time", SkillResult.FAILURE
+            time.sleep(0.05)
+
+        result = future.result()
+        if result is None or not result.success:
+            reason = getattr(result, "message", "") or "unknown error"
+            return f"Could not go to sleep: {reason}", SkillResult.FAILURE
+
+        return "Going to sleep — wake me with a head boop or from the app", SkillResult.SUCCESS
+
+    def cancel(self):
+        # The handoff to the power manager is near-instant; nothing to unwind.
+        return "Nothing to cancel"


### PR DESCRIPTION
## Summary

- Adds **light-sleep mode**: the robot powers down its big consumers after an idle timeout (or on demand), while keeping the network path and a small state-machine node alive so it stays remotely wakeable in seconds.
- New `power_manager` node (`mars_bringup`) owns an `awake → going_to_sleep → sleeping → waking` state machine. It serves `/power/sleep` and `/power/wake` (`std_srvs/Trigger`) and publishes `/power/state` (latched `std_msgs/String` + 1 Hz heartbeat, mirroring `/brain/agent_status` delivery so late-joining rosbridge clients get it). Because both apps share the rosbridge surface, one service reaches web app, mobile app, and skills.
- **Sleep sequence:** head droop cue → brain off → nav stack down → lidar `/stop_motor` → arm + head torque off → camera container stopped → `jetson-perf`/`speaker-keepalive` stopped + `nvpmodel` 7W. **Wake** runs it in reverse (compute-first for responsiveness) and restores the pre-sleep nav mode and brain-active state.
- **Triggers:** `/power/sleep`/`/power/wake` services; a new `go_to_sleep` agent skill (registered in `basic_agent`); a click-to-toggle power chip in the webapp teleop telemetry strip; and auto-sleep after `sleep_after_idle_minutes` (new setting, `0` = never, live-tunable).
- **Activity signals that block/reset auto-sleep:** joystick, chat, WebRTC viewers, running skills, mapping mode, and **established SSH connections** (per requirement — SSH must not count as idle).
- **Wake triggers:** the services, joystick input, a chat message, or a **head boop** — head torque is off during sleep but `mars_arm` keeps streaming head position, so the node watches for a fast push (10 Hz sampling, creep-tracked baseline so slow gravity sag doesn't false-trigger).

### Key implementation notes for reviewers

- **New nav `"off"` mode** in `mode_manager.py` tears the whole nav2 stack down for sleep. It is deliberately **not persisted** — `.last_mode` keeps the pre-sleep mode so both wake and reboot restore it.
- **Camera stop/start** reuses the existing tmux mechanism: the node sends `Ctrl-C` to the `cam-leader` pane (found by matching the `camera_composable` child process) and re-sends the launch command on wake. The pane keeps its sourced ROS env, so no relaunch of the whole window is needed.
- **Privileged ops** (`nvpmodel`, `systemctl stop jetson-perf`/`speaker-keepalive`) run via `sudo -n` against new whitelisted entries added to `scripts/update/post_update.sh`'s sudoers heredoc. If the entries aren't installed yet, the node **degrades to a warning** and continues — sleep still powers down lidar/cameras/nav/torque, just not the Jetson clocks.
- Service calls in the sleep/wake sequence run on a worker thread (not the executor callback) and each failure is logged-and-skipped, so a missing subsystem on a dev bench can't wedge a transition.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - Built `mars_bringup` + `mars_nav` with `colcon build` (clean). Restarted `ros-app`; `power_manager` comes up reporting `awake`.
  - **Full cycle tested live on a robot:** `/power/sleep` → verified nav `none`, `/scan_fast` silent, camera container down; simulated head-boop → state went `waking`; verified full restore (nav back to `mapfree`, lidar scanning, `/mars/main_camera/left/image_raw` publishing).
  - **SSH guard tested:** with `sleep_after_idle_minutes=1` and an SSH session connected, the robot stayed `awake` past the timeout.
  - `go_to_sleep` confirmed appearing in `/brain/available_skills`.
  - **Not yet exercised on the test robot:** the `nvpmodel`/`systemctl` steps — the sudoers entries in `post_update.sh` weren't installed on that unit, so those steps warned-and-skipped (Jetson clocks stayed pinned). They will apply on any unit that has run `post_update.sh`.
- [ ] Simulator behavior/config/assets unchanged — N/A.
- [ ] No simulator asset changes — N/A.

## Follow-ups (out of scope for this PR)

- Physical finger-test of the head boop and tuning of `boop_wake_threshold_degrees` if needed.
- Deeper power savings (PCB `CMD_POWER` rail cut, wake-on-BT) are Phase 2.
