### PR TITLE
ci: stream Cloud Build logs into the integration-test job output

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,6 +36,10 @@ jobs:
 
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
+        with:
+          # `gcloud beta builds submit` (used below for log streaming) needs the
+          # beta component.
+          install_components: beta
 
       - name: Submit integration tests to Cloud Build
         run: |
@@ -54,7 +58,11 @@ jobs:
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             publish_base="true"
           fi
-          gcloud builds submit \
+          # `beta`: the build logs go only to Cloud Logging (see the cloudbuild
+          # config's `logging: CLOUD_LOGGING_ONLY`), and only the beta command
+          # can stream logs from Cloud Logging into this step's output — the GA
+          # command only streams from a GCS logs bucket, so it would sit silent.
+          gcloud beta builds submit \
             --project="${{ vars.GCP_PROJECT_ID }}" \
             --region="${{ vars.GCP_REGION }}" \
             --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \

--- a/ci/cloudbuild.integration-test.yaml
+++ b/ci/cloudbuild.integration-test.yaml
@@ -32,6 +32,10 @@ substitutions:
 options:
   machineType: E2_HIGHCPU_8
   diskSizeGb: "150"
+  # A build with a user-specified service account must pick an explicit logging
+  # config. Logs go only to Cloud Logging (no GCS logs bucket); the GitHub
+  # workflow uses `gcloud beta builds submit`, which can stream from Cloud
+  # Logging (the GA command can only stream from a GCS bucket).
   logging: CLOUD_LOGGING_ONLY
 
 steps:


### PR DESCRIPTION
## Why

The integration-test job submits the build to Cloud Build and then sits silent until it finishes — the build logs never show up in the Actions output, only a Cloud Logging URL.

Root cause: the build uses `logging: CLOUD_LOGGING_ONLY` (required to pick an explicit logging config when the build runs under a user-specified service account), and the GA `gcloud builds submit` can only stream logs from a GCS logs bucket, not from Cloud Logging.

## What

- Switch the submit step to `gcloud beta builds submit` — the beta command streams logs from Cloud Logging live into the step output. Same single blocking command; its exit code still fails the job.
- Install the `beta` component in the setup-gcloud step.
- Comment the `logging: CLOUD_LOGGING_ONLY` line in the cloudbuild config to explain the arrangement.

No new cloud resources (no logs bucket, no trigger migration).

## Caveat

Streaming needs the GitHub WIF service account to be able to read logs (`roles/logging.viewer` or equivalent). If it can't, nothing breaks — gcloud prints the log URL and waits, same as today, and the step output will say why. This PR's own integration-test run is the test.