### PR TITLE
fix(update): use the +simple/ path for the Jetson AI Lab pip index

### DIFF
--- a/ros2_ws/pip-requirements.txt
+++ b/ros2_ws/pip-requirements.txt
@@ -6,7 +6,9 @@
 # Available indexes: jp6/cu126, jp6/cu128, jp6/cu129
 # See: https://pypi.jetson-ai-lab.io/
 # NOTE: torch is installed separately in post_update.sh with --index-url to ensure CUDA wheels
---extra-index-url https://pypi.jetson-ai-lab.io/jp6/cu126
+# The /+simple/ suffix is required -- it is the PEP 503 index; the bare URL is the
+# browsable web UI and 404s for anything the index doesn't host itself
+--extra-index-url https://pypi.jetson-ai-lab.io/jp6/cu126/+simple/
 
 # Core
 numpy<2

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -708,7 +708,14 @@ fi
         # Install Jetson-optimized PyTorch separately with ONLY the Jetson index
         # pip prefers manylinux wheels over platform-specific wheels, so we CANNOT
         # have PyPI as a fallback when installing torch or it will grab the CPU wheel
-        JETSON_INDEX="https://pypi.jetson-ai-lab.io/jp6/cu126"
+        #
+        # The URL MUST end in /+simple/ -- that is the PEP 503 index devpi serves.
+        # Without it pip scrapes the browsable web UI, which 404s for anything the
+        # index doesn't host itself: torch resolves by luck, but its pure-python
+        # deps (sympy, networkx, jinja2, pillow...) 404 and the install dies. On
+        # /+simple/ devpi proxies PyPI for those while still shadowing torch,
+        # torchvision and torchaudio with the Jetson aarch64 wheels.
+        JETSON_INDEX="https://pypi.jetson-ai-lab.io/jp6/cu126/+simple/"
         TORCH_VERSION="2.8.0"
         TORCHVISION_VERSION="0.23.0"
         

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -710,14 +710,18 @@ fi
         # have PyPI as a fallback when installing torch or it will grab the CPU wheel
         #
         # The URL MUST end in /+simple/ -- that is the PEP 503 index devpi serves.
-        # Without it pip scrapes the browsable web UI, which 404s for anything the
-        # index doesn't host itself: torch resolves by luck, but its pure-python
-        # deps (sympy, networkx, jinja2, pillow...) 404 and the install dies. On
+        # Without it pip hits the browsable web UI, which serves no wheel links
+        # (torch included) and 404s outright for anything the index doesn't host
+        # itself (sympy, networkx, jinja2, pillow...), so the install dies. On
         # /+simple/ devpi proxies PyPI for those while still shadowing torch,
         # torchvision and torchaudio with the Jetson aarch64 wheels.
         JETSON_INDEX="https://pypi.jetson-ai-lab.io/jp6/cu126/+simple/"
         TORCH_VERSION="2.8.0"
         TORCHVISION_VERSION="0.23.0"
+        # Pin torchaudio too: the index also carries 2.9.x/2.10.x builds whose
+        # metadata only requires "torch" (no version bound), so an unpinned
+        # torchaudio would pair 2.10 with torch 2.8 and fail at import time.
+        TORCHAUDIO_VERSION="2.8.0"
         
         CUDA_AVAILABLE=$(sudo -u "$ACTUAL_USER" python3 -c "import torch; print(torch.cuda.is_available())" 2>/dev/null || echo "False")
         if [[ "$CUDA_AVAILABLE" != "True" ]]; then
@@ -726,7 +730,7 @@ fi
             sudo -u "$ACTUAL_USER" pip3 install --no-cache-dir \
                 "torch==$TORCH_VERSION" \
                 "torchvision==$TORCHVISION_VERSION" \
-                torchaudio \
+                "torchaudio==$TORCHAUDIO_VERSION" \
                 --index-url "$JETSON_INDEX"
             log "  PyTorch installed from Jetson AI Lab"
         fi


### PR DESCRIPTION
## The bug

`post_update.sh` installs torch with the Jetson AI Lab index as the *only* index. The URL it uses is wrong:

```
https://pypi.jetson-ai-lab.io/jp6/cu126        # devpi's browsable web UI
https://pypi.jetson-ai-lab.io/jp6/cu126/+simple/   # the PEP 503 index pip wants
```

The index runs devpi. The bare path serves the human-facing UI and **404s for every project the index doesn't host itself**. `torch` resolved only by luck — pip scrapes the UI page and it happens to embed the wheel link — but torch's pure-python dependencies do not:

| pip's request | old URL | new URL |
|---|---|---|
| `sympy` | 404 | 200 (proxied from PyPI) |
| `networkx`, `jinja2`, `filelock`, `fsspec`, `typing-extensions` | 404 | 200 |
| `pillow`, `numpy` (torchvision deps) | 404 | 200 |
| `torch` | 200 (UI scrape) | 200 (Jetson wheels only) |

`post_update.sh` runs under `set -e`, so that 404 aborts the entire post-update run — apt, ROS rebuild and all. It is latent on a robot that already has those packages (pip never queries an index for a satisfied requirement), which is why it only bites on a **fresh flash**, and why it looks like an intermittent mirror outage rather than a bad URL.

## The fix

Append `/+simple/`. devpi then proxies PyPI for the pure-python deps while still *shadowing* torch/torchvision/torchaudio with the Jetson aarch64 wheels — so the CPU-manylinux-wheel hazard the existing comment warns about still cannot occur, and `--index-url` (not `--extra-index-url`) is still correct.

## Verification against the live index

```
$ pip index versions sympy --index-url https://pypi.jetson-ai-lab.io/jp6/cu126
ERROR: No matching distribution found for sympy
$ pip index versions sympy --index-url https://pypi.jetson-ai-lab.io/jp6/cu126/+simple/
sympy (1.14.0)
```

`+simple/torch/` lists exactly four `cp310-linux_aarch64` wheels (2.8.0 among them) and zero `files.pythonhosted.org` links; same for torchvision (0.23.0) and torchaudio. Dependency lists cross-checked against PyPI metadata for torch 2.8.0 and torchvision 0.23.0.

Not verified: an actual `pip install` on a JetPack 6 robot. Worth one dry run on hardware before this rides out in a release.

## Origin

The bare URL dates to c891327e (2026-01-20), where the install was wrapped in `|| { log WARNING; }` and a 404 was non-fatal. 14f91c84 (2026-01-26) reinstated it as the only index with no fallback under `set -e` — that is the commit that made it flash-blocking. Both landed via #210; first tagged in 0.2.9.

## Note

The `--extra-index-url` in `pip-requirements.txt` had the same bare URL and is fixed for consistency. None of the ~40 packages the Jetson index hosts appear in that file, so resolution there is unchanged. That line is arguably dead now that torch is installed separately — left in place rather than expanding this PR's scope.