### PR TITLE
feat(skills): follow_aruco closer (~0.35m) and smoother

### DIFF
--- a/workspace/innate_skills/follow_aruco.py
+++ b/workspace/innate_skills/follow_aruco.py
@@ -31,12 +31,19 @@ MAX_LINEAR = 0.3  # m/s forward
 MAX_REVERSE = 0.1  # m/s backward when too close
 MAX_ANGULAR = 0.8  # rad/s
 TURN_GAIN = 1.5  # rad/s per unit of normalized horizontal offset
-LINEAR_GAIN = 0.6  # m/s per unit of relative size error
+LINEAR_GAIN = 0.8  # m/s per unit of relative size error past the deadband
 
 # Follow distance is held by keeping the marker's apparent side length at this
-# fraction of image width (~0.8 m for an 8 cm tag on the main camera).
-TARGET_SIZE_FRAC = 0.07
+# fraction of image width (~0.35 m for an 8 cm tag on the main camera).
+TARGET_SIZE_FRAC = 0.16
 SIZE_DEADBAND = 0.15  # relative size error below which we don't drive
+
+# Smoothing: per-frame corner jitter would otherwise feed straight into the
+# command, and step changes in cmd_vel jerk the base.
+MEAS_SMOOTHING = 0.35  # EMA weight of the newest measurement, (0, 1]
+MAX_LINEAR_STEP = 0.05  # m/s change per loop tick (0.5 m/s^2 slew limit)
+MAX_ANGULAR_STEP = 0.2  # rad/s change per loop tick
+LOST_GRACE_FRAMES = 5  # ramp down this many missed frames before a hard stop
 
 
 class FollowAruco(Skill):
@@ -50,6 +57,10 @@ class FollowAruco(Skill):
         dictionary = cv2.aruco.getPredefinedDictionary(ARUCO_DICT)
         self._detector = cv2.aruco.ArucoDetector(dictionary, cv2.aruco.DetectorParameters())
         self._frame_width = 1  # real width set on every successful _detect_markers() decode
+        self._offset_filtered = None
+        self._size_error_filtered = None
+        self._cmd_linear = 0.0
+        self._cmd_angular = 0.0
 
     @property
     def name(self):
@@ -59,7 +70,7 @@ class FollowAruco(Skill):
         return (
             "Follow a person or object carrying an ArUco tag (DICT_4X4_50, ids 0-3). "
             "The robot waits until it sees one, locks onto that id, says 'Locked in', and "
-            "then drives to keep that marker centered and about 0.8m away. Showing "
+            "then drives to keep that marker centered and about 0.35m away. Showing "
             f"marker id {STOP_ID} stops the follow. Runs until the stop marker is seen "
             "or the skill is cancelled. No obstacle avoidance -- use in clear space."
         )
@@ -74,6 +85,7 @@ class FollowAruco(Skill):
         lock_candidate = None
         lock_streak = 0
         stop_streak = 0
+        lost_frames = 0
         while not self._cancelled:
             markers = self._detect_markers()
 
@@ -97,8 +109,13 @@ class FollowAruco(Skill):
 
             quad = markers.get(locked_id)
             if quad is None:
-                self._stop()  # marker out of sight: hold position, keep scanning
+                lost_frames += 1
+                if lost_frames > LOST_GRACE_FRAMES:
+                    self._stop()  # marker out of sight: hold position, keep scanning
+                else:
+                    self._send_cmd(0.0, 0.0)  # brief detection miss: ramp down, don't jerk
             else:
+                lost_frames = 0
                 self._drive_toward(quad)
             time.sleep(LOOP_PERIOD)
 
@@ -132,18 +149,38 @@ class FollowAruco(Skill):
         # Steer: normalized horizontal offset of the marker center, [-1, 1].
         center_x = quad[:, 0].mean()
         offset = (center_x - self._frame_width / 2) / (self._frame_width / 2)
-        # Positive angular_z is a left turn; marker right of center needs a right turn.
-        angular = float(np.clip(-TURN_GAIN * offset, -MAX_ANGULAR, MAX_ANGULAR))
-
         # Distance: apparent side length vs. target. Too small -> approach,
         # too large -> back off.
         side_frac = np.mean([np.linalg.norm(quad[i] - quad[(i + 1) % 4]) for i in range(4)]) / self._frame_width
         size_error = 1.0 - side_frac / TARGET_SIZE_FRAC
-        linear = 0.0
-        if abs(size_error) > SIZE_DEADBAND:
-            linear = float(np.clip(LINEAR_GAIN * size_error, -MAX_REVERSE, MAX_LINEAR))
 
