### PR TITLE
refactor(skills): shared skill_lib for arm primitives + camera geometry

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import threading
 import time
 import types
@@ -269,8 +270,17 @@ class SkillRepository:
         return f"{prefix}/{basename}"
 
     # --- reload ---
+    @staticmethod
+    def _evict_skill_lib() -> None:
+        """Drop cached workspace.skill_lib modules so a skills reload picks up
+        lib edits too — skill files re-import the lib as they load. Without
+        this, sys.modules keeps serving the pre-edit lib to reloaded skills."""
+        for name in [m for m in sys.modules if m.startswith("workspace.skill_lib")]:
+            del sys.modules[name]
+
     def reload_all(self) -> None:
         self._logger.info("Reloading skills...")
+        self._evict_skill_lib()
         self._skills_directories = self._resolve_skills_directories()
         new_code_skills = self._load_code_skills(self._skills_directories)
         new_physical, new_in_training = self._load_physical_skills(self._skills_directories)
@@ -291,6 +301,7 @@ class SkillRepository:
                 return list(self._code_skills.keys()) + list(self._physical_skills.keys())
 
         self._logger.info(f"Selectively reloading skills: {skill_ids}")
+        self._evict_skill_lib()
         reloaded = []
         for skill_id in skill_ids:
             basename = skill_id.split("/", 1)[-1] if "/" in skill_id else skill_id

--- a/workspace/innate_skills/gripper_close.py
+++ b/workspace/innate_skills/gripper_close.py
@@ -11,23 +11,20 @@ Callable from any skill's code as a plain function:
     gripper_close(strength=0.2) # close harder (firmer grip)
 
 (also from the agent, the webapp skills menu, and
-`scripts/innate skill run local/gripper_close`).
+`scripts/innate skill run gripper_close`).
 
-Enables arm torque first so the claw still moves after an overload left the
-servo torque-disabled.
+The implementation lives in workspace/skill_lib/arm.py (close): torque on
+first so the claw still moves after an overload left the servo disabled.
 """
 
 from brain_client.skills.types import Interface, InterfaceType, Skill, SkillResult
+from workspace.skill_lib import arm as armlib
 
 
 class GripperClose(Skill):
     """Close the gripper (claw)."""
 
     manipulation = Interface(InterfaceType.MANIPULATION)
-
-    def __init__(self, logger):
-        super().__init__(logger)
-        self._cancelled = False
 
     @property
     def name(self):
@@ -36,21 +33,17 @@ class GripperClose(Skill):
     def guidelines(self):
         return (
             "Close the gripper/claw. strength adds squeeze (radians past the "
-            "closed stop) for a firmer grip; default 0.0."
+            "closed stop) for a firmer grip; default 0.0. Keep it <= 0.6 on a "
+            "real object — more overcurrent-trips the servo."
         )
 
     def execute(self, strength: float = 0.0, duration: float = 1.0):
         """Close the claw. strength = extra radians of squeeze past closed."""
         if self.manipulation is None:
             return "Manipulation interface not available", SkillResult.FAILURE
-        self.manipulation.torque_on()
-        ok = self.manipulation.close_gripper(
-            strength=strength, duration=duration, blocking=True
-        )
-        if not ok:
+        if not armlib.close(self.manipulation, strength=strength, duration=duration):
             return "Failed to close gripper", SkillResult.FAILURE
         return "Gripper closed", SkillResult.SUCCESS
 
     def cancel(self):
-        self._cancelled = True
         return "Gripper motion cancelled"

--- a/workspace/innate_skills/gripper_open.py
+++ b/workspace/innate_skills/gripper_open.py
@@ -10,24 +10,29 @@ Callable from any skill's code as a plain function:
     gripper_open()      # fully open the claw
 
 (also from the agent, the webapp skills menu, and
-`scripts/innate skill run local/gripper_open`).
+`scripts/innate skill run gripper_open`).
 
-Enables arm torque first. A hard close that overloads the servo leaves its
-torque disabled, after which a plain open silently does nothing — that's why
-opening from a resting closed claw failed. Enabling torque first makes it move.
+The implementation lives in workspace/skill_lib/arm.py (open_checked):
+torque on first, then VERIFY the claw actually opened — an overcurrent-
+tripped servo no-ops silently — rebooting to clear a trip and retrying.
 """
 
