### PR TITLE
fix(sim): align launcher image-inputs hash with CI so prebuilt pulls work again

### DIFF
--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -72,9 +72,9 @@ SIM_IMAGE_INPUT_FILES = (
     "sim/Dockerfile",
     "sim/Dockerfile.ros-prebuilt",
     "sim/Dockerfile.ros-prebuilt.dockerignore",
-    "sim/apt-dependencies.txt",
     "ros2_ws/apt-dependencies.common.txt",
     "ros2_ws/apt-dependencies.hardware.txt",
+    "ros2_ws/apt-dependencies.sim.txt",
 )
 # What the local (deps-only) sim/Dockerfile build actually reads from the repo.
 LOCAL_OS_IMAGE_REPO = "innate-os-sim-clean-innate"


### PR DESCRIPTION
## Why

The launcher's prebuilt-image resolution has been silently broken for everyone, on every platform: `SIM_IMAGE_INPUT_FILES` still lists `sim/apt-dependencies.txt` (deleted in the deps restructure, silently skipped by the `is_file()` filter) and is missing `ros2_ws/apt-dependencies.sim.txt` (which CI's hash includes). The hash digests file *paths* as well as contents, so the launcher's `inputs-<hash>` can **never** equal any published tag — every `./innate-sim up` fails the prebuilt pull and falls back to the ~30 min local build. The "normal first-run build" everyone has been paying is this bug.

## How

One-line list fix: drop the dead entry, add the missing one. Verified `sim/launcher/config.py::compute_sim_image_inputs_hash` and CI now produce identical digests on the same tree (`4d355ca1…`).

Because CI's formula is unchanged, the corrected hash matches `inputs-…` tags **already published** from main — the fix starts working on merge with no rebuild (x86 immediately; arm64 once #524 lands).

## Related

- #524 makes the published tags multi-arch (and extracts this same hash into `ci/compute_sim_image_inputs_hash.py` for CI use)
- #525 pins main's `inputs-<hash>` versions against ghcr retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
