### PR TITLE
Simulator polish: brain prompt, Foxglove on dashboard, sim log labels, README parity

### DIFF
--- a/sim/README.md
+++ b/sim/README.md
@@ -41,14 +41,9 @@ brew install --cask docker
 <details>
 <summary><b>Linux (Ubuntu / Debian / Raspberry Pi OS)</b></summary>
 
-On Ubuntu:
-
-```bash
-sudo apt install docker.io docker-compose-v2
-```
-
-On Debian / Raspberry Pi OS (whose `docker-compose` package is the old v1
-tool), use Docker's own install script instead:
+Use Docker's own install script — it sets up the official apt repo and
+installs Docker plus the Compose v2 plugin, the same way on every
+Debian-family distro:
 
 ```bash
 curl -fsSL https://get.docker.com | sudo sh
@@ -60,8 +55,10 @@ Then let your user talk to Docker:
 sudo usermod -aG docker $USER && newgrp docker
 ```
 
-Desktop installs already have working OpenGL. On a headless server or VM,
-also install the offscreen rendering libraries:
+Install the rendering libraries. On a headless server or VM these provide
+offscreen rendering; on a desktop with working OpenGL they're mostly already
+present, and the extra software-rendering library is harmless — so it's safe
+to run either way:
 
 ```bash
 sudo apt install libegl1 libgl1 libopengl0 libosmesa6
@@ -95,14 +92,17 @@ Then, from the repository root:
 ./innate-sim up        # starts everything; leave the live dashboard open
 ```
 
