### PR TITLE
feat(webapp): copyable challenge instructions

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -653,6 +653,10 @@ button {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  /* Let the brief/goals be selected so the challenge instructions can be
+     copied into the agent chat (the .overlay default is user-select: none). */
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .challenge-title-row {


### PR DESCRIPTION
Makes the active challenge's brief + goals selectable so the instructions can be copied out of the panel and pasted into the agent chat.

**Why:** `.overlay` sets `user-select: none`, which the challenge panel inherits — so none of the challenge text could be selected/copied.

**Change:** `user-select: text` on `.challenge-active` (webapp/css/app.css). The clickable list items (buttons) are left non-selectable so click-to-start still behaves.

Targets `sim-challenge` (the branch that has the challenge panel).