### PR TITLE
feat(teleop): record video + full-rate lidar sensor bag for 3D reconstruction

### DIFF
--- a/ros2_ws/src/mars_bot/mars_bringup/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_bringup/CMakeLists.txt
@@ -40,6 +40,7 @@ ament_python_install_package(${PROJECT_NAME}
 install(PROGRAMS
   mars_bringup/bringup.py
   mars_bringup/rosbag.py
+  mars_bringup/video_recorder.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros2_ws/src/mars_bot/mars_bringup/launch/bringup_core.launch.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/launch/bringup_core.launch.py
@@ -23,11 +23,20 @@ def generate_launch_description():
         output="screen",
     )
 
+    # On-demand camera→MP4 recorder driven by the webapp's record button.
+    video_recorder_node = Node(
+        package="mars_bringup",
+        executable="video_recorder.py",
+        name="video_recorder",
+        output="screen",
+    )
+
     # base_link -> base_footprint static TF is now published by
     # robot_state_publisher via the URDF (base_footprint_joint).
 
     return LaunchDescription(
         [
             bringup_node,
+            video_recorder_node,
         ]
     )

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -208,8 +208,17 @@ class VideoRecorder(Node):
             return response
 
         stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.output_dir = os.path.join(self.recordings_root, f"video_{stamp}")
-        os.makedirs(self.output_dir, exist_ok=True)
+        output_dir = os.path.join(self.recordings_root, f"video_{stamp}")
+        # Claim output_dir (the "recording" flag) only once the directory
+        # exists: a failure here (disk full, permissions) must leave the
+        # node idle and startable, not wedged in a half-started state.
+        try:
+            os.makedirs(output_dir, exist_ok=True)
+        except OSError as exc:
+            response.success = False
+            response.message = f"Cannot create {output_dir}: {exc}"
+            return response
+        self.output_dir = output_dir
         self.started_at = datetime.now().astimezone().isoformat(timespec="seconds")
         self.start_monotonic = time.monotonic()
         self.tick = 0
@@ -289,8 +298,10 @@ class VideoRecorder(Node):
         self.bag_writer = None  # destructor flushes and closes the bag
         for q in self.write_qs.values():
             q.put(None)
-        for t in self.writer_threads.values():
+        for name, t in self.writer_threads.items():
             t.join(timeout=15)
+            if t.is_alive():
+                self.get_logger().error(f"{name} writer thread did not exit in time; file may be truncated")
         saved = sorted(self.writers)
         streams = {
             name: {
@@ -377,16 +388,29 @@ class VideoRecorder(Node):
                 self.get_logger().warning(f"{name}: write queue full, dropping a frame", throttle_duration_sec=5.0)
 
     def drain_writes(self, name: str) -> None:
+        # A failed stream stays failed but keeps draining its queue: recreating
+        # the writer would truncate the file, and returning early would leave
+        # handle_stop's blocking put(None) with no consumer.
+        failed = False
         while True:
             item = self.write_qs[name].get()
             if item is None:
                 return
+            if failed:
+                continue
             frame, stamp_ns, output_dir = item
             writer = self.writers.get(name)
             if writer is None:
                 height, width = frame.shape[:2]
                 path = os.path.join(output_dir, f"{name}.mp4")
-                writer = GstMp4Writer(path, RECORD_FPS.get(name, FPS), width, height, STREAM_CODEC.get(name, "h264"))
+                try:
+                    writer = GstMp4Writer(
+                        path, RECORD_FPS.get(name, FPS), width, height, STREAM_CODEC.get(name, "h264")
+                    )
+                except OSError as exc:
+                    self.get_logger().error(f"{name} encoder pipeline failed to start: {exc}; dropping stream")
+                    failed = True
+                    continue
                 self.writers[name] = writer
             try:
                 writer.write(frame)
@@ -395,6 +419,7 @@ class VideoRecorder(Node):
             except OSError:
                 self.get_logger().error(f"{name} encoder pipeline died; dropping stream")
                 self.writers.pop(name).release()
+                failed = True
 
 
 def main() -> None:
@@ -406,6 +431,7 @@ def main() -> None:
         pass
     finally:
         node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -7,7 +7,9 @@
 H.264 MP4 capture of the camera topics into <INNATE_OS_ROOT>/data/recordings/.
 Frames are written on a fixed-rate timer (latest frame per tick, duplicated on
 stalls) so the file plays back in real time regardless of camera or subscriber
-drops. Each recording also gets a recording_metadata.json (streams, timing,
+drops. Each recording also gets everything a 3D reconstruction needs later:
+a rosbag of odometry / TF / joints / lidar, per-frame ROS timestamps tying
+video frames to those poses, a recording_metadata.json (streams, timing,
 camera intrinsics when calibration is loaded) and a robot.urdf snapshot.
 """
 
@@ -24,11 +26,15 @@ from datetime import datetime
 import cv2
 import numpy as np
 import rclpy
+import rosbag2_py
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from nav_msgs.msg import Odometry
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, qos_profile_sensor_data
-from sensor_msgs.msg import CameraInfo, Image
+from sensor_msgs.msg import CameraInfo, Image, JointState, LaserScan
 from std_msgs.msg import Bool, String
 from std_srvs.srv import Trigger
+from tf2_msgs.msg import TFMessage
 
 CAMERA_TOPICS = {
     # Full-res left eye (subscriber-gated in the driver, so it only flows
@@ -43,6 +49,20 @@ CAMERA_INFO_TOPICS = [
     "/mars/main_camera/left/camera_info",
     "/mars/main_camera/right/camera_info",
 ]
+# Pose/sensor topics bagged alongside the videos for 3D reconstruction:
+# odometry + TF give the camera trajectory (tf_static carries the camera
+# extrinsics chain, joint_states the head tilt), /scan adds lidar geometry.
+# Topics without a live publisher just record zero messages.
+BAG_TOPICS = {
+    "/odom": ("nav_msgs/msg/Odometry", Odometry),
+    "/mapping_pose": ("nav_msgs/msg/Odometry", Odometry),
+    "/amcl_pose": ("geometry_msgs/msg/PoseWithCovarianceStamped", PoseWithCovarianceStamped),
+    "/tf": ("tf2_msgs/msg/TFMessage", TFMessage),
+    "/tf_static": ("tf2_msgs/msg/TFMessage", TFMessage),
+    "/joint_states": ("sensor_msgs/msg/JointState", JointState),
+    "/scan": ("sensor_msgs/msg/LaserScan", LaserScan),
+}
+
 # Write-timer rate. Streams whose camera publishes slower record at their own
 # rate below — encoding duplicated frames buys nothing.
 FPS = 30.0
@@ -143,6 +163,9 @@ class VideoRecorder(Node):
         self.frame_counts: dict[str, int] = {}
         self.camera_infos: dict[str, dict] = {}
         self.robot_description: str | None = None
+        self.bag_writer: rosbag2_py.SequentialWriter | None = None
+        self.bag_counts: dict[str, int] = {}
+        self.frame_stamps: dict[str, list] = {}
 
         self.create_service(Trigger, "/video_recorder/start", self.handle_start)
         self.create_service(Trigger, "/video_recorder/stop", self.handle_stop)
@@ -197,6 +220,29 @@ class VideoRecorder(Node):
                     qos_profile_sensor_data,
                 )
             )
+        self.bag_writer = rosbag2_py.SequentialWriter()
+        self.bag_writer.open(
+            rosbag2_py.StorageOptions(uri=os.path.join(self.output_dir, "sensors"), storage_id="sqlite3"),
+            rosbag2_py.ConverterOptions(input_serialization_format="cdr", output_serialization_format="cdr"),
+        )
+        for topic, (type_name, msg_cls) in BAG_TOPICS.items():
+            self.bag_writer.create_topic(
+                rosbag2_py.TopicMetadata(name=topic, type=type_name, serialization_format="cdr")
+            )
+            self.bag_counts[topic] = 0
+            # tf_static is latched; a volatile sub would miss the transforms
+            # published before recording started.
+            qos = (
+                QoSProfile(depth=10, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
+                if topic == "/tf_static"
+                else qos_profile_sensor_data
+            )
+            self.subs.append(
+                self.create_subscription(
+                    msg_cls, topic, lambda msg, topic=topic: self.on_bag_msg(topic, msg), qos, raw=True
+                )
+            )
+
         # Writes drain on their own thread: a pipe stall (encoder hiccup) must
         # never stall the executor, or message intake halves along with it.
         self.write_q = queue.Queue(maxsize=8)
@@ -224,6 +270,7 @@ class VideoRecorder(Node):
         for sub in self.subs:
             self.destroy_subscription(sub)
         self.subs.clear()
+        self.bag_writer = None  # destructor flushes and closes the bag
         self.write_q.put(None)
         self.writer_thread.join(timeout=15)
         saved = sorted(self.writers)
@@ -231,8 +278,8 @@ class VideoRecorder(Node):
             name: {
                 "file": f"{name}.mp4",
                 "topic": CAMERA_TOPICS[name],
-                "width": self.latest[name].shape[1],
-                "height": self.latest[name].shape[0],
+                "width": self.latest[name][0].shape[1],
+                "height": self.latest[name][0].shape[0],
                 "fps": RECORD_FPS.get(name, FPS),
                 "codec": STREAM_CODEC.get(name, "h264"),
                 "frames": self.frame_counts.get(name, 0),
@@ -255,6 +302,8 @@ class VideoRecorder(Node):
             response.success = True
             response.message = f"Saved {', '.join(f'{name}.mp4' for name in saved)} in {output_dir}"
         self.camera_infos.clear()
+        self.bag_counts = {}
+        self.frame_stamps = {}
         self.get_logger().info(response.message)
         return response
 
@@ -270,28 +319,41 @@ class VideoRecorder(Node):
             # resolution — scale fx, fy, cx, cy by width ratio to apply them.
             "camera_info": self.camera_infos
             or "unavailable: no stereo calibration loaded, camera_info topics were silent",
+            # Rosbag with the pose/sensor topics; <name>_frames.csv maps each
+            # video frame index to the ROS stamp of the image it came from.
+            "bag": {"path": "sensors", "message_counts": self.bag_counts},
         }
         with open(os.path.join(output_dir, "recording_metadata.json"), "w") as f:
             json.dump(metadata, f, indent=2)
+        for name, stamps in self.frame_stamps.items():
+            with open(os.path.join(output_dir, f"{name}_frames.csv"), "w") as f:
+                f.write("frame,stamp_ns\n")
+                f.writelines(f"{i},{ns}\n" for i, ns in enumerate(stamps))
         if self.robot_description:
             with open(os.path.join(output_dir, "robot.urdf"), "w") as f:
                 f.write(self.robot_description)
+
+    def on_bag_msg(self, topic: str, raw: bytes) -> None:
+        if self.bag_writer is None:
+            return
+        self.bag_writer.write(topic, raw, self.get_clock().now().nanoseconds)
+        self.bag_counts[topic] += 1
 
     def on_frame(self, name: str, msg: Image) -> None:
         frame = image_to_bgr(msg)
         if frame is None:
             return
-        self.latest[name] = frame
+        self.latest[name] = (frame, msg.header.stamp.sec * 1_000_000_000 + msg.header.stamp.nanosec)
 
     def write_tick(self) -> None:
         self.tick += 1
         output_dir = self.output_dir
-        for name, frame in list(self.latest.items()):
+        for name, (frame, stamp_ns) in list(self.latest.items()):
             step = max(1, round(FPS / RECORD_FPS.get(name, FPS)))
             if self.tick % step:
                 continue
             try:
-                self.write_q.put_nowait((name, frame, output_dir))
+                self.write_q.put_nowait((name, frame, stamp_ns, output_dir))
             except queue.Full:
                 self.get_logger().warning(f"{name}: write queue full, dropping a frame", throttle_duration_sec=5.0)
 
@@ -300,7 +362,7 @@ class VideoRecorder(Node):
             item = self.write_q.get()
             if item is None:
                 return
-            name, frame, output_dir = item
+            name, frame, stamp_ns, output_dir = item
             writer = self.writers.get(name)
             if writer is None:
                 height, width = frame.shape[:2]
@@ -310,6 +372,7 @@ class VideoRecorder(Node):
             try:
                 writer.write(frame)
                 self.frame_counts[name] = self.frame_counts.get(name, 0) + 1
+                self.frame_stamps.setdefault(name, []).append(stamp_ns)
             except OSError:
                 self.get_logger().error(f"{name} encoder pipeline died; dropping stream")
                 self.writers.pop(name).release()

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -37,10 +37,10 @@ from std_srvs.srv import Trigger
 from tf2_msgs.msg import TFMessage
 
 CAMERA_TOPICS = {
-    # Full-res left eye (subscriber-gated in the driver, so it only flows
-    # while recording). The 640x480 /left topic stays untouched for policies,
-    # datasets and teleop.
-    "main": "/mars/main_camera/left/image_full",
+    # Full-res side-by-side stereo pair, left eye in the left half
+    # (subscriber-gated in the driver, so it only flows while recording).
+    # The 640x480 /left topic stays untouched for policies, datasets, teleop.
+    "main": "/mars/main_camera/stereo",
     "arm": "/mars/arm/image_raw",
 }
 # Intrinsics published only while a stereo calibration is loaded; captured
@@ -66,7 +66,10 @@ BAG_TOPICS = {
 # Write-timer rate. Streams whose camera publishes slower record at their own
 # rate below — encoding duplicated frames buys nothing.
 FPS = 30.0
-RECORD_FPS = {"main": 15.0}  # main camera fps in stereo_depth_estimator.yaml
+# Main records below its 15 fps camera rate: the raw-BGR pipe + NVJPG chain
+# sustains ~12 fps at 3840x1080 under full robot load, so 15 silently drops
+# frames (measured 81% realtime); 10 holds with real margin.
+RECORD_FPS = {"main": 10.0}
 # 1080p records via the NVJPG hardware encoder (browsers can't play MJPEG-in-MP4,
 # but VLC/QuickTime/editors can); everything else via x264, which plays anywhere.
 STREAM_CODEC = {"main": "mjpeg"}
@@ -126,7 +129,9 @@ class GstMp4Writer:
         self._proc = subprocess.Popen(args, stdin=subprocess.PIPE)
 
     def write(self, frame: np.ndarray) -> None:
-        self._proc.stdin.write(frame.tobytes())
+        # Contiguous frames go straight from the numpy buffer; 12 MB stereo
+        # frames make a tobytes() copy measurable.
+        self._proc.stdin.write(frame.data if frame.flags.c_contiguous else frame.tobytes())
 
     def release(self) -> None:
         try:
@@ -243,11 +248,15 @@ class VideoRecorder(Node):
                 )
             )
 
-        # Writes drain on their own thread: a pipe stall (encoder hiccup) must
-        # never stall the executor, or message intake halves along with it.
-        self.write_q = queue.Queue(maxsize=8)
-        self.writer_thread = threading.Thread(target=self.drain_writes, daemon=True)
-        self.writer_thread.start()
+        # Writes drain on their own thread per stream: a pipe stall (encoder
+        # hiccup) must never stall the executor, and a 12 MB stereo write must
+        # never queue the arm camera's frames behind it.
+        self.write_qs = {name: queue.Queue(maxsize=8) for name in CAMERA_TOPICS}
+        self.writer_threads = {
+            name: threading.Thread(target=self.drain_writes, args=(name,), daemon=True) for name in CAMERA_TOPICS
+        }
+        for t in self.writer_threads.values():
+            t.start()
         self.timer = self.create_timer(1.0 / FPS, self.write_tick)
         self.publish_status()
         self.get_logger().info(f"Recording to {self.output_dir}")
@@ -271,8 +280,10 @@ class VideoRecorder(Node):
             self.destroy_subscription(sub)
         self.subs.clear()
         self.bag_writer = None  # destructor flushes and closes the bag
-        self.write_q.put(None)
-        self.writer_thread.join(timeout=15)
+        for q in self.write_qs.values():
+            q.put(None)
+        for t in self.writer_threads.values():
+            t.join(timeout=15)
         saved = sorted(self.writers)
         streams = {
             name: {
@@ -315,8 +326,9 @@ class VideoRecorder(Node):
             "duration_s": round(duration, 3),
             "streams": streams,
             # Intrinsics are for the published left/right topics at their
-            # native resolution; main.mp4 is the left eye at full stereo
-            # resolution — scale fx, fy, cx, cy by width ratio to apply them.
+            # native resolution; main.mp4 is the side-by-side stereo pair
+            # (left eye = left half) — scale fx, fy, cx, cy by the per-eye
+            # resolution ratio to apply them.
             "camera_info": self.camera_infos
             or "unavailable: no stereo calibration loaded, camera_info topics were silent",
             # Rosbag with the pose/sensor topics; <name>_frames.csv maps each
@@ -353,16 +365,16 @@ class VideoRecorder(Node):
             if self.tick % step:
                 continue
             try:
-                self.write_q.put_nowait((name, frame, stamp_ns, output_dir))
+                self.write_qs[name].put_nowait((frame, stamp_ns, output_dir))
             except queue.Full:
                 self.get_logger().warning(f"{name}: write queue full, dropping a frame", throttle_duration_sec=5.0)
 
-    def drain_writes(self) -> None:
+    def drain_writes(self, name: str) -> None:
         while True:
-            item = self.write_q.get()
+            item = self.write_qs[name].get()
             if item is None:
                 return
-            name, frame, stamp_ns, output_dir = item
+            frame, stamp_ns, output_dir = item
             writer = self.writers.get(name)
             if writer is None:
                 height, width = frame.shape[:2]

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Teleop video recorder.
+
+/video_recorder/start and /video_recorder/stop (std_srvs/Trigger) bracket an
+MP4 capture of the camera topics into <INNATE_OS_ROOT>/data/recordings/. Frames are
+written on a fixed-rate timer (latest frame per tick, duplicated on stalls) so
+the file plays back in real time regardless of camera or subscriber drops.
+"""
+
+import os
+import shutil
+from datetime import datetime
+
+import cv2
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile, qos_profile_sensor_data
+from sensor_msgs.msg import Image
+from std_msgs.msg import Bool
+from std_srvs.srv import Trigger
+
+CAMERA_TOPICS = {
+    "main": "/mars/main_camera/left/image_raw",
+    "arm": "/mars/arm/image_raw",
+}
+FPS = 30.0
+
+
+def image_to_bgr(msg: Image) -> np.ndarray | None:
+    if msg.encoding not in ("bgr8", "rgb8"):
+        return None
+    data = np.frombuffer(msg.data, dtype=np.uint8)
+    frame = data.reshape(msg.height, msg.step)[:, : msg.width * 3].reshape(msg.height, msg.width, 3)
+    if msg.encoding == "rgb8":
+        frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+    return frame
+
+
+class VideoRecorder(Node):
+    def __init__(self) -> None:
+        super().__init__("video_recorder")
+        root = os.environ.get("INNATE_OS_ROOT", os.path.expanduser("~/innate-os"))
+        self.recordings_root = os.path.join(root, "data", "recordings")
+
+        self.output_dir: str | None = None
+        self.subs: list = []
+        self.timer = None
+        self.latest: dict[str, np.ndarray] = {}
+        self.writers: dict[str, cv2.VideoWriter] = {}
+
+        self.create_service(Trigger, "/video_recorder/start", self.handle_start)
+        self.create_service(Trigger, "/video_recorder/stop", self.handle_stop)
+
+        # Latched so the webapp sees the current state on (re)connect, plus a
+        # 1 Hz heartbeat so a client holding a stale value (reconnect races,
+        # node restarts mid-recording) converges to the robot's real state.
+        status_qos = QoSProfile(depth=1, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
+        self.status_pub = self.create_publisher(Bool, "/video_recorder/status", status_qos)
+        self.publish_status()
+        self.create_timer(1.0, self.publish_status)
+
+    def publish_status(self) -> None:
+        self.status_pub.publish(Bool(data=self.output_dir is not None))
+
+    def handle_start(self, _request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        if self.output_dir is not None:
+            response.success = False
+            response.message = f"Already recording to {self.output_dir}"
+            return response
+
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.output_dir = os.path.join(self.recordings_root, f"video_{stamp}")
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        for name, topic in CAMERA_TOPICS.items():
+            self.subs.append(
+                self.create_subscription(
+                    Image,
+                    topic,
+                    lambda msg, name=name: self.on_frame(name, msg),
+                    qos_profile_sensor_data,
+                )
+            )
+        self.timer = self.create_timer(1.0 / FPS, self.write_tick)
+        self.publish_status()
+        self.get_logger().info(f"Recording to {self.output_dir}")
+
+        response.success = True
+        response.message = self.output_dir
+        return response
+
+    def handle_stop(self, _request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        if self.output_dir is None:
+            response.success = False
+            response.message = "Not recording"
+            return response
+
+        output_dir = self.output_dir
+        self.output_dir = None
+        self.destroy_timer(self.timer)
+        self.timer = None
+        for sub in self.subs:
+            self.destroy_subscription(sub)
+        self.subs.clear()
+        saved = sorted(self.writers)
+        for writer in self.writers.values():
+            writer.release()
+        self.writers.clear()
+        self.latest.clear()
+        self.publish_status()
+
+        if not saved:
+            shutil.rmtree(output_dir, ignore_errors=True)
+            response.success = False
+            response.message = "No camera frames received; nothing saved"
+        else:
+            response.success = True
+            response.message = f"Saved {', '.join(f'{name}.mp4' for name in saved)} in {output_dir}"
+        self.get_logger().info(response.message)
+        return response
+
+    def on_frame(self, name: str, msg: Image) -> None:
+        frame = image_to_bgr(msg)
+        if frame is not None:
+            self.latest[name] = frame
+
+    def write_tick(self) -> None:
+        for name, frame in self.latest.items():
+            writer = self.writers.get(name)
+            if writer is None:
+                height, width = frame.shape[:2]
+                path = os.path.join(self.output_dir, f"{name}.mp4")
+                writer = cv2.VideoWriter(path, cv2.VideoWriter_fourcc(*"mp4v"), FPS, (width, height))
+                self.writers[name] = writer
+            writer.write(frame)
+
+
+def main() -> None:
+    rclpy.init()
+    node = VideoRecorder()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -51,8 +51,9 @@ CAMERA_INFO_TOPICS = [
 ]
 # Pose/sensor topics bagged alongside the videos for 3D reconstruction:
 # odometry + TF give the camera trajectory (tf_static carries the camera
-# extrinsics chain, joint_states the head tilt), /scan adds lidar geometry.
-# Topics without a live publisher just record zero messages.
+# extrinsics chain, joint_states the head tilt); /scan_fast is the lidar at
+# full sensor rate — /scan is the same stream throttled to 6 Hz, so it isn't
+# bagged. Topics without a live publisher just record zero messages.
 BAG_TOPICS = {
     "/odom": ("nav_msgs/msg/Odometry", Odometry),
     "/mapping_pose": ("nav_msgs/msg/Odometry", Odometry),
@@ -60,7 +61,7 @@ BAG_TOPICS = {
     "/tf": ("tf2_msgs/msg/TFMessage", TFMessage),
     "/tf_static": ("tf2_msgs/msg/TFMessage", TFMessage),
     "/joint_states": ("sensor_msgs/msg/JointState", JointState),
-    "/scan": ("sensor_msgs/msg/LaserScan", LaserScan),
+    "/scan_fast": ("sensor_msgs/msg/LaserScan", LaserScan),
 }
 
 # Write-timer rate. Streams whose camera publishes slower record at their own
@@ -117,8 +118,14 @@ class GstMp4Writer:
         else:
             kbps = max(1500, int(width * height * fps * 0.25 / 1000))  # ~0.25 bit/px
             encode = [
-                "x264enc", "speed-preset=ultrafast", f"bitrate={kbps}", f"key-int-max={int(fps * 4)}",
-                "!", "h264parse", "!", "mp4mux",
+                "x264enc",
+                "speed-preset=ultrafast",
+                f"bitrate={kbps}",
+                f"key-int-max={int(fps * 4)}",
+                "!",
+                "h264parse",
+                "!",
+                "mp4mux",
             ]
         fmt = "i420" if self._i420 else "bgr"
         convert = [] if self._i420 else ["videoconvert", "n-threads=4", "!", "video/x-raw,format=I420", "!"]

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -4,13 +4,21 @@
 """Teleop video recorder.
 
 /video_recorder/start and /video_recorder/stop (std_srvs/Trigger) bracket an
-MP4 capture of the camera topics into <INNATE_OS_ROOT>/data/recordings/. Frames are
-written on a fixed-rate timer (latest frame per tick, duplicated on stalls) so
-the file plays back in real time regardless of camera or subscriber drops.
+H.264 MP4 capture of the camera topics into <INNATE_OS_ROOT>/data/recordings/.
+Frames are written on a fixed-rate timer (latest frame per tick, duplicated on
+stalls) so the file plays back in real time regardless of camera or subscriber
+drops. Each recording also gets a recording_metadata.json (streams, timing,
+camera intrinsics when calibration is loaded) and a robot.urdf snapshot.
 """
 
+import json
 import os
+import queue
 import shutil
+import socket
+import subprocess
+import threading
+import time
 from datetime import datetime
 
 import cv2
@@ -18,20 +26,30 @@ import numpy as np
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, qos_profile_sensor_data
-from sensor_msgs.msg import Image
-from std_msgs.msg import Bool
+from sensor_msgs.msg import CameraInfo, Image
+from std_msgs.msg import Bool, String
 from std_srvs.srv import Trigger
 
 CAMERA_TOPICS = {
-    # Full-res side-by-side stereo (subscriber-gated in the driver, so it only
-    # flows while recording); the left eye is cropped out below. The 640x480
-    # /left topic stays untouched for policies, datasets and teleop.
-    "main": "/mars/main_camera/stereo",
+    # Full-res left eye (subscriber-gated in the driver, so it only flows
+    # while recording). The 640x480 /left topic stays untouched for policies,
+    # datasets and teleop.
+    "main": "/mars/main_camera/left/image_full",
     "arm": "/mars/arm/image_raw",
 }
-# Topics carrying a side-by-side stereo frame: record the left half only.
-CROP_LEFT_HALF = {"main"}
+# Intrinsics published only while a stereo calibration is loaded; captured
+# into the metadata sidecar when present.
+CAMERA_INFO_TOPICS = [
+    "/mars/main_camera/left/camera_info",
+    "/mars/main_camera/right/camera_info",
+]
+# Write-timer rate. Streams whose camera publishes slower record at their own
+# rate below — encoding duplicated frames buys nothing.
 FPS = 30.0
+RECORD_FPS = {"main": 15.0}  # main camera fps in stereo_depth_estimator.yaml
+# 1080p records via the NVJPG hardware encoder (browsers can't play MJPEG-in-MP4,
+# but VLC/QuickTime/editors can); everything else via x264, which plays anywhere.
+STREAM_CODEC = {"main": "mjpeg"}
 
 
 def image_to_bgr(msg: Image) -> np.ndarray | None:
@@ -44,20 +62,95 @@ def image_to_bgr(msg: Image) -> np.ndarray | None:
     return frame
 
 
+def camera_info_to_dict(msg: CameraInfo) -> dict:
+    return {
+        "frame_id": msg.header.frame_id,
+        "width": msg.width,
+        "height": msg.height,
+        "distortion_model": msg.distortion_model,
+        "d": list(msg.d),
+        "k": list(msg.k),
+        "r": list(msg.r),
+        "p": list(msg.p),
+    }
+
+
+class GstMp4Writer:
+    """MP4 writer: raw BGR frames piped to a gst-launch subprocess.
+
+    The Orin Nano has no NVENC, and OpenCV's mp4v encoder tops out below
+    1080p30 (measured ~20 Hz), which silently time-compressed recordings.
+    1080p goes through the NVJPG hardware encoder (mjpeg): measured 2.5x
+    real-time under full robot load, and it never backpressures the write
+    timer the way software x264 at 1080p does (which halved every stream's
+    rate). Small streams use x264 (h264), which plays everywhere.
+    """
+
+    def __init__(self, path: str, fps: float, width: int, height: int, codec: str) -> None:
+        if codec == "mjpeg":
+            encode = ["nvjpegenc", "quality=85", "!", "qtmux"]
+        else:
+            kbps = max(1500, int(width * height * fps * 0.25 / 1000))  # ~0.25 bit/px
+            encode = [
+                "x264enc", "speed-preset=ultrafast", f"bitrate={kbps}", f"key-int-max={int(fps * 4)}",
+                "!", "h264parse", "!", "mp4mux",
+            ]
+        args = (
+            ["gst-launch-1.0", "-q", "fdsrc", "fd=0", "!"]
+            + ["rawvideoparse", "format=bgr", f"width={width}", f"height={height}", f"framerate={int(fps)}/1", "!"]
+            + ["queue", "max-size-buffers=8", "!", "videoconvert", "n-threads=4", "!"]
+            + ["video/x-raw,format=I420", "!", "queue", "max-size-buffers=8", "!"]
+            + encode
+            + ["!", "filesink", f"location={path}"]
+        )
+        self._proc = subprocess.Popen(args, stdin=subprocess.PIPE)
+
+    def write(self, frame: np.ndarray) -> None:
+        self._proc.stdin.write(frame.tobytes())
+
+    def release(self) -> None:
+        try:
+            self._proc.stdin.close()  # EOS -> mp4mux finalizes the file
+        except OSError:
+            pass
+        try:
+            self._proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+
+
 class VideoRecorder(Node):
     def __init__(self) -> None:
         super().__init__("video_recorder")
         root = os.environ.get("INNATE_OS_ROOT", os.path.expanduser("~/innate-os"))
         self.recordings_root = os.path.join(root, "data", "recordings")
+        try:
+            sha = subprocess.run(
+                ["git", "-C", root, "rev-parse", "--short", "HEAD"], capture_output=True, text=True, timeout=5
+            )
+            self.git_sha: str | None = sha.stdout.strip() or None
+        except OSError:
+            self.git_sha = None
 
         self.output_dir: str | None = None
         self.subs: list = []
         self.timer = None
+        self.tick = 0
+        self.started_at: str | None = None
+        self.start_monotonic = 0.0
         self.latest: dict[str, np.ndarray] = {}
-        self.writers: dict[str, cv2.VideoWriter] = {}
+        self.writers: dict[str, GstMp4Writer] = {}
+        self.frame_counts: dict[str, int] = {}
+        self.camera_infos: dict[str, dict] = {}
+        self.robot_description: str | None = None
 
         self.create_service(Trigger, "/video_recorder/start", self.handle_start)
         self.create_service(Trigger, "/video_recorder/stop", self.handle_stop)
+
+        # robot_state_publisher latches the URDF; keep the latest for the
+        # metadata sidecar.
+        latched_qos = QoSProfile(depth=1, durability=QoSDurabilityPolicy.TRANSIENT_LOCAL)
+        self.create_subscription(String, "/robot_description", self.on_robot_description, latched_qos)
 
         # Latched so the webapp sees the current state on (re)connect, plus a
         # 1 Hz heartbeat so a client holding a stale value (reconnect races,
@@ -70,6 +163,9 @@ class VideoRecorder(Node):
     def publish_status(self) -> None:
         self.status_pub.publish(Bool(data=self.output_dir is not None))
 
+    def on_robot_description(self, msg: String) -> None:
+        self.robot_description = msg.data
+
     def handle_start(self, _request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         if self.output_dir is not None:
             response.success = False
@@ -79,6 +175,9 @@ class VideoRecorder(Node):
         stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         self.output_dir = os.path.join(self.recordings_root, f"video_{stamp}")
         os.makedirs(self.output_dir, exist_ok=True)
+        self.started_at = datetime.now().astimezone().isoformat(timespec="seconds")
+        self.start_monotonic = time.monotonic()
+        self.tick = 0
 
         for name, topic in CAMERA_TOPICS.items():
             self.subs.append(
@@ -89,6 +188,20 @@ class VideoRecorder(Node):
                     qos_profile_sensor_data,
                 )
             )
+        for topic in CAMERA_INFO_TOPICS:
+            self.subs.append(
+                self.create_subscription(
+                    CameraInfo,
+                    topic,
+                    lambda msg, topic=topic: self.camera_infos.__setitem__(topic, camera_info_to_dict(msg)),
+                    qos_profile_sensor_data,
+                )
+            )
+        # Writes drain on their own thread: a pipe stall (encoder hiccup) must
+        # never stall the executor, or message intake halves along with it.
+        self.write_q = queue.Queue(maxsize=8)
+        self.writer_thread = threading.Thread(target=self.drain_writes, daemon=True)
+        self.writer_thread.start()
         self.timer = self.create_timer(1.0 / FPS, self.write_tick)
         self.publish_status()
         self.get_logger().info(f"Recording to {self.output_dir}")
@@ -104,17 +217,33 @@ class VideoRecorder(Node):
             return response
 
         output_dir = self.output_dir
+        duration = time.monotonic() - self.start_monotonic
         self.output_dir = None
         self.destroy_timer(self.timer)
         self.timer = None
         for sub in self.subs:
             self.destroy_subscription(sub)
         self.subs.clear()
+        self.write_q.put(None)
+        self.writer_thread.join(timeout=15)
         saved = sorted(self.writers)
+        streams = {
+            name: {
+                "file": f"{name}.mp4",
+                "topic": CAMERA_TOPICS[name],
+                "width": self.latest[name].shape[1],
+                "height": self.latest[name].shape[0],
+                "fps": RECORD_FPS.get(name, FPS),
+                "codec": STREAM_CODEC.get(name, "h264"),
+                "frames": self.frame_counts.get(name, 0),
+            }
+            for name in saved
+        }
         for writer in self.writers.values():
             writer.release()
         self.writers.clear()
         self.latest.clear()
+        self.frame_counts.clear()
         self.publish_status()
 
         if not saved:
@@ -122,29 +251,68 @@ class VideoRecorder(Node):
             response.success = False
             response.message = "No camera frames received; nothing saved"
         else:
+            self.write_metadata(output_dir, duration, streams)
             response.success = True
             response.message = f"Saved {', '.join(f'{name}.mp4' for name in saved)} in {output_dir}"
+        self.camera_infos.clear()
         self.get_logger().info(response.message)
         return response
+
+    def write_metadata(self, output_dir: str, duration: float, streams: dict) -> None:
+        metadata = {
+            "hostname": socket.gethostname(),
+            "innate_os_git": self.git_sha,
+            "started": self.started_at,
+            "duration_s": round(duration, 3),
+            "streams": streams,
+            # Intrinsics are for the published left/right topics at their
+            # native resolution; main.mp4 is the left eye at full stereo
+            # resolution — scale fx, fy, cx, cy by width ratio to apply them.
+            "camera_info": self.camera_infos
+            or "unavailable: no stereo calibration loaded, camera_info topics were silent",
+        }
+        with open(os.path.join(output_dir, "recording_metadata.json"), "w") as f:
+            json.dump(metadata, f, indent=2)
+        if self.robot_description:
+            with open(os.path.join(output_dir, "robot.urdf"), "w") as f:
+                f.write(self.robot_description)
 
     def on_frame(self, name: str, msg: Image) -> None:
         frame = image_to_bgr(msg)
         if frame is None:
             return
-        if name in CROP_LEFT_HALF:
-            # Copy: the half-width view is non-contiguous, which VideoWriter rejects.
-            frame = np.ascontiguousarray(frame[:, : frame.shape[1] // 2])
         self.latest[name] = frame
 
     def write_tick(self) -> None:
-        for name, frame in self.latest.items():
+        self.tick += 1
+        output_dir = self.output_dir
+        for name, frame in list(self.latest.items()):
+            step = max(1, round(FPS / RECORD_FPS.get(name, FPS)))
+            if self.tick % step:
+                continue
+            try:
+                self.write_q.put_nowait((name, frame, output_dir))
+            except queue.Full:
+                self.get_logger().warning(f"{name}: write queue full, dropping a frame", throttle_duration_sec=5.0)
+
+    def drain_writes(self) -> None:
+        while True:
+            item = self.write_q.get()
+            if item is None:
+                return
+            name, frame, output_dir = item
             writer = self.writers.get(name)
             if writer is None:
                 height, width = frame.shape[:2]
-                path = os.path.join(self.output_dir, f"{name}.mp4")
-                writer = cv2.VideoWriter(path, cv2.VideoWriter_fourcc(*"mp4v"), FPS, (width, height))
+                path = os.path.join(output_dir, f"{name}.mp4")
+                writer = GstMp4Writer(path, RECORD_FPS.get(name, FPS), width, height, STREAM_CODEC.get(name, "h264"))
                 self.writers[name] = writer
-            writer.write(frame)
+            try:
+                writer.write(frame)
+                self.frame_counts[name] = self.frame_counts.get(name, 0) + 1
+            except OSError:
+                self.get_logger().error(f"{name} encoder pipeline died; dropping stream")
+                self.writers.pop(name).release()
 
 
 def main() -> None:

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -66,10 +66,7 @@ BAG_TOPICS = {
 # Write-timer rate. Streams whose camera publishes slower record at their own
 # rate below — encoding duplicated frames buys nothing.
 FPS = 30.0
-# Main records below its 15 fps camera rate: the raw-BGR pipe + NVJPG chain
-# sustains ~12 fps at 3840x1080 under full robot load, so 15 silently drops
-# frames (measured 81% realtime); 10 holds with real margin.
-RECORD_FPS = {"main": 10.0}
+RECORD_FPS = {"main": 15.0}  # main camera fps in stereo_depth_estimator.yaml
 # 1080p records via the NVJPG hardware encoder (browsers can't play MJPEG-in-MP4,
 # but VLC/QuickTime/editors can); everything else via x264, which plays anywhere.
 STREAM_CODEC = {"main": "mjpeg"}
@@ -110,6 +107,11 @@ class GstMp4Writer:
     """
 
     def __init__(self, path: str, fps: float, width: int, height: int, codec: str) -> None:
+        # mjpeg streams are fed I420 (converted in write() via SIMD cv2, which
+        # releases the GIL): half the pipe bytes of BGR and no videoconvert
+        # element — measured 36 fps capacity at 3840x1080 vs 18 for the BGR
+        # chain. h264 streams are small; they keep the plain BGR feed.
+        self._i420 = codec == "mjpeg"
         if codec == "mjpeg":
             encode = ["nvjpegenc", "quality=85", "!", "qtmux"]
         else:
@@ -118,11 +120,14 @@ class GstMp4Writer:
                 "x264enc", "speed-preset=ultrafast", f"bitrate={kbps}", f"key-int-max={int(fps * 4)}",
                 "!", "h264parse", "!", "mp4mux",
             ]
+        fmt = "i420" if self._i420 else "bgr"
+        convert = [] if self._i420 else ["videoconvert", "n-threads=4", "!", "video/x-raw,format=I420", "!"]
         args = (
             ["gst-launch-1.0", "-q", "fdsrc", "fd=0", "!"]
-            + ["rawvideoparse", "format=bgr", f"width={width}", f"height={height}", f"framerate={int(fps)}/1", "!"]
-            + ["queue", "max-size-buffers=8", "!", "videoconvert", "n-threads=4", "!"]
-            + ["video/x-raw,format=I420", "!", "queue", "max-size-buffers=8", "!"]
+            + ["rawvideoparse", f"format={fmt}", f"width={width}", f"height={height}", f"framerate={int(fps)}/1", "!"]
+            + ["queue", "max-size-buffers=8", "!"]
+            + convert
+            + ["queue", "max-size-buffers=8", "!"]
             + encode
             + ["!", "filesink", f"location={path}"]
         )
@@ -131,6 +136,8 @@ class GstMp4Writer:
     def write(self, frame: np.ndarray) -> None:
         # Contiguous frames go straight from the numpy buffer; 12 MB stereo
         # frames make a tobytes() copy measurable.
+        if self._i420:
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2YUV_I420)
         self._proc.stdin.write(frame.data if frame.flags.c_contiguous else frame.tobytes())
 
     def release(self) -> None:

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -23,9 +23,14 @@ from std_msgs.msg import Bool
 from std_srvs.srv import Trigger
 
 CAMERA_TOPICS = {
-    "main": "/mars/main_camera/left/image_raw",
+    # Full-res side-by-side stereo (subscriber-gated in the driver, so it only
+    # flows while recording); the left eye is cropped out below. The 640x480
+    # /left topic stays untouched for policies, datasets and teleop.
+    "main": "/mars/main_camera/stereo",
     "arm": "/mars/arm/image_raw",
 }
+# Topics carrying a side-by-side stereo frame: record the left half only.
+CROP_LEFT_HALF = {"main"}
 FPS = 30.0
 
 
@@ -124,8 +129,12 @@ class VideoRecorder(Node):
 
     def on_frame(self, name: str, msg: Image) -> None:
         frame = image_to_bgr(msg)
-        if frame is not None:
-            self.latest[name] = frame
+        if frame is None:
+            return
+        if name in CROP_LEFT_HALF:
+            # Copy: the half-width view is non-contiguous, which VideoWriter rejects.
+            frame = np.ascontiguousarray(frame[:, : frame.shape[1] // 2])
+        self.latest[name] = frame
 
     def write_tick(self) -> None:
         for name, frame in self.latest.items():

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/video_recorder.py
@@ -17,11 +17,13 @@ import json
 import os
 import queue
 import shutil
+import signal
 import socket
 import subprocess
 import threading
 import time
 from datetime import datetime
+from typing import TextIO
 
 import cv2
 import numpy as np
@@ -29,6 +31,7 @@ import rclpy
 import rosbag2_py
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from nav_msgs.msg import Odometry
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, qos_profile_sensor_data
 from sensor_msgs.msg import CameraInfo, Image, JointState, LaserScan
@@ -71,6 +74,8 @@ RECORD_FPS = {"main": 15.0}  # main camera fps in stereo_depth_estimator.yaml
 # 1080p records via the NVJPG hardware encoder (browsers can't play MJPEG-in-MP4,
 # but VLC/QuickTime/editors can); everything else via x264, which plays anywhere.
 STREAM_CODEC = {"main": "mjpeg"}
+MAX_RECORDING_S = 4 * 3600
+METADATA_INTERVAL_TICKS = int(FPS * 5)
 
 
 def image_to_bgr(msg: Image) -> np.ndarray | None:
@@ -113,8 +118,13 @@ class GstMp4Writer:
         # element — measured 36 fps capacity at 3840x1080 vs 18 for the BGR
         # chain. h264 streams are small; they keep the plain BGR feed.
         self._i420 = codec == "mjpeg"
+        # Robust muxing: the index lives at the head of the file and is
+        # rewritten every second, so a SIGTERM (innate restart), an OOM kill or
+        # a power cut mid-recording loses the last second, not the whole file
+        # (a plain MP4 only gets its index at EOS). Caps one recording at 4 h.
+        robust = [f"reserved-max-duration={MAX_RECORDING_S * 1_000_000_000}", "reserved-moov-update-period=1000000000"]
         if codec == "mjpeg":
-            encode = ["nvjpegenc", "quality=85", "!", "qtmux"]
+            encode = ["nvjpegenc", "quality=85", "!", "qtmux", *robust]
         else:
             kbps = max(1500, int(width * height * fps * 0.25 / 1000))  # ~0.25 bit/px
             encode = [
@@ -126,6 +136,7 @@ class GstMp4Writer:
                 "h264parse",
                 "!",
                 "mp4mux",
+                *robust,
             ]
         fmt = "i420" if self._i420 else "bgr"
         convert = [] if self._i420 else ["videoconvert", "n-threads=4", "!", "video/x-raw,format=I420", "!"]
@@ -138,7 +149,9 @@ class GstMp4Writer:
             + encode
             + ["!", "filesink", f"location={path}"]
         )
-        self._proc = subprocess.Popen(args, stdin=subprocess.PIPE)
+        # Own session: a Ctrl-C / SIGHUP aimed at the recorder's process group
+        # must not kill the encoder before stdin closes and it can finalize.
+        self._proc = subprocess.Popen(args, stdin=subprocess.PIPE, start_new_session=True)
 
     def write(self, frame: np.ndarray) -> None:
         # Contiguous frames go straight from the numpy buffer; 12 MB stereo
@@ -184,7 +197,7 @@ class VideoRecorder(Node):
         self.robot_description: str | None = None
         self.bag_writer: rosbag2_py.SequentialWriter | None = None
         self.bag_counts: dict[str, int] = {}
-        self.frame_stamps: dict[str, list] = {}
+        self.frame_logs: dict[str, TextIO] = {}
 
         self.create_service(Trigger, "/video_recorder/start", self.handle_start)
         self.create_service(Trigger, "/video_recorder/stop", self.handle_stop)
@@ -203,7 +216,8 @@ class VideoRecorder(Node):
         self.create_timer(1.0, self.publish_status)
 
     def publish_status(self) -> None:
-        self.status_pub.publish(Bool(data=self.output_dir is not None))
+        if rclpy.ok():
+            self.status_pub.publish(Bool(data=self.output_dir is not None))
 
     def on_robot_description(self, msg: String) -> None:
         self.robot_description = msg.data
@@ -216,16 +230,20 @@ class VideoRecorder(Node):
 
         stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         output_dir = os.path.join(self.recordings_root, f"video_{stamp}")
-        # Claim output_dir (the "recording" flag) only once the directory
-        # exists: a failure here (disk full, permissions) must leave the
+        # Claim output_dir (the "recording" flag) only once everything that can
+        # fail has succeeded: a disk-full / permission error must leave the
         # node idle and startable, not wedged in a half-started state.
         try:
             os.makedirs(output_dir, exist_ok=True)
-        except OSError as exc:
+            bag_writer = self.open_bag(os.path.join(output_dir, "sensors"))
+        except (OSError, RuntimeError) as exc:
+            shutil.rmtree(output_dir, ignore_errors=True)
             response.success = False
-            response.message = f"Cannot create {output_dir}: {exc}"
+            response.message = f"Cannot start recording in {output_dir}: {exc}"
             return response
         self.output_dir = output_dir
+        self.bag_writer = bag_writer
+        self.bag_counts = dict.fromkeys(BAG_TOPICS, 0)
         self.started_at = datetime.now().astimezone().isoformat(timespec="seconds")
         self.start_monotonic = time.monotonic()
         self.tick = 0
@@ -248,16 +266,7 @@ class VideoRecorder(Node):
                     qos_profile_sensor_data,
                 )
             )
-        self.bag_writer = rosbag2_py.SequentialWriter()
-        self.bag_writer.open(
-            rosbag2_py.StorageOptions(uri=os.path.join(self.output_dir, "sensors"), storage_id="sqlite3"),
-            rosbag2_py.ConverterOptions(input_serialization_format="cdr", output_serialization_format="cdr"),
-        )
-        for topic, (type_name, msg_cls) in BAG_TOPICS.items():
-            self.bag_writer.create_topic(
-                rosbag2_py.TopicMetadata(name=topic, type=type_name, serialization_format="cdr")
-            )
-            self.bag_counts[topic] = 0
+        for topic, (_, msg_cls) in BAG_TOPICS.items():
             # tf_static is latched; a volatile sub would miss the transforms
             # published before recording started.
             qos = (
@@ -293,23 +302,63 @@ class VideoRecorder(Node):
             response.success = False
             response.message = "Not recording"
             return response
+        response.success, response.message = self.stop_recording()
+        return response
 
+    def stop_recording(self) -> tuple[bool, str]:
         output_dir = self.output_dir
         duration = time.monotonic() - self.start_monotonic
-        self.output_dir = None
         self.destroy_timer(self.timer)
         self.timer = None
         for sub in self.subs:
             self.destroy_subscription(sub)
         self.subs.clear()
-        self.bag_writer = None  # destructor flushes and closes the bag
+        self.bag_writer.close()
+        self.bag_writer = None
         for q in self.write_qs.values():
             q.put(None)
         for name, t in self.writer_threads.items():
             t.join(timeout=15)
             if t.is_alive():
                 self.get_logger().error(f"{name} writer thread did not exit in time; file may be truncated")
-        saved = sorted(self.writers)
+        # A stream whose encoder died mid-run is gone from self.writers but its
+        # frames are on disk (robust muxing), so "saved" is what got written,
+        # and only a run with no frames at all is discarded.
+        saved = sorted(name for name, count in self.frame_counts.items() if count)
+        if saved:
+            self.write_metadata(output_dir, duration)
+        for writer in self.writers.values():
+            writer.release()
+        for log in self.frame_logs.values():
+            log.close()
+        self.output_dir = None
+        self.writers.clear()
+        self.frame_logs.clear()
+        self.latest.clear()
+        self.frame_counts.clear()
+        self.camera_infos.clear()
+        self.bag_counts = {}
+        self.publish_status()
+
+        if not saved:
+            shutil.rmtree(output_dir, ignore_errors=True)
+            message = "No camera frames received; nothing saved"
+        else:
+            message = f"Saved {', '.join(f'{name}.mp4' for name in saved)} in {output_dir}"
+        self.get_logger().info(message)
+        return bool(saved), message
+
+    def open_bag(self, uri: str) -> rosbag2_py.SequentialWriter:
+        writer = rosbag2_py.SequentialWriter()
+        writer.open(
+            rosbag2_py.StorageOptions(uri=uri, storage_id="sqlite3"),
+            rosbag2_py.ConverterOptions(input_serialization_format="cdr", output_serialization_format="cdr"),
+        )
+        for topic, (type_name, _) in BAG_TOPICS.items():
+            writer.create_topic(rosbag2_py.TopicMetadata(name=topic, type=type_name, serialization_format="cdr"))
+        return writer
+
+    def write_metadata(self, output_dir: str, duration: float) -> None:
         streams = {
             name: {
                 "file": f"{name}.mp4",
@@ -318,32 +367,11 @@ class VideoRecorder(Node):
                 "height": self.latest[name][0].shape[0],
                 "fps": RECORD_FPS.get(name, FPS),
                 "codec": STREAM_CODEC.get(name, "h264"),
-                "frames": self.frame_counts.get(name, 0),
+                "frames": count,
             }
-            for name in saved
+            for name, count in sorted(self.frame_counts.items())
+            if count
         }
-        for writer in self.writers.values():
-            writer.release()
-        self.writers.clear()
-        self.latest.clear()
-        self.frame_counts.clear()
-        self.publish_status()
-
-        if not saved:
-            shutil.rmtree(output_dir, ignore_errors=True)
-            response.success = False
-            response.message = "No camera frames received; nothing saved"
-        else:
-            self.write_metadata(output_dir, duration, streams)
-            response.success = True
-            response.message = f"Saved {', '.join(f'{name}.mp4' for name in saved)} in {output_dir}"
-        self.camera_infos.clear()
-        self.bag_counts = {}
-        self.frame_stamps = {}
-        self.get_logger().info(response.message)
-        return response
-
-    def write_metadata(self, output_dir: str, duration: float, streams: dict) -> None:
         metadata = {
             "hostname": socket.gethostname(),
             "innate_os_git": self.git_sha,
@@ -362,10 +390,6 @@ class VideoRecorder(Node):
         }
         with open(os.path.join(output_dir, "recording_metadata.json"), "w") as f:
             json.dump(metadata, f, indent=2)
-        for name, stamps in self.frame_stamps.items():
-            with open(os.path.join(output_dir, f"{name}_frames.csv"), "w") as f:
-                f.write("frame,stamp_ns\n")
-                f.writelines(f"{i},{ns}\n" for i, ns in enumerate(stamps))
         if self.robot_description:
             with open(os.path.join(output_dir, "robot.urdf"), "w") as f:
                 f.write(self.robot_description)
@@ -385,6 +409,11 @@ class VideoRecorder(Node):
     def write_tick(self) -> None:
         self.tick += 1
         output_dir = self.output_dir
+        # Metadata is refreshed while recording (and the frame CSVs are written
+        # per frame) so a run that ends in a kill or a power cut still describes
+        # itself; only the bag's metadata.yaml then needs `ros2 bag reindex`.
+        if self.tick % METADATA_INTERVAL_TICKS == 0:
+            self.write_metadata(output_dir, time.monotonic() - self.start_monotonic)
         for name, (frame, stamp_ns) in list(self.latest.items()):
             step = max(1, round(FPS / RECORD_FPS.get(name, FPS)))
             if self.tick % step:
@@ -419,10 +448,13 @@ class VideoRecorder(Node):
                     failed = True
                     continue
                 self.writers[name] = writer
+                self.frame_logs[name] = open(os.path.join(output_dir, f"{name}_frames.csv"), "w", buffering=1)
+                self.frame_logs[name].write("frame,stamp_ns\n")
             try:
                 writer.write(frame)
-                self.frame_counts[name] = self.frame_counts.get(name, 0) + 1
-                self.frame_stamps.setdefault(name, []).append(stamp_ns)
+                index = self.frame_counts.get(name, 0)
+                self.frame_logs[name].write(f"{index},{stamp_ns}\n")
+                self.frame_counts[name] = index + 1
             except OSError:
                 self.get_logger().error(f"{name} encoder pipeline died; dropping stream")
                 self.writers.pop(name).release()
@@ -431,14 +463,17 @@ class VideoRecorder(Node):
 
 def main() -> None:
     rclpy.init()
+    signal.signal(signal.SIGHUP, signal.default_int_handler)
     node = VideoRecorder()
     try:
         rclpy.spin(node)
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
     finally:
+        if node.output_dir is not None:
+            node.stop_recording()
         node.destroy_node()
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
@@ -18,9 +18,7 @@ main_camera_driver:
     jpeg_quality: 80
     publish_compressed: true
     compressed_frame_interval: 2
-    # Stereo publishes only while something subscribes (the video recorder),
-    # so the full-res topic is free when idle.
-    publish_stereo: true
+    publish_stereo: false
     exposure: -1
     gain: -1
     default_gain: 110

--- a/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
@@ -18,7 +18,9 @@ main_camera_driver:
     jpeg_quality: 80
     publish_compressed: true
     compressed_frame_interval: 2
-    publish_stereo: false
+    # Full side-by-side stereo for the video recorder; subscriber-gated in the
+    # driver so it only serializes out while a recording runs.
+    publish_stereo: true
     exposure: -1
     gain: -1
     default_gain: 110

--- a/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
@@ -4,18 +4,23 @@
 main_camera_driver:
   ros__parameters:
     camera_symlink: "3D"
-    width: 2560
-    height: 720
+    # Capture at the sensor max so /mars/main_camera/stereo carries full-res
+    # frames for the video recorder. Decode/rotate stay on NVDEC/VIC; left and
+    # right are still downscaled to 640x480 for every existing consumer.
+    width: 3840
+    height: 1080
     publish_left_width: 640
     publish_left_height: 480
-    publish_stereo_width: 1280
-    publish_stereo_height: 480
+    publish_stereo_width: 3840
+    publish_stereo_height: 1080
     fps: 15.0
     frame_id: "camera_optical_frame"
     jpeg_quality: 80
     publish_compressed: true
     compressed_frame_interval: 2
-    publish_stereo: false
+    # Stereo publishes only while something subscribes (the video recorder),
+    # so the full-res topic is free when idle.
+    publish_stereo: true
     exposure: -1
     gain: -1
     default_gain: 110

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/main_camera_driver.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/main_camera_driver.hpp
@@ -248,6 +248,7 @@ class MainCameraDriver : public rclcpp::Node {
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_pub_;  // Right camera raw
     rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressed_pub_;
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr stereo_pub_;
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_full_pub_;  // Full-res left eye, on demand
 
     // Camera info publishers + calibration
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr left_info_pub_;

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/main_camera_driver.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/main_camera_driver.hpp
@@ -248,7 +248,6 @@ class MainCameraDriver : public rclcpp::Node {
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr right_pub_;  // Right camera raw
     rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressed_pub_;
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr stereo_pub_;
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr left_full_pub_;  // Full-res left eye, on demand
 
     // Camera info publishers + calibration
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr left_info_pub_;

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -21,7 +21,7 @@ Usage:
 import os
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer, Node
@@ -207,8 +207,16 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration("start_calibration_manager")),
     )
 
+    # The fleet default SHM segment (4 MiB, config/dds/setup_dds.zsh) is sized
+    # for point clouds; the 12 MB full-res stereo frames the video recorder
+    # subscribes to would fall back to loopback TCP. This is the per-process
+    # override that file's TODO anticipates — only the camera processes pay
+    # the locked /dev/shm cost.
+    camera_shm_size = SetEnvironmentVariable("ZENOH_SHM_ALLOC_SIZE", "67108864")
+
     return LaunchDescription(
         [
+            camera_shm_size,
             use_sim_time_arg,
             camera_config_arg,
             start_calibration_manager_arg,

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/calibration_debug_vis.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/calibration_debug_vis.py
@@ -207,6 +207,41 @@ def generate_debug_mosaic(node, result):
         node.get_logger().warn(f"Failed to generate debug mosaic: {e}")
 
 
+# Coverage grid: the image plane divided into cols x rows cells; a cell counts
+# as covered once any captured ChArUco corner lands in it. The managed
+# calibration run only finishes when every cell is covered in BOTH cameras
+# (see _execute_run_calibration), so intrinsics are constrained across the
+# whole frame — not just wherever the operator happened to hold the board.
+COVERAGE_GRID_COLS = 4
+COVERAGE_GRID_ROWS = 3
+
+
+def compute_coverage(node):
+    """Covered coverage-grid cells per camera from corners captured so far.
+
+    Args:
+        node: StereoCalibrator node instance (needs ``indiv_corners_left/right``,
+              ``image_width``/``image_height``).
+
+    Returns:
+        tuple(left_covered, right_covered, total_cells) — the first two are
+        sets of (col, row) cells containing at least one captured corner.
+    """
+    w, h = node.image_width, node.image_height
+
+    def _covered_cells(all_corners):
+        cells = set()
+        for corners in all_corners:
+            for corner in corners:
+                x, y = corner[0, 0], corner[0, 1]
+                if 0 <= x < w and 0 <= y < h:
+                    cells.add((int(x * COVERAGE_GRID_COLS // w), int(y * COVERAGE_GRID_ROWS // h)))
+        return cells
+
+    total = COVERAGE_GRID_COLS * COVERAGE_GRID_ROWS
+    return _covered_cells(node.indiv_corners_left), _covered_cells(node.indiv_corners_right), total
+
+
 def generate_coverage_images(node):
     """Build per-camera corner-coverage dot maps from corners captured so far.
 
@@ -214,10 +249,9 @@ def generate_coverage_images(node):
     this is cheap enough to call after every single capture and returns the
     images directly for use as action feedback.
 
-    TODO: alongside these two debug renders, compute and report a coverage
-    percentage metric (e.g. fraction of the image plane, gridded into cells,
-    that has at least one captured corner nearby) so the operator gets a
-    number to target, not just a visual dot map.
+    Coverage-grid cells that still have no corner are tinted red behind a
+    hairline grid, so the operator can see exactly where the board still needs
+    to go before the run can finish.
 
     Args:
         node: StereoCalibrator node instance (needs ``indiv_corners_left/right``,
@@ -227,9 +261,17 @@ def generate_coverage_images(node):
         tuple(left_coverage, right_coverage) as BGR ``np.ndarray`` images.
     """
     w, h = node.image_width, node.image_height
+    left_covered, right_covered, _ = compute_coverage(node)
 
-    def _coverage_canvas(all_corners):
+    def _coverage_canvas(all_corners, covered):
         canvas = np.zeros((h, w, 3), dtype=np.uint8)
+        for col in range(COVERAGE_GRID_COLS):
+            for row in range(COVERAGE_GRID_ROWS):
+                x0, y0 = col * w // COVERAGE_GRID_COLS, row * h // COVERAGE_GRID_ROWS
+                x1, y1 = (col + 1) * w // COVERAGE_GRID_COLS, (row + 1) * h // COVERAGE_GRID_ROWS
+                if (col, row) not in covered:
+                    canvas[y0:y1, x0:x1] = (16, 16, 56)  # BGR: dim red = still uncovered
+                cv2.rectangle(canvas, (x0, y0), (x1 - 1, y1 - 1), (60, 60, 60), 1)
         for corners in all_corners:
             for corner in corners:
                 x, y = int(corner[0, 0]), int(corner[0, 1])
@@ -237,8 +279,8 @@ def generate_coverage_images(node):
                     cv2.circle(canvas, (x, y), 3, (255, 255, 0), -1)
         return canvas
 
-    left_coverage = _coverage_canvas(node.indiv_corners_left)
-    right_coverage = _coverage_canvas(node.indiv_corners_right)
+    left_coverage = _coverage_canvas(node.indiv_corners_left, left_covered)
+    right_coverage = _coverage_canvas(node.indiv_corners_right, right_covered)
     return left_coverage, right_coverage
 
 

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
@@ -160,6 +160,12 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions& options) : Node("m
             "/mars/main_camera/stereo", rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort));
     }
 
+    // Full-resolution left eye for the video recorder. Only serialized out
+    // while subscribed (see processAndPublishFrame), so idle cost is zero.
+    left_full_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
+        "/mars/main_camera/left/image_full",
+        rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort));
+
     RCLCPP_DEBUG(this->get_logger(), "Publishers created:");
     RCLCPP_DEBUG(this->get_logger(), "  - /mars/main_camera/left/image_raw (%dx%d)", left_width_, left_height_);
     RCLCPP_DEBUG(this->get_logger(), "  - /mars/main_camera/right/image_raw (%dx%d)", left_width_, left_height_);
@@ -615,9 +621,23 @@ void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame) {
     // Publish with std::move() for zero-copy intra-process communication
     // Inter-process subscribers (via DDS) still receive serialized copies automatically
     // -------------------------
-    // Gated on demand: at full capture resolution the stereo frame is large
-    // (12 MB at 3840x1080), so only serialize it out when someone (the video
-    // recorder) is actually subscribed.
+    // Gated on demand: at full capture resolution these frames are large
+    // (12 MB stereo / 6 MB left at 3840x1080), so only serialize them out
+    // when someone (the video recorder) is actually subscribed.
+    if (left_full_pub_->get_subscription_count() > 0) {
+        auto left_full_msg = std::make_unique<sensor_msgs::msg::Image>();
+        left_full_msg->header.stamp = current_time;
+        left_full_msg->header.frame_id = frame_id_;
+        left_full_msg->height = left_height_;
+        left_full_msg->width = left_width_;
+        left_full_msg->encoding = "bgr8";
+        left_full_msg->is_bigendian = false;
+        left_full_msg->step = left_width_ * 3;
+        left_full_msg->data.resize(left_full_msg->height * left_full_msg->step);
+        cv::Mat left_full_out(left_height_, left_width_, CV_8UC3, left_full_msg->data.data(), left_full_msg->step);
+        left_view.copyTo(left_full_out);
+        left_full_pub_->publish(std::move(left_full_msg));
+    }
     if (publish_stereo_ && stereo_pub_->get_subscription_count() > 0) {
         stereo_pub_->publish(std::move(stereo_msg));
     }

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
@@ -615,7 +615,10 @@ void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame) {
     // Publish with std::move() for zero-copy intra-process communication
     // Inter-process subscribers (via DDS) still receive serialized copies automatically
     // -------------------------
-    if (publish_stereo_) {
+    // Gated on demand: at full capture resolution the stereo frame is large
+    // (12 MB at 3840x1080), so only serialize it out when someone (the video
+    // recorder) is actually subscribed.
+    if (publish_stereo_ && stereo_pub_->get_subscription_count() > 0) {
         stereo_pub_->publish(std::move(stereo_msg));
     }
     left_pub_->publish(std::move(left_msg));

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/main_camera_driver.cpp
@@ -160,12 +160,6 @@ MainCameraDriver::MainCameraDriver(const rclcpp::NodeOptions& options) : Node("m
             "/mars/main_camera/stereo", rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort));
     }
 
-    // Full-resolution left eye for the video recorder. Only serialized out
-    // while subscribed (see processAndPublishFrame), so idle cost is zero.
-    left_full_pub_ = this->create_publisher<sensor_msgs::msg::Image>(
-        "/mars/main_camera/left/image_full",
-        rclcpp::SensorDataQoS().reliability(rclcpp::ReliabilityPolicy::BestEffort));
-
     RCLCPP_DEBUG(this->get_logger(), "Publishers created:");
     RCLCPP_DEBUG(this->get_logger(), "  - /mars/main_camera/left/image_raw (%dx%d)", left_width_, left_height_);
     RCLCPP_DEBUG(this->get_logger(), "  - /mars/main_camera/right/image_raw (%dx%d)", left_width_, left_height_);
@@ -621,23 +615,9 @@ void MainCameraDriver::processAndPublishFrame(const cv::Mat& frame) {
     // Publish with std::move() for zero-copy intra-process communication
     // Inter-process subscribers (via DDS) still receive serialized copies automatically
     // -------------------------
-    // Gated on demand: at full capture resolution these frames are large
-    // (12 MB stereo / 6 MB left at 3840x1080), so only serialize them out
-    // when someone (the video recorder) is actually subscribed.
-    if (left_full_pub_->get_subscription_count() > 0) {
-        auto left_full_msg = std::make_unique<sensor_msgs::msg::Image>();
-        left_full_msg->header.stamp = current_time;
-        left_full_msg->header.frame_id = frame_id_;
-        left_full_msg->height = left_height_;
-        left_full_msg->width = left_width_;
-        left_full_msg->encoding = "bgr8";
-        left_full_msg->is_bigendian = false;
-        left_full_msg->step = left_width_ * 3;
-        left_full_msg->data.resize(left_full_msg->height * left_full_msg->step);
-        cv::Mat left_full_out(left_height_, left_width_, CV_8UC3, left_full_msg->data.data(), left_full_msg->step);
-        left_view.copyTo(left_full_out);
-        left_full_pub_->publish(std::move(left_full_msg));
-    }
+    // Gated on demand: at full capture resolution the stereo frame is large
+    // (12 MB at 3840x1080), so only serialize it out when someone (the video
+    // recorder) is actually subscribed.
     if (publish_stereo_ && stereo_pub_->get_subscription_count() > 0) {
         stereo_pub_->publish(std::move(stereo_msg));
     }

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -45,7 +45,12 @@ from sensor_msgs.msg import CompressedImage, Image
 from std_msgs.msg import Bool
 from std_srvs.srv import Trigger
 
-from mars_cam.calibration_debug_vis import generate_coverage_images, generate_debug_mosaic, generate_visualizations
+from mars_cam.calibration_debug_vis import (
+    compute_coverage,
+    generate_coverage_images,
+    generate_debug_mosaic,
+    generate_visualizations,
+)
 from mars_cam.calibration_utils import (
     find_calibration_dir,
     prompt_save,
@@ -442,6 +447,15 @@ class StereoCalibrator(Node):
 
         return response
 
+    def _coverage_progress(self):
+        """(left covered, right covered, total) coverage-grid cell counts."""
+        left_covered, right_covered, total = compute_coverage(self)
+        return len(left_covered), len(right_covered), total
+
+    def _coverage_complete(self):
+        left_cov, right_cov, total = self._coverage_progress()
+        return left_cov >= total and right_cov >= total
+
     def _execute_run_calibration(self, goal_handle):
         """Execute a managed stereo calibration run for app/API clients (manual capture only)."""
         with self._active_goal_lock:
@@ -519,7 +533,11 @@ class StereoCalibrator(Node):
                     goal_handle.abort()
                     return _make_result(False, msg, timed_out=True)
 
-                if self.images_captured >= self.num_images_required:
+                # Image count is a floor, not the finish line: the run only
+                # completes once every coverage-grid cell has seen a corner in
+                # BOTH cameras, so captures keep being accepted past the target
+                # until coverage is complete.
+                if self.images_captured >= self.num_images_required and self._coverage_complete():
                     break
 
                 time.sleep(0.1)
@@ -633,11 +651,16 @@ class StereoCalibrator(Node):
             goal_handle = self._active_goal
         if goal_handle is not None:
             left_coverage, right_coverage = generate_coverage_images(self)
-            feedback_message = (
-                f"Captured {self.images_captured}/{self.num_images_required}"
-                if result.success
-                else "No board detected in this capture"
-            )
+            if result.success:
+                left_cov, right_cov, total_cells = self._coverage_progress()
+                feedback_message = (
+                    f"Captured {self.images_captured}/{self.num_images_required} · "
+                    f"coverage L {left_cov}/{total_cells} R {right_cov}/{total_cells}"
+                )
+                if self.images_captured >= self.num_images_required and not self._coverage_complete():
+                    feedback_message += " — aim the board at the red regions to finish"
+            else:
+                feedback_message = "No board detected in this capture"
             self._publish_action_feedback(
                 goal_handle,
                 "CAPTURE",

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -128,6 +128,11 @@ class StereoCalibrator(Node):
         # How long to wait for a capture_trigger before timing out a managed run
         # (guards against an orphaned goal if the requesting client disconnects).
         self.declare_parameter("capture_timeout_sec", 60.0)
+        # Grace window after the image floor is met during which the run keeps
+        # accepting captures to finish the coverage grid. When it expires the
+        # run calibrates with the coverage it has, so an unreachable cell can
+        # never strand the operator (see _execute_run_calibration).
+        self.declare_parameter("coverage_grace_sec", 90.0)
 
         # Get parameters
         self.left_topic = self.get_parameter("left_topic").value
@@ -193,6 +198,8 @@ class StereoCalibrator(Node):
         self._last_capture_time = 0.0
         self._watchdog_active = False
         self._watchdog_timed_out = False
+        # When images_captured first reached the floor (None until it does).
+        self._floor_reached_at = None
 
         # Re-entrant callback group so services/cancel callbacks can run while
         # the long-running action execute callback is active.
@@ -456,6 +463,42 @@ class StereoCalibrator(Node):
         left_cov, right_cov, total = self._coverage_progress()
         return left_cov >= total and right_cov >= total
 
+    def _coverage_grace_sec(self):
+        """How long past the image floor to keep pushing for full coverage."""
+        return float(self.get_parameter("coverage_grace_sec").value)
+
+    def _should_finish_capturing(self):
+        """True once the run should stop capturing and calibrate.
+
+        Image count is a floor, not the finish line: captures keep being
+        accepted past the target until every coverage-grid cell has a corner in
+        BOTH cameras. But coverage is a target, not a trap — a capture only
+        counts when the board is seen in both cameras at once, and the outer
+        grid columns are exactly where the two views stop overlapping, so on a
+        given baseline some cells can be unreachable. Without a deadline such a
+        run would never end (the capture watchdog re-arms on every *attempt*,
+        so auto-capture keeps it alive indefinitely) and the operator's only
+        exit would be Stop, which discards every image they just captured.
+        """
+        if self.images_captured < self.num_images_required:
+            return False
+        if self._coverage_complete():
+            return True
+
+        if self._floor_reached_at is None:
+            self._floor_reached_at = time.time()
+            return False
+        if time.time() - self._floor_reached_at < self._coverage_grace_sec():
+            return False
+
+        left_cov, right_cov, total_cells = self._coverage_progress()
+        self.get_logger().warn(
+            f"Coverage still incomplete after {self._coverage_grace_sec():.0f}s past the image "
+            f"target (L {left_cov}/{total_cells} R {right_cov}/{total_cells}) — "
+            f"calibrating with what was captured"
+        )
+        return True
+
     def _execute_run_calibration(self, goal_handle):
         """Execute a managed stereo calibration run for app/API clients (manual capture only)."""
         with self._active_goal_lock:
@@ -496,6 +539,7 @@ class StereoCalibrator(Node):
             self._last_capture_time = time.time()
             self._watchdog_timed_out = False
             self._watchdog_active = True
+            self._floor_reached_at = None
 
             # One-shot "goal started" tick so the frontend can anchor a countdown
             # from goal-acceptance, not just after the first capture — otherwise a
@@ -533,11 +577,7 @@ class StereoCalibrator(Node):
                     goal_handle.abort()
                     return _make_result(False, msg, timed_out=True)
 
-                # Image count is a floor, not the finish line: the run only
-                # completes once every coverage-grid cell has seen a corner in
-                # BOTH cameras, so captures keep being accepted past the target
-                # until coverage is complete.
-                if self.images_captured >= self.num_images_required and self._coverage_complete():
+                if self._should_finish_capturing():
                     break
 
                 time.sleep(0.1)
@@ -658,7 +698,12 @@ class StereoCalibrator(Node):
                     f"coverage L {left_cov}/{total_cells} R {right_cov}/{total_cells}"
                 )
                 if self.images_captured >= self.num_images_required and not self._coverage_complete():
-                    feedback_message += " — aim the board at the red regions to finish"
+                    feedback_message += " — aim the board at the red regions"
+                    # Tell the operator this is bounded, so an unreachable cell
+                    # reads as "finishing soon", not "stuck forever".
+                    if self._floor_reached_at is not None:
+                        left_s = self._coverage_grace_sec() - (time.time() - self._floor_reached_at)
+                        feedback_message += f" ({max(0, int(left_s))}s left, then it calibrates as-is)"
             else:
                 feedback_message = "No board detected in this capture"
             self._publish_action_feedback(

--- a/scripts/upload_recording.sh
+++ b/scripts/upload_recording.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+# Upload a teleop recording (rosbag + metadata) to Google Drive via rclone.
+#
+# One-time setup (needs a browser on your laptop for the OAuth step):
+#   ~/.local/bin/rclone config
+#     n) new remote -> name: gdrive -> storage: drive -> leave the rest default
+#     "Use web browser to automatically authenticate?" -> n  (robot is headless)
+#     run the printed `rclone authorize "drive"` on your laptop, paste the token back
+#
+# Usage:
+#   upload_recording.sh <recording_name> [drive_folder_id]
+#     recording_name   e.g. teleop_20260718_080804 (a folder in data/recordings)
+#     drive_folder_id  optional Drive folder to upload INTO; without it the
+#                      files land in gdrive:mars-recordings/<recording_name>/
+set -euo pipefail
+
+RCLONE="${RCLONE:-$HOME/.local/bin/rclone}"
+REMOTE="${RCLONE_REMOTE:-gdrive}"
+ROOT="${INNATE_OS_ROOT:-$HOME/innate-os}"
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <recording_name> [drive_folder_id]" >&2
+    exit 1
+fi
+
+SRC="$ROOT/data/recordings/$1"
+[[ -d $SRC ]] || { echo "ERROR: no such recording: $SRC" >&2; exit 1; }
+"$RCLONE" listremotes | grep -q "^$REMOTE:" || {
+    echo "ERROR: rclone remote '$REMOTE:' not configured — run '$RCLONE config' first (see header)." >&2
+    exit 1
+}
+
+if [[ $# -ge 2 ]]; then
+    DEST="$REMOTE:"
+    FLAGS=(--drive-root-folder-id="$2")
+else
+    DEST="$REMOTE:mars-recordings/$1"
+    FLAGS=()
+fi
+
+echo "Uploading $SRC -> $DEST"
+"$RCLONE" copy "$SRC" "$DEST" "${FLAGS[@]}" --progress
+
+echo "Verifying..."
+"$RCLONE" check "$SRC" "$DEST" "${FLAGS[@]}" --one-way
+
+echo "Done — upload verified."

--- a/scripts/upload_when_authorized.sh
+++ b/scripts/upload_when_authorized.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+# Detached companion to upload_recording.sh: waits for the rclone 'gdrive:'
+# remote to exist (i.e. the operator finished the one-time `rclone config`
+# OAuth), then uploads the recording and verifies it. Designed to be launched
+# with setsid/nohup so it survives SSH disconnects:
+#
+#   setsid nohup scripts/upload_when_authorized.sh <recording> [folder_id] \
+#       >> data/recordings/<recording>.upload.log 2>&1 < /dev/null &
+#
+# Polls every 30s for up to 14 days. Progress goes to the log file; a final
+# "UPLOAD COMPLETE"/"UPLOAD FAILED" line makes the outcome grep-able.
+set -uo pipefail
+
+RCLONE="${RCLONE:-$HOME/.local/bin/rclone}"
+REMOTE="${RCLONE_REMOTE:-gdrive}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLL_S=30
+MAX_WAIT_S=$((14 * 24 * 3600))
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <recording_name> [drive_folder_id]" >&2
+    exit 1
+fi
+
+echo "[$(date -Is)] waiting for rclone remote '$REMOTE:' (poll ${POLL_S}s)..."
+waited=0
+until "$RCLONE" listremotes 2>/dev/null | grep -q "^$REMOTE:"; do
+    sleep "$POLL_S"
+    waited=$((waited + POLL_S))
+    if ((waited >= MAX_WAIT_S)); then
+        echo "[$(date -Is)] UPLOAD FAILED: gave up after 14 days waiting for '$REMOTE:'"
+        exit 1
+    fi
+done
+
+echo "[$(date -Is)] remote '$REMOTE:' found — starting upload of $1"
+if "$SCRIPT_DIR/upload_recording.sh" "$@"; then
+    echo "[$(date -Is)] UPLOAD COMPLETE: $1"
+else
+    echo "[$(date -Is)] UPLOAD FAILED: $1 (see above)"
+    exit 1
+fi

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -3088,6 +3088,19 @@ body:has(.agent-indicator:not([hidden], [data-off-route])) .tgt-hud {
   opacity: 0.2;
 }
 
+.record-toggle.active {
+  color: var(--danger);
+  border-color: var(--danger);
+  background: rgb(217 106 90 / 12%);
+  animation: rec-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes rec-pulse {
+  50% {
+    color: rgb(217 106 90 / 45%);
+  }
+}
+
 /* ---- TTS bar ---------------------------------------------------------------- */
 
 .tts-bar {

--- a/webapp/js/calibration/main.js
+++ b/webapp/js/calibration/main.js
@@ -4,7 +4,8 @@
 // Camera Calibration page — drives the mars_cam stereo_calibrator's interactive
 // ChArUco stereo calibration over the RunStereoCalibration action. Start opens
 // the goal and keeps it running while the operator moves the board in view of
-// the live feed and clicks Capture (one enter_events publish per click); live
+// the live feed and clicks Capture / presses Space (one enter_events publish
+// per trigger) or enables auto-capture (one publish per second); live
 // feedback after each capture shows progress + whether the board was seen, plus
 // the two coverage-dot debug images. The goal resolves (RMS errors) once enough
 // images are captured, Stop cancels it, or the server's capture watchdog times
@@ -110,6 +111,14 @@ function buildView(root) {
     "Save calibration when done (backs up the existing calibration file, then writes the new one)";
   saveRow.append(saveCheckbox, saveText);
 
+  const autoRow = document.createElement("label");
+  autoRow.className = "calib-checkbox-row";
+  const autoCheckbox = document.createElement("input");
+  autoCheckbox.type = "checkbox";
+  const autoText = document.createElement("span");
+  autoText.textContent = "Auto-capture every second while calibration is running";
+  autoRow.append(autoCheckbox, autoText);
+
   const boardLink = document.createElement("a");
   boardLink.className = "calib-board-link";
   boardLink.href = CALIBRATION_BOARD_PDF_URL;
@@ -160,7 +169,7 @@ function buildView(root) {
   const statusLine = document.createElement("p");
   statusLine.className = "calib-status microlabel";
 
-  controls.append(boardLink, numField.row, minField.row, saveRow, actionRow, statusLine);
+  controls.append(boardLink, numField.row, minField.row, saveRow, autoRow, actionRow, statusLine);
 
   // ---- live feedback --------------------------------------------------------
   const feedback = document.createElement("div");
@@ -372,10 +381,40 @@ function buildView(root) {
     );
   }
 
-  captureBtn.addEventListener("click", () => {
+  function doCapture() {
     if (!activeRun || activeRun.canceling) return;
     ros.publish(STEREO_CALIB_CAPTURE_TOPIC, { data: true });
-  });
+  }
+
+  captureBtn.addEventListener("click", doCapture);
+
+  // Space triggers a capture while a run is active (unless typing in a field).
+  // preventDefault stops the page from scrolling and a focused button from
+  // firing its own click on keyup, which would double-capture.
+  /** @param {KeyboardEvent} e */
+  function onKeydown(e) {
+    if (e.code !== "Space" || e.repeat || !activeRun) return;
+    const t = e.target;
+    if (t instanceof HTMLElement && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) return;
+    e.preventDefault();
+    doCapture();
+  }
+  document.addEventListener("keydown", onKeydown);
+
+  // Auto-capture: one publish per second while a run is active and the box is
+  // checked. Synced from render(), which runs on every state transition (start,
+  // stop, cancel, result) and checkbox change.
+  /** @type {number | null} */
+  let autoTimer = null;
+  function syncAutoCapture() {
+    const shouldRun = !!activeRun && !activeRun.canceling && autoCheckbox.checked;
+    if (shouldRun && autoTimer === null) autoTimer = setInterval(doCapture, 1000);
+    else if (!shouldRun && autoTimer !== null) {
+      clearInterval(autoTimer);
+      autoTimer = null;
+    }
+  }
+  autoCheckbox.addEventListener("change", () => render());
 
   stopBtn.addEventListener("click", () => {
     if (!activeRun || activeRun.canceling) return;
@@ -451,9 +490,12 @@ function buildView(root) {
     captureBtn.disabled = !activeRun || activeRun.canceling;
     stopBtn.disabled = !activeRun || activeRun.canceling;
     stopBtn.textContent = activeRun?.canceling ? "Stopping…" : "Stop";
+    syncAutoCapture();
 
     statusLine.textContent = activeRun
-      ? "Calibration running — move the board and click Capture"
+      ? autoCheckbox.checked
+        ? "Calibration running — auto-capturing every second"
+        : "Calibration running — move the board and click Capture or press Space"
       : ros.state === "connected"
         ? "Idle"
         : "Not connected";
@@ -538,6 +580,8 @@ function buildView(root) {
     destroy() {
       unsubState();
       unsubDepthCheck();
+      document.removeEventListener("keydown", onKeydown);
+      if (autoTimer !== null) clearInterval(autoTimer);
       clearInterval(countdownTicker);
       if (calibCheckTimer !== null) clearTimeout(calibCheckTimer);
       // A run left going while the operator navigates away must not keep

--- a/webapp/js/calibration/main.js
+++ b/webapp/js/calibration/main.js
@@ -7,9 +7,12 @@
 // the live feed and clicks Capture / presses Space (one enter_events publish
 // per trigger) or enables auto-capture (one publish per second); live
 // feedback after each capture shows progress + whether the board was seen, plus
-// the two coverage-dot debug images. The goal resolves (RMS errors) once enough
-// images are captured, Stop cancels it, or the server's capture watchdog times
-// out. Only MODE_MANUAL exists today, so the goal always sends mode: 0.
+// the two coverage-dot debug images (red-tinted cells = not yet covered). The
+// goal resolves (RMS errors) once enough images are captured AND every
+// coverage-grid cell has seen a corner in both cameras (the image count is a
+// floor, so captures keep counting past the target until coverage completes),
+// Stop cancels it, or the server's capture watchdog times out. Only
+// MODE_MANUAL exists today, so the goal always sends mode: 0.
 
 import { ros } from "../rosClient.js";
 import { mountPage } from "../pageMount.js";
@@ -98,7 +101,9 @@ function buildView(root) {
   const controls = document.createElement("div");
   controls.className = "calib-panel";
 
-  const numField = fieldRow("Images to capture", String(STEREO_CALIB_DEFAULT_NUM_IMAGES));
+  // A minimum, not a cap: the server keeps accepting captures past this count
+  // until the coverage grid is complete in both cameras.
+  const numField = fieldRow("Images to capture (min)", String(STEREO_CALIB_DEFAULT_NUM_IMAGES));
   const minField = fieldRow("Min corners per capture", String(STEREO_CALIB_DEFAULT_MIN_CORNERS));
 
   const saveRow = document.createElement("label");

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -192,6 +192,13 @@ export const SET_VOLUME_SERVICE = "/set_volume";
 // service the mobile app's power-off calls.
 export const SHUTDOWN_SERVICE = "/shutdown";
 
+// Teleop video recorder (mars_bringup video_recorder.py): std_srvs/Trigger
+// start/stop bracket an MP4 capture of the camera topics into the robot's
+// data/recordings/ folder. STATUS is a latched std_msgs/Bool (true while recording).
+export const VIDEO_RECORD_START_SERVICE = "/video_recorder/start";
+export const VIDEO_RECORD_STOP_SERVICE = "/video_recorder/stop";
+export const VIDEO_RECORD_STATUS_TOPIC = "/video_recorder/status";
+
 // WebRTC signaling over rosbridge. START is a std_msgs/String JSON payload that
 // carries our client_id: {"source":"live","audio":bool,"client_id":"...","video":[...]}.
 // The robot routes offer/answer/ICE on the *_id topics, each enveloped as {client_id, ...}

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -378,9 +378,10 @@ export const PANE_LAUNCH_LABELS = {
 // goal {mode: MODE_MANUAL(0), num_images, min_corners, save_calibration},
 // feedback streams after each capture attempt ({phase, images_captured,
 // capture_attempts, corners_found, image_names, images: CompressedImage[]}),
-// result lands once enough images are captured / the goal is cancelled / the
-// server's capture watchdog times out ({success, message, images_captured,
-// left_rms, right_rms, stereo_rms}).
+// result lands once enough images are captured AND the server's coverage grid
+// is complete in both cameras (num_images is a floor, not a cap) / the goal is
+// cancelled / the server's capture watchdog times out ({success, message,
+// images_captured, left_rms, right_rms, stereo_rms}).
 export const RUN_STEREO_CALIBRATION_ACTION = "/mars/main_camera/run_stereo_calibration";
 export const RUN_STEREO_CALIBRATION_ACTION_TYPE = "mars_msgs/action/RunStereoCalibration";
 // Publishing a std_msgs/Bool here (while a goal is running) triggers one

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -23,6 +23,7 @@ import { createJoystick } from "./joystick.js";
 import { createKeyboardDrive, createWasdChips } from "./keyboardDrive.js";
 import { createHeadTilt } from "./headTilt.js";
 import { createSpeedModes } from "./speedModes.js";
+import { createRecordButton } from "./recordButton.js";
 import { createTtsBar } from "./ttsBar.js";
 import { createTelemetry } from "./telemetry.js";
 import { createArmPanel } from "./armPanel.js";
@@ -92,6 +93,8 @@ function buildCockpit(root) {
   // is the sim deployment's feature flag (env-driven; false on the real robot).
   if (!config.simControls && videoStage.audioEl) {
     parts.push(createAudioToggle(rightRail, session, videoStage.audioEl));
+    // Camera MP4 recorder lives in the robot bringup, which the sim doesn't run.
+    parts.push(createRecordButton(rightRail, ros));
   }
   parts.push(
     createSpeedModes(rightRail, ros),

--- a/webapp/js/teleop/recordButton.js
+++ b/webapp/js/teleop/recordButton.js
@@ -40,10 +40,15 @@ export function createRecordButton(parent, rosClient) {
   }
   render();
 
-  const unsub = rosClient.subscribe(VIDEO_RECORD_STATUS_TOPIC, (msg) => {
-    recording = Boolean(msg?.data);
-    render();
-  });
+  const unsub = rosClient.subscribe(
+    VIDEO_RECORD_STATUS_TOPIC,
+    (msg) => {
+      recording = Boolean(msg?.data);
+      render();
+    },
+    undefined,
+    "std_msgs/msg/Bool",
+  );
 
   button.addEventListener("click", async () => {
     if (busy) return;

--- a/webapp/js/teleop/recordButton.js
+++ b/webapp/js/teleop/recordButton.js
@@ -1,0 +1,73 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Record toggle — right-rail button that starts/stops the on-robot MP4
+// recorder (video_recorder node). The lit state follows the latched
+// /video_recorder/status Bool so a reloaded page shows what the robot is
+// actually doing; files land in the robot's data/recordings/ folder.
+
+import {
+  VIDEO_RECORD_START_SERVICE,
+  VIDEO_RECORD_STOP_SERVICE,
+  VIDEO_RECORD_STATUS_TOPIC,
+} from "../constants.js";
+
+/**
+ * @param {HTMLElement} parent
+ * @param {import("../rosClient.js").RosClient} rosClient
+ * @returns {{ destroy: () => void }}
+ */
+export function createRecordButton(parent, rosClient) {
+  const button = document.createElement("button");
+  button.className = "icon-toggle record-toggle";
+  button.type = "button";
+  button.innerHTML =
+    '<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">' +
+    '<circle cx="12" cy="12" r="5.5"/>' +
+    "</svg>";
+  button.setAttribute("aria-label", "Record camera video");
+
+  let recording = false;
+  let busy = false;
+
+  function render() {
+    button.classList.toggle("active", recording);
+    button.disabled = busy;
+    button.title = recording
+      ? "Recording cameras — click to stop"
+      : "Record cameras to MP4 on the robot";
+    button.setAttribute("aria-pressed", String(recording));
+  }
+  render();
+
+  const unsub = rosClient.subscribe(VIDEO_RECORD_STATUS_TOPIC, (msg) => {
+    recording = Boolean(msg?.data);
+    render();
+  });
+
+  button.addEventListener("click", async () => {
+    if (busy) return;
+    busy = true;
+    render();
+    const starting = !recording;
+    try {
+      const res = await rosClient.callService(starting ? VIDEO_RECORD_START_SERVICE : VIDEO_RECORD_STOP_SERVICE);
+      if (!res?.success) console.warn("video recorder:", res?.message);
+      // A Trigger failure only means "already in that state", so either way
+      // the robot has now converged on what we asked for.
+      recording = starting;
+    } catch (err) {
+      console.warn("video recorder call failed:", err);
+    }
+    busy = false;
+    render();
+  });
+
+  parent.appendChild(button);
+  return {
+    destroy() {
+      unsub();
+      button.remove();
+    },
+  };
+}


### PR DESCRIPTION
Supersedes #568, which carried the same work — that PR is closed in favour of this one so the whole recording pipeline reviews as a single unit.

Originally recovered from a stash (`wip: video recorder + record button`) and rebuilt on current `main`. **Rebased onto latest `main` (2026-09-09, clean).**

## What

A record toggle in the teleop right rail brackets an on-robot capture of the cameras **plus everything a 3D reconstruction pipeline needs to place those frames in space** — full-rate 2D lidar, odometry, TF, joint states, per-frame timestamps, camera intrinsics, and the URDF. The goal: drive the robot around an apartment and hand the resulting folder to a scene-reconstruction pipeline, no screen-recording, no missing sensor data.

**Recorder**
- `video_recorder.py` (`mars_bringup`, launched by `bringup_core`) — `/video_recorder/start` and `/video_recorder/stop` (`std_srvs/Trigger`), plus a latched `/video_recorder/status` `Bool` with a 1 Hz heartbeat so a reloaded page (or a node restart mid-recording) converges on what the robot is actually doing.
- `recordButton.js` — right-rail toggle that follows the latched status. Hidden under `simControls`, since the sim doesn't run robot bringup.
- Frames are written on a fixed-rate timer — latest frame per tick, duplicated on stalls — so files play back in real time regardless of camera or subscriber drops. If no frames ever arrive, stop reports failure and removes the empty directory rather than leaving a zero-byte MP4.
- Start fails cleanly (disk full, permissions) instead of wedging; a dead encoder pipeline is terminal for its stream and can't truncate the file.

**Sensor bag for 3D reconstruction**

Each recording carries a `sensors/` rosbag2 alongside the videos:
- **`/scan_fast` — the 2D lidar at full sensor rate** (`/scan` is the same stream throttled to 6 Hz for the UI, so it isn't bagged). This is the metric-scale anchor for reconstruction.
- `/odom`, `/tf`, `/tf_static` (camera extrinsics chain), `/joint_states` (head tilt), and — when nav or mapping is active — `/amcl_pose` and `/mapping_pose`.
- Raw-bytes subscriptions, so bagging costs no deserialization.
- `<stream>_frames.csv` maps every video frame index to the ROS stamp of the image it came from — video↔pose association without guessing.
- `recording_metadata.json` (streams, timing, git SHA, left/right camera intrinsics when a stereo calibration is loaded) and a `robot.urdf` snapshot.

**Stereo capture path**
- Main camera captures at the sensor max (3840×1080 MJPG, up from 2560×720). Decode and rotate stay on NVDEC/VIC.
- `/mars/main_camera/stereo` publishes at full size, **gated on subscriber count** — the 12 MB frames only serialize out while the recorder is subscribed, so the topic is free when idle.
- `main.mp4` is the **full 3840×1080 side-by-side stereo pair** (left eye = left half) at 15 fps, so recordings carry both views for offline stereo work. Encoded via the NVJPG hardware encoder; per-stream write queues + an I420 feed + a 64M zenoh SHM override for the camera processes hold 99% wall-clock at full robot load.
- `left`/`right` stay 640×480, so policies, datasets, and VP8 teleop see exactly what they saw before. `arm.mp4` stays 640×480@30 (x264).

**Calibration quality** (better intrinsics → better reconstructions)
- The managed ChArUco run now only finishes once every 4×3 coverage-grid cell has seen a corner in **both** cameras; `num_images` becomes a floor. Uncovered cells tint red in the coverage debug images.
- Once the image floor is met, a bounded grace window (default 90 s) prevents unreachable outer cells from stranding a run — it calibrates with the coverage achieved and logs the shortfall.
- Webapp: Space triggers a capture; an auto-capture checkbox publishes one capture per second while a run is live.

**Crash safety** (a tour is a one-shot event — a restart or kill mid-recording must not lose it)
- MP4s use robust muxing: the index lives at the head of the file and is rewritten every second, so a SIGTERM/SIGHUP, an OOM kill or a power cut loses the last second, not the whole file. A plain MP4 only gets its index at EOS. One recording is capped at 4 h by the reserved index space.
- `<stream>_frames.csv` rows are appended per frame and `recording_metadata.json` is refreshed every 5 s while recording, so a killed run still describes itself.
- SIGHUP (how `systemctl stop ros-app` reaches the panes via `tmux kill-session`) is handled like Ctrl-C: an active recording is finalized on the way out. Encoder subprocesses run in their own session so they finalize on EOS instead of dying with the pane.
- A stream whose encoder died mid-run is still saved and reported (its frames are on disk); only a run with no frames at all is discarded.
- After a hard kill the bag's `sensors_0.db3` is intact (integrity ok) but has no `metadata.yaml` — `ros2 bag reindex <recording>/sensors` restores it.
- `handle_start` opens the bag before claiming the run, so a failed open (read-only fs, disk filling) returns a failed Trigger instead of wedging the node (review finding).

**Upload**
- `scripts/upload_recording.sh` — rclone-based upload of a `data/recordings/<name>` folder to Google Drive, verified with `rclone check`.
- `scripts/upload_when_authorized.sh` — detached waiter that polls for the rclone remote (up to 14 days) then uploads; survives SSH disconnects, so the upload can be armed before the operator's one-time OAuth.

Output: `<INNATE_OS_ROOT>/data/recordings/video_<timestamp>/{main,arm}.mp4 + sensors/ + *_frames.csv + recording_metadata.json + robot.urdf`.

## Live test (R7-27, 2026-09-09, rebased build deployed via `innate build`, node running under the real `bringup_core` launch)

Final check on the deployed node, 33.5 s start/stop through the Trigger services the button calls:

| Check | Result |
|---|---|
| `main.mp4` | 3840×1080 stereo pair @15, **100% wall-clock**, all 501 frames decode, `main_frames.csv` 501 rows |
| `arm.mp4` | 640×480 @30, **100% wall-clock**, all 1003 frames decode, `arm_frames.csv` 1003 rows |
| Sensor bag | 9.6k msgs: odom 30 Hz, tf 53 Hz, scan_fast 8 Hz, joint_states 196 Hz, tf_static latched; camera_info + URDF present |
| Queue drops | zero |
| Size | ~375 MB for 33.5 s (~11 MB/s, ~40 GB/h in an office scene at quality=85 — denser than the ~440 MB/min measured in July) |
| Idle | stereo topic has 0 subscribers, recorder RSS ~270 MB, no encoder children left behind |
| Stop while idle | clean `Not recording` failure |

Crash-safety checks, on a second standalone recorder instance on the same robot (own service names, scratch output dir, fed by the live camera and sensor topics) so the real node was never touched:

| Check | Result |
|---|---|
| SIGINT / SIGHUP / SIGTERM mid-recording | node exits in <1 s with videos, CSVs, metadata and `metadata.yaml` all finalized |
| SIGTERM to encoders + SIGKILL to node mid-recording | both MP4s playable to the last second, CSVs and metadata current, bag `integrity_check ok`; `ros2 bag reindex` restores `metadata.yaml` |
| 10 min / 4.37 GB `main.mp4` from July | seeks and decodes past the 4 GiB boundary (single-chunk `stco`) |

**Not covered by these tests**
- The robot was stationary for every recording: rates, timing and file integrity are verified, motion (blur, lidar/odom while driving) is not. Do one short drive-and-record before relying on it.
- The record button was not clicked in a browser this round. The teleop page serves and imports it and the status topic it follows flips correctly; the click itself was exercised in the July session only.
- The calibration coverage gate is deployed but has not been run end-to-end with a printed ChArUco board (no rig on this robot).

Earlier session (July, pre-rebase):

| Check | Result |
|---|---|
| `/mars/main_camera/left/image_raw` | 15.0 fps — no regression |
| `/mars/arm/image_raw` | 30.0 fps — no USB2 starvation at full capture width |
| Queue drops | zero over a 33 s run; steady-state cadence 67.0 ms vs 66.7 target |
| Bitrate | ~59 Mbps (~440 MB/min) at quality=85 |

## Notes

- Arm camera stays 640×480. Raising it means moving that driver off YUYV to MJPG, which touches the pick-policy camera path — deliberately out of scope.
- There is no IMU topic to bag — the MCU fuses the gyro into `/odom` in firmware, so odometry already carries it.
- If the container CPU cost matters later, dropping `width`/`publish_stereo_width` to 2560×720 in `stereo_depth_estimator.yaml` gives 720p recordings with proportionally less convert work. One knob, no code change.
- `bringup_core` gains an always-running node. It idles with no camera subscriptions until start is called, so the cost is one node (~270 MB RSS: python + cv2 + numpy + rosbag2), not a decode path.
- `main.mp4` is MJPEG-in-MP4: VLC, QuickTime and editors play it, a browser `<video>` tag does not. `arm.mp4` (h264) plays anywhere.
- `innate_os_git` in `recording_metadata.json` is read once at node start, so a node that outlives a commit reports the previous SHA until the next restart.


