### PR TITLE
perf(webapp): cheap ETag cache validators for the sim 3D assets

### DIFF
--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -1328,6 +1328,17 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
                 if not (member.isfile() or member.isdir()):
                     raise StackError(f"unsupported member type in asset bundle: {member.name}")
             tar.extractall(staging)
+        # The published tarball normalises every member to mtime 0 so its content
+        # hash -- and thus the asset tag -- is reproducible (tools/publish_assets.py),
+        # leaving ~all 1300+ files at mtime 0 on disk, which collapses the webapp's
+        # mtime+size ETag to size-only. Stamp one install time so the next bundle
+        # (extracted the same way) flips 0 -> non-zero and the ETag busts.
+        installed_at = time.time()
+        try:
+            for extracted in staging.rglob("*"):
+                os.utime(extracted, (installed_at, installed_at))
+        except OSError as exc:
+            raise StackError(f"Failed to stamp sim asset mtimes under {staging}: {exc}") from exc
         for unit in SIM_ASSET_UNITS:
             src = staging / unit
             if not src.is_dir():

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -31,7 +31,6 @@ import shutil
 import ssl
 import subprocess
 import sys
-from email.utils import formatdate, parsedate_to_datetime
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
@@ -180,88 +179,28 @@ SIM_VIEWER_ROUTES = {
     "/physics/": SIM_VIEWER_ROOT / "public" / "physics",
 }
 
-# The 3D asset trees ship in the pinned sim-assets release (sim/sim-assets.lock)
-# and only change when that lock bumps, so they are worth a real max-age: the SPA
-# remounts the stage on every visit, and revalidating ~63MB across 1300+ files
-# each time costs a round trip per file for an answer that is always "unchanged".
-# /sim-viewer/ is deliberately NOT here — viewer devs rebuild the bundle in place
-# (INNATE_SIM_VIEWER_DEV=1) and must see a rebuild without a hard refresh.
-CACHEABLE_ASSET_PREFIXES = ("/models/", "/robot/", "/physics/")
-ASSET_MAX_AGE_SECONDS = 86400
 
+def file_etag(path: Path) -> str:
+    """A cheap ETag for a file from a single stat(): mtime+size, the validator
+    nginx and Apache use. It changes on any write and costs one stat()
+    regardless of file size.
 
-def _sim_assets_tag() -> str:
-    """The pinned sim-assets release tag, mixed into the 3D assets' ETag.
+    Deliberately NOT a content hash: producing one means reading and digesting
+    the body, so every conditional request paid a full read + SHA-1 of the 34MB
+    apartment glb just to answer a bodyless 304.
 
-    Needed because the bundle is extracted from a tarball that preserves
-    epoch-0 mtimes — 1319 of the 1322 served asset files have mtime 0 — so a
-    bare mtime+size validator degrades to size-only for them, and a refreshed
-    asset whose size happened to match would keep its ETag and be served stale.
-    The tag is a content hash of the whole bundle and changes on every
-    republish, which is the only boundary at which these files can change.
+    ETag-only, no Last-Modified: the browser talks straight to this server (no
+    proxy in between), so If-None-Match always comes back — the date validator
+    would be dead weight and one more clock/timezone edge to get wrong.
 
-    Read from .assets-tag first: it sits next to the extracted bundle under
-    sim/assets, which IS bind-mounted into the sim container, whereas
-    sim-assets.lock (repo root) is NOT — so the lock is only reachable on host
-    dev runs, and relying on it alone silently degraded the ETag to size-only
-    in the container. Both carry the same tag string."""
-    sim = SIM_VIEWER_ROOT.parent
-    try:
-        tag = (sim / "assets" / ".assets-tag").read_text().strip()
-        if tag:
-            return tag
-    except OSError:
-        pass
-    try:
-        return json.loads((sim / "sim-assets.lock").read_text())["tag"]
-    except (OSError, ValueError, KeyError):
-        return "noassets"
-
-
-SIM_ASSETS_TAG = _sim_assets_tag()
-
-
-def cache_validators(path: Path, prefix: str = "") -> tuple[str, str, float]:
-    """ETag + Last-Modified (+ raw mtime) for a file, from a single stat().
-
-    Deliberately NOT a content hash: the body has to be read and digested to
-    produce one, so every conditional request paid a full read + SHA-1 of the
-    34MB apartment glb just to answer a bodyless 304. mtime+size is the same
-    validator nginx and Apache use — it changes on any write, and costs one
-    stat() regardless of file size.
-
-    prefix qualifies the ETag for files whose mtime carries no information (see
-    _sim_assets_tag); app files keep real mtimes and need none."""
+    The sim asset bundle ships mtime-normalised (epoch 0) for a reproducible
+    tag, which would collapse this to size-only; the launcher stamps a real
+    mtime on extraction (see ensure_sim_assets) so it stays a true validator."""
     st = path.stat()