-from brain_client.skills.types import Interface, InterfaceType, Skill, SkillResult
+from brain_client.skills.types import (
+    Interface,
+    InterfaceType,
+    RobotState,
+    RobotStateType,
+    Skill,
+    SkillResult,
+)
+from workspace.skill_lib import arm as armlib
 
 
 class GripperOpen(Skill):
     """Open the gripper (claw)."""
 
     manipulation = Interface(InterfaceType.MANIPULATION)
-
-    def __init__(self, logger):
-        super().__init__(logger)
-        self._cancelled = False
+    joint_states = RobotState(RobotStateType.LAST_JOINT_STATES)
 
     @property
     def name(self):
@@ -40,14 +45,13 @@ class GripperOpen(Skill):
         """Open the claw. percent 0-100 (default fully open)."""
         if self.manipulation is None:
             return "Manipulation interface not available", SkillResult.FAILURE
-        self.manipulation.torque_on()  # a torque-disabled servo won't move
-        ok = self.manipulation.open_gripper(
-            percent=percent, duration=duration, blocking=True
+        ok = armlib.open_checked(
+            self.manipulation, lambda: armlib.gripper_j6(self.joint_states),
+            percent=percent, duration=duration, logger=self.logger,
         )
         if not ok:
             return "Failed to open gripper", SkillResult.FAILURE
         return "Gripper opened", SkillResult.SUCCESS
 
     def cancel(self):
-        self._cancelled = True
         return "Gripper motion cancelled"

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -57,17 +57,9 @@ from brain_client.skills.types import (
     Skill,
     SkillResult,
 )
-from innate.skills import SkillFailed, arm_rest_position, gripper_close, gripper_open
-
-# -----------------------------------------------------------------------------
-# geometry from mars.urdf
-# base_footprint == base_link, so z=0 is the floor. Camera sits in the head,
-# head pitches about y. That's enough to raycast a pixel onto the floor.
-# -----------------------------------------------------------------------------
-HEAD_ORIGIN = (-0.040751, -0.0002, 0.25882)  # base_link -> head joint
-CAM_IN_HEAD = (0.04327, 0.0297, -0.000275)   # head -> left camera optical
-IMG_W, IMG_H = 640, 480
-HFOV_DEG = 70.0
+from innate.skills import SkillFailed, arm_rest_position
+from workspace.skill_lib import arm as armlib
+from workspace.skill_lib.geometry import IMG_H, IMG_W, floor_to_pixel, pixel_to_floor
 
 # hardware-tuned constants (not exposed to the live panel)
 GRIPPER_EMPTY_J6 = -0.085  # joint6 when fingers are open / empty
@@ -200,53 +192,8 @@ def _load_gemini_key() -> str:
     return ""
 
 
-# -----------------------------------------------------------------------------
-# floor localization: pixel + head tilt -> (x, y) in base_link
-# Pure math. No ROS, no depth. If the ray doesn't hit the floor (or hits
-# behind the robot), return None.
-# -----------------------------------------------------------------------------
-def _head_rot(tilt_rad):
-    # pitch about +y: nose down is negative tilt in our convention
-    c, s = math.cos(tilt_rad), math.sin(tilt_rad)
-    return ((c, 0.0, -s), (0.0, 1.0, 0.0), (s, 0.0, c))
-
-
-def _rot(R, v):
-    return tuple(sum(R[i][k] * v[k] for k in range(3)) for i in range(3))
-
-
-def pixel_to_floor(u, v, head_tilt_deg):
-    """Cast a ray from the camera through pixel (u,v) and intersect z=0."""
-    fx = IMG_W / (2.0 * math.tan(math.radians(HFOV_DEG) / 2.0))
-    cx, cy = IMG_W / 2.0, IMG_H / 2.0
-    R = _head_rot(math.radians(head_tilt_deg))
-    cam = tuple(HEAD_ORIGIN[i] + _rot(R, CAM_IN_HEAD)[i] for i in range(3))
-    # camera frame in base_link: forward, right, down (optical convention)
-    fwd, right, down = _rot(R, (1, 0, 0)), _rot(R, (0, -1, 0)), _rot(R, (0, 0, -1))
-    xo, yo = (u - cx) / fx, (v - cy) / fx
-    d = tuple(fwd[i] + xo * right[i] + yo * down[i] for i in range(3))
-    if d[2] >= -1e-6:  # ray not pointing at the floor
-        return None
-    t = -cam[2] / d[2]
-    x, y = cam[0] + t * d[0], cam[1] + t * d[1]
-    return (x, y) if x > 0 else None  # behind the robot = nonsense
-
-
-def floor_to_pixel(x, y, head_tilt_deg):
-    """Inverse: floor point (x,y,0) -> image pixel. Used to draw the pick box
-    and the grasp target back onto the live head-camera frame."""
-    fx = IMG_W / (2.0 * math.tan(math.radians(HFOV_DEG) / 2.0))
-    cx, cy = IMG_W / 2.0, IMG_H / 2.0
-    R = _head_rot(math.radians(head_tilt_deg))
-    cam = tuple(HEAD_ORIGIN[i] + _rot(R, CAM_IN_HEAD)[i] for i in range(3))
-    fwd, right, down = _rot(R, (1, 0, 0)), _rot(R, (0, -1, 0)), _rot(R, (0, 0, -1))
-    D = (x - cam[0], y - cam[1], -cam[2])
-    a = sum(D[i] * fwd[i] for i in range(3))
-    if a <= 1e-6:  # on or behind the image plane
-        return None
-    b = sum(D[i] * right[i] for i in range(3))
-    c = sum(D[i] * down[i] for i in range(3))
-    return (cx + (b / a) * fx, cy + (c / a) * fx)
+# floor localization (pixel + head tilt <-> base_link x,y) lives in
+# workspace/skill_lib/geometry.py — imported above, same names.
 
 
 def _r(v, nd=4):
@@ -539,52 +486,14 @@ class PickAnyObject(Skill):
         self._dbg("drive_done", err_m=round(err, 4), s=round(time.time() - t0, 2))
 
     # -------------------------------------------------------------------------
-    # arm. Servos can brown out mid-move — check FK, reboot once, then abort
-    # loudly rather than continuing limp into the floor.
+    # arm. Health-checked moves, recovery, and reach clamps live in
+    # workspace/skill_lib/arm.py (armlib) — thin state accessors stay here.
     # -------------------------------------------------------------------------
-    class ArmUnhealthy(RuntimeError):
-        pass
-
     def _ee_xyz(self):
-        pose = self.manipulation.get_current_end_effector_pose()
-        try:
-            p = pose["position"]
-            return (float(p["x"]), float(p["y"]), float(p["z"]))
-        except (KeyError, TypeError):
-            return None
+        return armlib.ee_xyz(self.manipulation)
 
     def _gripper_j6(self):
-        js = self.joint_states
-        try:
-            return js["position"][5] if js else None
-        except (KeyError, IndexError, TypeError):
-            return None
-
-    def _recover_arm(self):
-        self.logger.warning("[PickAnyObject] recovering arm (reboot + torque on)")
-        self.manipulation.reboot_servos()
-        time.sleep(2.0)
-        self.manipulation.torque_on()
-        time.sleep(0.5)
-
-    def _move_arm(self, x, y, z, pitch, duration=1.5, tol=0.05):
-        """Cartesian move with a health check. Recover + retry once, then raise."""
-        for attempt in (1, 2):
-            ok = self.manipulation.move_to_cartesian_pose(
-                x=x, y=y, z=z, roll=0.0, pitch=pitch, yaw=0.0,
-                duration=duration, blocking=True,
-            )
-            cur = self._ee_xyz()
-            err = math.dist(cur, (x, y, z)) if cur is not None else None
-            if ok and err is not None and err <= tol:
-                return True
-            self.logger.warning(
-                f"[PickAnyObject] arm not tracking (ok={ok} err={err}) — "
-                f"{'recovering' if attempt == 1 else 'giving up'}"
-            )
-            if attempt == 1:
-                self._recover_arm()
-        raise self.ArmUnhealthy(f"arm failed to reach ({x:.2f},{y:.2f},{z:.2f})")
+        return armlib.gripper_j6(self.joint_states)
 
     def _rest_arm(self, keep_grip):
         """Fold to home. If carrying: go to the operator's CARRY_ARM pose with
@@ -1032,13 +941,13 @@ class PickAnyObject(Skill):
                 cap = p["wrist_step_max"]
                 x += max(-cap, min(cap, p["wrist_kx"] / 100.0 * err_v * s))
                 y += max(-cap, min(cap, p["wrist_ky"] / 100.0 * err_u * s))
-                x = max(0.22, min(0.40, x))  # the arm's reach box
-                y = max(-0.10, min(0.10, y))
+                x, y = armlib.clamp_reach(x, y)
                 # feed-forward: this correction should land the object at the
                 # box center — tell the tracker to look for it there
                 guess = (p["wrist_box_u"], p["wrist_box_v"])
-            self._move_arm(x, y, z, pitch=p["wrist_pitch"],
-                           duration=p["wrist_move_s"])
+            armlib.move_checked(self.manipulation, x, y, z,
+                                pitch=p["wrist_pitch"],
+                                duration=p["wrist_move_s"], logger=self.logger)
             streak = 0
             centered = 0  # the view shifted — re-confirm centering
 
@@ -1067,19 +976,11 @@ class PickAnyObject(Skill):
         self._dbg("hover", ee=self._ee_dbg())
 
     def _open_gripper_checked(self):
-        """Open the claw, and make sure it actually opened. A prior hard
-        close can overcurrent-trip the gripper servo — a hardware fault
-        torque_on alone can't clear — after which open silently no-ops and
-        the hand stays shut straight into the grasp. Reboot clears the trip."""
-        gripper_open()
-        j6 = self._gripper_j6()
-        if j6 is not None and j6 < 0.10:
-            self.logger.warning(
-                f"[PickAnyObject] gripper did not open (j6={j6:.3f}); "
-                "rebooting servos to clear a trip, then retrying")
-            self._dbg("gripper_reboot", j6=_r(j6))
-            self._recover_arm()
-            gripper_open()
+        """Open the claw, verified (trip recovery) — see armlib.open_checked."""
+        armlib.open_checked(
+            self.manipulation, self._gripper_j6, logger=self.logger,
+            on_reboot=lambda j6: self._dbg("gripper_reboot", j6=_r(j6)),
+        )
 
     def _push_to_floor(self, x, y, z_from, deep):
         """The last blind centimeters: rotate to the grasp pitch and descend
@@ -1100,14 +1001,14 @@ class PickAnyObject(Skill):
             )
             self._dbg("descend", z=round(z, 3), ok=bool(ok), ee=self._ee_dbg())
             if not ok:
