### PR TITLE
feat(skills): follow_aruco skill + cancel running skill from any client

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -183,6 +183,7 @@ class SkillsActionServer(Node):
         self._reload_skills_srv = self.create_service(
             ReloadSkillsAgents, "/brain/reload_skills", self._handle_reload_skills_agents
         )
+        self._cancel_skill_srv = self.create_service(Trigger, "/brain/cancel_skill", self._handle_cancel_skill)
 
         self.get_logger().debug("Skills Action Server has started.")
         self.get_logger().info(f"Total skills available: {self.catalog.code_count + self.catalog.physical_count}")
@@ -249,6 +250,25 @@ class SkillsActionServer(Node):
         except Exception as e:
             response.success = False
             response.message = str(e)
+        return response
+
+    def _handle_cancel_skill(self, request, response):
+        """Cancel the currently running skill, whoever started it.
+
+        The action protocol only lets the goal's sender cancel; a client that
+        merely sees the run on /brain/skill_status_update (the mobile app,
+        another webapp tab) holds no goal handle — this service is its Stop.
+        """
+        with self._skill_execution_lock:
+            goal_handle = self._active_goal_handle if self._skill_running else None
+        if goal_handle is None:
+            response.success = False
+            response.message = "No skill is running"
+            return response
+        skill_type = goal_handle.request.skill_type
+        self.cancel_callback(goal_handle)
+        response.success = True
+        response.message = f"Cancellation requested for '{skill_type}'"
         return response
 
     def _handle_reload_skills_agents(self, request, response):

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -261,12 +261,15 @@ class SkillsActionServer(Node):
         """
         with self._skill_execution_lock:
             goal_handle = self._active_goal_handle if self._skill_running else None
-        if goal_handle is None:
-            response.success = False
-            response.message = "No skill is running"
-            return response
-        skill_type = goal_handle.request.skill_type
-        self.cancel_callback(goal_handle)
+            if goal_handle is None:
+                response.success = False
+                response.message = "No skill is running"
+                return response
+            skill_type = goal_handle.request.skill_type
+            # Dispatch under the lock: released, the slot could be freed and
+            # re-claimed by a new run of the same skill, and the cancel would
+            # hit that fresh execution instead.
+            self.cancel_callback(goal_handle)
         response.success = True
         response.message = f"Cancellation requested for '{skill_type}'"
         return response

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -171,6 +171,9 @@ export const PINNED_SKILLS = ["navigate with vision", "navigate with position", 
 // drives. Skill roster + per-skill input schema come from AVAILABLE_SKILLS_TOPIC.
 export const EXECUTE_SKILL_ACTION = "/execute_skill";
 export const EXECUTE_SKILL_ACTION_TYPE = "brain_messages/action/ExecuteSkill";
+// Cancels the running skill regardless of which client sent its goal (action
+// cancels only bind to the sender). std_srvs/Trigger.
+export const CANCEL_SKILL_SERVICE = "/brain/cancel_skill";
 
 export const HEAD_MIN_DEG = -40;
 export const HEAD_MAX_DEG = 70;

--- a/webapp/js/teleop/skillsMenu.js
+++ b/webapp/js/teleop/skillsMenu.js
@@ -8,6 +8,7 @@
 
 import {
   AVAILABLE_SKILLS_TOPIC,
+  CANCEL_SKILL_SERVICE,
   EXECUTE_SKILL_ACTION,
   EXECUTE_SKILL_ACTION_TYPE,
   PINNED_SKILLS,
@@ -68,6 +69,9 @@ export function createSkillsMenu(parent, rosClient) {
   /** Skill the robot reports running via /brain/skill_status_update (covers
    *  agent-driven runs too, not just ones launched from this menu). */
   let topicActiveName = "";
+  /** Stop requested (via /brain/cancel_skill) for a run started elsewhere;
+   *  cleared when the status topic reports the run over. */
+  let externCanceling = false;
 
   // ---- skill input schema (mirrors the sim console) -----------------------
 
@@ -238,6 +242,28 @@ export function createSkillsMenu(parent, rosClient) {
     render();
   }
 
+  /** Stop a run this tab didn't start: no goal handle to cancel, so ask the
+   *  skills server to cancel whatever is running. */
+  function stopExternRun() {
+    if (externCanceling) return;
+    externCanceling = true;
+    render();
+    rosClient.callService(CANCEL_SKILL_SERVICE).then(
+      (res) => {
+        // success=false means nothing was running (already over) — the status
+        // topic clears the readout; just re-arm the button.
+        if (res?.success === false) {
+          externCanceling = false;
+          render();
+        }
+      },
+      () => {
+        externCanceling = false;
+        render();
+      },
+    );
+  }
+
   // ---- open / close -------------------------------------------------------
 
   /** @param {boolean} next */
@@ -292,6 +318,9 @@ export function createSkillsMenu(parent, rosClient) {
   function render() {
     syncActive();
     const frag = document.createDocumentFragment();
+    // A run started elsewhere (agent, CLI, another tab) has no local cancel
+    // handle — offer a Stop that goes through /brain/cancel_skill instead.
+    if (topicActiveName && !(run && !run.done)) frag.appendChild(renderExternRow());
     for (const skill of skills) frag.appendChild(renderRow(skill));
     if (skills.length === 0) {
       const empty = document.createElement("p");
@@ -300,6 +329,25 @@ export function createSkillsMenu(parent, rosClient) {
       frag.appendChild(empty);
     }
     listEl.replaceChildren(frag);
+  }
+
+  /** Banner row for the externally-started run: name + Stop. */
+  function renderExternRow() {
+    const row = document.createElement("div");
+    row.className = "skills-pop-row";
+    const status = document.createElement("div");
+    status.className = "skills-pop-status";
+    const txt = document.createElement("span");
+    txt.textContent = `${topicActiveName} — running`;
+    const stop = document.createElement("button");
+    stop.type = "button";
+    stop.className = "skill-confirm stop";
+    stop.textContent = externCanceling ? "Stopping" : "Stop";
+    stop.disabled = externCanceling || rosClient.state !== "connected";
+    stop.addEventListener("click", stopExternRun);
+    status.append(txt, stop);
+    row.appendChild(status);
+    return row;
   }
 
   /** @param {any} skill */
@@ -522,12 +570,19 @@ export function createSkillsMenu(parent, rosClient) {
     const name = String(payload?.primitive_name ?? payload?.skill_name ?? payload?.skill_id ?? "");
     const status = String(payload?.status ?? "");
     if (!name || !status) return;
+    const prevActive = topicActiveName;
     topicActiveName = status === "running" ? prettify(name) : "";
+    if (topicActiveName === "") externCanceling = false;
     syncActive();
+    // The extern-run banner tracks this topic; repaint it while the popup is up.
+    if (open && topicActiveName !== prevActive) render();
   }, undefined, "std_msgs/msg/String");
 
   const unsubState = rosClient.onStateChange(() => {
-    if (rosClient.state !== "connected") topicActiveName = "";
+    if (rosClient.state !== "connected") {
+      topicActiveName = "";
+      externCanceling = false;
+    }
     syncActive();
     if (open) render();
   });

--- a/workspace/innate_skills/follow_aruco.py
+++ b/workspace/innate_skills/follow_aruco.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Follow ArUco Skill -- lock onto the first ArUco marker seen through the main
+camera and follow it with the base, steering by the marker's pixel position and
+keeping distance from its apparent size. Seeing the stop marker (id 4) ends the
+follow. No obstacle avoidance."""
+
+import base64
+import time
+
+import cv2
+import numpy as np
+from innate import Interface, InterfaceType, RobotState, RobotStateType, Skill, SkillResult
+
+# Must match the dictionary the tags were printed with (ids 0-4, DICT_4X4_50).
+# The calibration ChArUco boards use DICT_4X4_250 -- a different dictionary.
+ARUCO_DICT = cv2.aruco.DICT_4X4_50
+STOP_ID = 4  # seeing this marker ends the follow
+LOCK_IDS = {0, 1, 2, 3}  # the printed tag set minus the stop marker
+
+# Background texture occasionally decodes as a valid marker for a frame, so a
+# single detection is not trusted: locking and stopping both require the same
+# id in consecutive frames.
+LOCK_CONFIRM_FRAMES = 3
+STOP_CONFIRM_FRAMES = 2
+
+LOOP_PERIOD = 0.1  # control loop (s); camera state refreshes faster than this
+CMD_DURATION = 0.4  # cmd_vel deadman: base stops if the loop dies
+
+MAX_LINEAR = 0.3  # m/s forward
+MAX_REVERSE = 0.1  # m/s backward when too close
+MAX_ANGULAR = 0.8  # rad/s
+TURN_GAIN = 1.5  # rad/s per unit of normalized horizontal offset
+LINEAR_GAIN = 0.6  # m/s per unit of relative size error
+
+# Follow distance is held by keeping the marker's apparent side length at this
+# fraction of image width (~0.8 m for an 8 cm tag on the main camera).
+TARGET_SIZE_FRAC = 0.07
+SIZE_DEADBAND = 0.15  # relative size error below which we don't drive
+
+
+class FollowAruco(Skill):
+    """Follow the first ArUco marker seen until the stop marker appears."""
+
+    mobility = Interface(InterfaceType.MOBILITY)
+    image = RobotState(RobotStateType.LAST_MAIN_CAMERA_IMAGE_B64)
+
+    def __init__(self, logger):
+        super().__init__(logger)
+        dictionary = cv2.aruco.getPredefinedDictionary(ARUCO_DICT)
+        self._detector = cv2.aruco.ArucoDetector(dictionary, cv2.aruco.DetectorParameters())
+
+    @property
+    def name(self):
+        return "follow_aruco"
+
+    def guidelines(self):
+        return (
+            "Follow a person or object carrying an ArUco tag (DICT_4X4_50, ids 0-3). "
+            "The robot waits until it sees one, locks onto that id, says 'Locked in', and "
+            "then drives to keep that marker centered and about 0.8m away. Showing "
+            f"marker id {STOP_ID} stops the follow. Runs until the stop marker is seen "
+            "or the skill is cancelled. No obstacle avoidance -- use in clear space."
+        )
+
+    def execute(self):
+        if self.mobility is None:
+            return "Mobility interface not available", SkillResult.FAILURE
+        if not self._wait_for_frame():
+            return "No camera image available", SkillResult.FAILURE
+
+        locked_id = None
+        lock_candidate = None
+        lock_streak = 0
+        stop_streak = 0
+        while not self._cancelled:
+            markers = self._detect_markers()
+
+            stop_streak = stop_streak + 1 if STOP_ID in markers else 0
+            if stop_streak >= STOP_CONFIRM_FRAMES:
+                self._stop()
+                self.say("Stopping")
+                return f"Stop marker (id {STOP_ID}) seen, follow ended", SkillResult.SUCCESS
+
+            if locked_id is None:
+                seen = next((i for i in markers if i in LOCK_IDS), None)
+                lock_streak = lock_streak + 1 if seen is not None and seen == lock_candidate else 1
+                lock_candidate = seen
+                if seen is not None and lock_streak >= LOCK_CONFIRM_FRAMES:
+                    locked_id = seen
+                    self.say("Locked in")
+                    self._send_feedback(f"Locked onto marker id {locked_id}")
+                else:
+                    time.sleep(LOOP_PERIOD)
+                    continue
+
+            quad = markers.get(locked_id)
+            if quad is None:
+                self._stop()  # marker out of sight: hold position, keep scanning
+            else:
+                self._drive_toward(quad)
+            time.sleep(LOOP_PERIOD)
+
+        self._stop()
+        return "Follow cancelled", SkillResult.CANCELLED
+
+    def cancel(self):
+        self._cancelled = True
+        self._stop()
+        return "Follow cancelled"
+
+    def _detect_markers(self) -> dict:
+        """Detected markers in the current frame as {id: quad of 4 (x, y) corners}."""
+        frame = self._current_frame()
+        if frame is None:
+            return {}
+        self._frame_width = frame.shape[1]
+        corners, ids, _rejected = self._detector.detectMarkers(frame)
+        if ids is None:
+            return {}
+        return {int(marker_id): quad.reshape(4, 2) for marker_id, quad in zip(ids.flatten(), corners)}
+
+    def _current_frame(self):
+        b64 = self.image
+        if not b64:
+            return None
+        data = np.frombuffer(base64.b64decode(b64), dtype=np.uint8)
+        return cv2.imdecode(data, cv2.IMREAD_GRAYSCALE)
+
+    def _drive_toward(self, quad) -> None:
+        # Steer: normalized horizontal offset of the marker center, [-1, 1].
+        center_x = quad[:, 0].mean()
+        offset = (center_x - self._frame_width / 2) / (self._frame_width / 2)
+        # Positive angular_z is a left turn; marker right of center needs a right turn.
+        angular = float(np.clip(-TURN_GAIN * offset, -MAX_ANGULAR, MAX_ANGULAR))
+
+        # Distance: apparent side length vs. target. Too small -> approach,
+        # too large -> back off.
+        side_frac = np.mean([np.linalg.norm(quad[i] - quad[(i + 1) % 4]) for i in range(4)]) / self._frame_width
+        size_error = 1.0 - side_frac / TARGET_SIZE_FRAC
+        linear = 0.0
+        if abs(size_error) > SIZE_DEADBAND:
+            linear = float(np.clip(LINEAR_GAIN * size_error, -MAX_REVERSE, MAX_LINEAR))
+
+        self.mobility.send_cmd_vel(linear_x=linear, angular_z=angular, duration=CMD_DURATION)
+
+    def _wait_for_frame(self, timeout: float = 5.0) -> bool:
+        deadline = time.time() + timeout
+        while self.image is None and not self._cancelled:
+            if time.time() > deadline:
+                return False
+            time.sleep(0.05)
+        return True
+
+    def _stop(self):
+        if self.mobility is not None:
+            self.mobility.send_cmd_vel(linear_x=0.0, angular_z=0.0)

