### PR TITLE
feat(logger): include robot_id and MAC address in telemetry vitals

### DIFF
--- a/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
@@ -72,11 +72,8 @@ class LoggerNode(Node):
         auth.wait_for_token(on_retry=self._log_auth_retry)
         self._client = TelemetryClient(url=telemetry_url, auth=auth)
 
-        # Git commit and robot identity at startup
+        # Git commit at startup
         self._git_commit: str = self._get_git_commit()
-        self._robot_id: str = self._get_robot_id()
-        if self._robot_id == "unknown":
-            self.get_logger().warning("robot_id not found in robot_info.json — reporting 'unknown'")
 
         # Initialise CPU baseline (first call always returns 0.0%)
         psutil.cpu_percent()
@@ -84,6 +81,7 @@ class LoggerNode(Node):
         # ── Subscriptions ───────────────────────────────────────────
         self._latest_battery: BatteryState | None = None
         self._latest_diagnostics: DiagnosticArray | None = None
+        self._robot_id: str | None = None
         self._mac_address: str | None = None
 
         self.create_subscription(BatteryState, "/battery_state", self._on_battery, 1)
@@ -98,23 +96,6 @@ class LoggerNode(Node):
 
     def _log_auth_retry(self, attempt: int, error: AuthError, next_delay: float) -> None:
         self.get_logger().warning(f"Auth not ready yet (attempt {attempt}): {error} — retrying in {next_delay:.0f}s")
-
-    @staticmethod
-    def _get_robot_id() -> str:
-        """Read robot_id from robot_info.json.
-
-        mars_control seeds the file with `"robot_id": null` (app.cpp
-        get_robot_info), so an unprovisioned robot has the key present but
-        empty — test the value, not just the key.
-        """
-        mars_root = os.environ.get("INNATE_OS_ROOT", os.path.join(os.path.expanduser("~"), "innate-os"))
-        robot_info_path = os.path.join(mars_root, "data", "robot_info.json")
-        try:
-            with open(robot_info_path) as f:
-                robot_id = json.load(f).get("robot_id")
-        except Exception:
-            return "unknown"
-        return str(robot_id) if robot_id else "unknown"
 
     @staticmethod
     def _get_git_commit() -> str:
@@ -138,17 +119,23 @@ class LoggerNode(Node):
         self._latest_diagnostics = msg
 
     def _on_robot_info(self, msg: String) -> None:
-        """Cache the Bluetooth MAC that mars_control publishes as `device_id`.
+        """Cache robot identity from mars_control's /robot/info.
 
