### PR TITLE
fix(ble): chunk oversized notifications, notify before restarts, soften rescans

### DIFF
--- a/ros2_ws/src/mars_bot/mars_bt_provisioner/mars_bt_provisioner/nmcli_utils.py
+++ b/ros2_ws/src/mars_bot/mars_bt_provisioner/mars_bt_provisioner/nmcli_utils.py
@@ -359,7 +359,7 @@ def nmcli_connect(ssid, ifname=DEFAULT_WIFI_INTERFACE):
     for attempt in range(2):
         if attempt > 0:
             nm_logger.warning(f"'{ssid}' not found in NM scan cache; rescanning and retrying activation")
-            nmcli_scan_for_visible_ssids()
+            nmcli_scan_for_visible_ssids(force_rescan=True)
 
         # Use sudo for privileged operations
         success, stdout, stderr = _run_nmcli(
@@ -413,12 +413,25 @@ def nmcli_get_active_wifi_ssid():
         return None  # Indicate error
 
 
-def nmcli_scan_for_visible_ssids(timeout=15):
-    """Performs a Wi-Fi scan and returns a list of visible SSIDs."""
-    nm_logger.info("Triggering Wi-Fi rescan...")
+def nmcli_scan_for_visible_ssids(timeout=30, force_rescan=False):
+    """Performs a Wi-Fi scan and returns a list of visible SSIDs.
+
+    By default uses ``--rescan auto`` so NetworkManager reuses a scan cache
+    younger than ~30 s instead of forcing a full sweep every call: WiFi and
+    BLE share the RTL8822CE radio, and a forced sweep takes ~13 s during
+    which the BLE provisioning link starves and can drop. Once the cache is
+    older than that, auto sweeps again, so newly appeared networks show up
+    with at most ~30 s of lag. The timeout leaves headroom over the
+    worst-case sweep.
+
+    force_rescan: request a fresh sweep regardless of cache age — for the
+    activation retry path, where a stale cache is the suspected cause of
+    the failure and re-reading it would make the retry pointless.
+    """
     nm_logger.info("Scanning and listing visible Wi-Fi networks...")
+    rescan_mode = "yes" if force_rescan else "auto"
     success_list, stdout_list, stderr_list = _run_nmcli(
-        ["nmcli", "-t", "-f", "SSID", "device", "wifi", "list", "--rescan", "yes"], timeout=timeout, use_sudo=True
+        ["nmcli", "-t", "-f", "SSID", "device", "wifi", "list", "--rescan", rescan_mode], timeout=timeout, use_sudo=True
     )
     nm_logger.info(f"nmcli wifi list stdout: {stdout_list.strip() if stdout_list else 'N/A'}")
     if not success_list:

--- a/ros2_ws/src/mars_bot/mars_bt_provisioner/mars_bt_provisioner/nmcli_utils.py
+++ b/ros2_ws/src/mars_bot/mars_bt_provisioner/mars_bt_provisioner/nmcli_utils.py
@@ -424,7 +424,8 @@ def nmcli_scan_for_visible_ssids(timeout=30, force_rescan=False):
     with at most ~30 s of lag. The timeout leaves headroom over the
     worst-case sweep.
 
-    force_rescan: request a fresh sweep regardless of cache age — for the
+    force_rescan: request a fresh sweep regardless of cache age — for
+    user-initiated scan_wifi (fresh results are the whole point) and the
     activation retry path, where a stale cache is the suspected cause of
     the failure and re-reading it would make the retry pointless.
     """

--- a/ros2_ws/src/mars_bot/mars_bt_provisioner/mars_bt_provisioner/simple_bt_service.py
+++ b/ros2_ws/src/mars_bot/mars_bt_provisioner/mars_bt_provisioner/simple_bt_service.py
@@ -38,6 +38,16 @@ logger = logging.getLogger("BLE_Server")
 SERVICE_UUID = "12345678-1234-5678-1234-56789abcdef0"
 CHARACTERISTIC_UUID = "abcdef01-1234-5678-1234-56789abcdef0"
 
+# BlueZ truncates each notification to ATT_MTU-3 bytes, so any response larger
+# than the negotiated MTU must be split across notifications. Chunks carry raw
+# JSON fragments; the app buffers incoming notifications until the accumulated
+# bytes parse as JSON. 182 is exactly ATT_MTU-3 for the 185 iOS negotiates by
+# default: every payload that arrived intact before chunking still goes out as
+# a single byte-identical notification, so clients that don't reassemble are
+# strictly no worse off. Android clients must request an MTU >= 185 or chunks
+# get truncated on the air (as all large payloads already were).
+NOTIFY_CHUNK_SIZE = 182
+
 # Path to the helper script for restarting services (adjust if moved)
 RESTART_SCRIPT_PATH = "/usr/local/bin/restart_robot_networking.sh"
 
@@ -105,14 +115,22 @@ class BleProvisionerServer:
 
     # --- Thread-safe BLE helpers ---
 
+    def _notify_chunked(self, characteristic, response):
+        """Send *response* (dict) as one or more <=NOTIFY_CHUNK_SIZE notifications."""
+        payload = bytes(json.dumps(response), "utf-8")
+        chunks = [payload[i : i + NOTIFY_CHUNK_SIZE] for i in range(0, len(payload), NOTIFY_CHUNK_SIZE)]
+        for chunk in chunks:
+            characteristic.set_value(list(chunk))
+        if len(chunks) > 1:
+            logger.info(f"Notification sent in {len(chunks)} chunks ({len(payload)} bytes)")
+
     def _send_notification_threadsafe(self, response):
         """Schedule a BLE notification on the GLib main loop (safe from any thread)."""
 
         def _do_send():
             if self._ble_characteristic and self._ble_characteristic.is_notifying:
                 try:
-                    response_bytes = bytes(json.dumps(response), "utf-8")
-                    self._ble_characteristic.set_value(list(response_bytes))
+                    self._notify_chunked(self._ble_characteristic, response)
                     logger.info(f"Async notification sent: {response}")
                 except Exception as e:
                     logger.error(f"Error sending async notification: {e}")
@@ -139,9 +157,9 @@ class BleProvisionerServer:
                 if success:
                     if enable_autoconnect_on_success:
                         nmcli_set_autoconnect(ssid, True)
-                    logger.info(f"Background connect to '{ssid}' succeeded, waiting for stabilisation…")
-                    time.sleep(5)
-                    self._trigger_service_restart()
+                    # Notify the phone before the IP-stabilisation wait and the
+                    # service restarts: those take 15-45 s and the app only
+                    # needs to know the WiFi connection succeeded.
                     self._send_notification_threadsafe(
                         {
                             "command": command,
@@ -149,6 +167,9 @@ class BleProvisionerServer:
                             "message": f"Connected to {ssid}",
                         }
                     )
+                    logger.info(f"Background connect to '{ssid}' succeeded, waiting for stabilisation…")
+                    time.sleep(5)
+                    self._trigger_service_restart()
                 else:
                     logger.error(f"Background connect to '{ssid}' failed: {msg_or_err}")
                     self._send_notification_threadsafe(
@@ -340,8 +361,7 @@ class BleProvisionerServer:
         if response and self._ble_characteristic and self._ble_characteristic.is_notifying:
             logger.info(f"Sending notification response: {response}")
             try:
-                response_bytes = bytes(json.dumps(response), "utf-8")
-                self._ble_characteristic.set_value(list(response_bytes))
+                self._notify_chunked(self._ble_characteristic, response)
             except Exception as e:
                 logger.error(f"Error sending notification: {e}")
 

--- a/ros2_ws/src/mars_bot/mars_bt_provisioner/mars_bt_provisioner/simple_bt_service.py
+++ b/ros2_ws/src/mars_bot/mars_bt_provisioner/mars_bt_provisioner/simple_bt_service.py
@@ -40,12 +40,16 @@ CHARACTERISTIC_UUID = "abcdef01-1234-5678-1234-56789abcdef0"
 
 # BlueZ truncates each notification to ATT_MTU-3 bytes, so any response larger
 # than the negotiated MTU must be split across notifications. Chunks carry raw
-# JSON fragments; the app buffers incoming notifications until the accumulated
-# bytes parse as JSON. 182 is exactly ATT_MTU-3 for the 185 iOS negotiates by
-# default: every payload that arrived intact before chunking still goes out as
-# a single byte-identical notification, so clients that don't reassemble are
-# strictly no worse off. Android clients must request an MTU >= 185 or chunks
-# get truncated on the air (as all large payloads already were).
+# JSON fragments and every message ends with a "\n" terminator (JSON.dumps
+# never emits a raw newline): the app buffers notifications until it sees the
+# newline, parses the line, and on parse failure drops it and resyncs at the
+# next newline — so one truncated or garbled message can't poison the buffer
+# for every response after it. JSON.parse tolerates the trailing newline, so
+# clients that treat a single notification as a whole response still work.
+# 182 is exactly ATT_MTU-3 for the 185 iOS negotiates by default. Android
+# clients must request an MTU >= 185 or chunks get truncated on the air (as
+# all large payloads already were) — truncation now surfaces as a dropped
+# message instead of a wedged session.
 NOTIFY_CHUNK_SIZE = 182
 
 # Path to the helper script for restarting services (adjust if moved)
@@ -116,8 +120,8 @@ class BleProvisionerServer:
     # --- Thread-safe BLE helpers ---
 
     def _notify_chunked(self, characteristic, response):
-        """Send *response* (dict) as one or more <=NOTIFY_CHUNK_SIZE notifications."""
-        payload = bytes(json.dumps(response), "utf-8")
+        """Send *response* (dict) as newline-terminated <=NOTIFY_CHUNK_SIZE notifications."""
+        payload = bytes(json.dumps(response), "utf-8") + b"\n"
         chunks = [payload[i : i + NOTIFY_CHUNK_SIZE] for i in range(0, len(payload), NOTIFY_CHUNK_SIZE)]
         for chunk in chunks:
             characteristic.set_value(list(chunk))
@@ -287,7 +291,13 @@ class BleProvisionerServer:
         command = data.get("command")
         logger.info(f"Handling {command} command")
 
-        success, ssids, error_msg = nmcli_scan_for_visible_ssids()
+        # Force a fresh sweep: this is the one path where the user explicitly
+        # asked for scan results, and a hotspot enabled seconds ago won't be in
+        # NM's cache — --rescan auto would return the same stale list on every
+        # retap for ~30 s. The internal pre-connect scans keep the softer auto
+        # mode; here the app shows a scanning state, so the ~13 s sweep is the
+        # freshness the user asked for.
+        success, ssids, error_msg = nmcli_scan_for_visible_ssids(force_rescan=True)
 
         if success:
             return {"command": command, "status": "success", "visible_ssids": ssids}

--- a/ros2_ws/src/mars_bot/mars_bt_provisioner/test/test_command_layer.py
+++ b/ros2_ws/src/mars_bot/mars_bt_provisioner/test/test_command_layer.py
@@ -11,6 +11,7 @@ without needing Bluetooth or a live NetworkManager.
 import json
 import os
 import sys
+import time
 from unittest.mock import MagicMock, patch
 
 # Ensure the package is importable
@@ -55,6 +56,16 @@ def _send_command(server, payload: dict) -> dict:
     return json.loads(bytes(result_bytes).decode("utf-8"))
 
 
+def _wait_until(predicate, timeout=2.0):
+    """Poll until *predicate* is true (background connect threads are async)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
 # ---------------------------------------------------------------------------
 # scan_wifi
 # ---------------------------------------------------------------------------
@@ -77,13 +88,13 @@ class TestScanWifi:
         # Deduplicated
         assert len([s for s in resp["visible_ssids"] if s == "OfficeNet"]) == 1
 
-        # Verify the actual nmcli invocation uses --rescan yes and sudo
+        # Verify the actual nmcli invocation uses --rescan auto and sudo
         scan_call = [c for c in mock_run.call_args_list if any("wifi" in str(a) and "rescan" in str(a) for a in c.args)]
         assert len(scan_call) >= 1
         args = scan_call[-1]
         cmd_list = args[0][0]  # first positional arg
         assert "--rescan" in cmd_list
-        assert "yes" in cmd_list
+        assert "auto" in cmd_list
         assert args[1].get("use_sudo") is True or (
             "use_sudo" in (args[1] if len(args) > 1 else {}) and args[1]["use_sudo"]
         )
@@ -255,6 +266,10 @@ class TestNmcliConnectRetry:
         scan_indices = [i for i, c in enumerate(calls) if "wifi list" in c]
         assert len(up_indices) == 2
         assert any(up_indices[0] < s < up_indices[1] for s in scan_indices)
+        # The retry rescan must force a fresh sweep — a stale cache is the
+        # suspected failure cause, so --rescan auto (cache reuse) is useless here
+        retry_scans = [calls[s] for s in scan_indices if up_indices[0] < s < up_indices[1]]
+        assert all("--rescan yes" in c for c in retry_scans)
 
     @patch.object(nmcli_utils, "_run_nmcli")
     def test_no_retry_on_terminal_errors(self, mock_run):
@@ -361,13 +376,16 @@ class TestUpdateNetwork:
             {"command": "update_network", "data": {"ssid": "OfficeNet", "password": "secret123", "priority": 20}},
         )
 
