### PR TITLE
fix(cam): set V4L2 anti-flicker filter to local mains frequency (60 Hz default)

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
@@ -20,6 +20,7 @@ main_camera_driver:
     gain: -1
     default_gain: 110
     auto_exposure_mode: 0  # 0=hardware AE (camera built-in), 1=custom PID AE, 2=manual (no AE)
+    power_line_frequency: 60  # Anti-flicker filter, mains Hz: 0=disabled, 50 (EU), 60 (US)
     target_brightness: 128.0
     ae_kp: 0.8
     auto_exposure_update_interval: 3
@@ -36,6 +37,7 @@ arm_camera_driver:
     pixel_format: "YUYV"
     publish_compressed: true
     compressed_frame_interval: 6
+    power_line_frequency: 60  # Anti-flicker filter, mains Hz: 0=disabled, 50 (EU), 60 (US)
 
 # ============================================================================
 # STEREO DEPTH ESTIMATOR (VPI SGM on CUDA)

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/arm_camera_driver.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/arm_camera_driver.hpp
@@ -49,6 +49,11 @@ class ArmCameraDriver : public rclcpp::Node {
     std::string createGStreamerPipeline();
 
     /**
+     * @brief Apply the anti-flicker (power line frequency) V4L2 control
+     */
+    void applyPowerLineFrequency();
+
+    /**
      * @brief Frame processing loop (runs in separate thread)
      */
     void frameProcessingLoop();
@@ -81,6 +86,9 @@ class ArmCameraDriver : public rclcpp::Node {
     bool publish_compressed_{false};
     int compressed_frame_interval_{5};
     int compressed_frame_counter_{0};
+
+    // Anti-flicker filter: 0=disabled, 50 or 60 (Hz)
+    int power_line_frequency_{60};
 };
 
 }  // namespace mars_cam

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/main_camera_driver.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/main_camera_driver.hpp
@@ -300,6 +300,7 @@ class MainCameraDriver : public rclcpp::Node {
     int exposure_setting_{-1};
     int gain_setting_{-1};
     int default_gain_param_{110};
+    int power_line_frequency_{60};  // Anti-flicker filter: 0=disabled, 50 or 60 (Hz)
 
     // Auto exposure control
     AutoExposureController auto_exposure_controller_;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/arm_camera_driver.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/arm_camera_driver.cpp
@@ -2,6 +2,12 @@
 // Copyright (c) 2026 Innate Inc
 #include "mars_cam/arm_camera_driver.hpp"
 #include <filesystem>
+#include <linux/videodev2.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
 
 using namespace std::chrono_literals;
 
@@ -18,6 +24,7 @@ ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions& options) : Node("arm
     this->declare_parameter<std::string>("pixel_format", "YUYV");
     this->declare_parameter<bool>("publish_compressed", false);
     this->declare_parameter<int>("compressed_frame_interval", 5);
+    this->declare_parameter<int>("power_line_frequency", 60);  // Anti-flicker filter: 0=disabled, 50 or 60 (Hz)
 
     // Get parameters
     std::string camera_symlink = this->get_parameter("camera_symlink").as_string();
@@ -26,6 +33,7 @@ ArmCameraDriver::ArmCameraDriver(const rclcpp::NodeOptions& options) : Node("arm
     fps_ = this->get_parameter("fps").as_double();
     publish_compressed_ = this->get_parameter("publish_compressed").as_bool();
     compressed_frame_interval_ = this->get_parameter("compressed_frame_interval").as_int();
+    power_line_frequency_ = this->get_parameter("power_line_frequency").as_int();
 
     // Find camera symlink by pattern matching
     std::string camera_pattern = camera_symlink;
@@ -186,7 +194,49 @@ bool ArmCameraDriver::initializeCamera() {
         }
     }
 
+    applyPowerLineFrequency();
+
     return true;
+}
+
+void ArmCameraDriver::applyPowerLineFrequency() {
+    // Anti-flicker filter: match the camera's banding filter to the local mains
+    // frequency so indoor lighting doesn't flicker in auto-exposure mode.
+    int v4l2_value;
+    switch (power_line_frequency_) {
+        case 0:
+            v4l2_value = V4L2_CID_POWER_LINE_FREQUENCY_DISABLED;
+            break;
+        case 50:
+            v4l2_value = V4L2_CID_POWER_LINE_FREQUENCY_50HZ;
+            break;
+        case 60:
+            v4l2_value = V4L2_CID_POWER_LINE_FREQUENCY_60HZ;
+            break;
+        default:
+            RCLCPP_WARN(this->get_logger(),
+                        "Invalid power_line_frequency %d (expected 0, 50 or 60), keeping camera default",
+                        power_line_frequency_);
+            return;
+    }
+
+    int fd = open(device_path_.c_str(), O_RDWR);
+    if (fd == -1) {
+        RCLCPP_WARN(this->get_logger(), "Failed to open %s for V4L2 controls: %s", device_path_.c_str(),
+                    strerror(errno));
+        return;
+    }
+
+    struct v4l2_control ctrl;
+    ctrl.id = V4L2_CID_POWER_LINE_FREQUENCY;
+    ctrl.value = v4l2_value;
+    if (ioctl(fd, VIDIOC_S_CTRL, &ctrl) == -1) {
+        RCLCPP_WARN(this->get_logger(), "Failed to set anti-flicker filter to %d Hz: %s", power_line_frequency_,
+                    strerror(errno));
+    } else {
+        RCLCPP_INFO(this->get_logger(), "Anti-flicker (power line) filter set to %d Hz", power_line_frequency_);
+    }
+    close(fd);
 }
 
 std::string ArmCameraDriver::createGStreamerPipeline() {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
@@ -23,10 +23,11 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions& options) : Node("m
     this->declare_parameter<int>("jpeg_quality", 80);
     this->declare_parameter<bool>("publish_compressed", true);
     this->declare_parameter<int>("compressed_frame_interval", 3);
-    this->declare_parameter<bool>("publish_stereo", false);  // Combined stereo image for legacy compatibility
-    this->declare_parameter<int>("exposure", -1);            // -1 means use current value
-    this->declare_parameter<int>("gain", -1);                // -1 means use current value
-    this->declare_parameter<int>("default_gain", 110);       // Default gain for auto-exposure mode
+    this->declare_parameter<bool>("publish_stereo", false);    // Combined stereo image for legacy compatibility
+    this->declare_parameter<int>("exposure", -1);              // -1 means use current value
+    this->declare_parameter<int>("gain", -1);                  // -1 means use current value
+    this->declare_parameter<int>("default_gain", 110);         // Default gain for auto-exposure mode
+    this->declare_parameter<int>("power_line_frequency", 60);  // Anti-flicker filter: 0=disabled, 50 or 60 (Hz)
 
     // Auto exposure parameters
     this->declare_parameter<int>("auto_exposure_mode", 0);
@@ -55,6 +56,7 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions& options) : Node("m
     exposure_setting_ = this->get_parameter("exposure").as_int();
     gain_setting_ = this->get_parameter("gain").as_int();
     default_gain_param_ = this->get_parameter("default_gain").as_int();
+    power_line_frequency_ = this->get_parameter("power_line_frequency").as_int();
 
     // Get auto exposure parameter values
     auto_exposure_mode_ = static_cast<AutoExposureMode>(this->get_parameter("auto_exposure_mode").as_int());
@@ -300,6 +302,24 @@ bool MainCameraDriver::initializeCamera() {
                     RCLCPP_DEBUG(this->get_logger(), "AE mode: MANUAL (pure manual, no PID)");
                 }
                 break;
+        }
+
+        // Anti-flicker filter: match the camera's banding filter to the local mains
+        // frequency so indoor lighting doesn't flicker in auto-exposure mode.
+        int flicker_ctrl = -1;
+        if (power_line_frequency_ == 0) {
+            flicker_ctrl = V4L2_CID_POWER_LINE_FREQUENCY_DISABLED;
+        } else if (power_line_frequency_ == 50) {
+            flicker_ctrl = V4L2_CID_POWER_LINE_FREQUENCY_50HZ;
+        } else if (power_line_frequency_ == 60) {
+            flicker_ctrl = V4L2_CID_POWER_LINE_FREQUENCY_60HZ;
+        }
+        if (flicker_ctrl < 0) {
+            RCLCPP_WARN(this->get_logger(),
+                        "Invalid power_line_frequency %d (expected 0, 50 or 60), keeping camera default",
+                        power_line_frequency_);
+        } else if (setV4L2Control(V4L2_CID_POWER_LINE_FREQUENCY, flicker_ctrl)) {
+            RCLCPP_INFO(this->get_logger(), "Anti-flicker (power line) filter set to %d Hz", power_line_frequency_);
         }
 
         if (exposure_setting_ >= 0) {


### PR DESCRIPTION
## Problem

We're seeing flicker/banding from artificial lighting in the office camera feeds.

Root cause: neither camera driver ever sets `V4L2_CID_POWER_LINE_FREQUENCY`, so the camera's anti-banding filter runs at whatever the firmware defaults to — commonly 50 Hz or disabled. Under US 60 Hz mains (120 Hz light ripple), a 50 Hz/disabled filter produces exactly this rolling flicker. (Note: US mains is 60 Hz; 50 Hz is the EU setting.)

## Change

- Add a `power_line_frequency` ROS parameter (`0`=disabled, `50`, `60`; **default 60**) to both `MainCameraDriver` and `ArmCameraDriver`.
- Main camera: applied through the existing V4L2 control path in `initializeCamera()`.
- Arm camera (which had no V4L2 control plumbing): a small `applyPowerLineFrequency()` that opens the device fd, sets the control, and closes it — re-applied on camera recovery since `initializeCamera()` is the retry path.
- Exposed in `stereo_depth_estimator.yaml` for both drivers.
- Logs the applied value at INFO so it's verifiable from robot logs; unsupported values (e.g. a camera without the control) log a WARN and keep the firmware default.

## Verification

- `colcon build --packages-select mars_msgs mars_cam` passes in the CI test image (only pre-existing GStreamer WebRTC warnings).
- pre-commit (clang-format) clean.
- On-robot check after deploy: `v4l2-ctl -d /dev/videoX --get-ctrl power_line_frequency` should report `2` (60 Hz), and the driver log should show `Anti-flicker (power line) filter set to 60 Hz`.

## Caveat

This only affects auto-exposure operation. If a robot runs `auto_exposure_mode: 1` (custom PID) or `2` (manual), the filter can't help — flicker must instead be avoided by choosing exposure times near multiples of the 8.33 ms light period.