-    etag = f'"{prefix}{"-" if prefix else ""}{st.st_mtime_ns:x}-{st.st_size:x}"'
-    return etag, formatdate(st.st_mtime, usegmt=True), st.st_mtime
+    return f'"{st.st_mtime_ns:x}-{st.st_size:x}"'
 
 
-def client_has_current(etag: str, mtime: float, if_none_match: str, if_modified_since: str) -> bool:
-    """Whether the client's cached copy is still current, per RFC 9110 §13.1.3:
-    If-None-Match wins outright when present, and only in its absence does
-    If-Modified-Since get a say.
-
-    Honouring the date matters because we advertise Last-Modified: a client
-    whose cached ETag was evicted, or a proxy that strips ETags, revalidates
-    with the date alone. Without this it misses the 304 and re-downloads the
-    whole asset — 34MB for the apartment glb."""
-    if if_none_match:
-        return if_none_match == etag
-    if not if_modified_since:
-        return False
-    try:
-        since = parsedate_to_datetime(if_modified_since)
-    except (TypeError, ValueError):
-        return False  # malformed date -> treat as no validator, send the body
-    if since is None:
-        return False
-    # HTTP-dates carry whole seconds, so compare at that resolution: a
-    # sub-second-newer file must not read as modified against its own date.
-    return int(mtime) <= int(since.timestamp())
-
-
-def sim_viewer_response(path: str, if_none_match: str = "", if_modified_since: str = "") -> "Response | None":
+def sim_viewer_response(path: str, if_none_match: str = "") -> "Response | None":
     clean = path.split("?", 1)[0].split("#", 1)[0]
     for prefix, base in SIM_VIEWER_ROUTES.items():
         if not clean.startswith(prefix):