-                self._recover_arm()
+                armlib.recover(self.manipulation, self.logger)
                 break
         ee = self._ee_xyz()
         if ee is not None and ee[2] > p["descend_abort_z"]:
             self._dbg("grasp_abort", reason="arm would not descend",
                       ee_z=round(ee[2], 4))
-            self._recover_arm()
-            raise self.ArmUnhealthy("arm would not descend")
+            armlib.recover(self.manipulation, self.logger)
+            raise armlib.ArmUnhealthy("arm would not descend")
 
     def _close_twist_lift(self, x, y):
         """Take it: squeeze, wind the fabric onto the fingers, lift. Twist
@@ -1117,7 +1018,8 @@ class PickAnyObject(Skill):
         position instead relaxes the squeeze mid-lift and drops socks."""
         p = self._p
         j6_open = self._gripper_j6()
-        gripper_close(strength=p["close_strength"], duration=p["close_s"])
+        armlib.close(self.manipulation, strength=p["close_strength"],
+                     duration=p["close_s"])
         time.sleep(p["close_settle_s"])
         self._dbg("close", j6_open=_r(j6_open), j6=_r(self._gripper_j6()),
                   strength=p["close_strength"])
@@ -1139,8 +1041,9 @@ class PickAnyObject(Skill):
             time.sleep(0.3)
             self._dbg("lift", ee=self._ee_dbg(), j6=_r(self._gripper_j6()))
         except (KeyError, IndexError, TypeError):  # no joint state — IK lift
