### PR TITLE
fix(brain): agent starts wedged on a phantom skill — keep the trigger gate open across activation (INN-711)

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/core/lifecycle.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/lifecycle.py
@@ -170,11 +170,25 @@ class BrainLifecycle:
         self._reactivate_timer.cancel()  # one-shot
         if not self._state.is_brain_active:
             return  # deactivated during the wait; nothing to re-register
-        self.unregister_primitives()
-        self.catalog.register()
+        # No unregister/re-register cycle here. The webapp's Start sends
+        # set_directive (which registers) immediately before set_brain_active,
+        # so by now a registration for the current directive is usually acked
+        # or in flight; its ack has already opened the trigger gate and the
+        # first image may be out. Yanking primitives_registered to False for
+        # the ~2s of another register round trip closes the gate exactly while
+        # the cloud's first decision (VLM latency 2-4s) is in flight — the
+        # reply gets dropped unanswered, and the cloud waits forever on a
+        # primitive the robot never saw (INN-711's startup variant: the agent
+        # starts convinced a skill is running while nothing happens).
+        # register() replaces the server-side roster wholesale, so there is
+        # nothing to unregister first; only register when no registration for
+        # this activation has been acked yet (plain set_brain_active without a
+        # preceding set_directive — deactivate_brain cleared the flag).
+        if not self._state.primitives_registered:
+            self.catalog.register()
         self.activate_directive_inputs()
         self._state.ready_for_image = True
-        self._logger.info("[BrainClient] Brain reactivated and skills re-registered.")
+        self._logger.info("[BrainClient] Brain reactivated; skill registration confirmed or in flight.")
 
     # --- directive switching ---
     def set_directive(self, name: str) -> None:

--- a/ros2_ws/src/brain/brain_client/brain_client/core/vision_output.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/vision_output.py
@@ -34,9 +34,11 @@ class VisionOutputHandler:
             self._logger.info("[BrainClient] Received VisionAgentOutput")
             if not self._state.is_brain_active:
                 self._logger.warn("[BrainClient] Brain is not active. Skipping VisionAgentOutput.")
+                self._bounce_dropped_task(msg.payload, "the brain is not active")
                 return
             if not self._state.primitives_registered:
                 self._logger.warn("[BrainClient] Primitives not registered. Skipping VisionAgentOutput.")
+                self._bounce_dropped_task(msg.payload, "skills were mid (re-)registration")
                 return
 
             # HOTFIX: accept next_task with a "name" field by aliasing it to "type".
@@ -53,6 +55,28 @@ class VisionOutputHandler:
             self._handle_output(payload)
         except Exception as e:
             self._logger.error(f"Error processing vision output: {e}. Traceback: {traceback.format_exc()}")
+
+    def _bounce_dropped_task(self, raw_payload, why: str) -> None:
+        """A dropped trigger must never be dropped SILENTLY: the cloud marks
+        the primitive as running when it SENDS the task (optimistically, with
+        no timeout of its own) and only a terminal lifecycle message clears
+        it. Skipping a task without answering pins the agent in "the tool has
+        already been called and has to finish" until a lucky stop_current_task
+        (INN-711 tail — see PR #533 for the sibling never-started paths).
+        Typical hit: a task computed from a pre-stop image landing during a
+        stop, or during a registration round trip."""
+        try:
+            task = (raw_payload or {}).get("next_task") or {}
+            primitive_id = task.get("primitive_id")
+            if not primitive_id:
+                return  # nothing the cloud is waiting on
+            self._runner.report_start_failure(
+                primitive_name=str(task.get("type") or task.get("name") or "unknown"),
+                primitive_id=primitive_id,
+                reason=f"The robot dropped this task: {why}.",
+            )
+        except Exception as e:  # noqa: BLE001 -- best-effort courtesy reply
+            self._logger.warn(f"[BrainClient] Could not report dropped task to the cloud: {e}")
 
     def _handle_output(self, payload: VisionAgentOutput) -> None:
         execute_now = True

