### PR TITLE
feat(teleop): record camera video to MP4 from the webapp

### DIFF
--- a/ros2_ws/src/mars_bot/mars_bringup/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_bringup/CMakeLists.txt
@@ -40,6 +40,7 @@ ament_python_install_package(${PROJECT_NAME}
 install(PROGRAMS
   mars_bringup/bringup.py
   mars_bringup/rosbag.py
+  mars_bringup/video_recorder.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros2_ws/src/mars_bot/mars_bringup/launch/bringup_core.launch.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/launch/bringup_core.launch.py
@@ -23,11 +23,20 @@ def generate_launch_description():
         output="screen",
     )
 
+    # On-demand camera→MP4 recorder driven by the webapp's record button.
+    video_recorder_node = Node(
+        package="mars_bringup",
+        executable="video_recorder.py",
+        name="video_recorder",
+        output="screen",
+    )
+
     # base_link -> base_footprint static TF is now published by
     # robot_state_publisher via the URDF (base_footprint_joint).
 
     return LaunchDescription(
         [
             bringup_node,
+            video_recorder_node,
         ]
     )

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Teleop video recorder.
+
+/video_recorder/start and /video_recorder/stop (std_srvs/Trigger) bracket an
+MP4 capture of the camera topics into <INNATE_OS_ROOT>/data/recordings/. Frames are
+written on a fixed-rate timer (latest frame per tick, duplicated on stalls) so
+the file plays back in real time regardless of camera or subscriber drops.
+"""
+
+import os
+import shutil
+from datetime import datetime
+
+import cv2
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile, qos_profile_sensor_data
+from sensor_msgs.msg import Image
+from std_msgs.msg import Bool
+from std_srvs.srv import Trigger
+
+CAMERA_TOPICS = {
+    "main": "/mars/main_camera/left/image_raw",
+    "arm": "/mars/arm/image_raw",
+}
+FPS = 30.0
+
+
+def image_to_bgr(msg: Image) -> np.ndarray | None:
+    if msg.encoding not in ("bgr8", "rgb8"):
+        return None
+    data = np.frombuffer(msg.data, dtype=np.uint8)
+    frame = data.reshape(msg.height, msg.step)[:, : msg.width * 3].reshape(msg.height, msg.width, 3)
+    if msg.encoding == "rgb8":
+        frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+    return frame
+
+
+class VideoRecorder(Node):
+    def __init__(self) -> None:
+        super().__init__("video_recorder")
+        root = os.environ.get("INNATE_OS_ROOT", os.path.expanduser("~/innate-os"))
+        self.recordings_root = os.path.join(root, "data", "recordings")
+
+        self.output_dir: str | None = None
+        self.subs: list = []
+        self.timer = None
+        self.latest: dict[str, np.ndarray] = {}
+        self.writers: dict[str, cv2.VideoWriter] = {}
+
+        self.create_service(Trigger, "/video_recorder/start", self.handle_start)
+        self.create_service(Trigger, "/video_recorder/stop", self.handle_stop)
+
+        # Latched so the webapp sees the current state on (re)connect, plus a
+        # 1 Hz heartbeat so a client holding a stale value (reconnect races,
+        # node restarts mid-recording) converges to the robot's real state.
+        status_qos = QoSProfile(depth=1, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
+        self.status_pub = self.create_publisher(Bool, "/video_recorder/status", status_qos)
+        self.publish_status()
+        self.create_timer(1.0, self.publish_status)
+
+    def publish_status(self) -> None:
+        self.status_pub.publish(Bool(data=self.output_dir is not None))
+
+    def handle_start(self, _request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        if self.output_dir is not None:
+            response.success = False
+            response.message = f"Already recording to {self.output_dir}"
+            return response
+
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.output_dir = os.path.join(self.recordings_root, f"video_{stamp}")
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        for name, topic in CAMERA_TOPICS.items():
+            self.subs.append(
+                self.create_subscription(
+                    Image,
+                    topic,
+                    lambda msg, name=name: self.on_frame(name, msg),
+                    qos_profile_sensor_data,
+                )
+            )
+        self.timer = self.create_timer(1.0 / FPS, self.write_tick)
+        self.publish_status()
+        self.get_logger().info(f"Recording to {self.output_dir}")
+
+        response.success = True
+        response.message = self.output_dir
+        return response
+
+    def handle_stop(self, _request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        if self.output_dir is None:
+            response.success = False
+            response.message = "Not recording"
+            return response
+
+        output_dir = self.output_dir
+        self.output_dir = None
+        self.destroy_timer(self.timer)
+        self.timer = None
+        for sub in self.subs:
+            self.destroy_subscription(sub)
+        self.subs.clear()
+        saved = sorted(self.writers)
+        for writer in self.writers.values():
+            writer.release()
+        self.writers.clear()
+        self.latest.clear()
+        self.publish_status()
+
+        if not saved:
+            shutil.rmtree(output_dir, ignore_errors=True)
+            response.success = False
+            response.message = "No camera frames received; nothing saved"
+        else:
+            response.success = True
+            response.message = f"Saved {', '.join(f'{name}.mp4' for name in saved)} in {output_dir}"
+        self.get_logger().info(response.message)
+        return response
+
+    def on_frame(self, name: str, msg: Image) -> None:
+        frame = image_to_bgr(msg)
+        if frame is not None:
+            self.latest[name] = frame
+
+    def write_tick(self) -> None:
+        for name, frame in self.latest.items():
+            writer = self.writers.get(name)
+            if writer is None:
+                height, width = frame.shape[:2]
+                path = os.path.join(self.output_dir, f"{name}.mp4")
+                writer = cv2.VideoWriter(path, cv2.VideoWriter_fourcc(*"mp4v"), FPS, (width, height))
+                self.writers[name] = writer
+            writer.write(frame)
+
+
+def main() -> None:
+    rclpy.init()
+    node = VideoRecorder()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -23,9 +23,14 @@ from std_msgs.msg import Bool
 from std_srvs.srv import Trigger
 
 CAMERA_TOPICS = {
-    "main": "/mars/main_camera/left/image_raw",
+    # Full-res side-by-side stereo (subscriber-gated in the driver, so it only
+    # flows while recording); the left eye is cropped out below. The 640x480
+    # /left topic stays untouched for policies, datasets and teleop.
+    "main": "/mars/main_camera/stereo",
     "arm": "/mars/arm/image_raw",
 }
+# Topics carrying a side-by-side stereo frame: record the left half only.
+CROP_LEFT_HALF = {"main"}
 FPS = 30.0
 
 
@@ -124,8 +129,12 @@ class VideoRecorder(Node):
 
     def on_frame(self, name: str, msg: Image) -> None:
         frame = image_to_bgr(msg)
-        if frame is not None:
-            self.latest[name] = frame
+        if frame is None:
+            return
+        if name in CROP_LEFT_HALF:
+            # Copy: the half-width view is non-contiguous, which VideoWriter rejects.
+            frame = np.ascontiguousarray(frame[:, : frame.shape[1] // 2])
+        self.latest[name] = frame
 
     def write_tick(self) -> None:
         for name, frame in self.latest.items():

--- a/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
@@ -4,18 +4,23 @@
 main_camera_driver:
   ros__parameters:
     camera_symlink: "3D"
-    width: 2560
-    height: 720
+    # Capture at the sensor max so /mars/main_camera/stereo carries full-res
+    # frames for the video recorder. Decode/rotate stay on NVDEC/VIC; left and
+    # right are still downscaled to 640x480 for every existing consumer.
+    width: 3840
+    height: 1080
     publish_left_width: 640
     publish_left_height: 480
-    publish_stereo_width: 1280
-    publish_stereo_height: 480
+    publish_stereo_width: 3840
+    publish_stereo_height: 1080
     fps: 15.0
     frame_id: "camera_optical_frame"
     jpeg_quality: 80
     publish_compressed: true
     compressed_frame_interval: 2
-    publish_stereo: false
+    # Stereo publishes only while something subscribes (the video recorder),
+    # so the full-res topic is free when idle.
+    publish_stereo: true
     exposure: -1
     gain: -1
     default_gain: 110

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
@@ -615,7 +615,10 @@ void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame) {
     // Publish with std::move() for zero-copy intra-process communication
     // Inter-process subscribers (via DDS) still receive serialized copies automatically
     // -------------------------
-    if (publish_stereo_) {
+    // Gated on demand: at full capture resolution the stereo frame is large
+    // (12 MB at 3840x1080), so only serialize it out when someone (the video
+    // recorder) is actually subscribed.
+    if (publish_stereo_ && stereo_pub_->get_subscription_count() > 0) {
         stereo_pub_->publish(std::move(stereo_msg));
     }
     left_pub_->publish(std::move(left_msg));

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1387,6 +1387,19 @@ button {
   opacity: 0.2;
 }
 
+.record-toggle.active {
+  color: var(--danger);
+  border-color: var(--danger);
+  background: rgb(217 106 90 / 12%);
+  animation: rec-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes rec-pulse {
+  50% {
+    color: rgb(217 106 90 / 45%);
+  }
+}
+
 /* ---- TTS bar ---------------------------------------------------------------- */
 
 .tts-bar {

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -125,6 +125,13 @@ export const ROBOT_INFO_TOPIC = "/robot/info";
 // mobile app's volume slider calls; current value rides on /robot/info.
 export const SET_VOLUME_SERVICE = "/set_volume";
 
+// Teleop video recorder (mars_bringup video_recorder.py): std_srvs/Trigger
+// start/stop bracket an MP4 capture of the camera topics into the robot's
+// data/recordings/ folder. STATUS is a latched std_msgs/Bool (true while recording).
+export const VIDEO_RECORD_START_SERVICE = "/video_recorder/start";
+export const VIDEO_RECORD_STOP_SERVICE = "/video_recorder/stop";
+export const VIDEO_RECORD_STATUS_TOPIC = "/video_recorder/status";
+
 // WebRTC signaling over rosbridge. START is a std_msgs/String JSON payload that
 // carries our client_id: {"source":"live","audio":bool,"client_id":"...","video":[...]}.
 // The robot routes offer/answer/ICE on the *_id topics, each enveloped as {client_id, ...}

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -19,6 +19,7 @@ import { createVideoStage, createAudioToggle } from "./videoStage.js";
 import { createJoystick } from "./joystick.js";
 import { createKeyboardDrive, createWasdChips } from "./keyboardDrive.js";
 import { createHeadTilt } from "./headTilt.js";
+import { createRecordButton } from "./recordButton.js";
 import { createTtsBar } from "./ttsBar.js";
 import { createTelemetry } from "./telemetry.js";
 import { createArmPanel } from "./armPanel.js";
@@ -82,6 +83,8 @@ function buildCockpit(root) {
   // is the sim deployment's feature flag (env-driven; false on the real robot).
   if (!config.simControls && videoStage.audioEl) {
     parts.push(createAudioToggle(rightRail, session, videoStage.audioEl));
+    // Camera MP4 recorder lives in the robot bringup, which the sim doesn't run.
+    parts.push(createRecordButton(rightRail, ros));
   }
   parts.push(
     createHeadTilt(rightRail, ros),

--- a/webapp/js/teleop/recordButton.js
+++ b/webapp/js/teleop/recordButton.js
@@ -1,0 +1,73 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Record toggle — right-rail button that starts/stops the on-robot MP4
+// recorder (video_recorder node). The lit state follows the latched
+// /video_recorder/status Bool so a reloaded page shows what the robot is
+// actually doing; files land in the robot's data/recordings/ folder.
+
+import {
+  VIDEO_RECORD_START_SERVICE,
+  VIDEO_RECORD_STOP_SERVICE,
+  VIDEO_RECORD_STATUS_TOPIC,
+} from "../constants.js";
+
+/**
+ * @param {HTMLElement} parent
+ * @param {import("../rosClient.js").RosClient} rosClient
+ * @returns {{ destroy: () => void }}
+ */
+export function createRecordButton(parent, rosClient) {
+  const button = document.createElement("button");
+  button.className = "icon-toggle record-toggle";
+  button.type = "button";
+  button.innerHTML =
+    '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">' +
+    '<circle cx="12" cy="12" r="5.5"/>' +
+    "</svg>";
+  button.setAttribute("aria-label", "Record camera video");
+
+  let recording = false;
+  let busy = false;
+
+  function render() {
+    button.classList.toggle("active", recording);
+    button.disabled = busy;
+    button.title = recording
+      ? "Recording cameras — click to stop"
+      : "Record cameras to MP4 on the robot";
+    button.setAttribute("aria-pressed", String(recording));
+  }
+  render();
+
+  const unsub = rosClient.subscribe(VIDEO_RECORD_STATUS_TOPIC, (msg) => {
+    recording = Boolean(msg?.data);
+    render();
+  });
+
+  button.addEventListener("click", async () => {
+    if (busy) return;
+    busy = true;
+    render();
+    const starting = !recording;
+    try {
+      const res = await rosClient.callService(starting ? VIDEO_RECORD_START_SERVICE : VIDEO_RECORD_STOP_SERVICE);
+      if (!res?.success) console.warn("video recorder:", res?.message);
+      // A Trigger failure only means "already in that state", so either way
+      // the robot has now converged on what we asked for.
+      recording = starting;
+    } catch (err) {
+      console.warn("video recorder call failed:", err);
+    }
+    busy = false;
+    render();
+  });
+
+  parent.appendChild(button);
+  return {
+    destroy() {
+      unsub();
+      button.remove();
+    },
+  };
+}


### PR DESCRIPTION
Restores work that had been parked in a stash (`wip: video recorder + record button`) and rebuilds it on current `main` — it applied cleanly, no conflicts.

## What

A record toggle in the teleop right rail brackets an on-robot MP4 capture of the main and arm cameras, so you can grab clips of the robot driving around without screen-recording the browser.

- **`video_recorder.py`** (`mars_bringup`, launched by `bringup_core`) — `/video_recorder/start` and `/video_recorder/stop` (`std_srvs/Trigger`), plus a latched `/video_recorder/status` `Bool` with a 1 Hz heartbeat so a reloaded page (or a node restart mid-recording) converges on what the robot is actually doing.
- **`recordButton.js`** — right-rail toggle that follows the latched status. Hidden under `simControls`, since the sim doesn't run robot bringup.

Frames are written on a fixed-rate 30 Hz timer — latest frame per tick, duplicated on stalls — so the file plays back in real time regardless of camera or subscriber drops. If no frames ever arrive, stop reports failure and removes the empty directory instead of leaving a zero-byte MP4.

## Output

`<INNATE_OS_ROOT>/data/recordings/video_<timestamp>/{main,arm}.mp4`, `mp4v`, 30 fps.

The writer is sized from the first frame, so resolution is whatever the camera topics publish — today **640x480** for both (`/mars/main_camera/left/image_raw` is the left half of the 1280x480 stereo capture; `/mars/arm/image_raw` is 640x480 native). Nothing here caps it: raise the driver's publish size and the recordings follow.

## Testing

Not yet exercised on the robot since being restored — `python3 -m py_compile` passes and the webapp APIs it calls (`rosClient.subscribe` returning an unsubscribe, `callService(service)`) are unchanged on `main`. Wants a live pass: record while driving, confirm both MP4s play back at real-time length.

## Notes

- `bringup_core` gains an always-running node. It idles with no subscriptions until start is called, so the cost is one node, not one camera subscriber.
- The status subscription doesn't pass an explicit message `type`. That's fine while the node is in `bringup_core` (it publishes at construction), but if the node is ever made opt-in, rws will error on every retry until it comes up.
