### PR TITLE
fix(webapp): fetch /config.json once per load, not ~5 times

### DIFF
--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -11,6 +11,7 @@
 
 import { ros } from "../rosClient.js";
 import { mountPage } from "../pageMount.js";
+import { getConfig } from "../config.js";
 import { robotSessionFactory } from "../robotSession.js";
 import { createVideoStage } from "../teleop/videoStage.js";
 import { createTelemetry } from "../teleop/telemetry.js";
@@ -23,9 +24,7 @@ import { createAgentPanel } from "./agentPanel.js";
 // once on first import (the router's dynamic import awaits it) so the view reads
 // it synchronously.
 /** @type {any} */
-const config = await fetch("/config.json", { cache: "no-store" })
-  .then((r) => (r.ok ? r.json() : {}))
-  .catch(() => ({}));
+const config = await getConfig();
 
 // Resolved once at import time (the router's dynamic import awaits it):
 // WebRTC for real robots, the Three.js SimSession in simulation (see

--- a/webapp/js/collect/main.js
+++ b/webapp/js/collect/main.js
@@ -11,6 +11,7 @@
 
 import { ros } from "../rosClient.js";
 import { drive } from "../driveController.js";
+import { getConfig } from "../config.js";
 import { robotSessionFactory } from "../robotSession.js";
 import { mountPage } from "../pageMount.js";
 import { createVideoStage, createAudioToggle } from "../teleop/videoStage.js";
@@ -28,9 +29,7 @@ import { createRecordPanel } from "./recordPanel.js";
 const { createSession, createStage } = await robotSessionFactory();
 
 /** @type {any} */
-const config = await fetch("/config.json", { cache: "no-store" })
-  .then((r) => (r.ok ? r.json() : {}))
-  .catch(() => ({}));
+const config = await getConfig();
 
 /** @param {HTMLElement} stage */
 export function mount(stage) {

--- a/webapp/js/config.js
+++ b/webapp/js/config.js
@@ -1,0 +1,17 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Shared /config.json loader. The file is fetched once per page load and the
+// promise reused, so the router, shell, robot session, and the active section
+// don't each hit the proxy — it was ~5 requests a load before this. Still
+// no-store so a fresh load reflects env-driven flags, just deduped in-page.
+
+/** @type {Promise<{simControls?: boolean}> | undefined} */
+let _config;
+
+/** @returns {Promise<{simControls?: boolean}>} */
+export function getConfig() {
+  return (_config ??= fetch("/config.json", { cache: "no-store" })
+    .then((r) => (r.ok ? r.json() : {}))
+    .catch(() => ({})));
+}

--- a/webapp/js/robotSession.js
+++ b/webapp/js/robotSession.js
@@ -13,6 +13,7 @@
 
 import { WebRtcSession } from "./webrtcSession.js";
 import { ros } from "./rosClient.js";
+import { getConfig } from "./config.js";
 
 /**
  * @returns {Promise<{ createSession: () => WebRtcSession, createStage: ((root: HTMLElement, session: WebRtcSession) => { audioEl: HTMLAudioElement | null, destroy: () => void }) | null }>}
@@ -21,9 +22,7 @@ import { ros } from "./rosClient.js";
  */
 export async function robotSessionFactory() {
   /** @type {any} */
-  const config = await fetch("/config.json", { cache: "no-store" })
-    .then((r) => (r.ok ? r.json() : {}))
-    .catch(() => ({}));
+  const config = await getConfig();
   if (config.simControls) {
     try {
       // Served by proxy/https_server.py from sim/viewer's build -- a runtime

--- a/webapp/js/router.js
+++ b/webapp/js/router.js
@@ -17,6 +17,7 @@
 
 import { ros } from "./rosClient.js";
 import { initShell } from "./shell.js";
+import { getConfig } from "./config.js";
 
 /**
  * @typedef {{ destroy: () => void }} PageView
@@ -67,9 +68,7 @@ const shell = initShell(navigate);
 // a page whose services have no sim backing.
 const SIM_ROUTE_KEYS = new Set(["teleop", "agent", "nav", "logging", "settings"]);
 /** @type {Promise<{simControls?: boolean}>} */
-const configPromise = fetch("/config.json", { cache: "no-store" })
-  .then((r) => (r.ok ? r.json() : {}))
-  .catch(() => ({}));
+const configPromise = getConfig();
 
 /**
  * Tear down the current page and mount `route`. Pages read their own query

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -6,6 +6,7 @@
 
 import { ros } from "./rosClient.js";
 import { initTtsAudio } from "./ttsAudio.js";
+import { getConfig } from "./config.js";
 import { createAgentState } from "./teleop/agentState.js";
 import { createAgentIndicator } from "./agentIndicator.js";
 import { maybeShowAppPromo } from "./appPromo.js";
@@ -207,11 +208,7 @@ export function initShell(navigate) {
 async function applySimSectionFilter(nav) {
   /** @type {any} */
   let config;
-  try {
-    config = await fetch("/config.json", { cache: "no-store" }).then((r) => (r.ok ? r.json() : {}));
-  } catch {
-    return; // no config → assume real robot, keep every section
-  }
+  config = await getConfig(); // {} on any failure → assume real robot, keep every section
   if (!config?.simControls) return;
   for (const link of nav.querySelectorAll(".rail-link")) {
     const key = /** @type {HTMLElement} */ (link).dataset.section ?? "";

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -12,6 +12,7 @@
 
 import { ros } from "../rosClient.js";
 import { drive } from "../driveController.js";
+import { getConfig } from "../config.js";
 import { WebRtcSession } from "../webrtcSession.js";
 import { robotSessionFactory } from "../robotSession.js";
 import { mountPage } from "../pageMount.js";
@@ -30,9 +31,7 @@ import { createCameraSwitch } from "./cameraSwitch.js";
 // off unless a deployment opts in. Fetched once when this module first loads (the
 // router's dynamic import awaits this), so buildCockpit can read it synchronously.
 /** @type {any} */
-const config = await fetch("/config.json", { cache: "no-store" })
-  .then((r) => (r.ok ? r.json() : {}))
-  .catch(() => ({}));
+const config = await getConfig();
 
 // Console debugging hook (also handy alongside the Logging page).
 /** @type {{ ros: typeof ros, drive: typeof drive, session: WebRtcSession | null }} */


### PR DESCRIPTION
## Problem

Six modules each `fetch("/config.json", { cache: "no-store" })` independently — `router.js`, `shell.js`, `robotSession.js`, and the `teleop`/`agent`/`collect` section entries. Since the router dynamically imports a section on top of the shell + session, a single page load hits the proxy **~5 times**. And `cache: "no-store"` bypasses the HTTP cache entirely, so each one is a **full download** — it doesn't even benefit from the proxy's cheap `stat()`→304.

## Fix

A shared `js/config.js` that memoises the promise:

```js
let _config;
export function getConfig() {
  return (_config ??= fetch("/config.json", { cache: "no-store" })
    .then((r) => (r.ok ? r.json() : {}))
    .catch(() => ({})));
}
```

All six sites now `await getConfig()` (or reuse its promise). One request per page load, still `no-store` so a fresh load reflects env-driven flags — just deduped in-page. Behaviour is otherwise identical (each site got `{}` on failure before and still does).

## Verified
`node --check` passes on all seven files; the only remaining `/config.json` fetch is in `config.js`.