### PR TITLE
feat: inbound phone-mic path with STT

### DIFF
--- a/HANDOFF-add-mic-backend.md
+++ b/HANDOFF-add-mic-backend.md
@@ -1,0 +1,116 @@
+# Handoff — inbound phone-mic → ROS topic (backend, `feat/add-mic`)
+
+Backend half of the operator-microphone feature: receive the browser/phone mic over the existing WebRTC
+peer and republish it as a ROS topic. Companion to [HANDOFF-add-mic.md](HANDOFF-add-mic.md) (which is
+frontend-first and covers the full feature) — this doc focuses on the robot-side receive path so it can be
+understood and tested **without the webapp**.
+
+Scope: **WebRTC → ROS topic only.** The robot decodes the inbound opus track and publishes PCM; playing it
+out a physical speaker is future work (no consumer node yet).
+
+Data path:
+
+```
+browser/phone mic → WebRTC (opus) → mars_cam webrtc_streamer_node
+  → webrtcbin pad-added → rtpopusdepay → opusdec → audioconvert → audioresample
+  → S16LE/48k/mono → appsink → publish innate_audio/msg/Audio on /audio/remote_mic
+```
+
+## Status
+
+- **Committed** on `feat/add-mic` (`a1c078be feat(mars_cam): inbound phone-mic path`). Working tree is clean.
+- Compiles clean (`innate_audio` + `mars_cam`); the `mars_cam` unit tests pass.
+- **Not runtime-verified end to end** — no physical robot in the loop. The robot's running binary predates
+  this change, so it **must be rebuilt** with `innate_audio` present.
+
+## The node: `mars_cam::WebRTCStreamer` (GStreamer `webrtcbin`, robot is always the offerer)
+
+This is the same node the webapp signals over `/webrtc/*` (rosbridge). It already streamed video +
+**robot-mic → browser** (sendonly opus, PT 98). This change adds the reverse: **browser → robot** audio.
+
+Key mechanics:
+
+- **Opt-in per peer.** `/webrtc/start` gains a boolean `mic`. On `mic:true` the peer's transport gets a
+  **recvonly opus transceiver** (`add-transceiver`, `GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY`), added
+  as the **last** m-line (after all video + the send-audio m-line).
+- **PT 110** for the recv m-line — deliberately distinct from the send-audio PT 98 and every camera PT
+  (96,97,99,100,…), because all m-lines share one bundle (`max-bundle`) where the PT must be unique.
+  Constants live in `webrtc_internal.hpp` (`kAudioSendPayloadType`, `kMicRecvPayloadType`).
+- **Renegotiates.** Unlike the send-audio m-line (negotiated up front → reneg-free toggle), the mic m-line
+  is only present when requested, so toggling `mic` changes m-line topology and forces a reconnect. The
+  reneg-free fast path in `on_start` is gated on `with_mic == negotiate_mic` as well as audio.
+- **Receive → publish.** When RTP arrives, `webrtcbin` fires `pad-added`; `on_incoming_pad` builds the
+  decode branch into that peer's transport pipeline and links the pad. `on_mic_sample` maps each decoded
+  buffer to `int16[]` and publishes `innate_audio/Audio` (`seq++`, `rate=48000`, `channels=1`,
+  `frame_id="remote"`). Runs on a GStreamer streaming thread; does **not** take `peers_mutex_`, so it can't
+  deadlock against `~Peer`.
+- **SDP/ICE accounting** updated for the extra audio line: the offer/answer media-count guards
+  (`expected_audio_lines`) and the ICE `max_mline` range now count both audio m-lines.
+
+## The message: `innate_audio/msg/Audio` (new package)
+
+```
+std_msgs/Header header   # stamp = publish time; frame_id = "remote"
+uint32  seq              # per-stream, wraps; gaps = drops
+uint32  rate             # 48000
+uint8   channels         # 1
+int16[] samples          # S16LE mono PCM
+```
+
+## Parameters (on `webrtc_streamer_node`)
+
+- `remote_mic_topic` (default `/audio/remote_mic`) — where decoded PCM is published.
+- `enable_audio` (default `true`) — gates the existing robot-mic send path; the inbound mic path is
+  independent of it and keyed purely on the per-peer `mic` START flag.
+
+## Files
+
+**New package** `ros2_ws/src/innate_audio/` — `msg/Audio.msg`, `CMakeLists.txt`, `package.xml`.
+
+**`ros2_ws/src/mars_bot/mars_cam/`**
+- `include/mars_cam/webrtc_streamer.hpp` — `Peer::with_mic`; `remote_mic_pub_`, `remote_mic_seq_`,
+  `remote_mic_topic_`; `on_incoming_pad`/`on_mic_sample` decls; `create_peer_transport` gains `with_mic`.
+- `include/mars_cam/webrtc_internal.hpp` — `kAudioSendPayloadType`/`kMicRecvPayloadType`;
+  `OfferContext::expected_mic`.
+- `mars_cam/webrtc_transport.cpp` — recvonly transceiver on `mic:true`; `pad-added` wiring;
+  `on_incoming_pad` (decode branch) + `on_mic_sample` (publish); expected-media tags.
+- `mars_cam/webrtc_signaling.cpp` — parse `mic`; reneg-free gate on `with_mic`; offer/answer media-count
+  guards; ICE `max_mline`.
+- `mars_cam/webrtc_streamer.cpp` — declare/read `remote_mic_topic`; create `remote_mic_pub_`
+  (SensorData/best-effort QoS); startup log.
+- `package.xml` / `CMakeLists.txt` — depend on `innate_audio`.
+
+## Build & test
+
+```bash
+# In the robot's ros2_ws (innate_audio must be present):
+colcon build --packages-select innate_audio mars_cam
+source install/setup.bash
+# webrtc_streamer_node comes up via the normal camera/webrtc bringup.
+```
+
+**Testing without the webapp** (this backend can be exercised standalone): drive the signaling directly —
+publish a `/webrtc/start` (`std_msgs/String` JSON) with `"mic": true` and a `client_id`, answer the offer
+from any WebRTC client that adds an opus **send** track (a small `gst`/`aiortc`/browser-devtools sender),
+then:
+
+```bash
+ros2 topic hz  /audio/remote_mic
+ros2 topic echo /audio/remote_mic --field seq
+```
+
+The node logs `Inbound phone-mic connected for '<client_id>' -> publishing /audio/remote_mic` when the pad
+links. (For the full app-driven flow — mic-toggle button, permission prompt, reconnect behavior — see the
+frontend handoff.)
+
+## Known limitations / notes
+
+- **No speaker playout** — `/audio/remote_mic` is published but nothing plays it on the robot.
+- **`seq` is node-wide.** A single active sender is the tested case; concurrent senders would interleave on
+  the one topic.
+- **Toggling re-handshakes** (adds/removes the m-line) → brief video freeze-frame, inherent to changing
+  m-line topology.
+- **Sim.** The sim path uses rosbridge, not `WebRtcSession`; exercising this needs
+  `webrtc_streamer.sim.launch.py` running and a WebRTC (not sim) client.
+- `phntm_bridge_client/` and `phntm_interfaces/` in the tree are a **separate** WebRTC stack, unrelated to
+  this feature.

--- a/HANDOFF-add-mic.md
+++ b/HANDOFF-add-mic.md
@@ -1,0 +1,84 @@
+# Handoff — operator microphone over WebRTC (`feat/add-mic`)
+
+Two-way audio: send the **operator's browser microphone up to the robot** over the existing WebRTC
+peer. This is the opposite direction from the pre-existing robot-mic feature (`setAudio`), which
+*receives* the robot's mic and plays it in the browser.
+
+Data path: browser mic → WebRTC (opus) → robot `webrtc_streamer_node` → opus decode → PCM published on
+`/audio/remote_mic` (`innate_audio/msg/Audio`, S16LE mono 48k). Playing that PCM out a physical speaker
+is **not** part of this change — the robot just republishes it as a ROS topic; a downstream consumer/
+speaker node is future work.
+
+## Status
+
+- **Webapp**: complete, typechecks clean (`cd webapp && npx tsc --noEmit`).
+- **Backend (`mars_cam` C++)**: complete in source. **Must be rebuilt** — the dev container was running a
+  binary built *before* these changes (no mic symbols). Needs `innate_audio` present at build time.
+- **Not runtime-verified end to end.** No physical robot was available; verified by reading both sides of
+  the contract + typecheck. This branch is for **real-robot testing**.
+
+## The wire contract
+
+`/webrtc/start` (browser → robot, `std_msgs/String` JSON) gains one field:
+
+```jsonc
+{ "source": "live", "video": [...], "audio": <bool>, "mic": <bool>, "client_id": "...", "renegotiate": <bool> }
+```
+
+- `mic: true` → robot adds a **recvonly** opus audio m-line (browser → robot) to its offer, as the **last**
+  m-line (after all video + the send-audio m-line). PT 110.
+- The mic m-line is **not** negotiated up front (unlike the robot-mic send m-line), so toggling `mic`
+  changes m-line topology and forces a **renegotiating reconnect** (brief video freeze-frame). This is why
+  every `/webrtc/start` publish must carry the current `mic` value — dropping it tears the m-line down.
+- Robot decodes the inbound track and publishes PCM on `/audio/remote_mic`.
+
+Browser is the **answerer**; the robot is always the offerer. The webapp finds the mic m-line in the
+offer by its `a=recvonly` marker (unambiguous vs. the `a=sendonly` robot-mic slot), sets that
+transceiver `sendonly`, and `replaceTrack`s the local mic onto it before `createAnswer`.
+
+## Files changed
+
+**Webapp** (`webapp/js/`)
+- `webrtcSession.js` — `setMic(on)`, `#acquireMic()`/`#releaseMic()`, `#attachMic()`, `micRecvMid()` SDP
+  helper; `mic` added to every `/webrtc/start` publish; `micRequested` state + `#micStream`/`#micTrack`.
+- `teleop/videoStage.js` — `createMicToggle()` (mic-icon button, mirrors the robot-mic toggle).
+- `teleop/main.js` — mounts the toggle on the right rail (`!config.simControls`).
+- `types.d.ts` — `micRequested` on `WebRtcState`.
+
+**Backend** (`ros2_ws/src/`)
+- `innate_audio/` — **new package**: `Audio.msg` (PCM message). Required dependency.
+- `mars_bot/mars_cam/` — recvonly transceiver on `mic:true`; `pad-added` → opus decode branch →
+  `on_mic_sample` → publish `/audio/remote_mic`. `package.xml`/`CMakeLists.txt` depend on `innate_audio`.
+
+## Build & test on the real robot
+
+```bash
+# In the robot's ros2_ws (needs the innate_audio package present):
+colcon build --packages-select innate_audio mars_cam
+source install/setup.bash
+# webrtc_streamer_node is launched by the normal camera/webrtc bringup (real-robot launch).
+```
+
+1. Open the teleop page against the robot (WebRTC path — `simControls` off).
+2. **Button location:** right-edge overlay of the video, a **mic icon next to the speaker (robot-mic)
+   icon**. Click to toggle; the browser prompts for mic permission on first enable.
+3. Verify:
+   ```bash
+   ros2 topic hz /audio/remote_mic          # ticks while the toggle is on
+   ros2 topic echo /audio/remote_mic --field seq
+   ```
+   Browser devtools console should log `[webrtc] operator mic attached (mid=...)`.
+4. Toggling off → `/audio/remote_mic` goes quiet and the mic m-line is dropped on the next handshake.
+
+## Known limitations / notes
+
+- **Not supported in the sim.** The sim webapp uses `SimSession` (Three.js canvas over rosbridge), not
+  `WebRtcSession` — no peer connection, no `setMic`, so the toggle is intentionally hidden when
+  `config.simControls` is set. Exercising it against sim would require running `webrtc_streamer_node`
+  (`webrtc_streamer.sim.launch.py`) *and* forcing the webapp onto `WebRtcSession`.
+- **No speaker playout yet** — `/audio/remote_mic` is published but nothing plays it on the robot.
+- Toggling the mic re-handshakes (adds/removes the m-line), so it briefly freeze-frames the video. This
+  is inherent to changing m-line topology, unlike the reneg-free robot-mic toggle.
+- Concurrent senders: the backend seq is node-wide; a single active sender is the tested case.
+- `phntm_bridge_client/` and `phntm_interfaces/` in the tree are **unrelated** to this feature and are
+  not part of this branch's commits.

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/tts.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/tts.py
@@ -134,7 +134,7 @@ class TTSHandler:
         # Check if we're already playing audio
         with self.play_lock:
             if self.is_playing:
-                self.logger.debug("🔊 Audio already playing, skipping new speech request")
+                self.logger.info("🔊 Audio already playing, skipping new speech request")
                 return False
             self.is_playing = True
 

--- a/ros2_ws/src/brain/brain_client/package.xml
+++ b/ros2_ws/src/brain/brain_client/package.xml
@@ -30,6 +30,7 @@
   <depend>brain_messages</depend>
   <depend>mars_bringup</depend>
   <depend>mars_msgs</depend>
+  <exec_depend>innate_audio</exec_depend>
 
   <!-- Cloud client packages (colcon-built) -->
   <exec_depend>cloud_clients</exec_depend>

--- a/ros2_ws/src/innate_audio/CMakeLists.txt
+++ b/ros2_ws/src/innate_audio/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.10)
+project(innate_audio)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Audio.msg"
+  DEPENDENCIES
+    std_msgs
+    builtin_interfaces
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros2_ws/src/innate_audio/msg/Audio.msg
+++ b/ros2_ws/src/innate_audio/msg/Audio.msg
@@ -1,0 +1,8 @@
+# PCM audio. S16LE mono 48k is the contract; the typed array is the format.
+# rate/channels are self-description for bag readers, not degrees of freedom —
+# consumers may assert 48000/1 and reject anything else.
+std_msgs/Header header      # stamp = first sample; frame_id identifies the source (e.g. "remote")
+uint32  seq                 # per-stream, wraps; gaps = drops
+uint32  rate                # always 48000
+uint8   channels            # always 1
+int16[] samples

--- a/ros2_ws/src/innate_audio/package.xml
+++ b/ros2_ws/src/innate_audio/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>innate_audio</name>
+  <version>0.0.1</version>
+  <description>Audio message definitions for the Innate/Mars audio pipeline</description>
+  <maintainer email="karmalhotra@utexas.edu">Karmanyaah Malhotra</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>std_msgs</depend>
+  <depend>builtin_interfaces</depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2_ws/src/mars_bot/mars_cam/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_cam/CMakeLists.txt
@@ -296,6 +296,11 @@ install(PROGRAMS
   DESTINATION lib/${PROJECT_NAME}
   RENAME stereo_calibrator
 )
