### PR TITLE
ci: publish multi-arch simulator images (amd64 + arm64)

### DIFF
--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -25,6 +25,9 @@ concurrency:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    # SECURITY: deletes ghcr package versions -- schedule/dispatch on this
+    # repo only, never any pull_request trigger.
+    if: github.repository == 'innate-inc/innate-os' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     env:
       ORG: innate-inc
       # Retention policy (deps/ros; every branch tip publishes images):

--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -2,7 +2,7 @@ name: Cleanup Simulator Images
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 3 * * 0"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -15,7 +15,6 @@ on:
           - "false"
 
 permissions:
-  contents: read
   packages: write
 
 concurrency:
@@ -25,18 +24,12 @@ concurrency:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    # SECURITY: deletes ghcr package versions -- schedule/dispatch on this
-    # repo only, never any pull_request trigger.
-    if: github.repository == 'innate-inc/innate-os' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     env:
       ORG: innate-inc
-      # Retention policy (deps/ros; every branch tip publishes images):
-      #   - main / buildcache / main's current inputs-<hash>: kept forever
-      #   - head of a live branch: kept 30 days
-      #   - everything else (superseded mid-branch builds): kept 14 days
-      HEAD_OF_BRANCH_DAYS: "30"
-      OTHER_DAYS: "14"
+      KEEP_SHA_TAGS: "20"
+      KEEP_INPUTS_TAGS: "20"
       KEEP_ASSET_TAGS: "20"
+      KEEP_MANUAL_TAGS: "5"
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,9 +42,6 @@ jobs:
           - innate-os-sim-assets
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Cleanup old GHCR versions
         shell: bash
         run: |
@@ -61,61 +51,61 @@ jobs:
           keep_file="$(mktemp)"
           versions_file="$(mktemp)"
 
-          gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" \
-            | jq -s 'add' > "${versions_file}"
+          gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"
 
