### PR TITLE
fix(nav): mode startup survives a wedged lifecycle node; configure-only nodes land INACTIVE

### DIFF
--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -593,22 +593,22 @@ class ModeManager(Node):
             # transiently — most commonly it is stuck in a lifecycle transition
             # waiting on a peer this very pass brings up (e.g. a costmap's
             # on_activate blocked on a map publisher), which also makes its
-            # lifecycle services unresponsive. The transitions are idempotent,
-            # so the second pass simply re-runs them after a short settle and
-            # picks up whatever recovered. (Previously the first failure left
-            # the mode down and a manual retry of change_mode succeeded.)
-            map_load_success = False
-            for startup_pass in (1, 2):
+            # lifecycle services unresponsive. The second pass simply re-runs
+            # the sweep after a short settle and picks up whatever recovered.
+            # (Previously the first failure left the mode down and a manual
+            # retry of change_mode succeeded.)
+            # Exception: a map-load failure alone is not retried — the load
+            # already retries internally, so a second sweep can't fix it and
+            # would only double the time spent holding the mode lock.
+            failures, map_load_success = self._startup_pass(mode, node_names, configure_only)
+            if failures and any(not f.endswith("_map_load") for f in failures):
+                self.get_logger().warning(
+                    f"{mode.value} startup pass 1 failed on {failures}; retrying once after settle"
+                )
+                time.sleep(2.0)
                 failures, map_load_success = self._startup_pass(
                     mode, node_names, configure_only, map_already_loaded=map_load_success
                 )
-                if not failures:
-                    break
-                if startup_pass == 1:
-                    self.get_logger().warning(
-                        f"{mode.value} startup pass 1 failed on {failures}; retrying once after settle"
-                    )
-                    time.sleep(2.0)
 
             if failures:
                 message = f"{mode.value} mode started with {len(failures)} activation failures: {failures}"
@@ -631,12 +631,15 @@ class ModeManager(Node):
     ) -> tuple[list, bool]:
         """One configure+activate sweep over the mode's nodes.
 
-        Every transition is idempotent (nodes already at/above the target are
-        left alone), so this is safe to run repeatedly. Returns the nodes that
-        failed plus whether the map load succeeded (navigation mode only).
-        Pass map_already_loaded=True on a retry pass to skip reloading a map
-        that a previous pass already loaded (only_up transitions never take
-        the map server back down, so the loaded map persists).
+        Safe to run repeatedly, with two caveats the code below handles:
+        transitions are idempotent (nodes already at/above the target are
+        left alone) EXCEPT configure-only nodes, which are deliberately
+        pulled back down to INACTIVE; and the navigation map load is not a
+        lifecycle transition — pass map_already_loaded=True on a retry pass
+        to skip reloading a map a previous pass already loaded (only_up
+        transitions never take the map server back down, so it persists).
+        Returns the nodes that failed plus whether the map load succeeded
+        (navigation mode only).
         """
         failures = []
         map_load_success = False
@@ -656,9 +659,12 @@ class ModeManager(Node):
                 only_up=node_name not in configure_only,
             )
             if not success:
+                # Keep configuring the rest: a later peer coming up is exactly
+                # what un-wedges a node stuck mid-transition (see two-pass
+                # comment in request_mode_startup), so recovery must not
+                # depend on the wedged node's position in the list.
                 failures.append(node_name)
                 self.get_logger().warning(f"Failed to configure {node_name}, continuing...")
-                break
         self.get_logger().info("Configured nodes")
 
         # Phase 2: Activate nodes in forward order

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -599,7 +599,9 @@ class ModeManager(Node):
             # the mode down and a manual retry of change_mode succeeded.)
             map_load_success = False
             for startup_pass in (1, 2):
-                failures, map_load_success = self._startup_pass(mode, node_names, configure_only)
+                failures, map_load_success = self._startup_pass(
+                    mode, node_names, configure_only, map_already_loaded=map_load_success
+                )
                 if not failures:
                     break
                 if startup_pass == 1:
@@ -624,12 +626,17 @@ class ModeManager(Node):
             self.get_logger().error(error_msg)
             return False, error_msg
 