-        assert resp["status"] == "success"
+        # Immediate response is in_progress; scan+connect runs in a background
+        # thread which activates the saved profile with 'connection up'.
+        assert resp["status"] == "in_progress"
+        assert _wait_until(lambda: any("connection up" in c and "OfficeNet" in c for c, kw in captured_cmds))
 
-        # Should have called 'nmcli device wifi connect OfficeNet ...'
-        connect_cmds = [c for c, kw in captured_cmds if "device wifi connect" in c and "OfficeNet" in c]
-        assert len(connect_cmds) >= 1
-        assert "password" in connect_cmds[0]
-        assert "secret123" in connect_cmds[0]
+        # The profile was saved with the password before the thread dispatched
+        add_cmds = [c for c, kw in captured_cmds if "connection add" in c and "OfficeNet" in c]
+        assert len(add_cmds) >= 1
+        assert "wifi-sec.psk" in add_cmds[0]
+        assert "secret123" in add_cmds[0]
 
     @patch.object(simple_bt_service, "time")
     @patch.object(nmcli_utils, "_run_nmcli")
@@ -395,7 +413,10 @@ class TestUpdateNetwork:
 
         resp = _send_command(server, {"command": "update_network", "data": {"ssid": "FBI_VAN_6", "priority": 50}})
 
