### PR TITLE
fix(brain): report 'failed' to cloud when a primitive never starts (INN-711)

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/core/vision_output.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/vision_output.py
@@ -88,7 +88,11 @@ class VisionOutputHandler:
         self._logger.info(f"[BrainClient] Next task: {task.type}")
         skill_id = self._state.registry.resolve_skill_id(task.type)
         if skill_id is None:
-            self._logger.warn(f"Unknown primitive type: {task.type}")
+            self._runner.report_start_failure(
+                primitive_name=task.type,
+                primitive_id=task.primitive_id,
+                reason=f"Unknown skill '{task.type}' — not in the registered skill set.",
+            )
             return
 
         self._gaze.pause()

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -42,12 +42,23 @@ class PrimitiveRunner:
     def start_task(self, skill_id: str, primitive_id: str | None, inputs: dict) -> None:
         """Send a goal for ``skill_id`` and mark it running (announce + status).
 
+        "running" only goes out once the goal is actually dispatched — if the
+        action server is unavailable the cloud gets "failed" instead, so it never
+        believes a primitive is running that was never started.
+
         The local /brain/skill_status_update echo is skills_action_server's job now
         (it publishes for every goal it runs, not just the agent's) — announcing it
         here too would double the "running" entry in the chat.
         """
         skill_name = self._state.registry.name_for(skill_id)
