### PR TITLE
feat(power): light-sleep mode with idle timeout, app/skill triggers, and head-boop wake

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -60,6 +60,16 @@
 #       max_speed: 0.4              # m/s, hard /cmd_vel linear ceiling at the motors
 #       max_angular_speed: 2.5      # rad/s, hard /cmd_vel angular ceiling at the motors
 
+# ── Sleep mode (power_manager) ────────────────────────────────────────
+# Light sleep powers down lidar, cameras, nav and arm torque after the robot
+# has been idle for N minutes. Active SSH sessions, teleop, skills and camera
+# viewers all count as activity. Wake via the app, a chat message, joystick
+# input, or a boop on the head.
+# power_manager:
+#   ros__parameters:
+#     sleep_after_idle_minutes: 0     # auto-sleep after N idle minutes (0 = never)
+#     boop_wake_threshold_degrees: 4  # head movement that counts as a wake-up boop
+
 # ── Arm ───────────────────────────────────────────────────────────────
 # mars_arm:
 #   ros__parameters:

--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -39,6 +39,10 @@
 #       cost_scaling_factor: 10.0   # higher = cost decays faster with distance
 #     # TTS voice for BOTH speech paths (brain chat-TTS + realtime voice loop)
 #     cartesia_voice_id: "9fdaae0b-f885-4813-b589-3c07cf9d5fea"