@@ -272,22 +211,21 @@ def sim_viewer_response(path: str, if_none_match: str = "", if_modified_since: s
         # These routes carry the ~35MB apartment glb + robot meshes, re-requested
         # on every page mount now that the SPA router remounts the stage per
         # visit. Validate from stat() and return 304 *before* touching the body,
-        # so an unchanged asset costs a stat instead of a full read.
-        etag, last_modified, mtime = cache_validators(target, prefix=SIM_ASSETS_TAG)
-        cache_control = (
-            f"public, max-age={ASSET_MAX_AGE_SECONDS}" if clean.startswith(CACHEABLE_ASSET_PREFIXES) else "no-cache"
-        )
-        validators = {"ETag": etag, "Last-Modified": last_modified, "Cache-Control": cache_control}
-        if client_has_current(etag, mtime, if_none_match, if_modified_since):
-            return Response(304, "Not Modified", Headers(validators), b"")
+        # so an unchanged asset costs a stat instead of a full read. no-cache (not
+        # max-age): the viewer fetches these at bare, unversioned URLs, so a bundle
+        # bump must be picked up on the next revalidation, not up to a day later.
+        etag = file_etag(target)
+        cache_headers = {"ETag": etag, "Cache-Control": "no-cache"}
+        if if_none_match == etag:
+            return Response(304, "Not Modified", Headers(cache_headers), b"")
         body = target.read_bytes()
         ctype = CONTENT_TYPES.get(target.suffix) or mimetypes.guess_type(str(target))[0] or "application/octet-stream"
-        headers = Headers({**validators, "Content-Type": ctype, "Content-Length": str(len(body))})
+        headers = Headers({**cache_headers, "Content-Type": ctype, "Content-Length": str(len(body))})
         return Response(200, "OK", headers, body)
     return None
 
 
-def static_response(path: str, if_none_match: str = "", if_modified_since: str = "") -> Response:
+def static_response(path: str, if_none_match: str = "") -> Response:
     clean = path.split("?", 1)[0].split("#", 1)[0]
     target = (ROOT / clean.lstrip("/")).resolve()
     if target.is_dir():
@@ -308,13 +246,13 @@ def static_response(path: str, if_none_match: str = "", if_modified_since: str =
     # Cache-Control stays no-cache so a redeploy is always picked up — the
     # browser still revalidates every load, but revalidation is a tiny
     # conditional request that never reads the file.
-    etag, last_modified, mtime = cache_validators(body_path)
-    validators = {"ETag": etag, "Last-Modified": last_modified, "Cache-Control": "no-cache"}
-    if client_has_current(etag, mtime, if_none_match, if_modified_since):
-        return Response(304, "Not Modified", Headers(validators), b"")
+    etag = file_etag(body_path)
+    cache_headers = {"ETag": etag, "Cache-Control": "no-cache"}
+    if if_none_match == etag:
+        return Response(304, "Not Modified", Headers(cache_headers), b"")
     body = body_path.read_bytes()
     ctype = CONTENT_TYPES.get(body_path.suffix) or mimetypes.guess_type(str(body_path))[0] or "application/octet-stream"
-    headers = Headers({**validators, "Content-Type": ctype, "Content-Length": str(len(body))})
+    headers = Headers({**cache_headers, "Content-Type": ctype, "Content-Length": str(len(body))})
     return Response(200, "OK", headers, body)
 
 
@@ -379,7 +317,6 @@ async def _dispatch_request(connection, request):
         sim_viewer_response,
         request.path,
         request.headers.get("If-None-Match", ""),
-        request.headers.get("If-Modified-Since", ""),
     )
     if sim_viewer is not None:
         return sim_viewer
@@ -416,7 +353,6 @@ async def _dispatch_request(connection, request):
         static_response,
         request.path,
         request.headers.get("If-None-Match", ""),
-        request.headers.get("If-Modified-Since", ""),
     )
 
 

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -23,7 +23,6 @@ Persist:    launched on boot in the `console-webapp` tmux window
 
 import asyncio
 import contextlib
-import hashlib
 import json
 import logging
 import mimetypes
@@ -32,6 +31,7 @@ import shutil
 import ssl
 import subprocess
 import sys
+from email.utils import formatdate
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
@@ -180,6 +180,27 @@ SIM_VIEWER_ROUTES = {
     "/physics/": SIM_VIEWER_ROOT / "public" / "physics",
 }
 
+# The 3D asset trees ship in the pinned sim-assets release (sim/sim-assets.lock)
+# and only change when that lock bumps, so they are worth a real max-age: the SPA
+# remounts the stage on every visit, and revalidating ~63MB across 1300+ files
+# each time costs a round trip per file for an answer that is always "unchanged".
+# /sim-viewer/ is deliberately NOT here — viewer devs rebuild the bundle in place
+# (INNATE_SIM_VIEWER_DEV=1) and must see a rebuild without a hard refresh.
+CACHEABLE_ASSET_PREFIXES = ("/models/", "/robot/", "/physics/")
+ASSET_MAX_AGE_SECONDS = 86400
+
+
+def cache_validators(path: Path) -> tuple[str, str]:
+    """ETag + Last-Modified for a file, from a single stat().
+
+    Deliberately NOT a content hash: the body has to be read and digested to
+    produce one, so every conditional request paid a full read + SHA-1 of the
+    34MB apartment glb just to answer a bodyless 304. mtime+size is the same
+    validator nginx and Apache use — it changes on any write, and costs one
+    stat() regardless of file size."""
+    st = path.stat()
+    return f'"{st.st_mtime_ns:x}-{st.st_size:x}"', formatdate(st.st_mtime, usegmt=True)
+
 
 def sim_viewer_response(path: str, if_none_match: str = "") -> "Response | None":
     clean = path.split("?", 1)[0].split("#", 1)[0]