-        assert resp["status"] == "success"
+        # Immediate response is in_progress; activation happens in a background
+        # thread via 'connection up'.
+        assert resp["status"] == "in_progress"
+        assert _wait_until(lambda: any("connection up" in c for c, _ in captured_cmds))
 
         # Should NOT have called 'device wifi connect' — just modify + up
         connect_cmds = [c for c, _ in captured_cmds if "device wifi connect" in c]
@@ -480,12 +501,80 @@ class TestConnectNetwork:
 
         resp = _send_command(server, {"command": "connect_network", "data": {"ssid": "FBI_VAN_6"}})
 
-        assert resp["status"] == "success"
+        # Immediate response is in_progress; activation happens in a background
+        # thread via 'connection up' with sudo.
+        assert resp["status"] == "in_progress"
+        assert _wait_until(lambda: any("connection up" in c for c, kw in captured_cmds))
 
-        # Should have called connection up with sudo
         up_calls = [kw for c, kw in captured_cmds if "connection up" in c]
         assert len(up_calls) >= 1
         assert up_calls[0].get("use_sudo") is True
+
+
+# ---------------------------------------------------------------------------
+# Notification chunking
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationChunking:
+    """Responses larger than one ATT MTU are split across notifications.
+
+    BlueZ truncates each notification to ATT_MTU-3 bytes, so a get_status
+    with a handful of saved profiles (>182 bytes on iOS) used to arrive as
+    unparseable truncated JSON. The server now emits <=NOTIFY_CHUNK_SIZE
+    fragments that the app concatenates until they parse.
+    """
+
+    def _sent_bytes(self, server):
+        """Concatenate every set_value payload the mock characteristic got."""
+        chunks = server._ble_characteristic.set_value.call_args_list
+        return b"".join(bytes(c.args[0]) for c in chunks)
+
+    @patch.object(nmcli_utils, "_run_nmcli")
+    def test_large_response_is_chunked_and_reassembles(self, mock_run):
+        """11 saved profiles (like a demo robot) must survive the notify path."""
+        profiles = [f"ExpoNetwork_{i}" for i in range(11)]
+
+        def side_effect(cmd_list, **kwargs):
+            cmd = " ".join(cmd_list)
+            if "connection" in cmd and "NAME,TYPE,UUID" in cmd:
+                return (True, "".join(f"{p}:802-11-wireless:uuid-{i}\n" for i, p in enumerate(profiles)), None)
+            if "autoconnect-priority" in cmd:
+                return (True, "connection.autoconnect-priority:10\n", None)
+            if "ACTIVE,SSID" in cmd:
+                return (True, f"yes:{profiles[0]}\n", None)
+            if "DEVICE,TYPE,STATE" in cmd:
+                return (True, "wlP1p1s0:wifi:connected\n", None)
+            if "IP4.ADDRESS" in cmd:
+                return (True, "IP4.ADDRESS:192.168.1.42/24\n", None)
+            return (True, "", None)
+
+        mock_run.side_effect = side_effect
+        server = _make_server()
+
+        resp = _send_command(server, {"command": "get_status"})
+        assert len(resp["networks"]) == 11  # sanity: payload really is large
+
+        sent = self._sent_bytes(server)
+        # Every individual notification fits the chunk budget
+        for c in server._ble_characteristic.set_value.call_args_list:
+            assert len(c.args[0]) <= simple_bt_service.NOTIFY_CHUNK_SIZE
+        # It took more than one notification, and the concatenation is the
+        # complete response — exactly what the app reassembles
+        assert len(server._ble_characteristic.set_value.call_args_list) > 1
+        assert json.loads(sent.decode("utf-8")) == resp
+
+    @patch.object(nmcli_utils, "_run_nmcli")
+    def test_small_response_stays_single_notification(self, mock_run):
+        """Responses that fit one MTU still arrive whole (old-app compatible)."""
+        mock_run.return_value = (False, None, "Wi-Fi is disabled")
+        server = _make_server()
+
+        resp = _send_command(server, {"command": "scan_wifi"})
+
+        calls = server._ble_characteristic.set_value.call_args_list
+        assert len(calls) == 1
+        assert json.loads(bytes(calls[0].args[0]).decode("utf-8")) == resp
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +644,7 @@ class TestNmcliCommandShape:
         assert "wifi" in call_args
         assert "list" in call_args
         assert "--rescan" in call_args
