### PR TITLE
Remove motor stress protection

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -64,7 +64,6 @@
 # mars_arm:
 #   ros__parameters:
 #     max_jerk: 150.0               # rad/s^3 trajectory jerk limit (0 disables)
-#     stress_enabled: false         # motor-protection cooldown
 
 # ── Camera: main (stereo; hardware only) ──────────────────────────────
 # Resolution is staged: the sensor captures the full side-by-side stereo frame at

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -46,7 +46,7 @@ To tune something, **uncomment a whole stanza** (the `node:`, `ros__parameters:`
 | `joystick_controller` `joystick` | `slow_mode_factor` | `0.25` |
 | `bringup` `battery` | `warning_percentage` / `critical_percentage` | `20` / `10` |
 | `bringup` `safety` (hard `/cmd_vel` clamp) | `max_speed` / `max_angular_speed` | `0.4` / `2.5` |
-| `mars_arm` | `max_jerk` / `stress_enabled` | `150.0` / `false` |
+| `mars_arm` | `max_jerk` | `150.0` |
 | `main_camera_driver` (hardware) | `width/height` (capture), `publish_stereo_width/height`, `publish_left_width/height` (published size; downstream follows it automatically), `fps`, `jpeg_quality`, `auto_exposure_mode`, `exposure`, `gain`, `default_gain`, `target_brightness`, `ae_kp` | see template |
 | `arm_camera_driver` (hardware) | `width/height` (capture), `fps` | see template |
 | `webrtc_streamer` (teleop stream) | `main_width/main_height`, `arm_width/arm_height` (encode size per camera) | see template |

--- a/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
+++ b/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
@@ -7,23 +7,6 @@
     max_jerk: 150.0  # rad/s³ jerk limit for trajectories (0 = disabled)
 
     # =============================================================
-    # Dynamixel Failure Leaky Integrator Config
-    # =============================================================
-    # Score accumulates per-motor each tick:
-    #   score += (A * |load| - C) * dt    (clamped >= 0)
-    # When score >= threshold, torque is disabled for cooldown_sec.
-    #
-    # A (stress_multiplier): scales the raw load value (PWM % or mA)
-    # C (stress_leak):       constant drain — score decays when load is low
-    #
-    # Example: A=1.0, C=50.0 means load must exceed 50 to accumulate.
-    stress_enabled: false         # master enable (false = disabled)
-    stress_threshold: 100.0       # score to trigger cooldown
-    stress_cooldown_sec: 2.0      # seconds of torque-off rest
-    stress_multiplier: 1.0        # A: multiplier on |load|
-    stress_leak: 0.0              # C: constant leak rate
-
-    # =============================================================
     # Joint Configuration for Mars Arm (nav2-style)
     # =============================================================
     # List of joints, then each joint's parameters as a sub-map.

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
@@ -53,9 +53,6 @@ class MarsArmNode : public rclcpp::Node {
     void recordLoopTiming(std::array<std::chrono::steady_clock::time_point, 9>& ts);
     std::vector<int> applyLimitsAndConvertToEncoder(std::vector<double>& command_data);
 
-    // ── Motor stress protection (arm_control.cpp) ───────────────────────
-    void updateMotorStress(double dt, const std::vector<int>& loads);
-
     // ── Service & topic callbacks (arm_services.cpp) ────────────────────
     void armCommandCallback(const std_msgs::msg::Float64MultiArray::SharedPtr msg);
     void armTorqueOnCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
@@ -168,15 +165,6 @@ class MarsArmNode : public rclcpp::Node {
     int gs_cycle_counter_ = 0;
     GainMode gain_mode_{GainMode::TELEOP};
     GainMode last_applied_gain_mode_{GainMode::TELEOP};
-
-    // Motor stress protection (overload cooldown)
-    // Leaky integrator: score += (A * |PWM| - C) * dt, clamped >= 0
-    std::array<MotorStressTracker, 7> stress_trackers_;
-    bool stress_enabled_{false};       // master enable for leaky integrator
-    double stress_threshold_{100.0};   // score at which cooldown triggers
-    double stress_cooldown_sec_{2.0};  // how long to rest (seconds)
-    double stress_multiplier_{1.0};    // A: multiplier on |load|
-    double stress_leak_{0.0};          // C: constant leak rate
 
     // Control loop timing instrumentation
     std::array<TimingAccumulator, 10> timing_stats_{{TimingAccumulator{"total"}, TimingAccumulator{"lock_wait"},

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -7,7 +7,6 @@
 #include <array>
 #include <cmath>
 #include <algorithm>
-#include <chrono>
 #include <cstdint>
 
 namespace mars_arm {
@@ -73,13 +72,6 @@ inline GainProfile parseGainsArray(const std::vector<int64_t>& arr) {
         g.ff2 = std::clamp(static_cast<int>(arr[4]), 0, kMaxGain);
     return g;
 }
-
-// Per-motor stress tracking for overload protection
-struct MotorStressTracker {
-    double score = 0.0;                                    // accumulated stress score
-    bool in_cooldown = false;                              // currently resting?
-    std::chrono::steady_clock::time_point cooldown_until;  // when to re-enable
-};
 
 struct TimingAccumulator {
     const char* name = "";

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -30,12 +30,6 @@ void MarsArmNode::controlTimerCallback() {
         }
         ts[3] = std::chrono::steady_clock::now();
 
-        // ========== MOTOR STRESS PROTECTION ==========
-        double dt = 1.0 / control_frequency_;
-        if (stress_enabled_) {
-            updateMotorStress(dt, loads);
-        }
-
         // ========== PUBLISH ARM STATE ==========
         std::vector<double> positions_rad;
         for (int pos : positions) {
@@ -386,68 +380,6 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
         command_encoder.push_back(static_cast<int>((pos / (2 * M_PI)) * 4096 + 2048));
     }
     return command_encoder;
-}
-
-void MarsArmNode::updateMotorStress(double dt, const std::vector<int>& loads) {
-    auto now = std::chrono::steady_clock::now();
-
-    // Only track arm joints (0-5), not head (6)
-    for (size_t j = 0; j < 6 && j < loads.size(); ++j) {
-        auto& tracker = stress_trackers_[j];
-
-        // If in cooldown, check if it's time to re-enable
-        if (tracker.in_cooldown) {
-            if (now >= tracker.cooldown_until) {
-                tracker.in_cooldown = false;
-                tracker.score = 0.0;
-
-                // Re-enable torque on this servo
-                int servo_id = joint_configs_[j].servo_id;
-                RCLCPP_WARN(this->get_logger(), "Stress cooldown ended for joint %zu (servo %d) — re-enabling torque",
-                            j + 1, servo_id);
-                try {
-                    dynamixel_->enableTorque(servo_id);
-                } catch (const std::exception& e) {
-                    RCLCPP_ERROR(this->get_logger(), "Failed to re-enable torque on servo %d after cooldown: %s",
-                                 servo_id, e.what());
-                }
-            }
-            continue;  // skip scoring while in cooldown
-        }
-
-        // Leaky integrator: score += (A * |load| - C) * dt, clamped >= 0
-        // loads[j]: mA for x330, 0.1% for x430
-        double load_abs = std::abs(static_cast<double>(loads[j]));
-        double stress_delta = (stress_multiplier_ * load_abs - stress_leak_) * dt;
-        tracker.score = std::max(0.0, tracker.score + stress_delta);
-
-        // Check threshold
-        if (tracker.score >= stress_threshold_) {
-            int servo_id = joint_configs_[j].servo_id;
-            RCLCPP_WARN(
-                this->get_logger(),
-                "Stress threshold exceeded for joint %zu (servo %d): score=%.1f >= %.1f — disabling torque for %.1fs",
-                j + 1, servo_id, tracker.score, stress_threshold_, stress_cooldown_sec_);
-
-            tracker.in_cooldown = true;
-            tracker.cooldown_until = now + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-                                               std::chrono::duration<double>(stress_cooldown_sec_));
-
-            try {
-                dynamixel_->disableTorque(servo_id);
-            } catch (const std::exception& e) {
-                RCLCPP_ERROR(this->get_logger(), "Failed to disable torque on servo %d for stress cooldown: %s",
-                             servo_id, e.what());
-            }
-        }
-    }
-
-    // Periodic log of stress scores
-    RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                         "StressScores: J1=%.1f J2=%.1f J3=%.1f J4=%.1f J5=%.1f J6=%.1f (threshold=%.1f)",
-                         stress_trackers_[0].score, stress_trackers_[1].score, stress_trackers_[2].score,
-                         stress_trackers_[3].score, stress_trackers_[4].score, stress_trackers_[5].score,
-                         stress_threshold_);
 }
 
 }  // namespace mars_arm

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
@@ -80,21 +80,11 @@ MarsArmNode::MarsArmNode() : Node("mars_arm") {
     this->declare_parameter("baud_rate", 1000000);
     this->declare_parameter("control_frequency", 100.0);
     this->declare_parameter("trajectory_rate_hz", 30.0);
-    this->declare_parameter("max_jerk", 0.0);             // rad/s³, 0 = disabled
-    this->declare_parameter("stress_enabled", false);     // enable/disable leaky integrator
-    this->declare_parameter("stress_threshold", 100.0);   // score to trigger cooldown
-    this->declare_parameter("stress_cooldown_sec", 2.0);  // seconds to rest
-    this->declare_parameter("stress_multiplier", 1.0);    // A in leaky integrator: A*|PWM| - C
-    this->declare_parameter("stress_leak", 0.0);          // C in leaky integrator: A*|PWM| - C
+    this->declare_parameter("max_jerk", 0.0);  // rad/s³, 0 = disabled
     this->declare_parameter("joints", std::vector<std::string>{});
 
     int baud_rate = this->get_parameter("baud_rate").as_int();
     control_frequency_ = this->get_parameter("control_frequency").as_double();
-    stress_enabled_ = this->get_parameter("stress_enabled").as_bool();
-    stress_threshold_ = this->get_parameter("stress_threshold").as_double();
-    stress_cooldown_sec_ = this->get_parameter("stress_cooldown_sec").as_double();
-    stress_multiplier_ = this->get_parameter("stress_multiplier").as_double();
-    stress_leak_ = this->get_parameter("stress_leak").as_double();
     auto joint_names_param = this->get_parameter("joints").as_string_array();
 
     // Load joint configurations from sub-parameters (nav2 style)

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -93,7 +93,6 @@ export const CATALOG = [
     section: "Arm",
     knobs: [
       { path: ["mars_arm", P, "max_jerk"], label: "Max jerk", default: 150.0, type: "float", unit: "rad/s³", doc: "Trajectory jerk limit (0 disables)" },
-      { path: ["mars_arm", P, "stress_enabled"], label: "Motor stress protection", default: false, type: "bool", doc: "Motor-protection cooldown" },
     ],
   },
   {


### PR DESCRIPTION
Removes the motor stress protection feature from `mars_arm` entirely.

## Why

The leaky-integrator overload cooldown shipped disabled by default (`stress_enabled: false`) and was never enabled on any robot. Rather than keep a dead setting in the settings UI, the whole feature goes away — runtime behavior is identical to the default (no cooldown, torque is never cut on load).

## What's removed

- `updateMotorStress()` and its control-loop call site (`arm_control.cpp`)
- `MotorStressTracker` and the 6 `stress_*` members (`arm_types.hpp`, `arm_node.hpp`)
- The 5 `stress_*` ROS parameters (`arm_node.cpp`, `arm_config.yaml`)
- The "Motor stress protection" knob in the webapp settings Arm section (`webapp/js/settings/catalog.js`)
- The `settings.yaml.template` line and the `docs/PARAMETERS.md` table entry

Deletion-only: 118 lines out, 1 in.

## Compatibility

A leftover `stress_enabled:` line in a robot's own `config/settings.yaml` is harmless — rclcpp ignores YAML overrides for parameters the node doesn't declare.

## Verification

- `pre-commit run -c .config/pre-commit-config.yaml` on the changed files passes (clang-format, settings/nav2 guards).
- `node --check` on `catalog.js` passes; the module imports cleanly.
- No local ROS build — Docker wouldn't start on my machine, so the C++ build is on CI. Grepped all seven removed identifiers across `ros2_ws/`, `webapp/`, `config/`, `docs/`: zero remaining references.