### PR TITLE
ci: survive test-base image gaps — fix inline fallback, harden cleanup (INN-710)

### DIFF
--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -74,7 +74,7 @@ jobs:
 
           jq -r '
             .[]
-            | select((.metadata.container.tags // []) | any(. == "main" or . == "buildcache"))
+            | select((.metadata.container.tags // []) | any(. == "main" or startswith("buildcache")))
             | .id
           ' "${versions_file}" >> "${keep_file}"
 
@@ -144,9 +144,10 @@ jobs:
             ' "${versions_file}")"
             # Belt-and-braces (INN-710): whatever the keep-selection above
             # computed, never delete a version carrying a protected tag —
-            # CI depends on main/buildcache existing.
+            # CI depends on main/buildcache existing (including the per-arch
+            # buildcache-amd64/-arm64 tags ci/build_sim_images.sh pushes).
             case ",${tags}," in
-              *,main,*|*,buildcache,*)
+              *,main,*|*,buildcache,*|*,buildcache-*)
                 echo "SKIP protected ${package} version ${version_id}: ${tags}"
                 continue
                 ;;

--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -51,7 +51,12 @@ jobs:
           keep_file="$(mktemp)"
           versions_file="$(mktemp)"
 
-          gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"
+          # A package that has never been published is nothing to clean, not an
+          # error — every scheduled run used to die here on the 404.
+          if ! gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"; then
+            echo "Package ${package} not found on ghcr; nothing to clean up."
+            exit 0
+          fi
 
           jq -r '
             .[]
@@ -123,6 +128,15 @@ jobs:
             tags="$(jq -r --argjson id "${version_id}" '
               .[] | select(.id == $id) | (.metadata.container.tags // []) | join(",")
             ' "${versions_file}")"
+            # Belt-and-braces (INN-710): whatever the keep-selection above
+            # computed, never delete a version carrying a protected tag —
+            # CI depends on main/buildcache existing.
+            case ",${tags}," in
+              *,main,*|*,buildcache,*)
+                echo "SKIP protected ${package} version ${version_id}: ${tags}"
+                continue
+                ;;
+            esac
             if [[ "${DRY_RUN}" == "true" ]]; then
               echo "dry-run delete ${package} version ${version_id}: ${tags}"
             else

--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -52,10 +52,18 @@ jobs:
           versions_file="$(mktemp)"
 
           # A package that has never been published is nothing to clean, not an
-          # error — every scheduled run used to die here on the 404.
-          if ! gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" > "${versions_file}"; then
-            echo "Package ${package} not found on ghcr; nothing to clean up."
-            exit 0
+          # error — every scheduled run used to die here on the 404. Anything
+          # else (permissions, rate limit, transient API failure) still fails
+          # the job rather than silently skipping cleanup.
+          api_error_file="$(mktemp)"
+          if ! gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" \
+              > "${versions_file}" 2> "${api_error_file}"; then
+            if grep -q "HTTP 404" "${api_error_file}"; then
+              echo "Package ${package} not found on ghcr; nothing to clean up."
+              exit 0
+            fi
+            cat "${api_error_file}" >&2
+            exit 1
           fi
 
           jq -r '

--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -58,7 +58,13 @@ jobs:
           api_error_file="$(mktemp)"
           if ! gh api --paginate "/orgs/${ORG}/packages/container/${package}/versions" \
               > "${versions_file}" 2> "${api_error_file}"; then
-            if grep -q "HTTP 404" "${api_error_file}"; then
+            # 404 can also mean a broken token/visibility, not just a
+            # never-published package — only treat it as nothing-to-clean when
+            # the org's package listing works, i.e. our access is generally
+            # intact. Anything else fails the job rather than silently
+            # disabling cleanup.
+            if grep -q "HTTP 404" "${api_error_file}" \
+                && gh api "/orgs/${ORG}/packages?package_type=container" > /dev/null; then
               echo "Package ${package} not found on ghcr; nothing to clean up."
               exit 0
             fi

--- a/ci/Dockerfile.test-base
+++ b/ci/Dockerfile.test-base
@@ -112,8 +112,16 @@ RUN cd /root/innate-os/ros2_ws/src && \
 # mars_cam/nav/control build fine on non-Jetson: cam's VPI stereo component is
 # guarded by if(VPI_FOUND), nav's only Jetson dep (python3-cupy) is runtime-only.
 WORKDIR /root/innate-os/ros2_ws
-RUN . /opt/ros/humble/setup.sh && \
-    rosdep install --from-paths src --ignore-src -r -y || true && \
+# apt cache mounts + apt-get update: rosdep shells out to `apt-get install`,
+# and the apt lists populated by earlier layers live in BuildKit cache mounts,
+# not the image — without refreshed lists here every rosdep-resolved dep fails
+# with "Unable to locate package" (silently, via the -r/|| true guards) and
+# colcon then breaks on the packages that needed them.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    . /opt/ros/humble/setup.sh && \
+    { rosdep install --from-paths src --ignore-src -r -y || true; } && \
     colcon build --parallel-workers "$(( $(nproc) < 3 ? $(nproc) : 3 ))" --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -93,9 +93,20 @@ steps:
           docker push "$base_image:buildcache"
         else
           # PR: reuse the published warm base; only the thin layer rebuilds.
-          # Fall back to an inline base build if it has never been published yet
-          # (e.g. before the first main build after this change).
-          if ! docker pull "$base_image:main"; then
+          # Retry the pull before giving up: a transient ghcr "manifest unknown"
+          # blip should cost seconds, not the ~30 min inline rebuild (INN-710).
+          # Fall back to an inline base build if it really isn't there (e.g.
+          # never published yet, or deleted between main builds).
+          pulled="false"
+          for attempt in 1 2 3; do
+            if docker pull "$base_image:main"; then
+              pulled="true"
+              break
+            fi
+            echo "Pull of $base_image:main failed (attempt $attempt/3); retrying in 15s."
+            sleep 15
+          done
+          if [[ "$pulled" != "true" ]]; then
             echo "Base image $base_image:main unavailable; building it inline."
             build_base
           fi


### PR DESCRIPTION
Fixes [INN-710](https://linear.app/innate/issue/INN-710/integration-test-breaks-when-ghcr-retention-deletes-the-test-base).

## What happened

On Jul 14 at 06:38 UTC, the integration test on PR #522 failed with:

```
Base image ghcr.io/innate-inc/innate-os-test-base:main unavailable; building it inline
```

`test-base:main` was briefly unavailable on ghcr, the run fell back to building the base inline — and that fallback build **has never worked**, so the run went red. Runs 2 minutes before (06:33, 06:36) and 6 minutes after (06:44) passed. The original suspicion was that the new ghcr retention job had deleted the image.

## Problem 1: the inline fallback build was broken

When the prebuilt base can't be pulled, CI rebuilds it from `ci/Dockerfile.test-base`. That build always failed:

- Every earlier apt layer keeps its package lists in **BuildKit cache mounts**, which never land in the image filesystem.
- The final `rosdep install` layer had no cache mounts and no `apt-get update`, so it ran with **empty apt lists** — every `ros-humble-*` dependency failed with "Unable to locate package".
- Those failures were swallowed by `rosdep -r … || true`, and colcon then broke later on manipulation/mars_nav/etc.

**Fix:** the rosdep/colcon layer gets the same apt cache mounts as the earlier layers plus an `apt-get update`, so `rosdep install` can actually install what it resolves.

## Problem 2: a transient blip cost a full rebuild (or a red run)

A single failed `docker pull` immediately triggered the (~30 min) inline rebuild — or, while that fallback was broken, a failed run.

**Fix:** the pull retries 3× with 15s pauses before falling back. A transient ghcr "manifest unknown" now costs seconds.

## Problem 3: the cleanup job couldn't protect what CI depends on (and crashed weekly)

The retention job turned out **not** to be the culprit — it never ran in the failure window, and in fact **every scheduled run since May had died before deleting anything**: it 404s on `innate-os-sim-assets` (never published) and `set -e` kills the job. But the incident exposed real gaps, all fixed:

- **Hard tag guard:** the delete loop now refuses to delete any version tagged `main`, `buildcache`, or the per-arch `buildcache-amd64`/`-arm64` (pushed by `ci/build_sim_images.sh`), regardless of what the keep-selection computed.
- **Missing package ≠ crash:** a 404 on a never-published package is "nothing to clean up", so the weekly runs work again.
- **But only a real 404:** the skip additionally requires the org package listing to still succeed — a broken/downgraded token fails the run loudly instead of silently disabling cleanup.

## So what actually deleted the image?

Most likely nothing was "deleted" by us: the 04:22 UTC main push — the first under the new two-image flow — failed in the `prepare-base-image` step, and main had no successful publish from Jul 3 until 06:44 that day. The 06:38 failure sits in a 5-minute window between passing runs, consistent with a transient ghcr blip or fallout from that failed first publish. With the three fixes above, any of those causes now results in a green (at worst slower) run.

## Verification

- YAML parse + `bash -n` on the embedded scripts.
- Protected-tag matcher exercised against `main`, `buildcache`, `buildcache-amd64`, `sha-abc,buildcache-arm64`, and negatives (`sha-abc`, `notbuildcache-x`).
- The Dockerfile change mirrors the existing apt layers' mount pattern; the real proof is the next inline-fallback build on Cloud Build.