--- a/ros2_ws/src/brain/brain_client/test/test_reactivation_window.py
+++ b/ros2_ws/src/brain/brain_client/test/test_reactivation_window.py
@@ -48,7 +48,9 @@ def _make_lifecycle(state):
     runner = SimpleNamespace(abort_calls=0)
     runner.abort_running = lambda: setattr(runner, "abort_calls", runner.abort_calls + 1)
     lifecycle = BrainLifecycle(
-        SimpleNamespace(get_logger=lambda: FakeLogger(), create_timer=lambda *a: FakeTimer(), destroy_timer=lambda t: None),
+        SimpleNamespace(
+            get_logger=lambda: FakeLogger(), create_timer=lambda *a: FakeTimer(), destroy_timer=lambda t: None
+        ),
         state,
         SimpleNamespace(),
         ws_bridge=SimpleNamespace(send_message=lambda m: None),

--- a/ros2_ws/src/brain/brain_client/test/test_reactivation_window.py
+++ b/ros2_ws/src/brain/brain_client/test/test_reactivation_window.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Unit tests for the activation registration window (INN-711 startup variant).
+
+The webapp's Start sends set_directive (which registers the catalog) and
+set_brain_active back-to-back. _finish_reactivation used to unregister and
+re-register unconditionally 0.5s later — closing the trigger gate
+(primitives_registered) for a ~2s round trip exactly while the cloud's first
+decision (VLM latency 2-4s) was in flight, so the reply was dropped and the
+agent started wedged on a phantom "running" primitive. Pins the fix: an acked
+registration for the current directive survives reactivation untouched.
+"""
+
+from types import SimpleNamespace
+
+from brain_client.core.lifecycle import BrainLifecycle
+from brain_client.core.state import BrainState
+
+
+class FakeLogger:
+    def info(self, msg):
+        pass
+
+    def warn(self, msg):
+        pass
+
+    def error(self, msg):
+        pass
+
+    def debug(self, msg):
+        pass
+
+
+class FakeTimer:
+    def __init__(self):
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+    def is_canceled(self):
+        return self.cancelled
+
+
+def _make_lifecycle(state):
+    catalog = SimpleNamespace(register_calls=0)
+    catalog.register = lambda: setattr(catalog, "register_calls", catalog.register_calls + 1)
+    runner = SimpleNamespace(abort_calls=0)
+    runner.abort_running = lambda: setattr(runner, "abort_calls", runner.abort_calls + 1)
+    lifecycle = BrainLifecycle(
+        SimpleNamespace(get_logger=lambda: FakeLogger(), create_timer=lambda *a: FakeTimer(), destroy_timer=lambda t: None),
+        state,
+        SimpleNamespace(),
+        ws_bridge=SimpleNamespace(send_message=lambda m: None),
+        camera=SimpleNamespace(),
+        pose_tracker=SimpleNamespace(),
+        runner=runner,
+        gaze=SimpleNamespace(),
+        chat=SimpleNamespace(),
+        orchestrator=SimpleNamespace(),
+        catalog=catalog,
+        active_inputs_pub=SimpleNamespace(publish=lambda m: None),
+        stop_robot=lambda: None,
+        publish_status=lambda: None,
+    )
+    lifecycle._reactivate_timer = FakeTimer()
+    return lifecycle, catalog, runner
+
+
+def test_acked_registration_survives_reactivation():
+    # set_directive registered and the ack landed: the gate is open and the
+    # first image may already be answered mid-flight — reactivation must not
+    # close it, re-register, or abort anything.
+    state = BrainState(is_brain_active=True, primitives_registered=True)
+    lifecycle, catalog, runner = _make_lifecycle(state)
+
+    lifecycle._finish_reactivation()
+
+    assert state.primitives_registered is True  # gate never closed
+    assert catalog.register_calls == 0
+    assert runner.abort_calls == 0
+    assert state.ready_for_image is True
+
+
+def test_plain_activation_still_registers():
+    # set_brain_active without a preceding set_directive (deactivate cleared
+    # the flag): reactivation must still register the catalog.
+    state = BrainState(is_brain_active=True, primitives_registered=False)
+    lifecycle, catalog, _runner = _make_lifecycle(state)
+
+    lifecycle._finish_reactivation()
+
+    assert catalog.register_calls == 1
+    assert state.ready_for_image is True
+
+
+def test_deactivated_during_wait_is_a_noop():
+    state = BrainState(is_brain_active=False, primitives_registered=False)
+    lifecycle, catalog, _runner = _make_lifecycle(state)
+
+    lifecycle._finish_reactivation()
+
+    assert catalog.register_calls == 0
+    assert state.ready_for_image is False

--- a/ros2_ws/src/brain/brain_client/test/test_vision_output_dropped_task.py
+++ b/ros2_ws/src/brain/brain_client/test/test_vision_output_dropped_task.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Unit tests for dropped-trigger reporting (INN-711 startup variant).
+
+The cloud marks a primitive as running the moment it SENDS the task, with no
+timeout of its own; only a terminal lifecycle message clears it. So when the
+robot skips a VisionAgentOutput (brain inactive, or skills mid-registration),
+it must bounce a terminal "failed" for the task's primitive_id — a silent
+drop leaves the agent convinced forever that the skill is still running.
+"""
+
+from types import SimpleNamespace
+
+from brain_client.core.vision_output import VisionOutputHandler
+
+
+class FakeLogger:
+    def info(self, msg):
+        pass
+
+    def warn(self, msg):
+        pass
+
+    def error(self, msg):
+        pass
+
+
+class FakeRunner:
+    def __init__(self):
+        self.start_failures = []
+        self.started = []
+        self.pending_cleared = False
+
+    def report_start_failure(self, *, primitive_name, primitive_id, reason, skill_id=None):
+        self.start_failures.append({"primitive_name": primitive_name, "primitive_id": primitive_id, "reason": reason})
+
+    def start_task(self, skill_id, primitive_id, inputs):
+        self.started.append((skill_id, primitive_id, inputs))
+
+    def clear_pending(self):
+        self.pending_cleared = True
+
+    @property
+    def has_active_goal(self):
+        return False
+
+
+def _make_handler(*, active, registered):
+    runner = FakeRunner()
+    state = SimpleNamespace(
+        is_brain_active=active,
+        primitives_registered=registered,
+        log_everything=False,
+        pose_at_image_send=None,
+        registry=SimpleNamespace(resolve_skill_id=lambda t: f"innate-os/{t}"),
+    )
+    handler = VisionOutputHandler(
+        SimpleNamespace(get_logger=lambda: FakeLogger()),
+        state,
+        runner=runner,
+        chat=SimpleNamespace(emit=lambda *a, **k: None),
+        gaze=SimpleNamespace(pause=lambda: None),
+        pose_tracker=SimpleNamespace(),
+    )
+    return handler, runner
+
+
+def _msg(next_task):
+    payload = {
+        "stop_current_task": False,
+        "observation": "o",
+        "thoughts": "t",
+        "new_goal": None,
+        "anticipation": None,
+        "to_tell_user": None,
+        "next_task": next_task,
+    }
+    return SimpleNamespace(payload=payload)
+
+
+TASK = {"type": "turn_and_move", "inputs": {"x": 0.5}, "primitive_id": "prim-42"}
+
+
+def test_drop_while_inactive_bounces_terminal_failed():
+    handler, runner = _make_handler(active=False, registered=True)
+    handler.handle_message(_msg(TASK))
+    assert runner.started == []
+    assert len(runner.start_failures) == 1
+    assert runner.start_failures[0]["primitive_id"] == "prim-42"
+    assert "not active" in runner.start_failures[0]["reason"]
+
+
+def test_drop_while_unregistered_bounces_terminal_failed():
+    handler, runner = _make_handler(active=True, registered=False)
+    handler.handle_message(_msg(TASK))
+    assert runner.started == []
+    assert len(runner.start_failures) == 1
+    assert runner.start_failures[0]["primitive_id"] == "prim-42"
+    assert "registration" in runner.start_failures[0]["reason"]
+
+
+def test_drop_without_task_stays_silent():
+    # No primitive_id -> the cloud is not waiting on anything; no bounce.
+    handler, runner = _make_handler(active=False, registered=False)
+    handler.handle_message(_msg(None))
+    assert runner.start_failures == []
+
+
+def test_normal_path_dispatches_without_bounce():
+    handler, runner = _make_handler(active=True, registered=True)
+    handler.handle_message(_msg(TASK))
+    assert runner.start_failures == []
+    assert runner.started == [("innate-os/turn_and_move", "prim-42", {"x": 0.5})]


### PR DESCRIPTION
Fixes the startup variant of [INN-711](https://linear.app/innate/issue/INN-711) — still reproducible after #533: right after Start, the agent believes it called a skill, keeps saying "the tool has already been called and has to finish", and nothing ever moves.

## Root cause (reproduced 3/3 in the sim, log-correlated to the millisecond)

The webapp's Start sends `set_directive` (which registers the skill catalog) and `set_brain_active` back-to-back. That produces **two registrations with an unregister sandwiched between them**, and the first ACK opens the trigger gate just long enough for one image to slip out:

```
835.31  set_directive            -> registration #1 sent
835.33  reactivate_brain
835.60  registration #1 ACK      -> trigger gate opens (primitives_registered=True)
835.61  first image sent         -> cloud VLM starts thinking (2-4s latency)
836.32  _finish_reactivation     -> unregister: GATE CLOSED
838.01  VLM reply (the agent's FIRST task) arrives -> "Primitives not registered. Skipping." — dropped, unanswered
838.33  registration #2 ACK      -> gate reopens, 320 ms too late
```

The cloud marks a primitive as running **when it sends the task** (optimistically, with no timeout of its own) and only a terminal lifecycle message with the matching `primitive_id` clears it. A silently dropped reply therefore wedges the agent permanently: its prompt injects "the current primitive is: turn_and_move…", its validator discards every new task it proposes, and the only escape is the model spontaneously emitting `stop_current_task: true` (observed once in ~25 s; often never).

Whether a given Start wedges is a race between the VLM latency (2–4 s) and the re-registration round trip (~2 s) — which is why it "tends to" happen rather than always.

## Fix

1. **`lifecycle._finish_reactivation` no longer closes the gate it just opened.** When a registration for the current directive is already acked or in flight, the unregister/re-register cycle is skipped entirely — `register()` replaces the roster wholesale server-side, so the unregister bought nothing, and its `abort_running()` could even silently kill a legitimately-started first skill. A plain `set_brain_active` without a preceding `set_directive` (the flag was cleared by `deactivate_brain`) still registers.

2. **`vision_output.handle_message` never drops a trigger silently.** Both guard drops (brain inactive / mid-registration) now bounce a terminal `failed` via the existing `report_start_failure()` when the payload carries a `next_task` — same philosophy as #533, one layer further upstream. This also covers the sibling race: the cloud keeps finishing in-flight VLM work across stop boundaries, and those stale replies land during the stopped/re-registration window.

Fix 1 removes the deterministic startup cause; fix 2 converts every remaining (and future) drop race from "wedged until a lucky stop" into "one answered failure, then recovery".

## Tests

- `test_reactivation_window.py`: an acked registration survives reactivation untouched (gate stays open, no re-register, no abort); plain activation still registers; deactivation-during-wait stays a no-op.
- `test_vision_output_dropped_task.py`: both guard drops answer with the matching `primitive_id`; no bounce without a task; the normal path dispatches without bouncing.

Ran in the innate-dev container alongside the existing unit suites: **25 passed**.

Note: #533's tests were dropped in `e51e2a0f` as "temporary mitigation, not pinning". These fixes are the same family and are now load-bearing for agent startup, so this PR pins them.

## Remaining (cloud-side, separate PR in innate-cloud-agent)

The robot can now always answer; the cloud still has no watchdog if a message is lost in transit, and its `ready_for_image` loop is only re-armed by `primitive_activated`. Follow-up PR adds the watchdog + liveness there.
