### PR TITLE
feat: Foxglove bridge — auto-start in sim, opt-in innate foxglove CLI (INN-712)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ _Innate OS is developed for MARS; if you want to port it to your robot, we are h
 - [Skills](#skills)
 - [Agents](#agents)
 - [Simulator](#simulator)
+- [Foxglove](#foxglove)
 - [Additional Inputs](#additional-inputs)
 - [ROS Reference](#ros-reference)
 - [More Docs](#more-docs)
@@ -301,6 +302,22 @@ The first `up` provisions everything automatically (simulation assets, the 3D vi
 ```
 
 See [`sim/README.md`](sim/README.md) for everything else: the day-to-day workflow, the ROS-free VirtualMars Python API (with a walkthrough notebook), and the architecture.
+
+---
+
+## Foxglove
+
+[Foxglove Studio](https://foxglove.dev) gives you a live view of TF, `/scan`, camera images, point clouds, and `/cmd_vel` teleop for debugging. In the [simulator](#simulator) the bridge is always on; on a physical robot it is opt-in:
+
+```bash
+innate foxglove start   # start the bridge (ws://<robot-ip>:8765)
+innate foxglove stop    # stop it
+innate foxglove         # status
+```
+
+Then connect Foxglove Studio to the printed `ws://` URL.
+
+> **Over Wi-Fi, subscribe to the `/mars/main_camera/remote/*` topics, not the raw ones.** The raw camera images (~0.9 MB/frame) and point clouds (`/mars/main_camera/points`, ~10 MB/s) are far more than a Wi-Fi link can carry, so every panel — including `/cmd_vel` — falls seconds behind. The `remote/` namespace carries the same topics throttled to ~2 Hz (and images already compressed), which fits comfortably. Prefer `.../compressed` image topics and mono `remote/points` over `remote/points_color`.
 
 ---
 

--- a/scripts/innate
+++ b/scripts/innate
@@ -985,9 +985,10 @@ def _foxglove_sim_window_exists():
 
 def _foxglove_uri():
     if is_sim_mode():
-        # Host side is published by sim/docker-compose.dev.yml (8766 when the
-        # local brain owns 8765 — the launcher prints the actual port).
-        return f"ws://localhost:{FOXGLOVE_PORT}"
+        # The published host port is baked into the container env by
+        # docker-compose.dev.yml (8766 when the local brain owns 8765).
+        host_port = os.environ.get("SIM_FOXGLOVE_PORT", "").strip() or FOXGLOVE_PORT
+        return f"ws://localhost:{host_port}"
     try:
         out = subprocess.run(["hostname", "-I"], capture_output=True, text=True, timeout=2).stdout.strip()
         ip = out.split()[0] if out else None
@@ -1028,16 +1029,19 @@ def _foxglove_start():
 
 
 def _foxglove_stop():
+    stopped = False
+    # Both can exist at once (standalone session + sim-stack window) — stop all.
     if tmux_session_exists(FOXGLOVE_TMUX_SESSION):
         run(["tmux", "kill-session", "-t", FOXGLOVE_TMUX_SESSION])
         ok("Foxglove bridge stopped")
-        return 0
+        stopped = True
     if is_sim_mode() and _foxglove_sim_window_exists():
         run(["tmux", "kill-window", "-t", f"{TMUX_SESSION_SIM}:foxglove"])
         ok("Foxglove bridge stopped (sim stack window)")
         print(f"  It restarts with the sim; use {C.BOLD}innate foxglove start{C.NC} to bring it back now")
-        return 0
-    warn("Foxglove bridge is not running")
+        stopped = True
+    if not stopped:
+        warn("Foxglove bridge is not running")
     return 0
 
 

--- a/scripts/innate
+++ b/scripts/innate
@@ -1019,7 +1019,11 @@ def _foxglove_start():
             "send-keys",
             "-t",
             f"{FOXGLOVE_TMUX_SESSION}:foxglove",
-            f"{env_cmd} && ros2 launch foxglove_bridge foxglove_bridge_launch.xml",
+            # Low-latency defaults: shallow queue + small send buffer so the
+            # bridge drops stale frames instead of queuing seconds of lag over
+            # a slow (WiFi) link.
+            f"{env_cmd} && ros2 launch foxglove_bridge foxglove_bridge_launch.xml"
+            " send_buffer_limit:=2000000 max_qos_depth:=1",
             "C-m",
         ]
     )
@@ -2789,7 +2793,8 @@ def foxglove_cli(ctx):
       innate foxglove stop
     """
     if ctx.invoked_subcommand is None:
-        sys.exit(_foxglove_status())
+        click.echo(ctx.get_help())
+        ctx.exit(1)
 
 
 @foxglove_cli.command("start")

--- a/scripts/innate
+++ b/scripts/innate
@@ -651,7 +651,8 @@ SKILL_SOCKET_PATH = Path(os.environ.get("INNATE_SKILL_SOCKET", "/tmp/innate_skil
 TMUX_SESSION_HW = "ros_nodes"
 # Must match the session created by launch_sim_in_tmux.zsh (default "innate")
 # and tracked by the host sim launcher (sim/launcher TMUX_SESSION_NAME).
-TMUX_SESSION_SIM = "innate"
+# launch_sim_in_tmux.zsh honors INNATE_SIM_TMUX_SESSION, so follow it here.
+TMUX_SESSION_SIM = os.environ.get("INNATE_SIM_TMUX_SESSION", "").strip() or "innate"
 
 SYSTEMD_SERVICE_HW = "ros-app.service"
 

--- a/scripts/innate
+++ b/scripts/innate
@@ -868,6 +868,7 @@ def _show_status():
     print(f"  {C.BOLD}innate update{C.NC}       Check/apply updates")
     print(f"  {C.BOLD}innate diag{C.NC}         Check hardware")
     print(f"  {C.BOLD}innate volume{C.NC}       Get/set speaker volume")
+    print(f"  {C.BOLD}innate foxglove{C.NC}     Start/stop Foxglove bridge")
     print(f"  {C.BOLD}innate --help{C.NC}       All commands")
     print()
     return 0
@@ -966,6 +967,94 @@ def _service_view():
     except OSError as e:
         fail(f"Failed to attach to tmux: {e}")
         return 1
+
+
+FOXGLOVE_TMUX_SESSION = "foxglove"
+FOXGLOVE_PORT = 8765
+
+
+def _foxglove_sim_window_exists():
+    """Foxglove runs as a window of the sim session when auto-started."""
+    r = subprocess.run(
+        ["tmux", "list-windows", "-t", TMUX_SESSION_SIM, "-F", "#{window_name}"],
+        capture_output=True,
+        text=True,
+    )
+    return r.returncode == 0 and "foxglove" in r.stdout.split()
+
+
+def _foxglove_uri():
+    if is_sim_mode():
+        # Host side is published by sim/docker-compose.dev.yml (8766 when the
+        # local brain owns 8765 — the launcher prints the actual port).
+        return f"ws://localhost:{FOXGLOVE_PORT}"
+    try:
+        out = subprocess.run(["hostname", "-I"], capture_output=True, text=True, timeout=2).stdout.strip()
+        ip = out.split()[0] if out else None
+    except (OSError, subprocess.TimeoutExpired):
+        ip = None
+    return f"ws://{ip or '<robot-ip>'}:{FOXGLOVE_PORT}"
+
+
+def _foxglove_start():
+    if is_sim_mode() and _foxglove_sim_window_exists():
+        warn("Foxglove bridge already running (part of the sim stack)")
+        print(f"  Connect Foxglove to {C.BOLD}{_foxglove_uri()}{C.NC}")
+        return 0
+    if tmux_session_exists(FOXGLOVE_TMUX_SESSION):
+        warn(f"Foxglove bridge already running (tmux session '{FOXGLOVE_TMUX_SESSION}')")
+        print(f"  Connect Foxglove to {C.BOLD}{_foxglove_uri()}{C.NC}")
+        return 0
+
+    env_cmd = (
+        f"source {INNATE_OS_ROOT}/config/dds/setup_dds.zsh && "
+        f"source {ROS_WS}/install/setup.zsh"
+    )
+    r = run(["tmux", "new-session", "-d", "-s", FOXGLOVE_TMUX_SESSION, "-n", "foxglove"])
+    if r.returncode != 0:
+        fail("Failed to create tmux session for the Foxglove bridge")
+        return 1
+    run(
+        [
+            "tmux",
+            "send-keys",
+            "-t",
+            f"{FOXGLOVE_TMUX_SESSION}:foxglove",
+            f"{env_cmd} && ros2 launch foxglove_bridge foxglove_bridge_launch.xml",
+            "C-m",
+        ]
+    )
+    ok("Foxglove bridge starting")
+    print(f"  Connect Foxglove to {C.BOLD}{_foxglove_uri()}{C.NC}")
+    print(f"  Stop with {C.BOLD}innate foxglove stop{C.NC}")
+    return 0
+
+
+def _foxglove_stop():
+    if tmux_session_exists(FOXGLOVE_TMUX_SESSION):
+        run(["tmux", "kill-session", "-t", FOXGLOVE_TMUX_SESSION])
+        ok("Foxglove bridge stopped")
+        return 0
+    if is_sim_mode() and _foxglove_sim_window_exists():
+        run(["tmux", "kill-window", "-t", f"{TMUX_SESSION_SIM}:foxglove"])
+        ok("Foxglove bridge stopped (sim stack window)")
+        print(f"  It restarts with the sim; use {C.BOLD}innate foxglove start{C.NC} to bring it back now")
+        return 0
+    warn("Foxglove bridge is not running")
+    return 0
+
+
+def _foxglove_status():
+    if tmux_session_exists(FOXGLOVE_TMUX_SESSION):
+        ok(f"Foxglove bridge running (tmux session '{FOXGLOVE_TMUX_SESSION}')")
+    elif is_sim_mode() and _foxglove_sim_window_exists():
+        ok("Foxglove bridge running (part of the sim stack)")
+    else:
+        warn("Foxglove bridge is not running")
+        print(f"  Start with {C.BOLD}innate foxglove start{C.NC}")
+        return 1
+    print(f"  Connect Foxglove to {C.BOLD}{_foxglove_uri()}{C.NC}")
+    return 0
 
 
 def _build(packages, release=False):
@@ -2681,6 +2770,42 @@ def volume(level):
       innate volume 0        Mute
     """
     sys.exit(_volume(level))
+
+
+# -- foxglove -----------------------------------------------------------------
+
+
+@cli.group("foxglove", invoke_without_command=True)
+@click.pass_context
+def foxglove_cli(ctx):
+    """Foxglove bridge for topic/TF/image debugging (optional, off by default).
+
+    \b
+    In the sim it is part of the standard stack; on the robot start it on
+    demand:
+      innate foxglove start
+      innate foxglove stop
+    """
+    if ctx.invoked_subcommand is None:
+        sys.exit(_foxglove_status())
+
+
+@foxglove_cli.command("start")
+def foxglove_start():
+    """Start the Foxglove bridge (ws on port 8765)."""
+    sys.exit(_foxglove_start())
+
+
+@foxglove_cli.command("stop")
+def foxglove_stop():
+    """Stop the Foxglove bridge."""
+    sys.exit(_foxglove_stop())
+
+
+@foxglove_cli.command("status")
+def foxglove_status():
+    """Show whether the Foxglove bridge is running."""
+    sys.exit(_foxglove_status())
 
 
 # -- skill --------------------------------------------------------------------

--- a/scripts/innate
+++ b/scripts/innate
@@ -1006,10 +1006,7 @@ def _foxglove_start():
         print(f"  Connect Foxglove to {C.BOLD}{_foxglove_uri()}{C.NC}")
         return 0
 
-    env_cmd = (
-        f"source {INNATE_OS_ROOT}/config/dds/setup_dds.zsh && "
-        f"source {ROS_WS}/install/setup.zsh"
-    )
+    env_cmd = f"source {INNATE_OS_ROOT}/config/dds/setup_dds.zsh && source {ROS_WS}/install/setup.zsh"
     r = run(["tmux", "new-session", "-d", "-s", FOXGLOVE_TMUX_SESSION, "-n", "foxglove"])
     if r.returncode != 0:
         fail("Failed to create tmux session for the Foxglove bridge")

--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -172,7 +172,9 @@ echo "Started webapp (https :443 + http :80)..."
 # side published by sim/docker-compose.dev.yml; SIM_FOXGLOVE_PORT/BIND
 # override, and the launcher shifts it to 8766 when the local brain owns 8765).
 tmux new-window -t "$SESSION_NAME" -n foxglove
-tmux send-keys -t "${TMUX_TARGET_PREFIX}:foxglove" "ros2 launch foxglove_bridge foxglove_bridge_launch.xml" C-m
+# Low-latency defaults: shallow queue + small send buffer so the bridge drops
+# stale frames instead of queuing seconds of lag over a slow (WiFi) link.
+tmux send-keys -t "${TMUX_TARGET_PREFIX}:foxglove" "ros2 launch foxglove_bridge foxglove_bridge_launch.xml send_buffer_limit:=2000000 max_qos_depth:=1" C-m
 echo "Started Foxglove bridge (ws :${SIM_FOXGLOVE_PORT:-8765})..."
 
 # Select the rosbridge-app window

--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -167,6 +167,14 @@ tmux split-window -t "${TMUX_TARGET_PREFIX}:console-webapp" -h
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:console-webapp.1" "cd ~/innate-os/webapp && while true; do WEBAPP_SIM_CONTROLS=1 python3 proxy/https_server.py; sleep 2; done" C-m
 echo "Started webapp (https :443 + http :80)..."
 
+# === Window 8: Foxglove Bridge ===
+# Always on in the sim: connect Foxglove Studio to ws://localhost:8765 (host
+# side published by sim/docker-compose.dev.yml; SIM_FOXGLOVE_PORT/BIND
+# override, and the launcher shifts it to 8766 when the local brain owns 8765).
+tmux new-window -t "$SESSION_NAME" -n foxglove
+tmux send-keys -t "${TMUX_TARGET_PREFIX}:foxglove" "ros2 launch foxglove_bridge foxglove_bridge_launch.xml" C-m
+echo "Started Foxglove bridge (ws :8765)..."
+
 # Select the rosbridge-app window
 tmux select-window -t "${TMUX_TARGET_PREFIX}:rosbridge-app"
 

--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -173,7 +173,7 @@ echo "Started webapp (https :443 + http :80)..."
 # override, and the launcher shifts it to 8766 when the local brain owns 8765).
 tmux new-window -t "$SESSION_NAME" -n foxglove
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:foxglove" "ros2 launch foxglove_bridge foxglove_bridge_launch.xml" C-m
-echo "Started Foxglove bridge (ws :8765)..."
+echo "Started Foxglove bridge (ws :${SIM_FOXGLOVE_PORT:-8765})..."
 
 # Select the rosbridge-app window
 tmux select-window -t "${TMUX_TARGET_PREFIX}:rosbridge-app"

--- a/sim/README.md
+++ b/sim/README.md
@@ -202,9 +202,13 @@ More dev tooling (physics stress gate, asset pipeline) is documented in
 
 ### ROS access
 
-Prefer Foxglove or your own ROS tooling? Open a Rosbridge connection to
-`ws://localhost:9090` for TF, `/scan`, `/mars/main_camera/points`, camera
-topics and `/cmd_vel` teleop.
+A Foxglove bridge runs as part of the sim stack: connect Foxglove Studio to
+`ws://localhost:8765` for TF, `/scan`, `/mars/main_camera/points`, camera
+topics and `/cmd_vel` teleop. (With the local brain active the bridge is
+published on `ws://localhost:8766` instead — the cloud-agent owns 8765; the
+launcher prints the port. `SIM_FOXGLOVE_PORT`/`SIM_FOXGLOVE_BIND` override.)
+
+Rosbridge is also available for your own ROS tooling at `ws://localhost:9090`.
 
 ### Configuration
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -202,13 +202,32 @@ More dev tooling (physics stress gate, asset pipeline) is documented in
 
 ### ROS access
 
-A Foxglove bridge runs as part of the sim stack: connect Foxglove Studio to
-`ws://localhost:8765` for TF, `/scan`, `/mars/main_camera/points`, camera
-topics and `/cmd_vel` teleop. (With the local brain active the bridge is
-published on `ws://localhost:8766` instead — the cloud-agent owns 8765; the
-launcher prints the port. `SIM_FOXGLOVE_PORT`/`SIM_FOXGLOVE_BIND` override.)
+[Foxglove Studio](https://foxglove.dev) is a free app for visualizing what the
+robot sees — camera images, the map and laser scan, coordinate frames, and the
+`/cmd_vel` velocity commands from teleop. It's the easiest way to look inside the
+running sim.
 
-Rosbridge is also available for your own ROS tooling at `ws://localhost:9090`.
+You don't need to start anything: the sim launches a Foxglove bridge for you.
+To connect:
+
+1. Install and open [Foxglove Studio](https://foxglove.dev/download) (desktop or web).
+2. Choose **Open connection → Foxglove WebSocket**.
+3. Enter `ws://localhost:8765` and connect.
+4. Add panels (e.g. Image, 3D, Raw Messages) and pick the topics you want to see.
+
+> **Which port?** If you're running the local brain, the address is
+> `ws://localhost:8766` instead (the cloud agent uses 8765). The sim's startup
+> log always prints the exact address to use. To force a specific port or network
+> interface, set `SIM_FOXGLOVE_PORT` / `SIM_FOXGLOVE_BIND` before starting the sim.
+
+Because the sim runs on your own machine, every topic is fast — feel free to view
+the full-resolution cameras and point clouds. This is different from a **physical
+robot on Wi-Fi**, where those topics are too large to stream smoothly; there you'd
+use the lighter `/mars/main_camera/remote/*` topics instead. See
+[Foxglove](../README.md#foxglove) in the main README for that case.
+
+Prefer your own ROS tooling? A rosbridge server is also available at
+`ws://localhost:9090`.
 
 ### Configuration
 

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -68,6 +68,12 @@ services:
       # publish on a non-privileged port; the container always binds 443/80.
       - "${SIM_HTTPS_PORT:-443}:443"
       - "${SIM_HTTP_PORT:-80}:80"
+      # Foxglove bridge websocket (auto-started by launch_sim_in_tmux.zsh).
+      # Loopback by default, like rosbridge; SIM_FOXGLOVE_BIND=0.0.0.0 opens it
+      # to the LAN. The launcher publishes 8766 instead when the local brain is
+      # active (cloud-agent owns host 8765) — set SIM_FOXGLOVE_PORT yourself for
+      # raw `docker compose --profile local-brain` runs.
+      - "${SIM_FOXGLOVE_BIND:-127.0.0.1}:${SIM_FOXGLOVE_PORT:-8765}:8765"
 
     volumes:
       # 1) Mount your local code (paths are relative to this file's directory)

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -48,6 +48,10 @@ services:
       # rendering outside Docker, see mars_sim_driver/world_server.py);
       # required -- the sim world always runs outside the container.
       - VIRTUAL_MARS_REMOTE=${VIRTUAL_MARS_REMOTE:-}
+      # The Foxglove bridge's published host port, so in-container tooling
+      # (innate foxglove status) can print the address that actually works
+      # from the host. Must match the ports entry below.
+      - SIM_FOXGLOVE_PORT=${SIM_FOXGLOVE_PORT:-8765}
       # Brain ("agent") websocket the robot connects to. With
       # COMPOSE_PROFILES=local-brain the in-compose cloud-agent service starts and
       # the brain client is pointed at it over the shared x11 network. With no

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -519,6 +519,12 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         # argless and must inherit the same backend (compose's own default
         # only fires when COMPOSE_PROFILES is set, which it isn't here).
         compose_values["BRAIN_WEBSOCKET_URI"] = str(config.get("brain_websocket_uri", "") or "")
+        # Foxglove bridge publishes on host 8765 (Foxglove Studio's default) —
+        # but a local brain's cloud-agent owns that host port, so shift the
+        # bridge to 8766 unless the user pinned a port themselves.
+        if not os.environ.get("SIM_FOXGLOVE_PORT", "").strip() and config["mode"] not in (HOSTED_MODE, NONE_MODE):
+            compose_values["SIM_FOXGLOVE_PORT"] = "8766"
+            log("Local brain owns port 8765; Foxglove bridge published on ws://localhost:8766.")
         compose_env = os_compose_env(compose_values, env_file=os_env_file)
         log("Starting Innate OS dev container...")
         run_logged_with_heartbeat(

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -731,6 +731,24 @@ def cloud_agent_checkout_pinned(repo: Path, commit: str) -> bool:
     return True
 
 
+def _os_container_holds_host_8765() -> bool:
+    """True when a running innate-dev publishes its Foxglove port on host 8765
+    (a container created under hosted/no-brain mode, before a local-brain up
+    would have shifted the publish to 8766)."""
+    try:
+        result = subprocess.run(
+            ["docker", "port", "innate-dev", "8765"],
+            text=True,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+            timeout=DOCKER_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0 and any(line.strip().endswith(":8765") for line in result.stdout.splitlines())
+
+
 def start_cloud_agent(config: dict[str, object], cloud_env_file: Path) -> None:
     """Bring up the local brain as the `cloud-agent` service in the OS compose
     project (gated by the local-brain profile). Hosted/none modes run no local
@@ -752,6 +770,15 @@ def start_cloud_agent(config: dict[str, object], cloud_env_file: Path) -> None:
         "COMPOSE_PROFILES": LOCAL_BRAIN_COMPOSE_PROFILE,
         "INNATE_OS_ENV_FILE": str(cloud_env_file),
     }
+    # An OS container that predates this local-brain up may still publish the
+    # Foxglove bridge on host 8765 (this runs before ensure_os_container, and a
+    # running container is not recreated anyway). The cloud-agent host publish
+    # is debug-only — the brain reaches it over the compose network — so shift
+    # it clear rather than failing the bind (8767: 8766 is Foxglove's own
+    # local-brain port, live again as soon as the OS container is recreated).
+    if not os.environ.get("SIM_CLOUD_AGENT_PORT", "").strip() and _os_container_holds_host_8765():
+        base_env["SIM_CLOUD_AGENT_PORT"] = "8767"
+        log("Host port 8765 is held by the running OS container (Foxglove); publishing cloud-agent on 8767.")
     up_cmd = ["docker", "compose", "-f", "sim/docker-compose.dev.yml", "up", "-d"]
 
     if mode == LOCAL_IMAGE_MODE:


### PR DESCRIPTION
Implements [INN-712](https://linear.app/innate/issue/INN-712/foxglove-bridge-auto-start-in-sim-opt-in-innate-foxglove-cli-on-robot).

`ros-humble-foxglove-bridge` was already installed on both robot and sim (it's in `apt-dependencies.common.txt`) — this wires it up as a first-class debugging tool.

## Robot — optional, never auto-started

```
innate foxglove start    # bridge in its own tmux session, prints ws://<robot-ip>:8765
innate foxglove stop
innate foxglove status   # also the bare 'innate foxglove' default
```

Follows the `launch_arm_debug.zsh` pattern (tmux session + DDS/workspace sourcing), no systemd unit — it's a dev tool, not a service. Listed on the `innate` status screen.

## Sim — always on

- `launch_sim_in_tmux.zsh` gains a `foxglove` window
- `sim/docker-compose.dev.yml` publishes `${SIM_FOXGLOVE_BIND:-127.0.0.1}:${SIM_FOXGLOVE_PORT:-8765}:8765` — loopback by default, mirroring the rosbridge convention
- **Port conflict handled:** with the local brain active, `cloud-agent` owns host 8765, so the launcher publishes the bridge on **8766** and logs it (`SIM_FOXGLOVE_PORT` wins if set; raw `docker compose --profile local-brain` users need to set it — documented in the compose file)
- sim/README ROS-access section updated

The CLI is sim-aware: status/stop recognize the sim-stack window; start won't double-launch.

## Verification

Ran in the innate-dev container against a live sim: `foxglove status` (not running, exit 1) → `start` (bridge came up, advertised live channels — /amcl_pose, /battery_state, …) → websocket accepting connections on 8765 → `status` (running, exit 0) → `stop` → clean. `--help`/click wiring, zsh syntax, compose YAML, and `runtime.py` compile all checked.

## Rollout note

Port mappings are fixed at container creation, so an existing `innate-dev` container keeps running without the published 8765 until it's recreated (`./innate-sim down && ./innate-sim up`). Until then the bridge still runs in-container; only the host publish is missing. Startup order is safe in local-brain mode: `start_cloud_agent` binds host 8765 before `ensure_os_container` brings up the innate service on 8766.



> [!NOTE]
> Replaces #532 — the branch was renamed to follow the `type/short-description` convention, which closed the original. All review discussion and the resolved+replied Greptile threads live there.