@@ -189,17 +210,22 @@ def sim_viewer_response(path: str, if_none_match: str = "") -> "Response | None"
         target = (base / clean[len(prefix) :]).resolve()
         if not target.is_file() or not target.is_relative_to(base.resolve()):
             return Response(404, "Not Found", Headers({"Content-Type": "text/plain"}), b"not found")
-        body = target.read_bytes()
-        # Same ETag/304 revalidation as static_response -- these routes carry
-        # the ~35MB apartment glb + robot meshes, re-requested on every page
-        # mount now that the SPA router remounts the stage per visit.
-        etag = f'"{hashlib.sha1(body).hexdigest()}"'
-        if if_none_match == etag:
-            return Response(304, "Not Modified", Headers({"ETag": etag, "Cache-Control": "no-cache"}), b"")
-        ctype = CONTENT_TYPES.get(target.suffix) or mimetypes.guess_type(str(target))[0] or "application/octet-stream"
-        headers = Headers(
-            {"Content-Type": ctype, "Content-Length": str(len(body)), "Cache-Control": "no-cache", "ETag": etag}
+        # These routes carry the ~35MB apartment glb + robot meshes, re-requested
+        # on every page mount now that the SPA router remounts the stage per
+        # visit. Validate from stat() and return 304 *before* touching the body,
+        # so an unchanged asset costs a stat instead of a full read.
+        etag, last_modified = cache_validators(target)
+        cache_control = (
+            f"public, max-age={ASSET_MAX_AGE_SECONDS}"
+            if clean.startswith(CACHEABLE_ASSET_PREFIXES)
+            else "no-cache"
         )
+        validators = {"ETag": etag, "Last-Modified": last_modified, "Cache-Control": cache_control}
+        if if_none_match == etag:
+            return Response(304, "Not Modified", Headers(validators), b"")
+        body = target.read_bytes()
+        ctype = CONTENT_TYPES.get(target.suffix) or mimetypes.guess_type(str(target))[0] or "application/octet-stream"
+        headers = Headers({**validators, "Content-Type": ctype, "Content-Length": str(len(body))})
         return Response(200, "OK", headers, body)
     return None
 
@@ -220,24 +246,18 @@ def static_response(path: str, if_none_match: str = "") -> Response:
     # Refuse anything that escapes the app root (or the TLS keys, defensively).
     if body_path is None or not body_path.is_relative_to(ROOT) or body_path.suffix == ".pem":
         return Response(404, "Not Found", Headers({"Content-Type": "text/plain"}), b"not found")
-    body = body_path.read_bytes()
-    # Content-hash ETag: the first load (and any hard refresh) requests all ~27
-    # modules, but unchanged ones come back as a bodyless 304 instead of a full
-    # re-download. Cache-Control stays no-cache so a redeploy is always picked up
-    # — the browser still revalidates every load, but revalidation is now a tiny
-    # conditional request, not a transfer of the whole file.
-    etag = f'"{hashlib.sha1(body).hexdigest()}"'
+    # The first load (and any hard refresh) requests all ~27 modules, but
+    # unchanged ones come back as a bodyless 304 instead of a full re-download.
+    # Cache-Control stays no-cache so a redeploy is always picked up — the
+    # browser still revalidates every load, but revalidation is a tiny
+    # conditional request that never reads the file.
+    etag, last_modified = cache_validators(body_path)
+    validators = {"ETag": etag, "Last-Modified": last_modified, "Cache-Control": "no-cache"}
     if if_none_match == etag:
-        return Response(304, "Not Modified", Headers({"ETag": etag, "Cache-Control": "no-cache"}), b"")
+        return Response(304, "Not Modified", Headers(validators), b"")
+    body = body_path.read_bytes()
     ctype = CONTENT_TYPES.get(body_path.suffix) or mimetypes.guess_type(str(body_path))[0] or "application/octet-stream"
-    headers = Headers(
-        {
-            "Content-Type": ctype,
-            "Content-Length": str(len(body)),
-            "Cache-Control": "no-cache",
-            "ETag": etag,
-        }
-    )
+    headers = Headers({**validators, "Content-Type": ctype, "Content-Length": str(len(body))})
     return Response(200, "OK", headers, body)
 
 

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -216,9 +216,7 @@ def sim_viewer_response(path: str, if_none_match: str = "") -> "Response | None"
         # so an unchanged asset costs a stat instead of a full read.
         etag, last_modified = cache_validators(target)
         cache_control = (
-            f"public, max-age={ASSET_MAX_AGE_SECONDS}"
-            if clean.startswith(CACHEABLE_ASSET_PREFIXES)
-            else "no-cache"
+            f"public, max-age={ASSET_MAX_AGE_SECONDS}" if clean.startswith(CACHEABLE_ASSET_PREFIXES) else "no-cache"
         )
         validators = {"ETag": etag, "Last-Modified": last_modified, "Cache-Control": cache_control}
         if if_none_match == etag:

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -31,7 +31,7 @@ import shutil
 import ssl
 import subprocess
 import sys
-from email.utils import formatdate
+from email.utils import formatdate, parsedate_to_datetime
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
@@ -190,19 +190,65 @@ CACHEABLE_ASSET_PREFIXES = ("/models/", "/robot/", "/physics/")
 ASSET_MAX_AGE_SECONDS = 86400
 
 
-def cache_validators(path: Path) -> tuple[str, str]:
-    """ETag + Last-Modified for a file, from a single stat().
+def _sim_assets_tag() -> str:
+    """The pinned sim-assets release tag, mixed into the 3D assets' ETag.
+
+    Needed because the bundle is extracted from a tarball that preserves
+    epoch-0 mtimes — 1319 of the 1322 served asset files have mtime 0 — so a
+    bare mtime+size validator degrades to size-only for them, and a refreshed
+    asset whose size happened to match would keep its ETag and be served stale.
+    The tag is a content hash of the whole bundle and changes on every
+    republish, which is the only boundary at which these files can change."""
+    try:
+        return json.loads((SIM_VIEWER_ROOT.parent / "sim-assets.lock").read_text())["tag"]
+    except Exception:
+        return "noassets"
+
+
+SIM_ASSETS_TAG = _sim_assets_tag()
+
+
+def cache_validators(path: Path, prefix: str = "") -> tuple[str, str, float]:
+    """ETag + Last-Modified (+ raw mtime) for a file, from a single stat().
 
     Deliberately NOT a content hash: the body has to be read and digested to
     produce one, so every conditional request paid a full read + SHA-1 of the
     34MB apartment glb just to answer a bodyless 304. mtime+size is the same
     validator nginx and Apache use — it changes on any write, and costs one
-    stat() regardless of file size."""
+    stat() regardless of file size.
+
+    prefix qualifies the ETag for files whose mtime carries no information (see
+    _sim_assets_tag); app files keep real mtimes and need none."""
     st = path.stat()
-    return f'"{st.st_mtime_ns:x}-{st.st_size:x}"', formatdate(st.st_mtime, usegmt=True)
+    etag = f'"{prefix}{"-" if prefix else ""}{st.st_mtime_ns:x}-{st.st_size:x}"'
+    return etag, formatdate(st.st_mtime, usegmt=True), st.st_mtime
 
 
-def sim_viewer_response(path: str, if_none_match: str = "") -> "Response | None":
+def client_has_current(etag: str, mtime: float, if_none_match: str, if_modified_since: str) -> bool:
+    """Whether the client's cached copy is still current, per RFC 9110 §13.1.3:
+    If-None-Match wins outright when present, and only in its absence does
+    If-Modified-Since get a say.
+
+    Honouring the date matters because we advertise Last-Modified: a client
+    whose cached ETag was evicted, or a proxy that strips ETags, revalidates
+    with the date alone. Without this it misses the 304 and re-downloads the
+    whole asset — 34MB for the apartment glb."""
+    if if_none_match:
+        return if_none_match == etag
+    if not if_modified_since:
+        return False
+    try:
+        since = parsedate_to_datetime(if_modified_since)
+    except (TypeError, ValueError):
+        return False  # malformed date -> treat as no validator, send the body
+    if since is None:
+        return False
+    # HTTP-dates carry whole seconds, so compare at that resolution: a
+    # sub-second-newer file must not read as modified against its own date.
+    return int(mtime) <= int(since.timestamp())
+
+
+def sim_viewer_response(path: str, if_none_match: str = "", if_modified_since: str = "") -> "Response | None":
     clean = path.split("?", 1)[0].split("#", 1)[0]
     for prefix, base in SIM_VIEWER_ROUTES.items():
         if not clean.startswith(prefix):
@@ -214,12 +260,12 @@ def sim_viewer_response(path: str, if_none_match: str = "") -> "Response | None"
         # on every page mount now that the SPA router remounts the stage per
         # visit. Validate from stat() and return 304 *before* touching the body,
         # so an unchanged asset costs a stat instead of a full read.
-        etag, last_modified = cache_validators(target)
+        etag, last_modified, mtime = cache_validators(target, prefix=SIM_ASSETS_TAG)
         cache_control = (
             f"public, max-age={ASSET_MAX_AGE_SECONDS}" if clean.startswith(CACHEABLE_ASSET_PREFIXES) else "no-cache"
         )
         validators = {"ETag": etag, "Last-Modified": last_modified, "Cache-Control": cache_control}
-        if if_none_match == etag:
+        if client_has_current(etag, mtime, if_none_match, if_modified_since):
             return Response(304, "Not Modified", Headers(validators), b"")
         body = target.read_bytes()
         ctype = CONTENT_TYPES.get(target.suffix) or mimetypes.guess_type(str(target))[0] or "application/octet-stream"
@@ -228,7 +274,7 @@ def sim_viewer_response(path: str, if_none_match: str = "") -> "Response | None"
     return None
 
 
-def static_response(path: str, if_none_match: str = "") -> Response:
+def static_response(path: str, if_none_match: str = "", if_modified_since: str = "") -> Response:
     clean = path.split("?", 1)[0].split("#", 1)[0]
     target = (ROOT / clean.lstrip("/")).resolve()
     if target.is_dir():
@@ -249,9 +295,9 @@ def static_response(path: str, if_none_match: str = "") -> Response:
     # Cache-Control stays no-cache so a redeploy is always picked up — the
     # browser still revalidates every load, but revalidation is a tiny
     # conditional request that never reads the file.
-    etag, last_modified = cache_validators(body_path)
+    etag, last_modified, mtime = cache_validators(body_path)
     validators = {"ETag": etag, "Last-Modified": last_modified, "Cache-Control": "no-cache"}
-    if if_none_match == etag:
+    if client_has_current(etag, mtime, if_none_match, if_modified_since):
         return Response(304, "Not Modified", Headers(validators), b"")
     body = body_path.read_bytes()
     ctype = CONTENT_TYPES.get(body_path.suffix) or mimetypes.guess_type(str(body_path))[0] or "application/octet-stream"
@@ -316,7 +362,12 @@ async def _dispatch_request(connection, request):
         return None  # proceed with the WebSocket handshake
     if request.path.split("?", 1)[0] == "/config.json":
         return await asyncio.to_thread(config_response)
-    sim_viewer = await asyncio.to_thread(sim_viewer_response, request.path, request.headers.get("If-None-Match", ""))
+    sim_viewer = await asyncio.to_thread(
+        sim_viewer_response,
+        request.path,
+        request.headers.get("If-None-Match", ""),
+        request.headers.get("If-Modified-Since", ""),
+    )
     if sim_viewer is not None:
         return sim_viewer
     split = urlsplit(request.path)
@@ -348,7 +399,12 @@ async def _dispatch_request(connection, request):
         if request.headers.get("X-Requested-By", "") != "innate-webapp":
             return _plain(403, "Forbidden", "missing X-Requested-By header")
         return await asyncio.to_thread(restart_response)
-    return await asyncio.to_thread(static_response, request.path, request.headers.get("If-None-Match", ""))
+    return await asyncio.to_thread(
+        static_response,
+        request.path,
+        request.headers.get("If-None-Match", ""),
+        request.headers.get("If-Modified-Since", ""),
+    )
 
 
 async def relay(source, sink):

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -198,10 +198,23 @@ def _sim_assets_tag() -> str:
     bare mtime+size validator degrades to size-only for them, and a refreshed
     asset whose size happened to match would keep its ETag and be served stale.
     The tag is a content hash of the whole bundle and changes on every
-    republish, which is the only boundary at which these files can change."""
+    republish, which is the only boundary at which these files can change.
+
+    Read from .assets-tag first: it sits next to the extracted bundle under
+    sim/assets, which IS bind-mounted into the sim container, whereas
+    sim-assets.lock (repo root) is NOT — so the lock is only reachable on host
+    dev runs, and relying on it alone silently degraded the ETag to size-only
+    in the container. Both carry the same tag string."""
+    sim = SIM_VIEWER_ROOT.parent
     try:
-        return json.loads((SIM_VIEWER_ROOT.parent / "sim-assets.lock").read_text())["tag"]
-    except Exception:
+        tag = (sim / "assets" / ".assets-tag").read_text().strip()
+        if tag:
+            return tag
+    except OSError:
+        pass
+    try:
+        return json.loads((sim / "sim-assets.lock").read_text())["tag"]
+    except (OSError, ValueError, KeyError):
         return "noassets"
 
 


### PR DESCRIPTION
## Problem

The webapp already did ETag/304 revalidation — but built the ETag by **reading the whole file and SHA-1'ing it, before** checking `If-None-Match`:

```python
body = target.read_bytes()          # 34MB apartment glb, every request
etag = f'"{hashlib.sha1(body).hexdigest()}"'
if if_none_match == etag:
    return Response(304, ...)        # ...only now do we skip the body
```

So answering "not modified" for the 34MB `appartement.glb` still cost a full disk read + digest — repeated on every teleop/agent switch and route change (the SPA remounts the stage per visit) across ~63MB of `/models/`, `/robot/`, `/physics/`.

## Changes

**1. Validate from one `stat()`.** ETag is now `mtime+size` (the validator nginx and Apache use), and the 304 returns **before** the body is touched.

**2. Fix the epoch-0 mtime at its source.** The sim-asset bundle is a content-addressed tarball whose members are all normalised to `mtime=0` (`tools/publish_assets.py`, so the tarball sha256 / release tag stays reproducible). Extraction preserves that, so ~all 1300+ asset files land at mtime 0 — which would degrade the `mtime+size` ETag to size-only, and a same-size refreshed asset would keep its ETag and be served stale. Rather than work around it in the server, the launcher (`ensure_sim_assets`) now stamps one install-time mtime on every file right after extraction, so a later bundle (extracted the same way) flips `0 → non-zero` and the ETag busts.

**3. ETag-only.** Dropped `Last-Modified` / `If-Modified-Since`: this process *is* the front door (no proxy in between), so `If-None-Match` always comes back and the date validator was dead weight — one fewer clock/timezone edge.

**4. `no-cache` everywhere, no `max-age`.** The viewer loads these assets at bare, unversioned URLs (`scene.ts`: `/models/appartement.glb`, `/robot/mars.urdf`, `/physics/…`), so `max-age` would keep serving a stale asset for up to 24h after a bundle bump — the browser wouldn't revalidate, so the fresh ETag would never be consulted. `no-cache` + ETag revalidates every load, cheaply.

### Why mtime+size rather than a content hash

A content hash cannot be computed without reading the file, which is the whole cost being removed. mtime+size changes on any write, costs one `stat()` regardless of size, and is the standard static-server validator.

### Why stamp at extraction rather than qualify the ETag with the bundle tag

An earlier revision mixed the bundle's content-hash tag into the ETag to cover the epoch-0 mtimes. Stamping at extraction fixes the bad data where it originates, keeps the server a plain static server (no `.assets-tag`/`sim-assets.lock` reads, no container-vs-host mount caveats), and reflects a bundle bump per-request rather than freezing the tag at server-import time.

## Verified

- Same-size content change across a re-extraction produces a **new** ETag (no stale 304).
- Epoch-0 mtimes are stamped to a real value on extraction, so the validator is not size-only.
- Both files compile; the ETag-only 304 path (`If-None-Match == ETag`) is unchanged; path-traversal guards untouched.