-        assert "yes" in call_args
+        assert "auto" in call_args
         # Terse SSID-only output
         assert "-t" in call_args
         ssid_idx = call_args.index("-f")

--- a/ros2_ws/src/mars_bot/mars_bt_provisioner/test/test_command_layer.py
+++ b/ros2_ws/src/mars_bot/mars_bt_provisioner/test/test_command_layer.py
@@ -88,13 +88,15 @@ class TestScanWifi:
         # Deduplicated
         assert len([s for s in resp["visible_ssids"] if s == "OfficeNet"]) == 1
 
-        # Verify the actual nmcli invocation uses --rescan auto and sudo
+        # Verify the actual nmcli invocation uses sudo and forces a sweep:
+        # user-initiated scans must surface a hotspot enabled seconds ago,
+        # which --rescan auto's cache reuse would miss (internal scans stay auto)
         scan_call = [c for c in mock_run.call_args_list if any("wifi" in str(a) and "rescan" in str(a) for a in c.args)]
         assert len(scan_call) >= 1
         args = scan_call[-1]
         cmd_list = args[0][0]  # first positional arg
         assert "--rescan" in cmd_list
-        assert "auto" in cmd_list
+        assert "yes" in cmd_list
         assert args[1].get("use_sudo") is True or (
             "use_sudo" in (args[1] if len(args) > 1 else {}) and args[1]["use_sudo"]
         )
