### PR TITLE
fix(bringup): read the MCU's real 10-byte response frame (CRC at byte 9, gyroZ in twist)

### DIFF
--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/bringup.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/bringup.py
@@ -248,6 +248,11 @@ class Bringup(Node):
         odom.pose.pose.position.z = transform.transform.translation.z
         odom.pose.pose.orientation = transform.transform.rotation
 
+        # Yaw rate measured by the MCU's IMU (rad/s, base_link frame). Linear
+        # twist stays zero: the MCU reports no linear velocity, and deriving one
+        # from cm-quantised pose would be noise dressed up as measurement.
+        odom.twist.twist.angular.z = self.i2c_manager.gyro_z
+
         # Publish the odometry message
         self.odom_pub.publish(odom)
 

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
@@ -31,6 +31,9 @@ class I2CManager:
     RESP_STATUS = 0x83  # Health data
     RESP_CALIBRATE = 0x84  # Calibration status
 
+    # Seconds between "dropping frames" warnings while drops are ongoing.
+    DROP_REPORT_INTERVAL = 10.0
+
     def __init__(
         self,
         node: Node,
@@ -86,7 +89,8 @@ class I2CManager:
         self.motor_temperature = 0.0
         self.fault_code = 0
         self.calibration_status = None
-        self._unknown_resp_ids = set()
+        self._dropped_frames = 0
+        self._last_drop_report = 0.0
 
         # Communication thread control
         self.running = True
@@ -181,9 +185,19 @@ class I2CManager:
             # unrecognised id means the buffer was misaligned or corrupt, so the
             # payload behind it cannot be trusted either.
             if resp_id not in (self.RESP_MOVE, self.RESP_STATUS, self.RESP_CALIBRATE):
-                if resp_id not in self._unknown_resp_ids:
-                    self._unknown_resp_ids.add(resp_id)
-                    self.logger.warning(f"Ignoring unknown I2C response id 0x{resp_id:02X}")
+                self._dropped_frames += 1
+                now = time.time()
+                # Report the first drop at once, then at most every DROP_REPORT_INTERVAL
+                # while they keep coming. A persistent fault (0xFF NACK reads at 30Hz,
+                # say) has to stay visible: warning once per id and then falling silent
+                # is how the CRC gate hid this bug in the first place.
+                if now - self._last_drop_report >= self.DROP_REPORT_INTERVAL:
+                    self.logger.warning(
+                        f"Ignoring unknown I2C response id 0x{resp_id:02X} "
+                        f"({self._dropped_frames} frame(s) dropped since last report)"
+                    )
+                    self._dropped_frames = 0
+                    self._last_drop_report = now
                 return None
 
             self._process_response(resp_id, response_data)

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
@@ -43,11 +43,20 @@ class I2CManager:
         # this long without a command means the operator/controller is gone
         # and the base must stop, not coast on the last latched velocity.
         speed_command_timeout=0.5,
+        # The MCU firmware does not compute a CRC over its responses: it leaves
+        # the trailing byte at 0x00 (or 0xFF) on every frame, for every response
+        # id, regardless of payload. Verifying it therefore rejects ~100% of
+        # frames -- and the ~1/256 that slip through are the ones whose payload
+        # CRC happens to equal 0x00, i.e. a random dropout, not an integrity
+        # check. Leave this off until the firmware actually emits a CRC; the
+        # command direction (Jetson -> MCU) still sends one.
+        verify_response_crc=False,
     ):
         self.node = node
         self.debug = debug
         self.logger = self.node.get_logger()
         self.update_frequency = update_frequency
+        self.verify_response_crc = verify_response_crc
         self.speed_command_timeout = speed_command_timeout
         self.bus_number = bus_number
         self.device_address = device_address
@@ -77,6 +86,7 @@ class I2CManager:
         self.motor_temperature = 0.0
         self.fault_code = 0
         self.calibration_status = None
+        self._unknown_resp_ids = set()
 
         # Communication thread control
         self.running = True