-    def _startup_pass(self, mode: NavigationMode, node_names: list, configure_only: set) -> tuple[list, bool]:
+    def _startup_pass(
+        self, mode: NavigationMode, node_names: list, configure_only: set, map_already_loaded: bool = False
+    ) -> tuple[list, bool]:
         """One configure+activate sweep over the mode's nodes.
 
         Every transition is idempotent (nodes already at/above the target are
         left alone), so this is safe to run repeatedly. Returns the nodes that
         failed plus whether the map load succeeded (navigation mode only).
+        Pass map_already_loaded=True on a retry pass to skip reloading a map
+        that a previous pass already loaded (only_up transitions never take
+        the map server back down, so the loaded map persists).
         """
         failures = []
         map_load_success = False
@@ -674,9 +681,13 @@ class ModeManager(Node):
 
             # Load map immediately after map server is activated (navigation mode only)
             if mode == NavigationMode.NAV and "map_server" in node_name and success:
-                map_load_success = self._load_map_on_server(node_name)
-                if not map_load_success:
-                    failures.append(f"{node_name}_map_load")
+                if map_already_loaded:
+                    self.get_logger().info(f"Map already loaded on {node_name} in a previous pass; skipping reload")
+                    map_load_success = True
+                else:
+                    map_load_success = self._load_map_on_server(node_name)
+                    if not map_load_success:
+                        failures.append(f"{node_name}_map_load")
 
         self.get_logger().info("Activated nodes")
         return failures, map_load_success

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -568,7 +568,6 @@ class ModeManager(Node):
 
             node_names = nodes
 
-            failures = []
             for node_name in all_nodes_except_target:
                 # Check if this node should skip cleanup (only deactivate to INACTIVE)
                 if node_name in skip_cleanup_nodes:
@@ -587,50 +586,27 @@ class ModeManager(Node):
                 if not success:
                     self.get_logger().warning(f"Failed to shutdown non-target node {node_name} (continuing)")
 
-            # Phase 1: Configure all nodes in forward order
-            self.get_logger().info(f"Configuring {len(node_names)} nodes for {mode.value} mode")
-            for node_name in node_names:
-                success = transition_node(
-                    self._service_clients, self.get_logger(), node_name, State.PRIMARY_STATE_INACTIVE, only_up=True
-                )
-                if not success:
-                    failures.append(node_name)
-                    self.get_logger().warning(f"Failed to configure {node_name}, continuing...")
-                    break
-            self.get_logger().info("Configured nodes")
-
-            # Phase 2: Activate nodes in forward order
-            map_load_success = False
-
             # Get nodes that should only be configured (not activated) for this mode
             configure_only = configure_only_nodes.get(mode.value, set())
 
-            self.get_logger().info(f"Activating {len(node_names)} nodes for {mode.value} mode")
-            for node_name in node_names:
-                if node_name in failures:
-                    self.get_logger().warning(f"{node_name} failed configuration. Not proceeding further.")
-                    break  # don't process the rest of the nodes
-
-                # Skip activation for configure-only nodes
-                if node_name in configure_only:
-                    self.get_logger().info(f"Skipping activation for {node_name} (configure-only)")
-                    continue
-
-                success = transition_node(
-                    self._service_clients, self.get_logger(), node_name, State.PRIMARY_STATE_ACTIVE
-                )
-                if not success:
-                    failures.append(node_name)
-                    self.get_logger().warning(f"Failed to activate {node_name}. Not proceeding further.")
+            # Startup runs in up to two passes. A node can miss the first pass
+            # transiently — most commonly it is stuck in a lifecycle transition
+            # waiting on a peer this very pass brings up (e.g. a costmap's
+            # on_activate blocked on a map publisher), which also makes its
+            # lifecycle services unresponsive. The transitions are idempotent,
+            # so the second pass simply re-runs them after a short settle and
+            # picks up whatever recovered. (Previously the first failure left
+            # the mode down and a manual retry of change_mode succeeded.)
+            map_load_success = False
+            for startup_pass in (1, 2):
+                failures, map_load_success = self._startup_pass(mode, node_names, configure_only)
+                if not failures:
                     break
-
-                # Load map immediately after map server is activated (navigation mode only)
-                if mode == NavigationMode.NAV and "map_server" in node_name and success:
-                    map_load_success = self._load_map_on_server(node_name)
-                    if not map_load_success:
-                        failures.append(f"{node_name}_map_load")
-
-            self.get_logger().info("Activated nodes")
+                if startup_pass == 1:
+                    self.get_logger().warning(
+                        f"{mode.value} startup pass 1 failed on {failures}; retrying once after settle"
+                    )
+                    time.sleep(2.0)
 
             if failures:
                 message = f"{mode.value} mode started with {len(failures)} activation failures: {failures}"
