### PR TITLE
chore: migrate service hosts to *.svc.innate.bot domains

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -14,9 +14,9 @@
 # GEMINI_API_KEY=
 
 # --- Cloud endpoints (all read from the environment; set by default) ---
-# BRAIN_WEBSOCKET_URI=wss://agent-v1.innate.bot
-# TELEMETRY_URL=https://logs-v1.innate.bot
-# UNINAVID_WS_URL=wss://nav-v1.innate.bot
-# INNATE_PROXY_URL=https://proxy-v1.innate.bot
-# INNATE_AUTH_URL=https://auth-v1.innate.bot
-# INNATE_TRAINING_URL=https://training-v1.innate.bot
+# BRAIN_WEBSOCKET_URI=wss://agent-v1.svc.innate.bot
+# TELEMETRY_URL=https://logs.svc.innate.bot
+# UNINAVID_WS_URL=wss://uninavid-v1.svc.innate.bot
+# INNATE_PROXY_URL=https://proxy-v1.svc.innate.bot
+# INNATE_AUTH_URL=https://auth-v1.svc.innate.bot
+# INNATE_TRAINING_URL=https://training-v1.svc.innate.bot

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/ws_config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/ws_config.py
@@ -9,7 +9,11 @@ isolation.
 
 from __future__ import annotations
 
-_HOSTED_PREFIXES = ("wss://agent-v1.innate.bot", "wss://brain.innate.bot")
+_HOSTED_PREFIXES = (
+    "wss://agent-v1.svc.innate.bot",
+    "wss://agent-v1.innate.bot",
+    "wss://brain.innate.bot",
+)
 
 
 def validate_ws_uri(uri: str) -> bool:

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/ws_config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/ws_config.py
@@ -9,11 +9,7 @@ isolation.
 
 from __future__ import annotations
 
-_HOSTED_PREFIXES = (
-    "wss://agent-v1.svc.innate.bot",
-    "wss://agent-v1.innate.bot",
-    "wss://brain.innate.bot",
-)
+_HOSTED_PREFIXES = ("wss://agent-v1.svc.innate.bot",)
 
 
 def validate_ws_uri(uri: str) -> bool:

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/ws_config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/ws_config.py
@@ -9,7 +9,11 @@ isolation.
 
 from __future__ import annotations
 