-            self._move_arm(x, y, 0.22, pitch=p["arm_pitch"], duration=2.0,
-                           tol=0.10)
+            armlib.move_checked(self.manipulation, x, y, 0.22,
+                                pitch=p["arm_pitch"], duration=2.0, tol=0.10,
+                                logger=self.logger)
             self._dbg("lift", ee=self._ee_dbg(), j6=_r(self._gripper_j6()),
                       ik_fallback=True)
 
@@ -1150,8 +1053,7 @@ class PickAnyObject(Skill):
         so the panel can retune a grasp mid-run."""
         p = self._p
         # aim short: fingertips land ~grasp_x_off forward of ee_link
-        x = max(0.22, min(0.40, xy[0] - p["grasp_x_off"]))
-        y = max(-0.10, min(0.10, xy[1]))
+        x, y = armlib.clamp_reach(xy[0] - p["grasp_x_off"], xy[1])
 
         # telemetry: where the object is vs where the fingers will land (they
         # differ only when the object is outside the reach box — aim clamped)
@@ -1174,8 +1076,9 @@ class PickAnyObject(Skill):
             x, y, z = self._wrist_servo(prompt, x, y)
         else:  # classic blind grasp: IK hover above the estimate
             z = p["hover_z"]
-            self._move_arm(x, y, z, pitch=p["arm_pitch"],
-                           duration=p["hover_s"])
+            armlib.move_checked(self.manipulation, x, y, z,
+                                pitch=p["arm_pitch"], duration=p["hover_s"],
+                                logger=self.logger)
             self._dbg("hover", ee=self._ee_dbg())
 
         self._push_to_floor(x, y, z, deep)
@@ -1276,7 +1179,7 @@ class PickAnyObject(Skill):
                 "backing up)",
                 SkillResult.FAILURE,
             )
-        except self.ArmUnhealthy as e:
+        except armlib.ArmUnhealthy as e:
             self.say("My arm isn't responding properly, stopping.")
             return f"Arm servo failure: {e}", SkillResult.FAILURE
         finally:

--- a/workspace/skill_lib/README.md
+++ b/workspace/skill_lib/README.md
@@ -1,0 +1,31 @@
+# skill_lib — shared primitives for skills
+
+Plain Python modules skills import directly. No `Skill` classes here; no
+registration, no roster entry, no invoker round trip — just functions that
+take the interfaces they need as arguments.
+
+```python
+from workspace.skill_lib import arm as armlib
+
+armlib.open_checked(self.manipulation, self._gripper_j6)
+armlib.move_checked(self.manipulation, x, y, z, pitch=1.3, logger=self.logger)
+```
+
+## What belongs where
+
+- **Here**: short blocking device commands, recovery sequences (servo trip /
+  brownout handling), reach clamps, pure math (camera geometry). Functions
+  the *author of a skill* calls.
+- **A `Skill`**: anything the agent or an operator invokes by name, and
+  anything long-running enough to need cancellation checks and step
+  telemetry. The moment a second skill wants to copy a private helper,
+  that helper moves here.
+
+## Two rules
+
+1. **Import at the top of the skill file, never inside a function.** The
+   skill loader puts the repo root on `sys.path` only while the skill module
+   executes; a lazy import inside `execute()` will not resolve.
+2. **Editing a lib file mid-session:** `/brain/reload_primitives` evicts
+   `workspace.skill_lib*` from `sys.modules` before reloading skills, so a
+   normal skills reload picks up lib edits too (see `catalog.reload_all`).

--- a/workspace/skill_lib/arm.py
+++ b/workspace/skill_lib/arm.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Arm primitives shared by skills. The hardware lessons live here once.
+
+Plain functions: pass the manipulation interface (and, where needed, a
+joint-state getter) explicitly — no ambient context, no Skill machinery.
+Rule of thumb: short blocking device commands, recovery sequences, and
+pure math belong here; anything long-running or cancellable stays a Skill.
+
+Import gotcha (applies to all of workspace/skill_lib): import at the TOP of
+a skill file. The skill loader puts the repo root on sys.path only while the
+skill module executes, so a lazy import inside execute() will not resolve.
+"""
+
+import math
+import time
+
+# The arm's grasp-reach box in base_link meters — beyond it, IK strains or
+# the fingers land short. The webapp draws this box (REACH in pickTunePanel.js).
+REACH_X = (0.22, 0.40)
+REACH_Y = (-0.10, 0.10)
+
+
+class ArmUnhealthy(RuntimeError):
+    """Servo brownout / refusal — abort loudly, never continue limp."""
+
+
+def clamp_reach(x, y):
+    """Clamp a grasp / servo target into the arm's reach box."""
+    return (max(REACH_X[0], min(REACH_X[1], x)),
+            max(REACH_Y[0], min(REACH_Y[1], y)))
+
+
+def ee_xyz(manipulation):
+    """Current end-effector position from FK, or None while state is absent."""
+    pose = manipulation.get_current_end_effector_pose()
+    try:
+        p = pose["position"]
+        return (float(p["x"]), float(p["y"]), float(p["z"]))
+    except (KeyError, TypeError):
+        return None
+
+
+def gripper_j6(joint_states):
+    """Gripper joint (j6) from a joint_states dict, or None."""
+    try:
+        return joint_states["position"][5] if joint_states else None
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def recover(manipulation, logger=None):
+    """Reboot servos + torque on — the only cure for an overcurrent trip or
+    a brownout (torque_on alone can't clear a tripped servo's hardware error)."""
+    if logger:
+        logger.warning("[arm] recovering (reboot + torque on)")
+    manipulation.reboot_servos()
+    time.sleep(2.0)
+    manipulation.torque_on()
+    time.sleep(0.5)
+
+
+def move_checked(manipulation, x, y, z, pitch, duration=1.5, tol=0.05, logger=None):
+    """Cartesian move with a health check: verify FK landed within tol,
+    recover + retry once, then raise ArmUnhealthy rather than let a limp
+    arm continue into the floor."""
+    for attempt in (1, 2):
+        ok = manipulation.move_to_cartesian_pose(
+            x=x, y=y, z=z, roll=0.0, pitch=pitch, yaw=0.0,
+            duration=duration, blocking=True,
+        )
+        cur = ee_xyz(manipulation)
+        err = math.dist(cur, (x, y, z)) if cur is not None else None
+        if ok and err is not None and err <= tol:
+            return True
+        if logger:
+            logger.warning(f"[arm] not tracking (ok={ok} err={err}) — "
+                           f"{'recovering' if attempt == 1 else 'giving up'}")
+        if attempt == 1:
+            recover(manipulation, logger)
+    raise ArmUnhealthy(f"arm failed to reach ({x:.2f},{y:.2f},{z:.2f})")
+
+
+def open_checked(manipulation, get_j6, percent=100.0, duration=1.0,
+                 logger=None, on_reboot=None):
+    """Open the gripper and VERIFY it opened. A prior hard close can
+    overcurrent-TRIP the gripper servo — a hardware error torque_on alone
+    can't clear — after which open silently does nothing and the hand stays
+    shut. If j6 says it didn't open, reboot to clear the trip and retry.
+    on_reboot(j6) is called before the reboot (telemetry hook)."""
+    manipulation.torque_on()  # a torque-disabled servo won't move at all
+    ok = manipulation.open_gripper(percent=percent, duration=duration, blocking=True)
+    j6 = get_j6()
+    if j6 is not None and j6 < 0.10:
+        if logger:
+            logger.warning(f"[arm] gripper did not open (j6={j6:.3f}); "
+                           "rebooting servos to clear a trip, then retrying")
+        if on_reboot:
+            on_reboot(j6)
+        recover(manipulation, logger)
+        ok = manipulation.open_gripper(percent=percent, duration=duration, blocking=True)
+    return bool(ok)
+
+
+def close(manipulation, strength=0.0, duration=1.0):
+    """Close the gripper. strength = extra squeeze past the closed stop.
+    Keep it <= ~0.6 against a real object: higher stalls j6 at max current
+    on the fingers and overcurrent-trips the servo (open then no-ops until
+    a reboot)."""
+    manipulation.torque_on()
+    return bool(manipulation.close_gripper(strength=strength, duration=duration,
+                                           blocking=True))

