### PR TITLE
feat(challenges): victory_lap + lifesupport

### DIFF
--- a/sim/challenges/01_victory_lap.py
+++ b/sim/challenges/01_victory_lap.py
@@ -8,11 +8,11 @@ CHALLENGE = Challenge(
     brief=(
         "Tell the robot some cheerful news in the agent chat (e.g. \"We won the "
         "championship!\"). When it hears the good news, it should celebrate by "
-        "running its victory_lap skill."
+        "running its victory_spin skill."
     ),
     setup=[],
     goals=[
-        Goal("Run a victory lap to celebrate", SkillDone("victory_lap")),
+        Goal("Run a victory lap to celebrate", SkillDone("victory_spin")),
     ],
     time_limit_s=300,
 )

--- a/sim/challenges/01_victory_lap.py
+++ b/sim/challenges/01_victory_lap.py
@@ -1,0 +1,18 @@
+"""Victory Lap: celebrate good news with a lap."""
+
+from mars_sim_driver.challenges import Challenge, Goal, SkillDone
+
+CHALLENGE = Challenge(
+    id="victory_lap",
+    title="Victory Lap",
+    brief=(
+        "Tell the robot some cheerful news in the agent chat (e.g. \"We won the "
+        "championship!\"). When it hears the good news, it should celebrate by "
+        "running its victory_lap skill."
+    ),
+    setup=[],
+    goals=[
+        Goal("Run a victory lap to celebrate", SkillDone("victory_lap")),
+    ],
+    time_limit_s=300,
+)

--- a/sim/challenges/02_lifesupport.py
+++ b/sim/challenges/02_lifesupport.py
@@ -21,7 +21,7 @@ CHALLENGE = Challenge(
         Goal("Wave to check if they respond", SkillDone("wave", guard=Near("robot", "human", 1.5))),
         # The event carries no recipient, so this only verifies an email was
         # sent -- the 911@innate.bot address lives in the brief for the agent.
-        Goal("Email 911 for help", SkillDone("send_email")),
+        Goal("Email 911@innate.bot for help", SkillDone("send_email")),
     ],
     time_limit_s=600,
 )

--- a/sim/challenges/02_lifesupport.py
+++ b/sim/challenges/02_lifesupport.py
@@ -1,0 +1,27 @@
+"""Life Support: check a collapsed person, then call for help."""
+
+from mars_sim_driver.challenges import Challenge, Drop, Goal, Near, SkillDone
+
+CHALLENGE = Challenge(
+    id="lifesupport",
+    title="Life Support",
+    brief=(
+        "A person has collapsed right in front of the robot. Wave at them to "
+        "check whether they respond, then email 911@innate.bot to call for help."
+    ),
+    # ~1.5 m in front of spawn (-4.34, -0.17, facing -y). Body along x
+    # (yaw -90: the scan's head axis is +y at identity) -- collapsed, like
+    # rescue.py's human.
+    setup=[
+        Drop("human", -4.34, -1.67, yaw_deg=-90),
+    ],
+    goals=[
+        # Wave must happen while next to the person -- a wave across the room
+        # does not count as checking on them.
+        Goal("Wave to check if they respond", SkillDone("wave", guard=Near("robot", "human", 1.5))),
+        # The event carries no recipient, so this only verifies an email was
+        # sent -- the 911@innate.bot address lives in the brief for the agent.
+        Goal("Email 911 for help", SkillDone("send_email")),
+    ],
+    time_limit_s=600,
+)


### PR DESCRIPTION
Adds two sim challenges, ordered ahead of the existing rescue/shepherd via numeric filename prefixes (roster order = `sorted(glob("*.py"))`).

## 1. Victory Lap (`01_victory_lap.py`)
Robot celebrates good news with a lap.
- Goal: `SkillDone("victory_lap")`
- The "cheerful news" is delivered **manually** — the brief tells the user to message the agent (the challenge engine is inbound-only and can't publish to `/brain/chat_in`).
- ⚠️ **Depends on a `victory_lap` skill that doesn't exist yet** — being authored separately. Goal fires once a skill reporting `skill_name="victory_lap"` (or `skill_id="innate-os/victory_lap"`) completes.

## 2. Life Support (`02_lifesupport.py`)
A human is dropped ~1.5 m in front of spawn; the robot checks on them, then calls for help.
- Goal 1: `SkillDone("wave", guard=Near("robot","human",1.5))` — wave *while next to* the person
- Goal 2: `SkillDone("send_email")` — the `/brain/skill_status_update` payload carries no recipient, so `911@innate.bot` lives in the brief and the goal only verifies a send completed
- Uses the existing `wave` and `send_email` skills.

## Base
Targets `sim-challenge` (not `main`) — the challenge engine (`challenges.py`, `sim/challenges/`) only exists on that branch.

## Notes
- Human drop spot `(-4.34, -1.67)` is ~1.5 m south of spawn; not yet verified against the nav map's interior floor (see the `shepherd.py`/`rescue.py` caveat about the collision plane extending past walls).
- World server must be restarted to load new challenge files (`load_challenges` runs at engine init).