### PR TITLE
experiment(power): SLEEPNET — custom lowest nvpmodel mode with network wake

### DIFF
--- a/scripts/power/deep-sleep/README.md
+++ b/scripts/power/deep-sleep/README.md
@@ -55,6 +55,33 @@ Two ordering rules make this safe, both handled by `deep-sleep.sh`:
 - **`wake` restores the rail *before* the reboot** — so when `mars_arm` boots
   it finds powered servos to initialize (it inits once at startup, no retry).
 
+## USB peripheral cut (lidar board + cameras)
+
+All four onboard hubs are genuinely ppps-capable (verified: `uhubctl` port-off
+really cuts VBUS). Measured at the battery: hub `1-2.3` (lidar CP2102 board +
+3D camera) is worth **0.05 A**, the Arducam port another 0.01 A — **~0.7 W
+total**. The wake listener cuts both hubs at startup (WiFi/BT and the arm
+serial are on root ports, unaffected). Hub power state resets on reboot, which
+is why the cut runs at deep-sleep *boot* — and why the wake reboot restores
+port power with no code at all. Not applied to light sleep: there the lidar
+node holds the serial port open and cameras must re-enumerate on wake — real
+fragility for 0.7 W.
+
+## Measured results (jetson1, 2026-07-09)
+
+| State | Battery | Jetson VDD_IN |
+|---|---|---|
+| Awake (MAXN_SUPER, stack up) | ~1.5 A / ~18 W | 8.9 W |
+| Light sleep (PR #512) | ~1.13 A | 6.3 W |
+| Deep sleep (SLEEPNET + HSSW rail gated) | **0.75 A / 8.9 W** | 4.1 W |
+| + USB peripherals cut (projected) | **~0.69 A / ~8.2 W** | 4.1 W |
+
+Network wake (`POST :4022/wake`) verified end-to-end: full reboot back to
+MAXN_SUPER with the stack running. Remaining draw is the Jetson floor (~4 W —
+VDD_SOC's EMC-bound 1.2 W included), WiFi (the wake path — must stay), the
+PCB, and DC-DC losses: ~0.5-0.6 A is about the floor for a network-wakeable
+robot without new hardware.
+
 ## Flow
 
 ```

--- a/scripts/power/deep-sleep/README.md
+++ b/scripts/power/deep-sleep/README.md
@@ -40,33 +40,59 @@ Floors taken from this board's live tables (r36.4, Orin Nano Super):
 Further headroom if needed: try EMC below 665.6 MHz (bpmp clamps caps to its
 rate table; the floor is untested here), and single-core operation.
 
+## Rail gating too (the peripheral half)
+
+The Jetson is only ~half the idle draw; the arm/head Dynamixels on the PCB's
+HSSW rail are ~3-4 W of the rest. Because the whole ROS stack is down in deep
+sleep, `bringup` isn't there to drive the PCB — so `pcb-power.py` talks to the
+MCU (0x42) directly with the same `CMD_POWER` frame (firmware README §4.5) to
+gate the rail on `enter` and restore it on `wake`. No wake-on-motion is armed
+(the IMU sleeps too): deep sleep wakes over the network, so it doesn't need it.
+
+Two ordering rules make this safe, both handled by `deep-sleep.sh`:
+- **`enter` gates with the stack already stopped** — nothing else touches the
+  I2C bus. The MCU holds the gate low across the Jetson reboot (firmware §4.5).
+- **`wake` restores the rail *before* the reboot** — so when `mars_arm` boots
+  it finds powered servos to initialize (it inits once at startup, no retry).
+
 ## Flow
 
 ```
 sudo ./install.sh                       # add mode 4, install scripts + unit
-sudo innate-deep-sleep enter            # disable ros-app/jetson-perf/speaker,
-                                        # arm wake listener, reboot into SLEEPNET
-                                        # → only network + sshd + listener run
+sudo innate-deep-sleep enter            # stop ros-app, gate HSSW rail, arm wake
+                                        # listener, reboot into SLEEPNET
+                                        # → only network + sshd + listener run,
+                                        #   arm/head/wheels unpowered
 curl -X POST http://<robot>:4022/wake   # (or: sudo innate-deep-sleep wake)
-                                        # re-enable stack, reboot into MAXN_SUPER
+                                        # restore rail, re-enable stack,
+                                        # reboot into MAXN_SUPER
 ```
 
 Mode persistence across the reboots is `/var/lib/nvpmodel/status`; which stack
-comes up is plain systemd enablement. Wake latency ≈ one full boot (~90 s).
-The listener is deliberately unauthenticated for the experiment (waking is
-benign, LAN-only); add a token before any wider rollout.
+comes up is plain systemd enablement; the rail gate is the MCU's own latched
+state. Wake latency ≈ one full boot (~90 s). The listener is deliberately
+unauthenticated for the experiment (waking is benign, LAN-only); add a token
+before any wider rollout.
+
+Recovery: if the rail doesn't come back after a wake, SSH in and
+`sudo innate-deepsleep-pcb-power wake` (stack must be down), or restart the arm
+node once the rail is up. Gating is best-effort — an I2C error on `enter` still
+lets the Jetson deep-sleep (just without the rail cut).
 
 ## Validation checklist
 
 - [ ] `sudo nvpmodel -p --verbose | grep -A16 SLEEPNET` parses with the values above
 - [ ] `enter` reboots; after boot: `nproc` = 2, `nvpmodel -q` = SLEEPNET,
       policy0 max 422400, tegrastats VDD_SOC well under 2.5 W, VDD_IN recorded
+- [ ] after `enter`: arm/head go limp and servo LEDs go dark (rail actually cut)
 - [ ] `GET :4022/` answers; `POST :4022/wake` reboots to a fully working robot
-- [ ] battery ammeter reading in SLEEPNET vs light sleep vs awake
+      with the arm re-initialized and holding torque
+- [ ] battery ammeter: SLEEPNET+gated vs SLEEPNET-only vs light sleep vs awake
 
 ## Follow-ups (out of scope)
 
 - Wire `enter` into power_manager as a `/power/deep_sleep` service + app button
   (the app must then wake via `:4022/wake`, not rosbridge — the stack is down).
 - Auth token on the listener; mDNS advertisement so the app can find the robot.
-- Combine with the PCB's HSSW rail gating for the peripheral ~7 W.
+- Let the wake listener also poll the MCU motion latch (0x83 status byte) so a
+  physical nudge can wake deep sleep too, not only the network.

--- a/scripts/power/deep-sleep/README.md
+++ b/scripts/power/deep-sleep/README.md
@@ -1,0 +1,72 @@
+# Deep sleep via a custom nvpmodel mode (SLEEPNET) — experiment
+
+Goal: a sleep state far below what light sleep (PR #512) can reach, that still
+listens on the network for a wake signal. Reboots on entry/exit are accepted.
+
+## Why a custom mode
+
+Light sleep bottoms out around **6.3 W VDD_IN**: nvpmodel refuses to change
+the online-CPU set on a live system (the 7W mode prompts for a reboot and
+aborts), and even the 7W mode keeps EMC at 2133 MHz — VDD_SOC (~2.6 W) never
+drops. SC7 suspend (~1 W) would be lower still, but the RTL8822CE's vendor
+driver has no wake-on-WLAN, so a suspended robot is unreachable — a custom
+*running* mode with the radio up is the lowest state that can hear the network.
+
+## Prior art
+
+Custom `nvpmodel.conf` modes are supported (NVIDIA's [Power Estimator
+generates them](https://forums.developer.nvidia.com/t/how-to-create-a-custom-power-mode-configuration-for-a-orin-nano-super/350711)).
+On the [lowest-power thread](https://forums.developer.nvidia.com/t/jetson-orin-nano-8gb-lowest-theoretical-operating-power-consumption/348662)
+an Orin Nano 8GB reached **2.1–2.6 W VDD_IN** with a custom mode (2–4 cores at
+low clocks, low GPU/EMC) *plus* device-tree disables (display/audio/ISP/PCIe),
+SD-card boot and the WiFi module removed. [Another Super devkit
+thread](https://forums.developer.nvidia.com/t/reducing-idle-power-on-orin-nano-super-dev-kit/358482)
+got 4.7 → 2.5 W idle the same way. We keep WiFi (it *is* the wake path), NVMe
+and the stock device tree, so the conf-only target here is **~3.5–4.5 W VDD_IN**
+— roughly 2–3 W below light sleep, with tegrastats VDD_SOC finally moving.
+
+## The SLEEPNET mode (ID=4)
+
+Floors taken from this board's live tables (r36.4, Orin Nano Super):
+
+| Knob | Stock 7W mode | SLEEPNET |
+|---|---|---|
+| CPU cores online | 4 | **2** |
+| CPU clock | 729–960 MHz | **115–422 MHz** |
+| GPU cap (rail auto-gates) | 408 MHz | **306 MHz** (lowest OPP) |
+| EMC cap | 2133 MHz | **665.6 MHz** |
+| TPC gating mask | 252 | 252 |
+
+Further headroom if needed: try EMC below 665.6 MHz (bpmp clamps caps to its
+rate table; the floor is untested here), and single-core operation.
+
+## Flow
+
+```
+sudo ./install.sh                       # add mode 4, install scripts + unit
+sudo innate-deep-sleep enter            # disable ros-app/jetson-perf/speaker,
+                                        # arm wake listener, reboot into SLEEPNET
+                                        # → only network + sshd + listener run
+curl -X POST http://<robot>:4022/wake   # (or: sudo innate-deep-sleep wake)
+                                        # re-enable stack, reboot into MAXN_SUPER
+```
+
+Mode persistence across the reboots is `/var/lib/nvpmodel/status`; which stack
+comes up is plain systemd enablement. Wake latency ≈ one full boot (~90 s).
+The listener is deliberately unauthenticated for the experiment (waking is
+benign, LAN-only); add a token before any wider rollout.
+
+## Validation checklist
+
+- [ ] `sudo nvpmodel -p --verbose | grep -A16 SLEEPNET` parses with the values above
+- [ ] `enter` reboots; after boot: `nproc` = 2, `nvpmodel -q` = SLEEPNET,
+      policy0 max 422400, tegrastats VDD_SOC well under 2.5 W, VDD_IN recorded
+- [ ] `GET :4022/` answers; `POST :4022/wake` reboots to a fully working robot
+- [ ] battery ammeter reading in SLEEPNET vs light sleep vs awake
+
+## Follow-ups (out of scope)
+
+- Wire `enter` into power_manager as a `/power/deep_sleep` service + app button
+  (the app must then wake via `:4022/wake`, not rosbridge — the stack is down).
+- Auth token on the listener; mDNS advertisement so the app can find the robot.
+- Combine with the PCB's HSSW rail gating for the peripheral ~7 W.

--- a/scripts/power/deep-sleep/deep-sleep.sh
+++ b/scripts/power/deep-sleep/deep-sleep.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+#
+# Deep sleep for the robot: the whole ROS stack goes down, the Jetson reboots
+# into the custom SLEEPNET nvpmodel mode (2 cores / 422 MHz / EMC 665 MHz),
+# and only the network + a tiny HTTP wake listener stay up.
+#
+#   enter — disable the robot stack, arm the wake listener, reboot into SLEEPNET
+#   wake  — re-enable the robot stack, disarm the listener, reboot into MAXN_SUPER
+#
+# A reboot each way is unavoidable: nvpmodel refuses to change the online-core
+# set on a live system (it prompts for a reboot; we answer YES). The chosen
+# mode persists across the reboot via /var/lib/nvpmodel/status, and the
+# systemd enable/disable states select which stack comes up.
+
+set -eu
+[ "$(id -u)" = "0" ] || { echo "run as root" >&2; exit 1; }
+
+MODE_SLEEP=4  # SLEEPNET (installed by install.sh)
+MODE_AWAKE=2  # MAXN_SUPER
+
+ROBOT_SERVICES="ros-app.service jetson-perf.service speaker-keepalive.service"
+LISTENER=innate-deepsleep-wake.service
+
+case "${1:-}" in
+    enter)
+        systemctl disable $ROBOT_SERVICES
+        systemctl enable "$LISTENER"
+        echo "Entering deep sleep: rebooting into SLEEPNET (POST /wake on :4022 to wake)"
+        echo YES | /usr/sbin/nvpmodel -m "$MODE_SLEEP"
+        ;;
+    wake)
+        systemctl enable $ROBOT_SERVICES
+        systemctl disable "$LISTENER"
+        echo "Waking: rebooting into MAXN_SUPER with the robot stack enabled"
+        echo YES | /usr/sbin/nvpmodel -m "$MODE_AWAKE"
+        ;;
+    *)
+        echo "usage: $0 enter|wake" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/power/deep-sleep/deep-sleep.sh
+++ b/scripts/power/deep-sleep/deep-sleep.sh
@@ -2,17 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
 #
-# Deep sleep for the robot: the whole ROS stack goes down, the Jetson reboots
-# into the custom SLEEPNET nvpmodel mode (2 cores / 422 MHz / EMC 665 MHz),
-# and only the network + a tiny HTTP wake listener stay up.
+# Deep sleep for the robot: the whole ROS stack goes down, the PCB gates the
+# HSSW rail (arm/head Dynamixels + wheel drivers off), the Jetson reboots into
+# the custom SLEEPNET nvpmodel mode (2 cores / 422 MHz / EMC 665 MHz), and only
+# the network + a tiny HTTP wake listener stay up.
 #
-#   enter — disable the robot stack, arm the wake listener, reboot into SLEEPNET
-#   wake  — re-enable the robot stack, disarm the listener, reboot into MAXN_SUPER
+#   enter — gate the rail, disable the robot stack, arm the wake listener,
+#           reboot into SLEEPNET
+#   wake  — un-gate the rail, re-enable the robot stack, disarm the listener,
+#           reboot into MAXN_SUPER
 #
 # A reboot each way is unavoidable: nvpmodel refuses to change the online-core
 # set on a live system (it prompts for a reboot; we answer YES). The chosen
-# mode persists across the reboot via /var/lib/nvpmodel/status, and the
-# systemd enable/disable states select which stack comes up.
+# mode persists across the reboot via /var/lib/nvpmodel/status, the systemd
+# enable/disable states select which stack comes up, and the MCU holds the rail
+# gate across the reboot (firmware README §4.5). The rail is (un)gated with the
+# ROS stack DOWN so nothing contends for the I2C bus; on wake it is restored
+# BEFORE the reboot so mars_arm finds powered servos to initialize on boot.
 
 set -eu
 [ "$(id -u)" = "0" ] || { echo "run as root" >&2; exit 1; }
@@ -22,18 +28,22 @@ MODE_AWAKE=2  # MAXN_SUPER
 
 ROBOT_SERVICES="ros-app.service jetson-perf.service speaker-keepalive.service"
 LISTENER=innate-deepsleep-wake.service
+PCB_POWER=/usr/local/sbin/innate-deepsleep-pcb-power
 
 case "${1:-}" in
     enter)
         systemctl disable $ROBOT_SERVICES
+        systemctl stop ros-app.service           # free the I2C bus before gating
+        python3 "$PCB_POWER" sleep               # cut the HSSW rail (Dynamixels + drivers)
         systemctl enable "$LISTENER"
-        echo "Entering deep sleep: rebooting into SLEEPNET (POST /wake on :4022 to wake)"
+        echo "Entering deep sleep: rail gated, rebooting into SLEEPNET (POST /wake on :4022)"
         echo YES | /usr/sbin/nvpmodel -m "$MODE_SLEEP"
         ;;
     wake)
+        python3 "$PCB_POWER" wake                 # restore the rail before the stack boots
         systemctl enable $ROBOT_SERVICES
         systemctl disable "$LISTENER"
-        echo "Waking: rebooting into MAXN_SUPER with the robot stack enabled"
+        echo "Waking: rail restored, rebooting into MAXN_SUPER with the robot stack enabled"
         echo YES | /usr/sbin/nvpmodel -m "$MODE_AWAKE"
         ;;
     *)

--- a/scripts/power/deep-sleep/innate-deepsleep-wake.service
+++ b/scripts/power/deep-sleep/innate-deepsleep-wake.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Innate deep-sleep network wake listener (POST /wake on :4022)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/bin/python3 /usr/local/sbin/innate-deepsleep-wake-listener.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/power/deep-sleep/install.sh
+++ b/scripts/power/deep-sleep/install.sh
@@ -29,6 +29,7 @@ else
 fi
 
 install -o root -g root -m 755 "$SRC_DIR/deep-sleep.sh" /usr/local/sbin/innate-deep-sleep
+install -o root -g root -m 755 "$SRC_DIR/pcb-power.py" /usr/local/sbin/innate-deepsleep-pcb-power
 install -o root -g root -m 644 "$SRC_DIR/wake-listener.py" /usr/local/sbin/innate-deepsleep-wake-listener.py
 install -o root -g root -m 644 "$SRC_DIR/innate-deepsleep-wake.service" /etc/systemd/system/innate-deepsleep-wake.service
 systemctl daemon-reload

--- a/scripts/power/deep-sleep/install.sh
+++ b/scripts/power/deep-sleep/install.sh
@@ -28,6 +28,9 @@ else
     echo "Added SLEEPNET (ID=4) to $CONF (backup: $CONF.innate-bak)"
 fi
 
+# uhubctl cuts camera/lidar USB VBUS during deep sleep (~0.7 W measured)
+command -v uhubctl >/dev/null || apt-get install -y uhubctl
+
 install -o root -g root -m 755 "$SRC_DIR/deep-sleep.sh" /usr/local/sbin/innate-deep-sleep
 install -o root -g root -m 755 "$SRC_DIR/pcb-power.py" /usr/local/sbin/innate-deepsleep-pcb-power
 install -o root -g root -m 644 "$SRC_DIR/wake-listener.py" /usr/local/sbin/innate-deepsleep-wake-listener.py

--- a/scripts/power/deep-sleep/install.sh
+++ b/scripts/power/deep-sleep/install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+#
+# Installs the SLEEPNET deep-sleep experiment:
+#   - adds the SLEEPNET power mode (ID=4) to /etc/nvpmodel.conf (idempotent,
+#     original backed up once to /etc/nvpmodel.conf.innate-bak)
+#   - installs innate-deep-sleep + the wake listener to /usr/local/sbin
+#     (root-owned copies) and its systemd unit (not enabled — `enter` does that)
+
+set -eu
+[ "$(id -u)" = "0" ] || { echo "run as root: sudo $0" >&2; exit 1; }
+
+SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONF=/etc/nvpmodel.conf
+
+if grep -q "NAME=SLEEPNET" "$CONF"; then
+    echo "SLEEPNET mode already present in $CONF"
+else
+    [ -f "$CONF.innate-bak" ] || cp "$CONF" "$CONF.innate-bak"
+    # Insert the mode block before the (single, uncommented) PM_CONFIG section.
+    awk -v blockfile="$SRC_DIR/nvpmodel-sleepnet.conf" '
+        /^< PM_CONFIG/ && !done { while ((getline line < blockfile) > 0) print line; print ""; done=1 }
+        { print }
+    ' "$CONF" > "$CONF.tmp"
+    grep -q "NAME=SLEEPNET" "$CONF.tmp"  # sanity before replacing
+    mv "$CONF.tmp" "$CONF"
+    echo "Added SLEEPNET (ID=4) to $CONF (backup: $CONF.innate-bak)"
+fi
+
+install -o root -g root -m 755 "$SRC_DIR/deep-sleep.sh" /usr/local/sbin/innate-deep-sleep
+install -o root -g root -m 644 "$SRC_DIR/wake-listener.py" /usr/local/sbin/innate-deepsleep-wake-listener.py
+install -o root -g root -m 644 "$SRC_DIR/innate-deepsleep-wake.service" /etc/systemd/system/innate-deepsleep-wake.service
+systemctl daemon-reload
+
+echo "Installed. Verify the mode parses:  sudo nvpmodel -p --verbose | grep SLEEPNET"
+echo "Enter deep sleep (reboots):         sudo innate-deep-sleep enter"
+echo "Wake over the network:              curl -X POST http://<robot>:4022/wake"

--- a/scripts/power/deep-sleep/nvpmodel-sleepnet.conf
+++ b/scripts/power/deep-sleep/nvpmodel-sleepnet.conf
@@ -1,0 +1,27 @@
+# Innate SLEEPNET power mode — the lowest software-reachable profile on the
+# Orin Nano Super, for deep sleep with the network (wake listener) still up.
+# Installed into /etc/nvpmodel.conf by install.sh; entered/left via
+# innate-deep-sleep (a reboot each way: nvpmodel refuses live core changes).
+#
+# Values are the floors of this board's tables (JetPack 6 / r36.4):
+#   CPU  115.2–422 MHz on 2 cores (policy0; table floor 115200)
+#   GPU  cap 306 MHz = lowest OPP, rail auto-gates to 0 when idle
+#   EMC  cap 665.6 MHz — the big VDD_SOC lever; every stock mode (even 7W)
+#        keeps 2133 MHz. bpmp clamps the cap to the nearest supported rate.
+#   TPC_PG_MASK 252 gates the most GPU TPCs (mirrors the 7W mode).
+< POWER_MODEL ID=4 NAME=SLEEPNET >
+CPU_ONLINE CORE_0 1
+CPU_ONLINE CORE_1 1
+CPU_ONLINE CORE_2 0
+CPU_ONLINE CORE_3 0
+CPU_ONLINE CORE_4 0
+CPU_ONLINE CORE_5 0
+FBP_POWER_GATING FBP_PG_MASK 2
+TPC_POWER_GATING TPC_PG_MASK 252
+GPU_POWER_CONTROL_ENABLE GPU_PWR_CNTL_EN on
+CPU_A78_0 MIN_FREQ 115200
+CPU_A78_0 MAX_FREQ 422400
+GPU MIN_FREQ 0
+GPU MAX_FREQ 306000000
+GPU_POWER_CONTROL_DISABLE GPU_PWR_CNTL_DIS auto
+EMC MAX_FREQ 665600000

--- a/scripts/power/deep-sleep/pcb-power.py
+++ b/scripts/power/deep-sleep/pcb-power.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Standalone PCB power control over I2C, for deep sleep.
+
+Deep sleep tears the whole ROS stack down, so bringup's I2C driver isn't
+available to gate the HSSW rail. This talks to the MCU (0x42, bus 1) directly
+with the same CMD_POWER frame as mars_bringup/i2c.py (firmware README §4.5):
+
+    sleep — mode 0x01, flags GATE_HSSW: cut the arm/head Dynamixel + wheel-
+            driver rail. No wake-on-motion: deep sleep wakes over the network,
+            so the IMU sleeps too for the lowest draw.
+    wake  — mode 0x00: restore the rail.
+
+The MCU holds the gate across the Jetson's reboot, so gate-then-reboot (enter)
+and un-gate-then-reboot (wake) both land in the intended state. Best-effort:
+an I2C error warns and still exits 0 so it can't wedge the sleep/wake reboot.
+
+Run only when the ROS stack is DOWN — nothing else may drive the I2C bus.
+"""
+
+import sys
+
+import smbus2
+
+I2C_BUS = 1
+MCU_ADDR = 0x42
+REG = 0x00
+CMD_POWER = 0x06
+SLEEP_FLAG_GATE_HSSW = 0x01
+CRC8_POLY = 0x8C  # CRC-8/MAXIM, matches i2c.py and the firmware
+
+
+def _crc8(data: list[int]) -> int:
+    crc = 0
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ CRC8_POLY if crc & 0x01 else crc >> 1
+    return crc
+
+
+def _send_power(mode: int, flags: int) -> None:
+    payload = [CMD_POWER, mode, flags, 0x00, 0x00, 0x00, 0x00]  # cmd + 6 data bytes
+    frame = payload + [_crc8(payload)]
+    with smbus2.SMBus(I2C_BUS) as bus:
+        bus.write_i2c_block_data(MCU_ADDR, REG, frame)
+
+
+def main() -> int:
+    action = sys.argv[1] if len(sys.argv) > 1 else ""
+    if action == "sleep":
+        mode, flags = 0x01, SLEEP_FLAG_GATE_HSSW
+    elif action == "wake":
+        mode, flags = 0x00, 0x00
+    else:
+        print("usage: pcb-power.py sleep|wake", file=sys.stderr)
+        return 1
+    try:
+        _send_power(mode, flags)
+        print(f"PCB {action}: CMD_POWER mode={mode:#04x} flags={flags:#04x} sent")
+    except Exception as e:  # best-effort — must not wedge the reboot
+        print(f"WARN: PCB {action} over I2C failed: {e}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/power/deep-sleep/wake-listener.py
+++ b/scripts/power/deep-sleep/wake-listener.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Deep-sleep network wake listener.
+
+The only thing (besides sshd) listening while the robot deep-sleeps in the
+SLEEPNET nvpmodel mode. Stdlib-only, a few MB of RAM, happy on 2 cores at
+115 MHz.
+
+    GET  /      -> {"state": "deep_sleep", ...}
+    POST /wake  -> restores full power + robot stack and reboots (~90 s to up)
+
+Runs as root (systemd unit innate-deepsleep-wake.service) because waking
+means nvpmodel + systemctl + reboot. Unauthenticated by design for the
+experiment: waking is a benign action, and the port is LAN-only.
+"""
+
+import json
+import subprocess
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = 4022
+DEEP_SLEEP = "/usr/local/sbin/innate-deep-sleep"
+
+
+class WakeHandler(BaseHTTPRequestHandler):
+    def _reply(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        self._reply(200, {"state": "deep_sleep", "wake": f"POST http://<robot>:{PORT}/wake"})
+
+    def do_POST(self):
+        if self.path != "/wake":
+            self._reply(404, {"error": "unknown path"})
+            return
+        self._reply(200, {"ok": True, "message": "waking: restoring full power, rebooting"})
+        # Reply is written before this reboots the machine.
+        subprocess.Popen([DEEP_SLEEP, "wake"])
+
+    def log_message(self, fmt, *args):
+        pass  # keep journald quiet
+
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", PORT), WakeHandler).serve_forever()

--- a/scripts/power/deep-sleep/wake-listener.py
+++ b/scripts/power/deep-sleep/wake-listener.py
@@ -17,10 +17,40 @@ experiment: waking is a benign action, and the port is LAN-only.
 
 import json
 import subprocess
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 PORT = 4022
 DEEP_SLEEP = "/usr/local/sbin/innate-deep-sleep"
+
+# USB hubs whose VBUS we cut during deep sleep (~0.06 A / ~0.7 W at the
+# battery, measured): 1-2.3 carries the lidar board + 3D camera, its parent
+# 1-2 carries the Arducam and the child hub itself. Both are ppps-capable
+# (verified with uhubctl); WiFi/BT and the arm's serial are on root ports,
+# untouched. Child before parent — the child is unreachable once the parent
+# port is off. Hub power state resets on reboot, so this must run at
+# deep-sleep boot (here) and the wake reboot restores it for free.
+USB_HUBS_TO_CUT = ("1-2.3", "1-2")
+
+
+def _cut_usb_peripherals() -> None:
+    """Best-effort: a missing uhubctl or a failed cut must not break waking."""
+    for hub in USB_HUBS_TO_CUT:
+        for attempt in range(3):  # USB may still be enumerating right after boot
+            try:
+                result = subprocess.run(
+                    ["uhubctl", "-l", hub, "-a", "off"], capture_output=True, text=True, timeout=15
+                )
+            except (OSError, subprocess.SubprocessError) as e:
+                print(f"WARN: uhubctl {hub} failed: {e}")
+                break
+            if result.returncode == 0:
+                print(f"USB hub {hub}: ports powered off")
+                break
+            if attempt < 2:
+                time.sleep(3.0)
+            else:
+                print(f"WARN: uhubctl {hub} off failed: {result.stderr.strip()}")
 
 
 class WakeHandler(BaseHTTPRequestHandler):
@@ -48,4 +78,5 @@ class WakeHandler(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
+    _cut_usb_peripherals()
     HTTPServer(("0.0.0.0", PORT), WakeHandler).serve_forever()


### PR DESCRIPTION
## Summary

Experiment stacked on #512: a **deep sleep** far below light sleep's floor, still wakeable over the network. Reboots on entry/exit are accepted by design.

- **Custom nvpmodel mode `SLEEPNET` (ID=4)**, floors taken from the board's live tables: 2 CPU cores at 115–422 MHz, GPU capped at the 306 MHz lowest OPP (rail auto-gates to 0 idle), **EMC capped at 665.6 MHz** — the VDD_SOC (~2.6 W) lever that every stock mode, including 7W, leaves at 2133 MHz.
- **Why reboot-based:** nvpmodel refuses live core-count changes (verified on-robot in #512 — rc=234 + reboot prompt). The reboot doubles as stack teardown/restore: `innate-deep-sleep enter` disables ros-app/jetson-perf/speaker-keepalive and reboots into SLEEPNET; systemd enablement decides what comes up, `/var/lib/nvpmodel/status` persists the mode.
- **Network wake:** while asleep only network + sshd + a stdlib HTTP listener run. `POST :4022/wake` re-enables the stack and reboots into MAXN_SUPER (~90 s to fully up). Unauthenticated for the experiment (waking is benign, LAN-only) — token before wider rollout.
- **Why not SC7 suspend:** ~1 W but unreachable — the RTL8822CE vendor driver has no wake-on-WLAN (audited in the phase-1 design). A *running* minimal mode is the lowest state that can hear the network.

## Prior art (details + links in the README)

Custom conf modes are NVIDIA-supported (their Power Estimator generates them). Best documented result: **2.1–2.6 W VDD_IN** on an Orin Nano 8GB with a custom mode *plus* device-tree disables, SD boot and the WiFi module removed. Keeping WiFi/NVMe/stock DT, the conf-only target here is **~3.5–4.5 W VDD_IN vs 6.3 W measured in light sleep**.

## Validation

**Not yet run on hardware** — needs root + two reboots. Checklist in the README; short version:

```bash
sudo scripts/power/deep-sleep/install.sh      # idempotent; backs up /etc/nvpmodel.conf
sudo nvpmodel -p --verbose | grep -A16 SLEEPNET
sudo innate-deep-sleep enter                  # reboots; expect nproc=2, VDD_SOC well under 2.5 W
curl -X POST http://<robot>:4022/wake         # reboots back to a fully working robot
```

## Follow-ups (out of scope)

- `/power/deep_sleep` service in power_manager + app button (app wakes via `:4022/wake`, not rosbridge — the stack is down).
- Listener auth token; mDNS discovery.
- Try EMC below 665.6 MHz and single-core for the last few hundred mW.
- Combine with the PCB HSSW rail gate (mars-firmware#6) for the peripheral ~7 W.