### PR TITLE
fix(sim): unbreak the first run on Linux/WSL (Compose v2 preflight + prebuilt viewer assets)

### DIFF
--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -387,7 +387,9 @@ def main() -> int:
             ensure_docker_available(command_hint=f"{CLI_SIM} clean")
             cmd_clean(config, assume_yes=args.yes)
         elif args.sim_command == "sh":
-            ensure_docker_available(command_hint=f"{CLI_SIM} sh")
+            # Opens the running container with `docker exec`, so a missing
+            # Compose plugin must not block it.
+            ensure_docker_available(command_hint=f"{CLI_SIM} sh", require_compose=False)
             return open_os_container_shell()
         elif args.sim_command == "status":
             ensure_docker_available(command_hint=f"{CLI_SIM} status")

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -54,6 +54,7 @@ from config import (
 from dashboard import BOLD, GREEN, NC, RED, USE_COLOR
 
 DOCKER_INSTALL_URL = "https://docs.docker.com/get-started/get-docker/"
+COMPOSE_INSTALL_URL = "https://docs.docker.com/compose/install/linux/"
 
 
 def run_logged(
@@ -149,24 +150,44 @@ def ensure_docker_available(*, command_hint: str = CLI_SIM) -> None:
         stderr=subprocess.PIPE,
         check=False,
     )
-    if result.returncode == 0:
-        return
+    if result.returncode != 0:
+        detail = " ".join((result.stderr or result.stdout or "").split())
+        detail_lower = detail.lower()
+        daemon_unreachable = (
+            "daemon" in detail_lower or "docker desktop" in detail_lower or "failed to connect" in detail_lower
+        )
+        message = (
+            "Docker is installed, but the Docker daemon is not running or not reachable."
+            if daemon_unreachable
+            else "Docker is installed, but the Docker daemon check failed."
+        )
+        raise StackError(
+            f"{message}\n"
+            f"Start Docker Desktop or your Docker daemon, wait until it finishes starting, then rerun `{command_hint}`.\n"
+            f"Install/start guide: {DOCKER_INSTALL_URL}"
+        )
 
-    detail = " ".join((result.stderr or result.stdout or "").split())
-    detail_lower = detail.lower()
-    daemon_unreachable = (
-        "daemon" in detail_lower or "docker desktop" in detail_lower or "failed to connect" in detail_lower
+    # Compose v2 is a separate CLI plugin. On native-Linux/WSL engine installs
+    # `docker` can work while `docker compose` is missing -- the whole startup
+    # runs through `docker compose`, so without this it dies deep in with a
+    # cryptic bare-`docker` usage error instead of a clear diagnosis.
+    compose = subprocess.run(
+        ["docker", "compose", "version"],
+        text=True,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        check=False,
     )
-    message = (
-        "Docker is installed, but the Docker daemon is not running or not reachable."
-        if daemon_unreachable
-        else "Docker is installed, but the Docker daemon check failed."
-    )
-    raise StackError(
-        f"{message}\n"
-        f"Start Docker Desktop or your Docker daemon, wait until it finishes starting, then rerun `{command_hint}`.\n"
-        f"Install/start guide: {DOCKER_INSTALL_URL}"
-    )
+    if compose.returncode != 0:
+        # The package name follows the Docker install, not the distro version.
+        raise StackError(
+            "Docker is running, but Docker Compose v2 is not available (`docker compose` failed).\n"
+            "Install the Compose plugin matching your Docker:\n"
+            "  distro engine (docker.io): `sudo apt install docker-compose-v2` (Debian: `docker-compose`)\n"
+            "  Docker's own repo (docker-ce): `sudo apt install docker-compose-plugin` (dnf/yum: same name)\n"
+            "  Docker Desktop already bundles it.\n"
+            f"Then rerun `{command_hint}`. Guide: {COMPOSE_INSTALL_URL}"
+        )
 
 
 def docker_compose_env(base_env: dict[str, str] | None = None) -> dict[str, str]:

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -134,7 +134,12 @@ def run_logged_with_heartbeat(
         raise StackError(f"{failure_message}\nRecent log output:\n{tail_file(log_path, limit=60)}")
 
 
-def ensure_docker_available(*, command_hint: str = CLI_SIM) -> None:
+def ensure_docker_available(*, command_hint: str = CLI_SIM, require_compose: bool = True) -> None:
+    """Check Docker (and, unless opted out, the Compose v2 plugin).
+
+    `require_compose=False` is for commands that only touch an already-running
+    container via plain `docker` (e.g. `sh` -> `docker exec`).
+    """
     if shutil.which("docker") is None:
         raise StackError(
             "Docker is not installed or is not available on PATH.\n"
@@ -166,6 +171,9 @@ def ensure_docker_available(*, command_hint: str = CLI_SIM) -> None:
             f"Start Docker Desktop or your Docker daemon, wait until it finishes starting, then rerun `{command_hint}`.\n"
             f"Install/start guide: {DOCKER_INSTALL_URL}"
         )
+
+    if not require_compose:
+        return
 
     # Compose v2 is a separate CLI plugin. On native-Linux/WSL engine installs
     # `docker` can work while `docker compose` is missing -- the whole startup

--- a/sim/sim-assets.lock
+++ b/sim/sim-assets.lock
@@ -1,5 +1,5 @@
 {
-  "tag": "sim-assets-b7a0f5b5b0e1",
-  "url": "https://github.com/innate-inc/innate-sim-assets/releases/download/sim-assets-b7a0f5b5b0e1/innate-sim-assets-b7a0f5b5b0e1.tar.gz",
-  "sha256": "b7a0f5b5b0e13652077463cae028aade44cbeb2c70bd050708d6b688b3e32d53"
+  "tag": "sim-assets-0c17cc48b025",
+  "url": "https://github.com/innate-inc/innate-sim-assets/releases/download/sim-assets-0c17cc48b025/innate-sim-assets-0c17cc48b025.tar.gz",
+  "sha256": "0c17cc48b025030dcf96022969da66b2f62a7e433b48ac1d4df1e05754f2325a"
 }


### PR DESCRIPTION
Two independent papercuts that both bite a fresh Linux/WSL checkout, found while running the sim on Ubuntu 26.04 under WSL. macOS is immune to both, which is why they slipped through.

## 1. Fail fast when Docker Compose v2 is missing

`ensure_docker_available` probed only `docker info`. On a box with a working engine but **no Compose v2 plugin**, `setup` passed happily and startup then died deep in with:

```
unknown shorthand flag: 'f' in -f
Usage:  docker [OPTIONS] COMMAND [ARG...]
```

…because every compose call is `docker compose -f sim/docker-compose.dev.yml …`, and with no plugin the `compose` word never reaches Compose, so the root `docker` parser chokes on `-f`. Nothing in that message points at the actual cause.

Now `docker compose version` is probed right after the daemon check, and the error names the correct package. **The package tracks the Docker install, not the distro version** — this is the part that's easy to get wrong:

| Docker install | Compose v2 package |
|---|---|
| Ubuntu distro engine (`docker.io`) | `docker-compose-v2` (22.04 → 26.04) |
| Debian distro engine | `docker-compose` (trixie = v2; **bookworm's is v1**) |
| Docker's own repo (`docker-ce`), apt + dnf/yum | `docker-compose-plugin` |
| Docker Desktop | bundled |

Since `setup`, `up`, `down`, `sh` and `status` all call `ensure_docker_available`, every entry point is guarded — but it surfaces at `./innate-sim setup`, before anything is provisioned.

The daemon check is flipped to an early `raise` so the compose probe reads as the next step; its behaviour is unchanged.

## 2. Repin assets to the release that ships the prebuilt viewer bundle

The pinned bundle `sim-assets-b7a0f5b5b0e1` predated `viewer/dist-lib` being folded into the asset release. So on a checkout without npm there was no `sim-session.js`, the webapp's `import("/sim-viewer/sim-session.js")` threw, and it fell back to `WebRtcSession` — which has no pipeline in sim. Result: the 3D view sat on **"Establishing video link"** forever while only the 2D map (drawn from the rosbridge occupancy grid) worked.

Repinned to `sim-assets-0c17cc48b025`, verified to contain `viewer/dist-lib/sim-session.js`. The "no Node.js required" promise in `sim/README.md` now actually holds on a fresh Linux/WSL checkout.

## Testing

- `ruff check` + `ruff format --check` clean on `sim/launcher/runtime.py`.
- Error message rendered and read end-to-end.
- New asset release confirmed live (HTTP 200) and its tarball listed to confirm `viewer/dist-lib/sim-session.js` is present.
- Reproduced on Ubuntu 26.04 / WSL: `docker.io` engine 29.1.3 + missing plugin → `docker-compose-v2` resolves it; 3D view renders after the repin.

## Note for reviewers

The preflight fires only when `docker compose version` exits **non-zero**. The original WSL failure was a `-f` parse error rather than a clean "not found", so a shim that exits 0 while still being broken would slip past. If that ever resurfaces, the probe should escalate to `docker compose -f sim/docker-compose.dev.yml config`.