-_HOSTED_PREFIXES = ("wss://agent-v1.svc.innate.bot",)
+_HOSTED_PREFIXES = (
+    "wss://agent-v1.svc.innate.bot",
+    "wss://agent-v1.innate.bot",
+    "wss://brain.innate.bot",
+)
 
 
 def validate_ws_uri(uri: str) -> bool:

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
@@ -19,7 +19,7 @@ def generate_launch_description():
     # Declare new launch arguments
     websocket_uri_arg = DeclareLaunchArgument(
         "websocket_uri",
-        default_value=get_env("BRAIN_WEBSOCKET_URI", "wss://agent-v1.innate.bot"),
+        default_value=get_env("BRAIN_WEBSOCKET_URI", "wss://agent-v1.svc.innate.bot"),
         description="Websocket URI",
     )
     token_arg = DeclareLaunchArgument(

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
@@ -24,7 +24,7 @@ def generate_launch_description():
         # bare `innate restart` (no --brain-websocket-uri arg) lands an empty URI.
         # Treat empty as unset and fall back to the hosted default, matching the
         # launcher's own resolve_brain_websocket_uri.
-        default_value=get_env("BRAIN_WEBSOCKET_URI", "").strip() or "wss://agent-v1.innate.bot",
+        default_value=get_env("BRAIN_WEBSOCKET_URI", "").strip() or "wss://agent-v1.svc.innate.bot",
         description="Websocket URI",
     )
     token_arg = DeclareLaunchArgument(

--- a/ros2_ws/src/cloud/.env.template
+++ b/ros2_ws/src/cloud/.env.template
@@ -14,6 +14,6 @@ TRAINING_SERVER_URL=http://localhost:8082
 INNATE_PROXY_URL=http://localhost:8083
 #
 # Production (defaults if unset):
-# INNATE_AUTH_URL=https://auth-v1.innate.bot
-# TRAINING_SERVER_URL=https://training-v1.innate.bot
-# UNINAVID_WS_URL=wss://nav-v1.innate.bot
+# INNATE_AUTH_URL=https://auth-v1.svc.innate.bot
+# TRAINING_SERVER_URL=https://training-v1.svc.innate.bot
+# UNINAVID_WS_URL=wss://uninavid-v1.svc.innate.bot

--- a/ros2_ws/src/cloud/clients/auth-client/README.md
+++ b/ros2_ws/src/cloud/clients/auth-client/README.md
@@ -14,7 +14,7 @@ pip install -e clients/auth-client
 from auth_client import AuthProvider
 
 auth = AuthProvider(
-    issuer_url="https://auth-v1.innate.bot",
+    issuer_url="https://auth-v1.svc.innate.bot",
     service_key="sk_...",
 )
 print(auth.token)       # lazily discovers OIDC + fetches JWT
@@ -24,7 +24,7 @@ print(auth.expires_at)  # when the JWT expires
 ## CLI
 
 ```bash
-export INNATE_AUTH_URL="https://auth-v1.innate.bot"
+export INNATE_AUTH_URL="https://auth-v1.svc.innate.bot"
 export INNATE_SERVICE_KEY="sk_..."
 
 # If pip-installed:

--- a/ros2_ws/src/cloud/clients/auth-client/auth_client/__init__.py
+++ b/ros2_ws/src/cloud/clients/auth-client/auth_client/__init__.py
@@ -7,7 +7,7 @@ Usage::
     from auth_client import AuthProvider, AuthError
 
     auth = AuthProvider(
-        issuer_url="https://auth-v1.innate.bot",
+        issuer_url="https://auth-v1.svc.innate.bot",
         service_key="sk_...",
     )
     token = auth.token          # lazily discovers OIDC + fetches JWT

--- a/ros2_ws/src/cloud/clients/auth-client/auth_client/__main__.py
+++ b/ros2_ws/src/cloud/clients/auth-client/auth_client/__main__.py
@@ -26,7 +26,7 @@ def _fetch_and_print(auth: AuthProvider) -> None:
 
 
 def main() -> None:
-    issuer_url = os.environ.get("INNATE_AUTH_URL", "https://auth-v1.innate.bot")
+    issuer_url = os.environ.get("INNATE_AUTH_URL", "https://auth-v1.svc.innate.bot")
     service_key = os.environ.get("INNATE_SERVICE_KEY", "")
     watch = len(sys.argv) > 1 and sys.argv[1] == "watch"
 

--- a/ros2_ws/src/cloud/clients/auth-client/auth_client/cli.py
+++ b/ros2_ws/src/cloud/clients/auth-client/auth_client/cli.py
@@ -11,7 +11,7 @@ from auth_client.provider import AuthError, AuthProvider
 
 
 def main() -> None:
-    issuer_url = os.environ.get("INNATE_AUTH_URL", "https://auth-v1.innate.bot")
+    issuer_url = os.environ.get("INNATE_AUTH_URL", "https://auth-v1.svc.innate.bot")
     service_key = os.environ.get("INNATE_SERVICE_KEY", "")
 
     if not service_key:

--- a/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
+++ b/ros2_ws/src/cloud/clients/auth-client/auth_client/provider.py
@@ -9,7 +9,7 @@ Usage::
 
     from auth_client import AuthProvider
 
-    auth = AuthProvider(issuer_url="https://auth-v1.innate.bot", service_key="sk_...")
+    auth = AuthProvider(issuer_url="https://auth-v1.svc.innate.bot", service_key="sk_...")
     token = auth.token              # lazily discovers + fetches on first access
     print(auth.expires_at)          # datetime of JWT expiration
 

--- a/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/client.py
+++ b/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/client.py
@@ -49,7 +49,7 @@ class ProxyClient:
         auth_issuer_url: str | None = None,
         config: dict[str, Any] | None = None,
     ) -> None:
-        raw_url = (proxy_url or os.getenv("INNATE_PROXY_URL", "https://proxy-v1.innate.bot")).rstrip("/")
+        raw_url = (proxy_url or os.getenv("INNATE_PROXY_URL", "https://proxy-v1.svc.innate.bot")).rstrip("/")
         if raw_url and not raw_url.startswith(("http://", "https://")):
             raw_url = f"https://{raw_url}"
         self.proxy_url: str = raw_url
@@ -57,7 +57,7 @@ class ProxyClient:
         self._service_key: str = innate_service_key or os.getenv("INNATE_SERVICE_KEY", "")
         self.config: dict[str, Any] = config or {}
 
-        issuer_url = auth_issuer_url or os.getenv("INNATE_AUTH_URL", "https://auth-v1.innate.bot")
+        issuer_url = auth_issuer_url or os.getenv("INNATE_AUTH_URL", "https://auth-v1.svc.innate.bot")
         if issuer_url and self._service_key:
             self._auth: AuthProvider | None = AuthProvider(
                 issuer_url=issuer_url,

--- a/ros2_ws/src/cloud/clients/training-client/README.md
+++ b/ros2_ws/src/cloud/clients/training-client/README.md
@@ -35,7 +35,7 @@ python -m training_client.cli download ./skill <RUN_ID>
 By default the client authenticates via **OIDC** (OpenID Connect).  The
 `--token` / `INNATE_SERVICE_KEY` value is treated as a **service key** and
 exchanged for a short-lived JWT through the issuer at
-`https://auth-v1.innate.bot` (the default `--issuer`).
+`https://auth-v1.svc.innate.bot` (the default `--issuer`).
 
 - **OIDC discovery** is lazy — the `/.well-known/openid-configuration`
   endpoint is only called on the first request, not at startup.
@@ -197,7 +197,7 @@ Lifecycle node for ROS 2 Humble. ROS is **not** required by the core library —
 | Topic | `~/status` | `std_msgs/msg/String` | JSON run state + daemon_state on each poll |
 | Parameter | `server_url` | `string` | Orchestrator URL |
 | Parameter | `auth_token` | `string` | Service key (exchanged for JWT via OIDC) |
-| Parameter | `auth_issuer_url` | `string` | OIDC issuer (default `https://auth-v1.innate.bot`, `""` = plain bearer) |
+| Parameter | `auth_issuer_url` | `string` | OIDC issuer (default `https://auth-v1.svc.innate.bot`, `""` = plain bearer) |
 | Parameter | `poll_interval` | `double` | Status poll interval in seconds (default 20.0) |
 | Parameter | `source_dir` | `string` | Default source directory for submissions |
 | Parameter | `skill_name` | `string` | Optional skill name (default: directory name) |

--- a/ros2_ws/src/cloud/clients/training-client/training_client/src/types.py
+++ b/ros2_ws/src/cloud/clients/training-client/training_client/src/types.py
@@ -10,8 +10,8 @@ from typing import Any
 
 # ── Configuration ───────────────────────────────────────────────────
 
-DEFAULT_SERVER_URL = "https://training-v1.innate.bot"
-DEFAULT_AUTH_ISSUER_URL = "https://auth-v1.innate.bot"
+DEFAULT_SERVER_URL = "https://training-v1.svc.innate.bot"
+DEFAULT_AUTH_ISSUER_URL = "https://auth-v1.svc.innate.bot"
 
 
 @dataclass

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
@@ -20,8 +20,8 @@ from std_msgs.msg import String
 
 from innate_logger.client import TelemetryClient
 
-DEFAULT_TELEMETRY_URL = "https://logs-v1.innate.bot"
-DEFAULT_AUTH_ISSUER_URL = "https://auth-v1.innate.bot"
+DEFAULT_TELEMETRY_URL = "https://logs.svc.innate.bot"
+DEFAULT_AUTH_ISSUER_URL = "https://auth-v1.svc.innate.bot"
 
 
 class LoggerNode(Node):

--- a/ros2_ws/src/cloud/innate_uninavid/PROTOCOL.md
+++ b/ros2_ws/src/cloud/innate_uninavid/PROTOCOL.md
@@ -31,9 +31,9 @@ config file at `config/params.yaml` or overridden on the command line.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `ws_url` | string | env `UNINAVID_WS_URL` or `wss://nav-v1.innate.bot` | WebSocket server URL |
+| `ws_url` | string | env `UNINAVID_WS_URL` or `wss://uninavid-v1.svc.innate.bot` | WebSocket server URL |
 | `service_key` | string | env `INNATE_SERVICE_KEY` | Service key for auth token acquisition |
-| `auth_issuer_url` | string | env `INNATE_AUTH_URL` or `https://auth-v1.innate.bot` | Auth token issuer |
+| `auth_issuer_url` | string | env `INNATE_AUTH_URL` or `https://auth-v1.svc.innate.bot` | Auth token issuer |
 | `forward_speed` | float | 0.3 | Linear speed (m/s) for the FORWARD action |
 | `turn_speed` | float | 0.8 | Angular speed (rad/s) for the LEFT / RIGHT actions |
 | `cmd_duration_sec` | float | 0.1 | How long each action command is published |

--- a/ros2_ws/src/cloud/innate_uninavid/config/params.yaml
+++ b/ros2_ws/src/cloud/innate_uninavid/config/params.yaml
@@ -3,9 +3,9 @@ uninavid_node:
     # ── Connection ────────────────────────────────────────────────────────
     # ws_url, service_key, and auth_issuer_url default from env vars;
     # override here if needed.
-    # ws_url: "wss://nav-v1.innate.bot"
+    # ws_url: "wss://uninavid-v1.svc.innate.bot"
     # service_key: ""
-    # auth_issuer_url: "https://auth-v1.innate.bot"
+    # auth_issuer_url: "https://auth-v1.svc.innate.bot"
 
     # ── Motion ───────────────────────────────────────────────────────────
     forward_speed: 0.3

--- a/ros2_ws/src/cloud/innate_uninavid/innate_uninavid/node.py
+++ b/ros2_ws/src/cloud/innate_uninavid/innate_uninavid/node.py
@@ -40,8 +40,8 @@ from std_msgs.msg import Int32MultiArray, String
 
 from .ws_client import Action, ClientState, UninavidWsClient
 
-DEFAULT_WS_URL = "wss://nav-v1.innate.bot"
-DEFAULT_AUTH_ISSUER_URL = "https://auth-v1.innate.bot"
+DEFAULT_WS_URL = "wss://uninavid-v1.svc.innate.bot"
+DEFAULT_AUTH_ISSUER_URL = "https://auth-v1.svc.innate.bot"
 RUNTIME_BACKEND_CONFIG_TOPIC = "/brain/backend_config"
 
 # Default drive speeds for UniNavid's discrete actions (overridable via uninavid_node params).

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -188,9 +188,9 @@ if [ -f "$ENV_FILE" ]; then
         log "  Backed up .env to $ACTUAL_HOME/.env.backup"
 
         # Replace deprecated URLs with their new equivalents in-place
-        sed -i 's|^INNATE_PROXY_URL=https://robot-services\.innate\.bot.*|INNATE_PROXY_URL=https://proxy-v1.innate.bot|' "$ENV_FILE"
-        sed -i 's|^BRAIN_WEBSOCKET_URI=wss://brain\.innate\.bot.*|BRAIN_WEBSOCKET_URI=wss://agent-v1.innate.bot|' "$ENV_FILE"
-        sed -i 's|^TELEMETRY_URL=https://logs\.innate\.bot.*|TELEMETRY_URL=https://logs-v1.innate.bot|' "$ENV_FILE"
+        sed -i 's|^INNATE_PROXY_URL=https://robot-services\.innate\.bot.*|INNATE_PROXY_URL=https://proxy-v1.svc.innate.bot|' "$ENV_FILE"
+        sed -i 's|^BRAIN_WEBSOCKET_URI=wss://brain\.innate\.bot.*|BRAIN_WEBSOCKET_URI=wss://agent-v1.svc.innate.bot|' "$ENV_FILE"
+        sed -i 's|^TELEMETRY_URL=https://logs\.innate\.bot.*|TELEMETRY_URL=https://logs.svc.innate.bot|' "$ENV_FILE"
 
         # Add reference comment at the bottom of .env
         if ! grep -q 'Refer to .env.template for examples' "$ENV_FILE"; then
@@ -200,9 +200,9 @@ if [ -f "$ENV_FILE" ]; then
 
         chown "$ACTUAL_USER:$ACTUAL_USER" "$ENV_FILE"
         log "  Deprecated URLs replaced with new endpoints in .env"
-        log "    robot-services.innate.bot → proxy-v1.innate.bot"
-        log "    brain.innate.bot          → agent-v1.innate.bot"
-        log "    logs.innate.bot           → logs-v1.innate.bot"
+        log "    robot-services.innate.bot → proxy-v1.svc.innate.bot"
+        log "    brain.innate.bot          → agent-v1.svc.innate.bot"
+        log "    logs.innate.bot           → logs.svc.innate.bot"
     fi
 fi
 

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -173,9 +173,9 @@ if [ -f "$ENV_FILE" ]; then
     NEEDS_ENV_MIGRATION=false
 
     # Check for old/deprecated URL values
-    if grep -q '^INNATE_PROXY_URL=https://robot-services\.innate\.bot' "$ENV_FILE" || \
-       grep -q '^BRAIN_WEBSOCKET_URI=wss://brain\.innate\.bot' "$ENV_FILE" || \
-       grep -q '^TELEMETRY_URL=https://logs\.innate\.bot' "$ENV_FILE"; then
+    if grep -qE '^INNATE_PROXY_URL=https://(robot-services|proxy-v1)\.innate\.bot' "$ENV_FILE" || \
+       grep -qE '^BRAIN_WEBSOCKET_URI=wss://(brain|agent-v1)\.innate\.bot' "$ENV_FILE" || \
+       grep -qE '^TELEMETRY_URL=https://(logs|logs-v1)\.innate\.bot' "$ENV_FILE"; then
         NEEDS_ENV_MIGRATION=true
     fi
 
@@ -187,10 +187,14 @@ if [ -f "$ENV_FILE" ]; then
         chown "$ACTUAL_USER:$ACTUAL_USER" "$ACTUAL_HOME/.env.backup"
         log "  Backed up .env to $ACTUAL_HOME/.env.backup"
 
-        # Replace deprecated URLs with their new equivalents in-place
+        # Replace deprecated URLs with their new equivalents in-place.
+        # Both the oldest hosts and the -v1 generation migrate to the svc domains.
         sed -i 's|^INNATE_PROXY_URL=https://robot-services\.innate\.bot.*|INNATE_PROXY_URL=https://proxy-v1.svc.innate.bot|' "$ENV_FILE"
         sed -i 's|^BRAIN_WEBSOCKET_URI=wss://brain\.innate\.bot.*|BRAIN_WEBSOCKET_URI=wss://agent-v1.svc.innate.bot|' "$ENV_FILE"
         sed -i 's|^TELEMETRY_URL=https://logs\.innate\.bot.*|TELEMETRY_URL=https://logs.svc.innate.bot|' "$ENV_FILE"
+        sed -i 's|^INNATE_PROXY_URL=https://proxy-v1\.innate\.bot.*|INNATE_PROXY_URL=https://proxy-v1.svc.innate.bot|' "$ENV_FILE"
+        sed -i 's|^BRAIN_WEBSOCKET_URI=wss://agent-v1\.innate\.bot.*|BRAIN_WEBSOCKET_URI=wss://agent-v1.svc.innate.bot|' "$ENV_FILE"
+        sed -i 's|^TELEMETRY_URL=https://logs-v1\.innate\.bot.*|TELEMETRY_URL=https://logs.svc.innate.bot|' "$ENV_FILE"
 
         # Add reference comment at the bottom of .env
         if ! grep -q 'Refer to .env.template for examples' "$ENV_FILE"; then
@@ -200,9 +204,9 @@ if [ -f "$ENV_FILE" ]; then
 
         chown "$ACTUAL_USER:$ACTUAL_USER" "$ENV_FILE"
         log "  Deprecated URLs replaced with new endpoints in .env"
-        log "    robot-services.innate.bot → proxy-v1.svc.innate.bot"
-        log "    brain.innate.bot          → agent-v1.svc.innate.bot"
-        log "    logs.innate.bot           → logs.svc.innate.bot"
+        log "    robot-services / proxy-v1 → proxy-v1.svc.innate.bot"
+        log "    brain / agent-v1          → agent-v1.svc.innate.bot"
+        log "    logs / logs-v1            → logs.svc.innate.bot"
     fi
 fi
 

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -54,7 +54,7 @@ AUTO_MODE = "auto"
 NONE_MODE = "none"
 LOCAL_MODES = {LOCAL_IMAGE_MODE, LOCAL_SOURCE_MODE}
 VALID_CLOUD_AGENT_MODES = {AUTO_MODE, HOSTED_MODE, LOCAL_IMAGE_MODE, LOCAL_SOURCE_MODE, NONE_MODE}
-DEFAULT_HOSTED_BRAIN_WEBSOCKET_URI = "wss://agent-v1.innate.bot"
+DEFAULT_HOSTED_BRAIN_WEBSOCKET_URI = "wss://agent-v1.svc.innate.bot"
 # The local cloud-agent runs as the `local-brain` service inside the same compose
 # project as the OS container, reachable by service name on the shared network.
 DEFAULT_LOCAL_BRAIN_WEBSOCKET_URI = "ws://cloud-agent:8765"


### PR DESCRIPTION
## Summary

- Migrate the Innate cloud service hosts to their new svc-qualified domains across defaults, `.env` templates, clients, and docs:

  | Legacy host | New svc host |
  | --- | --- |
  | `agent-v1.innate.bot` | `agent-v1.svc.innate.bot` |
  | `auth-v1.innate.bot` | `auth-v1.svc.innate.bot` |
  | `link.innate.bot` | `link.svc.innate.bot` |
  | `logs-v1.innate.bot` | `logs.svc.innate.bot` |
  | `nav-v1.innate.bot` | `uninavid-v1.svc.innate.bot` |
  | `proxy-v1.innate.bot` | `proxy-v1.svc.innate.bot` |
  | `training-v1.innate.bot` | `training-v1.svc.innate.bot` |

- Note two hosts don't just gain a `.svc` label: `logs-v1` → `logs` (drops `-v1`) and `nav-v1` → `uninavid-v1` (renamed).
- `link.innate.bot` had no references in this repo, so nothing changed for it.
- `@innate.bot` maintainer emails in `package.xml` files were left untouched.

### Notes for reviewers
- `ws_config.py`: added `wss://agent-v1.svc.innate.bot` to `_HOSTED_PREFIXES` while **keeping** the legacy `agent-v1`/`brain` prefixes, so robots with existing configs are still detected as hosted and continue to require a service key.
- `scripts/update/post_update.sh`: the `.env` migration now rewrites **both** deprecated host generations to the svc domains:
  - oldest (`robot-services` / `brain` / `logs`) → svc
  - `-v1` (`proxy-v1` / `agent-v1` / `logs-v1`) → svc

  The `-v1` case is the important one — that's the generation most installs are currently on. Migration is idempotent: files already on `*.svc.innate.bot` neither trigger the migration nor get rewritten (verified with a table of before/after cases). Scope is unchanged — the block still only touches `INNATE_PROXY_URL`, `BRAIN_WEBSOCKET_URI`, and `TELEMETRY_URL`.

## Validation

- [x] Grep-verified no `*-v1.innate.bot` legacy hosts remain except the intentional backward-compat prefixes in `ws_config.py`.
- [x] Exercised the `post_update.sh` migration logic against both deprecated generations and already-migrated inputs; both generations rewrite to svc and svc inputs are left unchanged.
- [ ] Did not change simulator behavior, config, or assets.
- [ ] Did not change simulator asset files or references.

https://claude.ai/code/session_01PZ6i6isNQA7EMtPvhrAs5k