-          # Tags unique per package: a branch build with main's content hash
-          # steals the inputs-<hash> tag from the main-tagged version, so the
-          # main hash is pinned explicitly (this run checks out main).
-          main_inputs_hash="$(python3 ci/compute_sim_image_inputs_hash.py)"
+          jq -r '
+            .[]
+            | select((.metadata.container.tags // []) | any(. == "main" or . == "buildcache"))
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
 
-          # 12-hex heads of all live branches, matching the sha-<short_sha>
-          # tags the publish workflow pushes.
-          branch_heads="$(git ls-remote --heads origin | cut -f1 | cut -c1-12 | jq -R . | jq -s .)"
-
-          if [[ "${package}" == "innate-os-sim-assets" ]]; then
-            jq -r '
+          jq -r --argjson keep "${KEEP_SHA_TAGS}" '
+            [
               .[]
-              | select((.metadata.container.tags // []) | any(. == "main" or . == "buildcache"))
-              | .id
-            ' "${versions_file}" >> "${keep_file}"
+              | select((.metadata.container.tags // []) | any(startswith("sha-")))
+              | {id, updated_at}
+            ]
+            | sort_by(.updated_at)
+            | reverse
+            | .[:$keep][]
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
 
-            jq -r --argjson keep "${KEEP_ASSET_TAGS}" '
-              [
-                .[]
-                | select((.metadata.container.tags // []) | any(startswith("assets-")))
-                | {id, updated_at}
-              ]
-              | sort_by(.updated_at)
-              | reverse
-              | .[:$keep][]
-              | .id
-            ' "${versions_file}" >> "${keep_file}"
-          else
-            jq -r \
-              --argjson heads "${branch_heads}" \
-              --arg main_hash "${main_inputs_hash}" \
-              --argjson head_days "${HEAD_OF_BRANCH_DAYS}" \
-              --argjson other_days "${OTHER_DAYS}" '
-              def tags: .metadata.container.tags // [];
-              def age_days: (now - (.updated_at | fromdateiso8601)) / 86400;
-              def keep_forever:
-                tags | any(
-                  . == "main" or startswith("main-")
-                  or startswith("buildcache")
-                  or . == "inputs-\($main_hash)" or startswith("inputs-\($main_hash)-")
-                );
-              def head_of_branch:
-                tags | any(startswith("sha-") and (.[4:16] as $s | $heads | index($s)));
+          jq -r --argjson keep "${KEEP_INPUTS_TAGS}" '
+            [
               .[]
-              | select(
-                  keep_forever
-                  or (head_of_branch and age_days <= $head_days)
-                  or ((head_of_branch | not) and age_days <= $other_days)
-                )
-              | .id
-            ' "${versions_file}" >> "${keep_file}"
-          fi
+              | select((.metadata.container.tags // []) | any(startswith("inputs-")))
+              | {id, updated_at}
+            ]
+            | sort_by(.updated_at)
+            | reverse
+            | .[:$keep][]
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
+
+          jq -r --argjson keep "${KEEP_ASSET_TAGS}" '
+            [
+              .[]
+              | select((.metadata.container.tags // []) | any(startswith("assets-")))
+              | {id, updated_at}
+            ]
+            | sort_by(.updated_at)
+            | reverse
+            | .[:$keep][]
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
+
+          jq -r --argjson keep "${KEEP_MANUAL_TAGS}" '
+            [
+              .[]
+              | select((.metadata.container.tags // []) | any(startswith("manual-")))
+              | {id, updated_at}
+            ]
+            | sort_by(.updated_at)
+            | reverse
+            | .[:$keep][]
+            | .id
+          ' "${versions_file}" >> "${keep_file}"
 
           sort -u -o "${keep_file}" "${keep_file}"
 

--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -2,7 +2,7 @@ name: Cleanup Simulator Images
 
 on:
   schedule:
-    - cron: "17 3 * * 0"
+    - cron: "17 3 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -15,6 +15,7 @@ on:
           - "false"
 
 permissions:
+  contents: read
   packages: write
 
 concurrency:
@@ -26,10 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ORG: innate-inc
-      KEEP_SHA_TAGS: "20"
-      KEEP_INPUTS_TAGS: "20"
+      # Retention policy (deps/ros; every branch tip publishes images):
+      #   - main / buildcache / main's current inputs-<hash>: kept forever
+      #   - head of a live branch: kept 30 days
+      #   - everything else (superseded mid-branch builds): kept 14 days
+      HEAD_OF_BRANCH_DAYS: "30"
+      OTHER_DAYS: "14"
       KEEP_ASSET_TAGS: "20"
-      KEEP_MANUAL_TAGS: "5"
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,6 +46,9 @@ jobs:
           - innate-os-sim-assets
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Cleanup old GHCR versions
         shell: bash
         run: |
@@ -51,61 +58,61 @@ jobs:
           keep_file="$(mktemp)"
           versions_file="$(mktemp)"
 
-          gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"
+          gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" \
+            | jq -s 'add' > "${versions_file}"
 
-          jq -r '
-            .[]
-            | select((.metadata.container.tags // []) | any(. == "main" or . == "buildcache"))
-            | .id
-          ' "${versions_file}" >> "${keep_file}"
+          # Tags unique per package: a branch build with main's content hash
+          # steals the inputs-<hash> tag from the main-tagged version, so the
+          # main hash is pinned explicitly (this run checks out main).
+          main_inputs_hash="$(python3 ci/compute_sim_image_inputs_hash.py)"
 
-          jq -r --argjson keep "${KEEP_SHA_TAGS}" '
-            [
+          # 12-hex heads of all live branches, matching the sha-<short_sha>
+          # tags the publish workflow pushes.
+          branch_heads="$(git ls-remote --heads origin | cut -f1 | cut -c1-12 | jq -R . | jq -s .)"
+
+          if [[ "${package}" == "innate-os-sim-assets" ]]; then
+            jq -r '
               .[]
-              | select((.metadata.container.tags // []) | any(startswith("sha-")))
-              | {id, updated_at}
-            ]
-            | sort_by(.updated_at)
-            | reverse
-            | .[:$keep][]
-            | .id
-          ' "${versions_file}" >> "${keep_file}"
+              | select((.metadata.container.tags // []) | any(. == "main" or . == "buildcache"))
+              | .id
+            ' "${versions_file}" >> "${keep_file}"
 
-          jq -r --argjson keep "${KEEP_INPUTS_TAGS}" '
-            [
+            jq -r --argjson keep "${KEEP_ASSET_TAGS}" '
+              [
+                .[]
+                | select((.metadata.container.tags // []) | any(startswith("assets-")))
+                | {id, updated_at}
+              ]
+              | sort_by(.updated_at)
+              | reverse
+              | .[:$keep][]
+              | .id
+            ' "${versions_file}" >> "${keep_file}"
+          else
+            jq -r \
+              --argjson heads "${branch_heads}" \
+              --arg main_hash "${main_inputs_hash}" \
+              --argjson head_days "${HEAD_OF_BRANCH_DAYS}" \
+              --argjson other_days "${OTHER_DAYS}" '
+              def tags: .metadata.container.tags // [];
+              def age_days: (now - (.updated_at | fromdateiso8601)) / 86400;
+              def keep_forever:
+                tags | any(
+                  . == "main" or startswith("main-")
+                  or startswith("buildcache")
+                  or . == "inputs-\($main_hash)" or startswith("inputs-\($main_hash)-")
+                );
+              def head_of_branch:
+                tags | any(startswith("sha-") and (.[4:16] as $s | $heads | index($s)));
               .[]
-              | select((.metadata.container.tags // []) | any(startswith("inputs-")))
-              | {id, updated_at}
-            ]
-            | sort_by(.updated_at)
-            | reverse
-            | .[:$keep][]
-            | .id
-          ' "${versions_file}" >> "${keep_file}"
-
-          jq -r --argjson keep "${KEEP_ASSET_TAGS}" '
-            [
-              .[]
-              | select((.metadata.container.tags // []) | any(startswith("assets-")))
-              | {id, updated_at}
-            ]
-            | sort_by(.updated_at)
-            | reverse
-            | .[:$keep][]
-            | .id
-          ' "${versions_file}" >> "${keep_file}"
-
-          jq -r --argjson keep "${KEEP_MANUAL_TAGS}" '
-            [
-              .[]
-              | select((.metadata.container.tags // []) | any(startswith("manual-")))
-              | {id, updated_at}
-            ]
-            | sort_by(.updated_at)
-            | reverse
-            | .[:$keep][]
-            | .id
-          ' "${versions_file}" >> "${keep_file}"
+              | select(
+                  keep_forever
+                  or (head_of_branch and age_days <= $head_days)
+                  or ((head_of_branch | not) and age_days <= $other_days)
+                )
+              | .id
+            ' "${versions_file}" >> "${keep_file}"
+          fi
 
           sort -u -o "${keep_file}" "${keep_file}"
 

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -17,8 +17,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  packages: write
 
 concurrency:
   group: publish-sim-images-${{ github.ref }}
@@ -94,6 +92,9 @@ jobs:
   amd64:
     needs: tags
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -125,6 +126,9 @@ jobs:
     # Native arm64 larger runner (8 cores / 32 GB / 300 GB SSD): QEMU
     # emulation would turn the ros2_ws colcon build into a multi-hour crawl.
     runs-on: my-medium-runner-arm
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -151,6 +155,9 @@ jobs:
   manifest:
     needs: [tags, amd64, arm64]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -122,18 +122,12 @@ jobs:
 
   arm64:
     needs: tags
-    # Native arm64 runner: QEMU emulation would turn the ros2_ws colcon
-    # build into a multi-hour crawl.
-    runs-on: ubuntu-24.04-arm
+    # Native arm64 larger runner (8 cores / 32 GB / 300 GB SSD): QEMU
+    # emulation would turn the ros2_ws colcon build into a multi-hour crawl.
+    runs-on: my-medium-runner-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Free runner disk (the two images need ~20 GB)
-        run: |
-          sudo rm -rf /opt/hostedtoolcache /usr/local/lib/android /usr/share/dotnet || true
-          docker system prune -af >/dev/null 2>&1 || true
-          df -h /
 
       - name: Log in to ghcr
         uses: docker/login-action@v3

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -7,6 +7,7 @@ on:
       - .gcloudignore
       - ci/cloudbuild.sim-images.yaml
       - ci/build_sim_images.sh
+      - ci/compute_sim_image_inputs_hash.py
       - sim/Dockerfile
       - sim/Dockerfile.ros-prebuilt
       - sim/Dockerfile.ros-prebuilt.dockerignore
@@ -39,40 +40,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          image_inputs_hash="$(python3 - <<'PY'
-          import hashlib
-          from pathlib import Path
-
-          root = Path(".")
-          static_paths = (
-              ".dockerignore",
-              "sim/Dockerfile",
-              "sim/Dockerfile.ros-prebuilt",
-              "sim/Dockerfile.ros-prebuilt.dockerignore",
-              "ros2_ws/apt-dependencies.common.txt",
-              "ros2_ws/apt-dependencies.hardware.txt",
-              "ros2_ws/apt-dependencies.sim.txt",
-          )
-          paths = [Path(path) for path in static_paths if (root / path).is_file()]
-          src_root = root / "ros2_ws" / "src"
-          if src_root.exists():
-              for path in sorted(src_root.rglob("*")):
-                  if not path.is_file():
-                      continue
-                  relative_path = path.relative_to(root)
-                  if "__pycache__" in relative_path.parts or relative_path.suffix == ".pyc":
-                      continue
-                  paths.append(relative_path)
-
-          digest = hashlib.sha256()
-          for path in sorted(paths, key=lambda item: item.as_posix()):
-              digest.update(path.as_posix().encode("utf-8"))
-              digest.update(b"\0")
-              digest.update((root / path).read_bytes())
-              digest.update(b"\0")
-          print(digest.hexdigest())
-          PY
-          )"
+          # Shared with cleanup-sim-images.yml, which pins main's
+          # inputs-<hash> versions against retention.
+          image_inputs_hash="$(python3 ci/compute_sim_image_inputs_hash.py)"
           short_sha="${GITHUB_SHA::12}"
           push_main_tags="false"
 

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -1,5 +1,9 @@
 name: Publish Simulator Images
 
+# SECURITY: this workflow pushes to ghcr and mints GCP credentials. Triggers
+# must stay push + workflow_dispatch ONLY -- never add pull_request or
+# pull_request_target. Every job is additionally guarded on repository and
+# event name as defense in depth against future trigger edits.
 on:
   push:
     paths:
@@ -26,6 +30,7 @@ concurrency:
 jobs:
   tags:
     runs-on: ubuntu-latest
+    if: github.repository == 'innate-inc/innate-os' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     outputs:
       image_tag: ${{ steps.image_tags.outputs.image_tag }}
       image_inputs_hash: ${{ steps.image_tags.outputs.image_inputs_hash }}
@@ -62,6 +67,7 @@ jobs:
   amd64:
     needs: tags
     runs-on: ubuntu-latest
+    if: github.repository == 'innate-inc/innate-os' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
       id-token: write
@@ -93,6 +99,7 @@ jobs:
 
   arm64:
     needs: tags
+    if: github.repository == 'innate-inc/innate-os' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     # Native arm64 larger runner (8 cores / 32 GB / 300 GB SSD): QEMU
     # emulation would turn the ros2_ws colcon build into a multi-hour crawl.
     runs-on: my-medium-runner-arm
@@ -125,6 +132,7 @@ jobs:
   manifest:
     needs: [tags, amd64, arm64]
     runs-on: ubuntu-latest
+    if: github.repository == 'innate-inc/innate-os' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -158,6 +158,9 @@ jobs:
     needs: [tags, amd64, arm64]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Log in to ghcr
         uses: docker/login-action@v3
         with:
@@ -173,25 +176,7 @@ jobs:
           IMAGE_INPUTS_HASH: ${{ needs.tags.outputs.image_inputs_hash }}
           PUSH_MAIN_TAGS: ${{ needs.tags.outputs.push_main_tags }}
           SHORT_SHA: ${{ needs.tags.outputs.short_sha }}
-        run: |
-          set -euo pipefail
-
-          tags=("${IMAGE_TAG}" "sha-${SHORT_SHA}")
-          if [[ -n "${IMAGE_INPUTS_HASH}" && "${IMAGE_INPUTS_HASH}" != "manual" ]]; then
-            tags+=("inputs-${IMAGE_INPUTS_HASH}")
-          fi
-          if [[ "${PUSH_MAIN_TAGS}" == "true" ]]; then
-            tags+=("main")
-          fi
-
-          for image in "${IMAGE_PREFIX}/innate-os-sim-deps" "${IMAGE_PREFIX}/innate-os-sim-ros"; do
-            for tag in "${tags[@]}"; do
-              docker buildx imagetools create \
-                --tag "$image:$tag" \
-                "$image:$tag-amd64" \
-                "$image:$tag-arm64"
-            done
-          done
+        run: bash ci/stitch_sim_manifests.sh
 
       - name: Published image tags
         run: |

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/publish-sim-images.yml
       - .gcloudignore
       - ci/cloudbuild.sim-images.yaml
+      - ci/build_sim_images.sh
       - sim/Dockerfile
       - sim/Dockerfile.ros-prebuilt
       - sim/Dockerfile.ros-prebuilt.dockerignore
@@ -17,27 +18,23 @@ on:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 concurrency:
   group: publish-sim-images-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  publish:
+  tags:
     runs-on: ubuntu-latest
-
+    outputs:
+      image_tag: ${{ steps.image_tags.outputs.image_tag }}
+      image_inputs_hash: ${{ steps.image_tags.outputs.image_inputs_hash }}
+      push_main_tags: ${{ steps.image_tags.outputs.push_main_tags }}
+      short_sha: ${{ steps.image_tags.outputs.short_sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
 
       - name: Compute image tags
         id: image_tags
@@ -92,8 +89,25 @@ jobs:
           echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
           echo "image_inputs_hash=${image_inputs_hash}" >> "$GITHUB_OUTPUT"
           echo "push_main_tags=${push_main_tags}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
 
-      - name: Submit Cloud Build
+  amd64:
+    needs: tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Submit Cloud Build (amd64)
         shell: bash
         run: |
           set -euo pipefail
@@ -104,11 +118,82 @@ jobs:
             --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \
             --service-account="projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_CLOUD_BUILD_SERVICE_ACCOUNT }}" \
             --config=ci/cloudbuild.sim-images.yaml \
-            --substitutions="_IMAGE_PREFIX=${{ vars.SIM_IMAGE_PREFIX }},_IMAGE_TAG=${{ steps.image_tags.outputs.image_tag }},_IMAGE_INPUTS_HASH=${{ steps.image_tags.outputs.image_inputs_hash }},_PUSH_MAIN_TAGS=${{ steps.image_tags.outputs.push_main_tags }},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }},_COMMIT_SHA=${GITHUB_SHA},_SHORT_SHA=${GITHUB_SHA::12}"
+            --substitutions="_IMAGE_PREFIX=${{ vars.SIM_IMAGE_PREFIX }},_IMAGE_TAG=${{ needs.tags.outputs.image_tag }},_IMAGE_INPUTS_HASH=${{ needs.tags.outputs.image_inputs_hash }},_PUSH_MAIN_TAGS=${{ needs.tags.outputs.push_main_tags }},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }},_COMMIT_SHA=${GITHUB_SHA},_SHORT_SHA=${{ needs.tags.outputs.short_sha }}"
+
+  arm64:
+    needs: tags
+    # Native arm64 runner: QEMU emulation would turn the ros2_ws colcon
+    # build into a multi-hour crawl.
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Free runner disk (the two images need ~20 GB)
+        run: |
+          sudo rm -rf /opt/hostedtoolcache /usr/local/lib/android /usr/share/dotnet || true
+          docker system prune -af >/dev/null 2>&1 || true
+          df -h /
+
+      - name: Log in to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (arm64)
+        shell: bash
+        env:
+          ARCH: arm64
+          IMAGE_PREFIX: ${{ vars.SIM_IMAGE_PREFIX }}
+          IMAGE_TAG: ${{ needs.tags.outputs.image_tag }}
+          IMAGE_INPUTS_HASH: ${{ needs.tags.outputs.image_inputs_hash }}
+          PUSH_MAIN_TAGS: ${{ needs.tags.outputs.push_main_tags }}
+          COMMIT_SHA: ${{ github.sha }}
+          SHORT_SHA: ${{ needs.tags.outputs.short_sha }}
+        run: bash ci/build_sim_images.sh
+
+  manifest:
+    needs: [tags, amd64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stitch multi-arch manifests
+        shell: bash
+        env:
+          IMAGE_PREFIX: ${{ vars.SIM_IMAGE_PREFIX }}
+          IMAGE_TAG: ${{ needs.tags.outputs.image_tag }}
+          IMAGE_INPUTS_HASH: ${{ needs.tags.outputs.image_inputs_hash }}
+          PUSH_MAIN_TAGS: ${{ needs.tags.outputs.push_main_tags }}
+          SHORT_SHA: ${{ needs.tags.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+
+          tags=("${IMAGE_TAG}" "sha-${SHORT_SHA}")
+          if [[ -n "${IMAGE_INPUTS_HASH}" && "${IMAGE_INPUTS_HASH}" != "manual" ]]; then
+            tags+=("inputs-${IMAGE_INPUTS_HASH}")
+          fi
+          if [[ "${PUSH_MAIN_TAGS}" == "true" ]]; then
+            tags+=("main")
+          fi
+
+          for image in "${IMAGE_PREFIX}/innate-os-sim-deps" "${IMAGE_PREFIX}/innate-os-sim-ros"; do
+            for tag in "${tags[@]}"; do
+              docker buildx imagetools create \
+                --tag "$image:$tag" \
+                "$image:$tag-amd64" \
+                "$image:$tag-arm64"
+            done
+          done
 
       - name: Published image tags
         run: |
-          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-deps:${{ steps.image_tags.outputs.image_tag }}"
-          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-deps:inputs-${{ steps.image_tags.outputs.image_inputs_hash }}"
-          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-ros:${{ steps.image_tags.outputs.image_tag }}"
-          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-ros:inputs-${{ steps.image_tags.outputs.image_inputs_hash }}"
+          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-deps:inputs-${{ needs.tags.outputs.image_inputs_hash }} (multi-arch)"
+          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-ros:inputs-${{ needs.tags.outputs.image_inputs_hash }} (multi-arch)"

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - .github/workflows/publish-sim-images.yml
+      - .dockerignore
       - .gcloudignore
       - ci/cloudbuild.sim-images.yaml
       - ci/build_sim_images.sh

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -2,7 +2,6 @@ name: Publish Simulator Images
 
 on:
   push:
-    branches: [main]
     paths:
       - .github/workflows/publish-sim-images.yml
       - .gcloudignore

--- a/.github/workflows/sim-images-build-cost-analysis.md
+++ b/.github/workflows/sim-images-build-cost-analysis.md
@@ -1,0 +1,165 @@
+# Simulator image build: runner cost analysis
+
+**Date:** 2026-07-13
+**Scope:** Cost/architecture of `publish-sim-images.yml` (multi-arch sim images).
+**Question:** Can we drop the split Cloud Build (amd64) + native GH (arm64) setup
+for something less ugly, and what does each option cost?
+
+> All per-minute rates below are from research as of 2026-07-13 and **will drift** —
+> re-check the Cloud Build and GitHub larger-runner pricing pages before acting on
+> the dollar figures. The *relative* conclusions (Cloud Build ~2× cheaper per
+> core-min; QEMU multiplies cost) are stable; the absolute numbers are not.
+
+## TL;DR
+
+- Current split isn't a cost problem — it's a **maintenance/aesthetic** problem: two
+  build paths (Cloud Build plumbing for amd64, native GH for arm64) around one
+  already-shared script, `ci/build_sim_images.sh`.
+- **Recommended fix:** collapse both arches into a single GH Actions **matrix** over
+  the same script. One code path, symmetric, no GCP dependency. Keep the `manifest`
+  job (it's inherent to multi-arch, not part of the "two paths" problem).
+- **Cost of that fix:** the amd64 leg moves off Cloud Build (~2× cheaper) onto a GH
+  larger runner, costing roughly **+$45/month at ~300 builds/month** — and rising as
+  commit volume grows.
+- **Do NOT** unify via QEMU on one big runner: emulation multiplies the arm64 build
+  time (~3–8×), making it the most expensive *and* slowest option.
+- Unifying the other direction (both on Cloud Build) isn't possible — Cloud Build's
+  default pool has no native arm64, so it would fall back to QEMU too.
+
+## Empirical build times
+
+From `publish-sim-images.yml` run history (GitHub Actions API, "Submit Cloud Build"
+step duration), amd64 on Cloud Build `E2_HIGHCPU_8` (8 vCPU):
+
+| build type              | time        |
+| ----------------------- | ----------- |
+| warm (cache hit)        | ~5 min (4.4–5.8) |
+| cold / full             | ~11–14 min  |
+| incremental (cpp change → sim-ros layer rebuilds, deps cached) | ~7–11 min |
+
+Assumption (per project owner): **native arm64 build time ≈ amd64** on comparable
+cores. arm64 was never measured because the multi-arch workflow hadn't run on a
+triggering branch yet at time of writing.
+
+## Pricing logic
+
+The whole comparison reduces to **$ per vCPU-minute × minutes**, where minutes scale
+roughly inversely with core count for the parallel colcon build (with diminishing
+returns past ~16 cores).
+
+### Cloud Build (amd64 today)
+
+- Machine type `E2_HIGHCPU_8` bills at a flat **~$0.016 / build-minute** for the whole
+  8-vCPU machine → **~$0.002 / vCPU-min**.
+- No free tier applies here: the free 120 build-min/day only covers the default
+  `e2-medium` machine, not `E2_HIGHCPU_8`.
+- Disk (`diskSizeGb: 200`) is **not** billed separately — the per-minute rate is flat
+  per machine type.
+- GCS source staging + egress to ghcr are negligible (fractions of a cent).
+
+### GitHub-hosted larger runners
+
+- Linux **x64** larger runner = **$0.004 / vCPU-min** (i.e. 8-core = $0.032/min,
+  16-core = $0.064/min, 32-core = $0.128/min). This is **~2× the Cloud Build
+  per-vCPU-min rate.**
+- Linux **arm64** larger runners are ~30–40% cheaper than the x64 equivalent (verify).
+- **Standard** 2-/4-core runners are **free on public repos** (`innate-inc/innate-os`
+  is public) — but the sim build needs more cores/disk than standard runners give, so
+  standard/free runners don't apply to the heavy build legs. They *do* make the tiny
+  `manifest` job free.
+
+### QEMU penalty
+
+Building arm64 on an x64 runner via QEMU user-mode emulation runs a heavy C++/colcon
+build **~3–8× slower per instruction**. More cores don't buy this back — the
+bottleneck is emulation, not parallelism. So a native ~5 min build at 32 cores becomes
+~15–40 min emulated, at the big-runner rate. You pay the premium machine rate **and**
+the time multiplier.
+
+## Cost per run
+
+### amd64 leg only (the part that could move GCP → GH)
+
+| build     | Cloud Build `E2_HIGHCPU_8` | GH 8-core x64 |
+| --------- | -------------------------- | ------------- |
+| warm      | ~$0.08                     | ~$0.16        |
+| cold      | ~$0.18–0.22                | ~$0.36–0.42   |
+| incremental | ~$0.15                   | ~$0.30        |
+
+### Whole multi-arch run
+
+Two heavy legs (amd64 + arm64) run in parallel, plus a near-free `manifest` stitch.
+Total ≈ ~2× the single-leg figure. The arm64 leg is paid on GitHub regardless of what
+amd64 runs on.
+
+### Unification options compared (cold build, heavy runners)
+
+| option                          | arm64 leg      | wall-clock | $/run |
+| ------------------------------- | -------------- | ---------- | ----- |
+| Native GH matrix, 16-core each  | native, ~7 min | ~7 min     | ~$0.90 |
+| Native GH matrix, 32-core each  | native, ~5 min | ~5 min     | ~$1.30 |
+| QEMU on one 32-core runner      | emulated, ~15–40 min | ~15–40 min | ~$3–8 |
+
+QEMU is ~5–8× the cost and several times slower. Its *only* benefit is YAML simplicity
+(one job, no matrix, no manifest) — an expensive way to buy tidiness.
+
+## Volume projection
+
+`git log` on `main`: **~360 commits/month**, most touching C++. With `cancel-in-progress`
+concurrency, not all complete → estimate **~250–300 builds/month**, and **growing** as
+commit cadence increases.
+
+Monthly, amd64 leg only:
+
+| builds/mo | Cloud Build (~$0.15/run) | GH 8-core (~$0.30/run) | delta      |
+| --------- | ------------------------ | ---------------------- | ---------- |
+| 150       | ~$22                     | ~$45                   | ~$23/mo    |
+| 300       | ~$45                     | ~$90                   | ~$45/mo    |
+
+The 2× per-core-min gap compounds with volume: as commits grow, keeping amd64 on
+Cloud Build saves more each month. At 300 builds/mo the split is worth ~$45/mo
+(~$540/yr) — the *price* of keeping the ugly-but-cheap path.
+
+## Bigger levers than the runner choice
+
+At every-cpp-commit cadence, two changes save more than any runner swap:
+
+1. **Don't build arm64 on every commit.** If arm64 ships only on `main` merges /
+   releases while amd64 covers per-commit CI, the whole bill roughly halves. Biggest
+   single win.
+2. **Self-hosted runners.** At 250–300+ builds/month a fixed box (one amd64 + one
+   arm64) amortizes to near-zero marginal cost per build and beats both Cloud Build and
+   GH larger runners. Trades cloud spend for hardware + ops.
+
+## Recommendation
+
+Collapse the two heavy legs into one matrix over the existing `ci/build_sim_images.sh`
+(already arch-agnostic via `ARCH`). This deletes the entire Cloud Build path —
+`ci/cloudbuild.sim-images.yaml`, GCP auth steps, Secret Manager secrets, GCP repo vars
+— and leaves one symmetric build path plus the unchanged `manifest` stitch:
+
+```yaml
+build:
+  needs: tags
+  strategy:
+    matrix:
+      include:
+        - { arch: amd64, runner: <8- or 16-core x64 larger runner> }
+        - { arch: arm64, runner: ubuntu-24.04-arm }
+  runs-on: ${{ matrix.runner }}
+  steps:
+    - uses: actions/checkout@v6
+    - uses: docker/login-action@v3
+      with: { registry: ghcr.io, username: ${{ github.actor }}, password: ${{ secrets.GITHUB_TOKEN }} }
+    - run: bash ci/build_sim_images.sh
+      env: { ARCH: "${{ matrix.arch }}", IMAGE_PREFIX: ..., IMAGE_TAG: ..., ... }
+
+manifest:
+  needs: [tags, build]
+  # unchanged: docker buildx imagetools create
+```
+
+Accept ~$45/mo (at 300 builds, rising with volume) as the cost of a single, symmetric,
+GCP-free build path. If that monthly figure becomes uncomfortable as commits grow,
+pursue the "bigger levers" above (arm64 not-every-commit, or self-hosted) — not a
+return to the split.

--- a/ci/build_sim_images.sh
+++ b/ci/build_sim_images.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+#
+# Build + push the simulator images for ONE architecture. Every published
+# tag is suffixed with -$ARCH; a later workflow step stitches the per-arch
+# tags into multi-arch manifests under the unsuffixed names.
+#
+# Called by:
+#   - ci/cloudbuild.sim-images.yaml         (ARCH=amd64, on Cloud Build)
+#   - .github/workflows/publish-sim-images.yml (ARCH=arm64, on a native
+#     ubuntu-24.04-arm runner -- QEMU emulation would turn the ros2_ws
+#     colcon build into a multi-hour crawl)
+#
+# Required env: IMAGE_PREFIX, IMAGE_TAG, COMMIT_SHA, SHORT_SHA, ARCH
+# Optional env: IMAGE_INPUTS_HASH, PUSH_MAIN_TAGS
+# The caller must already be logged in to the registry.
+set -euo pipefail
+
+: "${IMAGE_PREFIX:?}" "${IMAGE_TAG:?}" "${COMMIT_SHA:?}" "${SHORT_SHA:?}" "${ARCH:?}"
+export DOCKER_BUILDKIT=1
+
+deps_image="${IMAGE_PREFIX}/innate-os-sim-deps"
+ros_image="${IMAGE_PREFIX}/innate-os-sim-ros"
+sha_tag="sha-${SHORT_SHA}"
+cache_tag="buildcache-${ARCH}"
+inputs_tag=""
+if [[ -n "${IMAGE_INPUTS_HASH:-}" && "${IMAGE_INPUTS_HASH}" != "manual" ]]; then
+  inputs_tag="inputs-${IMAGE_INPUTS_HASH}"
+fi
+
+push_tags() {
+  local image="$1"
+  local source_tag="$2"
+  shift 2
+
+  local pushed=""
+  for tag in "$@"; do
+    if [[ -z "$tag" || "$pushed" == *"|$tag|"* ]]; then
+      continue
+    fi
+
+    if [[ "$tag" != "$source_tag" ]]; then
+      docker tag "$image:$source_tag" "$image:$tag"
+    fi
+
+    docker push "$image:$tag"
+    pushed="$pushed|$tag|"
+  done
+}
+
+# The plain `buildcache` pulls seed the cache from the pre-multi-arch tags
+# during the transition; harmless no-ops once the -$ARCH caches exist.
+docker pull "$deps_image:$cache_tag" || docker pull "$deps_image:buildcache" || true
+docker build \
+  --progress=plain \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from "$deps_image:$cache_tag" \
+  --cache-from "$deps_image:buildcache" \
+  --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
+  --label "org.opencontainers.image.revision=${COMMIT_SHA}" \
+  --tag "$deps_image:${IMAGE_TAG}-${ARCH}" \
+  --file sim/Dockerfile \
+  .
+
+deps_tags=("${IMAGE_TAG}-${ARCH}" "${sha_tag}-${ARCH}" "$cache_tag")
+if [[ -n "$inputs_tag" ]]; then
+  deps_tags+=("${inputs_tag}-${ARCH}")
+fi
+if [[ "${PUSH_MAIN_TAGS:-false}" == "true" ]]; then
+  deps_tags+=("main-${ARCH}")
+fi
+push_tags "$deps_image" "${IMAGE_TAG}-${ARCH}" "${deps_tags[@]}"
+
+deps_ros_base="$deps_image:$cache_tag"
+docker pull "$ros_image:$cache_tag" || docker pull "$ros_image:buildcache" || true
+docker build \
+  --progress=plain \
+  --build-arg "BASE_IMAGE=$deps_ros_base" \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from "$ros_image:$cache_tag" \
+  --cache-from "$ros_image:buildcache" \
+  --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
+  --label "org.opencontainers.image.revision=${COMMIT_SHA}" \
+  --tag "$ros_image:${IMAGE_TAG}-${ARCH}" \
+  --file sim/Dockerfile.ros-prebuilt \
+  .
+
+ros_tags=("${IMAGE_TAG}-${ARCH}" "${sha_tag}-${ARCH}" "$cache_tag")
+if [[ -n "$inputs_tag" ]]; then
+  ros_tags+=("${inputs_tag}-${ARCH}")
+fi
+if [[ "${PUSH_MAIN_TAGS:-false}" == "true" ]]; then
+  ros_tags+=("main-${ARCH}")
+fi
+push_tags "$ros_image" "${IMAGE_TAG}-${ARCH}" "${ros_tags[@]}"

--- a/ci/cloudbuild.sim-images.yaml
+++ b/ci/cloudbuild.sim-images.yaml
@@ -1,7 +1,6 @@
 timeout: 7200s
 
 substitutions:
-  _DEPS_IMAGE_NAME: innate-os-sim-deps
   _GHCR_TOKEN_SECRET: innate-os-sim-ghcr-token
   _GHCR_USERNAME_SECRET: innate-os-sim-ghcr-username
   _COMMIT_SHA: manual
@@ -9,90 +8,31 @@ substitutions:
   _IMAGE_PREFIX: ghcr.io/innate-inc
   _IMAGE_TAG: manual
   _PUSH_MAIN_TAGS: "false"
-  _ROS_IMAGE_NAME: innate-os-sim-ros
   _SHORT_SHA: manual
 
 steps:
-  - id: build-and-push-simulator-images
+  # Builds the amd64 half; the arm64 half runs on a native GitHub arm runner
+  # and a final workflow job stitches both into multi-arch manifests under
+  # the unsuffixed tags. Build logic is shared: ci/build_sim_images.sh.
+  - id: build-and-push-simulator-images-amd64
     name: gcr.io/cloud-builders/docker
     entrypoint: bash
     secretEnv:
       - GHCR_TOKEN
       - GHCR_USERNAME
     env:
-      - DOCKER_BUILDKIT=1
+      - ARCH=amd64
+      - IMAGE_PREFIX=${_IMAGE_PREFIX}
+      - IMAGE_TAG=${_IMAGE_TAG}
+      - IMAGE_INPUTS_HASH=${_IMAGE_INPUTS_HASH}
+      - PUSH_MAIN_TAGS=${_PUSH_MAIN_TAGS}
+      - COMMIT_SHA=${_COMMIT_SHA}
+      - SHORT_SHA=${_SHORT_SHA}
     args:
       - -ceu
       - |
-        docker_login() {
-          echo "$$GHCR_TOKEN" | docker login ghcr.io -u "$$GHCR_USERNAME" --password-stdin
-        }
-
-        push_tags() {
-          local image="$1"
-          local source_tag="$2"
-          shift 2
-
-          local pushed=""
-          for tag in "$@"; do
-            if [[ -z "$tag" || "$pushed" == *"|$tag|"* ]]; then
-              continue
-            fi
-
-            if [[ "$tag" != "$source_tag" ]]; then
-              docker tag "$image:$source_tag" "$image:$tag"
-            fi
-
-            docker push "$image:$tag"
-            pushed="$pushed|$tag|"
-          done
-        }
-
-        deps_image="${_IMAGE_PREFIX}/${_DEPS_IMAGE_NAME}"
-        ros_image="${_IMAGE_PREFIX}/${_ROS_IMAGE_NAME}"
-        sha_tag="sha-${_SHORT_SHA}"
-        inputs_tag=""
-        if [[ -n "${_IMAGE_INPUTS_HASH}" && "${_IMAGE_INPUTS_HASH}" != "manual" ]]; then
-          inputs_tag="inputs-${_IMAGE_INPUTS_HASH}"
-        fi
-
-        docker_login
-
-        docker pull "$deps_image:buildcache" || true
-        docker build \
-          --progress=plain \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
-          --cache-from "$deps_image:buildcache" \
-          --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
-          --label "org.opencontainers.image.revision=${_COMMIT_SHA}" \
-          --tag "$deps_image:${_IMAGE_TAG}" \
-          --file sim/Dockerfile \
-          .
-
-        deps_tags=("${_IMAGE_TAG}" "$sha_tag" "$inputs_tag" "buildcache")
-        if [[ "${_PUSH_MAIN_TAGS}" == "true" ]]; then
-          deps_tags+=("main")
-        fi
-        push_tags "$deps_image" "${_IMAGE_TAG}" "${deps_tags[@]}"
-
-        deps_ros_base="$deps_image:buildcache"
-        docker pull "$ros_image:buildcache" || true
-        docker build \
-          --progress=plain \
-          --build-arg "BASE_IMAGE=$deps_ros_base" \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
-          --cache-from "$ros_image:buildcache" \
-          --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
-          --label "org.opencontainers.image.revision=${_COMMIT_SHA}" \
-          --tag "$ros_image:${_IMAGE_TAG}" \
-          --file sim/Dockerfile.ros-prebuilt \
-          .
-
-        ros_tags=("${_IMAGE_TAG}" "$sha_tag" "$inputs_tag" "buildcache")
-        if [[ "${_PUSH_MAIN_TAGS}" == "true" ]]; then
-          ros_tags+=("main")
-        fi
-        push_tags "$ros_image" "${_IMAGE_TAG}" "${ros_tags[@]}"
+        echo "$$GHCR_TOKEN" | docker login ghcr.io -u "$$GHCR_USERNAME" --password-stdin
+        bash ci/build_sim_images.sh
 
 availableSecrets:
   secretManager:

--- a/ci/compute_sim_image_inputs_hash.py
+++ b/ci/compute_sim_image_inputs_hash.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+#
+# Content hash of everything that goes into the simulator images. Prints the
+# hex digest for the checkout rooted at CWD.
+#
+# Called by:
+#   - .github/workflows/publish-sim-images.yml (tags job -> inputs-<hash> tags)
+#   - .github/workflows/cleanup-sim-images.yml (pins main's inputs-<hash>
+#     versions so retention can never delete the tag main users pull)
+#
+# The two must agree exactly -- cleanup deletes what publish names -- which is
+# why this lives in one file. sim/launcher/config.py computes the same hash
+# independently; keep them in sync.
+import hashlib
+from pathlib import Path
+
+root = Path(".")
+static_paths = (
+    ".dockerignore",
+    "sim/Dockerfile",
+    "sim/Dockerfile.ros-prebuilt",
+    "sim/Dockerfile.ros-prebuilt.dockerignore",
+    "ros2_ws/apt-dependencies.common.txt",
+    "ros2_ws/apt-dependencies.hardware.txt",
+    "ros2_ws/apt-dependencies.sim.txt",
+)
+paths = [Path(path) for path in static_paths if (root / path).is_file()]
+src_root = root / "ros2_ws" / "src"
+if src_root.exists():
+    for path in sorted(src_root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative_path = path.relative_to(root)
+        if "__pycache__" in relative_path.parts or relative_path.suffix == ".pyc":
+            continue
+        paths.append(relative_path)
+
+digest = hashlib.sha256()
+for path in sorted(paths, key=lambda item: item.as_posix()):
+    digest.update(path.as_posix().encode("utf-8"))
+    digest.update(b"\0")
+    digest.update((root / path).read_bytes())
+    digest.update(b"\0")
+print(digest.hexdigest())

--- a/ci/stitch_sim_manifests.sh
+++ b/ci/stitch_sim_manifests.sh
@@ -23,11 +23,23 @@ if [[ "${PUSH_MAIN_TAGS:-false}" == "true" ]]; then
   tags+=("main")
 fi
 
+# Every tag points at the same per-arch image pair, so stitch each image with
+# ONE imagetools call carrying all tags: the index is uploaded once and the
+# tag pointers are written back-to-back, keeping the window where a cancelled
+# run leaves some tags stitched and others stale to near zero.
 for image in "${IMAGE_PREFIX}/innate-os-sim-deps" "${IMAGE_PREFIX}/innate-os-sim-ros"; do
+  tag_args=()
+  seen="|"
   for tag in "${tags[@]}"; do
-    docker buildx imagetools create \
-      --tag "$image:$tag" \
-      "$image:$tag-amd64" \
-      "$image:$tag-arm64"
+    if [[ "$seen" == *"|$tag|"* ]]; then
+      continue
+    fi
+    tag_args+=(--tag "$image:$tag")
+    seen="$seen$tag|"
   done
+
+  docker buildx imagetools create \
+    "${tag_args[@]}" \
+    "$image:${IMAGE_TAG}-amd64" \
+    "$image:${IMAGE_TAG}-arm64"
 done

--- a/ci/stitch_sim_manifests.sh
+++ b/ci/stitch_sim_manifests.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+#
+# Stitch the per-arch simulator image tags (pushed as -amd64 / -arm64 by
+# ci/build_sim_images.sh) into multi-arch manifests under the unsuffixed names.
+#
+# Called by:
+#   - .github/workflows/publish-sim-images.yml (manifest job)
+#
+# Required env: IMAGE_PREFIX, IMAGE_TAG, SHORT_SHA
+# Optional env: IMAGE_INPUTS_HASH, PUSH_MAIN_TAGS
+# The caller must already be logged in to the registry.
+set -euo pipefail
+
+: "${IMAGE_PREFIX:?}" "${IMAGE_TAG:?}" "${SHORT_SHA:?}"
+
+tags=("${IMAGE_TAG}" "sha-${SHORT_SHA}")
+if [[ -n "${IMAGE_INPUTS_HASH:-}" && "${IMAGE_INPUTS_HASH}" != "manual" ]]; then
+  tags+=("inputs-${IMAGE_INPUTS_HASH}")
+fi
+if [[ "${PUSH_MAIN_TAGS:-false}" == "true" ]]; then
+  tags+=("main")
+fi
+
+for image in "${IMAGE_PREFIX}/innate-os-sim-deps" "${IMAGE_PREFIX}/innate-os-sim-ros"; do
+  for tag in "${tags[@]}"; do
+    docker buildx imagetools create \
+      --tag "$image:$tag" \
+      "$image:$tag-amd64" \
+      "$image:$tag-arm64"
+  done
+done


### PR DESCRIPTION
## Why

The prebuilt simulator images are **amd64-only** (Cloud Build runs a plain `docker build` on an x86 machine) — so Apple-Silicon Macs, arm64 VMs, and Raspberry Pis have never used a prebuilt image: every `./innate-sim up` on them pays a ~25–30 min local Docker build (plus ~10 GB of build cache) that amd64 users skip with a ~5 min pull. Since Apple-Silicon Macs are likely the primary developer machine, that's the main audience.

This PR also publishes from **every branch tip**, not just main, so checking out any branch whose CI has run gets a pull instead of a local build.

## How

Four jobs; amd64 and arm64 build in parallel:

1. **tags** — content-hash computation (now via the shared `ci/compute_sim_image_inputs_hash.py`), exposed as job outputs.
2. **amd64** — Cloud Build, as before, via the shared build script, pushing arch-suffixed tags (`inputs-<hash>-amd64`, …).
3. **arm64** — the org's native `my-medium-runner-arm` larger runner (8 cores / 32 GB / 300 GB SSD; billed per-minute — see `.github/workflows/sim-images-build-cost-analysis.md`) running the *same* script with `ARCH=arm64`. Native, because QEMU-emulating the ros2_ws colcon build would take hours.
4. **manifest** — `ci/stitch_sim_manifests.sh` stitches each pair into a multi-arch manifest under the **unsuffixed tags every consumer already pulls** (`inputs-<hash>`, `sha-…`, `main`). One `imagetools create` per image carries all tags, so a cancelled run can't leave some tags multi-arch and others stale. Docker resolves the right architecture automatically — no launcher changes needed here.

Build logic is deduplicated into `ci/build_sim_images.sh`, called by both builders; the Cloud Build config shrinks to login + invoke.

## Every-branch publishing

- `on.push` now has no branch filter (paths only, and the path list covers exactly the hash inputs — including `.dockerignore`, previously missing). Non-main pushes publish `inputs-<hash>`/`sha-…` tags but never `main`.
- Per-ref concurrency with cancel-in-progress: only a branch's tip build completes; rapid pushes don't pile up.
- Volume estimate from `format.yml`'s pull_request-synchronize runs: ~400–600 publishes/month vs ~50 in the main-only era.

## Security

- Triggers are `push` + `workflow_dispatch` ONLY — never `pull_request`/`pull_request_target` (contract documented at the top of the workflow). PRs cannot run this workflow at all.
- Defense in depth: every job requires `github.repository == 'innate-inc/innate-os'` and a push/dispatch event, so a future trigger edit or a fork can't reach the pushing jobs.
- Permissions scoped per job: `id-token: write` only on the Cloud Build leg, `packages: write` only on arm64 + manifest.

## Transition & compatibility

- Build caches are per-arch (`buildcache-amd64`/`-arm64`), seeded from the old unsuffixed `buildcache` on first run (a one-time no-op pull of useless amd64 layers on the arm64 side; self-heals from run two).
- Unsuffixed tags simply gain an arm64 half; old and new launchers both work.

## Validated

Full end-to-end run on this branch ([29300662258](https://github.com/innate-inc/innate-os/actions/runs/29300662258)): tags 4 s → amd64 2.5 min ∥ arm64 10 min (fully cold) → manifest 15 s, all green, ghcr pushes authorized. Since this branch's inputs-hash equals main's, main's `inputs-…` tags are **already multi-arch** — the intended end state. Warm arm64 runs should land ~3–5 min.

Shared scripts were also mock-run with a stubbed docker: correct tag set per arch, cache fallback chain, and stitch commands (including dedup when `IMAGE_TAG` equals the sha tag) for both main and manual-dispatch cases.

## Related PRs

- #526 fixes the launcher's inputs-hash drift — **without it the launcher never matches any published tag** (pre-existing bug; every platform currently falls back to local builds). This PR makes the tags multi-arch; #526 makes launchers find them.
- #525 adds age/branch-aware ghcr retention sized for every-branch publish volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
