### PR TITLE
ci: survive test-base image gaps — fix inline fallback, harden cleanup (INN-710)

### DIFF
--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -51,7 +51,12 @@ jobs:
           keep_file="$(mktemp)"
           versions_file="$(mktemp)"
 
-          gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"
+          # A package that has never been published is nothing to clean, not an
+          # error — every scheduled run used to die here on the 404.
+          if ! gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"; then
+            echo "Package ${package} not found on ghcr; nothing to clean up."
+            exit 0
+          fi
 
           jq -r '
             .[]
@@ -123,6 +128,15 @@ jobs:
             tags="$(jq -r --argjson id "${version_id}" '
               .[] | select(.id == $id) | (.metadata.container.tags // []) | join(",")
             ' "${versions_file}")"
+            # Belt-and-braces (INN-710): whatever the keep-selection above
+            # computed, never delete a version carrying a protected tag —
+            # CI depends on main/buildcache existing.
+            case ",${tags}," in
+              *,main,*|*,buildcache,*)
+                echo "SKIP protected ${package} version ${version_id}: ${tags}"
+                continue
+                ;;
+            esac
             if [[ "${DRY_RUN}" == "true" ]]; then
               echo "dry-run delete ${package} version ${version_id}: ${tags}"
             else

--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -52,10 +52,18 @@ jobs:
           versions_file="$(mktemp)"
 
           # A package that has never been published is nothing to clean, not an
-          # error — every scheduled run used to die here on the 404.
-          if ! gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"; then
-            echo "Package ${package} not found on ghcr; nothing to clean up."
-            exit 0
+          # error — every scheduled run used to die here on the 404. Anything
+          # else (permissions, rate limit, transient API failure) still fails
+          # the job rather than silently skipping cleanup.
+          api_error_file="$(mktemp)"
+          if ! gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" \
+              > "${versions_file}" 2> "${api_error_file}"; then
+            if grep -q "HTTP 404" "${api_error_file}"; then
+              echo "Package ${package} not found on ghcr; nothing to clean up."
+              exit 0
+            fi
+            cat "${api_error_file}" >&2
+            exit 1
           fi
 
           jq -r '

--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -58,7 +58,13 @@ jobs:
           api_error_file="$(mktemp)"
           if ! gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" \
               > "${versions_file}" 2> "${api_error_file}"; then
-            if grep -q "HTTP 404" "${api_error_file}"; then
+            # 404 can also mean a broken token/visibility, not just a
+            # never-published package — only treat it as nothing-to-clean when
+            # the org's package listing works, i.e. our access is generally
+            # intact. Anything else fails the job rather than silently
+            # disabling cleanup.
+            if grep -q "HTTP 404" "${api_error_file}" \
+                && gh api "/orgs/${ORG}/packages?package_type=container" > /dev/null; then
               echo "Package ${package} not found on ghcr; nothing to clean up."
               exit 0
             fi

--- a/ci/Dockerfile.test-base
+++ b/ci/Dockerfile.test-base
@@ -112,8 +112,16 @@ RUN cd /root/innate-os/ros2_ws/src && \
 # mars_cam/nav/control build fine on non-Jetson: cam's VPI stereo component is
 # guarded by if(VPI_FOUND), nav's only Jetson dep (python3-cupy) is runtime-only.
 WORKDIR /root/innate-os/ros2_ws
-RUN . /opt/ros/humble/setup.sh && \
-    rosdep install --from-paths src --ignore-src -r -y || true && \
+# apt cache mounts + apt-get update: rosdep shells out to `apt-get install`,
+# and the apt lists populated by earlier layers live in BuildKit cache mounts,
+# not the image — without refreshed lists here every rosdep-resolved dep fails
+# with "Unable to locate package" (silently, via the -r/|| true guards) and
+# colcon then breaks on the packages that needed them.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . /opt/ros/humble/setup.sh && \
+    { rosdep install --from-paths src --ignore-src -r -y || true; } && \
     colcon build --parallel-workers "$(( $(nproc) < 3 ? $(nproc) : 3 ))" --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -93,9 +93,20 @@ steps:
           docker push "$base_image:buildcache"
         else
           # PR: reuse the published warm base; only the thin layer rebuilds.
-          # Fall back to an inline base build if it has never been published yet
-          # (e.g. before the first main build after this change).
-          if ! docker pull "$base_image:main"; then
+          # Retry the pull before giving up: a transient ghcr "manifest unknown"
+          # blip should cost seconds, not the ~30 min inline rebuild (INN-710).
+          # Fall back to an inline base build if it really isn't there (e.g.
+          # never published yet, or deleted between main builds).
+          pulled="false"
+          for attempt in 1 2 3; do
+            if docker pull "$base_image:main"; then
+              pulled="true"
+              break
+            fi
+            echo "Pull of $base_image:main failed (attempt $attempt/3); retrying in 15s."
+            sleep 15
+          done
+          if [[ "$pulled" != "true" ]]; then
             echo "Base image $base_image:main unavailable; building it inline."
             build_base
           fi


### PR DESCRIPTION
Fixes [INN-710](https://linear.app/innate/issue/INN-710/integration-test-breaks-when-ghcr-retention-deletes-the-test-base).

## Investigation: the retention job (probably) didn't do it

Before writing the guard I checked what actually happened this morning:

- **cleanup-sim-images.yml never ran in the window.** It's scheduled weekly (Sun 03:17 UTC); the last run was **Jul 12 04:24 UTC**, two days before the incident, and there are no `workflow_dispatch` runs. On top of that, **every scheduled run since May has failed before deleting anything** — it 404s on `innate-os-sim-assets` (never published) and `set -e` kills the job.
- Its matrix only covers the three `innate-os-sim-*` packages — it never even enumerates `innate-os-test-base` — and its keep-filter already retains `main`/`buildcache`.
- What did happen: the **04:22 UTC push to main failed in `prepare-base-image` (step 0)** — the first main run under the new two-image flow — and main had no successful integration run from Jul 3 until 06:44 today. The 06:38 `manifest unknown` on PR #522 sits in a ~5-minute window between two passing PR runs (06:36, 06:44), which looks like a transient ghcr blip or fallout from the failed first publish, not a retention deletion.

The guard is still added (belt-and-braces), and both real bugs found along the way are fixed.

## Fixes

1. **`ci/Dockerfile.test-base` — inline fallback has never worked** (confirmed). The `rosdep install` layer ran with empty apt lists: earlier layers only populate BuildKit *cache mounts*, which never land in the image filesystem, so every `ros-humble-*` dep failed "Unable to locate package" behind the `-r`/`|| true` guards and colcon then broke on manipulation/mars_nav/etc. The layer now gets the same apt cache mounts + `apt-get update` as the earlier apt layers.
2. **`ci/cloudbuild.integration-test.yaml` — retry the base pull** (3 attempts, 15 s apart) before falling back to the inline build: a transient blip should cost seconds, not a ~30 min inline rebuild.
3. **`.github/workflows/cleanup-sim-images.yml`** —
   - hard guard in the delete loop: a version tagged `main`/`buildcache` is never deleted, regardless of what the keep-selection computed;
   - a 404 on a never-published package is now "nothing to clean", not a job failure — unbreaks the weekly runs that have died on `innate-os-sim-assets` since May.

## Verification

- YAML parse + `bash -n` on both embedded scripts.
- Protected-tag matcher exercised against `main`, `buildcache`, `sha-abc,main`, `sha-abc`, `maintenance` (no substring false-positives).
- The Dockerfile change mirrors the existing apt layers' mount pattern verbatim; the real proof is the next inline-fallback build on Cloud Build.