### PR TITLE
fix(nav): survive controller_server crashes — respawn + lifecycle watchdog

### DIFF
--- a/ros2_ws/src/mars_bot/mars_nav/launch/navigation.launch.py
+++ b/ros2_ws/src/mars_bot/mars_nav/launch/navigation.launch.py
@@ -138,6 +138,14 @@ def generate_launch_description():
         executable="controller_server",
         name="controller_server",
         output="screen",
+        # The Humble binaries have known memory bugs in teardown/abort paths
+        # (see mode_manager's skip_cleanup_nodes; observed live: repeated
+        # "Failed to make progress" aborts end in a double-free SIGABRT).
+        # Respawn brings the process back; mode_manager's lifecycle watchdog
+        # re-configures and re-activates it, so a controller crash costs
+        # seconds of navigation instead of the rest of the session.
+        respawn=True,
+        respawn_delay=2.0,
         parameters=[
             controller_params_file,
             costmap_params_file,

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -649,39 +649,59 @@ class ModeManager(Node):
         Observed live: controller_server dies with a double-free SIGABRT after
         repeated "Failed to make progress" aborts (a sibling of the known
         teardown crashes listed in skip_cleanup_nodes). launch respawns it,
-        and this watchdog notices the UNCONFIGURED state and re-drives it to
-        where the current mode needs it -- turning a crash into a few seconds
-        of downtime instead of a dead nav stack.
+        and this watchdog notices and re-drives it to where the current mode
+        needs it -- turning a crash into a few seconds of downtime instead of
+        a dead nav stack.
+
+        Restores nodes found UNCONFIGURED (fresh respawn) or stuck INACTIVE
+        when the mode expects ACTIVE (a previous restore's activate failed).
+        States are probed WITHOUT the mode lock on a short timeout, so a slow
+        or dead node never blocks user mode/map operations; the lock is taken
+        only to perform an actual repair, with the state re-checked under it.
         """
         if not self._lifecycle_watchdog_armed or self._watchdog_busy:
             return
         mode = getattr(self, "current_mode", None)
         if mode not in modes_nodes:
             return
-        # A mode/map operation owns the transitions while it holds the lock.
-        if not self._mode_change_lock.acquire(blocking=False):
-            return
         self._watchdog_busy = True
         try:
-            for node_name in modes_nodes[mode]:
-                state = get_node_state(self._service_clients, self.get_logger(), node_name)
-                if state != State.PRIMARY_STATE_UNCONFIGURED:
-                    continue  # healthy, mid-transition, or still respawning (unreachable)
+
+            def restore_target(node_name):
+                """(needs_restore, target_state) for a current-mode node."""
+                state = get_node_state(self._service_clients, self.get_logger(), node_name, timeout_sec=2.0)
                 expect_active = node_name not in configure_only_nodes.get(mode, set())
                 target = State.PRIMARY_STATE_ACTIVE if expect_active else State.PRIMARY_STATE_INACTIVE
-                self.get_logger().warning(
-                    f"{node_name} is UNCONFIGURED while {mode} mode is active -- "
-                    "it likely crashed and respawned; re-driving its lifecycle"
+                wrong = state == State.PRIMARY_STATE_UNCONFIGURED or (
+                    state == State.PRIMARY_STATE_INACTIVE and expect_active
                 )
-                if transition_node(self._service_clients, self.get_logger(), node_name, target):
-                    self.get_logger().info(
-                        f"{node_name} restored to {'ACTIVE' if expect_active else 'INACTIVE'} after respawn"
+                return wrong, target
+
+            needs_restore = [n for n in modes_nodes[mode] if restore_target(n)[0]]
+            if not needs_restore:
+                return
+            # A mode/map operation owns the transitions while it holds the lock.
+            if not self._mode_change_lock.acquire(blocking=False):
+                return
+            try:
+                for node_name in needs_restore:
+                    # Re-check under the lock: a mode operation may have just moved it.
+                    wrong, target = restore_target(node_name)
+                    if not wrong:
+                        continue
+                    self.get_logger().warning(
+                        f"{node_name} is below its expected lifecycle state while {mode} mode is active -- "
+                        "it likely crashed and respawned; re-driving its lifecycle"
                     )
-                else:
-                    self.get_logger().error(f"Failed to restore {node_name}; retrying on the next watchdog tick")
+                    # only_up: the watchdog may raise a node, never lower one.
+                    if transition_node(self._service_clients, self.get_logger(), node_name, target, only_up=True):
+                        self.get_logger().info(f"{node_name} restored after respawn")
+                    else:
+                        self.get_logger().error(f"Failed to restore {node_name}; retrying on the next watchdog tick")
+            finally:
+                self._mode_change_lock.release()
         finally:
             self._watchdog_busy = False
-            self._mode_change_lock.release()
 
     def _load_map_on_server(self, node_name: str, max_retries: int = 20) -> bool:
         """

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -261,6 +261,17 @@ class ModeManager(Node):
         # Auto-start in the saved mode after a short delay
         self.startup_timer = self.create_timer(3.0, self.auto_start_mode, callback_group=self._internal_callbacks_group)
 
+        # Lifecycle watchdog: launch respawns crashed nav2 nodes (see
+        # controller_server in navigation.launch.py), but a respawned
+        # lifecycle node comes back UNCONFIGURED and useless. Re-drive it for
+        # the current mode. Armed after the first successful mode startup so
+        # it never races the initial bringup.
+        self._lifecycle_watchdog_armed = False
+        self._watchdog_busy = False
+        self._lifecycle_watchdog_timer = self.create_timer(
+            5.0, self._lifecycle_watchdog, callback_group=self._internal_callbacks_group
+        )
+
     def odom_callback(self, msg):
         # Only publish mapping_pose in mapping mode
         if getattr(self, "current_mode", None) != "mapping":
@@ -624,12 +635,53 @@ class ModeManager(Node):
                 message = f"{mode.value} mode started successfully (map: {map_status})"
                 self.get_logger().info(message)
 
+            self._lifecycle_watchdog_armed = True
             return len(failures) == 0, message
 
         except Exception as e:
             error_msg = f"Error requesting {mode.value} startup: {str(e)}"
             self.get_logger().error(error_msg)
             return False, error_msg
+
+    def _lifecycle_watchdog(self):
+        """Restore nodes that crashed and respawned mid-session.
+
+        Observed live: controller_server dies with a double-free SIGABRT after
+        repeated "Failed to make progress" aborts (a sibling of the known
+        teardown crashes listed in skip_cleanup_nodes). launch respawns it,
+        and this watchdog notices the UNCONFIGURED state and re-drives it to
+        where the current mode needs it -- turning a crash into a few seconds
+        of downtime instead of a dead nav stack.
+        """
+        if not self._lifecycle_watchdog_armed or self._watchdog_busy:
+            return
+        mode = getattr(self, "current_mode", None)
+        if mode not in modes_nodes:
+            return
+        # A mode/map operation owns the transitions while it holds the lock.
+        if not self._mode_change_lock.acquire(blocking=False):
+            return
+        self._watchdog_busy = True
+        try:
+            for node_name in modes_nodes[mode]:
+                state = get_node_state(self._service_clients, self.get_logger(), node_name)
+                if state != State.PRIMARY_STATE_UNCONFIGURED:
+                    continue  # healthy, mid-transition, or still respawning (unreachable)
+                expect_active = node_name not in configure_only_nodes.get(mode, set())
+                target = State.PRIMARY_STATE_ACTIVE if expect_active else State.PRIMARY_STATE_INACTIVE
+                self.get_logger().warning(
+                    f"{node_name} is UNCONFIGURED while {mode} mode is active -- "
+                    "it likely crashed and respawned; re-driving its lifecycle"
+                )
+                if transition_node(self._service_clients, self.get_logger(), node_name, target):
+                    self.get_logger().info(
+                        f"{node_name} restored to {'ACTIVE' if expect_active else 'INACTIVE'} after respawn"
+                    )
+                else:
+                    self.get_logger().error(f"Failed to restore {node_name}; retrying on the next watchdog tick")
+        finally:
+            self._watchdog_busy = False
+            self._mode_change_lock.release()
 
     def _load_map_on_server(self, node_name: str, max_retries: int = 20) -> bool:
         """

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/service_utils.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/service_utils.py
@@ -55,11 +55,11 @@ def call_service(service_clients: dict, logger, service_name: str, request, time
         return None
 
 
-def get_node_state(service_clients: dict, logger, node_name: str) -> int:
+def get_node_state(service_clients: dict, logger, node_name: str, timeout_sec: float = 10.0) -> int:
     """Helper to get the current state of a node. Returns state ID or None if failed."""
     get_state_request = GetState.Request()
     get_state_result = call_service(
-        service_clients, logger, f"/{node_name}/get_state", get_state_request, timeout_sec=10.0
+        service_clients, logger, f"/{node_name}/get_state", get_state_request, timeout_sec=timeout_sec
     )
 
     if get_state_result is None:


### PR DESCRIPTION
## Problem

`controller_server` crashes in the field and nothing brings it back — navigation is silently dead until reboot. Observed live twice in one sim session, same signature both times:

```
[controller_server]: Failed to make progress
[controller_server]: [follow_path] [ActionServer] Aborting handle.
[controller_server-6] double free or corruption (!prev)
process has died [exit code -6]
```

Trigger: repeated progress-checker aborts (the robot stuck/rotating near clutter — a state this stack reaches routinely). After the crash, every navigation turns into recovery theater: the BT times out waiting for `follow_path` to acknowledge, cycles clear/spin/backup/wait, and aborts — indistinguishable from "navigation mysteriously broken."

## Root-cause investigation (summary)

- **It's a thread race in upstream code, not ours**: valgrind memcheck observed **21 executions of the abort path with zero invalid memory operations** — memcheck serializes threads, and serialized execution can't race; free-running execution crashes. Under gdb the timing shift also hides it.
- The race surface is nav2_util's `SimpleActionServer`: the control loop runs in a detached `std::async` thread and calls `terminate_current()` on failure while the executor thread concurrently handles preempts/cancels/expiry on the same goal handles.
- It is **not** the already-fixed rclcpp action race (ros2/rclcpp#2250, backported long ago — we run rclcpp-action 16.0.19 which includes it). This is an additional, unfixed race somewhere in nav2_util / rcl_action / rmw_zenoh.
- This is a sibling of the crash family already documented in `mode_manager.py`'s `skip_cleanup_nodes` ("Zenoh RMW crashes during TF unsubscription in cleanup", planner "Segfaults during costmap cleanup").
- Real-robot exposure is identical: same ARM64 Humble debs (`ros-humble-nav2-controller 1.1.20`), same `rmw_zenoh_cpp 0.1.8`, same abort-generating behaviors. An upstream issue with the reproduction recipe is the path to a true fix; this PR makes the crash survivable in the meantime (and for whatever the next such bug is).

## Fix

Two parts, both generic:

1. **`respawn=True, respawn_delay=2.0`** on `controller_server` (`navigation.launch.py`) — launch brings the process back.
2. **Lifecycle watchdog in `mode_manager`** — a respawned lifecycle node comes back `UNCONFIGURED` and useless. A 5 s watchdog checks the current mode's nodes and re-drives anything `UNCONFIGURED` to where the mode needs it (`ACTIVE`, or `INACTIVE` for configure-only nodes). It arms only after the first successful mode startup (never races bringup) and yields to in-flight mode/map operations via the existing `_mode_change_lock`. It heals **any** respawn-configured nav node, not just the controller.

## Verification (live, full digital twin)

Simulated the exact crash (`SIGABRT` to `controller_server`) during an active session:

```
T0      SIGABRT
T0+2s   launch respawn: "process started with pid [56382]"
T0+6s   watchdog: "controller_server is UNCONFIGURED while navigation mode is
        active -- it likely crashed and respawned; re-driving its lifecycle"
        "controller_server restored to ACTIVE after respawn"
T0+40s  next NavigateToPose goal: SUCCEEDED
```

A crash that previously cost the rest of the session now costs ~6 seconds and leaves a loud log line.

## Real-robot testing notes

- To exercise the heal path on hardware without waiting for a natural crash: `pkill -ABRT -f nav2_controller` mid-session, then watch for the watchdog log lines and send a goal.
- The watchdog acts only on `UNCONFIGURED` nodes of the *current* mode, so normal mode switches, map switches and bringup are untouched (they hold `_mode_change_lock`, which the watchdog defers to).
