### PR TITLE
fix(ci): install libopenmpi-dev so the manipulation package builds

### DIFF
--- a/ros2_ws/apt-dependencies.common.txt
+++ b/ros2_ws/apt-dependencies.common.txt
@@ -108,3 +108,4 @@ ros-humble-robot-state-publisher
 ros-humble-topic-tools
 ros-humble-xacro
 libhdf5-dev
+libopenmpi-dev


### PR DESCRIPTION
## Problem

Integration tests are red across `main` and every open PR (e.g. [run 29308799230](https://github.com/innate-inc/innate-os/actions/runs/29308799230/job/87007953281)). The failure is not in the tests — it's in building the test image's ROS workspace:

```
CMake Error: Could NOT find MPI (missing: MPI_C_FOUND MPI_CXX_FOUND)
  manipulation/CMakeLists.txt:27 (find_package)
Failed <<< manipulation
```

## Root cause

- `manipulation/CMakeLists.txt` has `find_package(MPI REQUIRED)` (for parallel HDF5 in the C++ recorder), but `libopenmpi-dev` was declared **only** in `apt-dependencies.sim.txt`.
- `ci/Dockerfile.test-base` installs `apt-dependencies.common.txt` **only** → MPI missing → `manipulation` fails to build.
- That build runs while (re)building the warm base on `main`, so the base was **never published**; PRs then fall back to an inline base build and hit the same error. Hence the failure is repo-wide.

## Fix

Add `libopenmpi-dev` to `apt-dependencies.common.txt` (the sim image concatenates common, so it's unaffected).

It is **not** declared in `manipulation/package.xml`: there is no rosdep key that resolves to `libopenmpi-dev` on Ubuntu (the `openmpi` rosdep key maps to an empty apt list on ubuntu/debian), so `rosdep install --from-paths src` cannot resolve it. It belongs in the apt list only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)