+install(PROGRAMS
+  mars_cam/remote_mic_player.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME remote_mic_player
+)
 
 # Install launch files
 install(DIRECTORY launch/

--- a/ros2_ws/src/mars_bot/mars_cam/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_cam/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(stereo_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
+find_package(innate_audio REQUIRED)
 
 # Find OpenCV
 find_package(OpenCV REQUIRED)
@@ -120,6 +121,7 @@ ament_target_dependencies(webrtc_streamer_component
   std_msgs
   sensor_msgs
   cv_bridge
+  innate_audio
 )
 rclcpp_components_register_nodes(webrtc_streamer_component "mars_cam::WebRTCStreamer")
 
@@ -215,6 +217,7 @@ ament_target_dependencies(webrtc_streamer_node
   std_msgs
   sensor_msgs
   cv_bridge
+  innate_audio
 )
 
 # Create stereo depth estimator executable (requires VPI)

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_internal.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_internal.hpp
@@ -66,6 +66,13 @@ inline int cam_pt_for_index(size_t index) {
     return pt >= 98 ? pt + 1 : pt;
 }
 
+// PT for the outbound (robot mic -> browser) opus send m-line.
+constexpr int kAudioSendPayloadType = 98;
+// PT for the inbound (browser phone mic -> robot) recvonly opus m-line. Must differ from the send audio PT
+// and every camera PT: all m-lines share one bundle (max-bundle), where the PT must be unique. 110 sits
+// clear of the camera range (96,97,99,100,…) and the send-audio 98.
+constexpr int kMicRecvPayloadType = 110;
+
 // Chrome/Firefox often obfuscate their host ICE candidates as "<uuid>.local" mDNS names (one per local
 // interface). These parsing helpers are kept for diagnostics and for a future non-destructive fast path:
 // if we ever resolve a .local name ourselves, we must ADD the resolved-IP candidate, not replace/drop the
@@ -106,7 +113,8 @@ struct OfferContext {
     uint64_t gen_value;
     std::string client_id;
     guint expected_videos = 0;
-    bool expected_audio = false;
+    bool expected_audio = false;  // outbound robot-mic send m-line negotiated
+    bool expected_mic = false;    // inbound phone-mic recvonly m-line negotiated
 };
 
 inline void offer_context_free(gpointer data) {

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -12,6 +12,7 @@
 #include <std_msgs/msg/string.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
+#include <innate_audio/msg/audio.hpp>
 
 #include <gst/gst.h>
 #include <gst/webrtc/webrtc.h>
@@ -81,6 +82,7 @@ struct Peer {
                                              // stream switch without renegotiating, so switches are instant
     bool with_audio = false;                 // audio m-line NEGOTIATED (an opus transceiver exists)
     bool audio_active = false;               // audio currently being SENT — toggled live like the cameras (no reneg)
+    bool with_mic = false;                   // recvonly opus m-line NEGOTIATED (phone-mic in): browser -> robot -> ROS
     // True only after webrtcbin CONNECTED; gates RTP fan-out into webrtcbin. Shared + atomic because it
     // is written from webrtcbin's PC thread (the connection-state callback, via a copy tagged on the
     // element) — that callback must NOT take peers_mutex_: ~Peer runs set_state(NULL) under the mutex,
@@ -163,6 +165,14 @@ class WebRTCStreamer : public rclcpp::Node {
     static GstFlowReturn on_audio_sample(GstElement* appsink, gpointer user_data);
     void fan_out_audio(GstElement* appsink);
 
+    // ---- Inbound audio (phone mic): browser opus track -> webrtcbin -> decode -> ROS topic ----
+    // A peer that requested `mic` gets a recvonly opus m-line in the offer. When RTP arrives, webrtcbin
+    // fires pad-added with a src pad; on_incoming_pad builds a per-peer decode branch
+    // (rtpopusdepay -> opusdec -> audioconvert -> audioresample -> S16LE/48k/mono -> appsink) into the
+    // peer's transport pipeline, and on_mic_sample publishes each PCM chunk as innate_audio/Audio.
+    static void on_incoming_pad(GstElement* webrtc, GstPad* pad, gpointer user_data);
+    static GstFlowReturn on_mic_sample(GstElement* appsink, gpointer user_data);
+
     // Per-peer RTCP-liveness probe on the peer's rtpbin recv_rtcp_sink pad (ticks per RTCP packet).
     static GstPadProbeReturn on_rtcp_buffer(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     bool install_rtcp_probe_for(Peer* peer);  // attach once the peer's rtcp pad exists
@@ -183,7 +193,8 @@ class WebRTCStreamer : public rclcpp::Node {
     // create_peer_transport builds the transport pipeline, wires signals, and kicks off create-offer.
     // Caller holds peers_mutex_. Returns the inserted Peer* (or nullptr on failure).
     Peer* create_peer_transport(const std::string& client_id, const std::vector<std::string>& negotiated,
-                                const std::vector<std::string>& active, bool with_audio, bool audio_active);
+                                const std::vector<std::string>& active, bool with_audio, bool audio_active,
+                                bool with_mic);
     // Toggle which negotiated cameras (and audio) a connected peer is being sent, with NO renegotiation:
     // adjusts the per-camera/audio want-count + push gate and forces a keyframe on newly-enabled cameras.
     // Caller holds peers_mutex_.
@@ -216,6 +227,10 @@ class WebRTCStreamer : public rclcpp::Node {
     rclcpp::Publisher<std_msgs::msg::String>::SharedPtr offer_id_pub_;    // {client_id, sdp}
     rclcpp::Publisher<std_msgs::msg::String>::SharedPtr ice_out_id_pub_;  // {client_id, ...}
     rclcpp::Publisher<std_msgs::msg::String>::SharedPtr active_streams_pub_;
+    // Decoded phone-mic PCM (browser -> robot over WebRTC). One shared topic across peers; seq is node-wide
+    // (a single active sender is the tested case — concurrent senders would interleave, see on_mic_sample).
+    rclcpp::Publisher<innate_audio::msg::Audio>::SharedPtr remote_mic_pub_;
+    std::atomic<uint32_t> remote_mic_seq_{0};
 
     // Subscribers (signaling only; the per-camera image subscriptions live in cameras_)
     rclcpp::Subscription<std_msgs::msg::String>::SharedPtr start_sub_;
@@ -256,6 +271,7 @@ class WebRTCStreamer : public rclcpp::Node {
     bool enable_audio_ = true;
     std::string audio_source_element_ = "alsasrc";
     std::string audio_capture_device_;
+    std::string remote_mic_topic_ = "/audio/remote_mic";  // decoded inbound phone-mic PCM
     guint playout_min_delay_ms_ = 0;
     guint playout_max_delay_ms_ = 40;
     bool enable_local_stun_ = true;

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -171,6 +171,15 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration("start_calibration_manager")),
     )
 
+    # Plays the inbound operator mic (/audio/remote_mic) out the robot speaker, gated on
+    # /audio/remote_mic/to_speaker (off until true). A plain Node (spawns aplay), not composable.
+    remote_mic_player = Node(
+        package="mars_cam",
+        executable="remote_mic_player",
+        name="remote_mic_player",
+        output="screen",
+    )
+
     return LaunchDescription(
         [
             use_sim_time_arg,
@@ -178,5 +187,6 @@ def generate_launch_description():
             start_calibration_manager_arg,
             camera_container,
             stereo_calibration_manager,
+            remote_mic_player,
         ]
     )

--- a/ros2_ws/src/mars_bot/mars_cam/launch/webrtc_streamer.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/webrtc_streamer.launch.py
@@ -25,6 +25,14 @@ def generate_launch_description():
                         "audio_capture_device": "sysdefault:CARD=Light",
                     }
                 ],
-            )
+            ),
+            # Plays the inbound operator mic (/audio/remote_mic) out the robot speaker, gated on
+            # /audio/remote_mic/to_speaker (off until true). Alongside the streamer that publishes it.
+            Node(
+                package="mars_cam",
+                executable="remote_mic_player",
+                name="remote_mic_player",
+                output="screen",
+            ),
         ]
     )

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/remote_mic_player.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/remote_mic_player.py
@@ -9,10 +9,15 @@ best-effort QoS. We forward the raw int16 samples straight into aplay's stdin.
 Playback is gated on a std_msgs/Bool topic (/audio/remote_mic/to_speaker):
 audio only reaches aplay while the latest value is True. Samples received while
 gated off are dropped, so re-enabling plays live audio, not a buffered backlog.
