### PR TITLE
Map view: localization + navigation controls, working route, grab-to-pan

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -269,6 +269,8 @@ button {
   display: block;
   width: 100%;
   height: 100%;
+  /* Drags pan the map (or place goals); never scroll the page. */
+  touch-action: none;
 }
 
 .map-controls {
@@ -286,7 +288,80 @@ button {
 
 .map-controls-row {
   display: flex;
+  flex-direction: column;
+  align-items: stretch;
   gap: 8px;
+  min-width: 210px;
+}
+
+/* Icon + label cards with a hint slot, mobile-app style but in this design
+   system's vocabulary: hairlines and signal amber, no glow. */
+.map-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px 6px 8px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 10px;
+  background: rgb(10 10 12 / 78%);
+  color: var(--text);
+  text-align: left;
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.map-btn:hover:not(:disabled) {
+  border-color: var(--accent-dim);
+}
+
+.map-btn:disabled {
+  color: var(--muted);
+  cursor: progress;
+}
+
+.map-btn.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-faint);
+}
+
+.map-btn-icon {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 50%;
+}
+
+.map-btn-icon svg {
+  width: 13px;
+  height: 13px;
+}
+
+.map-btn-label {
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.map-btn-hint {
+  margin-left: auto;
+  padding-left: 10px;
+  border-left: 1px solid var(--hairline);
+  max-width: 120px;
+  font-size: 10px;
+  line-height: 1.3;
+  color: var(--muted);
+}
+
+.map-btn-hint:empty {
+  display: none;
+}
+
+/* Icon-only (Back): don't stretch to the card width. */
+.map-btn-compact {
+  align-self: flex-start;
 }
 
 /* Outcome line for the widget's own navigation goals. */
@@ -308,15 +383,6 @@ button {
   color: var(--danger);
 }
 
-.map-goal-btn,
-.map-stop-btn {
-  background: rgba(10, 10, 12, 0.7);
-}
-
-.map-goal-btn.is-active {
-  border-color: var(--accent);
-  color: var(--accent);
-}
 
 .connect-layer {
   display: grid;
@@ -720,7 +786,7 @@ button {
   display: block;
 }
 
-/* The map's Set Goal control only makes sense at full size. */
+/* The map's Locate / Go To controls only make sense at full size. */
 .cam-map-host:not(.big) .map-controls {
   display: none;
 }
@@ -5534,6 +5600,14 @@ button {
     bottom: auto !important;
     top: calc(24px + min(120px, 24vw)) !important;
     left: 14px !important;
+  }
+
+  /* Map controls: the camera strip spans the whole top on phones (the
+     desktop position tucked them under the telemetry card, which is hidden
+     here) -- start below the tiles instead. */
+  .map-controls {
+    top: calc(26px + min(120px, 24vw));
+    left: 14px;
   }
 }
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -273,10 +273,39 @@ button {
 
 .map-controls {
   position: absolute;
-  top: 16px;
-  right: 56px;
+  /* Top-left under the robot info card: the top-right corner belongs to the
+     camera tile strip when the map is the primary stage view, which used to
+     cover these buttons entirely. */
+  top: 96px;
+  left: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.map-controls-row {
   display: flex;
   gap: 8px;
+}
+
+/* Outcome line for the widget's own navigation goals. */
+.map-status {
+  max-width: 340px;
+  padding: 4px 10px;
+  border-radius: 8px;
+  background: rgba(10, 10, 12, 0.7);
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
+.map-status[data-kind="ok"] {
+  color: var(--ok);
+}
+
+.map-status[data-kind="fail"] {
+  color: var(--danger);
 }
 
 .map-goal-btn,

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -275,9 +275,7 @@ button {
 
 .map-controls {
   position: absolute;
-  /* Top-left under the robot info card: the top-right corner belongs to the
-     camera tile strip when the map is the primary stage view, which used to
-     cover these buttons entirely. */
+  /* Top-left under the robot info card; top-right belongs to the camera strip. */
   top: 96px;
   left: 16px;
   display: flex;
@@ -294,8 +292,7 @@ button {
   min-width: 210px;
 }
 
-/* Icon + label cards with a hint slot, mobile-app style but in this design
-   system's vocabulary: hairlines and signal amber, no glow. */
+/* Icon + label cards with a hint slot (mobile-app style). */
 .map-btn {
   display: flex;
   align-items: center;
@@ -5602,9 +5599,7 @@ button {
     left: 14px !important;
   }
 
-  /* Map controls: the camera strip spans the whole top on phones (the
-     desktop position tucked them under the telemetry card, which is hidden
-     here) -- start below the tiles instead. */
+  /* The camera strip spans the whole top on phones -- start below the tiles. */
   .map-controls {
     top: calc(26px + min(120px, 24vw));
     left: 14px;

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -56,6 +56,10 @@ export const ODOM_TOPIC = "/odom"; // nav_msgs/Odometry
 // are namespaced (mars_nav launch), so the route arrives on one of these
 // depending on the active planner; there is no root /plan publisher.
 export const PLAN_TOPICS = ["/navigation/plan", "/mapfree/plan"];
+// AMCL's map-frame pose estimate (geometry_msgs/PoseWithCovarianceStamped).
+// The robot marker anchors here: /odom is the odom frame, and drawing it on
+// the map canvas is off by the whole map->odom correction on a real robot.
+export const AMCL_POSE_TOPIC = "/amcl_pose";
 // The exact goal navigate_to_position commanded (geometry_msgs/PoseStamped,
 // latched; frame_id is "map", or "odom" for local goals) — the true target,
 // unlike the plan endpoint which wiggles with every replan.

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -52,11 +52,14 @@ export const WEBSOCKET_STATUS_TOPIC = "/brain/websocket_status";
 // Navigation map + odometry for the 2D map page.
 export const MAP_TOPIC = "/map"; // nav_msgs/OccupancyGrid
 export const ODOM_TOPIC = "/odom"; // nav_msgs/Odometry
-export const PLAN_TOPIC = "/plan"; // nav_msgs/Path — the planner's route to the goal
-// Click-to-navigate goal. Publishing a geometry_msgs/PoseStamped here kicks off
-// planning; the resulting route streams back on PLAN_TOPIC. Same topic the sim
-// console's map view publishes to.
-export const GOAL_POSE_TOPIC = "/goal_pose";
+// nav_msgs/Path — the planner's route to the goal. Both Nav2 planner servers
+// are namespaced (mars_nav launch), so the route arrives on one of these
+// depending on the active planner; there is no root /plan publisher.
+export const PLAN_TOPICS = ["/navigation/plan", "/mapfree/plan"];
+// The exact goal navigate_to_position commanded (geometry_msgs/PoseStamped,
+// latched; frame_id is "map", or "odom" for local goals) — the true target,
+// unlike the plan endpoint which wiggles with every replan.
+export const COMMANDED_GOAL_TOPIC = "/nav/commanded_goal";
 // Stop all active navigation (std_srvs/Trigger) — cancels every NavigateToPose
 // goal, no matter which client started it.
 export const CANCEL_NAVIGATION_SERVICE = "/nav/cancel_navigation";

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -52,23 +52,16 @@ export const WEBSOCKET_STATUS_TOPIC = "/brain/websocket_status";
 // Navigation map + odometry for the 2D map page.
 export const MAP_TOPIC = "/map"; // nav_msgs/OccupancyGrid
 export const ODOM_TOPIC = "/odom"; // nav_msgs/Odometry
-// nav_msgs/Path — the planner's route to the goal. Both Nav2 planner servers
-// are namespaced (mars_nav launch), so the route arrives on one of these
-// depending on the active planner; there is no root /plan publisher.
+// nav_msgs/Path — the planner's route. Both planner servers are namespaced;
+// there is no root /plan publisher.
 export const PLAN_TOPICS = ["/navigation/plan", "/mapfree/plan"];
 // AMCL's map-frame pose estimate (geometry_msgs/PoseWithCovarianceStamped).
-// The robot marker anchors here: /odom is the odom frame, and drawing it on
-// the map canvas is off by the whole map->odom correction on a real robot.
 export const AMCL_POSE_TOPIC = "/amcl_pose";
-// The exact goal navigate_to_position commanded (geometry_msgs/PoseStamped,
-// latched; frame_id is "map", or "odom" for local goals) — the true target,
-// unlike the plan endpoint which wiggles with every replan.
+// The exact goal navigate_to_position commanded (geometry_msgs/PoseStamped, latched).
 export const COMMANDED_GOAL_TOPIC = "/nav/commanded_goal";
-// Stop all active navigation (std_srvs/Trigger) — cancels every NavigateToPose
-// goal, no matter which client started it.
+// Stop all active navigation (std_srvs/Trigger), no matter which client started it.
 export const CANCEL_NAVIGATION_SERVICE = "/nav/cancel_navigation";
-// Auto-localization (std_srvs/Trigger on grid_localizer): scan-match the lidar
-// against the map and seed AMCL with the best pose. Can take tens of seconds.
+// Auto-localization (std_srvs/Trigger on grid_localizer). Can take tens of seconds.
 export const LOCALIZE_SERVICE = "/localize";
 // AMCL's manual seed (nav2_msgs/srv/SetInitialPose) — place the robot by hand.
 export const SET_INITIAL_POSE_SERVICE = "/set_initial_pose";

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -67,6 +67,11 @@ export const COMMANDED_GOAL_TOPIC = "/nav/commanded_goal";
 // Stop all active navigation (std_srvs/Trigger) — cancels every NavigateToPose
 // goal, no matter which client started it.
 export const CANCEL_NAVIGATION_SERVICE = "/nav/cancel_navigation";
+// Auto-localization (std_srvs/Trigger on grid_localizer): scan-match the lidar
+// against the map and seed AMCL with the best pose. Can take tens of seconds.
+export const LOCALIZE_SERVICE = "/localize";
+// AMCL's manual seed (nav2_msgs/srv/SetInitialPose) — place the robot by hand.
+export const SET_INITIAL_POSE_SERVICE = "/set_initial_pose";
 
 // Skill-execution status (std_msgs/String JSON: {primitive_name|skill_name,
 // status: running|completed|failed|interrupted, primitive_id, ...}), published

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -14,7 +14,12 @@ import {
   PLAN_TOPICS,
   COMMANDED_GOAL_TOPIC,
   CANCEL_NAVIGATION_SERVICE,
+  LOCALIZE_SERVICE,
+  SET_INITIAL_POSE_SERVICE,
 } from "../constants.js";
+
+// /localize scan-matches for up to ~30 s before answering.
+const LOCALIZE_TIMEOUT_MS = 40_000;
 
 // Wheel-zoom bounds (metres of real-world width shown).
 const MIN_ZOOM_M = 1;
@@ -35,16 +40,49 @@ export function createMap(root, opts = {}) {
   root.appendChild(canvas);
   const ctx = canvas.getContext("2d");
 
-  const goalBtn = document.createElement("button");
-  goalBtn.className = "map-goal-btn sim-button";
-  goalBtn.textContent = "Set Goal";
-  const stopBtn = document.createElement("button");
-  stopBtn.className = "map-stop-btn sim-button";
-  stopBtn.textContent = "Stop";
+  // Controls mirror the mobile app's map: Locate expands to Auto (grid-localizer
+  // scan match) / Manual (place the robot by drag), Go To arms drag-to-navigate,
+  // and Stop takes Go To's place while a navigation is running. Each button is
+  // an icon + label card with a hint slot that render() keeps current.
+  const ICONS = {
+    back: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3L5 8l5 5"/></svg>',
+    locate:
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><circle cx="8" cy="8" r="4.5"/><path d="M8 .8v2.4M8 12.8v2.4M.8 8h2.4M12.8 8h2.4"/></svg>',
+    auto: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><circle cx="8" cy="8" r="6"/><circle cx="8" cy="8" r="1.6" fill="currentColor" stroke="none"/></svg>',
+    manual:
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 13l1-3.5L11.5 2 14 4.5 6.5 12 3 13z"/></svg>',
+    go: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 1.5L1.5 7l5 2 2 5 6-12.5z"/></svg>',
+    stop: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"><rect x="4" y="4" width="8" height="8" rx="1"/></svg>',
+    center:
+      '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"><circle cx="8" cy="8" r="4.5"/><circle cx="8" cy="8" r="1.5" fill="currentColor" stroke="none"/><path d="M8 .8v2.4M8 12.8v2.4M.8 8h2.4M12.8 8h2.4"/></svg>',
+  };
+  /** @param {string} icon @param {string} label @param {string} [hint] */
+  function makeButton(icon, label, hint = "") {
+    const btn = document.createElement("button");
+    btn.className = "map-btn";
+    btn.innerHTML =
+      `<span class="map-btn-icon">${icon}</span>` +
+      (label ? `<span class="map-btn-label">${label}</span>` : "") +
+      `<span class="map-btn-hint">${hint}</span>`;
+    return btn;
+  }
+  /** @param {HTMLButtonElement} btn @param {string} text */
+  function setHint(btn, text) {
+    const el = btn.querySelector(".map-btn-hint");
+    if (el && el.textContent !== text) el.textContent = text;
+  }
+  const backBtn = makeButton(ICONS.back, "");
+  backBtn.classList.add("map-btn-compact");
+  backBtn.title = "Back";
+  const locateBtn = makeButton(ICONS.locate, "Locate", "auto or manual");
+  const autoBtn = makeButton(ICONS.auto, "Auto", "match lidar to the map");
+  const manualBtn = makeButton(ICONS.manual, "Manual", "drag where the robot is");
+  const goBtn = makeButton(ICONS.go, "Go To", "tap a point to navigate");
+  const stopBtn = makeButton(ICONS.stop, "Stop", "cancel navigation");
+  const centerBtn = makeButton(ICONS.center, "Recenter", "follow the robot");
   const controlsRow = document.createElement("div");
   controlsRow.className = "map-controls-row";
-  controlsRow.appendChild(goalBtn);
-  controlsRow.appendChild(stopBtn);
+  for (const btn of [backBtn, locateBtn, autoBtn, manualBtn, goBtn, stopBtn, centerBtn]) controlsRow.appendChild(btn);
   // Outcome of the widget's own navigation goals: live progress while
   // driving, then success or a specific failure line (not just "failed").
   const statusEl = document.createElement("div");
@@ -59,7 +97,7 @@ export function createMap(root, opts = {}) {
   let goalGen = 0; // ignore settlements of superseded goals
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let statusClearTimer;
-  /** @param {"navigating" | "ok" | "fail" | "muted"} kind @param {string} text @param {boolean} [autoclear] */
+  /** @param {"navigating" | "ok" | "fail" | "muted" | "hint"} kind @param {string} text @param {boolean} [autoclear] */
   function setStatus(kind, text, autoclear = false) {
     clearTimeout(statusClearTimer);
     statusEl.hidden = false;
@@ -116,10 +154,21 @@ export function createMap(root, opts = {}) {
   /** @type {{ ox: number, oy: number, scale: number } | null} */
   let view = null;
 
-  // Goal-setting: click sets the position, drag sets the heading.
-  let goalMode = false;
+  // Control state: "locate" shows the Auto/Manual choice; "manual" and "goto"
+  // arm the map for a press-drag (click sets the position, drag the heading) —
+  // manual seeds AMCL where the user pointed, goto navigates there.
+  /** @type {"idle" | "locate" | "manual" | "goto"} */
+  let ui = "idle";
+  let locating = false; // auto-locate service call in flight
+  let navigating = false; // a goal sent from this widget is in flight
   /** @type {{ start: { x: number, y: number }, cur: { x: number, y: number } } | null} */
   let goalDrag = null;
+  // Grab-to-pan: while set, the view centres here instead of following the
+  // robot; Recenter clears it.
+  /** @type {{ x: number, y: number } | null} */
+  let panCenter = null;
+  /** @type {{ px: number, py: number, center: { x: number, y: number }, moved: boolean } | null} */
+  let panDrag = null;
   /** @type {{ x: number, y: number, yaw: number } | null} the active goal */
   let goalMarker = null;
   // True once /nav/commanded_goal set the marker for this navigation: the
@@ -246,6 +295,7 @@ export function createMap(root, opts = {}) {
       goalMarker = null;
       goalIsCommanded = false;
       plan = null;
+      render();
       draw();
     }, NAV_STALE_MS);
   }
@@ -262,6 +312,7 @@ export function createMap(root, opts = {}) {
     goalMarker = { x: pos.x, y: pos.y, yaw: Math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z)) };
     goalIsCommanded = true;
     armNavStale(); // the goal marks an active navigation; expire it like the route
+    render();
     draw();
   }
 
@@ -296,6 +347,7 @@ export function createMap(root, opts = {}) {
       goalIsCommanded = false;
       clearTimeout(navStaleTimer);
     }
+    render();
     draw();
   }
 
@@ -312,21 +364,26 @@ export function createMap(root, opts = {}) {
       return;
     }
 
+    // The view centres on the pan point if the user grabbed the map, else it
+    // follows the robot (zoom mode). Zoom mode shows a fixed real-world window
+    // (zoomMeters across) so the map stays legible at thumbnail size; anything
+    // outside is clipped by the canvas bounds.
     let scale, ox, oy;
-    if (zoomMeters && pose) {
-      // Robot-centred zoom: show a fixed real-world window (zoomMeters across) centred on the pose, so the
-      // map stays legible at thumbnail size instead of fitting the whole world into a few pixels. Anything
-      // outside the window is simply clipped by the canvas bounds.
+    const center = panCenter ?? (zoomMeters && pose ? pose : null);
+    if (zoomMeters && center) {
       const cellsAcross = zoomMeters / grid.resolution;
       scale = Math.min(canvas.width, canvas.height) / cellsAcross;
-      const poseCol = (pose.x - grid.originX) / grid.resolution;
-      const poseRowFromBottom = (pose.y - grid.originY) / grid.resolution;
-      ox = canvas.width / 2 - poseCol * scale;
-      oy = canvas.height / 2 - (grid.height - poseRowFromBottom) * scale;
     } else {
-      // Fit the whole grid (standalone page, or before the first pose arrives).
+      // Fit-the-whole-grid scale (no zoom set, or before the first pose).
       const pad = 16 * dpr();
       scale = Math.min((canvas.width - 2 * pad) / grid.width, (canvas.height - 2 * pad) / grid.height);
+    }
+    if (center) {
+      const col = (center.x - grid.originX) / grid.resolution;
+      const rowFromBottom = (center.y - grid.originY) / grid.resolution;
+      ox = canvas.width / 2 - col * scale;
+      oy = canvas.height / 2 - (grid.height - rowFromBottom) * scale;
+    } else {
       ox = (canvas.width - grid.width * scale) / 2;
       oy = (canvas.height - grid.height * scale) / 2;
     }
@@ -347,18 +404,20 @@ export function createMap(root, opts = {}) {
       ctx.stroke();
     }
 
-    // Goal: a green dot, plus a heading arrow while dragging.
+    // Goal: a green dot, plus a heading arrow while dragging. A manual-locate
+    // drag places the robot, not a goal — draw it in the robot's orange.
     const goalAt = goalDrag ? { x: goalDrag.start.x, y: goalDrag.start.y } : goalMarker;
     if (goalAt) {
+      const color = goalDrag && ui === "manual" ? "#e8a33d" : "#00ff88";
       const { px, py } = worldToCanvas(goalAt.x, goalAt.y);
       const r = Math.max(4, 6 * dpr());
-      ctx.fillStyle = "#00ff88";
+      ctx.fillStyle = color;
       ctx.beginPath();
       ctx.arc(px, py, r, 0, Math.PI * 2);
       ctx.fill();
       const yaw = goalDrag ? Math.atan2(goalDrag.cur.y - goalDrag.start.y, goalDrag.cur.x - goalDrag.start.x) : goalMarker?.yaw;
       if (typeof yaw === "number") {
-        ctx.strokeStyle = "#00ff88";
+        ctx.strokeStyle = color;
         ctx.lineWidth = 2 * dpr();
         ctx.beginPath();
         ctx.moveTo(px, py);
@@ -383,13 +442,78 @@ export function createMap(root, opts = {}) {
     }
   }
 
-  /** @param {boolean} on */
-  function setGoalMode(on) {
-    goalMode = on;
-    goalBtn.classList.toggle("is-active", on);
-    goalBtn.textContent = on ? "Click map…" : "Set Goal";
-    canvas.style.cursor = on ? "crosshair" : "";
-    if (!on) goalDrag = null;
+  function render() {
+    const navActive = navigating || goalMarker !== null;
+    backBtn.hidden = ui === "idle";
+    locateBtn.hidden = ui !== "idle";
+    locateBtn.disabled = locating || navActive;
+    locateBtn.classList.toggle("is-active", locating);
+    setHint(locateBtn, locating ? "locating…" : "auto or manual");
+    autoBtn.hidden = ui !== "locate";
+    autoBtn.disabled = locating;
+    manualBtn.hidden = ui !== "locate" && ui !== "manual";
+    manualBtn.classList.toggle("is-active", ui === "manual");
+    setHint(manualBtn, ui === "manual" ? "click & drag on the map" : "drag where the robot is");
+    goBtn.hidden = (ui !== "idle" && ui !== "goto") || (ui === "idle" && navActive);
+    goBtn.classList.toggle("is-active", ui === "goto");
+    setHint(goBtn, ui === "goto" ? "click & drag on the map" : "tap a point to navigate");
+    stopBtn.hidden = !(ui === "idle" && navActive);
+    centerBtn.hidden = panCenter === null;
+    canvas.style.cursor = ui === "manual" || ui === "goto" ? "crosshair" : "grab";
+  }
+
+  /** @param {typeof ui} next */
+  function setUi(next) {
+    ui = next;
+    if (ui !== "manual" && ui !== "goto") goalDrag = null;
+    render();
+  }
+
+  // Drag instructions live in the status line; only wipe them, never a result.
+  function clearHint() {
+    if (statusEl.dataset.kind === "hint") statusEl.hidden = true;
+  }
+
+  async function autoLocate() {
+    if (locating) return;
+    locating = true;
+    setUi("idle");
+    setStatus("hint", "Locating — matching the lidar scan against the map…");
+    try {
+      const res = await ros.callService(LOCALIZE_SERVICE, {}, LOCALIZE_TIMEOUT_MS);
+      if (res?.success) setStatus("ok", res.message || "Localized", true);
+      else setStatus("fail", res?.message || "Could not localize — try Manual");
+    } catch (err) {
+      setStatus("fail", `Locate failed — ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      locating = false;
+      render();
+    }
+  }
+
+  /** @param {number} x @param {number} y @param {number} yaw seed AMCL at the hand-placed pose */
+  async function sendInitialPose(x, y, yaw) {
+    setStatus("hint", "Setting position…");
+    // Hand placement is approximate — give AMCL room to converge (same
+    // covariance the mobile app uses).
+    const covariance = new Array(36).fill(0);
+    covariance[0] = 0.25;
+    covariance[7] = 0.25;
+    covariance[35] = 0.068;
+    try {
+      await ros.callService(SET_INITIAL_POSE_SERVICE, {
+        pose: {
+          header: { stamp: { sec: 0, nanosec: 0 }, frame_id: "map" },
+          pose: {
+            pose: { position: { x, y, z: 0 }, orientation: { x: 0, y: 0, z: Math.sin(yaw / 2), w: Math.cos(yaw / 2) } },
+            covariance,
+          },
+        },
+      });
+      setStatus("ok", "Position set", true);
+    } catch (err) {
+      setStatus("fail", `Set position failed — ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   /** @param {number} x @param {number} y @param {number} yaw */
@@ -405,6 +529,7 @@ export function createMap(root, opts = {}) {
     const gen = ++goalGen;
     /** @type {{ distance_remaining?: number, number_of_recoveries?: number } | null} */
     let lastFb = null;
+    navigating = true;
     setStatus("navigating", "Navigating…");
     ros
       .sendActionGoal(
@@ -444,34 +569,67 @@ export function createMap(root, opts = {}) {
             ? ` ${d.toFixed(1)} m from the goal${n ? ` after ${n} recover${n === 1 ? "y" : "ies"}` : ""} — route blocked or robot stuck?`
             : " — no path (goal unreachable or outside the map?)";
         setStatus("fail", `Failed${detail}`);
+      })
+      .finally(() => {
+        if (gen !== goalGen) return; // a newer goal took over the flag
+        navigating = false;
+        render();
       });
     plan = null; // drop the stale route; the new one streams in on /plan
     goalMarker = { x, y, yaw };
     goalIsCommanded = false; // a fresh click supersedes any previous skill goal
     armNavStale(); // hold the goal until the route starts, then while it runs
+    render();
   }
 
   /** @param {PointerEvent} e */
   function onPointerDown(e) {
-    if (!goalMode || !grid || !view) return;
+    if (!grid || !view) return;
     e.preventDefault();
     const { px, py } = eventToCanvas(e);
-    const w = canvasToWorld(px, py);
-    goalDrag = { start: w, cur: w };
     canvas.setPointerCapture(e.pointerId);
-    draw();
+    if (ui === "manual" || ui === "goto") {
+      const w = canvasToWorld(px, py);
+      goalDrag = { start: w, cur: w };
+      draw();
+      return;
+    }
+    // Otherwise grab-to-pan; it only becomes a pan after a few px of movement,
+    // so plain clicks don't nudge the view.
+    panDrag = { px, py, center: canvasToWorld(canvas.width / 2, canvas.height / 2), moved: false };
   }
 
   /** @param {PointerEvent} e */
   function onPointerMove(e) {
-    if (!goalDrag) return;
+    if (goalDrag) {
+      const { px, py } = eventToCanvas(e);
+      goalDrag.cur = canvasToWorld(px, py);
+      draw();
+      return;
+    }
+    if (!panDrag || !grid || !view) return;
     const { px, py } = eventToCanvas(e);
-    goalDrag.cur = canvasToWorld(px, py);
+    const dx = px - panDrag.px;
+    const dy = py - panDrag.py;
+    if (!panDrag.moved) {
+      if (Math.hypot(dx, dy) < 4 * dpr()) return;
+      panDrag.moved = true;
+      canvas.style.cursor = "grabbing";
+    }
+    // The world point under the cursor follows the cursor: shift the centre
+    // opposite the drag (canvas y grows downward, world y upward).
+    const mPerPx = grid.resolution / view.scale;
+    panCenter = { x: panDrag.center.x - dx * mPerPx, y: panDrag.center.y + dy * mPerPx };
     draw();
   }
 
   /** @param {PointerEvent} e */
   function onPointerUp(e) {
+    if (panDrag) {
+      panDrag = null;
+      render(); // restore the cursor, surface Recenter
+      return;
+    }
     if (!goalDrag) return;
     const { start, cur } = goalDrag;
     goalDrag = null;
@@ -479,8 +637,9 @@ export function createMap(root, opts = {}) {
     const dy = cur.y - start.y;
     // Short drag → no meaningful heading, just face "east".
     const yaw = Math.hypot(dx, dy) > 0.1 ? Math.atan2(dy, dx) : 0;
-    publishGoal(start.x, start.y, yaw);
-    setGoalMode(false);
+    if (ui === "manual") sendInitialPose(start.x, start.y, yaw);
+    else publishGoal(start.x, start.y, yaw);
+    setUi("idle");
     draw();
   }
 
@@ -495,30 +654,58 @@ export function createMap(root, opts = {}) {
     opts.onZoomChange?.(zoomMeters);
   }
 
-  goalBtn.addEventListener("click", () => setGoalMode(!goalMode));
+  backBtn.addEventListener("click", () => {
+    clearHint();
+    setUi("idle");
+  });
+  centerBtn.addEventListener("click", () => {
+    panCenter = null; // back to following the robot
+    render();
+    draw();
+  });
+  locateBtn.addEventListener("click", () => setUi("locate"));
+  autoBtn.addEventListener("click", autoLocate);
+  manualBtn.addEventListener("click", () => {
+    if (ui === "manual") {
+      clearHint();
+      setUi("locate");
+      return;
+    }
+    setStatus("hint", "Click the map where the robot is, drag to set its heading");
+    setUi("manual");
+  });
+  goBtn.addEventListener("click", () => {
+    if (ui === "goto") {
+      clearHint();
+      setUi("idle");
+      return;
+    }
+    setStatus("hint", "Click the destination, drag to set the final heading");
+    setUi("goto");
+  });
 
   // Stop cancels every active navigation goal server-side, then drops the
   // local goal marker and route.
   let stopRequested = 0; // goal generation the user stopped, for status wording
   stopBtn.addEventListener("click", async () => {
     stopBtn.disabled = true;
-    stopBtn.textContent = "Stopping…";
+    setHint(stopBtn, "stopping…");
     stopRequested = goalGen;
     try {
       await ros.callService(CANCEL_NAVIGATION_SERVICE, {});
       goalMarker = null;
       goalIsCommanded = false;
       plan = null;
-      setGoalMode(false);
       draw();
-      stopBtn.textContent = "Stopped";
+      setHint(stopBtn, "stopped");
     } catch (err) {
       console.error("[map] cancel navigation failed:", err);
-      stopBtn.textContent = "Stop failed";
+      setHint(stopBtn, "stop failed");
     } finally {
       stopBtn.disabled = false;
       setTimeout(() => {
-        stopBtn.textContent = "Stop";
+        setHint(stopBtn, "cancel navigation");
+        render();
       }, 1500);
     }
   });
@@ -532,6 +719,7 @@ export function createMap(root, opts = {}) {
   const ro = new ResizeObserver(() => fit());
   ro.observe(root);
   fit();
+  render();
 
   const unsubMap = ros.subscribe(MAP_TOPIC, onMap, 250);
   const unsubOdom = ros.subscribe(ODOM_TOPIC, onOdom, 100);

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -7,7 +7,14 @@
 // is all a 2D map needs.
 
 import { ros } from "../rosClient.js";
-import { MAP_TOPIC, ODOM_TOPIC, PLAN_TOPICS, COMMANDED_GOAL_TOPIC, CANCEL_NAVIGATION_SERVICE } from "../constants.js";
+import {
+  AMCL_POSE_TOPIC,
+  MAP_TOPIC,
+  ODOM_TOPIC,
+  PLAN_TOPICS,
+  COMMANDED_GOAL_TOPIC,
+  CANCEL_NAVIGATION_SERVICE,
+} from "../constants.js";
 
 // Wheel-zoom bounds (metres of real-world width shown).
 const MIN_ZOOM_M = 1;
@@ -71,8 +78,37 @@ export function createMap(root, opts = {}) {
 
   /** @type {{ width: number, height: number, resolution: number, originX: number, originY: number } | null} */
   let grid = null;
-  /** @type {{ x: number, y: number, yaw: number } | null} */
+  /** @type {{ x: number, y: number, yaw: number } | null} displayed robot pose (map frame) */
   let pose = null;
+  // The robot marker must live in the MAP frame like everything else drawn
+  // here. /odom alone is the odom frame -- on a real robot that's off by the
+  // whole map->odom correction (meters after drift). So: anchor at the last
+  // /amcl_pose fix and compose the odometry delta accumulated since, which
+  // stays smooth between AMCL updates. With no AMCL (mapfree mode), raw odom
+  // IS the global frame and is used directly.
+  /** @type {{ x: number, y: number, yaw: number } | null} */
+  let amclPose = null;
+  /** @type {{ x: number, y: number, yaw: number } | null} odom pose at the AMCL fix */
+  let odomAtAmcl = null;
+  /** @type {{ x: number, y: number, yaw: number } | null} latest raw odom */
+  let odomPose = null;
+
+  function composedPose() {
+    if (!amclPose) return odomPose;
+    if (!odomAtAmcl || !odomPose) return amclPose;
+    // Base motion since the fix, expressed in the base frame at fix time...
+    const ca = Math.cos(-odomAtAmcl.yaw);
+    const sa = Math.sin(-odomAtAmcl.yaw);
+    const dxo = odomPose.x - odomAtAmcl.x;
+    const dyo = odomPose.y - odomAtAmcl.y;
+    const dx = dxo * ca - dyo * sa;
+    const dy = dxo * sa + dyo * ca;
+    const dyaw = odomPose.yaw - odomAtAmcl.yaw;
+    // ...then re-applied at the AMCL fix in the map frame.
+    const c = Math.cos(amclPose.yaw);
+    const s = Math.sin(amclPose.yaw);
+    return { x: amclPose.x + dx * c - dy * s, y: amclPose.y + dx * s + dy * c, yaw: amclPose.yaw + dyaw };
+  }
   /** @type {Array<{ x: number, y: number }> | null} world-frame plan points */
   let plan = null;
 
@@ -170,15 +206,32 @@ export function createMap(root, opts = {}) {
     draw();
   }
 
-  /** @param {any} msg nav_msgs/Odometry */
-  function onOdom(msg) {
+  /** @param {any} msg pose-carrying message → {x, y, yaw} or null */
+  function poseOf(msg) {
     const p = msg?.pose?.pose;
     const x = p?.position?.x;
     const y = p?.position?.y;
     const q = p?.orientation;
-    if (typeof x !== "number" || typeof y !== "number" || !q) return;
-    const yaw = Math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z));
-    pose = { x, y, yaw };
+    if (typeof x !== "number" || typeof y !== "number" || !q) return null;
+    return { x, y, yaw: Math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z)) };
+  }
+
+  /** @param {any} msg nav_msgs/Odometry */
+  function onOdom(msg) {
+    const p = poseOf(msg);
+    if (!p) return;
+    odomPose = p;
+    pose = composedPose();
+    draw();
+  }
+
+  /** @param {any} msg geometry_msgs/PoseWithCovarianceStamped (map frame) */
+  function onAmcl(msg) {
+    const p = poseOf(msg);
+    if (!p) return;
+    amclPose = p;
+    odomAtAmcl = odomPose;
+    pose = composedPose();
     draw();
   }
 
@@ -482,6 +535,7 @@ export function createMap(root, opts = {}) {
 
   const unsubMap = ros.subscribe(MAP_TOPIC, onMap, 250);
   const unsubOdom = ros.subscribe(ODOM_TOPIC, onOdom, 100);
+  const unsubAmcl = ros.subscribe(AMCL_POSE_TOPIC, onAmcl, 0, "geometry_msgs/msg/PoseWithCovarianceStamped");
   // Only the active planner publishes, so both feeds can share one handler.
   const unsubPlans = PLAN_TOPICS.map((topic) => ros.subscribe(topic, onPlan, 250, "nav_msgs/msg/Path"));
   const unsubGoal = ros.subscribe(COMMANDED_GOAL_TOPIC, onCommandedGoal, 0, "geometry_msgs/msg/PoseStamped");
@@ -500,6 +554,7 @@ export function createMap(root, opts = {}) {
       ro.disconnect();
       unsubMap();
       unsubOdom();
+      unsubAmcl();
       for (const unsub of unsubPlans) unsub();
       unsubGoal();
       canvas.remove();

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -1,13 +1,13 @@
 // @ts-check
 // Reusable nav-map widget — a plain 2D <canvas> rendering the occupancy grid
 // (/map), robot pose (/odom), planner route (/plan), and click-to-navigate
-// (publishes /goal_pose). Sizes itself to its container via a ResizeObserver, so
+// (sends a NavigateToPose goal via the router). Sizes itself to its container via a ResizeObserver, so
 // it can be the standalone Map page OR a teleop PiP tile that reparents between
 // a small thumbnail and the full stage. No three.js — a canvas + putImageData
 // is all a 2D map needs.
 
 import { ros } from "../rosClient.js";
-import { MAP_TOPIC, ODOM_TOPIC, PLAN_TOPIC, GOAL_POSE_TOPIC, CANCEL_NAVIGATION_SERVICE } from "../constants.js";
+import { MAP_TOPIC, ODOM_TOPIC, PLAN_TOPICS, COMMANDED_GOAL_TOPIC, CANCEL_NAVIGATION_SERVICE } from "../constants.js";
 
 // Wheel-zoom bounds (metres of real-world width shown).
 const MIN_ZOOM_M = 1;
@@ -34,11 +34,36 @@ export function createMap(root, opts = {}) {
   const stopBtn = document.createElement("button");
   stopBtn.className = "map-stop-btn sim-button";
   stopBtn.textContent = "Stop";
+  const controlsRow = document.createElement("div");
+  controlsRow.className = "map-controls-row";
+  controlsRow.appendChild(goalBtn);
+  controlsRow.appendChild(stopBtn);
+  // Outcome of the widget's own navigation goals: live progress while
+  // driving, then success or a specific failure line (not just "failed").
+  const statusEl = document.createElement("div");
+  statusEl.className = "map-status mono";
+  statusEl.hidden = true;
   const controls = document.createElement("div");
   controls.className = "map-controls";
-  controls.appendChild(goalBtn);
-  controls.appendChild(stopBtn);
+  controls.appendChild(controlsRow);
+  controls.appendChild(statusEl);
   root.appendChild(controls);
+
+  let goalGen = 0; // ignore settlements of superseded goals
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let statusClearTimer;
+  /** @param {"navigating" | "ok" | "fail" | "muted"} kind @param {string} text @param {boolean} [autoclear] */
+  function setStatus(kind, text, autoclear = false) {
+    clearTimeout(statusClearTimer);
+    statusEl.hidden = false;
+    statusEl.dataset.kind = kind;
+    statusEl.textContent = text;
+    if (autoclear) {
+      statusClearTimer = setTimeout(() => {
+        statusEl.hidden = true;
+      }, 8000);
+    }
+  }
 
   // Offscreen 1px-per-cell buffer; scaled to the canvas on draw (crisp + cheap).
   const off = document.createElement("canvas");
@@ -61,6 +86,9 @@ export function createMap(root, opts = {}) {
   let goalDrag = null;
   /** @type {{ x: number, y: number, yaw: number } | null} the active goal */
   let goalMarker = null;
+  // True once /nav/commanded_goal set the marker for this navigation: the
+  // skill's exact target then wins over the per-replan plan endpoint.
+  let goalIsCommanded = false;
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let navStaleTimer;
 
@@ -163,9 +191,25 @@ export function createMap(root, opts = {}) {
     clearTimeout(navStaleTimer);
     navStaleTimer = setTimeout(() => {
       goalMarker = null;
+      goalIsCommanded = false;
       plan = null;
       draw();
     }, NAV_STALE_MS);
+  }
+
+  /** @param {any} msg geometry_msgs/PoseStamped — the skill's exact target */
+  function onCommandedGoal(msg) {
+    // Only trust map-frame targets: odom-frame (local) goals would drift
+    // against the map canvas; for those the plan-endpoint fallback at least
+    // matches the frame the route itself is drawn in.
+    if (msg?.header?.frame_id !== "map") return;
+    const pos = msg?.pose?.position;
+    const q = msg?.pose?.orientation;
+    if (typeof pos?.x !== "number" || typeof pos?.y !== "number" || !q) return;
+    goalMarker = { x: pos.x, y: pos.y, yaw: Math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z)) };
+    goalIsCommanded = true;
+    armNavStale(); // the goal marks an active navigation; expire it like the route
+    draw();
   }
 
   /** @param {any} msg nav_msgs/Path */
@@ -179,10 +223,24 @@ export function createMap(root, opts = {}) {
     }
     if (pts.length) {
       plan = pts;
+      // Fallback goal marker: the route's end. Only used until the skill's
+      // exact target arrives on /nav/commanded_goal (goalIsCommanded) — the
+      // endpoint wiggles with every replan, the commanded goal doesn't. Still
+      // needed for navigations that bypass the skill (e.g. map clicks routed
+      // straight to bt_navigator).
+      if (!goalIsCommanded) {
+        const end = poses[poses.length - 1]?.pose;
+        const q = end?.orientation;
+        if (q) {
+          const yaw = Math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z));
+          goalMarker = { x: pts[pts.length - 1].x, y: pts[pts.length - 1].y, yaw };
+        }
+      }
       armNavStale(); // route still streaming → keep the goal visible
     } else {
       plan = null; // empty path = navigation finished/aborted
       goalMarker = null;
+      goalIsCommanded = false;
       clearTimeout(navStaleTimer);
     }
     draw();
@@ -285,13 +343,58 @@ export function createMap(root, opts = {}) {
   function publishGoal(x, y, yaw) {
     const qz = Math.sin(yaw / 2);
     const qw = Math.cos(yaw / 2);
-    const now = Date.now();
-    ros.publish(GOAL_POSE_TOPIC, {
-      header: { stamp: { sec: Math.floor(now / 1000), nanosec: (now % 1000) * 1_000_000 }, frame_id: "map" },
-      pose: { position: { x, y, z: 0 }, orientation: { x: 0, y: 0, z: qz, w: qw } },
-    });
+    // A NavigateToPose ACTION goal through the router, pinned to the map
+    // planner ("navigation"): a map click is a map-frame gesture, so it must
+    // never run on whatever planner the previous navigation left latched
+    // (the /goal_pose topic bypasses the router and does exactly that).
+    // Zero stamp = "latest" to TF. Never wall time: the sim runs on ROS sim
+    // time, where a Date.now() stamp is decades in the future.
+    const gen = ++goalGen;
+    /** @type {{ distance_remaining?: number, number_of_recoveries?: number } | null} */
+    let lastFb = null;
+    setStatus("navigating", "Navigating…");
+    ros
+      .sendActionGoal(
+        "/navigate_to_pose",
+        "nav2_msgs/action/NavigateToPose",
+        {
+          pose: {
+            header: { stamp: { sec: 0, nanosec: 0 }, frame_id: "map" },
+            pose: { position: { x, y, z: 0 }, orientation: { x: 0, y: 0, z: qz, w: qw } },
+          },
+          behavior_tree: "navigation",
+        },
+        {
+          onFeedback: (v) => {
+            if (gen !== goalGen || typeof v?.distance_remaining !== "number") return;
+            lastFb = v;
+            const rec = v.number_of_recoveries ? `, ${v.number_of_recoveries} recover${v.number_of_recoveries === 1 ? "y" : "ies"}` : "";
+            setStatus("navigating", `Navigating — ${v.distance_remaining.toFixed(1)} m left${rec}`);
+          },
+        },
+      )
+      .promise.then(() => {
+        if (gen === goalGen) setStatus("ok", "Reached the goal", true);
+      })
+      .catch(() => {
+        if (gen !== goalGen) return;
+        if (stopRequested === gen) {
+          setStatus("muted", "Stopped", true);
+          return;
+        }
+        // NavigateToPose's result message is empty, so the reason must come
+        // from the last feedback: how far it got and how hard it tried.
+        const d = lastFb?.distance_remaining;
+        const n = lastFb?.number_of_recoveries ?? 0;
+        const detail =
+          typeof d === "number"
+            ? ` ${d.toFixed(1)} m from the goal${n ? ` after ${n} recover${n === 1 ? "y" : "ies"}` : ""} — route blocked or robot stuck?`
+            : " — no path (goal unreachable or outside the map?)";
+        setStatus("fail", `Failed${detail}`);
+      });
     plan = null; // drop the stale route; the new one streams in on /plan
     goalMarker = { x, y, yaw };
+    goalIsCommanded = false; // a fresh click supersedes any previous skill goal
     armNavStale(); // hold the goal until the route starts, then while it runs
   }
 
@@ -343,12 +446,15 @@ export function createMap(root, opts = {}) {
 
   // Stop cancels every active navigation goal server-side, then drops the
   // local goal marker and route.
+  let stopRequested = 0; // goal generation the user stopped, for status wording
   stopBtn.addEventListener("click", async () => {
     stopBtn.disabled = true;
     stopBtn.textContent = "Stopping…";
+    stopRequested = goalGen;
     try {
       await ros.callService(CANCEL_NAVIGATION_SERVICE, {});
       goalMarker = null;
+      goalIsCommanded = false;
       plan = null;
       setGoalMode(false);
       draw();
@@ -376,7 +482,9 @@ export function createMap(root, opts = {}) {
 
   const unsubMap = ros.subscribe(MAP_TOPIC, onMap, 250);
   const unsubOdom = ros.subscribe(ODOM_TOPIC, onOdom, 100);
-  const unsubPlan = ros.subscribe(PLAN_TOPIC, onPlan, 250, "nav_msgs/msg/Path");
+  // Only the active planner publishes, so both feeds can share one handler.
+  const unsubPlans = PLAN_TOPICS.map((topic) => ros.subscribe(topic, onPlan, 250, "nav_msgs/msg/Path"));
+  const unsubGoal = ros.subscribe(COMMANDED_GOAL_TOPIC, onCommandedGoal, 0, "geometry_msgs/msg/PoseStamped");
 
   return {
     /** Swap to a saved zoom (e.g. when this widget reparents between thumbnail and full stage). */
@@ -388,10 +496,12 @@ export function createMap(root, opts = {}) {
     },
     destroy() {
       clearTimeout(navStaleTimer);
+      clearTimeout(statusClearTimer);
       ro.disconnect();
       unsubMap();
       unsubOdom();
-      unsubPlan();
+      for (const unsub of unsubPlans) unsub();
+      unsubGoal();
       canvas.remove();
       controls.remove();
     },

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -40,10 +40,8 @@ export function createMap(root, opts = {}) {
   root.appendChild(canvas);
   const ctx = canvas.getContext("2d");
 
-  // Controls mirror the mobile app's map: Locate expands to Auto (grid-localizer
-  // scan match) / Manual (place the robot by drag), Go To arms drag-to-navigate,
-  // and Stop takes Go To's place while a navigation is running. Each button is
-  // an icon + label card with a hint slot that render() keeps current.
+  // Controls mirror the mobile app's map: Locate expands to Auto/Manual,
+  // Go To arms drag-to-navigate, Stop takes Go To's place while navigating.
   const ICONS = {
     back: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3L5 8l5 5"/></svg>',
     locate:
@@ -83,8 +81,7 @@ export function createMap(root, opts = {}) {
   const controlsRow = document.createElement("div");
   controlsRow.className = "map-controls-row";
   for (const btn of [backBtn, locateBtn, autoBtn, manualBtn, goBtn, stopBtn, centerBtn]) controlsRow.appendChild(btn);
-  // Outcome of the widget's own navigation goals: live progress while
-  // driving, then success or a specific failure line (not just "failed").
+  // Live progress / outcome of the widget's own goals and locate calls.
   const statusEl = document.createElement("div");
   statusEl.className = "map-status mono";
   statusEl.hidden = true;
@@ -118,12 +115,9 @@ export function createMap(root, opts = {}) {
   let grid = null;
   /** @type {{ x: number, y: number, yaw: number } | null} displayed robot pose (map frame) */
   let pose = null;
-  // The robot marker must live in the MAP frame like everything else drawn
-  // here. /odom alone is the odom frame -- on a real robot that's off by the
-  // whole map->odom correction (meters after drift). So: anchor at the last
-  // /amcl_pose fix and compose the odometry delta accumulated since, which
-  // stays smooth between AMCL updates. With no AMCL (mapfree mode), raw odom
-  // IS the global frame and is used directly.
+  // Robot marker in the MAP frame: anchor at the last /amcl_pose fix and add
+  // the odometry delta since (raw /odom is off by the whole map->odom
+  // correction on a real robot). No AMCL yet -> raw odom is the global frame.
   /** @type {{ x: number, y: number, yaw: number } | null} */
   let amclPose = null;
   /** @type {{ x: number, y: number, yaw: number } | null} odom pose at the AMCL fix */
@@ -134,7 +128,7 @@ export function createMap(root, opts = {}) {
   function composedPose() {
     if (!amclPose) return odomPose;
     if (!odomAtAmcl || !odomPose) return amclPose;
-    // Base motion since the fix, expressed in the base frame at fix time...
+    // Motion since the fix in the base frame, re-applied at the AMCL fix.
     const ca = Math.cos(-odomAtAmcl.yaw);
     const sa = Math.sin(-odomAtAmcl.yaw);
     const dxo = odomPose.x - odomAtAmcl.x;
@@ -142,7 +136,6 @@ export function createMap(root, opts = {}) {
     const dx = dxo * ca - dyo * sa;
     const dy = dxo * sa + dyo * ca;
     const dyaw = odomPose.yaw - odomAtAmcl.yaw;
-    // ...then re-applied at the AMCL fix in the map frame.
     const c = Math.cos(amclPose.yaw);
     const s = Math.sin(amclPose.yaw);
     return { x: amclPose.x + dx * c - dy * s, y: amclPose.y + dx * s + dy * c, yaw: amclPose.yaw + dyaw };
@@ -154,25 +147,23 @@ export function createMap(root, opts = {}) {
   /** @type {{ ox: number, oy: number, scale: number } | null} */
   let view = null;
 
-  // Control state: "locate" shows the Auto/Manual choice; "manual" and "goto"
-  // arm the map for a press-drag (click sets the position, drag the heading) —
-  // manual seeds AMCL where the user pointed, goto navigates there.
+  // "manual"/"goto" arm the map for a press-drag: click sets the position,
+  // drag sets the heading.
   /** @type {"idle" | "locate" | "manual" | "goto"} */
   let ui = "idle";
   let locating = false; // auto-locate service call in flight
   let navigating = false; // a goal sent from this widget is in flight
   /** @type {{ start: { x: number, y: number }, cur: { x: number, y: number } } | null} */
   let goalDrag = null;
-  // Grab-to-pan: while set, the view centres here instead of following the
-  // robot; Recenter clears it.
+  // Grab-to-pan: while set, the view centres here instead of on the robot.
   /** @type {{ x: number, y: number } | null} */
   let panCenter = null;
   /** @type {{ px: number, py: number, center: { x: number, y: number }, moved: boolean } | null} */
   let panDrag = null;
   /** @type {{ x: number, y: number, yaw: number } | null} the active goal */
   let goalMarker = null;
-  // True once /nav/commanded_goal set the marker for this navigation: the
-  // skill's exact target then wins over the per-replan plan endpoint.
+  // True once /nav/commanded_goal set the marker: the skill's exact target
+  // wins over the per-replan plan endpoint.
   let goalIsCommanded = false;
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let navStaleTimer;
@@ -284,9 +275,8 @@ export function createMap(root, opts = {}) {
     draw();
   }
 
-  // The planner republishes /plan (~1 Hz) the whole time it's driving to a goal,
-  // and stops once it arrives. So a lull in /plan means navigation has ended —
-  // that's when we drop the goal marker and the route, rather than on a timer.
+  // The planner republishes the route (~1 Hz) while driving and stops on
+  // arrival, so a lull means navigation ended — drop the route and goal then.
   const NAV_STALE_MS = 4000;
 
   function armNavStale() {
@@ -295,6 +285,7 @@ export function createMap(root, opts = {}) {
       goalMarker = null;
       goalIsCommanded = false;
       plan = null;
+      activePlanTopic = null;
       render();
       draw();
     }, NAV_STALE_MS);
@@ -302,9 +293,7 @@ export function createMap(root, opts = {}) {
 
   /** @param {any} msg geometry_msgs/PoseStamped — the skill's exact target */
   function onCommandedGoal(msg) {
-    // Only trust map-frame targets: odom-frame (local) goals would drift
-    // against the map canvas; for those the plan-endpoint fallback at least
-    // matches the frame the route itself is drawn in.
+    // Map-frame targets only: odom-frame goals would drift against the map canvas.
     if (msg?.header?.frame_id !== "map") return;
     const pos = msg?.pose?.position;
     const q = msg?.pose?.orientation;
@@ -316,8 +305,12 @@ export function createMap(root, opts = {}) {
     draw();
   }
 
-  /** @param {any} msg nav_msgs/Path */
-  function onPlan(msg) {
+  // The topic whose route is currently displayed; only it may clear the route.
+  /** @type {string | null} */
+  let activePlanTopic = null;
+
+  /** @param {string} topic @param {any} msg nav_msgs/Path */
+  function onPlan(topic, msg) {
     const poses = msg?.poses;
     if (!Array.isArray(poses)) return;
     const pts = [];
@@ -326,12 +319,11 @@ export function createMap(root, opts = {}) {
       if (typeof pos?.x === "number" && typeof pos?.y === "number") pts.push({ x: pos.x, y: pos.y });
     }
     if (pts.length) {
+      activePlanTopic = topic;
       plan = pts;
-      // Fallback goal marker: the route's end. Only used until the skill's
-      // exact target arrives on /nav/commanded_goal (goalIsCommanded) — the
-      // endpoint wiggles with every replan, the commanded goal doesn't. Still
-      // needed for navigations that bypass the skill (e.g. map clicks routed
-      // straight to bt_navigator).
+      // Fallback goal marker until the exact commanded goal arrives (the plan
+      // endpoint wiggles with every replan); also covers navigations that
+      // bypass the skill.
       if (!goalIsCommanded) {
         const end = poses[poses.length - 1]?.pose;
         const q = end?.orientation;
@@ -340,9 +332,12 @@ export function createMap(root, opts = {}) {
           goalMarker = { x: pts[pts.length - 1].x, y: pts[pts.length - 1].y, yaw };
         }
       }
-      armNavStale(); // route still streaming → keep the goal visible
+      armNavStale();
     } else {
-      plan = null; // empty path = navigation finished/aborted
+      // Empty path = navigation finished/aborted — but only from the planner
+      // that owns the displayed route; the inactive one must not clear it.
+      if (activePlanTopic && topic !== activePlanTopic) return;
+      plan = null;
       goalMarker = null;
       goalIsCommanded = false;
       clearTimeout(navStaleTimer);
@@ -364,10 +359,8 @@ export function createMap(root, opts = {}) {
       return;
     }
 
-    // The view centres on the pan point if the user grabbed the map, else it
-    // follows the robot (zoom mode). Zoom mode shows a fixed real-world window
-    // (zoomMeters across) so the map stays legible at thumbnail size; anything
-    // outside is clipped by the canvas bounds.
+    // Centre on the pan point if the user grabbed the map, else follow the
+    // robot; zoom mode shows a fixed real-world window (zoomMeters across).
     let scale, ox, oy;
     const center = panCenter ?? (zoomMeters && pose ? pose : null);
     if (zoomMeters && center) {
@@ -404,8 +397,8 @@ export function createMap(root, opts = {}) {
       ctx.stroke();
     }
 
-    // Goal: a green dot, plus a heading arrow while dragging. A manual-locate
-    // drag places the robot, not a goal — draw it in the robot's orange.
+    // Goal dot + heading arrow; a manual-locate drag places the robot, not a
+    // goal — draw it in the robot's orange.
     const goalAt = goalDrag ? { x: goalDrag.start.x, y: goalDrag.start.y } : goalMarker;
     if (goalAt) {
       const color = goalDrag && ui === "manual" ? "#e8a33d" : "#00ff88";
@@ -494,8 +487,7 @@ export function createMap(root, opts = {}) {
   /** @param {number} x @param {number} y @param {number} yaw seed AMCL at the hand-placed pose */
   async function sendInitialPose(x, y, yaw) {
     setStatus("hint", "Setting position…");
-    // Hand placement is approximate — give AMCL room to converge (same
-    // covariance the mobile app uses).
+    // Hand placement is approximate — same convergence room the mobile app gives AMCL.
     const covariance = new Array(36).fill(0);
     covariance[0] = 0.25;
     covariance[7] = 0.25;
@@ -520,12 +512,9 @@ export function createMap(root, opts = {}) {
   function publishGoal(x, y, yaw) {
     const qz = Math.sin(yaw / 2);
     const qw = Math.cos(yaw / 2);
-    // A NavigateToPose ACTION goal through the router, pinned to the map
-    // planner ("navigation"): a map click is a map-frame gesture, so it must
-    // never run on whatever planner the previous navigation left latched
-    // (the /goal_pose topic bypasses the router and does exactly that).
-    // Zero stamp = "latest" to TF. Never wall time: the sim runs on ROS sim
-    // time, where a Date.now() stamp is decades in the future.
+    // Action goal through the router, pinned to the map planner — /goal_pose
+    // would bypass it and run on whatever planner was last latched. Zero stamp
+    // = "latest" to TF; wall stamps break under ROS sim time.
     const gen = ++goalGen;
     /** @type {{ distance_remaining?: number, number_of_recoveries?: number } | null} */
     let lastFb = null;
@@ -560,8 +549,8 @@ export function createMap(root, opts = {}) {
           setStatus("muted", "Stopped", true);
           return;
         }
-        // NavigateToPose's result message is empty, so the reason must come
-        // from the last feedback: how far it got and how hard it tried.
+        // NavigateToPose's result message is empty on Humble — reconstruct
+        // the reason from the last feedback.
         const d = lastFb?.distance_remaining;
         const n = lastFb?.number_of_recoveries ?? 0;
         const detail =
@@ -594,8 +583,7 @@ export function createMap(root, opts = {}) {
       draw();
       return;
     }
-    // Otherwise grab-to-pan; it only becomes a pan after a few px of movement,
-    // so plain clicks don't nudge the view.
+    // Otherwise grab-to-pan.
     panDrag = { px, py, center: canvasToWorld(canvas.width / 2, canvas.height / 2), moved: false };
   }
 
@@ -612,12 +600,12 @@ export function createMap(root, opts = {}) {
     const dx = px - panDrag.px;
     const dy = py - panDrag.py;
     if (!panDrag.moved) {
+      // A few px of dead zone so plain clicks don't nudge the view.
       if (Math.hypot(dx, dy) < 4 * dpr()) return;
       panDrag.moved = true;
       canvas.style.cursor = "grabbing";
     }
-    // The world point under the cursor follows the cursor: shift the centre
-    // opposite the drag (canvas y grows downward, world y upward).
+    // Shift the centre opposite the drag (canvas y down, world y up).
     const mPerPx = grid.resolution / view.scale;
     panCenter = { x: panDrag.center.x - dx * mPerPx, y: panDrag.center.y + dy * mPerPx };
     draw();
@@ -724,8 +712,7 @@ export function createMap(root, opts = {}) {
   const unsubMap = ros.subscribe(MAP_TOPIC, onMap, 250);
   const unsubOdom = ros.subscribe(ODOM_TOPIC, onOdom, 100);
   const unsubAmcl = ros.subscribe(AMCL_POSE_TOPIC, onAmcl, 0, "geometry_msgs/msg/PoseWithCovarianceStamped");
-  // Only the active planner publishes, so both feeds can share one handler.
-  const unsubPlans = PLAN_TOPICS.map((topic) => ros.subscribe(topic, onPlan, 250, "nav_msgs/msg/Path"));
+  const unsubPlans = PLAN_TOPICS.map((topic) => ros.subscribe(topic, (msg) => onPlan(topic, msg), 250, "nav_msgs/msg/Path"));
   const unsubGoal = ros.subscribe(COMMANDED_GOAL_TOPIC, onCommandedGoal, 0, "geometry_msgs/msg/PoseStamped");
 
   return {

--- a/webapp/js/rosClient.js
+++ b/webapp/js/rosClient.js
@@ -21,6 +21,20 @@ const RECONNECT_CAP_MS = 10_000;
 const SUB_RETRY_CAP_MS = 30_000;
 
 /**
+ * True when a value carries no actual data: null/undefined, or an object/array
+ * whose leaves are all empty. Catches action results built from empty
+ * sub-messages (e.g. NavigateToPose's {result: {}}), while {success: false} or
+ * {message: ""} still count as data.
+ * @param {any} v
+ * @returns {boolean}
+ */
+function isEmptyDeep(v) {
+  if (v == null) return true;
+  if (typeof v !== "object") return false;
+  return Object.values(v).every(isEmptyDeep);
+}
+
+/**
  * @typedef {Object} Subscription
  * @property {Set<(msg: any) => void>} handlers
  * @property {number | undefined} throttleRate
@@ -390,16 +404,13 @@ export class RosClient {
       const pending = data.id ? this.#pendingActions.get(data.id) : undefined;
       if (!pending) return;
       this.#pendingActions.delete(data.id);
-      // rws sets `result: false` for any non-SUCCEEDED goal (aborted/canceled/
-      // rejected). A goal that actually terminated still carries its result
-      // message (e.g. {success, message, success_type}), so resolve with the
-      // payload and let the caller read the skill-level outcome. Reject only when
-      // it didn't succeed AND no usable result came back (rejected outright):
-      // otherwise a non-null-but-empty {} would masquerade as success, unlike the
-      // service_response path which rejects any result === false.
+      // rws sets `result: false` for any non-SUCCEEDED goal, but the payload may
+      // still carry the skill-level outcome ({success, message, ...}) — resolve
+      // with it and let the caller judge. Reject only when nothing usable came
+      // back, checked deeply: NavigateToPose's aborted result is {result: {}},
+      // which would otherwise resolve and read as "reached".
       const values = data.values;
-      const emptyResult = values == null || (typeof values === "object" && Object.keys(values).length === 0);
-      if (data.result === false && emptyResult) {
+      if (data.result === false && isEmptyDeep(values)) {
         pending.reject(new Error(`Action ${pending.action} was rejected`));
       } else {
         pending.resolve(values);

--- a/webapp/js/rosClient.js
+++ b/webapp/js/rosClient.js
@@ -22,9 +22,7 @@ const SUB_RETRY_CAP_MS = 30_000;
 
 /**
  * True when a value carries no actual data: null/undefined, or an object/array
- * whose leaves are all empty. Catches action results built from empty
- * sub-messages (e.g. NavigateToPose's {result: {}}), while {success: false} or
- * {message: ""} still count as data.
+ * whose leaves are all empty ({success: false} still counts as data).
  * @param {any} v
  * @returns {boolean}
  */
@@ -405,11 +403,10 @@ export class RosClient {
       const pending = data.id ? this.#pendingActions.get(data.id) : undefined;
       if (!pending) return;
       this.#pendingActions.delete(data.id);
-      // rws sets `result: false` for any non-SUCCEEDED goal, but the payload may
-      // still carry the skill-level outcome ({success, message, ...}) — resolve
-      // with it and let the caller judge. Reject only when nothing usable came
-      // back, checked deeply: NavigateToPose's aborted result is {result: {}},
-      // which would otherwise resolve and read as "reached".
+      // rws sets `result: false` for any non-SUCCEEDED goal but the payload may
+      // still carry the skill-level outcome — resolve with it. Reject only when
+      // nothing came back, checked deeply: NavigateToPose's aborted result is
+      // just {result: {}}.
       const values = data.values;
       if (data.result === false && isEmptyDeep(values)) {
         pending.reject(new Error(`Action ${pending.action} was rejected`));

--- a/webapp/js/rosClient.js
+++ b/webapp/js/rosClient.js
@@ -38,6 +38,7 @@ function isEmptyDeep(v) {
  * @typedef {Object} Subscription
  * @property {Set<(msg: any) => void>} handlers
  * @property {number | undefined} throttleRate
+ * @property {string | undefined} type
  * @property {number} retryCount
  * @property {number | null} retryTimer
  */

--- a/workspace/innate_skills/navigate_to_position.py
+++ b/workspace/innate_skills/navigate_to_position.py
@@ -8,6 +8,7 @@ import rclpy
 from geometry_msgs.msg import PoseStamped, Twist
 from nav2_simple_commander.robot_navigator import BasicNavigator, TaskResult
 from rclpy.duration import Duration
+from rclpy.qos import DurabilityPolicy, QoSProfile
 from rclpy.time import Time
 from tf2_ros import TransformException
 from tf2_ros.buffer import Buffer
@@ -51,6 +52,13 @@ class Nav2Controller:
         # TF listener used to resolve local goals into LOCAL_GOAL_FIXED_FRAME
         self.tf_buffer = Buffer()
         self.tf_listener = TransformListener(self.tf_buffer, self.navigator)
+
+        # The exact goal this skill commands, resolved to its fixed frame
+        # (map, or odom for local goals) -- lets UIs render the true target
+        # rather than inferring it from the replanned path's endpoint.
+        # Latched so a viewer that connects mid-navigation still sees it.
+        latched = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+        self._commanded_goal_pub = self.navigator.create_publisher(PoseStamped, "/nav/commanded_goal", latched)
 
         self.logger.info("Nav2 position primitive node created")
 
@@ -132,6 +140,8 @@ class Nav2Controller:
         goal_pose.pose.orientation.y = 0.0
         goal_pose.pose.orientation.z = math.sin(goal_yaw / 2.0)
         goal_pose.pose.orientation.w = math.cos(goal_yaw / 2.0)
+
+        self._commanded_goal_pub.publish(goal_pose)
 
         self.logger.debug(f"Sending goal pose ... behavior_tree: {behavior_tree}")
         path_navigator = self.navigator_mapfree if local_frame else self.navigator_navigation

--- a/workspace/innate_skills/navigate_to_position.py
+++ b/workspace/innate_skills/navigate_to_position.py
@@ -53,10 +53,8 @@ class Nav2Controller:
         self.tf_buffer = Buffer()
         self.tf_listener = TransformListener(self.tf_buffer, self.navigator)
 
-        # The exact goal this skill commands, resolved to its fixed frame
-        # (map, or odom for local goals) -- lets UIs render the true target
-        # rather than inferring it from the replanned path's endpoint.
-        # Latched so a viewer that connects mid-navigation still sees it.
+        # The exact goal this skill commands, latched so UIs can render the
+        # true target (the replanned path's endpoint wiggles).
         latched = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
         self._commanded_goal_pub = self.navigator.create_publisher(PoseStamped, "/nav/commanded_goal", latched)
 


### PR DESCRIPTION
## What

Makes the webapp map a working navigation **and localization** surface — route display, a true target marker, reliable click-to-navigate, localization controls matching the mobile app, and map panning — for the real robot as much as the sim.

### 1. Route display was silently broken (bug fix)

The widget subscribed to `/plan`, which **nothing publishes**: both Nav2 planner servers are namespaced (`mars_nav` launch), so the route arrives on `/navigation/plan` or `/mapfree/plan`. The widget now subscribes to both (only the active one publishes). The blue route line works again.

### 2. Robot marker in the map frame (bug fix)

The marker drew raw `/odom` on the map canvas — on a real robot that's off by the whole map→odom correction (meters after drift), so the dot sat detached from the route. It now anchors at the last `/amcl_pose` fix and composes the odometry delta accumulated since (smooth between AMCL updates); with no AMCL (mapfree), raw odom *is* the global frame and is used directly.

### 3. True target marker

`navigate_to_position` publishes its resolved goal on latched `/nav/commanded_goal`, and the map renders it as the goal marker — agent-driven navigations show their exact commanded target rather than the plan endpoint (which wiggles with every replan). Map-frame goals only; odom-frame goals fall back to the plan endpoint, matching the frame the drawn route uses.

### 4. Localization + navigation controls (mobile-app scheme)

The Set Goal/Stop buttons are replaced by the controller app's control scheme, styled as icon + label + hint cards:

- **Locate → Auto**: calls `/localize` (grid_localizer scan-match, up to ~30 s); the service's own result message lands in the status line.
- **Locate → Manual**: press-drag places the robot (position + heading, drawn in robot-orange), seeding AMCL via `/set_initial_pose` with the same hand-placement covariance the mobile app uses.
- **Go To**: press-drag sets destination + final heading, sent as a `NavigateToPose` **action goal** through the router with `behavior_tree: "navigation"` — deterministically the map planner. (The old `/goal_pose` publish bypassed the router and ran on whatever planner was last latched — frequently the map-blind lidar-only one.) Goals are stamped zero ("latest" to TF; wall stamps break under ROS sim time).
- **Stop** replaces Go To while any navigation is active (yours or the agent's, detected via the streaming route) and cancels server-side via `/nav/cancel_navigation`.

### 5. Grab-to-pan + Recenter

Google-Maps-style panning: drag moves the map (the world point under the cursor follows it), with a 4 px threshold so plain clicks don't nudge the view. Once panned the view stops following the robot and a **Recenter** card appears; wheel zoom works around the panned point. `touch-action: none` so drags work on touch screens.

### 6. Navigation result line

The action's feedback/result drive a status line under the buttons:

- `Navigating — 2.3 m left, 1 recovery` (live)
- `Reached the goal` (auto-clears)
- `Failed 1.4 m from the goal after 2 recoveries — route blocked or robot stuck?` (persists; reconstructed from the last feedback since `NavigateToPose`'s result message is empty on Humble)
- `Stopped` when the user pressed Stop

Aborted goals no longer read as success: rws marks non-SUCCEEDED goals `result: false`, but NavigateToPose's empty result (`{result: {}}`) passed the old shallow emptiness check and resolved. The client now checks emptiness deeply; skill results (`{success, message, ...}`) still resolve as before.

### 7. Layout fixes

- `.map-controls` sat top-right — exactly under the camera tile strip when the map is the primary stage view, hiding the buttons entirely. Moved top-left under the robot info card.
- On phones (≤640 px) the camera strip spans the whole top, so the controls start below the tiles.

## Testing

- Live against the full digital twin: route renders from the namespaced topics; `/nav/commanded_goal` verified publishing the exact skill target; action-goal path verified to flip `/nav/current_planner` to `navigation`; goal → drive → `SUCCEEDED` end to end; failure line verified against induced progress-checker aborts.
- Localization calls verified at the wire level with the widget's exact payloads: `/set_initial_pose` seeds AMCL (it republishes from the seeded pose immediately); `/localize` returns `{success: true}` and snaps AMCL back.
- Real-robot session: caught and fixed the odom-frame marker bug and the aborted-goal-reads-as-success bug (both above).
- `tsc` (checkJs) clean on changed files; ruff clean on the skill.

## Notes for real-robot review

- `/nav/commanded_goal` is a new, additive latched topic — no consumer required; the map uses it opportunistically.
- Map clicks now *always* run the map planner; clicks during mapping mode are rejected by the router (as before, but now explicitly).
- On the real robot, Locate → Auto runs the CUDA grid localizer's scan-match; in sim the same service reseeds from ground truth. Identical interface, different backend.
