### PR TITLE
fix(skills): address code-review findings on the pick/skills-API branch

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/agents/initializer.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/initializer.py
@@ -17,10 +17,6 @@ from brain_client.common.script_paths import (
 )
 from brain_client.skills.physical_refs import render_refs, write_refs
 
-# roster types that are physical skills (data, no code class) — these are what
-# the generated physical_skills package covers
-_PHYSICAL_TYPES = frozenset({"learned", "replay", "eval", "physical"})
-
 
 def initialize_agents(logger, skills_dict: dict[str, dict] | None = None) -> tuple[dict[str, Agent], Agent | None]:
     """
@@ -84,5 +80,10 @@ def _regenerate_physical_refs(logger, skills_dict: dict[str, dict] | None) -> No
     left alone rather than emptied)."""
     if not skills_dict:
         return
-    entries = [meta for meta in skills_dict.values() if meta.get("type") in _PHYSICAL_TYPES]
+    # Everything on the roster that isn't a code skill is a physical skill
+    # (learned/replay/eval/poses/...; broken entries never reach the registry).
+    # This must mirror catalog._write_physical_refs exactly: an allowlist that
+    # disagreed made the two writers regenerate each other's file forever,
+    # each write triggering the watcher's full reload.
+    entries = [meta for meta in skills_dict.values() if meta.get("type") != "code"]
     write_refs(get_workspace_dir() / "physical_skills", render_refs(entries), logger)

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/catalog.py
@@ -109,11 +109,16 @@ class SkillRepository:
         # but it makes construction deterministic when workspace modules are
         # already cached (tests, re-instantiation) — same path as reload_all.
         self._evict_workspace_modules()
-        self._code_skills, code_broken = self._load_code_skills()
-        self._logger.info(f"Successfully loaded {len(self._code_skills)} code skills")
+        # Physical first, refs second, code last: skills `from physical_skills
+        # import X`, and on a fresh workspace that package doesn't exist until
+        # we write it — importing code first would roster every such skill
+        # broken for the whole first pass.
         self._physical_skills, self._in_training_skills, physical_broken = self._load_physical_skills(
             self._skills_directories
         )
+        self._refresh_physical_refs(self._physical_skills, self._in_training_skills)
+        self._code_skills, code_broken = self._load_code_skills()
+        self._logger.info(f"Successfully loaded {len(self._code_skills)} code skills")
         self._broken_skills = {**code_broken, **physical_broken}
         self._logger.info(f"Successfully loaded {len(self._physical_skills)} physical skills")
         self._logger.info(f"Found {len(self._in_training_skills)} in-training skills")
@@ -418,8 +423,10 @@ class SkillRepository:
         self._logger.info("Reloading skills...")
         self._skills_directories = self._resolve_skills_directories()
         self._evict_workspace_modules()
-        new_code_skills, code_broken = self._load_code_skills()
+        # Physical before code, refs in between — see __init__ for why.
         new_physical, new_in_training, physical_broken = self._load_physical_skills(self._skills_directories)
+        self._refresh_physical_refs(new_physical, new_in_training)
+        new_code_skills, code_broken = self._load_code_skills()
         with self._skills_lock:
             self._code_skills = new_code_skills
             self._physical_skills = new_physical
@@ -807,6 +814,22 @@ class SkillRepository:
             # whichever was seen first is already in deduped; append the newcomer
             deduped.append(skill)
         return deduped