--- a/workspace/innate_skills/follow_aruco.py
+++ b/workspace/innate_skills/follow_aruco.py
@@ -119,7 +119,7 @@ class FollowAruco(Skill):
         corners, ids, _rejected = self._detector.detectMarkers(frame)
         if ids is None:
             return {}
-        return {int(marker_id): quad.reshape(4, 2) for marker_id, quad in zip(ids.flatten(), corners)}
+        return {int(marker_id): quad.reshape(4, 2) for marker_id, quad in zip(ids.flatten(), corners, strict=True)}
 
     def _current_frame(self):
         b64 = self.image

--- a/workspace/innate_skills/follow_aruco.py
+++ b/workspace/innate_skills/follow_aruco.py
@@ -49,6 +49,7 @@ class FollowAruco(Skill):
         super().__init__(logger)
         dictionary = cv2.aruco.getPredefinedDictionary(ARUCO_DICT)
         self._detector = cv2.aruco.ArucoDetector(dictionary, cv2.aruco.DetectorParameters())
+        self._frame_width = 1  # real width set on every successful _detect_markers() decode
 
     @property
     def name(self):


### PR DESCRIPTION
## What

Two related changes from live testing on jetson1:

### 1. `follow_aruco` skill (`workspace/innate_skills/follow_aruco.py`)