@@ -647,6 +623,63 @@ class ModeManager(Node):
             error_msg = f"Error requesting {mode.value} startup: {str(e)}"
             self.get_logger().error(error_msg)
             return False, error_msg
+
+    def _startup_pass(self, mode: NavigationMode, node_names: list, configure_only: set) -> tuple[list, bool]:
+        """One configure+activate sweep over the mode's nodes.
+
+        Every transition is idempotent (nodes already at/above the target are
+        left alone), so this is safe to run repeatedly. Returns the nodes that
+        failed plus whether the map load succeeded (navigation mode only).
+        """
+        failures = []
+        map_load_success = False
+
+        # Phase 1: Configure all nodes in forward order
+        self.get_logger().info(f"Configuring {len(node_names)} nodes for {mode.value} mode")
+        for node_name in node_names:
+            # Configure-only nodes must land exactly at INACTIVE: a leftover
+            # ACTIVE one (e.g. recovered from a wedged activation) would keep
+            # its costmap running against this mode's stand-in map, spamming
+            # warnings and wasting CPU — so no only_up for them.
+            success = transition_node(
+                self._service_clients,
+                self.get_logger(),
+                node_name,
+                State.PRIMARY_STATE_INACTIVE,
+                only_up=node_name not in configure_only,
+            )
+            if not success:
+                failures.append(node_name)
+                self.get_logger().warning(f"Failed to configure {node_name}, continuing...")
+                break
+        self.get_logger().info("Configured nodes")
+
+        # Phase 2: Activate nodes in forward order
+        self.get_logger().info(f"Activating {len(node_names)} nodes for {mode.value} mode")
+        for node_name in node_names:
+            if node_name in failures:
+                self.get_logger().warning(f"{node_name} failed configuration. Not proceeding further.")
+                break  # don't process the rest of the nodes
+
+            # Skip activation for configure-only nodes
+            if node_name in configure_only:
+                self.get_logger().info(f"Skipping activation for {node_name} (configure-only)")
+                continue
+
+            success = transition_node(self._service_clients, self.get_logger(), node_name, State.PRIMARY_STATE_ACTIVE)
+            if not success:
+                failures.append(node_name)
+                self.get_logger().warning(f"Failed to activate {node_name}. Not proceeding further.")
+                break
+
+            # Load map immediately after map server is activated (navigation mode only)
+            if mode == NavigationMode.NAV and "map_server" in node_name and success:
+                map_load_success = self._load_map_on_server(node_name)
+                if not map_load_success:
+                    failures.append(f"{node_name}_map_load")
+
+        self.get_logger().info("Activated nodes")
+        return failures, map_load_success
 
     def _lifecycle_watchdog(self):
         """Restore nodes that crashed and respawned mid-session.

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -593,19 +593,21 @@ class ModeManager(Node):
             # transiently — most commonly it is stuck in a lifecycle transition
             # waiting on a peer this very pass brings up (e.g. a costmap's
             # on_activate blocked on a map publisher), which also makes its
-            # lifecycle services unresponsive. The second pass simply re-runs
-            # the sweep after a short settle and picks up whatever recovered.
+            # lifecycle services unresponsive. The second pass re-runs the
+            # sweep once the failed nodes have settled back into a primary
+            # state (bounded poll) and picks up whatever recovered.
             # (Previously the first failure left the mode down and a manual
             # retry of change_mode succeeded.)
             # Exception: a map-load failure alone is not retried — the load
             # already retries internally, so a second sweep can't fix it and
             # would only double the time spent holding the mode lock.
             failures, map_load_success = self._startup_pass(mode, node_names, configure_only)
-            if failures and any(not f.endswith("_map_load") for f in failures):
+            failed_nodes = [f for f in failures if not f.endswith("_map_load")]
+            if failed_nodes:
                 self.get_logger().warning(
                     f"{mode.value} startup pass 1 failed on {failures}; retrying once after settle"
                 )
-                time.sleep(2.0)
+                self._wait_for_nodes_to_settle(failed_nodes)
                 failures, map_load_success = self._startup_pass(
                     mode, node_names, configure_only, map_already_loaded=map_load_success
                 )
@@ -697,6 +699,31 @@ class ModeManager(Node):
 
         self.get_logger().info("Activated nodes")
         return failures, map_load_success
+
+    def _wait_for_nodes_to_settle(self, node_names: list, timeout_sec: float = 10.0, poll_sec: float = 0.5) -> None:
+        """Wait for the given nodes to settle into a primary lifecycle state.
+
+        A pass-1 failure usually means the node is wedged mid-transition
+        (e.g. ACTIVATING until a peer's map arrives), with its lifecycle
+        services unresponsive. Rather than guessing a fixed delay, poll
+        get_state until every node answers with a primary state, so the
+        retry pass runs exactly when it can succeed. Bounded by timeout_sec
+        so a permanently dead node can't hold the mode lock long; the retry
+        pass still runs and reports whatever remains broken.
+        """
+
+        def is_settled(node_name: str) -> bool:
+            state = get_node_state(self._service_clients, self.get_logger(), node_name, timeout_sec=2.0)
+            return state is not None and state < State.TRANSITION_STATE_CONFIGURING
+
+        deadline = time.monotonic() + timeout_sec
+        pending = list(node_names)
+        while pending and time.monotonic() < deadline:
+            pending = [n for n in pending if not is_settled(n)]
+            if pending:
+                time.sleep(poll_sec)
+        if pending:
+            self.get_logger().warning(f"Nodes still unsettled after {timeout_sec:.0f}s: {pending}; retrying anyway")
 
     def _lifecycle_watchdog(self):
         """Restore nodes that crashed and respawned mid-session.

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/service_utils.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/service_utils.py
@@ -101,6 +101,14 @@ def transition_node(service_clients: dict, logger, node_name: str, target_state:
             logger.warning(f"Failed to get state for {node_name}")
             return False
 
+        # A node mid-transition (CONFIGURING/ACTIVATING/...) can't accept a
+        # new change_state request, and its transient-state id would compare
+        # above every primary state and silently fall through as success.
+        # Report failure so the caller retries once the node has settled.
+        if current_state >= State.TRANSITION_STATE_CONFIGURING:
+            logger.warning(f"{node_name} is mid-transition (state {current_state}); cannot transition it now")
+            return False
+
         # Already at target state
         if current_state == target_state:
             logger.debug(f"{node_name} already at target state {target_state}")


### PR DESCRIPTION
## Summary

- **Fixes the "first `/nav/change_mode` fails, retry succeeds" failure that leaves the robot with no active nav mode** (every nav goal then fails instantly — this bit the brain's first live driving test, and would equally bite the webapp's mode switching).
- Root cause from the live logs: when a lifecycle node wedges mid-transition (`navigation/planner_server` stuck in ACTIVATING because its costmap's `on_activate` blocks waiting for a map publisher), its lifecycle services stop responding — so the next mode change fails on it. But that same failed attempt activates `null_map_node`, whose map un-wedges the node, which is exactly why the manual retry then succeeded.
- `request_mode_startup` now runs its configure+activate sweep in **up to two passes**: every transition is idempotent, so pass 2 just re-runs them after a 2 s settle and picks up whatever recovered during pass 1 — automating the manual retry that was proven to work.
- Second fix: **configure-only nodes now land exactly at INACTIVE** (`only_up=False` for them in the configure phase). Previously a recovered-but-ACTIVE `navigation/planner_server` was left running in mapfree mode, grinding its costmap against the 1-cell null map and spamming `Robot is out of bounds of the costmap!` at 5 Hz indefinitely.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - **Live on the robot**: restarted the whole `mode_manager.launch.py` stack — boot auto-start came up **straight into mapfree** (clean pass 1, no retry needed on a fresh stack). `mapping → mapfree` round-trip both succeed **first-call** (~5 s each). `navigation/planner_server` verified `inactive` in mapfree with **zero** costmap-spam lines. A deterministic 0.25 m `navigate_to_position(local_frame)` hop through `execute_skill` completed successfully afterwards.
  - The wedged-ACTIVATING recovery path itself can't be reproduced on demand (it needs the boot-time navigation-mode map race), but the two-pass retry mechanically reproduces the manual `change_mode` retry that recovered the live robot from exactly that state today (log excerpts in the commit message).
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — *No simulator-facing changes; pure mode_manager orchestration logic.*
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — *No asset changes.*

## Notes

- Not addressed here (pre-existing, separate): why `navigation` mode's planner activation can block on the map in the first place at boot (June nav-audit territory). With this change the system now degrades to a working retry instead of a dead mode, and a subsequent mapfree switch always recovers.
- Related: innate-os#565 (local brain) — its `go_to_point` driving test is what surfaced this.