+
+    def _refresh_physical_refs(
+        self, physical: dict[str, PhysicalSkillEntry], in_training: dict[str, PhysicalSkillEntry]
+    ) -> None:
+        """Regenerate the refs from freshly loaded entries — the pre-pass run
+        before each code-skill import (see __init__). publish_skills_list
+        writes them again from the roster; the content-compare in write_refs
+        makes the second write a no-op."""
+        infos = []
+        for snapshot in (physical, in_training):
+            for skill_id, entry in snapshot.items():
+                try:
+                    infos.append(self._build_physical_skill_info(skill_id, entry))
+                except Exception as e:
+                    self._logger.error(f"Skipping physical skill '{skill_id}' in physical refs: {e}")
+        self._write_physical_refs(infos)
 
     def _write_physical_refs(self, physical_infos: list[SkillInfo]) -> None:
         """Regenerate workspace/physical_skills/ — the typed refs agents and

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -966,15 +966,20 @@ class Skill(ABC):
         self._tts_playing = msg.data
 
     def _wait_for_speech_end(self, text: str) -> None:
+        # A cancel abandons the wait (best effort, like the rest of say():
+        # no raise — teardown paths speak after the latch is set). Without
+        # the check a Stop would ride out the full budget below.
         # if playback never starts (TTS off, muted), don't hang the skill
-        deadline = time.time() + 15.0
+        deadline = time.monotonic() + 15.0
         while self._tts_playing != "true":
-            if time.time() > deadline:
+            if self.cancelled or time.monotonic() > deadline:
                 return
             time.sleep(0.05)
         # finish budget scales with utterance length
-        deadline = time.time() + max(30.0, 0.1 * len(text))
-        while self._tts_playing == "true" and time.time() < deadline:
+        deadline = time.monotonic() + max(30.0, 0.1 * len(text))
+        while self._tts_playing == "true" and time.monotonic() < deadline:
+            if self.cancelled:
+                return
             time.sleep(0.05)
 
     def update_robot_state(self, **kwargs):

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -129,6 +129,13 @@ void MarsArmNode::controlTimerCallback() {
                 if (idle_s > kScheduledHoldTimeoutS && unloaded) {
                     gain_mode_ = GainMode::TELEOP;
                     RCLCPP_INFO(this->get_logger(), "Gain mode -> TELEOP (idle %.1fs, arm unloaded)", idle_s);
+                } else if (idle_s > kScheduledHoldTimeoutS && loads.size() <= 2) {
+                    // A short state read leaves the load unknown; staying stiff is
+                    // the safe call, but say so — silently holding scheduled gains
+                    // is exactly what ran joint 2 up to 70 C.
+                    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 30000,
+                                         "Idle gain decay blocked: no shoulder/elbow load reading — holding "
+                                         "scheduled (stiff) gains");
                 }
             }
 

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -283,8 +283,9 @@ class PickAnyObject(Skill):
         u, v = seed_px
         grid = vision.grid_pts(u, v)
         in_box = 0
-        t0 = time.time()
-        while time.time() - t0 < FOLLOW_TIMEOUT_S:
+        (cu, cv), _half, accept = self._sweet_box()
+        t0 = time.monotonic()
+        while time.monotonic() - t0 < FOLLOW_TIMEOUT_S:
             # Only track NEW frames: the camera runs slower than this loop,
             # and a stale frame re-tracked would count one observation twice.
             img = self.main_image
@@ -307,7 +308,6 @@ class PickAnyObject(Skill):
                 self.mobility.stop()
                 return "lost", None
 
-            (cu, cv), _half, accept = self._sweet_box()
             if _inside_box((u, v), cu, cv, accept):
                 in_box += 1
                 self.mobility.stop()
@@ -409,8 +409,8 @@ class PickAnyObject(Skill):
 
     def _next_wrist_hsv(self, last_b64, timeout=1.5):
         """Wait for a new wrist frame -> (hsv|None, b64)."""
-        t0 = time.time()
-        while time.time() - t0 < timeout:
+        t0 = time.monotonic()
+        while time.monotonic() - t0 < timeout:
             img = self.wrist_image
             if img and img != last_b64:
                 hsv = vision.b64_to_hsv(img)
@@ -461,13 +461,17 @@ class PickAnyObject(Skill):
         if not tracker.ok:
             return self._wrist_done(tx, ty, z, "not seen")
 
-        deadline = time.time() + WRIST_ALIGN_TIMEOUT_S
+        deadline = time.monotonic() + WRIST_ALIGN_TIMEOUT_S
         streak = 0  # verified matches since the arm last moved
         centered = 0  # consecutive matches INSIDE the box
         stalled = 0  # consecutive steps eaten by the reach clamp
         reason = "reached stop z"
         while z > p["wrist_stop_z"] + 1e-6:
-            if time.time() > deadline:
+            # Explicit cancel point: with a fresh frame already buffered (the
+            # common case after each blocking move) _next_wrist_hsv returns
+            # without ever sleeping, so a Stop would ride the whole descent.
+            self.check_cancelled()
+            if time.monotonic() > deadline:
                 reason = "timeout"
                 break
             hsv, raw = self._next_wrist_hsv(raw)
@@ -630,6 +634,7 @@ class PickAnyObject(Skill):
         # The twist winds FABRIC onto the fingers; on a rigid shell it helps
         # eject the object. Gemini's grip_strength doubles as the hardness signal.
         soft = self._grip_strength is None or self._grip_strength >= SOFT_GRIP_MIN
+        lifted = False
         try:
             if soft:
                 j = self._arm_joints()
@@ -640,12 +645,19 @@ class PickAnyObject(Skill):
             j = self._arm_joints()
             j[1] = max(-1.4, j[1] - p["lift_rad"])
             j[5] = grip
-            self.manipulation.move_to_joint_positions(joint_positions=j, duration=2.0, blocking=True)
+            # move_to_joint_positions reports failure by returning False, not
+            # raising — a silently skipped lift would leave the EE at floor_z
+            # for _grasp_verified's 0.15 m backup drive.
+            lifted = self.manipulation.move_to_joint_positions(joint_positions=j, duration=2.0, blocking=True)
             time.sleep(0.3)
         except LookupError:
+            pass
+        if not lifted:
             # gripper=grip, never the default: the default re-seeds j6 from the
             # measured (stalled) position, zeroing the grip preload — the
-            # object would drop out mid-lift.
+            # object would drop out mid-lift. move_checked verifies by FK and
+            # recover-retries, so the arm is confirmed off the floor (or the
+            # run fails cleanly and teardown carries with the grip kept).
             self.manipulation.move_checked(
                 x, y, 0.22, pitch=p["arm_pitch"], duration=2.0, tol_xy=0.10, gripper=grip, logger=self.logger
             )


### PR DESCRIPTION
## Summary

Fixes for the findings from [this review of #542](https://github.com/innate-inc/innate-os/pull/542#issuecomment-5128204084), targeting `theo/pick-wrist-servo` so they fold into that PR.

- **`pick_any_object._wrist_descend`**: explicit `check_cancelled()` at the top of the descend loop — the fast path (fresh wrist frame already buffered, the common case after each 0.5 s blocking move) never reached `self.sleep()`, so a Stop rode the descent for up to 60 s.
- **`pick_any_object._close_twist_lift`**: the joint-space lift's `move_to_joint_positions` return is now checked (it returns `False` instead of raising); a failed/skipped lift falls back to the FK-verified `move_checked` cartesian lift with the grip kept, instead of letting `_grasp_verified` back the base up 0.15 m with the EE still at `floor_z`.
- **`pick_any_object`**: loop deadlines moved from `time.time()` to `time.monotonic()` (matching `brain_client_node`'s NTP-step rationale); `_sweet_box()` hoisted out of the 30 ms follow loop.
- **`Skill.say(wait=True)`**: `_wait_for_speech_end` now aborts on cancel instead of ignoring a Stop for up to 45 s. Best-effort early return, no raise — `say()` also runs in post-cancel teardown paths.
- **`catalog.py`**: `__init__` and `reload_all` now load physical skills and write the `physical_skills/` refs **before** importing code skills. Previously, on a fresh workspace every `from physical_skills import X` skill was rostered broken for the whole first pass, self-healing only via the optional watchdog-based watcher.
- **`initializer.py`**: `_regenerate_physical_refs` now includes every non-`code` roster entry instead of a 4-type allowlist. The allowlist omitted `"poses"` (a real roster type per `SkillInfo.msg`), so with a poses skill present the two writers of `physical_skills/__init__.py` never agreed — each rewrite retriggered the other's full reload forever; the content-compare could never converge.
- **`arm_control.cpp`**: throttled warning when the idle gain decay is blocked by a short load read, instead of silently holding stiff gains (behavior unchanged — staying stiff on unknown load is the safe call).

Deliberately **not** addressed (author's call): the emptied `CLAUDE.md` (confirmed intentional), the removed test suites / `test_backwards_compat.py` (deliberate per the PR body), composed children's interface-halt at call end (design question — halting shared interfaces mid-parent-run could stop parent-commanded motion), per-skill storage namespace collisions (changing the path orphans existing stored data — needs a migration decision), the double reload per recorded episode, and the head-camera constants scaling wrist pixels (latent only — both cameras run 640×480).

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped: `ruff check` + `ruff format --check` clean on the touched Python files, `clang-format --dry-run --Werror` clean on `arm_control.cpp`, pyright error count identical to the branch baseline (57, all missing-ROS-deps environment noise). No robot here — the descend-cancel and lift-fallback paths need a hardware pass.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — N/A, no simulator changes.
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — N/A.

https://claude.ai/code/session_01QePrpqbeHd4TN8KGB5RTNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QePrpqbeHd4TN8KGB5RTNY)_