### PR TITLE
ci: drop the vestigial manual- image tag

### DIFF
--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -50,13 +50,12 @@ jobs:
           # inputs-<hash> versions against retention.
           image_inputs_hash="$(python3 ci/compute_sim_image_inputs_hash.py)"
           short_sha="${GITHUB_SHA::12}"
+          # Every build is content/commit-addressed (sha-, inputs-); only
+          # main-branch builds may move the floating `main` alias.
+          image_tag="sha-${short_sha}"
           push_main_tags="false"
-
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            image_tag="sha-${short_sha}"
             push_main_tags="true"
-          else
-            image_tag="manual-${short_sha}"
           fi
 
           echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Re-lands #538, which was merged into `ci/multi-arch-sim-images` after #524 had already merged — so the change never reached main. Same commit, cherry-picked onto main.

Non-main builds push `manual-<sha>` **and** `sha-<sha>` pointing at the same manifest — the build script pushes the sha tag unconditionally, so `manual-` duplicates it exactly. The name predates every-branch publishing and is now misleading: every branch push mints them.

`image_tag` becomes `sha-<short_sha>` unconditionally; `push_main_tags` remains the only main/non-main difference (only main builds move the floating `main` alias). The manifest stitch already dedupes `IMAGE_TAG == sha-tag`, and retention classifies by the sha- tag, so no downstream changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)