### PR TITLE
fix(update): repair /etc/innate.env mode even when .env has no key

### DIFF
--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -250,10 +250,22 @@ if [ -f "$ENV_FILE" ]; then
             (umask 077; printf '%s\n' "$SERVICE_KEY_LINE" > "$SYSTEM_ENV_FILE")
             log "Copied INNATE_SERVICE_KEY from .env to $SYSTEM_ENV_FILE"
         fi
-        # Unconditional: older updaters left this 0600 root:root, unreadable by
-        # the non-root launch readers.
+    fi
+fi
+
+# Repair the mode outside the seeding branch above: a robot whose .env lost its key — the
+# very case this fallback exists for — or one flashed with a pre-seeded /etc/innate.env
+# never reaches that branch, so gating the repair on it leaves the file 0600 root:root,
+# unreadable by the non-root launch readers. Skipped when ACTUAL_USER resolves to root
+# (run from a root shell, no sudo): "root:root 640" would revoke the launch readers'
+# group access on a file that may currently be correct.
+if [ -f "$SYSTEM_ENV_FILE" ]; then
+    if [ "$ACTUAL_USER" != "root" ]; then
         chown "root:$ACTUAL_USER" "$SYSTEM_ENV_FILE"
         chmod 640 "$SYSTEM_ENV_FILE"
+        log "Set $SYSTEM_ENV_FILE to 640 root:$ACTUAL_USER"
+    else
+        log "Skipping $SYSTEM_ENV_FILE permission repair (no non-root user; re-run via sudo)"
     fi
 fi
 


### PR DESCRIPTION
## Problem

`/etc/innate.env` is the fallback that lets `INNATE_SERVICE_KEY` survive a repo reset that loses the repo `.env`. But the `chown`/`chmod` that makes it readable sat *inside* the seeding branch:

```bash
if [ -n "$SERVICE_KEY_LINE" ]; then     # only true when the repo .env HAS a key
    ... seed ...
    chown "root:$ACTUAL_USER" ...        # the repair, stranded behind the gate
    chmod 640 ...
fi
```

So the repair only ran when the repo `.env` still held a key — excluding the exact scenario the fallback exists for. A robot whose `.env` lost its key, or one flashed with a pre-seeded `/etc/innate.env`, skips the block whole and keeps `0600 root:root` forever.

Observed in the field: `/etc/innate.env` is `600 root:root`, the repo `.env` has no key line, and `logs/post_update.log` has no `innate.env` entry at all for the run that completed today. The non-root readers (`config_loader.load_env_file`, `print_runtime_env`) get `EACCES`, both swallow it as "no env file", and `launch_ros_in_tmux.sh` reports the service key as `missing` — the robot runs as if unpaired while the key sits readable-by-root the whole time.

The file's `stat` shows `Birth: 1970-01-01 00:03:08` — created during a first boot before NTP sync, i.e. factory provisioning, not by post_update.

## Change

Hoist the repair out of the seeding branch into its own guard:

```bash
if [ -f "$SYSTEM_ENV_FILE" ]; then
    if [ "$ACTUAL_USER" != "root" ]; then
        chown "root:$ACTUAL_USER" "$SYSTEM_ENV_FILE"
        chmod 640 "$SYSTEM_ENV_FILE"
        log "Set $SYSTEM_ENV_FILE to 640 root:$ACTUAL_USER"
    else
        log "Skipping $SYSTEM_ENV_FILE permission repair (no non-root user; re-run via sudo)"
    fi
fi
```

Any existing `/etc/innate.env` is normalized to `640 root:$ACTUAL_USER` however it got there — factory-provisioned, seeded by an older updater, or written by this run.

Two hardening points on the hoisted block (from self-review):
- **Root guard**: `ACTUAL_USER=${SUDO_USER:-$USER}` resolves to `root` when the script runs from a root shell without `sudo`. Chowning to `root:root` then would revoke the launch readers' group access on a file that may currently be correct — so that case is skipped, with a logged reason.
- **Logging**: both outcomes log. The original bug was diagnosed by the *absence* of any `innate.env` line in `post_update.log`; now every run records what happened to the file.

Seeding is deliberately unchanged: robots keyed via `./innate setup` only ever get the key in the repo `.env`, so the write-once seed is what gives them a fallback at all. Removing it would leave those robots with no backup against a repo reset.

## Verification

- `bash -n scripts/update/post_update.sh` passes.
- Block extracted and run against stubbed `chown`/`chmod` across four cases:
  1. `.env` has no key + `/etc` file pre-seeded → **repairs** (this is the bug)
  2. both have a key → write-once respected, still repairs
  3. `.env` has key, no `/etc` file → seeds, then repairs
  4. no key, no `/etc` file → clean no-op

## Note, not fixed here

Both readers treat "unreadable" identically to "absent", which is why this failed silently. A permission error on a file that exists is arguably worth a louder warning — left out to keep this focused.
