### PR TITLE
Vig/playing with nuked acceleration

### DIFF
--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/bringup.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/bringup.py
@@ -248,6 +248,12 @@ class Bringup(Node):
         odom.pose.pose.position.z = transform.transform.translation.z
         odom.pose.pose.orientation = transform.transform.rotation
 
+        # Report the commanded speed as measured twist. The MCU returns position only, and its
+        # cm / rad*100 quantization makes differencing it at odom rate unusable (~0.3 m/s per LSB).
+        speed, turn = self.i2c_manager.get_effective_speed()
+        odom.twist.twist.linear.x = speed
+        odom.twist.twist.angular.z = -turn  # undo the hardware sign inversion applied on the command path
+
         # Publish the odometry message
         self.odom_pub.publish(odom)
 

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/i2c.py
@@ -230,14 +230,18 @@ class I2CManager:
         else:
             self.logger.warning(f"Unknown Response ID: {resp_id}")
 
+    def get_effective_speed(self):
+        """Return the (forward, turn) speed actually being sent to the MCU.
+
+        Zero once the command timeout has lapsed, matching what _send_move_command sends.
+        """
+        if time.time() - self.last_speed_command_time > self.speed_command_timeout:
+            return (0.0, 0.0)
+        return self.latest_speed
+
     def _send_move_command(self):
         """Send movement command with timeout handling"""
-        current_time = time.time()
-        if current_time - self.last_speed_command_time > self.speed_command_timeout:
-            # Timeout exceeded, send zero speed
-            speed, turn = 0.0, 0.0
-        else:
-            speed, turn = self.latest_speed
+        speed, turn = self.get_effective_speed()
 
         # Scale and clamp values
         speed_int = int(max(-32767, min(32767, speed * 100)))

--- a/ros2_ws/src/mars_bot/mars_nav/config/velocity_smoother.yaml
+++ b/ros2_ws/src/mars_bot/mars_nav/config/velocity_smoother.yaml
@@ -10,8 +10,8 @@ velocity_smoother:
     max_velocity: [0.45, 0.0, 0.6]   # Based on controller max_vel_x, max_vel_y, max_vel_theta
     min_velocity: [-0.2, 0.0, -0.6]  # Based on controller min_vel_x, min_vel_y, symmetric min_vel_theta
     
-    max_accel: [0.3, 0.0, 0.5]
-    max_decel: [-0.3, 0.0, -0.5]
+    max_accel: [0.1, 0.0, 0.5]
+    max_decel: [-0.5, 0.0, -0.5]
 
     deadband_velocity: [0.01, 0.0, 0.02] # Deadband for x, y, theta based on previous 'min_velocity_deadband'
 


### PR DESCRIPTION
## Summary

-

## Validation

- [ ] I ran the relevant local validation, or explained why it was skipped.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`.
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`.