Lock onto the first ArUco marker seen through the main camera and follow it with the base:

- Waits until a marker from the printed tag set (`DICT_4X4_50`, ids 0–3) is visible, locks onto that id, and says **"Locked in"**. Note this is a different dictionary than the `DICT_4X4_250` used by the ChArUco calibration boards.
- Follows by pixel servoing — steers on the marker's horizontal offset, holds ~0.8 m by keeping the apparent marker side at ~7% of image width (8 cm tags). Backs up gently when too close, stops in place when the marker goes out of view, and never re-locks onto a different id.
- **Marker id 4 is the kill switch**: showing it ends the follow (SUCCESS, says "Stopping").
- Robustness learned the hard way: on the first live run, background texture decoded as marker id 34 for a single frame and the skill locked instantly on launch. Locking now requires the same id in 3 consecutive frames, the stop marker requires 2, and ids outside the printed set can't be locked at all.
- Every `cmd_vel` carries a deadman `duration` so the base halts if the loop dies. Speeds clamped to the same envelope as `move_straight`. No obstacle avoidance (stated in guidelines).

### 2. Cancel the running skill from any client

The `execute_skill` action only lets the client that *sent* the goal cancel it. A run started by the agent, the CLI, or another tab was visible to everyone via `/brain/skill_status_update` but stoppable by no one else.

- **skills_server**: new `/brain/cancel_skill` service (`std_srvs/Trigger`) that cancels the currently active run whoever started it, routing through the existing `cancel_callback` (code skills get `cancel()`, physical skills get their behavior goal cancelled). Returns `success=false` when nothing is running.
- **webapp**: the skills menu shows a banner row with a **Stop** button whenever a skill is running that the tab didn't launch, wired to the new service. Stops for the tab's own runs are unchanged.

## Testing

- Skill logic verified off-robot with synthetic `generateImageMarker` frames and a fake mobility interface: lock/steer/reverse/deadband behavior, phantom-marker scenarios (persistent id 34 never locks; one-frame flicker of a real tag never locks; one-frame id 4 doesn't stop a follow), and the full lock → follow → distraction → stop sequence.
- Live on jetson1: skill loads, locks, speaks, and drives through the mux; the false-positive lock reproduced and is fixed by the confirmation logic above.
- `/brain/cancel_skill` + webapp Stop banner not yet exercised live (stack was down after the build); syntax-checked and `brain_client` builds clean.