### PR TITLE
fix(cam): publish depth as 16UC1 (unsigned millimeters)

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
@@ -59,7 +59,7 @@ arm_camera_driver:
     # ── Topics ────────────────────────────────────────────────────────────
     left_topic: "/mars/main_camera/left/image_raw"
     right_topic: "/mars/main_camera/right/image_raw"
-    depth_topic: "/mars/main_camera/depth/image_rect_raw"     # 16SC1 mm
+    depth_topic: "/mars/main_camera/depth/image_rect_raw"     # 16UC1 mm
     disparity_topic: "/mars/main_camera/disparity"             # filtered DisparityImage
     disparity_unfiltered_topic: "/mars/main_camera/disparity_unfiltered"  # raw VPI output
     left_rectified_topic: "/mars/main_camera/left/image_rect"  # mono8 rectified

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/publishing.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/publishing.cpp
@@ -124,22 +124,23 @@ void StereoDepthEstimator::publishDisparityMsg(const cv::Mat& disparity_float, c
 }
 
 // =============================================================================
-// Convert disparity → 16SC1 depth (mm) and publish
+// Convert disparity → 16UC1 depth (mm) and publish (unsigned: depth in mm
+// is never negative, and unlike 16SC1 every standard viewer can decode it)
 // =============================================================================
 void StereoDepthEstimator::publishDepth(const cv::Mat& disparity_float, const rclcpp::Time& ts) {
     const float fb = static_cast<float>(focal_length_) * std::abs(static_cast<float>(baseline_));
     const float MAX_DEPTH_M = 10.0f;
 
-    cv::Mat depth_calib(calib_height_, calib_width_, CV_16SC1);
+    cv::Mat depth_calib(calib_height_, calib_width_, CV_16UC1);
     for (int y = 0; y < calib_height_; y++) {
         const float* disp_row = disparity_float.ptr<float>(y);
-        int16_t* depth_row = depth_calib.ptr<int16_t>(y);
+        uint16_t* depth_row = depth_calib.ptr<uint16_t>(y);
         for (int x = 0; x < calib_width_; x++) {
             const float d = disp_row[x];
             if (d > 0.0f) {
                 float z = fb / d;
                 if (z > 0.0f && z <= MAX_DEPTH_M) {
-                    depth_row[x] = static_cast<int16_t>(std::clamp(z * 1000.0f, -32768.0f, 32767.0f));
+                    depth_row[x] = static_cast<uint16_t>(std::clamp(z * 1000.0f, 0.0f, 65535.0f));
                 } else {
                     depth_row[x] = 0;
                 }
@@ -157,9 +158,9 @@ void StereoDepthEstimator::publishDepth(const cv::Mat& disparity_float, const rc
     msg->header.frame_id = frame_id_;
     msg->height = image_height_;
     msg->width = image_width_;
-    msg->encoding = "16SC1";
+    msg->encoding = "16UC1";
     msg->is_bigendian = false;
-    msg->step = image_width_ * sizeof(int16_t);
+    msg->step = image_width_ * sizeof(uint16_t);
     msg->data.resize(msg->height * msg->step);
     memcpy(msg->data.data(), depth_full.data, msg->data.size());
     depth_pub_->publish(std::move(msg));

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_depth_estimator.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_depth_estimator.cpp
@@ -622,7 +622,7 @@ int main(int argc, char** argv) {
 //         ▼                ▼                  ▼                ▼
 //  ┌──────────────┐  ┌───────────┐  ┌─────────────┐ ┌───────────────┐
 //  │.../disparity │  │.../depth  │  │.../points   │ │.../points_    │
-//  │(DisparityImg)│  │ (16SC1 mm)│  │(PointCloud2 │ │    color      │
+//  │(DisparityImg)│  │ (16UC1 mm)│  │(PointCloud2 │ │    color      │
 //  └──────────────┘  └───────────┘  │   XYZ)      │ │(PointCloud2   │
 //                                   └─────────────┘ │  XYZRGB)      │
 //                                                    └───────────────┘

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
@@ -8,7 +8,7 @@ run unchanged -- see README "Virtual MARS driver".
   pub /scan                                       sensor_msgs/LaserScan @6Hz, frame base_laser
   pub /mars/main_camera/left/image_raw/compressed sensor_msgs/CompressedImage @7.5Hz (lazy)
   pub /mars/arm/image_raw/compressed              sensor_msgs/CompressedImage @5Hz (lazy)
-  pub /mars/main_camera/depth/image_rect_raw      sensor_msgs/Image 16SC1 mm @8Hz (lazy)
+  pub /mars/main_camera/depth/image_rect_raw      sensor_msgs/Image 16UC1 mm @8Hz (lazy)
   pub /mars/main_camera/points                    sensor_msgs/PointCloud2 xyz @8Hz (lazy)
   pub /mars/main_camera/left/camera_info          sensor_msgs/CameraInfo @8Hz
   pub /mars/arm/state                             sensor_msgs/JointState (joint1..6, rad) @20Hz
@@ -517,17 +517,17 @@ class VirtualMarsNode(Node):
         img_scale = CAMERA_HEIGHT // depth.shape[0]
 
         if want_depth:
-            # 16SC1 mm, invalid=0 (publishing.cpp convention); nearest-neighbor
+            # 16UC1 mm, invalid=0 (publishing.cpp convention); nearest-neighbor
             # upscale only -- depth must not interpolate across edges.
             mm = np.where(invalid, 0, depth * 1000.0)
-            mm = np.clip(mm, 0, np.iinfo(np.int16).max).astype(np.int16)
+            mm = np.clip(mm, 0, np.iinfo(np.uint16).max).astype(np.uint16)
             if img_scale > 1:
                 mm = np.repeat(np.repeat(mm, img_scale, axis=0), img_scale, axis=1)
             msg = Image()
             msg.header.stamp = stamp
             msg.header.frame_id = "camera_optical_frame"
             msg.height, msg.width = mm.shape
-            msg.encoding = "16SC1"
+            msg.encoding = "16UC1"
             msg.is_bigendian = False
             msg.step = msg.width * 2
             msg.data = mm.tobytes()


### PR DESCRIPTION
Depth in millimeters is never negative, and the signed 16SC1 encoding is
nonstandard enough that stock viewers refuse it -- Foxglove's image panel
errors out on the sim's (and robot's) depth topic. 16UC1 is the ROS
convention for millimeter depth.

Changed on both sides of the digital twin so the wire contract stays
identical: the robot's disparity->depth publisher (mars_cam publishing.cpp)
and the sim driver (mars_sim_driver node.py), plus the comments/docstrings
that named the old encoding. The clamp ceiling rises from 32767 to 65535,
which is moot below the 10m MAX_DEPTH cutoff.

Not changed: filterSpeckles' internal CV_16SC1 buffer -- OpenCV's API
requires that exact type and it never reaches the wire.

Consumers audited: the webapp calibration indicator only checks message
arrival; the controller app's DepthCheckScreen already decodes both 16U and
16S; nav consumes the points topic; /mars/main_camera/remote/depth is a
passthrough throttle.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Validation
- Sim-side conversion exercised against a live render: uint16, sane mm range, invalid=0 preserved.
- Foxglove image panel on the sim depth topic is the acceptance test for the sim half; a robot-side depth check (controller app DepthCheckScreen) covers the hardware half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)