--- a/workspace/skill_lib/geometry.py
+++ b/workspace/skill_lib/geometry.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Head-camera <-> floor geometry. Pure math: no ROS, no depth sensor — a
+pinhole model plus the URDF head kinematics is enough to raycast a pixel
+onto the floor plane (base_footprint == base_link, so the floor is z=0).
+
+The webapp mirrors these constants and both projections (pickTunePanel.js)
+so the pick box can be drawn without a skill round trip — keep them in sync.
+"""
+
+import math
+
+HEAD_ORIGIN = (-0.040751, -0.0002, 0.25882)  # base_link -> head joint (URDF)
+CAM_IN_HEAD = (0.04327, 0.0297, -0.000275)   # head -> left camera optical
+IMG_W, IMG_H = 640, 480
+HFOV_DEG = 70.0
+
+
+def _head_rot(tilt_rad):
+    # pitch about +y: nose down is negative tilt in our convention
+    c, s = math.cos(tilt_rad), math.sin(tilt_rad)
+    return ((c, 0.0, -s), (0.0, 1.0, 0.0), (s, 0.0, c))
+
+
+def _rot(R, v):
+    return tuple(sum(R[i][k] * v[k] for k in range(3)) for i in range(3))
+
+
+def pixel_to_floor(u, v, head_tilt_deg):
+    """Cast a ray from the camera through pixel (u,v) and intersect z=0.
+    None if the ray misses the floor or lands behind the robot."""
+    fx = IMG_W / (2.0 * math.tan(math.radians(HFOV_DEG) / 2.0))
+    cx, cy = IMG_W / 2.0, IMG_H / 2.0
+    R = _head_rot(math.radians(head_tilt_deg))
+    cam = tuple(HEAD_ORIGIN[i] + _rot(R, CAM_IN_HEAD)[i] for i in range(3))
+    # camera frame in base_link: forward, right, down (optical convention)
+    fwd, right, down = _rot(R, (1, 0, 0)), _rot(R, (0, -1, 0)), _rot(R, (0, 0, -1))
+    xo, yo = (u - cx) / fx, (v - cy) / fx
+    d = tuple(fwd[i] + xo * right[i] + yo * down[i] for i in range(3))
+    if d[2] >= -1e-6:  # ray not pointing at the floor
+        return None
+    t = -cam[2] / d[2]
+    x, y = cam[0] + t * d[0], cam[1] + t * d[1]
+    return (x, y) if x > 0 else None  # behind the robot = nonsense
+
+
+def floor_to_pixel(x, y, head_tilt_deg):
+    """Inverse: floor point (x,y,0) -> image pixel, or None behind the
+    image plane. Exact inverse of pixel_to_floor (round-trips to <0.1 px)."""
+    fx = IMG_W / (2.0 * math.tan(math.radians(HFOV_DEG) / 2.0))
+    cx, cy = IMG_W / 2.0, IMG_H / 2.0
+    R = _head_rot(math.radians(head_tilt_deg))
+    cam = tuple(HEAD_ORIGIN[i] + _rot(R, CAM_IN_HEAD)[i] for i in range(3))
+    fwd, right, down = _rot(R, (1, 0, 0)), _rot(R, (0, -1, 0)), _rot(R, (0, 0, -1))
+    D = (x - cam[0], y - cam[1], -cam[2])
+    a = sum(D[i] * fwd[i] for i in range(3))
+    if a <= 1e-6:  # on or behind the image plane
+        return None
+    b = sum(D[i] * right[i] for i in range(3))
+    c = sum(D[i] * down[i] for i in range(3))
+    return (cx + (b / a) * fx, cy + (c / a) * fx)


### PR DESCRIPTION
Stacked on #542 (base: `theo/pick-wrist-servo`).

## What

Introduces `workspace/skill_lib/` — plain Python modules skills import directly. No `Skill` classes, no roster entries, no invoker round-trip; functions take the interfaces they need as explicit arguments. The idea: **short blocking device commands, recovery sequences, and pure math are library functions; anything the agent/operator invokes by name or that runs long enough to need cancellation stays a `Skill`.**

The hardware lessons this robot taught us now live in exactly one place:

- **`skill_lib/arm.py`** — verified gripper open (overcurrent-trip → reboot recovery), close with the strength-cap lesson, health-checked cartesian moves (FK verify → recover + retry → raise `ArmUnhealthy`), servo recovery, reach clamps.
- **`skill_lib/geometry.py`** — head-camera ↔ floor pinhole projection, moved verbatim from `pick_any_object` (pure math; the webapp panel mirrors it).

## Effect on existing skills

- `gripper_open` / `gripper_close` become thin wrappers over the lib — and `gripper_open` **gains** the trip-recovery verification that previously only `pick_any_object` had.
- `pick_any_object` drops ~150 lines of private helpers (`_move_arm`, `_recover_arm`, the geometry functions, inline reach clamps) for lib calls, and calls the lib directly instead of round-tripping the gripper skills through the invoker.

## Import contract

Skills import the lib **at module top**: the loader puts the repo root on `sys.path` only while a skill module executes (namespace-package import — verified live). `catalog.reload_all` / `reload_selective` now evict cached `workspace.skill_lib` modules before reloading, so a normal skills reload picks up lib edits too (otherwise `sys.modules` keeps serving the pre-edit lib).

## Compatibility

No behavior or interface changes: skill IDs, `innate.skills` chaining, panel debug events, and `TUNABLE` keys are all unchanged.

## Testing

Verified live on the robot:
- `/brain/reload_primitives` loads all 23 code skills (same count/IDs).
- `pick_any_object` acks its tuning params through the new lib imports.
- `gripper_close @strength=0.1` then `gripper_open` ran end-to-end via the skill CLI — claw physically cycled and returned to its starting joint value (j6 = 0.463).
- All files compile; lines within the 120-char ruff limit.

## Note for reviewers

The `catalog.py` change is in `brain_client` (ROS package), so it takes effect on the next colcon build + skills-server restart. Everything under `workspace/` is live-reloadable and already running on `mars`.