### PR TITLE
Show launch-file labels for sim logs, matching the robot

### DIFF
--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -263,10 +263,13 @@ export const GET_RUN_LOGS_SERVICE = "/innate_training/get_run_logs";
 export const BRAIN_RELOAD_SERVICE = "/brain/reload";
 
 // Friendly subpane names per tmux window — index = pane (0 = left, 1 = right).
-// Mirrors innate-os/scripts/launch_ros_in_tmux.sh ROS_COMMAND_GROUPS; keep the
-// two in sync. Labels the Logging page's subpane picker by launch file.
+// Robot windows mirror innate-os/scripts/launch_ros_in_tmux.sh ROS_COMMAND_GROUPS;
+// sim windows mirror innate-os/scripts/launch_sim_in_tmux.zsh. Keep both in sync
+// so the Logging page labels each subpane by launch file (in the sim and on the
+// robot alike) instead of falling back to the raw "window.pane" id.
 /** @type {Record<string, string[]>} */
 export const PANE_LAUNCH_LABELS = {
+  // Robot (launch_ros_in_tmux.sh)
   "app-bringup": ["app.launch.py", "mars_bringup.launch.py"],
   "arm-recorder": ["arm.launch.py", "recorder.launch.py"],
   "brain-nav": ["brain_client.launch.py", "mode_manager.launch.py"],
@@ -275,6 +278,16 @@ export const PANE_LAUNCH_LABELS = {
   "ik-logger": ["ik.launch.py", "logger.launch.py"],
   "training-uninavid": ["training_node", "uninavid.launch.py"],
   "console": ["console.launch.py", "dataset_encoder.launch.py"],
+  // Sim (launch_sim_in_tmux.zsh) — different window split, .sim launch variants
+  "zenoh": ["rmw_zenohd"],
+  "rosbridge-app": ["sim_rosbridge.launch.py", "app.sim.launch.py"],
+  "sim-driver": ["sim_driver.launch.py"],
+  "nav-brain": ["mode_manager.launch.py", "brain_client.sim.launch.py"],
+  "behavior": ["behavior.launch.py"],
+  "arm-ik": ["ik.py"],
+  "vision-nav": ["uninavid.launch.py"],
+  "console-webapp": ["console.launch.py", "https_server.py"],
+  "foxglove": ["foxglove_bridge_launch.xml"],
 };
 
 // ---- Camera Calibration page ----------------------------------------------


### PR DESCRIPTION
## Problem

In the sim, the Logging page labels each source by its raw tmux `window.pane` id (`nav-brain.1`, `arm-ik.0`, `foxglove.0`), while on the robot the same page shows launch-file names (`mode_manager.launch.py`, …). Same webapp, different output.

## Root cause

The top-level label comes from a static lookup, `PANE_LAUNCH_LABELS` in [`webapp/js/constants.js`](../blob/main/webapp/js/constants.js), keyed by tmux window name → per-pane launch file, resolved in [`format.js`](../blob/main/webapp/js/logging/format.js):

```js
return (PANE_LAUNCH_LABELS[win] || [])[idx] || pane;  // ← falls back to raw "window.idx"
```

The map only contained the **robot's** windows (from `launch_ros_in_tmux.sh`). The sim's windows (from `launch_sim_in_tmux.zsh`) weren't there, so every sim pane fell through to the raw id.

## Fix

Add the sim's windows to the map with their real pane→launch-file layout. Purely additive data through the exact render path the robot already uses — no rename, no logic change, and nothing that touches `runtime.py`'s hardcoded `nav-brain.1` capture.

Note the sim's layout genuinely differs from the robot's (different window split, `.sim.launch.py` variants, `mode_manager` in pane 0 of `nav-brain`), which is exactly why a plain window-rename would have mislabeled panes — hence encoding the sim's actual layout instead.

## Test
- `node --check` passes on constants.js.
- Manual: bring up the sim, open the Logging page — sources now read as launch files.