### PR TITLE
The Best PR Ever

### DIFF
--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -110,9 +110,16 @@ ensure_log_ownership() {
 apt_update() {
     local attempt output
     for attempt in $(seq 1 60); do
-        # tee streams apt's output live (to stderr and the log); the captured
-        # copy feeds the lock check — only lock contention is worth retrying.
-        output=$(set -o pipefail; apt-get update 2>&1 | tee -a "$LOG_FILE" /dev/stderr) && return 0
+        # Capture apt's output (appended to the log) for the lock check — only
+        # lock contention is worth retrying. Echoed to stderr via fd 2 rather
+        # than tee'd to /dev/stderr: under systemd fd 2 is a journald socket,
+        # which tee cannot re-open (ENXIO), failing the pipeline even when apt
+        # succeeded.
+        if output=$(set -o pipefail; apt-get update 2>&1 | tee -a "$LOG_FILE"); then
+            printf '%s\n' "$output" >&2
+            return 0
+        fi
+        printf '%s\n' "$output" >&2
         grep -q "Could not get lock" <<<"$output" || return 1
         log "  apt lists lock busy (attempt $attempt/60), retrying in 5s..."
         sleep 5


### PR DESCRIPTION
## Problem

Since #571 (81080852), `post_update.sh` fails unconditionally at the `apt_update` step when run under systemd — which is how `innate-first-boot.service` runs it on every boot. The first-boot service then never reaches the step that starts `ros-app.service`, leaving the robot with no ROS nodes running (`zenoh-router.service` and `ros-app.service` both dead).

## Root cause

`apt_update()` streamed apt's output with:

```bash
output=$(set -o pipefail; apt-get update 2>&1 | tee -a "$LOG_FILE" /dev/stderr)
```

Under systemd, fd 2 is a **journald socket**. `tee` tries to `open()` the `/dev/stderr` symlink as a regular path, which fails with `ENXIO` ("No such device or address") on a socket. With `set -o pipefail`, tee's failure poisons the pipeline exit status, so `apt_update` reports failure **even when `apt-get update` succeeded**. Since the output doesn't contain "Could not get lock", the retry loop correctly bails immediately.

Observed on-robot: the journal shows `tee: /dev/stderr: No such device or address`, while `logs/post_update.log` shows all repos returning `Hit:` with no apt errors, immediately followed by `ERROR: Failed to update package lists`. All 5 first-boot attempts fail identically.

The bug is invisible when the script is run from an interactive shell (fd 2 is a tty, which `tee` can open), which is presumably how it was tested.

## Fix

Capture apt's output via `tee` to the log file only, then emit it to stderr with `printf '%s\n' "$output" >&2` — writing through the already-open fd 2 instead of re-opening it by path, which works whether fd 2 is a tty, file, or socket. Output is no longer streamed live, but under systemd both streams end up in the journal anyway.

## Testing

- `bash -n` passes.
- Verified the failure chain on a robot (mars-the-44th) hitting this exact bug; with the patched script the apt step's success is reported correctly.