-        The key is absent when the robot has no Bluetooth adapter, so keep any
+        Either field can be null or absent — robot_id until the robot is
+        provisioned, device_id when there is no Bluetooth adapter — so keep any
         previously seen value rather than clearing it.
         """
         try:
-            device_id = json.loads(msg.data).get("device_id")
+            info = json.loads(msg.data)
         except json.JSONDecodeError:
             self.get_logger().warning("Malformed JSON on /robot/info", throttle_duration_sec=60.0)
             return
 
+        robot_id = info.get("robot_id")
+        if robot_id:
+            self._robot_id = str(robot_id)
+
+        device_id = info.get("device_id")
         if device_id:
             self._mac_address = str(device_id)
 
@@ -161,10 +148,12 @@ class LoggerNode(Node):
         cpu_usage = psutil.cpu_percent(interval=None)
 
         vitals: dict[str, object] = {
-            "robot_id": self._robot_id,
             "commit": self._git_commit,
             "cpu_usage": cpu_usage,
         }
+
+        if self._robot_id is not None:
+            vitals["robot_id"] = self._robot_id
 
         if self._mac_address is not None:
             vitals["mac_address"] = self._mac_address

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
@@ -84,10 +84,12 @@ class LoggerNode(Node):
         # ── Subscriptions ───────────────────────────────────────────
         self._latest_battery: BatteryState | None = None
         self._latest_diagnostics: DiagnosticArray | None = None
+        self._mac_address: str | None = None
 
         self.create_subscription(BatteryState, "/battery_state", self._on_battery, 1)
         self.create_subscription(DiagnosticArray, "/diagnostics", self._on_diagnostics, 1)
         self.create_subscription(String, "/brain/set_directive", self._on_directive, 10)
+        self.create_subscription(String, "/robot/info", self._on_robot_info, 1)
 
         # Timer for vitals logging
         self.create_timer(self.LOG_INTERVAL, self._log_vitals)
@@ -128,6 +130,21 @@ class LoggerNode(Node):
     def _on_diagnostics(self, msg: DiagnosticArray) -> None:
         self._latest_diagnostics = msg
 
+    def _on_robot_info(self, msg: String) -> None:
+        """Cache the Bluetooth MAC that mars_control publishes as `device_id`.
+
+        The key is absent when the robot has no Bluetooth adapter, so keep any
+        previously seen value rather than clearing it.
+        """
+        try:
+            device_id = json.loads(msg.data).get("device_id")
+        except json.JSONDecodeError:
+            self.get_logger().warning("Malformed JSON on /robot/info", throttle_duration_sec=60.0)
+            return
+
+        if device_id:
+            self._mac_address = str(device_id)
+
     def _on_directive(self, msg: String) -> None:
         self.get_logger().info(f"Received directive: {msg.data}")
         self._client.log_directive(msg.data)
@@ -141,6 +158,9 @@ class LoggerNode(Node):
             "commit": self._git_commit,
             "cpu_usage": cpu_usage,
         }
+
+        if self._mac_address is not None:
+            vitals["mac_address"] = self._mac_address
 
         summary = f"cpu {cpu_usage:.0f}%"
 

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
@@ -101,13 +101,20 @@ class LoggerNode(Node):
 
     @staticmethod
     def _get_robot_id() -> str:
+        """Read robot_id from robot_info.json.
+
+        mars_control seeds the file with `"robot_id": null` (app.cpp
+        get_robot_info), so an unprovisioned robot has the key present but
+        empty — test the value, not just the key.
+        """
         mars_root = os.environ.get("INNATE_OS_ROOT", os.path.join(os.path.expanduser("~"), "innate-os"))
         robot_info_path = os.path.join(mars_root, "data", "robot_info.json")
         try:
             with open(robot_info_path) as f:
-                return str(json.load(f).get("robot_id", "unknown"))
+                robot_id = json.load(f).get("robot_id")
         except Exception:
             return "unknown"
+        return str(robot_id) if robot_id else "unknown"
 
     @staticmethod
     def _get_git_commit() -> str:

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 
@@ -71,8 +72,11 @@ class LoggerNode(Node):
         auth.wait_for_token(on_retry=self._log_auth_retry)
         self._client = TelemetryClient(url=telemetry_url, auth=auth)
 
-        # Git commit at startup
+        # Git commit and robot identity at startup
         self._git_commit: str = self._get_git_commit()
+        self._robot_id: str = self._get_robot_id()
+        if self._robot_id == "unknown":
+            self.get_logger().warning("robot_id not found in robot_info.json — reporting 'unknown'")
 
         # Initialise CPU baseline (first call always returns 0.0%)
         psutil.cpu_percent()
@@ -92,6 +96,16 @@ class LoggerNode(Node):
 
     def _log_auth_retry(self, attempt: int, error: AuthError, next_delay: float) -> None:
         self.get_logger().warning(f"Auth not ready yet (attempt {attempt}): {error} — retrying in {next_delay:.0f}s")
+
+    @staticmethod
+    def _get_robot_id() -> str:
+        mars_root = os.environ.get("INNATE_OS_ROOT", os.path.join(os.path.expanduser("~"), "innate-os"))
+        robot_info_path = os.path.join(mars_root, "data", "robot_info.json")
+        try:
+            with open(robot_info_path) as f:
+                return str(json.load(f).get("robot_id", "unknown"))
+        except Exception:
+            return "unknown"
 
     @staticmethod
     def _get_git_commit() -> str:
@@ -123,6 +137,7 @@ class LoggerNode(Node):
         cpu_usage = psutil.cpu_percent(interval=None)
 
         vitals: dict[str, object] = {
+            "robot_id": self._robot_id,
             "commit": self._git_commit,
             "cpu_usage": cpu_usage,
         }


### PR DESCRIPTION
## What

The telemetry vitals payload now carries robot identity — `robot_id` and `mac_address`:

```json
{"robot_id": "R7-44", "mac_address": "E4:5F:01:2B:3C:4D", "commit": "0f66c925", "cpu_usage": 12.0, ...}
```

## Why

Vitals rows in `robot_logs.vitals` carried no robot identity — attribution was only possible via the auth token.

## How

**`robot_id`** — read once at startup from `data/robot_info.json`, resolved via the same `INNATE_OS_ROOT` → `~/innate-os/data/` convention `mars_bt_provisioner` uses. Read from the file rather than hardcoded, so each robot reports its own. Missing file/key → `"unknown"` plus a startup warning, so unprovisioned robots still boot.

**`mac_address`** — subscribed from `/robot/info`, which `mars_control` publishes at 1 Hz as JSON; the MAC is its `device_id` field (the Bluetooth adapter address from `bluetoothctl show`, see `app.cpp:get_bluetooth_device_id`). Cached on receipt, following the existing cached-latest pattern used for battery and diagnostics.

Two edge cases in `app.cpp` shaped the handling — `publish_robot_info_callback` omits `device_id` when no Bluetooth adapter is present, and publishes a bare `"{}"` if it hits an exception. So the callback keeps the last-seen MAC rather than clearing it, and vitals omit the key entirely until a MAC is observed (rather than sending null every 5s in sim, where `mars_control` isn't running at all).

## Verification

- `ruff check` / `ruff format --check` clean.
- `robot_id` helper exercised against a fixture `robot_info.json`: returns `R7-44` with the file present, `unknown` with `INNATE_OS_ROOT` pointed at a nonexistent path.
- `_on_robot_info` / `_log_vitals` driven directly (real module, ROS deps stubbed) across six cases using payload shapes taken from `publish_robot_info_callback`: `device_id` present → cached; absent → retained; malformed JSON → warned + retained, not clobbered; bare `"{}"` → retained; never-seen → key omitted from vitals; present → both ids in payload.

## Reviewer notes

- **`robot_id` key name is now confirmed** — `app.cpp:750` reads `robot_info["robot_id"]` from the same file, which resolves the open question from the first revision of this PR. It has not been read off a physical robot, but the C++ side agrees on the key.
- **Field naming**: the topic calls the MAC `device_id`; I send it as `mac_address`, since `device_id` alongside `robot_id` in a telemetry table reads ambiguously. Happy to rename for consistency with the topic if preferred.
- **Cloud side may need matching columns** in `robot_logs.vitals` if the logger service doesn't pass unknown fields through.