@@ -138,8 +148,10 @@ class I2CManager:
         Format: [resp_id] + [6 data bytes] + [crc]
         """
         try:
-            # Small delay to allow MCU to prepare response
-            time.sleep(0.001)  # 1ms delay
+            # Delay to allow the MCU to fill its response buffer. At 1ms ~18% of
+            # reads come back empty (id byte 0x00); at 5ms that is 0%, measured
+            # over 60-frame sweeps. Cheap against the 33ms loop budget.
+            time.sleep(0.005)
 
             # Read 8 bytes from MCU
             data = self.bus.read_i2c_block_data(self.device_address, 0x00, 8)
@@ -153,18 +165,26 @@ class I2CManager:
                     self.logger.debug("Received empty response from MCU")
                 return None
 
-            # Verify CRC
-            message = data[:7]
-            received_crc = data[7]
-            calculated_crc = self._calculate_crc(message)
-
-            if received_crc != calculated_crc:
-                if self.debug:
-                    self.logger.debug(f"CRC mismatch: expected 0x{calculated_crc:02X}, got 0x{received_crc:02X}")
-                return None
-
             resp_id = data[0]
             response_data = data[1:7]
+
+            # Only validate the response CRC if the firmware actually emits one.
+            # See verify_response_crc in __init__ for why this is off by default.
+            if self.verify_response_crc:
+                calculated_crc = self._calculate_crc(data[:7])
+                if data[7] != calculated_crc:
+                    if self.debug:
+                        self.logger.debug(f"CRC mismatch: expected 0x{calculated_crc:02X}, got 0x{data[7]:02X}")
+                    return None
+
+            # Structural validation, standing in for the missing CRC: an
+            # unrecognised id means the buffer was misaligned or corrupt, so the
+            # payload behind it cannot be trusted either.
+            if resp_id not in (self.RESP_MOVE, self.RESP_STATUS, self.RESP_CALIBRATE):
+                if resp_id not in self._unknown_resp_ids:
+                    self._unknown_resp_ids.add(resp_id)
+                    self.logger.warning(f"Ignoring unknown I2C response id 0x{resp_id:02X}")
+                return None
 
             self._process_response(resp_id, response_data)
             return True

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
@@ -247,8 +247,6 @@ class I2CManager:
                 self.logger.info(f"Calibration Status: {status_str} ({status})")
             except Exception as e:
                 self.logger.error(f"Failed to unpack calibration response: {e}")
-        else:
-            self.logger.warning(f"Unknown Response ID: {resp_id}")
 
     def _send_move_command(self):
         """Send movement command with timeout handling"""

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
@@ -26,10 +26,27 @@ class I2CManager:
     CMD_STATUS = 0x03
     CMD_CALIBRATE = 0x04
 
-    # Response definitions (MCU → Jetson)
+    # Response definitions (MCU → Jetson). The firmware also defines
+    # RESP_RESET (0x85), but only ever sends it in reply to a reset command,
+    # which this node never issues.
     RESP_MOVE = 0x81  # Position feedback
     RESP_STATUS = 0x83  # Health data
     RESP_CALIBRATE = 0x84  # Calibration status
+
+    # Two response frame layouts exist in flashed mars-firmware builds:
+    #
+    #   8-byte  (main branch):        [id, payload(6), crc]
+    #   10-byte (feat/useRealRPM):    [id, payload(6), gyroZ(2), crc]
+    #
+    # Both put the CRC-8/MAXIM over everything before it, and bytes 0-6 are
+    # laid out identically (RESP_MOVE carries x, y in cm and theta in rad*100
+    # at the same offsets). The 10-byte layout appends the IMU's body-frame
+    # yaw rate (rad/s * 100, big-endian int16) on RESP_MOVE; on other ids
+    # those two bytes are reserved zeros. We read the larger size and accept
+    # whichever layout's CRC verifies -- reading 10 bytes from an 8-byte
+    # firmware just clocks two junk bytes past the real frame, which the
+    # 8-byte CRC check never looks at.
+    READ_LENGTH = 10
 
     # Seconds between "dropping frames" warnings while drops are ongoing.
     DROP_REPORT_INTERVAL = 10.0
@@ -46,20 +63,11 @@ class I2CManager:
         # this long without a command means the operator/controller is gone
         # and the base must stop, not coast on the last latched velocity.
         speed_command_timeout=0.5,
-        # The MCU firmware does not compute a CRC over its responses: it leaves
-        # the trailing byte at 0x00 (or 0xFF) on every frame, for every response
-        # id, regardless of payload. Verifying it therefore rejects ~100% of
-        # frames -- and the ~1/256 that slip through are the ones whose payload
-        # CRC happens to equal 0x00, i.e. a random dropout, not an integrity
-        # check. Leave this off until the firmware actually emits a CRC; the
-        # command direction (Jetson -> MCU) still sends one.
-        verify_response_crc=False,
     ):
         self.node = node
         self.debug = debug
         self.logger = self.node.get_logger()
         self.update_frequency = update_frequency
-        self.verify_response_crc = verify_response_crc
         self.speed_command_timeout = speed_command_timeout
         self.bus_number = bus_number
         self.device_address = device_address
@@ -85,6 +93,9 @@ class I2CManager:
         # -------------------------
         # Initialize zero transform for odom->base_link using a dedicated method.
         self.current_transform = self._initialize_transform()
+        # Body-frame yaw rate from the MCU's IMU (rad/s). Only the 10-byte
+        # firmware reports it; stays 0.0 on the 8-byte protocol.
+        self.gyro_z = 0.0
         self.battery_voltage = 0.0
         self.motor_temperature = 0.0
         self.fault_code = 0
@@ -146,10 +157,27 @@ class I2CManager:
                 self.logger.debug(f"Failed to send command 0x{cmd_id:02X}: {e}")
             return False
 
+    def _report_dropped_frame(self, reason):
+        """Rate-limited warning for discarded response frames.
+
+        Reports the first drop at once, then at most every DROP_REPORT_INTERVAL
+        while they keep coming. A persistent fault (0xFF NACK reads at 30Hz,
+        say) has to stay visible: warning once and then falling silent is how
+        the original odometry bug went unnoticed.
+        """
+        self._dropped_frames += 1
+        now = time.time()
+        if now - self._last_drop_report >= self.DROP_REPORT_INTERVAL:
+            self.logger.warning(
+                f"Dropping I2C response frames ({reason}); {self._dropped_frames} dropped since last report"
+            )
+            self._dropped_frames = 0
+            self._last_drop_report = now
+
     def _read_response(self):
         """
