### PR TITLE
fix(teleop): show overflowing skill params on expand

### DIFF
--- a/webapp/js/teleop/skillsMenu.js
+++ b/webapp/js/teleop/skillsMenu.js
@@ -386,6 +386,10 @@ export function createSkillsMenu(parent, rosClient) {
       if (expandable) {
         expandedId = isExpanded ? null : skill.id;
         render();
+        const expandedRow = listEl.querySelector(".skills-pop-row.expanded");
+        if (!expandedRow) return;
+        const expandedRowOverflow = expandedRow.getBoundingClientRect().bottom - scrollEl.getBoundingClientRect().bottom;
+        if (expandedRowOverflow > 0) scrollEl.scrollTop += expandedRowOverflow;
         return;
       }
       // Same ANY-run guard as the form Run button/Enter key: launching while


### PR DESCRIPTION
Problem:
- skill params is hidden if the skill is at the end of list or did not fit within the given scroll area
- when I did my first custom skill following the docs, the victory_spin showed but not the expanded params since the skill was at the bottom of the scroll area.

| Current UX | Proposed UX |
|------------|-------------|
| <video src="https://github.com/user-attachments/assets/43a3be8b-5708-4910-8be1-e2c7e7273b98" controls width="100%"></video> | <video src="https://github.com/user-attachments/assets/713736b4-82d8-44b7-92cb-32c8313183c4" controls width="100%"></video> |