-        self._send_goal(skill_id, inputs)
+        if not self._send_goal(skill_id, inputs):
+            self.report_start_failure(
+                primitive_name=skill_name,
+                primitive_id=primitive_id,
+                skill_id=skill_id,
+                reason="Skill execution server unavailable — the skill never started.",
+            )
+            return
         self._ws.send_message(
             primitive_lifecycle_message(
                 status="running",
@@ -60,6 +71,31 @@ class PrimitiveRunner:
             "primitive_id": primitive_id,
             "skill_id": skill_id,
         }
+
+    def report_start_failure(self, *, primitive_name, primitive_id, reason, skill_id=None) -> None:
+        """Tell the cloud and the app that a task never started (no goal exists).
+
+        The action server never saw the goal, so nobody else will publish a
+        terminal status — without this the cloud would wait on the primitive
+        forever and refuse to re-trigger it.
+        """
+        self._logger.error(f"Primitive '{primitive_name}' failed to start: {reason}")
+        self._ws.send_message(
+            primitive_lifecycle_message(
+                status="failed",
+                primitive_name=primitive_name,
+                primitive_id=primitive_id,
+                reason=reason,
+            )
+        )
+        self._chat.publish_task_status(
+            primitive_name=primitive_name,
+            primitive_id=primitive_id,
+            status="failed",
+            skill_id=skill_id,
+            reason=reason,
+        )
+        self._on_task_finished()
 
     @property
     def has_active_goal(self) -> bool:
@@ -110,16 +146,18 @@ class PrimitiveRunner:
         self._pending_next_task = None
 
     # --- action plumbing ---
-    def _send_goal(self, task_type: str, inputs: dict) -> None:
+    def _send_goal(self, task_type: str, inputs: dict) -> bool:
+        """Dispatch the goal; returns False if the action server is unavailable."""
         goal_msg = ExecuteSkill.Goal()
         goal_msg.skill_type = task_type
         goal_msg.inputs = json.dumps(inputs if inputs is not None else {})
         self._logger.info(f"Sending goal for skill: {task_type} with inputs: {goal_msg.inputs}")
         if not self.action_client.wait_for_server(timeout_sec=1.0):
             self._logger.error("Primitive execution action server not available!")
-            return
+            return False
         future = self.action_client.send_goal_async(goal_msg, feedback_callback=self._on_feedback)
         future.add_done_callback(self._on_goal_response)
+        return True
 
     def _on_feedback(self, feedback_wrapper) -> None:
         try:
@@ -165,6 +203,16 @@ class PrimitiveRunner:
         if not goal_handle.accepted:
             self._logger.info("Primitive execution goal rejected.")
             if self._state.primitive_running:
+                # The cloud was told "running" on dispatch; a rejected goal produces
+                # no result, so send the terminal "failed" here or it waits forever.
+                self._ws.send_message(
+                    primitive_lifecycle_message(
+                        status="failed",
+                        primitive_name=self._state.primitive_running["primitive_name"],
+                        primitive_id=self._state.primitive_running["primitive_id"],
+                        reason="Goal rejected by action server",
+                    )
+                )
                 self._chat.publish_task_status(
                     primitive_name=self._state.primitive_running["primitive_name"],
                     primitive_id=self._state.primitive_running["primitive_id"],
@@ -268,7 +316,11 @@ class PrimitiveRunner:
             if skill_id is not None:
                 self.start_task(skill_id, pending.primitive_id, pending.inputs)
             else:
-                self._logger.warn(f"Unknown pending primitive: {pending.type}")
+                self.report_start_failure(
+                    primitive_name=pending.type,
+                    primitive_id=pending.primitive_id,
+                    reason=f"Unknown skill '{pending.type}' — not in the registered skill set.",
+                )
         else:
             self._logger.warn(
                 f"Clearing pending task {self._pending_next_task.type} because previous task "

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -51,7 +51,7 @@ class PrimitiveRunner:
         here too would double the "running" entry in the chat.
         """
         skill_name = self._state.registry.name_for(skill_id)
-        if not self._send_goal(skill_id, inputs):
+        if not self._send_goal(skill_id, inputs, primitive_id=primitive_id, skill_name=skill_name):
             self.report_start_failure(
                 primitive_name=skill_name,
                 primitive_id=primitive_id,
@@ -95,7 +95,11 @@ class PrimitiveRunner:
             skill_id=skill_id,
             reason=reason,
         )
-        self._on_task_finished()
+        # Don't fire on_task_finished (gaze resume, deferred re-registration)
+        # over a *different* primitive that is still running — e.g. the cloud
+        # naming an unknown skill while another one executes.
+        if self._state.primitive_running is None and self._goal_handle is None:
+            self._on_task_finished()
 
     @property
     def has_active_goal(self) -> bool:
@@ -146,8 +150,14 @@ class PrimitiveRunner:
         self._pending_next_task = None
 
     # --- action plumbing ---
-    def _send_goal(self, task_type: str, inputs: dict) -> bool:
-        """Dispatch the goal; returns False if the action server is unavailable."""
+    def _send_goal(self, task_type: str, inputs: dict, *, primitive_id, skill_name) -> bool:
+        """Dispatch the goal; returns False if the action server is unavailable.
+
+        The task identity rides along into the goal-response callback: a
+        deactivate/unregister racing that callback clears primitive_running
+        without telling the cloud (there is no goal handle to cancel yet), so
+        the rejection path must not depend on state to name the task.
+        """
         goal_msg = ExecuteSkill.Goal()
         goal_msg.skill_type = task_type
         goal_msg.inputs = json.dumps(inputs if inputs is not None else {})
@@ -156,7 +166,9 @@ class PrimitiveRunner:
             self._logger.error("Primitive execution action server not available!")
             return False
         future = self.action_client.send_goal_async(goal_msg, feedback_callback=self._on_feedback)
-        future.add_done_callback(self._on_goal_response)
+        future.add_done_callback(
+            lambda f: self._on_goal_response(f, skill_name=skill_name, primitive_id=primitive_id, skill_id=task_type)
+        )
         return True
 
     def _on_feedback(self, feedback_wrapper) -> None:
@@ -198,31 +210,36 @@ class PrimitiveRunner:
         if event == "completed" and output and output.strip():
             self._chat.emit("skill_output", output, speak=False)
 
-    def _on_goal_response(self, future) -> None:
+    def _on_goal_response(self, future, *, skill_name, primitive_id, skill_id) -> None:
         goal_handle = future.result()
         if not goal_handle.accepted:
             self._logger.info("Primitive execution goal rejected.")
-            if self._state.primitive_running:
-                # The cloud was told "running" on dispatch; a rejected goal produces
-                # no result, so send the terminal "failed" here or it waits forever.
-                self._ws.send_message(
-                    primitive_lifecycle_message(
-                        status="failed",
-                        primitive_name=self._state.primitive_running["primitive_name"],
-                        primitive_id=self._state.primitive_running["primitive_id"],
-                        reason="Goal rejected by action server",
-                    )
-                )
-                self._chat.publish_task_status(
-                    primitive_name=self._state.primitive_running["primitive_name"],
-                    primitive_id=self._state.primitive_running["primitive_id"],
+            # The cloud was told "running" on dispatch; a rejected goal produces
+            # no result, so send the terminal "failed" here or it waits forever.
+            # Uses the identity captured at dispatch, not primitive_running — a
+            # racing deactivate/unregister clears that without telling the cloud.
+            self._ws.send_message(
+                primitive_lifecycle_message(
                     status="failed",
-                    skill_id=self._state.primitive_running.get("skill_id"),
+                    primitive_name=skill_name,
+                    primitive_id=primitive_id,
                     reason="Goal rejected by action server",
                 )
-            self._state.primitive_running = None
-            self._goal_handle = None
-            self._on_task_finished()
+            )
+            self._chat.publish_task_status(
+                primitive_name=skill_name,
+                primitive_id=primitive_id,
+                status="failed",
+                skill_id=skill_id,
+                reason="Goal rejected by action server",
+            )
+            # Only touch shared state if it is still this task's: a new task may
+            # already be running after the race that cleared ours.
+            running = self._state.primitive_running
+            if running is None or (running.get("primitive_id"), running.get("skill_id")) == (primitive_id, skill_id):
+                self._state.primitive_running = None
+                self._goal_handle = None
+                self._on_task_finished()
             return
         self._goal_handle = goal_handle
         self._logger.info("Primitive execution goal accepted.")

--- a/ros2_ws/src/brain/brain_client/test/test_runner_start_failure.py
+++ b/ros2_ws/src/brain/brain_client/test/test_runner_start_failure.py
@@ -44,9 +44,7 @@ class FakeActionClient:
 
 
 def _make_runner(monkeypatch, server_available):
-    monkeypatch.setattr(
-        runner_module, "ActionClient", lambda node, action, name: FakeActionClient(server_available)
-    )
+    monkeypatch.setattr(runner_module, "ActionClient", lambda node, action, name: FakeActionClient(server_available))
     node = SimpleNamespace(get_logger=lambda: FakeLogger())
     ws_messages = []
     ws = SimpleNamespace(send_message=ws_messages.append)

--- a/ros2_ws/src/brain/brain_client/test/test_runner_start_failure.py
+++ b/ros2_ws/src/brain/brain_client/test/test_runner_start_failure.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Unit tests for primitive start-failure reporting (INN-711).
+
+Pins the fix for the phantom-running bug: "running" must only reach the cloud
+once the goal is actually dispatched. If the action server is unavailable (or
+the skill ID is unknown), the cloud gets a terminal "failed" instead — never a
+"running" it will wait on forever.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import brain_client.skills.runner as runner_module
+from brain_client.skills.runner import PrimitiveRunner
+from brain_client.transport.messages import MessageInType
+
+
+class FakeLogger:
+    def info(self, msg):
+        pass
+
+    def warn(self, msg):
+        pass
+
+    def error(self, msg):
+        pass
+
+
+class FakeActionClient:
+    """Stands in for rclpy's ActionClient; server availability is scripted."""
+
+    def __init__(self, server_available):
+        self.server_available = server_available
+        self.sent_goals = []
+
+    def wait_for_server(self, timeout_sec=None):
+        return self.server_available
+
+    def send_goal_async(self, goal_msg, feedback_callback=None):
+        self.sent_goals.append(goal_msg)
+        return SimpleNamespace(add_done_callback=lambda cb: None)
+
+
+def _make_runner(monkeypatch, server_available):
+    monkeypatch.setattr(
+        runner_module, "ActionClient", lambda node, action, name: FakeActionClient(server_available)
+    )
+    node = SimpleNamespace(get_logger=lambda: FakeLogger())
+    ws_messages = []
+    ws = SimpleNamespace(send_message=ws_messages.append)
+    chat_statuses = []
+    chat = SimpleNamespace(
+        publish_task_status=lambda **kwargs: chat_statuses.append(kwargs),
+        emit=lambda *args, **kwargs: None,
+    )
+    state = SimpleNamespace(
+        primitive_running=None,
+        registry=SimpleNamespace(name_for=lambda skill_id: "victory_spin"),
+    )
+    finished = []
+    runner = PrimitiveRunner(
+        node,
+        ws,
+        chat,
+        state,
+        stop_robot=lambda: None,
+        on_task_finished=lambda: finished.append(True),
+    )
+    return runner, ws_messages, chat_statuses, finished
+
+
+def test_start_task_reports_failed_when_server_unavailable(monkeypatch):
+    runner, ws_messages, chat_statuses, finished = _make_runner(monkeypatch, server_available=False)
+
+    runner.start_task("local/victory_spin", "prim-1", {})
+
+    assert runner.action_client.sent_goals == []
+    assert runner._state.primitive_running is None
+    types = [m.type for m in ws_messages]
+    assert MessageInType.PRIMITIVE_ACTIVATED not in types
+    assert types == [MessageInType.PRIMITIVE_FAILED]
+    assert ws_messages[0].payload["primitive_name"] == "victory_spin"
+    assert "never started" in ws_messages[0].payload["reason"]
+    assert chat_statuses and chat_statuses[0]["status"] == "failed"
+    assert finished == [True]
+
+
+def test_start_task_reports_running_when_goal_dispatched(monkeypatch):
+    runner, ws_messages, chat_statuses, finished = _make_runner(monkeypatch, server_available=True)
+
+    runner.start_task("local/victory_spin", "prim-1", {})
+
+    assert len(runner.action_client.sent_goals) == 1
+    types = [m.type for m in ws_messages]
+    assert types == [MessageInType.PRIMITIVE_ACTIVATED]
+    assert runner._state.primitive_running == {
+        "primitive_name": "victory_spin",
+        "primitive_id": "prim-1",
+        "skill_id": "local/victory_spin",
+    }
+    assert finished == []
+
+
+def test_rejected_goal_sends_terminal_failed_to_cloud(monkeypatch):
+    runner, ws_messages, chat_statuses, finished = _make_runner(monkeypatch, server_available=True)
+    runner.start_task("local/victory_spin", "prim-1", {})
+    ws_messages.clear()
+
+    rejected_handle = SimpleNamespace(accepted=False)
+    runner._on_goal_response(SimpleNamespace(result=lambda: rejected_handle))
+
+    types = [m.type for m in ws_messages]
+    assert types == [MessageInType.PRIMITIVE_FAILED]
+    assert runner._state.primitive_running is None
+    assert finished == [True]
+
+
+def test_report_start_failure_used_for_unknown_skill(monkeypatch):
+    runner, ws_messages, chat_statuses, finished = _make_runner(monkeypatch, server_available=True)
+
+    runner.report_start_failure(
+        primitive_name="does_not_exist",
+        primitive_id="prim-2",
+        reason="Unknown skill 'does_not_exist' — not in the registered skill set.",
+    )
+
+    types = [m.type for m in ws_messages]
+    assert types == [MessageInType.PRIMITIVE_FAILED]
+    assert ws_messages[0].payload["primitive_id"] == "prim-2"
+    assert runner._state.primitive_running is None
+    assert finished == [True]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/ros2_ws/src/brain/brain_client/test/test_runner_start_failure.py
+++ b/ros2_ws/src/brain/brain_client/test/test_runner_start_failure.py
@@ -101,18 +101,58 @@ def test_start_task_reports_running_when_goal_dispatched(monkeypatch):
     assert finished == []
 
 
+def _reject_goal(runner):
+    rejected_handle = SimpleNamespace(accepted=False)
+    runner._on_goal_response(
+        SimpleNamespace(result=lambda: rejected_handle),
+        skill_name="victory_spin",
+        primitive_id="prim-1",
+        skill_id="local/victory_spin",
+    )
+
+
 def test_rejected_goal_sends_terminal_failed_to_cloud(monkeypatch):
     runner, ws_messages, chat_statuses, finished = _make_runner(monkeypatch, server_available=True)
     runner.start_task("local/victory_spin", "prim-1", {})
     ws_messages.clear()
 
-    rejected_handle = SimpleNamespace(accepted=False)
-    runner._on_goal_response(SimpleNamespace(result=lambda: rejected_handle))
+    _reject_goal(runner)
 
     types = [m.type for m in ws_messages]
     assert types == [MessageInType.PRIMITIVE_FAILED]
     assert runner._state.primitive_running is None
     assert finished == [True]
+
+
+def test_rejected_goal_reports_failed_even_after_state_cleared(monkeypatch):
+    """A deactivate/unregister racing the goal response clears primitive_running
+    without telling the cloud (no goal handle yet) — the rejection must still
+    send the terminal 'failed'."""
+    runner, ws_messages, chat_statuses, finished = _make_runner(monkeypatch, server_available=True)
+    runner.start_task("local/victory_spin", "prim-1", {})
+    ws_messages.clear()
+    runner._state.primitive_running = None  # the race
+
+    _reject_goal(runner)
+
+    types = [m.type for m in ws_messages]
+    assert types == [MessageInType.PRIMITIVE_FAILED]
+    assert ws_messages[0].payload["primitive_id"] == "prim-1"
+
+
+def test_rejected_goal_leaves_a_newer_running_task_alone(monkeypatch):
+    """If another task started after the race cleared ours, its state and gaze
+    pause must survive our late rejection."""
+    runner, ws_messages, chat_statuses, finished = _make_runner(monkeypatch, server_available=True)
+    runner.start_task("local/victory_spin", "prim-1", {})
+    ws_messages.clear()
+    newer = {"primitive_name": "wave", "primitive_id": "prim-2", "skill_id": "local/wave"}
+    runner._state.primitive_running = dict(newer)
+
+    _reject_goal(runner)
+
+    assert runner._state.primitive_running == newer
+    assert finished == []
 
 
 def test_report_start_failure_used_for_unknown_skill(monkeypatch):
@@ -129,6 +169,25 @@ def test_report_start_failure_used_for_unknown_skill(monkeypatch):
     assert ws_messages[0].payload["primitive_id"] == "prim-2"
     assert runner._state.primitive_running is None
     assert finished == [True]
+
+
+def test_report_start_failure_keeps_active_task_undisturbed(monkeypatch):
+    """An unknown next_task while another primitive runs must tell the cloud
+    'failed' but NOT fire on_task_finished (gaze resume) over the active task."""
+    runner, ws_messages, chat_statuses, finished = _make_runner(monkeypatch, server_available=True)
+    runner.start_task("local/victory_spin", "prim-1", {})
+    ws_messages.clear()
+
+    runner.report_start_failure(
+        primitive_name="does_not_exist",
+        primitive_id="prim-2",
+        reason="Unknown skill 'does_not_exist' — not in the registered skill set.",
+    )
+
+    types = [m.type for m in ws_messages]
+    assert types == [MessageInType.PRIMITIVE_FAILED]
+    assert runner._state.primitive_running["primitive_id"] == "prim-1"
+    assert finished == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes [INN-711](https://linear.app/innate/issue/INN-711/brain-client-reports-primitive-running-to-cloud-even-when-the-goal-was).

## Problem

`PrimitiveRunner.start_task()` sent the `running` lifecycle message and set `state.primitive_running` unconditionally — even when `_send_goal()` silently failed because the `execute_skill` action server didn't respond within its 1s `wait_for_server` window (typical right after a directive switch / skill reload).

Since no goal existed, no terminal result ever arrived, so the cloud agent believed the primitive was running forever and refused to re-trigger it ("should not stop running primitives").

## Fix

- `running` is announced only after the goal is actually dispatched (`_send_goal()` now returns whether it dispatched).
- Every never-started path now sends a terminal `failed` lifecycle message to the cloud via a new `report_start_failure()` helper, which also publishes the local app status and fires `on_task_finished` (gaze resume + deferred re-registration drain):
  - action server unavailable (`wait_for_server` timeout)
  - unknown skill ID from the cloud (`vision_output._start_next_task`)
  - unknown pending task after a stop+next_task sequence (`_maybe_run_pending`)
- A goal **rejected** by the action server now also sends the cloud a terminal `failed` — previously only the local app was told, leaving the cloud waiting on the `running` it had received at dispatch.

## Tests

New `test/test_runner_start_failure.py` (4 tests) pins: no `running` + terminal `failed` when the server is unavailable; `running` + state set when dispatched; terminal `failed` on goal rejection; unknown-skill reporting. Ran in the innate-dev container alongside the existing suite: 22 passed.