-        Read 8-byte response from MCU via I2C
-        Format: [resp_id] + [6 data bytes] + [crc]
+        Read one response frame from the MCU via I2C.
+        See READ_LENGTH for the two frame layouts in circulation.
         """
         try:
             # Delay to allow the MCU to fill its response buffer. At 1ms ~18% of
@@ -157,10 +185,9 @@ class I2CManager:
             # over 60-frame sweeps. Cheap against the 33ms loop budget.
             time.sleep(0.005)
 
-            # Read 8 bytes from MCU
-            data = self.bus.read_i2c_block_data(self.device_address, 0x00, 8)
+            data = self.bus.read_i2c_block_data(self.device_address, 0x00, self.READ_LENGTH)
 
-            if len(data) != 8:
+            if len(data) != self.READ_LENGTH:
                 return None
 
             # Check if response is empty (all zeros or first byte is 0)
@@ -170,37 +197,28 @@ class I2CManager:
                 return None
 
             resp_id = data[0]
-            response_data = data[1:7]
 
-            # Only validate the response CRC if the firmware actually emits one.
-            # See verify_response_crc in __init__ for why this is off by default.
-            if self.verify_response_crc:
-                calculated_crc = self._calculate_crc(data[:7])
-                if data[7] != calculated_crc:
-                    if self.debug:
-                        self.logger.debug(f"CRC mismatch: expected 0x{calculated_crc:02X}, got 0x{data[7]:02X}")
-                    return None
-
-            # Structural validation, standing in for the missing CRC: an
-            # unrecognised id means the buffer was misaligned or corrupt, so the
-            # payload behind it cannot be trusted either.
+            # Cheap structural check before the CRC math: an unrecognised id
+            # (0xFF idle/NACK reads, say) can't be a frame worth checksumming.
             if resp_id not in (self.RESP_MOVE, self.RESP_STATUS, self.RESP_CALIBRATE):
-                self._dropped_frames += 1
-                now = time.time()
-                # Report the first drop at once, then at most every DROP_REPORT_INTERVAL
-                # while they keep coming. A persistent fault (0xFF NACK reads at 30Hz,
-                # say) has to stay visible: warning once per id and then falling silent
-                # is how the CRC gate hid this bug in the first place.
-                if now - self._last_drop_report >= self.DROP_REPORT_INTERVAL:
-                    self.logger.warning(
-                        f"Ignoring unknown I2C response id 0x{resp_id:02X} "
-                        f"({self._dropped_frames} frame(s) dropped since last report)"
-                    )
-                    self._dropped_frames = 0
-                    self._last_drop_report = now
+                self._report_dropped_frame(f"unknown id 0x{resp_id:02X}")
                 return None
 
-            self._process_response(resp_id, response_data)
+            # Accept whichever frame layout's CRC verifies. Check the 8-byte
+            # layout first: on 8-byte firmware it always verifies (the trailing
+            # junk bytes are never read), while a 10-byte frame only passes it
+            # by 1/256 accident -- and then still decodes to the same pose,
+            # since bytes 0-6 agree between layouts.
+            extra = None
+            if data[7] == self._calculate_crc(data[:7]):
+                pass  # 8-byte frame; no gyro field
+            elif data[9] == self._calculate_crc(data[:9]):
+                extra = data[7:9]  # 10-byte frame; gyroZ on RESP_MOVE
+            else:
+                self._report_dropped_frame(f"CRC mismatch on id 0x{resp_id:02X}")
+                return None
+
+            self._process_response(resp_id, data[1:7], extra)
             return True
 
         except Exception as e:
@@ -208,7 +226,7 @@ class I2CManager:
                 self.logger.debug(f"Failed to read response: {e}")
             return None
 
-    def _process_response(self, resp_id, data):
+    def _process_response(self, resp_id, data, extra=None):
         """Process received response from MCU"""
         if self.debug:
             self.logger.debug(f"Received response 0x{resp_id:02X}: {[hex(b) for b in data]}")
@@ -234,6 +252,9 @@ class I2CManager:
             self.current_transform.transform.rotation.y = 0.0
             self.current_transform.transform.rotation.z = math.sin(theta_rad / 2.0)
             self.current_transform.transform.rotation.w = math.cos(theta_rad / 2.0)
+            if extra is not None:
+                # 10-byte firmware: IMU body-frame yaw rate, rad/s * 100
+                self.gyro_z = struct.unpack(">h", bytes(extra))[0] / 100.0
             if self.debug:
                 self.logger.debug(f"Position Update - X: {x / 100.0}, Y: {y / 100.0}, θ: {theta_rad} rad")
         elif resp_id == self.RESP_STATUS:


### PR DESCRIPTION
## The bug

`/odom` republished a **cached pose**: position/yaw refreshed only every few seconds, jumping 0.4–8.7 m per update, with bit-identical samples in between. In a 215 s drive recording, removing the 15 discrete jumps left exactly 0.0 m of motion across 6,434 samples. `/battery_state` sat at 0.0 V, and calibration acknowledgements were silently lost, for the same underlying reason.

## Root cause — a protocol version mismatch, not a missing CRC

> **Revision note:** an earlier version of this PR concluded "the firmware never sends a response CRC" and disabled the check. That diagnosis was wrong — the firmware sends a CRC, just not where this side was looking. The observations below are unchanged; their interpretation is corrected.

`I2CManager` reads **8** bytes per response and verifies a CRC-8/MAXIM at **byte 7**. That matches `mars-firmware` `main`. But builds from the **`feat/useRealRPM`** lineage — which is what the wire data shows flashed on `mars-the-27th` — send **10-byte** frames:

```
main             [id, payload(6), crc]              8 bytes, CRC over 0–6 at byte 7
feat/useRealRPM  [id, payload(6), gyroZ(2), crc]   10 bytes, CRC over 0–8 at byte 9
```

On the 10-byte layout, byte 7 — the byte we were checking as a CRC — is **gyroZ's high byte** on MOVE frames and a reserved `0x00` on STATUS/CALIBRATE. Every anomaly observed on hardware follows from that:

- Trailing byte pinned at `0x00` while payloads varied (gyro at rest / reserved field) — and **`0xFF` under slight negative rotation** (int16 sign extension).
- **0/300 frames accepted**: byte 7 is payload, so it equals the computed CRC only by ~1/256 accident — hence one accepted frame every 8–14 s, the observed staircase.
- Brute-forcing CRC variants over bytes 0–7 matched nothing, because no CRC lives in those 8 bytes. It lives at byte 9, which the 8-byte read never clocked in.
- The status frame `0x83, 0x04, 0xD0, …` → 12.32 V decodes identically in both layouts: bytes 0–6 are laid out the same, which is also why pose decoded correctly from truncated frames.

The command direction (Jetson → MCU) is 8 bytes with CRC at byte 7 in **all** firmware branches, which is why commands always worked.

## The fix

- **Read 10 bytes and accept whichever layout's CRC verifies** — byte 7 (8-byte `main` firmware) or byte 9 (10-byte). Bytes 0–6 agree between layouts, so pose/battery/calibration decode unchanged. Reading 10 bytes from an 8-byte firmware just clocks two junk bytes the 8-byte check never looks at. Frames failing both checks are dropped. **This restores real integrity checking on the response path**; the earlier revision's `verify_response_crc=False` escape hatch is gone.
- **Decode gyroZ into `/odom` `twist.angular.z`** (rad/s, base_link frame). The 10-byte layout's extra field is the IMU's measured body-frame yaw rate — the earlier claim that "the MCU reports no velocity" was wrong. Linear twist stays zero: that, the MCU genuinely does not measure.
- **Structural id validation** before the CRC math rejects all-`0xFF` idle/NACK reads cheaply.
- **Rate-limited drop reporting** (first drop warns immediately, then every 10 s with a count): a persistent fault must stay visible in logs — warning once and falling silent is how this bug survived. (Addresses the review finding on suppressed warnings.)
- **Read delay 1 ms → 5 ms.** At 1 ms ~18% of reads came back empty; at 5 ms, 0%. Cheap against the 33 ms loop budget.

## Verification

**On hardware (earlier revision, CRC check disabled):** position acceptance went 0/150 → 150/150 loops at 30.0 Hz; pose gaps ~14 s → 58 ms mean / 114 ms worst at 0.12 m/s; per-update steps ≤1.4 cm; 0 spurious changes stationary; battery 0.0 V → 12.3 V. Commanded 1.2 rad yaw + 0.20 m forward measured 1.15 rad / 0.187 m, projecting to (0.077, 0.171) vs measured (0.05, 0.18) — physically coherent.

**This revision (protocol-aware CRC):** verified against reconstructed frames of both firmware layouts driven through the real `_read_response`/`_process_response`: 10-byte MOVE/STATUS accept with correct pose, battery, and gyro decode; 8-byte frames accept with gyro untouched; `0xFF` idle reads, bit-flipped payloads, no-CRC frames, and empty responses all drop with a rate-limited warning.

**⚠️ Needs hardware re-verification before merge.** The 8-byte read window meant byte 9 was never observed on a real robot — the flashed build is inferred from bytes 0–7 matching `feat/useRealRPM` exactly. If the flashed build's CRC differs, frames now drop *loudly* (periodic warnings with counts) instead of silently, and the failure is diagnosable from logs. Re-run: `/odom` at 30 Hz while driving, battery non-zero, no "Dropping I2C response frames" warnings.

## Follow-ups (not in this PR)

- **Firmware version telemetry.** Robots are flashed from unmerged `mars-firmware` branches (≥3 incompatible wire formats exist: `main` 8 B, `feat/useRealRPM` 10 B, `kar/experiments` 24 B) with no way to ask a robot what it runs. The STATUS payload has a reserved byte that `_process_response` already unpacks and discards — a version number there would make this auditable, and this class of bug detectable in one log line.
- **`scripts/diagnostics.py` PCB check only validates the response id byte**, so it passes on every protocol variant — it green-lit robots whose frames bringup then rejected wholesale. It should verify the CRC per this PR's dual-layout logic.
- **Pose covariance is never set** (all zeros). Left alone rather than inventing numbers, since AMCL and `mode_manager` subscribe to `/odom` and plausible-looking covariance could destabilise them more than honest zeros.
- Downstream `/odom` consumers (`mode_manager`, `grid_localizer`, `odom_to_tf_node`) were checked and contain no staircase-workaround filtering; nothing needs cleanup there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