-        self.mobility.send_cmd_vel(linear_x=linear, angular_z=angular, duration=CMD_DURATION)
+        self._offset_filtered = self._smooth(self._offset_filtered, offset)
+        self._size_error_filtered = self._smooth(self._size_error_filtered, size_error)
+
+        # Positive angular_z is a left turn; marker right of center needs a right turn.
+        angular = float(np.clip(-TURN_GAIN * self._offset_filtered, -MAX_ANGULAR, MAX_ANGULAR))
+
+        linear = 0.0
+        err = self._size_error_filtered
+        if abs(err) > SIZE_DEADBAND:
+            # Ramp from zero at the deadband edge instead of jumping to full gain.
+            past_deadband = err - np.copysign(SIZE_DEADBAND, err)
+            linear = float(np.clip(LINEAR_GAIN * past_deadband, -MAX_REVERSE, MAX_LINEAR))
+
+        self._send_cmd(linear, angular)
+
+    @staticmethod
+    def _smooth(filtered, measurement):
+        if filtered is None:
+            return measurement
+        return filtered + MEAS_SMOOTHING * (measurement - filtered)
+
+    def _send_cmd(self, linear, angular) -> None:
+        # Slew-limit toward the requested velocities so the base accelerates
+        # and decelerates gradually.
+        self._cmd_linear += float(np.clip(linear - self._cmd_linear, -MAX_LINEAR_STEP, MAX_LINEAR_STEP))
+        self._cmd_angular += float(np.clip(angular - self._cmd_angular, -MAX_ANGULAR_STEP, MAX_ANGULAR_STEP))
+        self.mobility.send_cmd_vel(linear_x=self._cmd_linear, angular_z=self._cmd_angular, duration=CMD_DURATION)
 
     def _wait_for_frame(self, timeout: float = 5.0) -> bool:
         deadline = time.time() + timeout
@@ -154,5 +191,9 @@ class FollowAruco(Skill):
         return True
 
     def _stop(self):
+        self._offset_filtered = None
+        self._size_error_filtered = None
+        self._cmd_linear = 0.0
+        self._cmd_angular = 0.0
         if self.mobility is not None:
             self.mobility.send_cmd_vel(linear_x=0.0, angular_z=0.0)

--- a/workspace/innate_skills/follow_aruco.py
+++ b/workspace/innate_skills/follow_aruco.py
@@ -41,8 +41,8 @@ SIZE_DEADBAND = 0.15  # relative size error below which we don't drive
 # Smoothing: per-frame corner jitter would otherwise feed straight into the
 # command, and step changes in cmd_vel jerk the base.
 MEAS_SMOOTHING = 0.35  # EMA weight of the newest measurement, (0, 1]
-MAX_LINEAR_STEP = 0.05  # m/s change per loop tick (0.5 m/s^2 slew limit)
-MAX_ANGULAR_STEP = 0.2  # rad/s change per loop tick
+LINEAR_SLEW = 0.5  # m/s^2 max change in commanded linear velocity
+ANGULAR_SLEW = 2.0  # rad/s^2 max change in commanded angular velocity
 LOST_GRACE_FRAMES = 5  # ramp down this many missed frames before a hard stop
 
 
@@ -61,6 +61,7 @@ class FollowAruco(Skill):
         self._size_error_filtered = None
         self._cmd_linear = 0.0
         self._cmd_angular = 0.0
+        self._last_cmd_time = None
 
     @property
     def name(self):
@@ -110,6 +111,10 @@ class FollowAruco(Skill):
             quad = markers.get(locked_id)
             if quad is None:
                 lost_frames += 1
+                # Drop stale measurements so a re-acquired marker that moved
+                # during the miss doesn't steer off the old filter state.
+                self._offset_filtered = None
+                self._size_error_filtered = None
                 if lost_frames > LOST_GRACE_FRAMES:
                     self._stop()  # marker out of sight: hold position, keep scanning
                 else:
@@ -177,9 +182,15 @@ class FollowAruco(Skill):
 
     def _send_cmd(self, linear, angular) -> None:
         # Slew-limit toward the requested velocities so the base accelerates
-        # and decelerates gradually.
-        self._cmd_linear += float(np.clip(linear - self._cmd_linear, -MAX_LINEAR_STEP, MAX_LINEAR_STEP))
-        self._cmd_angular += float(np.clip(angular - self._cmd_angular, -MAX_ANGULAR_STEP, MAX_ANGULAR_STEP))
+        # and decelerates gradually. The step scales with real elapsed time, so
+        # a slow loop iteration doesn't silently lower the slew rate. dt is
+        # capped at CMD_DURATION: past that the deadman has stopped the base,
+        # and a bigger step would jerk it from standstill.
+        now = time.monotonic()
+        dt = min(now - self._last_cmd_time, CMD_DURATION) if self._last_cmd_time is not None else LOOP_PERIOD
+        self._last_cmd_time = now
+        self._cmd_linear += float(np.clip(linear - self._cmd_linear, -LINEAR_SLEW * dt, LINEAR_SLEW * dt))
+        self._cmd_angular += float(np.clip(angular - self._cmd_angular, -ANGULAR_SLEW * dt, ANGULAR_SLEW * dt))
         self.mobility.send_cmd_vel(linear_x=self._cmd_linear, angular_z=self._cmd_angular, duration=CMD_DURATION)
 
     def _wait_for_frame(self, timeout: float = 5.0) -> bool:
@@ -195,5 +206,6 @@ class FollowAruco(Skill):
         self._size_error_filtered = None
         self._cmd_linear = 0.0
         self._cmd_angular = 0.0
+        self._last_cmd_time = None
         if self.mobility is not None:
             self.mobility.send_cmd_vel(linear_x=0.0, angular_z=0.0)


### PR DESCRIPTION
## Summary
- Target follow distance tightened from ~0.8m to ~0.35m (`TARGET_SIZE_FRAC` 0.07 → 0.16)
- Smoother motion:
  - EMA low-pass on the marker offset/size measurements so corner jitter doesn't feed straight into cmd_vel
  - Linear command ramps from zero at the deadband edge instead of jumping to full gain (gain bumped 0.6 → 0.8 to compensate)
  - Slew-limited velocity commands (0.5 m/s² linear, 2 rad/s² angular)
  - 5-frame (~0.5s) ramp-down grace on missed detections before hard-stopping; filters reset on stop so a re-acquired lock starts clean