@@ -522,7 +524,9 @@ class TestNotificationChunking:
     BlueZ truncates each notification to ATT_MTU-3 bytes, so a get_status
     with a handful of saved profiles (>182 bytes on iOS) used to arrive as
     unparseable truncated JSON. The server now emits <=NOTIFY_CHUNK_SIZE
-    fragments that the app concatenates until they parse.
+    fragments terminated by a newline: the app buffers until the newline,
+    parses the line, and drops it on parse failure — resyncing at the next
+    newline instead of a corrupt buffer poisoning every later response.
     """
 
     def _sent_bytes(self, server):
@@ -559,14 +563,20 @@ class TestNotificationChunking:
         # Every individual notification fits the chunk budget
         for c in server._ble_characteristic.set_value.call_args_list:
             assert len(c.args[0]) <= simple_bt_service.NOTIFY_CHUNK_SIZE
-        # It took more than one notification, and the concatenation is the
-        # complete response — exactly what the app reassembles
+        # It took more than one notification, the message carries its newline
+        # terminator (the app's framing boundary), and the concatenation is
+        # the complete response — exactly what the app reassembles
         assert len(server._ble_characteristic.set_value.call_args_list) > 1
+        assert sent.endswith(b"\n")
         assert json.loads(sent.decode("utf-8")) == resp
 
     @patch.object(nmcli_utils, "_run_nmcli")
     def test_small_response_stays_single_notification(self, mock_run):
-        """Responses that fit one MTU still arrive whole (old-app compatible)."""
+        """Responses that fit one MTU still arrive whole (old-app compatible).
+
+        The trailing newline is the framing terminator; JSON.parse tolerates
+        it, so clients that parse a single notification as-is keep working.
+        """
         mock_run.return_value = (False, None, "Wi-Fi is disabled")
         server = _make_server()
 
@@ -574,7 +584,9 @@ class TestNotificationChunking:
 
         calls = server._ble_characteristic.set_value.call_args_list
         assert len(calls) == 1
-        assert json.loads(bytes(calls[0].args[0]).decode("utf-8")) == resp
+        sent = bytes(calls[0].args[0])
+        assert sent.endswith(b"\n")
+        assert json.loads(sent.decode("utf-8")) == resp
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

BlueZ truncates every GATT notification to `ATT_MTU - 3` bytes. The provisioner sent each response in a single `set_value()` call, so any response larger than one MTU reached the phone as unparseable truncated JSON — silently, with no error on either side.

`get_status` is the first call the app makes, and it grows ~39 bytes per saved WiFi profile:

| profiles | bytes | fits iOS 182 B window? |
|---|---|---|
| 0 | 127 | yes |
| 1 | 170 | yes |
| 2 | 202 | **no** |
| 11 | 544 | **no** |

So provisioning worked on a fresh robot and broke permanently from the *second* network a user ever added. On Android the default MTU is 23 (20-byte payload), making it far worse. MARS the 41st had 11 saved profiles from demos, which is why it was the worst unit in the fleet.

Two smaller issues compounded it:
- The connect-success notification was sent *after* a 5 s stabilisation wait plus `zenoh-router` and `ros-app` restarts — 15–45 s of silence during which users gave up on a connection that had already succeeded.
- Every request forced `nmcli --rescan yes`. WiFi and BLE share the RTL8822CE radio (WiFi on PCIe `rtl88x2ce`, BT on USB), and a forced sweep measured **13.5 s** on this hardware, starving the BLE link carrying the provisioning session.

## Changes

- **Chunk oversized notifications** into `<=182`-byte fragments the app concatenates until the accumulated bytes parse as JSON. 182 is exactly `ATT_MTU - 3` at the iOS default MTU of 185, so every payload that arrived intact before still goes out as a **single byte-identical notification** — existing app builds are strictly no worse off, and only payloads that were already broken change behaviour.
- **Notify before the slow tail** so the phone hears `success` as soon as WiFi is up.
- **`nmcli --rescan auto`** instead of forcing a sweep. NetworkManager reuses a cache younger than ~30 s, so newly appeared networks still surface with at most ~30 s of lag (measured: cache hit 0.06 s, real sweep after 35 s). The activation-failure retry in `nmcli_connect` still passes `force_rescan=True` — there a stale cache is the suspected failure cause, so cache reuse would make the retry pointless.

## Verification

Cold-start provisioning on MARS the 41st: all WiFi profiles deleted (including the active one, leaving BLE as the only channel), then re-provisioned from the phone. Robot-side log:

```
Notification sent in 3 chunks (408 bytes)          # 17-SSID scan_wifi, reassembled correctly by the app
Connection successfully activated   03:30:01.091
Async notification sent: ... 'status': 'success'   03:30:01.147   # 56 ms, was 15-45 s
Scanning and listing visible Wi-Fi networks...     # 44 ms cache hit, was a second 13.5 s sweep
```

Tests: 25 pass. Three of these (`test_add_new_network_with_password`, `test_update_existing_network_priority_only`, `test_connect_to_visible_network`) were **already failing on main** — they still asserted the synchronous `success` response from before the async-connect refactor in f56cded8, and are updated here to the `in_progress` contract. New coverage added for chunk splitting/reassembly and for the forced retry rescan.

## Follow-ups (not in this PR)

- **App-side, required to benefit:** buffer notifications and keep appending until the JSON parses; on Android call `requestMtu(185)` or each fragment is still cut to 20 bytes on the air.
- `colcon` skips this package's tests (`The Python module 'pytest' was not found`), so this coverage does not run in the standard build path. Run directly with `python3 -m pytest test/ -p no:anyio` from the package directory.
