### PR TITLE
apt: consume innate-built nav2 packages

### DIFF
--- a/ros2_ws/apt-dependencies.hardware.txt
+++ b/ros2_ws/apt-dependencies.hardware.txt
@@ -35,9 +35,9 @@ nvidia-l4t-dla-compiler
 # nav2 sub-packages in apt-dependencies.sim.txt)
 ros-humble-navigation2
 ros-humble-nav2-bringup
-ros-humble-nav2-amcl
-ros-humble-nav2-map-server
-ros-humble-nav2-velocity-smoother
+ros-humble-innate-nav2-amcl
+ros-humble-innate-nav2-map-server
+ros-humble-innate-nav2-velocity-smoother
 ros-humble-spatio-temporal-voxel-layer
 ros-humble-slam-toolbox-humble-lifecycle
 

--- a/ros2_ws/apt-dependencies.sim.txt
+++ b/ros2_ws/apt-dependencies.sim.txt
@@ -35,21 +35,21 @@ ros-humble-behaviortree-cpp-v3
 ros-humble-dwb-core
 ros-humble-dwb-critics
 ros-humble-dwb-plugins
-ros-humble-nav2-behavior-tree
-ros-humble-nav2-core
-ros-humble-nav2-costmap-2d
+ros-humble-innate-nav2-behavior-tree
+ros-humble-innate-nav2-core
+ros-humble-innate-nav2-costmap-2d
 ros-humble-nav2-dwb-controller
-ros-humble-nav2-msgs
+ros-humble-innate-nav2-msgs
 ros-humble-nav2-navfn-planner
-ros-humble-nav2-planner
-ros-humble-nav2-util
-ros-humble-nav2-voxel-grid
+ros-humble-innate-nav2-planner
+ros-humble-innate-nav2-util
+ros-humble-innate-nav2-voxel-grid
 # Real navigation stack (mode_manager.launch) now runs in sim too.
-ros-humble-nav2-amcl
-ros-humble-nav2-map-server
-ros-humble-nav2-velocity-smoother
-ros-humble-nav2-mppi-controller
-ros-humble-nav2-smac-planner
+ros-humble-innate-nav2-amcl
+ros-humble-innate-nav2-map-server
+ros-humble-innate-nav2-velocity-smoother
+ros-humble-innate-nav2-mppi-controller
+ros-humble-innate-nav2-smac-planner
 # Innate's lifecycle build of slam_toolbox: mode_manager must be able to
 # deactivate SLAM in navigation mode or it clobbers /map.
 ros-humble-slam-toolbox-humble-lifecycle


### PR DESCRIPTION
## What

Swaps the nav2 debs in `apt-dependencies.hardware.txt` (3 packages) and `apt-dependencies.sim.txt` (12 packages) from stock `ros-humble-nav2-*` to our `ros-humble-innate-nav2-*` builds from innate-packages (fork branch `innate-humble`). First payload: the MPPI acceleration-limit backport (innate-inc/navigation2#2) — activates the `ax_max/ax_min/az_max` values already present in `controller.yaml`, measured on R7-27 to halve cross-track weave at `az_max 0.5` vs `2.0`.

## ⚠️ Merge gate

**Do not merge until the innate-packages debs are built and published for both architectures** (innate-inc/innate-packages#6 + the manual build/publish flow) — provisioning would otherwise fail to resolve the new names.

## Left on stock (excluded from the innate shipped set by build.sh's REMOVE list)

- `ros-humble-nav2-bringup` (hardware)
- `ros-humble-nav2-dwb-controller`, `ros-humble-nav2-navfn-planner` (sim)

## Validation notes

- The stock leftovers depend on upstream names (e.g. dwb → `ros-humble-nav2-costmap-2d`), which the innate debs satisfy via Provides — worth one clean sim-container build and one robot provision to confirm apt resolves the mixed seam.
- End-to-end check on a robot after upgrade: `ros2 param get /controller_server InnateFollowPath.az_max` → `0.5` (instead of "Parameter not set") proves the accel-limit build is live.
- Follow-up decision tracked in innate-inc/innate-os#583's context: `az_max` default 0.5 vs the field-favorite 0.01 (arc-follower regime), pending tight-space validation with the experiments panel.