### PR TITLE
Sim nav: lidar-consistent map (fixes AMCL divergence) + specific navigation failure reasons

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -347,6 +347,105 @@ class VirtualMars:
         mujoco.mj_forward(self.model, self.data)
         return grid, float(xmin), float(ymin)
 
+    def lidar_occupancy_grid(
+        self,
+        resolution: float = 0.05,
+        origin_stride_m: float = 0.4,
+        n_rays: int = 720,
+        max_range: float = 12.0,
+    ) -> tuple[np.ndarray, float, float]:
+        """Rasterize the world the way the robot's own lidar would map it --
+        a virtual SLAM pass with perfect poses. Horizontal rays are cast at
+        the laser mount height against the same visual surfaces lidar_scan()
+        hits, from a grid of reachable floor positions; beams clear free
+        space, endpoints mark obstacles, everything unseen stays unknown.
+
+        This is the nav map that keeps AMCL consistent: a real robot
+        localizes against a map made BY its lidar, so at shin height a couch
+        is legs and a gap, not the solid footprint occupancy_grid() rasterizes
+        from collision geometry. Returns (grid, origin_x, origin_y) like
+        occupancy_grid()."""
+        # Reachable-floor candidates for scan origins (also fixes the bounds).
+        base_grid, xmin, ymin = self.occupancy_grid(resolution)
+        height, width = base_grid.shape
+
+        # True laser height above the floor, from the model itself.
+        mujoco.mj_forward(self.model, self.data)
+        laser_z = float(self.data.xpos[self.model.body("robot_base_laser").id][2])
+
+        # Park the robot far away so rays never hit it.
+        saved = self.data.qpos.copy()
+        self.data.qpos[self._base["x"][0]] += 100.0
+        mujoco.mj_forward(self.model, self.data)
+
+        try:
+            stride = max(1, int(round(origin_stride_m / resolution)))
+            rows, cols = np.nonzero(base_grid == 0)
+            pick = (rows % stride == 0) & (cols % stride == 0)
+            origin_xy = np.column_stack(
+                [xmin + (cols[pick] + 0.5) * resolution, ymin + (rows[pick] + 0.5) * resolution]
+            )
+
+            angles = np.arange(n_rays) * (2.0 * math.pi / n_rays)
+            vecs = np.zeros((n_rays, 3))
+            vecs[:, 0] = np.cos(angles)
+            vecs[:, 1] = np.sin(angles)
+            step = resolution * 0.9
+            ts = (np.arange(int(max_range / step)) + 0.5) * step  # sample offsets along a beam
+
+            def cells(x: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+                c = ((x - xmin) / resolution).astype(np.int64)
+                r = ((y - ymin) / resolution).astype(np.int64)
+                ok = (c >= 0) & (c < width) & (r >= 0) & (r < height)
+                return r[ok], c[ok]
+
+            seen_free = np.zeros((height, width), dtype=bool)
+            seen_occ = np.zeros((height, width), dtype=bool)
+            geomids = np.full(n_rays, -1, dtype=np.int32)
+            dists = np.full(n_rays, -1.0)
+            for ox, oy in origin_xy:
+                origin = np.array([ox, oy, laser_z])
+                geomids.fill(-1)
+                dists.fill(-1.0)
+                mujoco.mj_multiRay(
+                    self.model,
+                    self.data,
+                    origin,
+                    vecs.flatten(),
+                    self._lidar_groups,
+                    1,
+                    self._base_id,
+                    geomids,
+                    dists,
+                    None,
+                    n_rays,
+                    max_range,
+                )
+                hit = (geomids != -1) & (dists >= 0)
+                if not hit.any():
+                    continue
+                d = dists[hit]
+                dirs = vecs[hit, :2]
+                # Clear along each beam, stopping one cell short of the surface.
+                mask = ts[None, :] < (d - resolution)[:, None]
+                px = ox + (dirs[:, 0:1] * ts[None, :])[mask]
+                py = oy + (dirs[:, 1:2] * ts[None, :])[mask]
+                r, c = cells(px, py)
+                seen_free[r, c] = True
+                # Endpoints are the surfaces the lidar actually returns from.
+                r, c = cells(ox + dirs[:, 0] * d, oy + dirs[:, 1] * d)
+                seen_occ[r, c] = True
+        finally:
+            # Restore even if a ray call raises: a leaked parked pose would
+            # corrupt every later scan/step on this instance.
+            self.data.qpos[:] = saved
+            mujoco.mj_forward(self.model, self.data)
+
+        grid = np.full((height, width), -1, dtype=np.int8)
+        grid[seen_free] = 0
+        grid[seen_occ] = 100  # occupied wins over any grazing clear
+        return grid, float(xmin), float(ymin)
+
     def _rasterize_static_slab(
         self, zlo: float, zhi: float, xmin: float, ymin: float, width: int, height: int, resolution: float
     ) -> np.ndarray:

--- a/sim/sim-assets.lock
+++ b/sim/sim-assets.lock
@@ -1,5 +1,5 @@
 {
-  "tag": "sim-assets-0c17cc48b025",
-  "url": "https://github.com/innate-inc/innate-sim-assets/releases/download/sim-assets-0c17cc48b025/innate-sim-assets-0c17cc48b025.tar.gz",
-  "sha256": "0c17cc48b025030dcf96022969da66b2f62a7e433b48ac1d4df1e05754f2325a"
+  "tag": "sim-assets-097aa85b3b53",
+  "url": "https://github.com/innate-inc/innate-sim-assets/releases/download/sim-assets-097aa85b3b53/innate-sim-assets-097aa85b3b53.tar.gz",
+  "sha256": "097aa85b3b533fd4fab8bf3f2694b00cfdf579d994016038b968a857ea09f2d8"
 }

--- a/sim/tools/export_nav_map.py
+++ b/sim/tools/export_nav_map.py
@@ -21,7 +21,12 @@ RESOLUTION = 0.05
 
 def main() -> None:
     sim = VirtualMars()
-    grid, ox, oy = sim.occupancy_grid(RESOLUTION)
+    # Lidar-consistent map (virtual SLAM at the laser's true height): AMCL
+    # localizes against what the lidar actually returns, exactly like a real
+    # robot localizing against its own SLAM map. occupancy_grid() (collision
+    # slab) systematically disagrees with the lidar around furniture and
+    # walks AMCL off the map.
+    grid, ox, oy = sim.lidar_occupancy_grid(RESOLUTION)
     # map_server PGM: 254 free, 0 occupied, 205 unknown; row 0 at the TOP.
     img = np.where(grid == 100, 0, np.where(grid == 0, 254, 205)).astype(np.uint8)[::-1]
     out = Path(__file__).resolve().parents[1] / "assets" / "map"

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -314,13 +314,14 @@ export function createAgentPanel(root, rosClient, agentState) {
     if (run.hasDetail) run.wrap.classList.add("has-detail");
     run.status.textContent = cls;
 
-    // A failed run carries the failure reason / error — make it expandable in-place.
+    // A failed run carries the failure reason / error — show it expanded
+    // in-place (collapsible so a long trace can be tucked away).
     if (cls === "failed" && reason && !run.hasDetail) {
       run.hasDetail = true;
-      run.wrap.classList.add("has-detail");
+      run.wrap.classList.add("has-detail", "open");
       const chevron = document.createElement("span");
       chevron.className = "chat-skill-chevron mono";
-      chevron.textContent = "▾";
+      chevron.textContent = "▴";
       run.head.appendChild(chevron);
       const detail = document.createElement("div");
       detail.className = "chat-skill-detail";

--- a/workspace/innate_skills/navigate_to_position.py
+++ b/workspace/innate_skills/navigate_to_position.py
@@ -77,8 +77,6 @@ class Nav2Controller:
     def go_to_position(self, x: float, y: float, theta: float, local_frame: bool):
         """
         Sends a navigation goal to the navigator and waits until navigation ends.
-        The method returns the TaskResult indicating whether the goal
-        succeeded, was canceled, or failed/timed out.
 
         Args:
             x (float): x-coordinate of the target position.
@@ -86,7 +84,8 @@ class Nav2Controller:
             theta (float): The orientation angle in radians.
 
         Returns:
-            TaskResult: The result status from the navigator.
+            (TaskResult, str | None): the navigator's result status, plus a
+            human-readable detail explaining a failure (None on success/cancel).
         """
         navigator = self.navigator
         # Reset cancellation flag
@@ -104,7 +103,10 @@ class Nav2Controller:
                 self.logger.error(
                     f"No fresh base_link->{LOCAL_GOAL_FIXED_FRAME} transform available; cannot resolve local goal"
                 )
-                return TaskResult.FAILED
+                return TaskResult.FAILED, (
+                    "could not determine the robot's current pose "
+                    f"(no fresh {LOCAL_GOAL_FIXED_FRAME} transform), so the local goal could not be resolved"
+                )
             base = base_tf.transform
             goal_x, goal_y, goal_yaw = resolve_local_goal(
                 base.translation.x, base.translation.y, quaternion_to_yaw(base.rotation), x, y, theta
@@ -138,7 +140,10 @@ class Nav2Controller:
         # If the path is None, we can't navigate to the goal
         if path is None:
             self.logger.error("Failed to get path to goal")
-            return TaskResult.FAILED
+            return TaskResult.FAILED, (
+                f"the planner found no path to ({goal_x:.2f}, {goal_y:.2f}) in the {goal_frame} frame "
+                "— the goal may be unreachable, blocked, or outside the map"
+            )
 
         navigator.goToPose(goal_pose, behavior_tree=behavior_tree)
 
@@ -148,6 +153,9 @@ class Nav2Controller:
         initial_distance_remaining = -1.0  # Not set until the first valid feedback
         feedback_sent_close_to_goal = False  # Flag to track if feedback has been sent
         last_progress_log = 0.0
+        # Last feedback snapshot, so a failure can say how far the robot got.
+        last_distance_remaining = -1.0
+        last_recoveries = 0
 
         # Modified loop to check for cancellation
         while not navigator.isTaskComplete():
@@ -169,6 +177,9 @@ class Nav2Controller:
             # in the navigator's global frame while our goal may be in
             # another, so computing distances ourselves would be wrong.
             distance_remaining = feedback.distance_remaining
+            last_recoveries = feedback.number_of_recoveries
+            if distance_remaining > 0.0:
+                last_distance_remaining = distance_remaining
 
             if initial_distance_remaining < 0.0 and distance_remaining > 0.0:
                 initial_distance_remaining = distance_remaining
@@ -193,6 +204,7 @@ class Nav2Controller:
                 feedback_sent_close_to_goal = True
 
         result = navigator.getResult()
+        detail = None
 
         if was_canceled:
             self.logger.debug("Goal was canceled!")
@@ -202,6 +214,12 @@ class Nav2Controller:
             self.logger.debug("Goal succeeded!")
         else:
             self.logger.debug(f"Goal failed or timed out. result: {result}")
+            detail = f"Nav2 reported {getattr(result, 'name', result)}"
+            if last_distance_remaining >= 0.0:
+                detail += f" with {last_distance_remaining:.2f}m still to go"
+            if last_recoveries > 0:
+                detail += f" after {last_recoveries} recovery attempt{'s' if last_recoveries != 1 else ''}"
+            detail += " — the route may be blocked or the robot may be stuck"
 
         # Stop the robot by publishing a stop command.
         stop_cmd = Twist()
@@ -209,7 +227,7 @@ class Nav2Controller:
         stop_cmd.angular.z = 0.0
         # self.cmd_vel_pub.publish(stop_cmd)
 
-        return result
+        return result, detail
 
     def cancel_navigation(self):
         """
@@ -267,7 +285,7 @@ class NavigateToPosition(Skill):
             f"Initiating navigation to position: x={x}, y={y}, theta_degrees={theta_degrees}, local_frame={local_frame}"
         )
 
-        result = self.nav2_controller.go_to_position(x, y, theta, local_frame)
+        result, detail = self.nav2_controller.go_to_position(x, y, theta, local_frame)
 
         # Check if the navigation was canceled
         if result == TaskResult.CANCELED:
@@ -279,8 +297,10 @@ class NavigateToPosition(Skill):
             )
             return f"Reached position ({x}, {y}, {theta_degrees} deg)", SkillResult.SUCCESS
         else:
-            self.logger.info(f"Navigation failed with result: {result}")
-            return f"Navigation failed with result: {result}", SkillResult.FAILURE
+            goal_desc = f"({x}, {y}, {theta_degrees} deg, {'local' if local_frame else 'map'} frame)"
+            message = f"Navigation to {goal_desc} failed: {detail}"
+            self.logger.info(message)
+            return message, SkillResult.FAILURE
 
     def cancel(self):
         """


### PR DESCRIPTION
## What

Two fixes from debugging navigation in the sim (`feat/visualise-plan-in-sim` is the debug branch; this PR carries only the ship-worthy pieces).

### 1. Generate the sim nav map the way the robot's lidar sees the world

**Problem:** AMCL diverged badly in sim — a controlled 15 s in-place spin moved its estimate **~2.6 m and ~180°**, after which navigation drove to "random" places (it plans from where AMCL *believes* the robot is).

**Root cause:** on the real robot, the map is made *by the robot's lidar* (SLAM), so scans and map agree by construction. The sim map was rasterized from **collision geometry** (solid furniture footprints, 0.1–1.4 m slab) while the sim lidar scans **visual surfaces at its true mount height (~0.17 m)** — at shin height a couch is legs and a gap, not a solid blob. That systematic scan-vs-map mismatch near furniture, under the real robot's hand-tuned AMCL config (large alphas, `resample_interval: 1`, `recovery_alpha_fast: 0.2`), walks the filter off the map during rotation-heavy maneuvers.

**Fix:** `VirtualMars.lidar_occupancy_grid()` — a virtual SLAM pass: horizontal `mj_multiRay` casts at the laser's model-derived height against the same visual surfaces `lidar_scan()` hits, from a 0.4 m grid of reachable floor poses. Beams clear free space, endpoints mark obstacles, everything unseen stays unknown. `export_nav_map.py` now uses it; the asset bundle is republished with the new map (`sim-assets-097aa85b3b53`, lock repinned).

**Verification:** same 15 s spin stress test — AMCL error went from **~2.6 m to ~3 cm**. Boot-seed accuracy < 1 cm.

No robot-stack changes: AMCL/Nav2 configs and code are untouched, so sim navigation now previews real-robot behavior against a map with real-robot statistics (thin walls, chair-leg dots, unknown couch interiors).

### 2. Specific navigation failure reasons instead of a bare "Failed"

`navigate_to_position` failures previously surfaced as `Navigation failed with result: TaskResult.FAILED` — invisible to the operator (collapsed) and useless to the agent. Now the skill reports what actually happened, with the goal it was attempting:

- `could not determine the robot's current pose (no fresh odom transform), so the local goal could not be resolved`
- `the planner found no path to (x, y) in the map frame — the goal may be unreachable, blocked, or outside the map`
- `Nav2 reported FAILED with 1.42m still to go after 2 recovery attempts — the route may be blocked or the robot may be stuck`

The webapp agent panel shows the failure detail expanded in place instead of hidden behind a chevron.

## Testing

- Spin stress test before/after the map change (numbers above), run against the full digital twin.
- Navigation end-to-end on the new map: boot → grid-localizer seed → goal → completes; AMCL stays within cm.
- `python -m py_compile` on all touched Python; the map renders as expected (walls / legs / unknown interiors).
