### PR TITLE
fix(sim): make the prebuilt image tag reproducible (hash git-tracked files)

### DIFF
--- a/ci/compute_sim_image_inputs_hash.py
+++ b/ci/compute_sim_image_inputs_hash.py
@@ -14,6 +14,7 @@
 # why this lives in one file. sim/launcher/config.py computes the same hash
 # independently; keep them in sync.
 import hashlib
+import subprocess
 from pathlib import Path
 
 root = Path(".")
@@ -27,14 +28,24 @@ static_paths = (
     "ros2_ws/apt-dependencies.sim.txt",
 )
 paths = [Path(path) for path in static_paths if (root / path).is_file()]
-src_root = root / "ros2_ws" / "src"
-if src_root.exists():
-    for path in sorted(src_root.rglob("*")):
-        if not path.is_file():
-            continue
-        relative_path = path.relative_to(root)
-        if "__pycache__" in relative_path.parts or relative_path.suffix == ".pyc":
-            continue
+# Only git-tracked files, NOT a filesystem walk: rglob would also pull in
+# untracked/gitignored cruft (macOS .DS_Store, gitignored dirs, build
+# artifacts) that a dev's working tree has but this clean checkout does not,
+# making the hash non-reproducible between a dev machine and CI. Keep this in
+# sync with sim/launcher/config.py.
+tracked = subprocess.run(
+    ["git", "ls-files", "-z", "--", "ros2_ws/src"],
+    capture_output=True,
+    text=True,
+    check=True,
+).stdout.split("\0")
+for name in tracked:
+    if not name:
+        continue
+    relative_path = Path(name)
+    if "__pycache__" in relative_path.parts or relative_path.suffix == ".pyc":
+        continue
+    if (root / relative_path).is_file():
         paths.append(relative_path)
 
 digest = hashlib.sha256()

--- a/ci/compute_sim_image_inputs_hash.py
+++ b/ci/compute_sim_image_inputs_hash.py
@@ -35,6 +35,7 @@ paths = [Path(path) for path in static_paths if (root / path).is_file()]
 # sync with sim/launcher/config.py.
 tracked = subprocess.run(
     ["git", "ls-files", "-z", "--", "ros2_ws/src"],
+    cwd=root,
     capture_output=True,
     text=True,
     check=True,

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -360,6 +360,21 @@ def require_path(path: Path, label: str) -> Path:
     return path
 
 
+def git_tracked_files(repo_root: Path, pathspec: str) -> list[Path]:
+    """Repo-relative paths of the git-tracked files under pathspec. Errors
+    loudly rather than falling back to a filesystem walk: a silent fallback
+    would reintroduce the untracked-cruft non-reproducibility this exists to
+    avoid (see iter_sim_image_input_files)."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--", pathspec],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [Path(name) for name in result.stdout.split("\0") if name]
+
+
 def iter_sim_image_input_files(repo_root: Path) -> list[Path]:
     relative_paths: list[Path] = []
     for raw_path in SIM_IMAGE_INPUT_FILES:
@@ -367,14 +382,17 @@ def iter_sim_image_input_files(repo_root: Path) -> list[Path]:
         if (repo_root / relative_path).is_file():
             relative_paths.append(relative_path)
 
-    src_root = repo_root / "ros2_ws" / "src"
-    if src_root.exists():
-        for path in sorted(src_root.rglob("*")):
-            if not path.is_file():
-                continue
-            relative_path = path.relative_to(repo_root)
-            if "__pycache__" in relative_path.parts or relative_path.suffix == ".pyc":
-                continue
+    # Only git-tracked files, NOT a filesystem walk: rglob would also pull in
+    # untracked/gitignored cruft (macOS .DS_Store, gitignored dirs, build
+    # artifacts) that a dev's working tree has but CI's clean checkout does
+    # not -- making this content-addressed hash, and thus the prebuilt image
+    # tag, non-reproducible. CI publishes inputs-<hash> from a clean checkout,
+    # so the tracked set is exactly what it built from.
+    # ci/compute_sim_image_inputs_hash.py must enumerate the same set.
+    for relative_path in git_tracked_files(repo_root, "ros2_ws/src"):
+        if "__pycache__" in relative_path.parts or relative_path.suffix == ".pyc":
+            continue
+        if (repo_root / relative_path).is_file():
             relative_paths.append(relative_path)
 
     return sorted(relative_paths, key=lambda path: path.as_posix())


### PR DESCRIPTION
## Problem

`./innate-sim up` never finds a matching prebuilt Innate OS image on macOS and rebuilds locally every time, even for a commit CI *did* build and publish.

The launcher pulls a content-addressed tag `inputs-<hash>`, where the hash covers the sim build inputs. Both the launcher ([sim/launcher/config.py](../blob/main/sim/launcher/config.py)) and CI ([ci/compute_sim_image_inputs_hash.py](../blob/main/ci/compute_sim_image_inputs_hash.py)) enumerated `ros2_ws/src` with `rglob("*")` — a **filesystem walk**, so it also hashes untracked/gitignored files. On a Mac, the stray `.DS_Store` files under `ros2_ws/src` (and gitignored dirs like `live_agent/`) get hashed; CI's clean Linux checkout has none. Same commit → different hash → the launcher looks for a tag CI never published.

Concretely, for commit `4966356`:
- local hash (with `.DS_Store`): `d7acecfdd9b7…` → **not in registry**
- CI hash / tracked-only: `59cda85e7477…` → **published, exists**

## Fix

Enumerate **git-tracked** files under `ros2_ws/src` (`git ls-files`) instead of walking the filesystem, in both hash implementations (they must stay in sync). CI publishes `inputs-<hash>` from a clean checkout, so the tracked set is exactly what it built from — this makes the hash reproducible across machines.

Notes:
- **CI's hash is unchanged** (its checkout has no untracked files), so already-published images and `cleanup-sim-images.yml` pinning stay valid.
- Not `.dockerignore`-based: the ros image's dockerignore re-includes all of `ros2_ws/src/**`, so it would *still* hash `.DS_Store` and wouldn't fix this.
- The helper errors loudly if `git ls-files` fails rather than silently falling back to `rglob`, which would reintroduce the non-reproducibility.

## Verification

- Both implementations produce an identical hash on `main`'s tree.
- Planting `.DS_Store` files under `ros2_ws/src` no longer changes the hash.
- Tracked-only hashing reproduces CI's published `59cda85e7477` for `4966356` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)