### PR TITLE
chore(sim): world-server polish -- warm depth renderer, log separators, quiet Ctrl+C

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -110,7 +110,11 @@ class WorldServer:
                 behind = target - self.sim.data.time
                 if behind > 0.5:
                     # Catching up a long stall would monopolize the lock; drop it.
-                    print(f"[world-server] dropping {behind:.1f}s of physics backlog after a stall", flush=True)
+                    print(
+                        f"[world-server] {time.strftime('%H:%M:%S')} "
+                        f"dropping {behind:.1f}s of physics backlog after a stall",
+                        flush=True,
+                    )
                     start_wall = time.perf_counter()
                     start_sim = self.sim.data.time
                 elif behind > 0:
@@ -336,6 +340,12 @@ def main() -> None:
         f"[world-server] GL self-test ({backend}): {steady_ms:.0f} ms/frame (first frame {first_ms:.0f} ms)",
         flush=True,
     )
+    # Warm the depth renderer too: its one-time GL context creation took ~1.4s
+    # INSIDE the physics lock when the first client requested depth mid-run
+    # (measured as a physics stall on a Pi). Here physics hasn't started and
+    # nobody is connected, so the cost is invisible -- and a broken depth
+    # path fails the boot instead of the first depth consumer.
+    server.sim.render_depth("main")
     release_freed_heap()  # model-compile + GL-context scratch, ~1GB on glibc
 
     binds = [b.strip() for b in args.bind.split(",") if b.strip()]
@@ -362,7 +372,10 @@ def main() -> None:
 
     for listener in listeners:
         threading.Thread(target=accept_loop, args=(listener,), daemon=True).start()
-    server.render_loop()  # main thread owns the GL context
+    try:
+        server.render_loop()  # main thread owns the GL context
+    except KeyboardInterrupt:
+        print("[world-server] interrupted -- shutting down", flush=True)
 
 
 if __name__ == "__main__":

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -97,6 +97,7 @@ LOG_TARGETS = {
     "viewer-build": VIEWER_BUILD_LOG_PATH,
     "world-server": WORLD_SERVER_LOG_PATH,
     "os-session": OS_SESSION_LOG_PATH,
+    "sim-driver": OS_SESSION_LOG_PATH,  # alias: the driver logs inside the ROS session
     "down": DOWN_LOG_PATH,
 }
 

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -1675,6 +1675,11 @@ def _start_world_server(uv: str, sim_repo: Path, *, bind: str, mujoco_gl: str | 
     if mujoco_gl:
         env["MUJOCO_GL"] = mujoco_gl
     with WORLD_SERVER_LOG_PATH.open("a", encoding="utf-8") as log_file:
+        # The log is append-mode across runs; without a dated separator, a
+        # previous run's errors read as current ones (cost two diagnostic
+        # round-trips during the Pi debugging).
+        log_file.write(f"\n----- world-server start {time.strftime('%Y-%m-%d %H:%M:%S')} -----\n")
+        log_file.flush()
         proc = subprocess.Popen(
             [uv, "run", "--project", str(sim_repo), "python", "-c", bootstrap, "--bind", bind] + _render_scale_args(),
             cwd=sim_repo.parent,


### PR DESCRIPTION
## Why

The #522 stall investigations (Raspberry Pi, then a loaded MacBook) left a short list of world-server irritations — one measured performance bug, two log-forensics papercuts, one shutdown wart. This PR closes all of them, and documents the two bigger refactors that were **measured and deliberately not built**.

## What it adds

**1. The depth renderer warms up at boot** — its one-time GL context creation (~1.4 s) used to run *inside the physics lock* whenever the first client requested depth mid-run, measured as a physics stall on the Pi. It now happens right after the RGB self-test, before the physics thread starts and before anyone connects, where the cost is invisible.

- Measured: first client depth request went from ~1.4 s+ to **183 ms** (just the render).
- Bonus: a broken depth path now fails the boot with a clear error instead of ambushing the first depth consumer at runtime.

**2. The world-server log becomes forensically usable.** It is append-mode across runs, and twice during the Pi debugging a *previous* run's errors were misread as current ones, costing a diagnostic round-trip each time. Now:

- every launcher start writes a dated separator (`----- world-server start 2026-07-14 15:46:55 -----`),
- every backlog-drop line carries a timestamp, so a wall of drops reads as a rate, not a mystery.

**3. `./innate-sim logs sim-driver` works** — an alias for the ROS session log, where the driver's output actually lands (reached for instinctively during debugging; it didn't exist).

**4. Ctrl+C on a manually-run world server** prints one shutdown line instead of a threading traceback.

## What it deliberately does NOT add

Two architectural refactors from the same investigation — moving the render-scene snapshot and the lidar ray-cast out of the physics lock — are **deferred with evidence**. A synthetic client drove a standalone world server at ~3× the real stack's demand (55 renders/s, 6 Hz × 360-ray lidar, 34 Hz state polls, 7 Hz cmd_vel):

| Load | Physics backlog drops / 2 min |
|---|---|
| driver-equivalent RPC load alone | **0** |
| same + a second full-res MuJoCo process | 1 |

The lock has no demonstrated victim on healthy hardware; the stalls observed on loaded machines trace to whole-machine oversubscription (and on Apple Silicon, unified-memory bandwidth shared with GPU clients — a live QoS/renice boost of the world server measurably changed nothing). If a Pi-class target ever becomes supported, the two-phase experiment script reruns in five minutes and will either convict the lock there or spare the refactor again.

## Validation

- Live boot + RPC round-trip: depth request 183 ms post-warm-up, correct shape/encoding.
- SIGINT exits with the clean line.
- `ruff` + repo pre-commit hooks pass; log separator verified in a real `up` cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