-`setup` asks which brain the robot's AI agent should use:
+`setup` asks which brain — the robot's AI agent — to run. The agent is the
+open-source [innate-cloud-agent](https://github.com/innate-inc/innate-cloud-agent);
+the choice is only about *where* it runs:
 
-- **Hosted Innate brain** — uses your Innate service key (it comes with a
-  MARS robot). The full experience, including voice — the robot speaks.
-- **Local brain (Gemini)** — runs the open-source agent on your machine
-  against a [Gemini API key](https://aistudio.google.com/api-keys).
-  Everything works except voice: the web app's speak bar is disabled
-  without a service key.
+- **Local brain (Gemini)** — the default. Clones `innate-cloud-agent` and
+  runs it on your machine against a
+  [Gemini API key](https://aistudio.google.com/api-keys). Everything works
+  except voice: the web app's speak bar is disabled without a service key.
+- **Hosted Innate brain** — the same agent, run on Innate's servers with
+  your Innate service key (it ships with a MARS robot). The full experience,
+  including voice — the robot speaks.
 - **None** — no agent; you can still drive, navigate, and trigger skills
   manually.
 
@@ -124,7 +124,7 @@ If something stops you anyway, we want to hear about it —
 ./innate-sim status      # startup checks + health snapshot
 ./innate-sim logs        # startup logs; `logs os` / `logs agent` follow live
 ./innate-sim sh          # shell into the container; `innate build` rebuilds ros2_ws
-./innate-sim down        # stop
+./innate-sim down        # stop the container + world server (keeps data)
 ./innate-sim clean       # remove containers/volumes (keeps .env + config)
 ```
 

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -482,6 +482,14 @@ def get_config() -> dict[str, object]:
 
     mode = resolve_cloud_agent_mode(sim_config, merged_env)
 
+    # Foxglove bridge lives on 8765 (Foxglove Studio's default), but a local
+    # brain's cloud-agent owns that host port, so it shifts to 8766 unless the
+    # user pinned SIM_FOXGLOVE_PORT. Mirror runtime.py's start-up logic here so
+    # the dashboard advertises the address it actually listens on.
+    foxglove_port = os.environ.get("SIM_FOXGLOVE_PORT", "").strip() or (
+        "8766" if mode in LOCAL_MODES else "8765"
+    )
+
     os_repo = require_path(REPO_ROOT, "innate-os repository")
     sim_repo = require_path(REPO_ROOT / "sim", "sim repository")
 
@@ -511,6 +519,7 @@ def get_config() -> dict[str, object]:
         "sim_repo": sim_repo,
         "cloud_repo": cloud_repo,
         "cloud_port": cloud_port,
+        "foxglove_port": foxglove_port,
         "brain_websocket_uri": resolve_brain_websocket_uri(mode, merged_env),
         "brain_client_version": resolve_brain_client_version(os_repo),
         "cloud_image": get_nested_str(sim_config, "cloud_agent", "image") or "",

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -486,9 +486,7 @@ def get_config() -> dict[str, object]:
     # brain's cloud-agent owns that host port, so it shifts to 8766 unless the
     # user pinned SIM_FOXGLOVE_PORT. Mirror runtime.py's start-up logic here so
     # the dashboard advertises the address it actually listens on.
-    foxglove_port = os.environ.get("SIM_FOXGLOVE_PORT", "").strip() or (
-        "8766" if mode in LOCAL_MODES else "8765"
-    )
+    foxglove_port = os.environ.get("SIM_FOXGLOVE_PORT", "").strip() or ("8766" if mode in LOCAL_MODES else "8765")
 
     os_repo = require_path(REPO_ROOT, "innate-os repository")
     sim_repo = require_path(REPO_ROOT / "sim", "sim repository")

--- a/sim/launcher/dashboard.py
+++ b/sim/launcher/dashboard.py
@@ -844,6 +844,11 @@ def render_status(
         term_width,
     )
     used_lines += 1
+    print_dashboard_line(
+        f"{BOLD}Foxglove:{NC} ws://localhost:{config['foxglove_port']}",
+        term_width,
+    )
+    used_lines += 1
     if config["mode"] in options.local_modes:
         print_dashboard_line(
             f"{BOLD}Local agent:{NC} ws://localhost:{config['cloud_port']}",

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -313,7 +313,7 @@ def build_parser() -> argparse.ArgumentParser:
     sim_subparsers.add_parser(
         "down",
         prog=f"{CLI_SIM} down",
-        help="Stop the local simulator-backed runtime",
+        help="Stop the running container and world server (keeps data; use `clean` to remove volumes)",
     )
     sim_subparsers.add_parser(
         "assets",

--- a/sim/launcher/setup_wizard.py
+++ b/sim/launcher/setup_wizard.py
@@ -410,16 +410,21 @@ def configure_brain_backend(config: dict[str, object]) -> None:
     print()
     print(f"{CYAN}{BOLD}Brain Backend{NC}")
     print(
-        f"{DIM}The brain is the robot's agent. Run it locally with a Gemini key, "
-        f"use Innate's hosted brain with a service key, or run the sim with no agent.{NC}"
+        f"{DIM}The brain is the robot's AI agent. Pick where it runs:\n"
+        f"  - Local: clones the open-source agent\n"
+        f"    (https://github.com/innate-inc/innate-cloud-agent) and runs it on this\n"
+        f"    machine against a Gemini key. Everything works except voice.\n"
+        f"  - Hosted: the same agent, run by Innate on a service key that ships with a\n"
+        f"    MARS robot. Full experience, including the robot's voice.\n"
+        f"  - None: drive, navigate, and trigger skills manually, with no agent.{NC}"
     )
     print()
     default_choice = "1" if has_gemini else ("2" if has_service_key else "3")
     choice = _prompt_choice(
         "Which brain backend?",
         {
-            "1": "Local cloud-agent (Gemini key: get from https://aistudio.google.com/api-keys)",
-            "2": "Hosted Innate brain (service key)",
+            "1": "Local brain (Gemini key: get one at https://aistudio.google.com/api-keys)",
+            "2": "Hosted Innate brain (service key from a MARS robot)",
             "3": "None (run the sim without an agent)",
         },
         default=default_choice,

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -263,10 +263,13 @@ export const GET_RUN_LOGS_SERVICE = "/innate_training/get_run_logs";
 export const BRAIN_RELOAD_SERVICE = "/brain/reload";
 
 // Friendly subpane names per tmux window — index = pane (0 = left, 1 = right).
-// Mirrors innate-os/scripts/launch_ros_in_tmux.sh ROS_COMMAND_GROUPS; keep the
-// two in sync. Labels the Logging page's subpane picker by launch file.
+// Robot windows mirror innate-os/scripts/launch_ros_in_tmux.sh ROS_COMMAND_GROUPS;
+// sim windows mirror innate-os/scripts/launch_sim_in_tmux.zsh. Keep both in sync
+// so the Logging page labels each subpane by launch file (in the sim and on the
+// robot alike) instead of falling back to the raw "window.pane" id.
 /** @type {Record<string, string[]>} */
 export const PANE_LAUNCH_LABELS = {
+  // Robot (launch_ros_in_tmux.sh)
   "app-bringup": ["app.launch.py", "mars_bringup.launch.py"],
   "arm-recorder": ["arm.launch.py", "recorder.launch.py"],
   "brain-nav": ["brain_client.launch.py", "mode_manager.launch.py"],
@@ -275,6 +278,16 @@ export const PANE_LAUNCH_LABELS = {
   "ik-logger": ["ik.launch.py", "logger.launch.py"],
   "training-uninavid": ["training_node", "uninavid.launch.py"],
   "console": ["console.launch.py", "dataset_encoder.launch.py"],
+  // Sim (launch_sim_in_tmux.zsh) — different window split, .sim launch variants
+  "zenoh": ["rmw_zenohd"],
+  "rosbridge-app": ["sim_rosbridge.launch.py", "app.sim.launch.py"],
+  "sim-driver": ["sim_driver.launch.py"],
+  "nav-brain": ["mode_manager.launch.py", "brain_client.sim.launch.py"],
+  "behavior": ["behavior.launch.py"],
+  "arm-ik": ["ik.py"],
+  "vision-nav": ["uninavid.launch.py"],
+  "console-webapp": ["console.launch.py", "https_server.py"],
+  "foxglove": ["foxglove_bridge_launch.xml"],
 };
 
 // ---- Camera Calibration page ----------------------------------------------


### PR DESCRIPTION
Polish pass on the simulator, from user-test observations.

## Setup wizard — clearer brain prompt
`sim/launcher/setup_wizard.py` — the brain-backend prompt dropped the term "cloud-agent" with no explanation. Now it describes the choice as *where the same open-source agent runs*: Local clones [innate-cloud-agent](https://github.com/innate-inc/innate-cloud-agent) and runs it locally against a Gemini key; Hosted runs it on Innate's servers with a service key. Local stays the default.

## Dashboard — show the Foxglove address
`sim/launcher/config.py` + `dashboard.py` — the live dashboard listed Web UI / ROSBridge / Local agent but never the Foxglove address. Added a `Foxglove: ws://localhost:<port>` line; the port is computed the same way `runtime.py` picks it (8765, or 8766 when a local brain owns 8765, honoring `SIM_FOXGLOVE_PORT`).

## `down` help
`sim/launcher/main.py` — `down`'s `--help` was just "Stop the local simulator-backed runtime"; now spells out that it stops the container + world server and keeps data (vs `clean`).

## README parity
`sim/README.md` — mirrors the docs update: single `get.docker.com` install for all Linux (the old `docker.io docker-compose-v2` line fails on Ubuntu 22.04 LTS); OpenGL libs safe on desktop or headless; brain list leads with Local (the default) and links the agent repo; clearer `down` comment.

## Sim logs — launch-file labels, matching the robot
`webapp/js/constants.js` — the Logging page resolves each pane's label through `PANE_LAUNCH_LABELS`, keyed by tmux window name. Only the robot's windows were in the map, so on the robot logs read as launch files (`mode_manager.launch.py`, …) while the sim fell back to the raw `window.pane` id (`nav-brain.1`, `arm-ik.0`). Added the sim's windows (`launch_sim_in_tmux.zsh`) with their actual pane→launch-file layout so sim logs read the same way — purely additive to the label map, no rename, no logic change (and nothing that touches `runtime.py`'s hardcoded `nav-brain.1` capture).

## Test
- `py_compile` passes on all four launcher files.
- `node --check` passes on `constants.js`.

## Companion PR (docs)
- innate-inc/docs#23 — Simulator & Foxglove docs polish.
