### PR TITLE
ci: drop the vestigial manual- image tag

### DIFF
--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -50,13 +50,12 @@ jobs:
           # inputs-<hash> versions against retention.
           image_inputs_hash="$(python3 ci/compute_sim_image_inputs_hash.py)"
           short_sha="${GITHUB_SHA::12}"
+          # Every build is content/commit-addressed (sha-, inputs-); only
+          # main-branch builds may move the floating `main` alias.
+          image_tag="sha-${short_sha}"
           push_main_tags="false"
-
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            image_tag="sha-${short_sha}"
             push_main_tags="true"
-          else
-            image_tag="manual-${short_sha}"
           fi
 
           echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Stacked on #524 (base branch is `ci/multi-arch-sim-images`; GitHub will retarget to main when it merges).

Non-main builds currently push `manual-<sha>` **and** `sha-<sha>` pointing at the same manifest — the build script pushes the sha tag unconditionally, so `manual-` duplicates it exactly. The name predates every-branch publishing (non-main builds used to exist only via workflow_dispatch, hence "manual") and is now misleading: every branch push mints them.

This makes `image_tag` always `sha-<short_sha>`; `push_main_tags` remains the only main/non-main difference (only main builds move the floating `main` alias). One less tag per non-main publish; the manifest stitch already dedupes `IMAGE_TAG == sha-tag` (that's the main-branch path today), and retention classifies by the sha- tag, so neither downstream consumer changes.

The `_IMAGE_TAG: manual` default in `ci/cloudbuild.sim-images.yaml` (for hand-run `gcloud builds submit`) is a separate literal and intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)