+
+aplay is spawned per gate-on and killed on gate-off (the ALSA default is dmix,
+so holding it open would be harmless, but a crashed aplay must not be fatal:
+it is respawned on the next chunk instead of taking the node down).
 """
 
 import subprocess
 import sys
+import time
 
 import rclpy
 from rclpy.node import Node
@@ -24,42 +29,117 @@ from innate_audio.msg import Audio
 RATE = 48000
 CHANNELS = 1
 GATE_TOPIC = "/audio/remote_mic/to_speaker"
+# Gate on but no audio for this long -> the inbound mic path is down, warn.
+NO_AUDIO_WARN_S = 5.0
 
 
 class RemoteMicPlayer(Node):
     def __init__(self):
         super().__init__("remote_mic_player")
         self.play_enabled = False
-        self.aplay = subprocess.Popen(
-            ["aplay", "-t", "raw", "-f", "S16_LE", "-r", str(RATE), "-c", str(CHANNELS), "-q"],
-            stdin=subprocess.PIPE,
-        )
+        self.aplay = None
+        self.last_audio_t = None
+        self.enabled_t = None
+        self.no_audio_warned = False
+        self.gated_drop_count = 0
+        self.last_gated_log_t = 0.0
+        self.chunks_played = 0
         self.sub = self.create_subscription(
             Audio, "/audio/remote_mic", self.on_audio, qos_profile_sensor_data
         )
         self.gate_sub = self.create_subscription(Bool, GATE_TOPIC, self.on_gate, 10)
+        self.watchdog = self.create_timer(1.0, self.check_flow)
         self.get_logger().info(f"Ready: /audio/remote_mic -> aplay, gated on {GATE_TOPIC} (off until True)")
 
+    def _spawn_aplay(self):
+        self.aplay = subprocess.Popen(
+            ["aplay", "-t", "raw", "-f", "S16_LE", "-r", str(RATE), "-c", str(CHANNELS), "-q"],
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.get_logger().info(f"aplay started (pid {self.aplay.pid})")
+
+    def _stop_aplay(self, reason: str):
+        if self.aplay is None:
+            return
+        proc, self.aplay = self.aplay, None
+        if proc.poll() is None:
+            try:
+                proc.stdin.close()
+            except Exception:
+                pass
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            self.get_logger().info(f"aplay stopped ({reason})")
+        else:
+            stderr = proc.stderr.read().decode(errors="replace").strip() if proc.stderr else ""
+            self.get_logger().error(
+                f"aplay had died (rc={proc.returncode}{', ' + stderr if stderr else ''}); {reason}"
+            )
+
     def on_gate(self, msg: Bool):
-        if msg.data != self.play_enabled:
-            self.play_enabled = msg.data
-            self.get_logger().info(f"Playback {'enabled' if msg.data else 'disabled'}")
+        if msg.data == self.play_enabled:
+            return
+        self.play_enabled = msg.data
+        self.get_logger().info(f"Playback {'enabled' if msg.data else 'disabled'} (gate {GATE_TOPIC})")
+        if msg.data:
+            self.enabled_t = time.monotonic()
+            self.no_audio_warned = False
+            self.chunks_played = 0
+            self.gated_drop_count = 0
+        else:
+            self._stop_aplay("gate off")
 
     def on_audio(self, msg: Audio):
+        now = time.monotonic()
+        self.last_audio_t = now
+        if not self.play_enabled:
+            # Audio IS arriving but the speaker gate is off — the discriminator between
+            # "mic path down" and "gate Bool never reached us". Logged sparsely.
+            self.gated_drop_count += 1
+            if now - self.last_gated_log_t > 10.0:
+                self.last_gated_log_t = now
+                self.get_logger().info(
+                    f"Receiving /audio/remote_mic (seq {msg.seq}) but gate is off — "
+                    f"dropped {self.gated_drop_count} chunks while gated off"
+                )
+            return
+        if self.aplay is not None and self.aplay.poll() is not None:
+            self._stop_aplay("respawning")
+        if self.aplay is None:
+            self._spawn_aplay()
+        try:
+            # int16[] samples -> little-endian raw bytes for aplay's stdin.
+            self.aplay.stdin.write(bytes(memoryview(msg.samples).cast("B")))
+            self.aplay.stdin.flush()
+        except (BrokenPipeError, OSError):
+            self._stop_aplay("write failed")
+            return
+        self.chunks_played += 1
+        if self.chunks_played == 1:
+            self.get_logger().info(f"Playing (first chunk: seq {msg.seq}, rate {msg.rate}, {len(msg.samples)} samples)")
+
+    def check_flow(self):
         if not self.play_enabled:
             return
-        if self.aplay.poll() is not None:
-            self.get_logger().error("aplay exited; shutting down")
-            rclpy.shutdown()
-            return
-        # int16[] samples -> little-endian raw bytes for aplay's stdin.
-        self.aplay.stdin.write(bytes(memoryview(msg.samples).cast("B")))
-        self.aplay.stdin.flush()
+        now = time.monotonic()
+        since = now - max(self.last_audio_t or 0.0, self.enabled_t or 0.0)
+        if since > NO_AUDIO_WARN_S:
+            if not self.no_audio_warned:
+                self.no_audio_warned = True
+                self.get_logger().warning(
+                    f"Gate is ON but no /audio/remote_mic data for {since:.0f}s — "
+                    "is the operator mic toggle on and the WebRTC peer connected?"
+                )
+        elif self.no_audio_warned:
+            self.no_audio_warned = False
+            self.get_logger().info("Audio flow resumed")
 
     def destroy_node(self):
-        if self.aplay.stdin:
-            self.aplay.stdin.close()
-        self.aplay.wait()
+        self._stop_aplay("shutdown")
         super().destroy_node()
 
 

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/remote_mic_player.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/remote_mic_player.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
 """Subscribe to /audio/remote_mic and play it through aplay.
 
 The publisher (mars_cam webrtc) emits innate_audio/Audio: S16LE, 48000 Hz, mono,

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_signaling.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_signaling.cpp
@@ -88,6 +88,7 @@ const char* peer_label(const std::string& client_id) {
 void WebRTCStreamer::on_start(const std_msgs::msg::String::SharedPtr msg) {
     std::string source = "live";
     bool request_audio = false;
+    bool request_mic = false;
     std::string client_id;
     std::vector<std::string> videos;
     bool video_specified = false;
@@ -125,6 +126,13 @@ void WebRTCStreamer::on_start(const std_msgs::msg::String::SharedPtr msg) {
         }
         request_audio = json["audio"].get<bool>();
     }
+    if (json.contains("mic")) {
+        if (!json["mic"].is_boolean()) {
+            RCLCPP_WARN(this->get_logger(), "Ignoring START for '%s': mic must be boolean", client_id.c_str());
+            return;
+        }
+        request_mic = json["mic"].get<bool>();
+    }
     if (json.contains("renegotiate")) {
         if (!json["renegotiate"].is_boolean()) {
             RCLCPP_WARN(this->get_logger(), "Ignoring START for '%s': renegotiate must be boolean", client_id.c_str());
@@ -161,9 +169,9 @@ void WebRTCStreamer::on_start(const std_msgs::msg::String::SharedPtr msg) {
     for (const auto& v : videos) {
         video_list += (video_list.empty() ? "" : "+") + v;
     }
-    RCLCPP_INFO(this->get_logger(), "START '%s' (source=%s, video=[%s], audio=%s, renegotiate=%s)", client_id.c_str(),
-                source.c_str(), video_list.c_str(), request_audio ? "requested" : "off",
-                renegotiate ? "true" : "false");
+    RCLCPP_INFO(this->get_logger(), "START '%s' (source=%s, video=[%s], audio=%s, mic=%s, renegotiate=%s)",
+                client_id.c_str(), source.c_str(), video_list.c_str(), request_audio ? "requested" : "off",
+                request_mic ? "requested" : "off", renegotiate ? "true" : "false");
 
     std::lock_guard<std::mutex> lock(peers_mutex_);
 
@@ -178,29 +186,33 @@ void WebRTCStreamer::on_start(const std_msgs::msg::String::SharedPtr msg) {
     const bool audio_active = enable_audio_ && request_audio;
     // Peers negotiate the audio m-line up front (if a mic exists) so toggling is reneg-free, like cameras.
     const bool negotiate_audio = enable_audio_;
+    // Phone-mic (recvonly, browser -> robot) is opt-in per START. Unlike the send audio it is NOT negotiated
+    // up front — it only exists on the offer when the peer asked for it, so adding/removing it renegotiates.
+    const bool negotiate_mic = request_mic;
 
-    if (videos.empty() && !audio_active) {
+    if (videos.empty() && !audio_active && !negotiate_mic) {
         RCLCPP_INFO(this->get_logger(), "START requested no streams; releasing peer");
         destroy_peer(client_id);
         return;
     }
 
     // Stream/audio switch on an already-set-up independent peer (its negotiated m-lines unchanged): flip
-    // which cameras + audio are pushed live, with no renegotiation/ICE — instant, not a reconnect.
+    // which cameras + audio are pushed live, with no renegotiation/ICE — instant, not a reconnect. The mic
+    // m-line's presence is fixed at negotiation, so a change in it forces the reconnect path below.
     if (!renegotiate) {
         auto it = peers_.find(client_id);
-        if (it != peers_.end() && it->second->with_audio == negotiate_audio) {
+        if (it != peers_.end() && it->second->with_audio == negotiate_audio && it->second->with_mic == negotiate_mic) {
             update_peer_active(it->second.get(), videos, audio_active);
             return;
         }
     }
 
-    // Connect (or audio-negotiation change). Peers negotiate ALL cameras up front so future switches stay
+    // Connect (or audio/mic-negotiation change). Peers negotiate ALL cameras up front so future switches stay
     // reneg-free.
     std::vector<std::string> all_cams;
     for (auto& cam : cameras_)
         all_cams.push_back(cam->name);
-    if (!create_peer_transport(client_id, all_cams, videos, negotiate_audio, audio_active)) {
+    if (!create_peer_transport(client_id, all_cams, videos, negotiate_audio, audio_active, negotiate_mic)) {
         RCLCPP_ERROR(this->get_logger(), "Failed to start transport for peer");
     }
 }
@@ -240,12 +252,13 @@ void WebRTCStreamer::on_offer_created(GstPromise* promise, gpointer user_data) {
     // webrtcbin that still holds transceivers is the _connect_input_stream abort. on-negotiation-needed
     // should prevent this, but a dropped offer just trips the connect timeout — an abort kills the robot.
     const SdpMediaCounts counts = count_sdp_media(offer->sdp);
+    const guint expected_audio_lines = (ctx->expected_audio ? 1u : 0u) + (ctx->expected_mic ? 1u : 0u);
     const bool missing_video = counts.video < ctx->expected_videos;
-    const bool missing_audio = ctx->expected_audio && counts.audio == 0;
+    const bool missing_audio = counts.audio < expected_audio_lines;
     if (missing_video || missing_audio) {
-        RCLCPP_WARN(self->get_logger(), "Dropping incomplete offer for '%s' (video=%u/%u audio=%u%s)",
+        RCLCPP_WARN(self->get_logger(), "Dropping incomplete offer for '%s' (video=%u/%u audio=%u/%u)",
                     peer_label(ctx->client_id), counts.video, ctx->expected_videos, counts.audio,
-                    ctx->expected_audio ? " required" : "");
+                    expected_audio_lines);
         // Do not retry create-offer on this same webrtcbin; an immediate second offer can disrupt it. The
         // client offer watchdog will send a renegotiate START, which creates a fresh transport; until then
         // the connect timeout releases this peer. The offer-once latch (set when this offer was kicked off)
@@ -279,12 +292,13 @@ void WebRTCStreamer::apply_answer(Peer* peer, const std::string& sdp) {
         return;
     }
     const SdpMediaCounts counts = count_sdp_media(sdp_msg);
+    const guint expected_audio_lines = (peer->with_audio ? 1u : 0u) + (peer->with_mic ? 1u : 0u);
     const bool missing_video = counts.video < peer->videos.size();
-    const bool missing_audio = peer->with_audio && counts.audio == 0;
+    const bool missing_audio = counts.audio < expected_audio_lines;
     if (missing_video || missing_audio) {
-        RCLCPP_WARN(this->get_logger(), "Ignoring incomplete SDP answer for '%s' (video=%u/%zu audio=%u%s)",
+        RCLCPP_WARN(this->get_logger(), "Ignoring incomplete SDP answer for '%s' (video=%u/%zu audio=%u/%u)",
                     peer_label(peer->client_id), counts.video, peer->videos.size(), counts.audio,
-                    peer->with_audio ? " required" : "");
+                    expected_audio_lines);
         gst_sdp_message_free(sdp_msg);
         return;
     }
@@ -339,7 +353,8 @@ void WebRTCStreamer::deliver_ice(const std::string& client_id, const std::string
     auto it = peers_.find(client_id);
     if (it != peers_.end()) {
         Peer* peer = it->second.get();
-        const int max_mline = static_cast<int>(peer->videos.size()) + (peer->with_audio ? 1 : 0);
+        const int max_mline =
+            static_cast<int>(peer->videos.size()) + (peer->with_audio ? 1 : 0) + (peer->with_mic ? 1 : 0);
         if (mline >= max_mline) {
             RCLCPP_WARN(this->get_logger(), "Ignoring ICE for '%s': m-line %d outside negotiated range [0,%d)",
                         client_id.c_str(), mline, max_mline - 1);

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_signaling.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_signaling.cpp
@@ -186,11 +186,12 @@ void WebRTCStreamer::on_start(const std_msgs::msg::String::SharedPtr msg) {
     const bool audio_active = enable_audio_ && request_audio;
     // Peers negotiate the audio m-line up front (if a mic exists) so toggling is reneg-free, like cameras.
     const bool negotiate_audio = enable_audio_;
-    // Phone-mic (recvonly, browser -> robot) is opt-in per START. Unlike the send audio it is NOT negotiated
-    // up front — it only exists on the offer when the peer asked for it, so adding/removing it renegotiates.
-    const bool negotiate_mic = request_mic;
+    // Phone-mic (recvonly, browser -> robot): ALWAYS negotiated, like the send audio, so the browser flips
+    // its track live (replaceTrack) with no renegotiation. Whether audio flows is the browser's choice;
+    // START's mic flag only participates in the release decision below.
+    const bool negotiate_mic = true;
 
-    if (videos.empty() && !audio_active && !negotiate_mic) {
+    if (videos.empty() && !audio_active && !request_mic) {
         RCLCPP_INFO(this->get_logger(), "START requested no streams; releasing peer");
         destroy_peer(client_id);
         return;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -164,7 +164,7 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     RCLCPP_INFO(this->get_logger(), "WebRTC Streamer ready (%zu cameras, source: %s, compressed: %s)", cameras_.size(),
                 current_source_.c_str(), use_compressed_images_ ? "true" : "false");
     RCLCPP_INFO(this->get_logger(), "  Mic audio: %s", enable_audio_ ? "enabled (opt-in per peer)" : "disabled");
-    RCLCPP_INFO(this->get_logger(), "  Inbound phone-mic: opt-in per peer (START mic:true) -> %s",
+    RCLCPP_INFO(this->get_logger(), "  Inbound phone-mic: m-line always negotiated (browser flips track live) -> %s",
                 remote_mic_topic_.c_str());
     RCLCPP_INFO(this->get_logger(), "  Local STUN: %s", enable_local_stun_ ? "enabled" : "disabled");
     RCLCPP_INFO(this->get_logger(), "  RTCP-inactivity teardown: %.1f s", rtcp_inactivity_timeout_s_);

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -84,6 +84,7 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     this->declare_parameter("enable_audio", true);
     this->declare_parameter("audio_source_element", "alsasrc");
     this->declare_parameter("audio_capture_device", "");
+    this->declare_parameter("remote_mic_topic", "/audio/remote_mic");
     this->declare_parameter("playout_min_delay_ms", 0);
     this->declare_parameter("playout_max_delay_ms", 40);
     this->declare_parameter("enable_local_stun", true);
@@ -98,6 +99,7 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     enable_audio_ = this->get_parameter("enable_audio").as_bool();
     audio_source_element_ = this->get_parameter("audio_source_element").as_string();
     audio_capture_device_ = this->get_parameter("audio_capture_device").as_string();
+    remote_mic_topic_ = this->get_parameter("remote_mic_topic").as_string();
     playout_min_delay_ms_ = static_cast<guint>(this->get_parameter("playout_min_delay_ms").as_int());
     playout_max_delay_ms_ = static_cast<guint>(this->get_parameter("playout_max_delay_ms").as_int());
     enable_local_stun_ = this->get_parameter("enable_local_stun").as_bool();
@@ -127,6 +129,9 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     offer_id_pub_ = this->create_publisher<std_msgs::msg::String>("/webrtc/offer_id", 10);
     ice_out_id_pub_ = this->create_publisher<std_msgs::msg::String>("/webrtc/ice_out_id", 10);
     active_streams_pub_ = this->create_publisher<std_msgs::msg::String>("/webrtc/active_streams", 10);
+    // Decoded inbound phone-mic PCM. sensor_data QoS (best-effort): mic audio is a lossy live stream, and
+    // the Audio.msg seq field lets a consumer detect the drops rather than block on them.
+    remote_mic_pub_ = this->create_publisher<innate_audio::msg::Audio>(remote_mic_topic_, rclcpp::SensorDataQoS());
 
     start_sub_ = this->create_subscription<std_msgs::msg::String>(
         "/webrtc/start", 10, std::bind(&WebRTCStreamer::on_start, this, std::placeholders::_1));
@@ -159,6 +164,8 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     RCLCPP_INFO(this->get_logger(), "WebRTC Streamer ready (%zu cameras, source: %s, compressed: %s)", cameras_.size(),
                 current_source_.c_str(), use_compressed_images_ ? "true" : "false");
     RCLCPP_INFO(this->get_logger(), "  Mic audio: %s", enable_audio_ ? "enabled (opt-in per peer)" : "disabled");
+    RCLCPP_INFO(this->get_logger(), "  Inbound phone-mic: opt-in per peer (START mic:true) -> %s",
+                remote_mic_topic_.c_str());
     RCLCPP_INFO(this->get_logger(), "  Local STUN: %s", enable_local_stun_ ? "enabled" : "disabled");
     RCLCPP_INFO(this->get_logger(), "  RTCP-inactivity teardown: %.1f s", rtcp_inactivity_timeout_s_);
 }

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -55,7 +55,7 @@ bool WebRTCStreamer::link_rtp_appsrc(GstElement* webrtc, GstElement* appsrc, Gst
 
 Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const std::vector<std::string>& negotiated,
                                             const std::vector<std::string>& active, bool with_audio,
-                                            bool audio_active) {
+                                            bool audio_active, bool with_mic) {
     if (client_id.empty()) {
         RCLCPP_WARN(this->get_logger(), "Refusing to create WebRTC peer without client_id");
         return nullptr;
@@ -82,6 +82,7 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
     peer->active = active;
     peer->with_audio = with_audio;
     peer->audio_active = with_audio && audio_active;  // can only be active if the m-line was negotiated
+    peer->with_mic = with_mic;                        // recvonly phone-mic m-line (set true below once linked)
     peer->created_ns = std::chrono::steady_clock::now().time_since_epoch().count();
     peer->webrtc = gst_bin_get_by_name(GST_BIN(pipeline), "webrtc");
     if (!peer->webrtc) {
@@ -121,10 +122,10 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
     if (ok && peer->with_audio) {
         GstElement* asrc = gst_bin_get_by_name(GST_BIN(pipeline), "rtp_audio");
         if (asrc) {
-            GstCaps* caps =
-                gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, "audio", "encoding-name",
-                                    G_TYPE_STRING, "OPUS", "clock-rate", G_TYPE_INT, 48000, "encoding-params",
-                                    G_TYPE_STRING, "2", "payload", G_TYPE_INT, 98, nullptr);
+            GstCaps* caps = gst_caps_new_simple(
+                "application/x-rtp", "media", G_TYPE_STRING, "audio", "encoding-name", G_TYPE_STRING, "OPUS",
+                "clock-rate", G_TYPE_INT, 48000, "encoding-params", G_TYPE_STRING, "2", "payload", G_TYPE_INT,
+                kAudioSendPayloadType, nullptr);
             if (link_rtp_appsrc(peer->webrtc, asrc, caps, 1 * 1024 * 1024)) {
                 peer->rtp["audio"] = asrc;  // keep the ref
             } else {
@@ -143,6 +144,26 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         return nullptr;  // ~Peer() tears down the pipeline + the rtp appsrcs stored so far
     }
 
+    // Inbound phone-mic (recvonly): add an opus transceiver so the offer carries a recvonly audio m-line
+    // (browser -> robot). No appsrc — the RTP arrives on a webrtcbin src pad, handled by on_incoming_pad.
+    // Added as the LAST m-line, after the video/send-audio appsrcs, so its index is deterministic.
+    if (with_mic) {
+        GstCaps* caps = gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, "audio", "encoding-name",
+                                            G_TYPE_STRING, "OPUS", "clock-rate", G_TYPE_INT, 48000, "encoding-params",
+                                            G_TYPE_STRING, "2", "payload", G_TYPE_INT, kMicRecvPayloadType, nullptr);
+        GstWebRTCRTPTransceiver* trans = nullptr;
+        g_signal_emit_by_name(peer->webrtc, "add-transceiver", GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY, caps,
+                              &trans);
+        gst_caps_unref(caps);
+        if (trans) {
+            gst_object_unref(trans);
+            g_signal_connect(peer->webrtc, "pad-added", G_CALLBACK(on_incoming_pad), this);
+        } else {
+            RCLCPP_WARN(this->get_logger(), "Failed to add recvonly mic transceiver; no phone-mic for this peer");
+            peer->with_mic = false;
+        }
+    }
+
     // Tag the webrtcbin with its client_id (ICE-candidate routing) and a copy of its generation token,
     // so the on-negotiation-needed handler can build the offer context lock-free off the element alone.
     g_object_set_data_full(G_OBJECT(peer->webrtc), "client_id", g_strdup(client_id.c_str()), g_free);
@@ -158,6 +179,7 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
     g_object_set_data(G_OBJECT(peer->webrtc), "mars_expected_videos",
                       GUINT_TO_POINTER(static_cast<guint>(negotiated.size())));
     g_object_set_data(G_OBJECT(peer->webrtc), "mars_expected_audio", GINT_TO_POINTER(peer->with_audio ? 1 : 0));
+    g_object_set_data(G_OBJECT(peer->webrtc), "mars_expected_mic", GINT_TO_POINTER(peer->with_mic ? 1 : 0));
     // Offer-once latch: CAS'd 0->1 by whichever of the racing negotiation-needed callers wins (the explicit
     // one below on the executor thread vs. webrtcbin's queued signal on the GLib thread). A second create-offer
     // would renegotiate and disrupt the live connection; the atomic prevents it.
@@ -290,7 +312,8 @@ void WebRTCStreamer::on_negotiation_needed(GstElement* webrtc, gpointer user_dat
         (*genp)->load(),
         client_id,
         static_cast<guint>(GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(webrtc), "mars_expected_videos"))),
-        static_cast<bool>(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(webrtc), "mars_expected_audio")))};
+        static_cast<bool>(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(webrtc), "mars_expected_audio"))),
+        static_cast<bool>(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(webrtc), "mars_expected_mic")))};
     GstPromise* promise = gst_promise_new_with_change_func(on_offer_created, ctx, offer_context_free);
     g_signal_emit_by_name(webrtc, "create-offer", nullptr, promise);
     RCLCPP_INFO(self->get_logger(), "Negotiation needed for '%s'; offering...", client_id.c_str());
@@ -314,6 +337,106 @@ void WebRTCStreamer::destroy_peer(const std::string& client_id) {
     RCLCPP_INFO(this->get_logger(), "Released peer '%s'", client_id.c_str());
     peers_.erase(it);           // ~Peer() NULLs the transport (joining its streaming threads) and releases the refs
     reconcile_subscriptions();  // last peer wanting a camera may have just left — drop its sub if so
+}
+
+// =============================================================================
+// Inbound phone-mic: webrtcbin src pad -> opus decode -> ROS topic
+// =============================================================================
+
+// webrtcbin fires this when incoming RTP arrives on a negotiated recv m-line (our recvonly mic). Build a
+// decode branch into the peer's transport pipeline and link the pad to it. Runs on a GStreamer thread and
+// does NOT take peers_mutex_ (dynamic linking only), so it can't deadlock against ~Peer.
+void WebRTCStreamer::on_incoming_pad(GstElement* webrtc, GstPad* pad, gpointer user_data) {
+    auto* self = static_cast<WebRTCStreamer*>(user_data);
+    if (GST_PAD_DIRECTION(pad) != GST_PAD_SRC) {
+        return;  // only webrtcbin src pads carry incoming media
+    }
+    // Only handle audio (opus) pads; ignore anything else (there is only the mic recv m-line today).
+    GstCaps* caps = gst_pad_get_current_caps(pad);
+    if (!caps) {
+        caps = gst_pad_query_caps(pad, nullptr);
+    }
+    const GstStructure* st = caps ? gst_caps_get_structure(caps, 0) : nullptr;
+    const char* media = st ? gst_structure_get_string(st, "media") : nullptr;
+    const bool is_audio = media && g_strcmp0(media, "audio") == 0;
+    if (caps) {
+        gst_caps_unref(caps);
+    }
+    if (!is_audio) {
+        return;
+    }
+    const char* cid = static_cast<const char*>(g_object_get_data(G_OBJECT(webrtc), "client_id"));
+
+    GstElement* pipeline = GST_ELEMENT_PARENT(webrtc);  // the peer's transport pipeline
+    if (!pipeline) {
+        return;
+    }
+    // Depayload -> decode -> S16LE/48k/mono -> appsink. drop=false: don't silently discard mic packets;
+    // new-sample pulls immediately, so backpressure stays bounded.
+    const char* desc =
+        "rtpopusdepay ! opusdec ! audioconvert ! audioresample ! "
+        "audio/x-raw,format=S16LE,rate=48000,channels=1,layout=interleaved ! "
+        "appsink name=mic_appsink emit-signals=true sync=false async=false max-buffers=8 drop=false";
+    GError* error = nullptr;
+    GstElement* bin = gst_parse_bin_from_description(desc, TRUE, &error);  // ghost the unlinked depay sink
+    if (error || !bin) {
+        RCLCPP_ERROR(self->get_logger(), "Failed to build mic decode branch for '%s': %s",
+                     (cid && *cid) ? cid : "(peer)", error ? error->message : "unknown");
+        if (error) {
+            g_error_free(error);
+        }
+        if (bin) {
+            gst_object_unref(bin);
+        }
+        return;
+    }
+    gst_bin_add(GST_BIN(pipeline), bin);  // transfer: pipeline owns the bin now
+    GstPad* sinkpad = gst_element_get_static_pad(bin, "sink");
+    if (!sinkpad || gst_pad_link(pad, sinkpad) != GST_PAD_LINK_OK) {
+        RCLCPP_ERROR(self->get_logger(), "Failed to link incoming mic pad for '%s'", (cid && *cid) ? cid : "(peer)");
+        if (sinkpad) {
+            gst_object_unref(sinkpad);
+        }
+        gst_bin_remove(GST_BIN(pipeline), bin);  // unref + tears the half-built branch back down
+        return;
+    }
+    gst_object_unref(sinkpad);
+    gst_element_sync_state_with_parent(bin);
+
+    if (GstElement* appsink = gst_bin_get_by_name(GST_BIN(bin), "mic_appsink")) {
+        g_signal_connect(appsink, "new-sample", G_CALLBACK(on_mic_sample), self);
+        gst_object_unref(appsink);
+    }
+    RCLCPP_INFO(self->get_logger(), "Inbound phone-mic connected for '%s' -> publishing %s",
+                (cid && *cid) ? cid : "(peer)", self->remote_mic_topic_.c_str());
+}
+
+// appsink new-sample: one decoded S16LE/48k/mono PCM chunk -> one innate_audio/Audio message. Runs on the
+// decode branch's streaming thread; publish + now() are thread-safe. seq is node-wide (see remote_mic_seq_).
+GstFlowReturn WebRTCStreamer::on_mic_sample(GstElement* appsink, gpointer user_data) {
+    auto* self = static_cast<WebRTCStreamer*>(user_data);
+    GstSample* sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink));
+    if (!sample) {
+        return GST_FLOW_OK;
+    }
+    if (GstBuffer* buffer = gst_sample_get_buffer(sample)) {
+        GstMapInfo map;
+        if (gst_buffer_map(buffer, &map, GST_MAP_READ)) {
+            const size_t n = map.size / sizeof(int16_t);
+            const int16_t* pcm = reinterpret_cast<const int16_t*>(map.data);
+            innate_audio::msg::Audio msg;
+            msg.header.stamp = self->now();
+            msg.header.frame_id = "remote";
+            msg.seq = self->remote_mic_seq_.fetch_add(1, std::memory_order_relaxed);
+            msg.rate = 48000;
+            msg.channels = 1;
+            msg.samples.assign(pcm, pcm + n);
+            gst_buffer_unmap(buffer, &map);
+            self->remote_mic_pub_->publish(std::move(msg));
+        }
+    }
+    gst_sample_unref(sample);
+    return GST_FLOW_OK;
 }
 
 }  // namespace mars_cam

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -158,6 +158,8 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         if (trans) {
             gst_object_unref(trans);
             g_signal_connect(peer->webrtc, "pad-added", G_CALLBACK(on_incoming_pad), this);
+            RCLCPP_INFO(this->get_logger(), "Negotiated recvonly phone-mic m-line for '%s' (pt %d)",
+                        client_id.c_str(), kMicRecvPayloadType);
         } else {
             RCLCPP_WARN(this->get_logger(), "Failed to add recvonly mic transceiver; no phone-mic for this peer");
             peer->with_mic = false;
@@ -229,9 +231,10 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
     reconcile_subscriptions();  // this peer just negotiated its cameras — make sure they're subscribed
 
     on_negotiation_needed(raw->webrtc, this);
-    RCLCPP_INFO(this->get_logger(), "Peer '%s' transport PLAYING (negotiated=%zu, active=%zu, audio=%s)",
+    RCLCPP_INFO(this->get_logger(), "Peer '%s' transport PLAYING (negotiated=%zu, active=%zu, audio=%s, mic=%s)",
                 client_id.c_str(), negotiated.size(), active.size(),
-                raw->audio_active ? "on" : (raw->with_audio ? "negotiated/off" : "off"));
+                raw->audio_active ? "on" : (raw->with_audio ? "negotiated/off" : "off"),
+                raw->with_mic ? "negotiated" : "off");
     return raw;
 }
 
@@ -432,7 +435,13 @@ GstFlowReturn WebRTCStreamer::on_mic_sample(GstElement* appsink, gpointer user_d
             msg.channels = 1;
             msg.samples.assign(pcm, pcm + n);
             gst_buffer_unmap(buffer, &map);
+            const uint32_t seq = msg.seq;
             self->remote_mic_pub_->publish(std::move(msg));
+            // Flow heartbeat: proves decoded mic audio is being published, and shows whether the
+            // consumers (speaker player / STT) are actually subscribed.
+            RCLCPP_INFO_THROTTLE(self->get_logger(), *self->get_clock(), 30000,
+                                 "Phone-mic flowing: seq %u -> %s (%zu subscriber(s))", seq,
+                                 self->remote_mic_topic_.c_str(), self->remote_mic_pub_->get_subscription_count());
         }
     }
     gst_sample_unref(sample);

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -147,6 +147,8 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
     // Inbound phone-mic (recvonly): add an opus transceiver so the offer carries a recvonly audio m-line
     // (browser -> robot). No appsrc — the RTP arrives on a webrtcbin src pad, handled by on_incoming_pad.
     // Added as the LAST m-line, after the video/send-audio appsrcs, so its index is deterministic.
+    // Always negotiated (with_mic is true for every peer): the browser answers it sendonly with a null
+    // track and flips the real track in via replaceTrack — mic toggles never renegotiate.
     if (with_mic) {
         GstCaps* caps = gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, "audio", "encoding-name",
                                             G_TYPE_STRING, "OPUS", "clock-rate", G_TYPE_INT, 48000, "encoding-params",

--- a/ros2_ws/src/mars_bot/mars_cam/package.xml
+++ b/ros2_ws/src/mars_bot/mars_cam/package.xml
@@ -28,6 +28,7 @@
   <depend>message_filters</depend>
   <depend>OpenCV</depend>
   <depend>mars_msgs</depend>
+  <depend>innate_audio</depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>ament_index_python</exec_depend>

--- a/scripts/play_remote_mic.py
+++ b/scripts/play_remote_mic.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Subscribe to /audio/remote_mic and play it through aplay.
+
+The publisher (mars_cam webrtc) emits innate_audio/Audio: S16LE, 48000 Hz, mono,
+best-effort QoS. We forward the raw int16 samples straight into aplay's stdin.
+
+Playback is gated on a std_msgs/Bool topic (/audio/remote_mic/to_speaker):
+audio only reaches aplay while the latest value is True. Samples received while
+gated off are dropped, so re-enabling plays live audio, not a buffered backlog.
+"""
+
+import subprocess
+import sys
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from std_msgs.msg import Bool
+
+from innate_audio.msg import Audio
+
+RATE = 48000
+CHANNELS = 1
+GATE_TOPIC = "/audio/remote_mic/to_speaker"
+
+
+class RemoteMicPlayer(Node):
+    def __init__(self):
+        super().__init__("remote_mic_player")
+        self.play_enabled = False
+        self.aplay = subprocess.Popen(
+            ["aplay", "-t", "raw", "-f", "S16_LE", "-r", str(RATE), "-c", str(CHANNELS), "-q"],
+            stdin=subprocess.PIPE,
+        )
+        self.sub = self.create_subscription(
+            Audio, "/audio/remote_mic", self.on_audio, qos_profile_sensor_data
+        )
+        self.gate_sub = self.create_subscription(Bool, GATE_TOPIC, self.on_gate, 10)
+        self.get_logger().info(f"Ready: /audio/remote_mic -> aplay, gated on {GATE_TOPIC} (off until True)")
+
+    def on_gate(self, msg: Bool):
+        if msg.data != self.play_enabled:
+            self.play_enabled = msg.data
+            self.get_logger().info(f"Playback {'enabled' if msg.data else 'disabled'}")
+
+    def on_audio(self, msg: Audio):
+        if not self.play_enabled:
+            return
+        if self.aplay.poll() is not None:
+            self.get_logger().error("aplay exited; shutting down")
+            rclpy.shutdown()
+            return
+        # int16[] samples -> little-endian raw bytes for aplay's stdin.
+        self.aplay.stdin.write(bytes(memoryview(msg.samples).cast("B")))
+        self.aplay.stdin.flush()
+
+    def destroy_node(self):
+        if self.aplay.stdin:
+            self.aplay.stdin.close()
+        self.aplay.wait()
+        super().destroy_node()
+
+
+def main():
+    rclpy.init()
+    node = RemoteMicPlayer()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -5428,6 +5428,15 @@ button {
   background: rgb(232 163 61 / 22%);
 }
 
+/* Operator-mic + speaker + stt toggles at the head of the composer — stretch to the input height. */
+.agent-compose .mic-toggle,
+.agent-compose .speaker-toggle,
+.agent-compose .stt-toggle {
+  align-self: stretch;
+  height: auto;
+  border-radius: 11px;
+}
+
 /* Bottom-left "agent active" chip — only while the brain is running. */
 .agent-active-chip {
   position: absolute;

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -5428,7 +5428,8 @@ button {
   background: rgb(232 163 61 / 22%);
 }
 
-/* Operator-mic + speaker + stt toggles at the head of the composer — stretch to the input height. */
+/* Listen + operator-mic + speaker + stt toggles at the head of the composer — stretch to the input height. */
+.agent-compose .audio-toggle,
 .agent-compose .mic-toggle,
 .agent-compose .speaker-toggle,
 .agent-compose .stt-toggle {

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -14,14 +14,16 @@
 // (it originated in the old teleop chat pane, since removed).
 
 import { CHAT_IN_TOPIC, CHAT_OUT_TOPIC, GET_CHAT_HISTORY_SERVICE, SKILL_STATUS_UPDATE_TOPIC } from "../constants.js";
+import { createMicToggle, createSpeakerToggle, createSttToggle } from "../teleop/videoStage.js";
 
 /**
  * @param {HTMLElement} root cockpit root — the panel mounts as a right-edge overlay.
  * @param {import("../rosClient.js").RosClient} rosClient
  * @param {ReturnType<typeof import("../teleop/agentState.js").createAgentState>} agentState
+ * @param {import("../webrtcSession.js").WebRtcSession} session
  * @returns {{ destroy: () => void }}
  */
-export function createAgentPanel(root, rosClient, agentState) {
+export function createAgentPanel(root, rosClient, agentState, session) {
   const selfOrigin = crypto.randomUUID?.() ?? `web-${Date.now()}-${Math.random()}`;
 
   const panel = document.createElement("section");
@@ -90,6 +92,16 @@ export function createAgentPanel(root, rosClient, agentState) {
   // ---- composer -----------------------------------------------------------
   const form = document.createElement("form");
   form.className = "agent-compose";
+  // Operator-mic toggle at the head of the composer (browser mic -> robot ->
+  // /audio/remote_mic), left of the input. Only WebRtcSession can send it; sim's
+  // SimSession has no setMic, so gate on it and skip the toggle there.
+  const micToggle = typeof session?.setMic === "function" ? createMicToggle(form, session) : null;
+  // Speaker-gate toggle beside it: publishes /audio/remote_mic/to_speaker so the
+  // robot plays (or drops) the operator's mic out its physical speaker.
+  const speakerToggle = micToggle ? createSpeakerToggle(form, rosClient) : null;
+  // STT-gate toggle beside it: publishes /audio/remote_mic/stt so the robot
+  // transcribes (or ignores) the operator's mic. Remote STT defaults off.
+  const sttToggle = micToggle ? createSttToggle(form, rosClient) : null;
   const input = document.createElement("textarea");
   input.className = "agent-compose-input";
   input.rows = 1;
@@ -496,6 +508,9 @@ export function createAgentPanel(root, rosClient, agentState) {
 
   return {
     destroy() {
+      micToggle?.destroy();
+      speakerToggle?.destroy();
+      sttToggle?.destroy();
       unsubAgents();
       unsubConn();
       unsubIn();

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -14,16 +14,17 @@
 // (it originated in the old teleop chat pane, since removed).
 
 import { CHAT_IN_TOPIC, CHAT_OUT_TOPIC, GET_CHAT_HISTORY_SERVICE, SKILL_STATUS_UPDATE_TOPIC } from "../constants.js";
-import { createMicToggle, createSpeakerToggle, createSttToggle } from "../teleop/videoStage.js";
+import { createAudioToggle, createMicToggle, createSpeakerToggle, createSttToggle } from "../teleop/videoStage.js";
 
 /**
  * @param {HTMLElement} root cockpit root — the panel mounts as a right-edge overlay.
  * @param {import("../rosClient.js").RosClient} rosClient
  * @param {ReturnType<typeof import("../teleop/agentState.js").createAgentState>} agentState
  * @param {import("../webrtcSession.js").WebRtcSession} session
+ * @param {HTMLAudioElement} [audioEl] video stage's hidden <audio> — enables the robot-mic listen toggle
  * @returns {{ destroy: () => void }}
  */
-export function createAgentPanel(root, rosClient, agentState, session) {
+export function createAgentPanel(root, rosClient, agentState, session, audioEl) {
   const selfOrigin = crypto.randomUUID?.() ?? `web-${Date.now()}-${Math.random()}`;
 
   const panel = document.createElement("section");
@@ -96,6 +97,10 @@ export function createAgentPanel(root, rosClient, agentState, session) {
   // /audio/remote_mic), left of the input. Only WebRtcSession can send it; sim's
   // SimSession has no setMic, so gate on it and skip the toggle there.
   const micToggle = typeof session?.setMic === "function" ? createMicToggle(form, session) : null;
+  // Robot-mic listen toggle: on a real robot TTS plays ONLY out the physical speaker
+  // (/tts/audio is sim-only), so this is the one way to hear agent speech remotely.
+  const audioToggle =
+    micToggle && audioEl && typeof session?.setAudio === "function" ? createAudioToggle(form, session, audioEl) : null;
   // Speaker-gate toggle beside it: publishes /audio/remote_mic/to_speaker so the
   // robot plays (or drops) the operator's mic out its physical speaker.
   const speakerToggle = micToggle ? createSpeakerToggle(form, rosClient) : null;
@@ -509,6 +514,7 @@ export function createAgentPanel(root, rosClient, agentState, session) {
   return {
     destroy() {
       micToggle?.destroy();
+      audioToggle?.destroy();
       speakerToggle?.destroy();
       sttToggle?.destroy();
       unsubAgents();

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -6,9 +6,9 @@
 //
 // Connect/disconnect lifecycle and optimistic mount mirror teleop (see
 // pageMount.js): the view builds immediately and panels fill in once the socket
-// is up. The robot-mic *receive* toggle is omitted (robot speech already plays
-// in-browser via the shell's ttsAudio); the operator-mic *send* toggle lives at
-// the head of the Agent panel's composer.
+// is up. The audio toggles (robot-mic *receive* — the only way to hear agent TTS
+// remotely, since a real robot never publishes /tts/audio — plus the operator-mic
+// *send*/speaker/stt set) live at the head of the Agent panel's composer.
 
 import { ros } from "../rosClient.js";
 import { mountPage } from "../pageMount.js";
@@ -57,7 +57,7 @@ function buildAgentView(root) {
     createTelemetry(telemetryOverlay, ros, { showBattery: !config.simControls }),
     // Square, always-live camera tiles (own prefs key so teleop's defaults stay put).
     createCameraSwitch(root, session, ros, { storeKey: "innate.cameras.agent" }),
-    createAgentPanel(root, ros, agentState, session),
+    createAgentPanel(root, ros, agentState, session, videoStage.audioEl),
     createActiveChip(root, agentState),
     { destroy: () => agentState.destroy() },
   ];

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -6,8 +6,9 @@
 //
 // Connect/disconnect lifecycle and optimistic mount mirror teleop (see
 // pageMount.js): the view builds immediately and panels fill in once the socket
-// is up. No mic toggle here — robot speech already plays in-browser via the
-// shell's ttsAudio.
+// is up. The robot-mic *receive* toggle is omitted (robot speech already plays
+// in-browser via the shell's ttsAudio); the operator-mic *send* toggle lives at
+// the head of the Agent panel's composer.
 
 import { ros } from "../rosClient.js";
 import { mountPage } from "../pageMount.js";
@@ -56,7 +57,7 @@ function buildAgentView(root) {
     createTelemetry(telemetryOverlay, ros, { showBattery: !config.simControls }),
     // Square, always-live camera tiles (own prefs key so teleop's defaults stay put).
     createCameraSwitch(root, session, ros, { storeKey: "innate.cameras.agent" }),
-    createAgentPanel(root, ros, agentState),
+    createAgentPanel(root, ros, agentState, session),
     createActiveChip(root, agentState),
     { destroy: () => agentState.destroy() },
   ];

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -125,6 +125,14 @@ export const ROBOT_INFO_TOPIC = "/robot/info";
 // mobile app's volume slider calls; current value rides on /robot/info.
 export const SET_VOLUME_SERVICE = "/set_volume";
 
+// std_msgs/Bool gate for playing the operator's mic (received on /audio/remote_mic)
+// out the robot's physical speaker. The robot-side player drops samples while false.
+export const REMOTE_MIC_SPEAKER_TOPIC = "/audio/remote_mic/to_speaker";
+
+// std_msgs/Bool gate for transcribing the operator's mic (received on
+// /audio/remote_mic). The robot's MicroInput remote stream is off until this is true.
+export const REMOTE_MIC_STT_TOPIC = "/audio/remote_mic/stt";
+
 // WebRTC signaling over rosbridge. START is a std_msgs/String JSON payload that
 // carries our client_id: {"source":"live","audio":bool,"client_id":"...","video":[...]}.
 // The robot routes offer/answer/ICE on the *_id topics, each enveloped as {client_id, ...}

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -15,7 +15,7 @@ import { drive } from "../driveController.js";
 import { WebRtcSession } from "../webrtcSession.js";
 import { robotSessionFactory } from "../robotSession.js";
 import { mountPage } from "../pageMount.js";
-import { createVideoStage, createAudioToggle } from "./videoStage.js";
+import { createVideoStage, createAudioToggle, createMicToggle } from "./videoStage.js";
 import { createJoystick } from "./joystick.js";
 import { createKeyboardDrive, createWasdChips } from "./keyboardDrive.js";
 import { createHeadTilt } from "./headTilt.js";
@@ -82,6 +82,11 @@ function buildCockpit(root) {
   // is the sim deployment's feature flag (env-driven; false on the real robot).
   if (!config.simControls && videoStage.audioEl) {
     parts.push(createAudioToggle(rightRail, session, videoStage.audioEl));
+  }
+  // Operator-mic toggle (browser mic -> robot). Skipped in the sim: sim uses SimSession (a Three.js
+  // canvas over rosbridge, no WebRTC peer and no setMic), so there is nowhere to send the mic.
+  if (!config.simControls) {
+    parts.push(createMicToggle(rightRail, session));
   }
   parts.push(
     createHeadTilt(rightRail, ros),

--- a/webapp/js/teleop/videoStage.js
+++ b/webapp/js/teleop/videoStage.js
@@ -227,9 +227,9 @@ export function createAudioToggle(parent, session, audioEl) {
 
 /**
  * Operator-mic toggle. Sends the browser microphone up to the robot (browser -> robot -> ROS), the
- * opposite direction from the robot-mic toggle above. The click both requests the recvonly audio m-line
- * (a renegotiating rebuild in the session) and — because setMic acquires getUserMedia — surfaces the
- * permission prompt inside the gesture.
+ * opposite direction from the robot-mic toggle above. The mic m-line is always negotiated, so the click
+ * is a live replaceTrack flip in the session; because setMic acquires getUserMedia, the permission
+ * prompt surfaces inside the gesture.
  * @param {HTMLElement} parent
  * @param {import("../webrtcSession.js").WebRtcSession} session
  * @returns {{ destroy: () => void }}

--- a/webapp/js/teleop/videoStage.js
+++ b/webapp/js/teleop/videoStage.js
@@ -294,21 +294,36 @@ export function createSpeakerToggle(parent, rosClient) {
   };
   render();
 
+  const publishGate = (why) => {
+    if (rosClient.state !== "connected") {
+      console.warn("[speaker-gate] not connected — gate", on, "not sent (" + why + ")");
+      return;
+    }
+    rosClient.publish(REMOTE_MIC_SPEAKER_TOPIC, { data: on });
+    console.log("[speaker-gate] ->", on, "(" + why + ")");
+  };
+
   button.addEventListener("click", () => {
     on = !on;
-    rosClient.publish(REMOTE_MIC_SPEAKER_TOPIC, { data: on });
+    publishGate("click");
     render();
   });
 
-  // Re-assert the gate whenever the socket comes up (the robot's player restarts muted).
+  // Re-assert the gate on reconnect AND periodically while on: publish is fire-and-forget
+  // (dropped if the player node isn't up yet / rws hasn't seen the topic), and the robot's
+  // player restarts muted — a lost Bool would strand the button visually on but silent.
   const unsub = rosClient.onStateChange((state) => {
-    if (state === "connected") rosClient.publish(REMOTE_MIC_SPEAKER_TOPIC, { data: on });
+    if (state === "connected") publishGate("reconnect");
   });
+  const reassert = setInterval(() => {
+    if (on) publishGate("re-assert");
+  }, 5000);
 
   parent.appendChild(button);
   return {
     destroy() {
       unsub();
+      clearInterval(reassert);
       button.remove();
     },
   };
@@ -342,21 +357,36 @@ export function createSttToggle(parent, rosClient) {
   };
   render();
 
+  const publishGate = (why) => {
+    if (rosClient.state !== "connected") {
+      console.warn("[stt-gate] not connected — gate", on, "not sent (" + why + ")");
+      return;
+    }
+    rosClient.publish(REMOTE_MIC_STT_TOPIC, { data: on });
+    console.log("[stt-gate] ->", on, "(" + why + ")");
+  };
+
   button.addEventListener("click", () => {
     on = !on;
-    rosClient.publish(REMOTE_MIC_STT_TOPIC, { data: on });
+    publishGate("click");
     render();
   });
 
-  // Re-assert the gate whenever the socket comes up (the remote STT stream defaults off).
+  // Re-assert on reconnect AND periodically while on: publish is fire-and-forget and the
+  // remote STT stream defaults off, so a Bool lost during an input_manager restart would
+  // strand the button visually on with no transcription.
   const unsub = rosClient.onStateChange((state) => {
-    if (state === "connected") rosClient.publish(REMOTE_MIC_STT_TOPIC, { data: on });
+    if (state === "connected") publishGate("reconnect");
   });
+  const reassert = setInterval(() => {
+    if (on) publishGate("re-assert");
+  }, 5000);
 
   parent.appendChild(button);
   return {
     destroy() {
       unsub();
+      clearInterval(reassert);
       button.remove();
     },
   };

--- a/webapp/js/teleop/videoStage.js
+++ b/webapp/js/teleop/videoStage.js
@@ -309,11 +309,13 @@ export function createSpeakerToggle(parent, rosClient) {
     render();
   });
 
-  // Re-assert the gate on reconnect AND periodically while on: publish is fire-and-forget
-  // (dropped if the player node isn't up yet / rws hasn't seen the topic), and the robot's
-  // player restarts muted — a lost Bool would strand the button visually on but silent.
+  // Re-assert the gate on reconnect AND periodically, but only while ON: publish is
+  // fire-and-forget (dropped if the player node isn't up yet), and the robot's player
+  // restarts muted — a lost true would strand the button visually on but silent. Never
+  // push false on reconnect: off is the robot default, and an idle second tab doing so
+  // would stomp the tab that has it on.
   const unsub = rosClient.onStateChange((state) => {
-    if (state === "connected") publishGate("reconnect");
+    if (state === "connected" && on) publishGate("reconnect");
   });
   const reassert = setInterval(() => {
     if (on) publishGate("re-assert");
@@ -372,11 +374,12 @@ export function createSttToggle(parent, rosClient) {
     render();
   });
 
-  // Re-assert on reconnect AND periodically while on: publish is fire-and-forget and the
-  // remote STT stream defaults off, so a Bool lost during an input_manager restart would
-  // strand the button visually on with no transcription.
+  // Re-assert on reconnect AND periodically, but only while ON: the remote STT stream
+  // defaults off, so a lost true would strand the button visually on with no
+  // transcription — while a false pushed on reconnect from an idle second tab would
+  // stomp the tab that has it on (off is the default; it never needs asserting).
   const unsub = rosClient.onStateChange((state) => {
-    if (state === "connected") publishGate("reconnect");
+    if (state === "connected" && on) publishGate("reconnect");
   });
   const reassert = setInterval(() => {
     if (on) publishGate("re-assert");

--- a/webapp/js/teleop/videoStage.js
+++ b/webapp/js/teleop/videoStage.js
@@ -6,6 +6,8 @@
 // audio toggle, which must flip the track and call audio.play() inside the
 // click gesture to satisfy autoplay policy.
 
+import { REMOTE_MIC_SPEAKER_TOPIC, REMOTE_MIC_STT_TOPIC } from "../constants.js";
+
 /**
  * @param {HTMLElement} parent
  * @param {import("../webrtcSession.js").WebRtcSession} session
@@ -252,6 +254,103 @@ export function createMicToggle(parent, session) {
 
   button.addEventListener("click", () => {
     void session.setMic(!session.state.micRequested);
+  });
+
+  parent.appendChild(button);
+  return {
+    destroy() {
+      unsub();
+      button.remove();
+    },
+  };
+}
+
+/**
+ * Speaker-gate toggle: publishes REMOTE_MIC_SPEAKER_TOPIC (std_msgs/Bool) to
+ * decide whether the operator's mic (received on the robot as /audio/remote_mic)
+ * is played out the robot's physical speaker. Purely a command — the state is
+ * local; re-published on (re)connect so a robot restart doesn't strand it.
+ * @param {HTMLElement} parent
+ * @param {import("../rosClient.js").RosClient} rosClient
+ * @returns {{ destroy: () => void }}
+ */
+export function createSpeakerToggle(parent, rosClient) {
+  let on = false;
+  const button = document.createElement("button");
+  button.className = "icon-toggle speaker-toggle";
+  button.type = "button";
+  button.innerHTML =
+    '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M11 5 6.5 9H3.5v6h3L11 19z"/>' +
+    '<path class="wave wave1" d="M15 9.5a4 4 0 0 1 0 5"/>' +
+    '<path class="wave wave2" d="M17.5 7a8 8 0 0 1 0 10"/>' +
+    "</svg>";
+
+  const render = () => {
+    button.classList.toggle("active", on);
+    button.title = on ? "Playing on robot speaker — click to mute" : "Play your voice on the robot speaker";
+    button.setAttribute("aria-pressed", String(on));
+    button.setAttribute("aria-label", "Robot speaker output");
+  };
+  render();
+
+  button.addEventListener("click", () => {
+    on = !on;
+    rosClient.publish(REMOTE_MIC_SPEAKER_TOPIC, { data: on });
+    render();
+  });
+
+  // Re-assert the gate whenever the socket comes up (the robot's player restarts muted).
+  const unsub = rosClient.onStateChange((state) => {
+    if (state === "connected") rosClient.publish(REMOTE_MIC_SPEAKER_TOPIC, { data: on });
+  });
+
+  parent.appendChild(button);
+  return {
+    destroy() {
+      unsub();
+      button.remove();
+    },
+  };
+}
+
+/**
+ * STT-gate toggle: publishes REMOTE_MIC_STT_TOPIC (std_msgs/Bool) to decide
+ * whether the operator's mic (received on the robot as /audio/remote_mic) is
+ * transcribed. Purely a command — the state is local; re-published on (re)connect
+ * so a robot restart doesn't strand it (the remote STT stream defaults off).
+ * @param {HTMLElement} parent
+ * @param {import("../rosClient.js").RosClient} rosClient
+ * @returns {{ destroy: () => void }}
+ */
+export function createSttToggle(parent, rosClient) {
+  let on = false;
+  const button = document.createElement("button");
+  button.className = "icon-toggle stt-toggle";
+  button.type = "button";
+  button.innerHTML =
+    '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<rect x="3" y="5" width="18" height="14" rx="2"/>' +
+    '<path d="M7 10h4M7 14h7"/>' +
+    "</svg>";
+
+  const render = () => {
+    button.classList.toggle("active", on);
+    button.title = on ? "Transcribing your voice — click to stop" : "Transcribe your voice to the agent";
+    button.setAttribute("aria-pressed", String(on));
+    button.setAttribute("aria-label", "Transcribe operator mic");
+  };
+  render();
+
+  button.addEventListener("click", () => {
+    on = !on;
+    rosClient.publish(REMOTE_MIC_STT_TOPIC, { data: on });
+    render();
+  });
+
+  // Re-assert the gate whenever the socket comes up (the remote STT stream defaults off).
+  const unsub = rosClient.onStateChange((state) => {
+    if (state === "connected") rosClient.publish(REMOTE_MIC_STT_TOPIC, { data: on });
   });
 
   parent.appendChild(button);

--- a/webapp/js/teleop/videoStage.js
+++ b/webapp/js/teleop/videoStage.js
@@ -222,3 +222,43 @@ export function createAudioToggle(parent, session, audioEl) {
     },
   };
 }
+
+/**
+ * Operator-mic toggle. Sends the browser microphone up to the robot (browser -> robot -> ROS), the
+ * opposite direction from the robot-mic toggle above. The click both requests the recvonly audio m-line
+ * (a renegotiating rebuild in the session) and — because setMic acquires getUserMedia — surfaces the
+ * permission prompt inside the gesture.
+ * @param {HTMLElement} parent
+ * @param {import("../webrtcSession.js").WebRtcSession} session
+ * @returns {{ destroy: () => void }}
+ */
+export function createMicToggle(parent, session) {
+  const button = document.createElement("button");
+  button.className = "icon-toggle mic-toggle";
+  button.type = "button";
+  button.innerHTML =
+    '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<rect x="9" y="3" width="6" height="11" rx="3"/>' +
+    '<path d="M5.5 11a6.5 6.5 0 0 0 13 0"/>' +
+    '<path d="M12 17.5V21"/>' +
+    "</svg>";
+
+  const unsub = session.onChange((state) => {
+    button.classList.toggle("active", state.micRequested);
+    button.title = state.micRequested ? "Your mic on — click to mute" : "Your mic off — click to talk";
+    button.setAttribute("aria-pressed", String(state.micRequested));
+    button.setAttribute("aria-label", "Your microphone");
+  });
+
+  button.addEventListener("click", () => {
+    void session.setMic(!session.state.micRequested);
+  });
+
+  parent.appendChild(button);
+  return {
+    destroy() {
+      unsub();
+      button.remove();
+    },
+  };
+}

--- a/webapp/js/types.d.ts
+++ b/webapp/js/types.d.ts
@@ -258,6 +258,8 @@ interface WebRtcState {
   videoLive: boolean[];
   audioStream: MediaStream | null;
   audioRequested: boolean;
+  /** True while the operator's microphone is being SENT to the robot (browser -> robot -> ROS). */
+  micRequested: boolean;
   /** Live RTCPeerConnection.iceConnectionState ("new" before a peer exists). */
   iceState: string;
   /** True once we've fallen back to a public STUN server after the local-only config failed. */

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -259,6 +259,7 @@ export class WebRtcSession {
     if (!this.#started || this.#ros.state !== "connected") return;
     // Adding/removing the recvonly mic m-line requires a fresh offer, so re-handshake rather than sending a
     // reneg-free active-toggle START. #onOffer binds the mic track to the new offer's recvonly audio m-line.
+    console.log("[webrtc] operator mic ->", on, "(mic m-line is per-request: full re-handshake, not a live flip)");
     this.#handshakeAttempts = 0;
     this.#handshake();
   }

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -12,6 +12,11 @@
 // Tracks: audio starts disabled (robot mic must never be audible before the
 // operator opts in); video dispatched by transceiver mid with arrival-order
 // fallback; only the main camera is exposed (the arm camera is ignored in v1).
+// Operator mic (setMic) sends the reverse direction — the browser's mic up to
+// the robot on a recvonly audio m-line the robot only offers when we ask, so
+// toggling it re-handshakes (the m-line isn't negotiated up front like the
+// robot-mic one); #onOffer binds the local mic track to that m-line before
+// answering.
 //
 // Self-heal: 30 s initial-handshake watchdog, ICE disconnected/failed
 // persisting 10 s → re-handshake, and a re-handshake whenever the rosbridge
@@ -50,6 +55,31 @@ const OFFER_GUARD_RESET_MS = 1_000;
 // refreshing feel faster.
 const MAX_HANDSHAKE_ATTEMPTS = 3;
 
+/**
+ * Mid of the robot's recvonly audio m-line — the phone-mic slot we send into — or null if absent.
+ * The robot marks this m-line a=recvonly (it receives); the robot->browser send-audio m-line is
+ * a=sendonly, so recvonly uniquely identifies the mic slot regardless of m-line order.
+ * @param {string} sdp
+ * @returns {string | null}
+ */
+function micRecvMid(sdp) {
+  let inAudio = false;
+  let mid = null;
+  let recvonly = false;
+  for (const line of sdp.split(/\r?\n/)) {
+    if (line.startsWith("m=")) {
+      if (inAudio && recvonly && mid) return mid; // the section that just ended was the mic slot
+      inAudio = line.startsWith("m=audio");
+      mid = null;
+      recvonly = false;
+    } else if (inAudio) {
+      if (line.startsWith("a=mid:")) mid = line.slice(6).trim();
+      else if (line.trim() === "a=recvonly") recvonly = true;
+    }
+  }
+  return inAudio && recvonly && mid ? mid : null;
+}
+
 export class WebRtcSession {
   /** @type {import("./rosClient.js").RosClient} */ #ros;
   /** @type {RTCPeerConnection | null} */ #pc = null;
@@ -60,6 +90,7 @@ export class WebRtcSession {
     videoLive: [],
     audioStream: null,
     audioRequested: false,
+    micRequested: false,
     iceState: "new",
     stunFallback: false,
   };
@@ -68,6 +99,11 @@ export class WebRtcSession {
 
   #started = false;
   #builtWithAudio = false;
+  // Operator microphone captured for sending to the robot. Kept across pc rebuilds (like the video
+  // freeze-frame) so a re-handshake re-binds the same track without re-prompting for permission; only
+  // stopped when the operator turns the mic off or the session stops.
+  /** @type {MediaStream | null} */ #micStream = null;
+  /** @type {MediaStreamTrack | null} */ #micTrack = null;
   #processingOffer = false;
   #remoteDescriptionSet = false;
   /** @type {RTCIceCandidateInit[]} */ #iceQueue = [];
@@ -150,9 +186,17 @@ export class WebRtcSession {
     this.#useFallbackStun = false;
     this.#closePc();
     this.#clearAudioDebounce();
-    // No mic stream once stopped (e.g. leaving the teleop page) — let TTS play.
+    this.#releaseMic();
+    // No robot-mic stream once stopped (e.g. leaving the teleop page) — let TTS play.
     setMicAudioActive(false);
-    this.#patch({ status: "idle", videoStream: null, audioStream: null, iceState: "new", stunFallback: false });
+    this.#patch({
+      status: "idle",
+      videoStream: null,
+      audioStream: null,
+      micRequested: false,
+      iceState: "new",
+      stunFallback: false,
+    });
   }
 
   destroy() {
@@ -180,12 +224,91 @@ export class WebRtcSession {
     if (!this.#started || this.#ros.state !== "connected") return;
     if (this.#pc) {
       this.#ros.publish(WEBRTC_START_TOPIC, {
-        data: JSON.stringify({ source: "live", audio: on, client_id: this.#clientId, video: this.#activeCams }),
+        data: JSON.stringify({
+          source: "live",
+          audio: on,
+          mic: this.#state.micRequested,
+          client_id: this.#clientId,
+          video: this.#activeCams,
+        }),
       });
       console.log("[webrtc] audio toggle ->", on, "(no reconnect)");
     } else {
       // No live peer (map-only, all cameras off) — bring one up so the mic can flow.
       this.#handshake();
+    }
+  }
+
+  /**
+   * Toggle sending the OPERATOR's microphone up to the robot (browser -> robot -> ROS, played out the
+   * robot). This is the opposite direction from setAudio, which RECEIVES the robot's mic. The recvonly
+   * m-line is NOT negotiated up front (the robot only offers it when we ask), so toggling adds/removes an
+   * m-line — a renegotiating rebuild, not a live flip. Acquiring the mic here (inside the click gesture)
+   * both keeps the permission prompt off the happy path and lets a denial leave us cleanly off.
+   * @param {boolean} on
+   * @returns {Promise<void>}
+   */
+  async setMic(on) {
+    if (this.#state.micRequested === on) return;
+    if (on) {
+      if (!(await this.#acquireMic())) return; // permission denied / no device — stay off
+    } else {
+      this.#releaseMic();
+    }
+    this.#patch({ micRequested: on });
+    if (!this.#started || this.#ros.state !== "connected") return;
+    // Adding/removing the recvonly mic m-line requires a fresh offer, so re-handshake rather than sending a
+    // reneg-free active-toggle START. #onOffer binds the mic track to the new offer's recvonly audio m-line.
+    this.#handshakeAttempts = 0;
+    this.#handshake();
+  }
+
+  /** @returns {Promise<boolean>} true once a live mic track is held. */
+  async #acquireMic() {
+    if (this.#micTrack && this.#micTrack.readyState === "live") return true;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      this.#micStream = stream;
+      this.#micTrack = stream.getAudioTracks()[0] ?? null;
+      return this.#micTrack != null;
+    } catch (err) {
+      console.warn("[webrtc] microphone unavailable:", err);
+      return false;
+    }
+  }
+
+  /** Stop and drop the local mic track, releasing the OS microphone. */
+  #releaseMic() {
+    if (this.#micStream) {
+      for (const track of this.#micStream.getTracks()) track.stop();
+    }
+    this.#micStream = null;
+    this.#micTrack = null;
+  }
+
+  /**
+   * Bind the operator mic track to the robot-offered recvonly audio m-line so this pc's answer sends it.
+   * A no-op unless the mic is requested and the offer actually carries the m-line.
+   * @param {RTCPeerConnection} pc owning connection
+   * @param {string} offerSdp the robot's offer SDP (already applied via setRemoteDescription)
+   * @returns {Promise<void>}
+   */
+  async #attachMic(pc, offerSdp) {
+    const track = this.#micTrack;
+    if (!this.#state.micRequested || !track) return;
+    const mid = micRecvMid(offerSdp);
+    if (!mid) {
+      console.warn("[webrtc] mic requested but offer has no recvonly audio m-line");
+      return;
+    }
+    const transceiver = pc.getTransceivers().find((t) => t.mid === mid);
+    if (!transceiver) return;
+    try {
+      transceiver.direction = "sendonly";
+      await transceiver.sender.replaceTrack(track);
+      console.log("[webrtc] operator mic attached (mid=" + mid + ")");
+    } catch (err) {
+      console.warn("[webrtc] failed to attach operator mic:", err);
     }
   }
 
@@ -210,7 +333,13 @@ export class WebRtcSession {
       return;
     }
     this.#ros.publish(WEBRTC_START_TOPIC, {
-      data: JSON.stringify({ source: "live", video: next, audio: this.#state.audioRequested, client_id: this.#clientId }),
+      data: JSON.stringify({
+        source: "live",
+        video: next,
+        audio: this.#state.audioRequested,
+        mic: this.#state.micRequested,
+        client_id: this.#clientId,
+      }),
     });
     console.log("[webrtc] active cameras ->", next.join("+"), "(no reconnect)");
   }
@@ -243,13 +372,13 @@ export class WebRtcSession {
     // Map-only view: no cameras (and no mic) requested. Tear the peer down and stay idle — the robot
     // releases its side on an empty START, and arming a watchdog for media that will never come would
     // just thrash. The map runs over rosbridge, so it's unaffected. (Mic-only still builds a peer below.)
-    if (this.#activeCams.length === 0 && !this.#state.audioRequested) {
+    if (this.#activeCams.length === 0 && !this.#state.audioRequested && !this.#state.micRequested) {
       this.#closePc();
       this.#videoLive = [];
       this.#patch({ status: "idle", videoStream: null, ...this.#videoArrays() });
       if (this.#ros.state === "connected") {
         this.#ros.publish(WEBRTC_START_TOPIC, {
-          data: JSON.stringify({ source: "live", video: [], audio: false, client_id: this.#clientId }),
+          data: JSON.stringify({ source: "live", video: [], audio: false, mic: false, client_id: this.#clientId }),
         });
       }
       console.log("[webrtc] no streams requested — peer released (map-only)");
@@ -334,12 +463,17 @@ export class WebRtcSession {
       data: JSON.stringify({
         source: "live",
         audio: this.#state.audioRequested,
+        mic: this.#state.micRequested,
         client_id: this.#clientId,
         renegotiate: true,
         video: this.#activeCams,
       }),
     });
-    console.log("[webrtc] handshake: START sent", { client_id: this.#clientId, audio: this.#builtWithAudio });
+    console.log("[webrtc] handshake: START sent", {
+      client_id: this.#clientId,
+      audio: this.#builtWithAudio,
+      mic: this.#state.micRequested,
+    });
   }
 
   /**
@@ -459,6 +593,12 @@ export class WebRtcSession {
         }
       }
       this.#iceQueue = [];
+
+      // Attach the operator mic to the robot's recvonly audio m-line before answering, so the answer's
+      // matching m-line is sendonly (browser -> robot). Must happen after setRemoteDescription (the
+      // transceiver only exists once the offer is applied) and before createAnswer.
+      await this.#attachMic(pc, sdp);
+      if (this.#pc !== pc) return;
 
       const answer = await pc.createAnswer();
       if (this.#pc !== pc) return;

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -13,10 +13,9 @@
 // operator opts in); video dispatched by transceiver mid with arrival-order
 // fallback; only the main camera is exposed (the arm camera is ignored in v1).
 // Operator mic (setMic) sends the reverse direction — the browser's mic up to
-// the robot on a recvonly audio m-line the robot only offers when we ask, so
-// toggling it re-handshakes (the m-line isn't negotiated up front like the
-// robot-mic one); #onOffer binds the local mic track to that m-line before
-// answering.
+// the robot on a recvonly audio m-line the robot always offers. #onOffer binds
+// that m-line sendonly (with the current mic track, or none) before answering,
+// so toggling the mic is a live replaceTrack flip — no renegotiation.
 //
 // Self-heal: 30 s initial-handshake watchdog, ICE disconnected/failed
 // persisting 10 s → re-handshake, and a re-handshake whenever the rosbridge
@@ -104,6 +103,8 @@ export class WebRtcSession {
   // stopped when the operator turns the mic off or the session stops.
   /** @type {MediaStream | null} */ #micStream = null;
   /** @type {MediaStreamTrack | null} */ #micTrack = null;
+  // Sender of the always-negotiated mic m-line on the current pc; replaceTrack on it flips the mic live.
+  /** @type {RTCRtpSender | null} */ #micSender = null;
   #processingOffer = false;
   #remoteDescriptionSet = false;
   /** @type {RTCIceCandidateInit[]} */ #iceQueue = [];
@@ -241,9 +242,9 @@ export class WebRtcSession {
 
   /**
    * Toggle sending the OPERATOR's microphone up to the robot (browser -> robot -> ROS, played out the
-   * robot). This is the opposite direction from setAudio, which RECEIVES the robot's mic. The recvonly
-   * m-line is NOT negotiated up front (the robot only offers it when we ask), so toggling adds/removes an
-   * m-line — a renegotiating rebuild, not a live flip. Acquiring the mic here (inside the click gesture)
+   * robot). This is the opposite direction from setAudio, which RECEIVES the robot's mic. The robot
+   * always negotiates the recvonly mic m-line and #onOffer binds it sendonly, so toggling is a live
+   * replaceTrack flip — no renegotiation, no reconnect. Acquiring the mic here (inside the click gesture)
    * both keeps the permission prompt off the happy path and lets a denial leave us cleanly off.
    * @param {boolean} on
    * @returns {Promise<void>}
@@ -257,9 +258,28 @@ export class WebRtcSession {
     }
     this.#patch({ micRequested: on });
     if (!this.#started || this.#ros.state !== "connected") return;
-    // Adding/removing the recvonly mic m-line requires a fresh offer, so re-handshake rather than sending a
-    // reneg-free active-toggle START. #onOffer binds the mic track to the new offer's recvonly audio m-line.
-    console.log("[webrtc] operator mic ->", on, "(mic m-line is per-request: full re-handshake, not a live flip)");
+    if (this.#pc && this.#micSender) {
+      try {
+        await this.#micSender.replaceTrack(on ? this.#micTrack : null);
+        // Reneg-free START keeps the robot's view of the mic flag current (status/release decisions).
+        this.#ros.publish(WEBRTC_START_TOPIC, {
+          data: JSON.stringify({
+            source: "live",
+            audio: this.#state.audioRequested,
+            mic: on,
+            client_id: this.#clientId,
+            video: this.#activeCams,
+          }),
+        });
+        console.log("[webrtc] operator mic ->", on, "(live replaceTrack, no reconnect)");
+        return;
+      } catch (err) {
+        console.warn("[webrtc] mic replaceTrack failed, falling back to re-handshake:", err);
+      }
+    } else if (this.#pc) {
+      console.warn("[webrtc] no mic sender on this pc (old robot offer?) — re-handshaking");
+    }
+    // No live pc (map-only) or no bound mic sender — a fresh handshake binds the mic in #onOffer.
     this.#handshakeAttempts = 0;
     this.#handshake();
   }
@@ -288,28 +308,29 @@ export class WebRtcSession {
   }
 
   /**
-   * Bind the operator mic track to the robot-offered recvonly audio m-line so this pc's answer sends it.
-   * A no-op unless the mic is requested and the offer actually carries the m-line.
+   * Bind the robot-offered recvonly audio m-line sendonly on this pc — with the current mic track when
+   * the mic is on, or trackless otherwise — and remember its sender so setMic can flip the track live
+   * (replaceTrack, no renegotiation). The robot always offers this m-line.
    * @param {RTCPeerConnection} pc owning connection
    * @param {string} offerSdp the robot's offer SDP (already applied via setRemoteDescription)
    * @returns {Promise<void>}
    */
   async #attachMic(pc, offerSdp) {
-    const track = this.#micTrack;
-    if (!this.#state.micRequested || !track) return;
     const mid = micRecvMid(offerSdp);
     if (!mid) {
-      console.warn("[webrtc] mic requested but offer has no recvonly audio m-line");
+      if (this.#state.micRequested) console.warn("[webrtc] mic requested but offer has no recvonly audio m-line");
       return;
     }
     const transceiver = pc.getTransceivers().find((t) => t.mid === mid);
     if (!transceiver) return;
     try {
       transceiver.direction = "sendonly";
+      const track = this.#state.micRequested ? this.#micTrack : null;
       await transceiver.sender.replaceTrack(track);
-      console.log("[webrtc] operator mic attached (mid=" + mid + ")");
+      this.#micSender = transceiver.sender;
+      console.log("[webrtc] mic m-line bound (mid=" + mid + ", track=" + (track ? "live" : "none") + ")");
     } catch (err) {
-      console.warn("[webrtc] failed to attach operator mic:", err);
+      console.warn("[webrtc] failed to bind mic m-line:", err);
     }
   }
 
@@ -718,6 +739,7 @@ export class WebRtcSession {
   #closePc() {
     this.#clearWatchdog();
     this.#clearDegradeTimer();
+    this.#micSender = null;
     this.#processingOffer = false;
     this.#remoteDescriptionSet = false;
     this.#iceQueue = [];

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -4,12 +4,19 @@
 """
 Microphone Input Device
 
-Connects to microphone hardware and OpenAI's realtime API to get voice transcripts.
-This is a pure Python class with NO ROS dependencies.
+Transcribes voice via OpenAI's realtime API. Runs two independent streams:
+- "local"  — the on-robot hardware mic (arecord), gated by /audio/local_mic/stt (default ON)
+- "remote" — the inbound phone mic on /audio/remote_mic, gated by /audio/remote_mic/stt (default OFF)
+
+Each stream owns its own OpenAI connection and transcribes separately. This is a
+pure Python class with NO ROS dependencies beyond the node handle the manager
+injects (used only to subscribe to the control + remote-audio topics).
 
 Uses proxy services via self.proxy (injected by InputManager).
 """
 
+import array
+import audioop
 import base64
 import json
 import queue
@@ -23,34 +30,37 @@ import sounddevice as sd
 from brain_client.common.logging import UniversalLogger
 from brain_client.inputs.types import InputDevice
 
-DEFAULT_SAMPLE_RATE = 24_000
+DEFAULT_SAMPLE_RATE = 24_000  # rate the OpenAI Realtime API expects (pcm16)
 DEFAULT_CHANNELS = 1
 DTYPE = "int16"
 CHUNK_DURATION_SEC = 0.02
 
+LOCAL_STT_TOPIC = "/audio/local_mic/stt"
+REMOTE_STT_TOPIC = "/audio/remote_mic/stt"
+REMOTE_MIC_TOPIC = "/audio/remote_mic"
+
 
 class MicroInput(InputDevice):
     """
-    Microphone input device.
+    Microphone input device — orchestrates a local and a remote transcription stream.
 
-    Connects to OpenAI Realtime API via proxy (self.proxy.openai.realtime).
-    Config comes from self.proxy.config (set by InputManagerNode).
+    Each stream connects to the OpenAI Realtime API via proxy (self.proxy.openai.realtime)
+    and emits transcripts independently. The local stream is on by default (preserving the
+    old behaviour when /audio/local_mic/stt is never published); the remote stream is off
+    until /audio/remote_mic/stt publishes true.
 
     Supports "ducking" - suppresses audio while robot is speaking.
-    Automatically reconnects if WebSocket connection is lost.
+    Streams automatically reconnect if their WebSocket connection is lost.
     """
 
     def __init__(self):
         super().__init__()
-        self.mic = None
-        self.client = None
-        self._stop_evt = threading.Event()
-        self._audio_thread = None
+        self._local: TranscriptionStream | None = None
+        self._remote: TranscriptionStream | None = None
+        self._local_enabled = True  # old stt on if /audio/local_mic/stt never published
+        self._remote_enabled = False  # remote mic off by default
         self._is_robot_talking = False  # For ducking (mic-specific)
-        self._reconnect_thread = None
-        self._is_connected = False
-        self._reconnect_delay = 1  # Start with 1 second
-        self._max_reconnect_delay = 30  # Max 30 seconds between retries
+        self._control_subs: list = []
         # Initialize logger wrapper (will be updated when set_logger is called)
         self.logger = UniversalLogger(enabled=False)
 
@@ -64,6 +74,11 @@ class MicroInput(InputDevice):
     def name(self) -> str:
         return "micro"
 
+    def initialize(self) -> bool:
+        """Subscribe to the two Bool stt-control topics for the device's lifetime."""
+        self._subscribe_controls()
+        return True
+
     def set_tts_playing(self, is_playing: bool):
         """
         Called when TTS (text-to-speech) status changes.
@@ -74,40 +89,170 @@ class MicroInput(InputDevice):
             is_playing: True if robot is speaking, False otherwise
         """
         self._is_robot_talking = is_playing
+        for stream in (self._local, self._remote):
+            if stream:
+                stream.set_ducking(is_playing)
 
     def on_open(self):
-        """Start microphone and connect to OpenAI via proxy."""
-        # Check proxy is available
+        """Start whichever streams are currently enabled."""
         if not self.proxy or not self.proxy.is_available():
             self.logger.error("❌ Proxy not configured - cannot start microphone input")
             return
 
+        if self._local_enabled:
+            self._start_local()
+        if self._remote_enabled:
+            self._start_remote()
+
+    def on_close(self):
+        """Stop both streams (control subscriptions stay up until shutdown)."""
+        self._stop_local()
+        self._stop_remote()
+
+    def shutdown(self):
+        """Tear down the control subscriptions."""
+        for sub in self._control_subs:
+            try:
+                self.node.destroy_subscription(sub)
+            except Exception:  # noqa: BLE001
+                pass
+        self._control_subs = []
+
+    # --- control topics ---
+    def _subscribe_controls(self):
+        if self._control_subs or self.node is None:
+            return
+        from std_msgs.msg import Bool
+
+        self._control_subs = [
+            self.node.create_subscription(Bool, LOCAL_STT_TOPIC, self._on_local_toggle, 1),
+            self.node.create_subscription(Bool, REMOTE_STT_TOPIC, self._on_remote_toggle, 1),
+        ]
+        self.logger.info(f"🎚️ stt control: {LOCAL_STT_TOPIC} (default on), {REMOTE_STT_TOPIC} (default off)")
+
+    def _on_local_toggle(self, msg):
+        enabled = bool(msg.data)
+        if enabled == self._local_enabled:
+            return
+        self.logger.info(f"🎚️ local mic stt {'enabled' if enabled else 'disabled'}")
+        self._local_enabled = enabled
+        if not self.is_active():
+            return  # device closed; applied on next on_open()
+        self._start_local() if enabled else self._stop_local()
+
+    def _on_remote_toggle(self, msg):
+        enabled = bool(msg.data)
+        if enabled == self._remote_enabled:
+            return
+        self.logger.info(f"🎚️ remote mic stt {'enabled' if enabled else 'disabled'}")
+        self._remote_enabled = enabled
+        if not self.is_active():
+            return  # device closed; applied on next on_open()
+        self._start_remote() if enabled else self._stop_remote()
+
+    # --- stream lifecycle ---
+    def _start_local(self):
+        if self._local:
+            return
+        self._local = self._make_stream("local", LocalMicStreamer(self.logger))
+
+    def _stop_local(self):
+        if self._local:
+            self._local.stop()
+            self._local = None
+
+    def _start_remote(self):
+        if self._remote:
+            return
+        self._remote = self._make_stream("remote", RemoteMicStreamer(self.node, REMOTE_MIC_TOPIC, self.logger))
+
+    def _stop_remote(self):
+        if self._remote:
+            self._remote.stop()
+            self._remote = None
+
+    def _make_stream(self, name: str, source) -> "TranscriptionStream | None":
+        stream = TranscriptionStream(
+            name=name,
+            source=source,
+            proxy=self.proxy,
+            logger=self.logger,
+            on_transcript=lambda text: self._on_transcript(text, name),
+            is_active=self.is_active,
+        )
+        stream.set_ducking(self._is_robot_talking)
         try:
-            # Auto-detect and start microphone
-            detected_device = self._detect_audio_device()
-            if not detected_device:
-                detected_device = "default"
-
-            self.logger.info(f"🎙️ Using audio device: {detected_device}")
-
-            # Pass logger to ArecordStreamer
-            self.mic = ArecordStreamer(self.logger)
-            self.mic.start(
-                device=detected_device if detected_device != "default" else "default",
-                sample_rate=DEFAULT_SAMPLE_RATE,
-                channels=DEFAULT_CHANNELS,
-            )
-
-            self.logger.info(f"🎙️ Microphone started (rate: {DEFAULT_SAMPLE_RATE}, channels: {DEFAULT_CHANNELS})")
-
-            # Connect via proxy
-            self._connect_via_proxy()
-
+            stream.start()
+            return stream
         except Exception as e:
-            self.logger.error(f"❌ Failed to start microphone: {e}")
+            self.logger.error(f"❌ Failed to start {name} mic stream: {e}")
             import traceback
 
             traceback.print_exc()
+            return None
+
+    def _on_transcript(self, text: str, source: str):
+        """Called when a transcript is ready from either stream."""
+        if text:
+            self.logger.info(f"🎤 [{source}] Transcript: {text}")
+            self.send_data(text, data_type="chat_in")
+
+
+# ========== Transcription stream ==========
+
+
+class TranscriptionStream:
+    """
+    Streams one audio source to the OpenAI Realtime API and emits transcripts.
+
+    Owns its own websocket client, audio-forwarding thread, and reconnect loop, so
+    multiple sources (local mic, remote mic) transcribe independently. The source is
+    any object exposing a `.queue` of raw 24 kHz PCM16 bytes plus `start()`/`stop()`.
+    """
+
+    def __init__(self, name, source, proxy, logger, on_transcript, is_active):
+        self.name = name
+        self._source = source
+        self._proxy = proxy
+        self.logger = logger
+        self._on_transcript = on_transcript
+        self._is_active = is_active
+        self.client = None
+        self._stop_evt = threading.Event()
+        self._audio_thread = None
+        self._reconnect_thread = None
+        self._is_connected = False
+        self._is_robot_talking = False
+        self._reconnect_delay = 1  # Start with 1 second
+        self._max_reconnect_delay = 30  # Max 30 seconds between retries
+
+    def set_ducking(self, is_playing: bool):
+        self._is_robot_talking = is_playing
+
+    def start(self):
+        """Start the audio source and connect to OpenAI."""
+        self._stop_evt.clear()
+        self._source.start()
+        self._connect_via_proxy()
+
+    def stop(self):
+        """Stop the source, audio thread, and OpenAI client."""
+        self._stop_evt.set()
+        self._is_connected = False  # Prevent reconnection attempts
+
+        if self._audio_thread:
+            self._audio_thread.join(timeout=1.0)
+        if self._reconnect_thread:
+            self._reconnect_thread.join(timeout=1.0)
+
+        try:
+            self._source.stop()
+        except Exception:  # noqa: BLE001
+            pass
+
+        if self.client:
+            self.client.stop()
+            self.client = None
 
     def _on_openai_message(self, ws, message: str):
         """Handle incoming messages from OpenAI Realtime API."""
@@ -122,17 +267,18 @@ class MicroInput(InputDevice):
         # Event type to handler mapping
         event_handlers = {
             "session.updated": lambda e: self.logger.info(
-                f"📋 Session updated - transcription: {e.get('session', {}).get('input_audio_transcription', {})}, "
+                f"📋 [{self.name}] Session updated - transcription: "
+                f"{e.get('session', {}).get('input_audio_transcription', {})}, "
                 f"turn_detection: {e.get('session', {}).get('turn_detection', {})}"
             ),
-            "input_audio_buffer.speech_started": lambda e: self.logger.info("🎤 Speech detected"),
-            "input_audio_buffer.speech_stopped": lambda e: self.logger.info("🔇 Speech stopped"),
+            "input_audio_buffer.speech_started": lambda e: self.logger.info(f"🎤 [{self.name}] Speech detected"),
+            "input_audio_buffer.speech_stopped": lambda e: self.logger.info(f"🔇 [{self.name}] Speech stopped"),
             "conversation.item.input_audio_transcription.completed": lambda e: (
-                self._on_transcript(e.get("transcript", "")) if e.get("transcript") and self.is_active() else None
+                self._on_transcript(e.get("transcript", "")) if e.get("transcript") and self._is_active() else None
             ),
             "error": lambda e: (
                 self.logger.error(
-                    f"❌ OpenAI error: {e.get('error', {}).get('code', '')} - "
+                    f"❌ [{self.name}] OpenAI error: {e.get('error', {}).get('code', '')} - "
                     f"{e.get('error', {}).get('message', '')} "
                     f"(param: {e.get('error', {}).get('param', '')})"
                 )
@@ -146,14 +292,14 @@ class MicroInput(InputDevice):
         if handler:
             handler(event)
         else:
-            self.logger.info(f"📨 OpenAI event: {etype}")
+            self.logger.info(f"📨 [{self.name}] OpenAI event: {etype}")
 
     def _on_openai_open(self):
         """Handle WebSocket open event - send session configuration."""
-        transcribe_model = self.proxy.config.get("openai_transcribe_model", "gpt-4o-mini-transcribe")
+        transcribe_model = self._proxy.config.get("openai_transcribe_model", "gpt-4o-mini-transcribe")
         vad_threshold = 0.3  # Lower = more sensitive to speech
 
-        self.logger.info("📤 WebSocket opened, sending session.update...")
+        self.logger.info(f"📤 [{self.name}] WebSocket opened, sending session.update...")
         session_update = {
             "type": "session.update",
             "session": {
@@ -169,17 +315,17 @@ class MicroInput(InputDevice):
                 "instructions": "Transcribe user audio only in English; do not reply.",
             },
         }
-        self.logger.info(f"📤 Session config: model={transcribe_model}, vad_threshold={vad_threshold}")
+        self.logger.info(f"📤 [{self.name}] Session config: model={transcribe_model}, vad_threshold={vad_threshold}")
         self.client.send_json(session_update)
-        self.logger.info("📤 session.update sent")
+        self.logger.info(f"📤 [{self.name}] session.update sent")
 
     def _on_openai_error(self, error):
         """Handle WebSocket error event."""
-        self.logger.error(f"[ws error] {error}")
+        self.logger.error(f"[{self.name}] [ws error] {error}")
 
     def _on_openai_close(self):
         """Handle WebSocket close event - trigger reconnection."""
-        self.logger.warning("WebSocket closed")
+        self.logger.warning(f"[{self.name}] WebSocket closed")
         self._is_connected = False
 
         # Don't reconnect if we're shutting down
@@ -191,13 +337,13 @@ class MicroInput(InputDevice):
 
     def _connect_via_proxy(self):
         """Connect to OpenAI Realtime API via proxy."""
-        self.logger.info("🔗 Connecting to OpenAI via proxy...")
+        self.logger.info(f"🔗 [{self.name}] Connecting to OpenAI via proxy...")
 
         # Get config from proxy (injected by InputManager)
-        model = self.proxy.config.get("openai_realtime_model", "gpt-4o-realtime-preview")
+        model = self._proxy.config.get("openai_realtime_model", "gpt-4o-realtime-preview")
 
         # Use proxy's OpenAI adapter
-        self.client = self.proxy.openai.realtime.connect_sync(
+        self.client = self._proxy.openai.realtime.connect_sync(
             model=model,
             on_message=self._on_openai_message,
             on_open=self._on_openai_open,
@@ -211,7 +357,7 @@ class MicroInput(InputDevice):
 
         self._is_connected = True
         self._reconnect_delay = 1  # Reset delay on successful connection
-        self.logger.info(f"✅ Connected to OpenAI Realtime (model: {model})")
+        self.logger.info(f"✅ [{self.name}] Connected to OpenAI Realtime (model: {model})")
 
     def _schedule_reconnect(self):
         """Schedule a reconnection attempt in a background thread."""
@@ -220,7 +366,7 @@ class MicroInput(InputDevice):
 
         def reconnect_loop():
             while not self._stop_evt.is_set() and not self._is_connected:
-                self.logger.info(f"🔄 Reconnecting to OpenAI in {self._reconnect_delay}s...")
+                self.logger.info(f"🔄 [{self.name}] Reconnecting to OpenAI in {self._reconnect_delay}s...")
 
                 # Wait before reconnecting (interruptible)
                 if self._stop_evt.wait(timeout=self._reconnect_delay):
@@ -245,11 +391,11 @@ class MicroInput(InputDevice):
                     self._connect_via_proxy()
 
                     if self._is_connected:
-                        self.logger.info("✅ Reconnection successful!")
+                        self.logger.info(f"✅ [{self.name}] Reconnection successful!")
                         break
 
                 except Exception as e:
-                    self.logger.error(f"❌ Reconnection failed: {e}")
+                    self.logger.error(f"❌ [{self.name}] Reconnection failed: {e}")
                     # Exponential backoff
                     self._reconnect_delay = min(self._reconnect_delay * 2, self._max_reconnect_delay)
 
@@ -262,22 +408,22 @@ class MicroInput(InputDevice):
 
         def audio_loop():
             if not self.client.wait_until_connected(timeout=10):
-                self.logger.error("WebSocket didn't connect in time")
+                self.logger.error(f"[{self.name}] WebSocket didn't connect in time")
                 return
 
-            self.logger.info("🎧 Audio streaming thread started")
+            self.logger.info(f"🎧 [{self.name}] Audio streaming thread started")
 
             chunks_sent = 0
             empty_count = 0
             ducking_logged = False
             while not self._stop_evt.is_set():
                 try:
-                    chunk = self.mic.queue.get(timeout=0.1)
+                    chunk = self._source.queue.get(timeout=0.1)
                     empty_count = 0  # Reset on successful get
                 except queue.Empty:
                     empty_count += 1
                     if empty_count == 50:
-                        self.logger.warning("⚠️ No audio chunks received (queue empty for 5s)")
+                        self.logger.warning(f"⚠️ [{self.name}] No audio chunks received (queue empty for 5s)")
                     continue
 
                 try:
@@ -288,7 +434,7 @@ class MicroInput(InputDevice):
                     # Skip sending while ducking (robot is speaking)
                     if self._is_robot_talking:
                         if not ducking_logged:
-                            self.logger.info("🔇 Ducking active - not sending audio")
+                            self.logger.info(f"🔇 [{self.name}] Ducking active - not sending audio")
                         ducking_logged = True
                         continue
                     ducking_logged = False
@@ -302,38 +448,41 @@ class MicroInput(InputDevice):
 
                     # Log periodically (much less frequently)
                     if chunks_sent == 100:
-                        self.logger.info(f"🎧 Streaming audio ({chunks_sent} chunks)")
+                        self.logger.info(f"🎧 [{self.name}] Streaming audio ({chunks_sent} chunks)")
                     elif chunks_sent % 2500 == 0:
-                        self.logger.info(f"🎧 Audio chunks sent: {chunks_sent}")
+                        self.logger.info(f"🎧 [{self.name}] Audio chunks sent: {chunks_sent}")
                 except Exception as e:
                     # Only log if we think we're connected (avoid spam during reconnect)
                     if self._is_connected:
-                        self.logger.error(f"Send error: {e}")
+                        self.logger.error(f"[{self.name}] Send error: {e}")
 
         self._audio_thread = threading.Thread(target=audio_loop, daemon=True)
         self._audio_thread.start()
 
-    def on_close(self):
-        """Stop microphone and disconnect."""
-        self._stop_evt.set()
-        self._is_connected = False  # Prevent reconnection attempts
 
-        if self._audio_thread:
-            self._audio_thread.join(timeout=1.0)
+# ========== Audio Streaming Helpers ==========
 
-        if self._reconnect_thread:
-            self._reconnect_thread.join(timeout=1.0)
 
-        if self.mic:
-            try:
-                self.mic.stop()
-            except:  # noqa: E722
-                pass
-            self.mic = None
+class LocalMicStreamer:
+    """On-robot hardware mic: auto-detects an ALSA device and streams 24 kHz PCM via arecord."""
 
-        if self.client:
-            self.client.stop()
-            self.client = None
+    def __init__(self, logger):
+        self.logger = logger
+        self._arecord = ArecordStreamer(logger)
+        self.queue = self._arecord.queue
+
+    def start(self):
+        detected_device = self._detect_audio_device() or "default"
+        self.logger.info(f"🎙️ Using audio device: {detected_device}")
+        self._arecord.start(
+            device=detected_device,
+            sample_rate=DEFAULT_SAMPLE_RATE,
+            channels=DEFAULT_CHANNELS,
+        )
+        self.logger.info(f"🎙️ Microphone started (rate: {DEFAULT_SAMPLE_RATE}, channels: {DEFAULT_CHANNELS})")
+
+    def stop(self):
+        self._arecord.stop()
 
     def _detect_audio_device(self):
         """Detect and list available audio capture devices."""
@@ -402,15 +551,52 @@ class MicroInput(InputDevice):
 
         return preferred_device["id"] if preferred_device else None
 
-    def _on_transcript(self, text: str):
-        """Called when transcript is ready."""
-        if text:
-            self.logger.info(f"🎤 Transcript: {text}")
 
-            self.send_data(text, data_type="chat_in")
+class RemoteMicStreamer:
+    """
+    Inbound phone mic: subscribes to /audio/remote_mic (innate_audio/Audio) and exposes
+    24 kHz PCM. The topic contract is S16LE mono 48 kHz; each message is downsampled to the
+    24 kHz the OpenAI Realtime API expects. Same `.queue` contract as the local streamers.
+    """
 
+    def __init__(self, node, topic, logger):
+        self.queue: queue.Queue[bytes] = queue.Queue(maxsize=100)
+        self._node = node
+        self._topic = topic
+        self.logger = logger
+        self._sub = None
+        self._ratecv_state = None  # audioop filter state, carried across chunks
+        self._chunks = 0
 
-# ========== Audio Streaming Helpers ==========
+    def start(self):
+        # Imported lazily: the remote path is off by default and innate_audio may be absent.
+        from innate_audio.msg import Audio
+        from rclpy.qos import qos_profile_sensor_data
+
+        self._sub = self._node.create_subscription(Audio, self._topic, self._on_audio, qos_profile_sensor_data)
+        self.logger.info(f"🎙️ Subscribed to remote mic topic: {self._topic}")
+
+    def _on_audio(self, msg):
+        pcm = array.array("h", msg.samples).tobytes()
+        if msg.rate != DEFAULT_SAMPLE_RATE:
+            pcm, self._ratecv_state = audioop.ratecv(
+                pcm, 2, msg.channels or DEFAULT_CHANNELS, msg.rate, DEFAULT_SAMPLE_RATE, self._ratecv_state
+            )
+        try:
+            self.queue.put_nowait(pcm)
+            self._chunks += 1
+            if self._chunks == 1:
+                self.logger.info(f"🎙️ First remote-mic audio ({len(pcm)} bytes @ {DEFAULT_SAMPLE_RATE}Hz)")
+        except queue.Full:
+            pass
+
+    def stop(self):
+        if self._sub is not None and self._node is not None:
+            try:
+                self._node.destroy_subscription(self._sub)
+            except Exception:  # noqa: BLE001
+                pass
+            self._sub = None
 
 
 class ArecordStreamer:

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -89,28 +89,31 @@ class MicroInput(InputDevice):
             is_playing: True if robot is speaking, False otherwise
         """
         self._is_robot_talking = is_playing
-        for stream in (self._local, self._remote):
-            if stream:
-                stream.set_ducking(is_playing)
+        # Only the local stream is ducked: the on-robot mic hears the robot's own speaker,
+        # but the operator's phone mic doesn't — ducking it would drop operator speech
+        # whenever the robot talks.
+        if self._local:
+            self._local.set_ducking(is_playing)
 
     def on_open(self):
-        """Start whichever streams are currently enabled."""
+        """Start the local stream (the remote one follows only its own gate)."""
         if not self.proxy or not self.proxy.is_available():
             self.logger.error("❌ Proxy not configured - cannot start microphone input")
             return
 
         if self._local_enabled:
             self._start_local()
-        if self._remote_enabled:
-            self._start_remote()
 
     def on_close(self):
-        """Stop both streams (control subscriptions stay up until shutdown)."""
+        """Stop the local stream. The remote stream is deliberately left running:
+        it is the operator's own phone mic, gated solely by /audio/remote_mic/stt,
+        not by which directive (and thus which declared inputs) is active."""
         self._stop_local()
-        self._stop_remote()
 
     def shutdown(self):
-        """Tear down the control subscriptions."""
+        """Tear down the streams and control subscriptions."""
+        self._stop_local()
+        self._stop_remote()
         for sub in self._control_subs:
             try:
                 self.node.destroy_subscription(sub)
@@ -146,8 +149,8 @@ class MicroInput(InputDevice):
             return
         self.logger.info(f"🎚️ remote mic stt {'enabled' if enabled else 'disabled'}")
         self._remote_enabled = enabled
-        if not self.is_active():
-            return  # device closed; applied on next on_open()
+        # Operator's own phone mic: the Bool gate alone starts/stops it — no device-active
+        # gate, so it works regardless of the running directive's declared inputs.
         self._start_remote() if enabled else self._stop_remote()
 
     # --- stream lifecycle ---
@@ -164,23 +167,30 @@ class MicroInput(InputDevice):
     def _start_remote(self):
         if self._remote:
             return
-        self._remote = self._make_stream("remote", RemoteMicStreamer(self.node, REMOTE_MIC_TOPIC, self.logger))
+        if not self.proxy or not self.proxy.is_available():
+            self.logger.error("❌ Proxy not configured - cannot start remote mic stream")
+            return
+        # is_active=True: transcripts flow whenever the gate is on, device active or not.
+        self._remote = self._make_stream(
+            "remote", RemoteMicStreamer(self.node, REMOTE_MIC_TOPIC, self.logger), is_active=lambda: True
+        )
 
     def _stop_remote(self):
         if self._remote:
             self._remote.stop()
             self._remote = None
 
-    def _make_stream(self, name: str, source) -> "TranscriptionStream | None":
+    def _make_stream(self, name: str, source, is_active=None) -> "TranscriptionStream | None":
         stream = TranscriptionStream(
             name=name,
             source=source,
             proxy=self.proxy,
             logger=self.logger,
             on_transcript=lambda text: self._on_transcript(text, name),
-            is_active=self.is_active,
+            is_active=is_active or self.is_active,
         )
-        stream.set_ducking(self._is_robot_talking)
+        if name == "local":
+            stream.set_ducking(self._is_robot_talking)
         try:
             stream.start()
             return stream


### PR DESCRIPTION
## Inbound phone-mic → robot: WebRTC → topic → STT + speaker playout

Operator-microphone feature. The browser/phone mic streams to the robot over the
existing WebRTC peer, is republished as a ROS topic, and can be **transcribed** and/or
**played out the robot's speaker** — each gated independently from the UI.

### Data path
```
phone mic → WebRTC (opus) → mars_cam webrtc_streamer_node
  → /audio/remote_mic (innate_audio/Audio, S16LE mono 48k)
  ├─ MicroInput remote stream → OpenAI Realtime → /brain/chat_in   (gate: /audio/remote_mic/stt)
  └─ play_remote_mic.py → aplay (robot speaker)                    (gate: /audio/remote_mic/to_speaker)
```

### Commits
- `a1c078b` **mars_cam**: decode inbound opus, publish `/audio/remote_mic`.
- `6a8e427` **webapp**: capture + send operator mic over WebRTC.
- `243c10c` **docs**: backend handoff for the receive path.
- `de3afb0` **brain_client STT**: `MicroInput` now runs two independent transcription
  streams, each with its own OpenAI Realtime connection:

  | Stream | Source | Gate (`std_msgs/Bool`) | Default |
  |--------|--------|------------------------|---------|
  | `local` | on-robot mic (arecord, 24k) | `/audio/local_mic/stt` | **on** (unchanged if never published) |
  | `remote` | `/audio/remote_mic` (48k → 24k via `audioop`) | `/audio/remote_mic/stt` | **off** |

  The single OpenAI pipeline was factored into a reusable `TranscriptionStream`;
  `innate_audio` is imported lazily so the default-off remote path can't break startup.
- `ec3844b` **webapp + player**: mount the operator-mic send toggle into the Agent
  composer (created earlier but never wired), plus two sibling gates — an **STT toggle**
  (`/audio/remote_mic/stt`) and a **speaker-playout toggle** (`/audio/remote_mic/to_speaker`).
  The robot-side player (`mars_cam/remote_mic_player`, launched automatically alongside `webrtc_streamer_node`) plays it out the speaker. Toggles re-assert on
  (re)connect; shown only for `WebRtcSession` (sim has no `setMic`).

### Status
- **Not runtime-verified end to end** — no robot/phone in the loop. Rebuild required:
  `colcon build --packages-select innate_audio mars_cam brain_client`.
- Ducking (TTS-playing suppression) currently applies to the remote STT stream too;
  transcripts from both mics route identically to `/brain/chat_in`.
- The unrelated `i2c.py` MCU CRC/timing fix in the working tree is deliberately **not** part of this PR.

### Test
```bash
colcon build --packages-select innate_audio mars_cam brain_client
# or drive the gates directly:
ros2 topic pub -1 /audio/remote_mic/stt std_msgs/Bool "{data: true}"
ros2 topic echo /brain/chat_in     # speak into phone mic → transcripts appear
# speaker: the remote_mic_player node launches with mars_cam; toggle /audio/remote_mic/to_speaker true → hear it
```

