### PR TITLE
fix(nav): raise wz_std to restore assertive turning

### DIFF
--- a/ros2_ws/src/mars_bot/mars_nav/config/controller.yaml
+++ b/ros2_ws/src/mars_bot/mars_nav/config/controller.yaml
@@ -53,7 +53,7 @@
       # Sampling standard deviations
       vx_std: 0.2                       # Forward velocity sampling std
       vy_std: 0.0                       # No lateral sampling for diff drive
-      wz_std: 0.2                       # Angular velocity sampling std (matched to vx_std)
+      wz_std: 0.8                       # Angular velocity sampling std (raised high to explore assertive turns)
       
       # Path handling
       transform_tolerance: 0.2          # matches existing transform_tolerance


### PR DESCRIPTION
## What

Raises the MPPI angular sampling std in the nav controller:

- `wz_std: 0.2 → 0.8` in `ros2_ws/src/mars_bot/mars_nav/config/controller.yaml`

**We only changed this one param.** This is a first, deliberately-aggressive test of a single knob — not a full revert.

## Why

The robot stopped turning assertively toward paths planned *behind* it — a regression vs the Sep/Oct 2025 tuning. In the March 2026 tuning burst, angular sampling std `wz_std` was halved (0.4 → 0.2), so MPPI explores far less rotation and rarely commits to a hard rotate-in-place. Bumping it to 0.8 (above `wz_max`) lets it sample the full turn range again.

## Other knobs we did NOT try

If this one param isn't enough, these all moved in the same "less assertive turning" direction vs Sep/Oct 2025 and remain untouched here:

| Param | Sep/Oct 2025 | Current | Note |
|---|---|---|---|
| PathAlignCritic `cost_weight` | 14.0 | 4.0 | pull back *onto* the path — 3.5× weaker |
| PathAngleCritic `cost_weight` | 2.2 | 1.0 | rotate to *face* the path — 2.2× weaker |
| PreferForwardCritic `cost_weight` | 5.0 | 15.0 | discourages reversing — 3× stronger |
| `wz_max` | 0.8 | 0.6 | caps executed turn rate (still clips sampled turns) |

Note `az_max` (angular acceleration) is unchanged vs Sep/Oct (0.5) — it only spiked during Jan–Mar and was reverted, so it is intentionally left alone.