+#     # Sleep: cut the HSSW rail (arm/head Dynamixels + wheel drivers) to drop
+#     # idle peripheral power. bringup + power_manager both read this so they
+#     # stay in lockstep. false = soft sleep (bus stays alive, head-boop wake).
+#     gate_hssw_on_sleep: true
 
 # ── Teleop: joystick ──────────────────────────────────────────────────
 # joystick_controller:

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
@@ -80,6 +80,8 @@ class MarsArmNode : public rclcpp::Node {
                                 std::shared_ptr<std_srvs::srv::Trigger::Response> response);
     void headEnableServoCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                                  std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+    void lowPowerModeCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                              std::shared_ptr<std_srvs::srv::SetBool::Response> response);
 
     // ── Trajectory planning & execution (arm_trajectory.cpp) ────────────
     std::vector<std::vector<double>> computeCubicSplineTrajectory(const std::vector<double>& start,
@@ -137,6 +139,13 @@ class MarsArmNode : public rclcpp::Node {
     rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr head_ai_position_service_;
     rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr head_enable_service_;
     rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
+
+    // Low-power mode (robot sleep): the control loop runs 1-in-N ticks so the
+    // dynamixel bus and downstream subscribers drop to ~10 Hz.
+    rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr low_power_service_;
+    std::atomic<bool> low_power_mode_{false};
+    int low_power_divider_{20};
+    unsigned low_power_tick_{0};  // only touched from the control-loop timer
     int latest_head_command_{0};
     std::mutex head_command_mutex_;
     std::atomic<bool> has_head_command_{false};

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
@@ -82,6 +82,8 @@ class MarsArmNode : public rclcpp::Node {
                                  std::shared_ptr<std_srvs::srv::SetBool::Response> response);
     void lowPowerModeCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                               std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+    void busSuspendCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                            std::shared_ptr<std_srvs::srv::SetBool::Response> response);
 
     // ── Trajectory planning & execution (arm_trajectory.cpp) ────────────
     std::vector<std::vector<double>> computeCubicSplineTrajectory(const std::vector<double>& start,
@@ -146,6 +148,12 @@ class MarsArmNode : public rclcpp::Node {
     std::atomic<bool> low_power_mode_{false};
     int low_power_divider_{20};
     unsigned low_power_tick_{0};  // only touched from the control-loop timer
+
+    // Bus suspend (HSSW-gated robot sleep): the Dynamixel rail is cut, so the
+    // control loop and health monitor must stop touching the (dead) bus
+    // entirely; resume re-initializes the power-cycled servos.
+    rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr bus_suspend_service_;
+    std::atomic<bool> bus_suspended_{false};
     int latest_head_command_{0};
     std::mutex head_command_mutex_;
     std::atomic<bool> has_head_command_{false};

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -6,6 +6,17 @@
 namespace mars_arm {
 
 void MarsArmNode::controlTimerCallback() {
+    // Low-power mode (robot sleep): run 1-in-N ticks (~10 Hz). The timer keeps
+    // firing — recreating it at a lower rate would mean destroying a timer
+    // under a spinning executor.
+    if (low_power_mode_.load(std::memory_order_relaxed)) {
+        if (low_power_tick_++ % low_power_divider_ != 0) {
+            return;
+        }
+    } else {
+        low_power_tick_ = 0;
+    }
+
     // ts[0..8]: loop_start, lock_acquired, read_done, effort_done,
     //           pub_arm_done, pub_head_js_done, gain_sched_done, cmd_write_done, loop_end
     std::array<std::chrono::steady_clock::time_point, 9> ts;

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -6,6 +6,12 @@
 namespace mars_arm {
 
 void MarsArmNode::controlTimerCallback() {
+    // Bus suspended (HSSW rail gated during deep sleep): the servos are
+    // unpowered, so do not touch the bus at all until resume re-inits them.
+    if (bus_suspended_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
     // Low-power mode (robot sleep): run 1-in-N ticks (~10 Hz). The timer keeps
     // firing — recreating it at a lower rate would mean destroying a timer
     // under a spinning executor.

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
@@ -180,6 +180,12 @@ MarsArmNode::MarsArmNode() : Node("mars_arm") {
         std::bind(&MarsArmNode::headEnableServoCallback, this, std::placeholders::_1, std::placeholders::_2),
         rmw_qos_profile_services_default, service_callback_group_);
 
+    low_power_divider_ = std::max(1, static_cast<int>(std::lround(control_frequency_ / 10.0)));
+    low_power_service_ = this->create_service<std_srvs::srv::SetBool>(
+        "/mars/arm/low_power_mode",
+        std::bind(&MarsArmNode::lowPowerModeCallback, this, std::placeholders::_1, std::placeholders::_2),
+        rmw_qos_profile_services_default, service_callback_group_);
+
     // ── Initialize messages ──
     RCLCPP_DEBUG(this->get_logger(), "Initializing joint state message with 6 joint names");
     arm_state_msg_.name = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6"};

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
@@ -186,6 +186,11 @@ MarsArmNode::MarsArmNode() : Node("mars_arm") {
         std::bind(&MarsArmNode::lowPowerModeCallback, this, std::placeholders::_1, std::placeholders::_2),
         rmw_qos_profile_services_default, service_callback_group_);
 
+    bus_suspend_service_ = this->create_service<std_srvs::srv::SetBool>(
+        "/mars/arm/bus_suspend",
+        std::bind(&MarsArmNode::busSuspendCallback, this, std::placeholders::_1, std::placeholders::_2),
+        rmw_qos_profile_services_default, service_callback_group_);
+
     // ── Initialize messages ──
     RCLCPP_DEBUG(this->get_logger(), "Initializing joint state message with 6 joint names");
     arm_state_msg_.name = {"joint1", "joint2", "joint3", "joint4", "joint5", "joint6"};

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_services.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_services.cpp
@@ -542,4 +542,13 @@ void MarsArmNode::headEnableServoCallback(const std::shared_ptr<std_srvs::srv::S
     }
 }
 
+void MarsArmNode::lowPowerModeCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                       std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+    low_power_mode_.store(request->data);
+    response->success = true;
+    response->message = request->data ? "Control loop decimated to ~10 Hz" : "Control loop at full rate";
+    RCLCPP_INFO(this->get_logger(), "Low-power mode %s (loop at %s)", request->data ? "on" : "off",
+                request->data ? "~10 Hz" : "full rate");
+}
+
 }  // namespace mars_arm

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_services.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_services.cpp
@@ -169,6 +169,11 @@ void MarsArmNode::syncTargetToMotorPositions() {
 // ========== HEALTH MONITORING ==========
 
 void MarsArmNode::healthMonitorCallback() {
+    // The bus is dead while the rail is gated — skip the health poll entirely.
+    if (bus_suspended_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
     mars_msgs::msg::ArmStatus status_msg;
     status_msg.is_ok = true;
     status_msg.error = "All servos nominal";
@@ -549,6 +554,37 @@ void MarsArmNode::lowPowerModeCallback(const std::shared_ptr<std_srvs::srv::SetB
     response->message = request->data ? "Control loop decimated to ~10 Hz" : "Control loop at full rate";
     RCLCPP_INFO(this->get_logger(), "Low-power mode %s (loop at %s)", request->data ? "on" : "off",
                 request->data ? "~10 Hz" : "full rate");
+}
+
+void MarsArmNode::busSuspendCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                     std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+    if (request->data) {
+        // Suspend: quiesce the bus before the rail is gated. Taking the mutex
+        // waits for any in-flight control/health transaction; setting the flag
+        // under it means the next tick early-returns before touching the bus.
+        std::lock_guard<std::mutex> lock(dynamixel_mutex_);
+        bus_suspended_.store(true);
+        response->success = true;
+        response->message = "Bus polling suspended";
+        RCLCPP_INFO(this->get_logger(), "Dynamixel bus suspended (rail may now be gated)");
+        return;
+    }
+
+    // Resume: the servos power-cycled while gated, so re-apply their full
+    // configuration (torque left off — the wake sequence re-enables it) before
+    // letting the control loop resume.
+    try {
+        std::lock_guard<std::mutex> lock(dynamixel_mutex_);
+        configureServosLocked(/*enable_torque=*/false);
+        response->message = "Bus resumed, servos re-initialized";
+        RCLCPP_INFO(this->get_logger(), "Dynamixel bus resumed, servos re-initialized");
+    } catch (const std::exception& e) {
+        // Clear the flag anyway so the system isn't wedged; torque-on will retry.
+        response->message = std::string("Bus resumed with re-init errors: ") + e.what();
+        RCLCPP_ERROR(this->get_logger(), "Servo re-init on resume failed: %s", e.what());
+    }
+    bus_suspended_.store(false);
+    response->success = true;
 }
 
 }  // namespace mars_arm

--- a/ros2_ws/src/mars_bot/mars_bringup/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_bringup/CMakeLists.txt
@@ -40,6 +40,7 @@ ament_python_install_package(${PROJECT_NAME}
 install(PROGRAMS
   mars_bringup/bringup.py
   mars_bringup/rosbag.py
+  mars_bringup/power_manager.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros2_ws/src/mars_bot/mars_bringup/launch/bringup_core.launch.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/launch/bringup_core.launch.py
@@ -23,11 +23,21 @@ def generate_launch_description():
         output="screen",
     )
 
+    # Sleep/wake orchestration (light sleep) — see mars_bringup/power_manager.py
+    power_manager_node = Node(
+        package="mars_bringup",
+        executable="power_manager.py",
+        name="power_manager",
+        parameters=[*settings_params()],
+        output="screen",
+    )
+
     # base_link -> base_footprint static TF is now published by
     # robot_state_publisher via the URDF (base_footprint_joint).
 
     return LaunchDescription(
         [
             bringup_node,
+            power_manager_node,
         ]
     )

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/bringup.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/bringup.py
@@ -10,7 +10,8 @@ from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 from sensor_msgs.msg import BatteryState
-from std_srvs.srv import Trigger
+from std_msgs.msg import Bool
+from std_srvs.srv import SetBool, Trigger
 from tf2_ros import TransformBroadcaster
 
 from mars_bringup.battery import BatteryManager
@@ -119,6 +120,12 @@ class Bringup(Node):
         # Add the calibrate service
         self.calibrate_srv = self.create_service(Trigger, "/calibrate", self._handle_calibrate_request)
 
+        # PCB sleep/wake (called by power_manager during its sleep/wake
+        # sequences), plus fast surfacing of the MCU's motion-wake latch.
+        self.pcb_power_srv = self.create_service(SetBool, "/pcb/power_mode", self._handle_pcb_power_mode)
+        self.motion_wake_pub = self.create_publisher(Bool, "/pcb/motion_wake_pending", 10)
+        self.power_poll_timer = self.create_timer(2.0, self._poll_pcb_power)
+
         # Create odometry publisher
         self.odom_pub = self.create_publisher(
             Odometry,
@@ -225,6 +232,26 @@ class Bringup(Node):
                 self.get_logger().debug(f"Calibration response: {response.success}, {response.message}")
 
         return response
+
+    def _handle_pcb_power_mode(self, request, response):
+        """PCB sleep/wake. Sleep arms wake-on-motion as the physical wake path
+        (it survives HSSW gating, unlike servo-polling boop detection). HSSW
+        gating stays off until the arm node can stop bus polling during a
+        gated sleep and re-init the Dynamixels on wake (rollout stage c)."""
+        self.i2c_manager.set_power_mode(sleep=request.data, wake_on_motion=request.data)
+        response.success = True
+        response.message = "PCB sleep requested" if request.data else "PCB wake requested"
+        return response
+
+    def _poll_pcb_power(self):
+        """While the PCB sleeps, poll status at 2 s (vs the routine 60 s health
+        cadence) so a physical-disturbance wake surfaces promptly, and publish
+        the MCU's motion-wake latch for power_manager."""
+        if self.i2c_manager.current_power_mode != 1:
+            return
+        self.i2c_manager.request_health()
+        if self.i2c_manager.motion_wake_pending:
+            self.motion_wake_pub.publish(Bool(data=True))
 
     def _publish_odometry(self):
         """Publish odometry data, transform, and battery state from I2C readings."""

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/bringup.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/bringup.py
@@ -59,6 +59,10 @@ class Bringup(Node):
                 ("battery.num_cells", 6),
                 ("battery.warning_percentage", 20),
                 ("battery.critical_percentage", 10),
+                # Cut the HSSW rail (arm/head Dynamixels + wheel drivers) during
+                # PCB sleep. Shared with power_manager via a /** setting so the
+                # two agree; power_manager suspends the arm bus in lockstep.
+                ("gate_hssw_on_sleep", True),
                 ("ros_topics.odom_frequency", 30.0),
                 ("ros_topics.battery_state_frequency", 0.2),
             ],
@@ -235,10 +239,11 @@ class Bringup(Node):
 
     def _handle_pcb_power_mode(self, request, response):
         """PCB sleep/wake. Sleep arms wake-on-motion as the physical wake path
-        (it survives HSSW gating, unlike servo-polling boop detection). HSSW
-        gating stays off until the arm node can stop bus polling during a
-        gated sleep and re-init the Dynamixels on wake (rollout stage c)."""
-        self.i2c_manager.set_power_mode(sleep=request.data, wake_on_motion=request.data)
+        (it survives HSSW gating, unlike servo-polling boop detection) and,
+        when gate_hssw_on_sleep is set, cuts the HSSW rail to drop the idle
+        Dynamixels. power_manager suspends the arm bus in lockstep."""
+        gate = bool(self.get_parameter("gate_hssw_on_sleep").value) if request.data else False
+        self.i2c_manager.set_power_mode(sleep=request.data, gate_hssw=gate, wake_on_motion=request.data)
         response.success = True
         response.message = "PCB sleep requested" if request.data else "PCB wake requested"
         return response

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
@@ -25,11 +25,18 @@ class I2CManager:
     CMD_MOVE = 0x01
     CMD_STATUS = 0x03
     CMD_CALIBRATE = 0x04
+    CMD_POWER = 0x06
 
     # Response definitions (MCU → Jetson)
     RESP_MOVE = 0x81  # Position feedback
     RESP_STATUS = 0x83  # Health data
     RESP_CALIBRATE = 0x84  # Calibration status
+    RESP_POWER = 0x86  # Power mode state
+
+    # CMD_POWER sleep flags (firmware README §4.5)
+    POWER_FLAG_GATE_HSSW = 0x01  # hold the arm/head/wheel-driver rail off
+    POWER_FLAG_WAKE_ON_MOTION = 0x02  # IMU watches for tap/nudge/pickup
+    POWER_FLAG_MOTION_AUTO_WAKE = 0x04  # MCU self-wakes on motion (needs bit 1)
 
     def __init__(
         self,
@@ -67,6 +74,8 @@ class I2CManager:
         self.last_speed_command_time = 0.0
         self.status_requested = False
         self.calibration_requested = False
+        self.power_mode_requested = False
+        self._pending_power_payload = bytes(6)
 
         # -------------------------
         # Stored responses
@@ -77,6 +86,9 @@ class I2CManager:
         self.motor_temperature = 0.0
         self.fault_code = 0
         self.calibration_status = None
+        self.current_power_mode = 0  # as reported by the MCU: 0 = active, 1 = sleep
+        self.power_flags = 0  # effective sleep flags (MCU clears unsupported bits)
+        self.motion_wake_pending = False  # MCU motion latch; cleared by every power command
 
         # Communication thread control
         self.running = True
@@ -203,12 +215,18 @@ class I2CManager:
             if self.debug:
                 self.logger.debug(f"Position Update - X: {x / 100.0}, Y: {y / 100.0}, θ: {theta_rad} rad")
         elif resp_id == self.RESP_STATUS:
-            # Health status: battery voltage, motor temp, fault code
+            # Health status: battery voltage, motor temp, fault code, power/wake flags
             try:
-                battery, temp, fault, _ = struct.unpack(">HHBB", bytes(data))
+                battery, temp, fault, power_wake_flags = struct.unpack(">HHBB", bytes(data))
                 self.battery_voltage = battery / 100.0  # Convert to volts
                 self.motor_temperature = temp  # Temperature in Celsius
                 self.fault_code = fault
+                # Power/wake flags bitfield: bit 0 = sleep mode active,
+                # bit 1 = motion wake pending (physical disturbance during sleep).
+                # The MCU latch is authoritative (cleared only by a power
+                # command), so mirror it rather than OR-ing.
+                self.current_power_mode = power_wake_flags & 0x01
+                self.motion_wake_pending = bool(power_wake_flags & 0x02)
                 if self.debug:
                     self.logger.debug(
                         f"Status - Battery: {self.battery_voltage:.2f}V, Motor Temp: {temp}°C, Fault: {fault}"
@@ -227,6 +245,18 @@ class I2CManager:
                 self.logger.info(f"Calibration Status: {status_str} ({status})")
             except Exception as e:
                 self.logger.error(f"Failed to unpack calibration response: {e}")
+        elif resp_id == self.RESP_POWER:
+            # Power mode state (post-command): mode, effective flags,
+            # wheel-driver reinit marker, motion wake latch.
+            self.current_power_mode = data[0]
+            self.power_flags = data[1]
+            self.motion_wake_pending = bool(data[3])
+            if data[2]:
+                self.logger.info("MCU re-initialized wheel drivers on wake")
+            self.logger.info(
+                f"MCU power mode: {'sleep' if data[0] else 'active'} "
+                f"(flags=0x{data[1]:02X}, motion pending={bool(data[3])})"
+            )
         else:
             self.logger.warning(f"Unknown Response ID: {resp_id}")
 
@@ -275,6 +305,16 @@ class I2CManager:
             self.calibration_requested = False  # Clear after sending
         return success
 
+    def _send_power_command(self):
+        """Send power mode command if pending"""
+        if not self.power_mode_requested:
+            return False
+
+        success = self._send_command(self.CMD_POWER, self._pending_power_payload)
+        if success:
+            self.power_mode_requested = False  # Clear after sending
+        return success
+
     def _communication_loop(self):
         """Main communication loop running at fixed frequency"""
         while self.running:
@@ -291,6 +331,10 @@ class I2CManager:
 
             if self.calibration_requested:
                 self._send_calibrate_command()
+                self._read_response()
+
+            if self.power_mode_requested:
+                self._send_power_command()
                 self._read_response()
 
             # Maintain fixed update rate
@@ -330,6 +374,35 @@ class I2CManager:
         Triggers a calibration command.
         """
         self.calibration_requested = True
+
+    def set_power_mode(
+        self,
+        sleep: bool,
+        gate_hssw: bool = False,
+        wake_on_motion: bool = False,
+        auto_wake: bool = False,
+        motion_threshold_mg: int = 0,
+    ):
+        """
+        Queues a power mode command (firmware README §4.5).
+          sleep: True to enter sleep, False to wake to active mode.
+          gate_hssw: hold the HSSW rail (arm/head Dynamixels + wheel drivers)
+            off during sleep. The Dynamixel bus is dead while gated.
+          wake_on_motion: keep the IMU accelerometer watching for a
+            tap/nudge/pickup during sleep (survives HSSW gating).
+          auto_wake: MCU self-wakes on motion instead of only latching the
+            event (firmware ignores it without wake_on_motion).
+          motion_threshold_mg: detection threshold (4–1020 mg, coded in 4 mg
+            steps); 0 = firmware default (120 mg).
+        """
+        flags = 0
+        if sleep:
+            flags |= self.POWER_FLAG_GATE_HSSW if gate_hssw else 0
+            flags |= self.POWER_FLAG_WAKE_ON_MOTION if wake_on_motion else 0
+            flags |= self.POWER_FLAG_MOTION_AUTO_WAKE if auto_wake else 0
+        threshold_code = 0 if motion_threshold_mg <= 0 else max(1, min(255, round(motion_threshold_mg / 4)))
+        self._pending_power_payload = bytes([0x01 if sleep else 0x00, flags, threshold_code, 0x00, 0x00, 0x00])
+        self.power_mode_requested = True
 
     # --- Destructor ---
     def __del__(self):

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Light-sleep power manager.
+
+Owns the robot's AWAKE <-> SLEEPING state. Sleep powers down the big
+consumers (lidar motor, cameras, nav2 stack, arm/head torque, Jetson clocks)
+while keeping the network path (zenoh, rosbridge) and this node alive, so the
+robot stays remotely wakeable in seconds.
+
+Triggers:
+  - /power/sleep, /power/wake (std_srvs/Trigger) — apps, skills, CLI
+  - auto-sleep after `sleep_after_idle_minutes` of inactivity (0 = never);
+    active SSH connections count as activity
+  - wake on joystick input, chat message, or a head boop (head torque is off
+    during sleep, but mars_arm keeps publishing the head position, so pushing
+    the head is detectable)
+
+State is broadcast on /power/state ("awake" / "going_to_sleep" / "sleeping" /
+"waking"), latched + 1 Hz heartbeat, mirroring /brain/agent_status delivery.
+"""
+
+import json
+import subprocess
+import threading
+import time
+
+import rclpy
+from brain_messages.srv import ChangeNavigationMode
+from geometry_msgs.msg import Vector3
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+from std_msgs.msg import Int32, String
+from std_srvs.srv import Empty, SetBool, Trigger
+
+STATE_AWAKE = "awake"
+STATE_GOING_TO_SLEEP = "going_to_sleep"
+STATE_SLEEPING = "sleeping"
+STATE_WAKING = "waking"
+
+# tmux layout from scripts/launch_ros_in_tmux.sh — the camera container runs in
+# the first pane of this window, and its shell keeps the sourced ROS env, so we
+# can Ctrl-C the launch to sleep and re-send the command to wake.
+TMUX_SESSION = "ros_nodes"
+CAMERA_WINDOW = "cam-leader"
+CAMERA_LAUNCH_CMD = "ros2 launch mars_cam camera_composable.launch.py"
+
+# Terminal statuses from skills_server._publish_skill_status; anything else
+# (i.e. "running") means a skill is in flight.
+_SKILL_TERMINAL_STATUSES = {"completed", "interrupted", "failed"}
+
+_SS_ESTABLISHED_SSH = ["ss", "-tnH", "state", "established", "( sport = :22 )"]
+
+
+class PowerManager(Node):
+    def __init__(self):
+        super().__init__("power_manager")
+
+        self.declare_parameter("sleep_after_idle_minutes", 0)
+        self.declare_parameter("boop_wake_threshold_degrees", 4)
+
+        self._state = STATE_AWAKE
+        self._state_lock = threading.Lock()
+        self._transition_lock = threading.Lock()
+
+        self._last_activity = time.monotonic()
+        self._skill_in_flight = False
+        self._nav_mode = "none"  # live value from /nav/current_mode
+        self._nav_mode_before_sleep = "none"
+        self._brain_active = False  # live value from /brain/agent_status
+        self._brain_active_before_sleep = False
+        self._camera_pane_id: str | None = None
+
+        # Head-boop detection (armed while sleeping)
+        self._head_baseline_deg: float | None = None
+        self._boop_arm_time = 0.0
+        self._boop_hits = 0
+        self._last_boop_sample = 0.0
+
+        latched = QoSProfile(
+            depth=1,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+        )
+        self._state_pub = self.create_publisher(String, "/power/state", latched)
+        self._head_position_pub = self.create_publisher(Int32, "/mars/head/set_position", 10)
+
+        self.create_service(Trigger, "/power/sleep", self._on_sleep_request)
+        self.create_service(Trigger, "/power/wake", self._on_wake_request)
+
+        # Downstream controls
+        self._brain_active_client = self.create_client(SetBool, "/brain/set_brain_active")
+        self._nav_mode_client = self.create_client(ChangeNavigationMode, "/nav/change_mode")
+        self._lidar_stop_client = self.create_client(Empty, "/stop_motor")
+        self._lidar_start_client = self.create_client(Empty, "/start_motor")
+        self._arm_torque_off_client = self.create_client(Trigger, "/mars/arm/torque_off")
+        self._arm_torque_on_client = self.create_client(Trigger, "/mars/arm/torque_on")
+        self._head_servo_client = self.create_client(SetBool, "/mars/head/enable_servo")
+
+        # Activity signals
+        self.create_subscription(Vector3, "/joystick", self._on_joystick, 10)
+        self.create_subscription(String, "/brain/chat_in", self._on_chat_in, 10)
+        self.create_subscription(String, "/webrtc/active_streams", self._on_webrtc_streams, 10)
+        self.create_subscription(String, "/brain/skill_status_update", self._on_skill_status, 10)
+        self.create_subscription(String, "/nav/current_mode", self._on_nav_mode, 10)
+        self.create_subscription(String, "/brain/agent_status", self._on_agent_status, latched)
+        self.create_subscription(String, "/mars/head/current_position", self._on_head_position, 10)
+
+        self.create_timer(1.0, self._publish_state)
+        self.create_timer(10.0, self._idle_tick)
+
+        self.get_logger().info("Power manager ready (state: awake)")
+
+    # ------------------------------------------------------------------ state
+
+    @property
+    def state(self) -> str:
+        with self._state_lock:
+            return self._state
+
+    def _set_state(self, state: str) -> None:
+        with self._state_lock:
+            self._state = state
+        self._state_pub.publish(String(data=state))
+        self.get_logger().info(f"Power state: {state}")
+
+    def _publish_state(self) -> None:
+        self._state_pub.publish(String(data=self.state))
+
+    # -------------------------------------------------------------- services
+
+    def _on_sleep_request(self, request, response):
+        del request
+        started = self._start_transition(self._sleep_sequence, from_state=STATE_AWAKE)
+        response.success = started
+        response.message = "Going to sleep" if started else f"Cannot sleep from state '{self.state}'"
+        return response
+
+    def _on_wake_request(self, request, response):
+        del request
+        started = self._start_transition(self._wake_sequence, from_state=STATE_SLEEPING, reason="wake service")
+        response.success = started
+        response.message = "Waking up" if started else f"Cannot wake from state '{self.state}'"
+        return response
+
+    def _start_transition(self, sequence, from_state: str, reason: str = "") -> bool:
+        """Kick off a sleep/wake sequence in a worker thread (service callbacks
+        must not block the executor — the sequences themselves call services)."""
+        with self._state_lock:
+            if self._state != from_state:
+                return False
+            self._state = STATE_GOING_TO_SLEEP if sequence is self._sleep_sequence else STATE_WAKING
+        self._state_pub.publish(String(data=self.state))
+        self.get_logger().info(f"Power state: {self.state}" + (f" ({reason})" if reason else ""))
+        threading.Thread(target=self._run_transition, args=(sequence,), daemon=True).start()
+        return True
+
+    def _run_transition(self, sequence) -> None:
+        with self._transition_lock:
+            try:
+                sequence()
+            except Exception as e:  # a half-finished transition is recoverable via the other service
+                self.get_logger().error(f"Power transition failed: {e}")
+                self._set_state(STATE_AWAKE if sequence is self._wake_sequence else STATE_SLEEPING)
+
+    # ------------------------------------------------------------- activity
+
+    def _touch_activity(self) -> None:
+        self._last_activity = time.monotonic()
+
+    def _on_joystick(self, msg: Vector3) -> None:
+        # driveController publishes a zero vector on release/pagehide — only
+        # real input counts as activity (and wakes the robot).
+        if abs(msg.x) < 1e-3 and abs(msg.y) < 1e-3 and abs(msg.z) < 1e-3:
+            return
+        self._touch_activity()
+        self._wake_if_sleeping("joystick input")
+
+    def _on_chat_in(self, msg: String) -> None:
+        del msg
+        self._touch_activity()
+        self._wake_if_sleeping("chat message")
+
+    def _on_webrtc_streams(self, msg: String) -> None:
+        try:
+            count = json.loads(msg.data).get("count", 0)
+        except (json.JSONDecodeError, AttributeError):
+            return
+        if count > 0:
+            self._touch_activity()
+
+    def _on_skill_status(self, msg: String) -> None:
+        self._touch_activity()
+        try:
+            status = json.loads(msg.data).get("status", "")
+        except json.JSONDecodeError:
+            return
+        self._skill_in_flight = status not in _SKILL_TERMINAL_STATUSES
+
+    def _on_nav_mode(self, msg: String) -> None:
+        self._nav_mode = msg.data
+
+    def _on_agent_status(self, msg: String) -> None:
+        try:
+            self._brain_active = bool(json.loads(msg.data).get("brain_active", False))
+        except json.JSONDecodeError:
+            pass
+
+    def _ssh_session_active(self) -> bool:
+        try:
+            out = subprocess.run(_SS_ESTABLISHED_SSH, capture_output=True, text=True, timeout=5)
+            return bool(out.stdout.strip())
+        except (OSError, subprocess.SubprocessError) as e:
+            self.get_logger().warning(f"SSH activity check failed: {e}")
+            return False
+
+    def _idle_tick(self) -> None:
+        if self.state != STATE_AWAKE:
+            return
+        idle_minutes = self.get_parameter("sleep_after_idle_minutes").value
+        if idle_minutes <= 0:
+            return
+        if self._skill_in_flight or self._nav_mode in ("mapping", "switching"):
+            self._touch_activity()
+            return
+        if self._ssh_session_active():
+            self._touch_activity()
+            return
+        if time.monotonic() - self._last_activity >= idle_minutes * 60:
+            self.get_logger().info(f"Idle for {idle_minutes} minutes — going to sleep")
+            self._start_transition(self._sleep_sequence, from_state=STATE_AWAKE, reason="idle timeout")
+
+    # ------------------------------------------------------------- head boop
+
+    def _on_head_position(self, msg: String) -> None:
+        if self.state != STATE_SLEEPING or time.monotonic() < self._boop_arm_time:
+            return
+        # The arm node streams this at its control-loop rate; sample at 10 Hz.
+        if time.monotonic() - self._last_boop_sample < 0.1:
+            return
+        self._last_boop_sample = time.monotonic()
+        try:
+            position = float(json.loads(msg.data).get("current_position"))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return
+        if self._head_baseline_deg is None:
+            self._head_baseline_deg = position
+            return
+        threshold = self.get_parameter("boop_wake_threshold_degrees").value
+        delta = position - self._head_baseline_deg
+        if abs(delta) >= threshold:
+            self._boop_hits += 1
+            # two consecutive readings past the threshold, so a single glitched
+            # sample or a floor vibration doesn't wake the robot
+            if self._boop_hits >= 2:
+                self._wake_if_sleeping("head boop")
+        else:
+            self._boop_hits = 0
+            # Creep-track the baseline (≤0.5°/s): a torque-less head can sag
+            # slowly under gravity, and untracked sag would eventually read as
+            # a boop. A real boop is a fast >threshold push the creep can't absorb.
+            self._head_baseline_deg += max(-0.05, min(0.05, delta))
+
+    def _wake_if_sleeping(self, reason: str) -> None:
+        if self.state == STATE_SLEEPING:
+            self._start_transition(self._wake_sequence, from_state=STATE_SLEEPING, reason=reason)
+
+    # ------------------------------------------------------------- sequences
+
+    def _sleep_sequence(self) -> None:
+        # Let whatever triggered us (e.g. the go_to_sleep skill) finish its
+        # goodbye before we start tearing subsystems down.
+        time.sleep(2.0)
+
+        self._nav_mode_before_sleep = self._nav_mode
+        self._brain_active_before_sleep = self._brain_active
+
+        self._droop_head()
+        self._call(self._brain_active_client, SetBool.Request(data=False), "brain off")
+        self._call(
+            self._nav_mode_client,
+            ChangeNavigationMode.Request(mode="off"),
+            "nav stack off",
+            timeout=45.0,
+        )
+        self._call(self._lidar_stop_client, Empty.Request(), "lidar motor off")
+        self._call(self._arm_torque_off_client, Trigger.Request(), "arm torque off")
+        self._call(self._head_servo_client, SetBool.Request(data=False), "head torque off")
+        self._stop_camera_container()
+        self._run_privileged(["systemctl", "stop", "speaker-keepalive.service"])
+        self._run_privileged(["systemctl", "stop", "jetson-perf.service"])
+        self._run_privileged(["/usr/sbin/nvpmodel", "-m", "3"])  # 7W profile
+
+        # Arm the boop detector: give the torque-less head a moment to settle,
+        # then take the first reading after that as the baseline.
+        self._head_baseline_deg = None
+        self._boop_hits = 0
+        self._boop_arm_time = time.monotonic() + 2.0
+
+        self._set_state(STATE_SLEEPING)
+
+    def _wake_sequence(self) -> None:
+        # Compute first so the robot feels responsive from the very first second.
+        self._run_privileged(["systemctl", "start", "jetson-perf.service"])
+        self._start_camera_container()
+        self._call(self._lidar_start_client, Empty.Request(), "lidar motor on")
+        self._call(self._head_servo_client, SetBool.Request(data=True), "head torque on")
+        self._call(self._arm_torque_on_client, Trigger.Request(), "arm torque on")
+        self._run_privileged(["systemctl", "start", "speaker-keepalive.service"])
+
+        if self._nav_mode_before_sleep in ("navigation", "mapping", "mapfree"):
+            self._call(
+                self._nav_mode_client,
+                ChangeNavigationMode.Request(mode=self._nav_mode_before_sleep),
+                f"nav stack -> {self._nav_mode_before_sleep}",
+                timeout=60.0,
+            )
+        if self._brain_active_before_sleep:
+            self._call(self._brain_active_client, SetBool.Request(data=True), "brain on")
+
+        self._head_position_pub.publish(Int32(data=0))
+        self._touch_activity()
+        self._set_state(STATE_AWAKE)
+
+    def _droop_head(self) -> None:
+        """Slow droop to the head's lower limit — the visible 'falling asleep' cue."""
+        for angle in (-5, -12, -20, -25):
+            self._head_position_pub.publish(Int32(data=angle))
+            time.sleep(0.35)
+
+    # -------------------------------------------------------------- helpers
+
+    def _call(self, client, request, label: str, timeout: float = 10.0) -> None:
+        """Fire a service call from the transition thread and wait for it.
+
+        Failures are logged and skipped: a missing subsystem (e.g. lidar
+        unplugged on a dev bench) must not abort the whole transition."""
+        if not client.wait_for_service(timeout_sec=3.0):
+            self.get_logger().warning(f"[{label}] service {client.srv_name} unavailable, skipping")
+            return
+        future = client.call_async(request)
+        deadline = time.monotonic() + timeout
+        while not future.done():
+            if time.monotonic() > deadline:
+                self.get_logger().warning(f"[{label}] timed out after {timeout}s")
+                return
+            time.sleep(0.05)
+        self.get_logger().info(f"[{label}] done")
+
+    def _run_privileged(self, cmd: list[str]) -> None:
+        """Run a whitelisted root command (sudoers entries installed by
+        scripts/update/post_update.sh). Degrades to a warning if not granted."""
+        try:
+            result = subprocess.run(
+                ["sudo", "-n", *cmd],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                stdin=subprocess.DEVNULL,
+            )
+            if result.returncode != 0:
+                self.get_logger().warning(
+                    f"'{' '.join(cmd)}' failed (rc={result.returncode}): "
+                    f"{result.stderr.strip() or result.stdout.strip()} — "
+                    "run scripts/update/post_update.sh to install the sudoers entries"
+                )
+        except (OSError, subprocess.SubprocessError) as e:
+            self.get_logger().warning(f"'{' '.join(cmd)}' failed: {e}")
+
+    def _tmux(self, *args: str) -> subprocess.CompletedProcess | None:
+        try:
+            return subprocess.run(["tmux", *args], capture_output=True, text=True, timeout=10)
+        except (OSError, subprocess.SubprocessError) as e:
+            self.get_logger().warning(f"tmux {' '.join(args)} failed: {e}")
+            return None
+
+    def _find_camera_pane(self) -> str | None:
+        """The pane in cam-leader whose shell has the camera launch as a child."""
+        listing = self._tmux(
+            "list-panes", "-t", f"{TMUX_SESSION}:{CAMERA_WINDOW}", "-F", "#{pane_id} #{pane_pid}"
+        )
+        if listing is None or listing.returncode != 0:
+            return None
+        for line in listing.stdout.splitlines():
+            pane_id, _, pane_pid = line.partition(" ")
+            try:
+                children = subprocess.run(
+                    ["ps", "--ppid", pane_pid.strip(), "-o", "args="],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                ).stdout
+            except (OSError, subprocess.SubprocessError):
+                continue
+            if "camera_composable" in children:
+                return pane_id
+        return None
+
+    def _stop_camera_container(self) -> None:
+        pane = self._find_camera_pane()
+        if pane is None:
+            self.get_logger().warning("Camera launch pane not found — cameras may already be down")
+            return
+        self._camera_pane_id = pane
+        self._tmux("send-keys", "-t", pane, "C-c")
+        time.sleep(5.0)  # ros2 launch tears the container down gracefully on SIGINT
+        self.get_logger().info("[cameras off] done")
+
+    def _start_camera_container(self) -> None:
+        # Fall back to the window's first pane — the launcher always puts the
+        # camera command there (see scripts/launch_ros_in_tmux.sh).
+        pane = self._camera_pane_id or f"{TMUX_SESSION}:{CAMERA_WINDOW}.0"
+        if self._find_camera_pane() is not None:
+            self.get_logger().info("[cameras on] already running")
+            return
+        self._tmux("send-keys", "-t", pane, CAMERA_LAUNCH_CMD, "Enter")
+        self.get_logger().info("[cameras on] launch sent")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = PowerManager()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -39,12 +39,21 @@ STATE_GOING_TO_SLEEP = "going_to_sleep"
 STATE_SLEEPING = "sleeping"
 STATE_WAKING = "waking"
 
-# tmux layout from scripts/launch_ros_in_tmux.sh — the camera container runs in
-# the first pane of this window, and its shell keeps the sourced ROS env, so we
-# can Ctrl-C the launch to sleep and re-send the command to wake.
+# tmux layout from scripts/launch_ros_in_tmux.sh. These panes run the camera
+# container and heavy nodes with no role in sleeping or waking; their shells
+# keep the sourced ROS env, so we can Ctrl-C the launch to sleep and re-send
+# the command to wake. Deliberately kept alive: app-bringup (rosbridge + this
+# node + PCB/battery i2c), the arm node (head-boop source), mode_manager (nav
+# restore service), input_manager, and console/webapp (the app surface).
 TMUX_SESSION = "ros_nodes"
-CAMERA_WINDOW = "cam-leader"
-CAMERA_LAUNCH_CMD = "ros2 launch mars_cam camera_composable.launch.py"
+# (window, fallback pane index, process match, relaunch command)
+_SLEEP_PANES = [
+    ("cam-leader", 0, "camera_composable", "ros2 launch mars_cam camera_composable.launch.py"),
+    ("brain-nav", 0, "brain_client.launch.py", "ros2 launch brain_client brain_client.launch.py"),
+    ("behaviors-inputs", 0, "behavior.launch.py", "ros2 launch manipulation behavior.launch.py"),
+    ("arm-recorder", 1, "recorder.launch.py", "ros2 launch manipulation recorder.launch.py"),
+    ("ik-logger", 0, "ik.launch.py", "ros2 launch mars_arm ik.launch.py"),
+]
 
 # Terminal statuses from skills_server._publish_skill_status; anything else
 # (i.e. "running") means a skill is in flight.
@@ -76,7 +85,7 @@ class PowerManager(Node):
         self._nav_mode_before_sleep = "none"
         self._brain_active = False  # live value from /brain/agent_status
         self._brain_active_before_sleep = False
-        self._camera_pane_id: str | None = None
+        self._pane_ids: dict[str, str] = {}  # process match -> tmux pane id, saved at stop
 
         # Head-boop detection (armed while sleeping)
         self._head_baseline_deg: float | None = None
@@ -322,7 +331,7 @@ class PowerManager(Node):
         # main CPU load during sleep (it fans out through /joint_states -> /tf
         # into every Python subscriber and TF listener).
         self._call(self._arm_low_power_client, SetBool.Request(data=True), "arm loop 10Hz")
-        self._stop_camera_container()
+        self._stop_sleep_panes()
         self._run_privileged(["systemctl", "stop", "speaker-keepalive.service"])
         self._run_privileged(["systemctl", "stop", "jetson-perf.service"])
         # 15W profile — the lowest reachable live: 7W (-m 3) takes CPU cores
@@ -348,7 +357,9 @@ class PowerManager(Node):
         self._run_privileged([_SLEEP_CLOCKS_SCRIPT, "wake"])
         self._run_privileged(["/usr/sbin/nvpmodel", "-m", "2"])
         self._run_privileged(["systemctl", "start", "jetson-perf.service"])
-        self._start_camera_container()
+        # Relaunch the stopped panes first — brain/MoveIt startup overlaps the
+        # rest of the wake sequence.
+        self._start_sleep_panes()
         self._call(self._lidar_start_client, Empty.Request(), "lidar motor on")
         self._call(self._arm_low_power_client, SetBool.Request(data=False), "arm loop full rate")
         self._call(self._head_servo_client, SetBool.Request(data=True), "head torque on")
@@ -363,7 +374,8 @@ class PowerManager(Node):
                 timeout=60.0,
             )
         if self._brain_active_before_sleep:
-            self._call(self._brain_active_client, SetBool.Request(data=True), "brain on")
+            # brain_client is still booting from the pane relaunch above.
+            self._call(self._brain_active_client, SetBool.Request(data=True), "brain on", wait=30.0)
 
         self._head_position_pub.publish(Int32(data=0))
         self._touch_activity()
@@ -377,12 +389,12 @@ class PowerManager(Node):
 
     # -------------------------------------------------------------- helpers
 
-    def _call(self, client, request, label: str, timeout: float = 10.0) -> None:
+    def _call(self, client, request, label: str, timeout: float = 10.0, wait: float = 3.0) -> None:
         """Fire a service call from the transition thread and wait for it.
 
         Failures are logged and skipped: a missing subsystem (e.g. lidar
         unplugged on a dev bench) must not abort the whole transition."""
-        if not client.wait_for_service(timeout_sec=3.0):
+        if not client.wait_for_service(timeout_sec=wait):
             self.get_logger().warning(f"[{label}] service {client.srv_name} unavailable, skipping")
             return
         future = client.call_async(request)
@@ -421,10 +433,10 @@ class PowerManager(Node):
             self.get_logger().warning(f"tmux {' '.join(args)} failed: {e}")
             return None
 
-    def _find_camera_pane(self) -> str | None:
-        """The pane in cam-leader whose shell has the camera launch as a child."""
+    def _find_pane(self, window: str, match: str) -> str | None:
+        """The pane in `window` whose shell has `match` in a child process's args."""
         listing = self._tmux(
-            "list-panes", "-t", f"{TMUX_SESSION}:{CAMERA_WINDOW}", "-F", "#{pane_id} #{pane_pid}"
+            "list-panes", "-t", f"{TMUX_SESSION}:{window}", "-F", "#{pane_id} #{pane_pid}"
         )
         if listing is None or listing.returncode != 0:
             return None
@@ -439,29 +451,33 @@ class PowerManager(Node):
                 ).stdout
             except (OSError, subprocess.SubprocessError):
                 continue
-            if "camera_composable" in children:
+            if match in children:
                 return pane_id
         return None
 
-    def _stop_camera_container(self) -> None:
-        pane = self._find_camera_pane()
-        if pane is None:
-            self.get_logger().warning("Camera launch pane not found — cameras may already be down")
-            return
-        self._camera_pane_id = pane
-        self._tmux("send-keys", "-t", pane, "C-c")
-        time.sleep(5.0)  # ros2 launch tears the container down gracefully on SIGINT
-        self.get_logger().info("[cameras off] done")
+    def _stop_sleep_panes(self) -> None:
+        stopped = []
+        for window, _, match, _ in _SLEEP_PANES:
+            pane = self._find_pane(window, match)
+            if pane is None:
+                self.get_logger().warning(f"[{match}] pane not found — may already be down")
+                continue
+            self._pane_ids[match] = pane
+            self._tmux("send-keys", "-t", pane, "C-c")
+            stopped.append(match)
+        time.sleep(5.0)  # ros2 launch tears everything down gracefully on SIGINT
+        self.get_logger().info(f"[panes off] {', '.join(stopped) if stopped else 'none found'}")
 
-    def _start_camera_container(self) -> None:
-        # Fall back to the window's first pane — the launcher always puts the
-        # camera command there (see scripts/launch_ros_in_tmux.sh).
-        pane = self._camera_pane_id or f"{TMUX_SESSION}:{CAMERA_WINDOW}.0"
-        if self._find_camera_pane() is not None:
-            self.get_logger().info("[cameras on] already running")
-            return
-        self._tmux("send-keys", "-t", pane, CAMERA_LAUNCH_CMD, "Enter")
-        self.get_logger().info("[cameras on] launch sent")
+    def _start_sleep_panes(self) -> None:
+        for window, fallback_index, match, command in _SLEEP_PANES:
+            if self._find_pane(window, match) is not None:
+                self.get_logger().info(f"[{match}] already running")
+                continue
+            # Fall back to the launcher's fixed pane layout if we never saw
+            # the pane (e.g. woke after a power_manager restart).
+            pane = self._pane_ids.get(match) or f"{TMUX_SESSION}:{window}.{fallback_index}"
+            self._tmux("send-keys", "-t", pane, command, "Enter")
+        self.get_logger().info("[panes on] launches sent")
 
 
 def main(args=None):

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -27,6 +27,7 @@ import time
 
 import rclpy
 from brain_messages.srv import ChangeNavigationMode
+from mars_bringup.config_loader import innate_os_root
 from geometry_msgs.msg import Vector3
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
@@ -50,6 +51,10 @@ CAMERA_LAUNCH_CMD = "ros2 launch mars_cam camera_composable.launch.py"
 _SKILL_TERMINAL_STATUSES = {"completed", "interrupted", "failed"}
 
 _SS_ESTABLISHED_SSH = ["ss", "-tnH", "state", "established", "( sport = :22 )"]
+
+# Offlines CPU cores 4-5 and caps clocks during sleep — the part of the 7W
+# profile nvpmodel refuses to apply without a reboot (see the script header).
+_SLEEP_CLOCKS_SCRIPT = str(innate_os_root() / "scripts" / "power" / "sleep-clocks.sh")
 
 
 class PowerManager(Node):
@@ -324,6 +329,9 @@ class PowerManager(Node):
         # offline, which nvpmodel only does across a reboot (it prompts and
         # aborts, rc=234 "Golden image context is already created").
         self._run_privileged(["/usr/sbin/nvpmodel", "-m", "0"])
+        # ...then do the core-offline + clock-cap part ourselves via sysfs
+        # (must run after nvpmodel, which rewrites the cpufreq limits).
+        self._run_privileged([_SLEEP_CLOCKS_SCRIPT, "sleep"])
 
         # Arm the boop detector: give the torque-less head a moment to settle,
         # then take the first reading after that as the baseline.
@@ -337,6 +345,7 @@ class PowerManager(Node):
         # Compute first so the robot feels responsive from the very first second.
         # jetson-perf pins nvpmodel -m 2 + jetson_clocks in its loop; the explicit
         # nvpmodel call restores the power budget even if the service is absent.
+        self._run_privileged([_SLEEP_CLOCKS_SCRIPT, "wake"])
         self._run_privileged(["/usr/sbin/nvpmodel", "-m", "2"])
         self._run_privileged(["systemctl", "start", "jetson-perf.service"])
         self._start_camera_container()

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -24,6 +24,7 @@ import json
 import subprocess
 import threading
 import time
+from collections import deque
 
 import rclpy
 from brain_messages.srv import ChangeNavigationMode
@@ -88,7 +89,7 @@ class PowerManager(Node):
         self._pane_ids: dict[str, str] = {}  # process match -> tmux pane id, saved at stop
 
         # Head-boop detection (armed while sleeping)
-        self._head_baseline_deg: float | None = None
+        self._head_history: deque[tuple[float, float]] = deque()  # (monotonic, degrees)
         self._boop_arm_time = 0.0
         self._boop_hits = 0
         self._last_boop_sample = 0.0
@@ -271,23 +272,31 @@ class PowerManager(Node):
 
     # ------------------------------------------------------------- head boop
 
+    # A boop is a *fast* push: >threshold within this window. Gravity sag on a
+    # torque-less head is slow (≲1°/s → ≲0.6° per window) and can never trip
+    # it, no matter how long the robot sleeps.
+    _BOOP_WINDOW_SEC = 0.6
+
     def _on_head_position(self, msg: String) -> None:
         if self.state != STATE_SLEEPING or time.monotonic() < self._boop_arm_time:
             return
-        # The arm node streams this at its control-loop rate; sample at 10 Hz.
-        if time.monotonic() - self._last_boop_sample < 0.1:
+        # The arm node streams this at ~10 Hz while sleeping (200 Hz awake);
+        # sample at most at 10 Hz either way.
+        now = time.monotonic()
+        if now - self._last_boop_sample < 0.1:
             return
-        self._last_boop_sample = time.monotonic()
+        self._last_boop_sample = now
         try:
             position = float(json.loads(msg.data).get("current_position"))
         except (json.JSONDecodeError, TypeError, ValueError):
             return
-        if self._head_baseline_deg is None:
-            self._head_baseline_deg = position
+        self._head_history.append((now, position))
+        while self._head_history and now - self._head_history[0][0] > self._BOOP_WINDOW_SEC:
+            self._head_history.popleft()
+        if len(self._head_history) < 3:  # need a real window span first
             return
         threshold = self.get_parameter("boop_wake_threshold_degrees").value
-        delta = position - self._head_baseline_deg
-        if abs(delta) >= threshold:
+        if abs(position - self._head_history[0][1]) >= threshold:
             self._boop_hits += 1
             # two consecutive readings past the threshold, so a single glitched
             # sample or a floor vibration doesn't wake the robot
@@ -295,10 +304,6 @@ class PowerManager(Node):
                 self._wake_if_sleeping("head boop")
         else:
             self._boop_hits = 0
-            # Creep-track the baseline (≤0.5°/s): a torque-less head can sag
-            # slowly under gravity, and untracked sag would eventually read as
-            # a boop. A real boop is a fast >threshold push the creep can't absorb.
-            self._head_baseline_deg += max(-0.05, min(0.05, delta))
 
     def _wake_if_sleeping(self, reason: str) -> None:
         if self.state == STATE_SLEEPING:
@@ -342,9 +347,9 @@ class PowerManager(Node):
         # (must run after nvpmodel, which rewrites the cpufreq limits).
         self._run_privileged([_SLEEP_CLOCKS_SCRIPT, "sleep"])
 
-        # Arm the boop detector: give the torque-less head a moment to settle,
-        # then take the first reading after that as the baseline.
-        self._head_baseline_deg = None
+        # Arm the boop detector: give the torque-less head a moment to settle
+        # before the rolling window starts filling.
+        self._head_history.clear()
         self._boop_hits = 0
         self._boop_arm_time = time.monotonic() + 2.0
 
@@ -466,6 +471,15 @@ class PowerManager(Node):
             self._tmux("send-keys", "-t", pane, "C-c")
             stopped.append(match)
         time.sleep(5.0)  # ros2 launch tears everything down gracefully on SIGINT
+        # Second Ctrl-C for launches still up (ros2 launch escalates to SIGTERM).
+        for window, _, match, _ in _SLEEP_PANES:
+            if match in self._pane_ids and self._find_pane(window, match) is not None:
+                self._tmux("send-keys", "-t", self._pane_ids[match], "C-c")
+                time.sleep(3.0)
+        # move_group regularly hangs on SIGINT and outlives its dying launch;
+        # an orphan would be duplicated by the wake relaunch. Both launches
+        # that own one are stopped here, so any survivor is fair game.
+        subprocess.run(["pkill", "-f", "moveit_ros_move_group/move_group"], check=False)
         self.get_logger().info(f"[panes off] {', '.join(stopped) if stopped else 'none found'}")
 
     def _start_sleep_panes(self) -> None:

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -65,6 +65,8 @@ class PowerManager(Node):
 
         self._last_activity = time.monotonic()
         self._skill_in_flight = False
+        self._ssh_active = False  # cached; refreshed off-executor by _idle_tick
+        self._ssh_check_inflight = False
         self._nav_mode = "none"  # live value from /nav/current_mode
         self._nav_mode_before_sleep = "none"
         self._brain_active = False  # live value from /brain/agent_status
@@ -206,13 +208,17 @@ class PowerManager(Node):
         except json.JSONDecodeError:
             pass
 
-    def _ssh_session_active(self) -> bool:
+    def _refresh_ssh_activity(self) -> None:
+        """Runs on a short-lived thread — `ss` can stall for seconds under load,
+        and _idle_tick is an executor callback that must never block."""
         try:
             out = subprocess.run(_SS_ESTABLISHED_SSH, capture_output=True, text=True, timeout=5)
-            return bool(out.stdout.strip())
+            self._ssh_active = bool(out.stdout.strip())
         except (OSError, subprocess.SubprocessError) as e:
             self.get_logger().warning(f"SSH activity check failed: {e}")
-            return False
+            self._ssh_active = False
+        finally:
+            self._ssh_check_inflight = False
 
     def _idle_tick(self) -> None:
         if self.state != STATE_AWAKE:
@@ -223,7 +229,12 @@ class PowerManager(Node):
         if self._skill_in_flight or self._nav_mode in ("mapping", "switching"):
             self._touch_activity()
             return
-        if self._ssh_session_active():
+        if not self._ssh_check_inflight:
+            self._ssh_check_inflight = True
+            threading.Thread(target=self._refresh_ssh_activity, daemon=True).start()
+        # Reads the previous tick's result — one 10 s tick of lag is nothing
+        # against an idle window measured in minutes.
+        if self._ssh_active:
             self._touch_activity()
             return
         if time.monotonic() - self._last_activity >= idle_minutes * 60:
@@ -301,6 +312,9 @@ class PowerManager(Node):
 
     def _wake_sequence(self) -> None:
         # Compute first so the robot feels responsive from the very first second.
+        # jetson-perf pins nvpmodel -m 2 + jetson_clocks in its loop; the explicit
+        # nvpmodel call restores the power budget even if the service is absent.
+        self._run_privileged(["/usr/sbin/nvpmodel", "-m", "2"])
         self._run_privileged(["systemctl", "start", "jetson-perf.service"])
         self._start_camera_container()
         self._call(self._lidar_start_client, Empty.Request(), "lidar motor on")

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -21,7 +21,6 @@ State is broadcast on /power/state ("awake" / "going_to_sleep" / "sleeping" /
 """
 
 import json
-import os
 import subprocess
 import threading
 import time
@@ -41,20 +40,18 @@ STATE_GOING_TO_SLEEP = "going_to_sleep"
 STATE_SLEEPING = "sleeping"
 STATE_WAKING = "waking"
 
-# tmux layout from scripts/launch_ros_in_tmux.sh. These panes run the camera
-# container and heavy nodes with no role in sleeping or waking; their shells
-# keep the sourced ROS env, so we can Ctrl-C the launch to sleep and re-send
-# the command to wake. Deliberately kept alive: app-bringup (rosbridge + this
-# node + PCB/battery i2c), the arm node (head-boop source), mode_manager (nav
-# restore service), input_manager, and console/webapp (the app surface).
+# tmux layout from scripts/launch_ros_in_tmux.sh. Light sleep stops only the
+# camera container (real USB/encode power) and the data recorder (useless while
+# asleep, cheap to relaunch); their pane shells keep the sourced ROS env, so we
+# Ctrl-C the launch to sleep and re-send the command to wake. The rest of the
+# graph stays up so wake is instant — killing brain/MoveIt/ik saved ~30 mA for
+# a 10-20 s slower wake, not worth it for a light sleep. Neither pane here owns
+# a move_group, so no orphan cleanup is needed.
 TMUX_SESSION = "ros_nodes"
 # (window, fallback pane index, process match, relaunch command)
 _SLEEP_PANES = [
     ("cam-leader", 0, "camera_composable", "ros2 launch mars_cam camera_composable.launch.py"),
-    ("brain-nav", 0, "brain_client.launch.py", "ros2 launch brain_client brain_client.launch.py"),
-    ("behaviors-inputs", 0, "behavior.launch.py", "ros2 launch manipulation behavior.launch.py"),
     ("arm-recorder", 1, "recorder.launch.py", "ros2 launch manipulation recorder.launch.py"),
-    ("ik-logger", 0, "ik.launch.py", "ros2 launch mars_arm ik.launch.py"),
 ]
 
 # Terminal statuses from skills_server._publish_skill_status; anything else
@@ -363,8 +360,6 @@ class PowerManager(Node):
         self._run_privileged([_SLEEP_CLOCKS_SCRIPT, "wake"])
         self._run_privileged(["/usr/sbin/nvpmodel", "-m", "2"])
         self._run_privileged(["systemctl", "start", "jetson-perf.service"])
-        # Relaunch the stopped panes first — brain/MoveIt startup overlaps the
-        # rest of the wake sequence.
         self._start_sleep_panes()
         self._call(self._lidar_start_client, Empty.Request(), "lidar motor on")
         self._call(self._arm_low_power_client, SetBool.Request(data=False), "arm loop full rate")
@@ -380,8 +375,7 @@ class PowerManager(Node):
                 timeout=60.0,
             )
         if self._brain_active_before_sleep:
-            # brain_client is still booting from the pane relaunch above.
-            self._call(self._brain_active_client, SetBool.Request(data=True), "brain on", wait=30.0)
+            self._call(self._brain_active_client, SetBool.Request(data=True), "brain on")
 
         self._head_position_pub.publish(Int32(data=0))
         self._touch_activity()
@@ -395,12 +389,12 @@ class PowerManager(Node):
 
     # -------------------------------------------------------------- helpers
 
-    def _call(self, client, request, label: str, timeout: float = 10.0, wait: float = 3.0) -> None:
+    def _call(self, client, request, label: str, timeout: float = 10.0) -> None:
         """Fire a service call from the transition thread and wait for it.
 
         Failures are logged and skipped: a missing subsystem (e.g. lidar
         unplugged on a dev bench) must not abort the whole transition."""
-        if not client.wait_for_service(timeout_sec=wait):
+        if not client.wait_for_service(timeout_sec=3.0):
             self.get_logger().warning(f"[{label}] service {client.srv_name} unavailable, skipping")
             return
         future = client.call_async(request)
@@ -461,58 +455,17 @@ class PowerManager(Node):
                 return pane_id
         return None
 
-    def _pane_move_group_pids(self, pane: str) -> list[str]:
-        """move_group PIDs spawned under this pane (a grandchild of the pane
-        shell via `ros2 launch`), captured *before* the pane is stopped —
-        move_group hangs on SIGINT and orphans to init, and killing by name
-        later would also hit the arm's move_group, whose pane we keep running."""
-        listing = self._tmux("list-panes", "-t", pane, "-F", "#{pane_id} #{pane_pid}")
-        if listing is None or listing.returncode != 0:
-            return []
-        shell_pid = None
-        for line in listing.stdout.splitlines():
-            pid_field, _, ppid_field = line.partition(" ")
-            if pid_field == pane:
-                shell_pid = ppid_field.strip()
-                break
-        if not shell_pid:
-            return []
-        pids, frontier = [], [shell_pid]
-        while frontier:
-            try:
-                out = subprocess.run(
-                    ["ps", "-o", "pid=,args=", "--ppid", frontier.pop()],
-                    capture_output=True, text=True, timeout=5,
-                ).stdout
-            except (OSError, subprocess.SubprocessError):
-                continue
-            for entry in out.splitlines():
-                child_pid, _, child_args = entry.strip().partition(" ")
-                if not child_pid:
-                    continue
-                frontier.append(child_pid)
-                if "moveit_ros_move_group/move_group" in child_args:
-                    pids.append(child_pid)
-        return pids
-
     def _stop_sleep_panes(self) -> None:
         stopped = []
-        move_group_pids: set[str] = set()
         for window, _, match, _ in _SLEEP_PANES:
             pane = self._find_pane(window, match)
             if pane is None:
                 self.get_logger().warning(f"[{match}] pane not found — may already be down")
                 continue
             self._pane_ids[match] = pane
-            move_group_pids.update(self._pane_move_group_pids(pane))
             self._tmux("send-keys", "-t", pane, "C-c")
             stopped.append(match)
-        time.sleep(5.0)  # ros2 launch escalates SIGINT -> SIGTERM for its children
-        # Force-kill only the move_group copies these panes owned (they hang on
-        # SIGINT). The arm's move_group is a different PID we never captured.
-        for pid in move_group_pids:
-            if os.path.exists(f"/proc/{pid}"):
-                subprocess.run(["kill", "-9", pid], check=False)
+        time.sleep(5.0)  # ros2 launch tears the launch down gracefully on SIGINT
         self.get_logger().info(f"[panes off] {', '.join(stopped) if stopped else 'none found'}")
 
     def _start_sleep_panes(self) -> None:

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -21,6 +21,7 @@ State is broadcast on /power/state ("awake" / "going_to_sleep" / "sleeping" /
 """
 
 import json
+import os
 import subprocess
 import threading
 import time
@@ -460,26 +461,58 @@ class PowerManager(Node):
                 return pane_id
         return None
 
+    def _pane_move_group_pids(self, pane: str) -> list[str]:
+        """move_group PIDs spawned under this pane (a grandchild of the pane
+        shell via `ros2 launch`), captured *before* the pane is stopped —
+        move_group hangs on SIGINT and orphans to init, and killing by name
+        later would also hit the arm's move_group, whose pane we keep running."""
+        listing = self._tmux("list-panes", "-t", pane, "-F", "#{pane_id} #{pane_pid}")
+        if listing is None or listing.returncode != 0:
+            return []
+        shell_pid = None
+        for line in listing.stdout.splitlines():
+            pid_field, _, ppid_field = line.partition(" ")
+            if pid_field == pane:
+                shell_pid = ppid_field.strip()
+                break
+        if not shell_pid:
+            return []
+        pids, frontier = [], [shell_pid]
+        while frontier:
+            try:
+                out = subprocess.run(
+                    ["ps", "-o", "pid=,args=", "--ppid", frontier.pop()],
+                    capture_output=True, text=True, timeout=5,
+                ).stdout
+            except (OSError, subprocess.SubprocessError):
+                continue
+            for entry in out.splitlines():
+                child_pid, _, child_args = entry.strip().partition(" ")
+                if not child_pid:
+                    continue
+                frontier.append(child_pid)
+                if "moveit_ros_move_group/move_group" in child_args:
+                    pids.append(child_pid)
+        return pids
+
     def _stop_sleep_panes(self) -> None:
         stopped = []
+        move_group_pids: set[str] = set()
         for window, _, match, _ in _SLEEP_PANES:
             pane = self._find_pane(window, match)
             if pane is None:
                 self.get_logger().warning(f"[{match}] pane not found — may already be down")
                 continue
             self._pane_ids[match] = pane
+            move_group_pids.update(self._pane_move_group_pids(pane))
             self._tmux("send-keys", "-t", pane, "C-c")
             stopped.append(match)
-        time.sleep(5.0)  # ros2 launch tears everything down gracefully on SIGINT
-        # Second Ctrl-C for launches still up (ros2 launch escalates to SIGTERM).
-        for window, _, match, _ in _SLEEP_PANES:
-            if match in self._pane_ids and self._find_pane(window, match) is not None:
-                self._tmux("send-keys", "-t", self._pane_ids[match], "C-c")
-                time.sleep(3.0)
-        # move_group regularly hangs on SIGINT and outlives its dying launch;
-        # an orphan would be duplicated by the wake relaunch. Both launches
-        # that own one are stopped here, so any survivor is fair game.
-        subprocess.run(["pkill", "-f", "moveit_ros_move_group/move_group"], check=False)
+        time.sleep(5.0)  # ros2 launch escalates SIGINT -> SIGTERM for its children
+        # Force-kill only the move_group copies these panes owned (they hang on
+        # SIGINT). The arm's move_group is a different PID we never captured.
+        for pid in move_group_pids:
+            if os.path.exists(f"/proc/{pid}"):
+                subprocess.run(["kill", "-9", pid], check=False)
         self.get_logger().info(f"[panes off] {', '.join(stopped) if stopped else 'none found'}")
 
     def _start_sleep_panes(self) -> None:

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -32,7 +32,7 @@ from mars_bringup.config_loader import innate_os_root
 from geometry_msgs.msg import Vector3
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
-from std_msgs.msg import Int32, String
+from std_msgs.msg import Bool, Int32, String
 from std_srvs.srv import Empty, SetBool, Trigger
 
 STATE_AWAKE = "awake"
@@ -112,6 +112,7 @@ class PowerManager(Node):
         self._arm_torque_on_client = self.create_client(Trigger, "/mars/arm/torque_on")
         self._head_servo_client = self.create_client(SetBool, "/mars/head/enable_servo")
         self._arm_low_power_client = self.create_client(SetBool, "/mars/arm/low_power_mode")
+        self._pcb_power_client = self.create_client(SetBool, "/pcb/power_mode")
 
         # Activity signals
         self.create_subscription(Vector3, "/joystick", self._on_joystick, 10)
@@ -121,6 +122,7 @@ class PowerManager(Node):
         self.create_subscription(String, "/nav/current_mode", self._on_nav_mode, 10)
         self.create_subscription(String, "/brain/agent_status", self._on_agent_status, latched)
         self.create_subscription(String, "/mars/head/current_position", self._on_head_position, 10)
+        self.create_subscription(Bool, "/pcb/motion_wake_pending", self._on_pcb_motion_wake, 10)
 
         self.create_timer(1.0, self._publish_state)
         self.create_timer(10.0, self._idle_tick)
@@ -303,6 +305,12 @@ class PowerManager(Node):
         else:
             self._boop_hits = 0
 
+    def _on_pcb_motion_wake(self, msg: Bool) -> None:
+        # The PCB's IMU latched a physical disturbance (tap/nudge/pickup)
+        # during sleep — the wake path that survives HSSW rail gating.
+        if msg.data:
+            self._wake_if_sleeping("PCB motion wake")
+
     def _wake_if_sleeping(self, reason: str) -> None:
         if self.state == STATE_SLEEPING:
             self._start_transition(
@@ -345,6 +353,11 @@ class PowerManager(Node):
         # (must run after nvpmodel, which rewrites the cpufreq limits).
         self._run_privileged([_SLEEP_CLOCKS_SCRIPT, "sleep"])
 
+        # PCB sleep last, once the mechanics have settled: torque-off slump
+        # and the head droop would otherwise latch a phantom motion event the
+        # moment wake-on-motion arms. (Soft sleep — HSSW gating comes later.)
+        self._call(self._pcb_power_client, SetBool.Request(data=True), "PCB sleep")
+
         # Arm the boop detector: give the torque-less head a moment to settle
         # before the rolling window starts filling.
         self._head_history.clear()
@@ -360,6 +373,9 @@ class PowerManager(Node):
         self._run_privileged([_SLEEP_CLOCKS_SCRIPT, "wake"])
         self._run_privileged(["/usr/sbin/nvpmodel", "-m", "2"])
         self._run_privileged(["systemctl", "start", "jetson-perf.service"])
+        # PCB wake early: once HSSW gating lands, the rail needs its ~550 ms
+        # re-init done before any Dynamixel traffic (torque-on below).
+        self._call(self._pcb_power_client, SetBool.Request(data=False), "PCB wake")
         self._start_sleep_panes()
         self._call(self._lidar_start_client, Empty.Request(), "lidar motor on")
         self._call(self._arm_low_power_client, SetBool.Request(data=False), "arm loop full rate")

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -133,37 +133,45 @@ class PowerManager(Node):
 
     def _on_sleep_request(self, request, response):
         del request
-        started = self._start_transition(self._sleep_sequence, from_state=STATE_AWAKE)
+        started = self._start_transition(
+            self._sleep_sequence, from_state=STATE_AWAKE, during_state=STATE_GOING_TO_SLEEP
+        )
         response.success = started
         response.message = "Going to sleep" if started else f"Cannot sleep from state '{self.state}'"
         return response
 
     def _on_wake_request(self, request, response):
         del request
-        started = self._start_transition(self._wake_sequence, from_state=STATE_SLEEPING, reason="wake service")
+        started = self._start_transition(
+            self._wake_sequence, from_state=STATE_SLEEPING, during_state=STATE_WAKING, reason="wake service"
+        )
         response.success = started
         response.message = "Waking up" if started else f"Cannot wake from state '{self.state}'"
         return response
 
-    def _start_transition(self, sequence, from_state: str, reason: str = "") -> bool:
+    def _start_transition(self, sequence, from_state: str, during_state: str, reason: str = "") -> bool:
         """Kick off a sleep/wake sequence in a worker thread (service callbacks
-        must not block the executor — the sequences themselves call services)."""
+        must not block the executor — the sequences themselves call services).
+
+        `during_state` is passed explicitly rather than derived from `sequence`:
+        bound methods are recreated per attribute access, so identity checks
+        like `sequence is self._sleep_sequence` are always False."""
         with self._state_lock:
             if self._state != from_state:
                 return False
-            self._state = STATE_GOING_TO_SLEEP if sequence is self._sleep_sequence else STATE_WAKING
+            self._state = during_state
         self._state_pub.publish(String(data=self.state))
         self.get_logger().info(f"Power state: {self.state}" + (f" ({reason})" if reason else ""))
-        threading.Thread(target=self._run_transition, args=(sequence,), daemon=True).start()
+        threading.Thread(target=self._run_transition, args=(sequence, during_state), daemon=True).start()
         return True
 
-    def _run_transition(self, sequence) -> None:
+    def _run_transition(self, sequence, during_state: str) -> None:
         with self._transition_lock:
             try:
                 sequence()
             except Exception as e:  # a half-finished transition is recoverable via the other service
                 self.get_logger().error(f"Power transition failed: {e}")
-                self._set_state(STATE_AWAKE if sequence is self._wake_sequence else STATE_SLEEPING)
+                self._set_state(STATE_SLEEPING if during_state == STATE_GOING_TO_SLEEP else STATE_AWAKE)
 
     # ------------------------------------------------------------- activity
 
@@ -239,7 +247,12 @@ class PowerManager(Node):
             return
         if time.monotonic() - self._last_activity >= idle_minutes * 60:
             self.get_logger().info(f"Idle for {idle_minutes} minutes — going to sleep")
-            self._start_transition(self._sleep_sequence, from_state=STATE_AWAKE, reason="idle timeout")
+            self._start_transition(
+                self._sleep_sequence,
+                from_state=STATE_AWAKE,
+                during_state=STATE_GOING_TO_SLEEP,
+                reason="idle timeout",
+            )
 
     # ------------------------------------------------------------- head boop
 
@@ -274,7 +287,9 @@ class PowerManager(Node):
 
     def _wake_if_sleeping(self, reason: str) -> None:
         if self.state == STATE_SLEEPING:
-            self._start_transition(self._wake_sequence, from_state=STATE_SLEEPING, reason=reason)
+            self._start_transition(
+                self._wake_sequence, from_state=STATE_SLEEPING, during_state=STATE_WAKING, reason=reason
+            )
 
     # ------------------------------------------------------------- sequences
 
@@ -300,7 +315,10 @@ class PowerManager(Node):
         self._stop_camera_container()
         self._run_privileged(["systemctl", "stop", "speaker-keepalive.service"])
         self._run_privileged(["systemctl", "stop", "jetson-perf.service"])
-        self._run_privileged(["/usr/sbin/nvpmodel", "-m", "3"])  # 7W profile
+        # 15W profile — the lowest reachable live: 7W (-m 3) takes CPU cores
+        # offline, which nvpmodel only does across a reboot (it prompts and
+        # aborts, rc=234 "Golden image context is already created").
+        self._run_privileged(["/usr/sbin/nvpmodel", "-m", "0"])
 
         # Arm the boop detector: give the torque-less head a moment to settle,
         # then take the first reading after that as the baseline.

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -71,6 +71,12 @@ class PowerManager(Node):
 
         self.declare_parameter("sleep_after_idle_minutes", 0)
         self.declare_parameter("boop_wake_threshold_degrees", 4)
+        # Cut the HSSW rail (arm/head Dynamixels + wheel drivers) during sleep.
+        # Shared with bringup via a /** setting so the two stay in lockstep:
+        # when set, the arm bus is fully suspended (not just decimated) and the
+        # servos are re-initialized on wake. Physical wake is then the PCB's IMU
+        # motion latch, not the servo-polling boop (the bus is dead).
+        self.declare_parameter("gate_hssw_on_sleep", True)
 
         self._state = STATE_AWAKE
         self._state_lock = threading.Lock()
@@ -112,6 +118,7 @@ class PowerManager(Node):
         self._arm_torque_on_client = self.create_client(Trigger, "/mars/arm/torque_on")
         self._head_servo_client = self.create_client(SetBool, "/mars/head/enable_servo")
         self._arm_low_power_client = self.create_client(SetBool, "/mars/arm/low_power_mode")
+        self._arm_bus_suspend_client = self.create_client(SetBool, "/mars/arm/bus_suspend")
         self._pcb_power_client = self.create_client(SetBool, "/pcb/power_mode")
 
         # Activity signals
@@ -338,10 +345,15 @@ class PowerManager(Node):
         self._call(self._lidar_stop_client, Empty.Request(), "lidar motor off")
         self._call(self._arm_torque_off_client, Trigger.Request(), "arm torque off")
         self._call(self._head_servo_client, SetBool.Request(data=False), "head torque off")
-        # ~10 Hz is plenty for the boop detector, and the 200 Hz stream is the
-        # main CPU load during sleep (it fans out through /joint_states -> /tf
-        # into every Python subscriber and TF listener).
-        self._call(self._arm_low_power_client, SetBool.Request(data=True), "arm loop 10Hz")
+        gate = self.get_parameter("gate_hssw_on_sleep").value
+        if gate:
+            # Rail about to be cut: fully stop the arm bus (the servos go dead).
+            # Must precede the PCB gate below so the loop never polls a dead bus.
+            self._call(self._arm_bus_suspend_client, SetBool.Request(data=True), "arm bus suspend")
+        else:
+            # Soft sleep: keep the bus alive but slow (~10 Hz is plenty for the
+            # boop detector; the 200 Hz stream is the main CPU load asleep).
+            self._call(self._arm_low_power_client, SetBool.Request(data=True), "arm loop 10Hz")
         self._stop_sleep_panes()
         self._run_privileged(["systemctl", "stop", "speaker-keepalive.service"])
         self._run_privileged(["systemctl", "stop", "jetson-perf.service"])
@@ -355,7 +367,8 @@ class PowerManager(Node):
 
         # PCB sleep last, once the mechanics have settled: torque-off slump
         # and the head droop would otherwise latch a phantom motion event the
-        # moment wake-on-motion arms. (Soft sleep — HSSW gating comes later.)
+        # moment wake-on-motion arms. Gates the HSSW rail when gate_hssw_on_sleep
+        # is set (bringup reads the same /** setting).
         self._call(self._pcb_power_client, SetBool.Request(data=True), "PCB sleep")
 
         # Arm the boop detector: give the torque-less head a moment to settle
@@ -373,12 +386,21 @@ class PowerManager(Node):
         self._run_privileged([_SLEEP_CLOCKS_SCRIPT, "wake"])
         self._run_privileged(["/usr/sbin/nvpmodel", "-m", "2"])
         self._run_privileged(["systemctl", "start", "jetson-perf.service"])
-        # PCB wake early: once HSSW gating lands, the rail needs its ~550 ms
-        # re-init done before any Dynamixel traffic (torque-on below).
+        # PCB wake early: the gated HSSW rail needs its ~550 ms re-init done
+        # before any Dynamixel traffic (bus resume / torque-on below).
         self._call(self._pcb_power_client, SetBool.Request(data=False), "PCB wake")
         self._start_sleep_panes()
         self._call(self._lidar_start_client, Empty.Request(), "lidar motor on")
-        self._call(self._arm_low_power_client, SetBool.Request(data=False), "arm loop full rate")
+        gate = self.get_parameter("gate_hssw_on_sleep").value
+        if gate:
+            # Let the rail settle after the MCU's ~550 ms wheel-driver re-init,
+            # then re-initialize the power-cycled servos (torque still off).
+            time.sleep(1.0)
+            self._call(
+                self._arm_bus_suspend_client, SetBool.Request(data=False), "arm bus resume", timeout=25.0
+            )
+        else:
+            self._call(self._arm_low_power_client, SetBool.Request(data=False), "arm loop full rate")
         self._call(self._head_servo_client, SetBool.Request(data=True), "head torque on")
         self._call(self._arm_torque_on_client, Trigger.Request(), "arm torque on")
         self._run_privileged(["systemctl", "start", "speaker-keepalive.service"])

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/power_manager.py
@@ -98,6 +98,7 @@ class PowerManager(Node):
         self._arm_torque_off_client = self.create_client(Trigger, "/mars/arm/torque_off")
         self._arm_torque_on_client = self.create_client(Trigger, "/mars/arm/torque_on")
         self._head_servo_client = self.create_client(SetBool, "/mars/head/enable_servo")
+        self._arm_low_power_client = self.create_client(SetBool, "/mars/arm/low_power_mode")
 
         # Activity signals
         self.create_subscription(Vector3, "/joystick", self._on_joystick, 10)
@@ -312,6 +313,10 @@ class PowerManager(Node):
         self._call(self._lidar_stop_client, Empty.Request(), "lidar motor off")
         self._call(self._arm_torque_off_client, Trigger.Request(), "arm torque off")
         self._call(self._head_servo_client, SetBool.Request(data=False), "head torque off")
+        # ~10 Hz is plenty for the boop detector, and the 200 Hz stream is the
+        # main CPU load during sleep (it fans out through /joint_states -> /tf
+        # into every Python subscriber and TF listener).
+        self._call(self._arm_low_power_client, SetBool.Request(data=True), "arm loop 10Hz")
         self._stop_camera_container()
         self._run_privileged(["systemctl", "stop", "speaker-keepalive.service"])
         self._run_privileged(["systemctl", "stop", "jetson-perf.service"])
@@ -336,6 +341,7 @@ class PowerManager(Node):
         self._run_privileged(["systemctl", "start", "jetson-perf.service"])
         self._start_camera_container()
         self._call(self._lidar_start_client, Empty.Request(), "lidar motor on")
+        self._call(self._arm_low_power_client, SetBool.Request(data=False), "arm loop full rate")
         self._call(self._head_servo_client, SetBool.Request(data=True), "head torque on")
         self._call(self._arm_torque_on_client, Trigger.Request(), "arm torque on")
         self._run_privileged(["systemctl", "start", "speaker-keepalive.service"])

--- a/ros2_ws/src/mars_bot/mars_bringup/package.xml
+++ b/ros2_ws/src/mars_bot/mars_bringup/package.xml
@@ -30,6 +30,7 @@
   <depend>tf2_geometry_msgs</depend>
 
   <!-- Internal package dependencies -->
+  <exec_depend>brain_messages</exec_depend>
   <exec_depend>mars_msgs</exec_depend>
   <exec_depend>mars_sim</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -909,13 +909,28 @@ class ModeManager(Node):
 
         try:
             target_mode = request.mode.strip().lower()
+
+            # "off" tears the whole nav stack down (used by the power manager's
+            # sleep mode). Deliberately not persisted: .last_mode keeps the
+            # pre-sleep mode so boot and wake restore it.
+            if target_mode == "off":
+                self.current_mode = "switching"
+                self.publish_status()
+                for mode in NavigationMode:
+                    self.shutdown_mode(mode.value)
+                self.current_mode = "none"
+                response.success = True
+                response.message = "Navigation stack off"
+                self.get_logger().info(response.message)
+                return response
+
             if self.current_map is None:
                 target_mode = "mapping"
 
             # Validate mode
             if target_mode not in ["navigation", "mapping", "mapfree"]:
                 response.success = False
-                response.message = f"Invalid mode '{target_mode}'. Use 'navigation', 'mapping', or 'mapfree'"
+                response.message = f"Invalid mode '{target_mode}'. Use 'navigation', 'mapping', 'mapfree', or 'off'"
                 self.get_logger().error(response.message)
                 return response
 

--- a/scripts/power/sleep-clocks.sh
+++ b/scripts/power/sleep-clocks.sh
@@ -14,8 +14,19 @@
 
 set -u
 
-SLEEP_MAX_FREQ=422400
+# Cores idle at the 115 MHz floor either way; the max only caps bursts. 268 MHz
+# keeps zenoh/rosbridge/SSH usable — don't go to 115: wake itself starts at
+# these clocks.
+SLEEP_MAX_FREQ=268800
 WAKE_MIN_FREQ=729600  # matches every nvpmodel profile's min
+
+# EMC (memory) cap — VDD_SOC (~2.6 W) tracks EMC and is the largest fixed
+# Jetson draw during sleep. 665.6 MHz is a standard Orin OPP; nothing needs
+# bandwidth while asleep. The wake value matches MAXN_SUPER, and the wake
+# sequence runs nvpmodel -m 2 right after, which rewrites the cap anyway.
+EMC_CAP=/sys/kernel/nvpmodel_clk_cap/emc
+SLEEP_EMC_FREQ=665600000
+WAKE_EMC_FREQ=3199000000
 
 case "${1:-}" in
     sleep)
@@ -27,8 +38,10 @@ case "${1:-}" in
             cat "$policy/cpuinfo_min_freq" > "$policy/scaling_min_freq"
             echo "$SLEEP_MAX_FREQ" > "$policy/scaling_max_freq"
         done
+        [ -w "$EMC_CAP" ] && echo "$SLEEP_EMC_FREQ" > "$EMC_CAP"
         ;;
     wake)
+        [ -w "$EMC_CAP" ] && echo "$WAKE_EMC_FREQ" > "$EMC_CAP"
         for cpu in 4 5; do
             echo 1 > "/sys/devices/system/cpu/cpu$cpu/online"
         done

--- a/scripts/power/sleep-clocks.sh
+++ b/scripts/power/sleep-clocks.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+#
+# Live CPU power reduction for robot sleep mode. Called by the power_manager
+# node via `sudo -n` (sudoers entry installed by scripts/update/post_update.sh).
+#
+# "sleep" mimics the CPU side of nvpmodel's 7W profile, which nvpmodel itself
+# refuses to apply without a reboot: offline cores 4-5 and let the rest scale
+# down to the lowest OPP (115 MHz idle, capped at 422 MHz under load — enough
+# to keep zenoh/rosbridge responsive for wake triggers).
+# "wake" undoes it; the wake sequence re-pins full performance right after via
+# nvpmodel -m 2 + jetson-perf.
+
+set -u
+
+SLEEP_MAX_FREQ=422400
+WAKE_MIN_FREQ=729600  # matches every nvpmodel profile's min
+
+case "${1:-}" in
+    sleep)
+        for cpu in 4 5; do
+            echo 0 > "/sys/devices/system/cpu/cpu$cpu/online"
+        done
+        for policy in /sys/devices/system/cpu/cpufreq/policy*; do
+            [ -f "$policy/scaling_max_freq" ] || continue  # fully-offline cluster
+            cat "$policy/cpuinfo_min_freq" > "$policy/scaling_min_freq"
+            echo "$SLEEP_MAX_FREQ" > "$policy/scaling_max_freq"
+        done
+        ;;
+    wake)
+        for cpu in 4 5; do
+            echo 1 > "/sys/devices/system/cpu/cpu$cpu/online"
+        done
+        for policy in /sys/devices/system/cpu/cpufreq/policy*; do
+            [ -f "$policy/scaling_max_freq" ] || continue
+            cat "$policy/cpuinfo_max_freq" > "$policy/scaling_max_freq"
+            echo "$WAKE_MIN_FREQ" > "$policy/scaling_min_freq"
+        done
+        ;;
+    *)
+        echo "usage: $0 sleep|wake" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -849,6 +849,7 @@ $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop jetson-perf.service
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start speaker-keepalive.service
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop speaker-keepalive.service
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/sbin/nvpmodel -m 0, /usr/sbin/nvpmodel -m 1, /usr/sbin/nvpmodel -m 2, /usr/sbin/nvpmodel -m 3
+$ACTUAL_USER ALL=(ALL) NOPASSWD: $REPO_DIR/scripts/power/sleep-clocks.sh
 EOF
 chmod 440 "$SUDOERS_FILE"
 log "  Sudoers configured for $ACTUAL_USER"

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -842,6 +842,13 @@ $ACTUAL_USER ALL=(ALL) NOPASSWD: /bin/nmcli
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start ros-app.service
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop ros-app.service
 $ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart ros-app.service
+
+# Sleep mode (called by the power_manager node)
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start jetson-perf.service
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop jetson-perf.service
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl start speaker-keepalive.service
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop speaker-keepalive.service
+$ACTUAL_USER ALL=(ALL) NOPASSWD: /usr/sbin/nvpmodel -m 0, /usr/sbin/nvpmodel -m 1, /usr/sbin/nvpmodel -m 2, /usr/sbin/nvpmodel -m 3
 EOF
 chmod 440 "$SUDOERS_FILE"
 log "  Sudoers configured for $ACTUAL_USER"

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -81,6 +81,13 @@ export const ROBOT_INFO_TOPIC = "/robot/info";
 // mobile app's volume slider calls; current value rides on /robot/info.
 export const SET_VOLUME_SERVICE = "/set_volume";
 
+// Light sleep (power_manager). State is a plain std_msgs/String:
+// "awake" | "going_to_sleep" | "sleeping" | "waking" (latched + 1 Hz heartbeat).
+// Sleep/wake are std_srvs/Trigger. Same services the mobile app should call.
+export const POWER_STATE_TOPIC = "/power/state";
+export const POWER_SLEEP_SERVICE = "/power/sleep";
+export const POWER_WAKE_SERVICE = "/power/wake";
+
 // WebRTC signaling over rosbridge. START is a std_msgs/String JSON payload that
 // carries our client_id: {"source":"live","audio":bool,"client_id":"...","video":[...]}.
 // The robot routes offer/answer/ICE on the *_id topics, each enveloped as {client_id, ...}

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -90,6 +90,14 @@ export const CATALOG = [
     ],
   },
   {
+    section: "Sleep mode",
+    note: "Light sleep powers down lidar, cameras, nav and arm torque. SSH sessions, teleop, skills and camera viewers count as activity. Wake from the app or boop the head.",
+    knobs: [
+      { path: ["power_manager", P, "sleep_after_idle_minutes"], label: "Auto-sleep after idle", default: 0, type: "int", unit: "min", doc: "Enter sleep after this many idle minutes (0 = never)", min: 0, max: 1440 },
+      { path: ["power_manager", P, "boop_wake_threshold_degrees"], label: "Boop sensitivity", default: 4, type: "int", unit: "°", doc: "Head movement that counts as a wake-up boop", min: 2, max: 20 },
+    ],
+  },
+  {
     section: "Arm",
     knobs: [
       { path: ["mars_arm", P, "max_jerk"], label: "Max jerk", default: 150.0, type: "float", unit: "rad/s³", doc: "Trajectory jerk limit (0 disables)" },

--- a/webapp/js/teleop/telemetry.js
+++ b/webapp/js/teleop/telemetry.js
@@ -5,7 +5,14 @@
 // sensor_msgs/BatteryState at 0.2 Hz; name/version ride /robot/info's
 // JSON-in-String payload.
 
-import { BATTERY_STATE_TOPIC, ROBOT_INFO_TOPIC, WEBSOCKET_STATUS_TOPIC } from "../constants.js";
+import {
+  BATTERY_STATE_TOPIC,
+  POWER_SLEEP_SERVICE,
+  POWER_STATE_TOPIC,
+  POWER_WAKE_SERVICE,
+  ROBOT_INFO_TOPIC,
+  WEBSOCKET_STATUS_TOPIC,
+} from "../constants.js";
 
 /**
  * @param {HTMLElement} parent
@@ -21,12 +28,28 @@ export function createTelemetry(parent, rosClient, opts = {}) {
 
   const name = item("robot", "—");
   const battery = showBattery ? item("batt", "—") : null;
+  // Sleep/wake state; click toggles it (sleep when awake, wake when asleep).
+  const power = item("power", "—");
   const link = item("link", "—");
   // Cloud/local agent backend connection (the brain's websocket to its agent
   // backend) — distinct from the rosbridge LINK above.
   const agent = item("agent", "—");
-  wrap.append(name.el, ...(battery ? [battery.el] : []), link.el, agent.el);
+  wrap.append(name.el, ...(battery ? [battery.el] : []), power.el, link.el, agent.el);
   parent.appendChild(wrap);
+
+  let powerState = "";
+  power.el.style.cursor = "pointer";
+  power.el.title = "Click to put the robot to sleep / wake it up";
+  power.el.addEventListener("click", async () => {
+    // Ignore clicks mid-transition; the state heartbeat will flip the label.
+    if (powerState !== "awake" && powerState !== "sleeping") return;
+    const service = powerState === "sleeping" ? POWER_WAKE_SERVICE : POWER_SLEEP_SERVICE;
+    try {
+      await rosClient.callService(service, {});
+    } catch (e) {
+      console.warn("power toggle failed", e);
+    }
+  });
 
   /**
    * @param {string} labelText
@@ -46,6 +69,19 @@ export function createTelemetry(parent, rosClient, opts = {}) {
   }
 
   const unsubs = [
+    rosClient.subscribe(POWER_STATE_TOPIC, (payload) => {
+      if (typeof payload?.data !== "string") return;
+      powerState = payload.data;
+      const labels = {
+        awake: "awake",
+        going_to_sleep: "sleeping…",
+        sleeping: "asleep",
+        waking: "waking…",
+      };
+      power.value.textContent = labels[powerState] ?? powerState;
+      power.el.classList.toggle("live", powerState === "awake");
+      power.el.classList.toggle("warn", powerState === "sleeping");
+    }),
     rosClient.subscribe(ROBOT_INFO_TOPIC, (payload) => {
       if (typeof payload?.data !== "string") return;
       /** @type {RobotInfo} */

--- a/workspace/innate_agents/basic_agent.py
+++ b/workspace/innate_agents/basic_agent.py
@@ -19,7 +19,7 @@ class BasicAgent(Agent):
 
     def get_skills(self) -> list[str]:
         """Return the list of skill IDs this directive can use"""
-        return ["innate-os/navigate_to_position", "innate-os/navigate_with_vision"]
+        return ["innate-os/navigate_to_position", "innate-os/navigate_with_vision", "innate-os/go_to_sleep"]
 
     def get_inputs(self) -> list[str]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_skills/go_to_sleep.py
+++ b/workspace/innate_skills/go_to_sleep.py
@@ -45,9 +45,9 @@ class GoToSleep(Skill):
         self.say("Going to sleep. Boop my head or use the app to wake me up.", wait=True)
 
         future = self._sleep_client.call_async(Trigger.Request())
-        deadline = time.time() + 10.0
+        deadline = time.monotonic() + 10.0
         while not future.done():
-            if time.time() > deadline:
+            if time.monotonic() > deadline:
                 return "Power manager did not answer in time", SkillResult.FAILURE
             time.sleep(0.05)
 

--- a/workspace/innate_skills/go_to_sleep.py
+++ b/workspace/innate_skills/go_to_sleep.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""
+Go To Sleep Skill - Put the robot into low-power sleep mode.
+"""
+
+import time
+
+from brain_client.skills.types import Skill, SkillResult
+from std_srvs.srv import Trigger
+
+
+class GoToSleep(Skill):
+    """Ask the power manager to enter light sleep."""
+
+    def __init__(self, logger):
+        super().__init__(logger)
+        self._sleep_client = None
+
+    @property
+    def name(self):
+        return "go_to_sleep"
+
+    def guidelines(self):
+        return (
+            "Put the robot into low-power sleep mode (lidar, cameras, navigation and "
+            "arm power down; the agent goes offline until wake-up). Use when asked to "
+            "sleep, rest, nap, or power down. The robot wakes from the app, joystick "
+            "or chat input, or a gentle push on its head."
+        )
+
+    def execute(self):
+        if self.node is None:
+            return "Robot node not available", SkillResult.FAILURE
+
+        if self._sleep_client is None:
+            self._sleep_client = self.node.create_client(Trigger, "/power/sleep")
+
+        if not self._sleep_client.wait_for_service(timeout_sec=5.0):
+            return "Power manager is not available", SkillResult.FAILURE
+
+        # Speak first: the power manager deactivates the brain (and with it TTS)
+        # a couple of seconds after accepting the sleep request.
+        self.say("Going to sleep. Boop my head or use the app to wake me up.", wait=True)
+
+        future = self._sleep_client.call_async(Trigger.Request())
+        deadline = time.time() + 10.0
+        while not future.done():
+            if time.time() > deadline:
+                return "Power manager did not answer in time", SkillResult.FAILURE
+            time.sleep(0.05)
+
+        result = future.result()
+        if result is None or not result.success:
+            reason = getattr(result, "message", "") or "unknown error"
+            return f"Could not go to sleep: {reason}", SkillResult.FAILURE
+
+        return "Going to sleep — wake me with a head boop or from the app", SkillResult.SUCCESS
+
+    def cancel(self):
+        # The handoff to the power manager is near-instant; nothing to unwind.
+        return "Nothing to cancel"


### PR DESCRIPTION
## Summary

- Adds **light-sleep mode**: the robot powers down its big consumers after an idle timeout (or on demand), while keeping the network path and a small state-machine node alive so it stays remotely wakeable in seconds.
- New `power_manager` node (`mars_bringup`) owns an `awake → going_to_sleep → sleeping → waking` state machine. It serves `/power/sleep` and `/power/wake` (`std_srvs/Trigger`) and publishes `/power/state` (latched `std_msgs/String` + 1 Hz heartbeat, mirroring `/brain/agent_status` delivery so late-joining rosbridge clients get it). Because both apps share the rosbridge surface, one service reaches web app, mobile app, and skills.
- **Sleep sequence:** head droop cue → brain off → nav stack down → lidar `/stop_motor` → arm + head torque off → camera container stopped → `jetson-perf`/`speaker-keepalive` stopped + `nvpmodel` 7W. **Wake** runs it in reverse (compute-first for responsiveness) and restores the pre-sleep nav mode and brain-active state.
- **Triggers:** `/power/sleep`/`/power/wake` services; a new `go_to_sleep` agent skill (registered in `basic_agent`); a click-to-toggle power chip in the webapp teleop telemetry strip; and auto-sleep after `sleep_after_idle_minutes` (new setting, `0` = never, live-tunable).
- **Activity signals that block/reset auto-sleep:** joystick, chat, WebRTC viewers, running skills, mapping mode, and **established SSH connections** (per requirement — SSH must not count as idle).
- **Wake triggers:** the services, joystick input, a chat message, or a **head boop** — head torque is off during sleep but `mars_arm` keeps streaming head position, so the node watches for a fast push (10 Hz sampling, creep-tracked baseline so slow gravity sag doesn't false-trigger).

### Key implementation notes for reviewers

- **New nav `"off"` mode** in `mode_manager.py` tears the whole nav2 stack down for sleep. It is deliberately **not persisted** — `.last_mode` keeps the pre-sleep mode so both wake and reboot restore it.
- **Camera stop/start** reuses the existing tmux mechanism: the node sends `Ctrl-C` to the `cam-leader` pane (found by matching the `camera_composable` child process) and re-sends the launch command on wake. The pane keeps its sourced ROS env, so no relaunch of the whole window is needed.
- **Privileged ops** (`nvpmodel`, `systemctl stop jetson-perf`/`speaker-keepalive`) run via `sudo -n` against new whitelisted entries added to `scripts/update/post_update.sh`'s sudoers heredoc. If the entries aren't installed yet, the node **degrades to a warning** and continues — sleep still powers down lidar/cameras/nav/torque, just not the Jetson clocks.
- Service calls in the sleep/wake sequence run on a worker thread (not the executor callback) and each failure is logged-and-skipped, so a missing subsystem on a dev bench can't wedge a transition.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - Built `mars_bringup` + `mars_nav` with `colcon build` (clean). Restarted `ros-app`; `power_manager` comes up reporting `awake`.
  - **Full cycle tested live on a robot:** `/power/sleep` → verified nav `none`, `/scan_fast` silent, camera container down; simulated head-boop → state went `waking`; verified full restore (nav back to `mapfree`, lidar scanning, `/mars/main_camera/left/image_raw` publishing).
  - **SSH guard tested:** with `sleep_after_idle_minutes=1` and an SSH session connected, the robot stayed `awake` past the timeout.
  - `go_to_sleep` confirmed appearing in `/brain/available_skills`.
  - **Not yet exercised on the test robot:** the `nvpmodel`/`systemctl` steps — the sudoers entries in `post_update.sh` weren't installed on that unit, so those steps warned-and-skipped (Jetson clocks stayed pinned). They will apply on any unit that has run `post_update.sh`.
- [ ] Simulator behavior/config/assets unchanged — N/A.
- [ ] No simulator asset changes — N/A.

## Follow-ups (out of scope for this PR)

- Physical finger-test of the head boop and tuning of `boop_wake_threshold_degrees` if needed.
- Deeper power savings (PCB `CMD_POWER` rail cut, wake-on-BT) are Phase 2.
