### PR TITLE
fix(webapp): inset select chevron and truncate long labels

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -95,11 +95,11 @@ button {
 /* Native select chevron cannot be inset reliably.
    30px end padding = 10px inset + 10px icon + 10px text gap. */
 .agent-directive,
-.record-skill,
 .log-select,
+.modal-select,
+.record-skill,
 .set-ctl > select.set-text,
-select.episodes-tool,
-.modal-select {
+select.episodes-tool {
   -webkit-appearance: none;
   appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%23e7e7ea' stroke-width='1.4'/></svg>");

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -2395,7 +2395,7 @@ select.skill-input {
   color: var(--muted);
 }
 
-/* Select variant (Training filter): room for the inset custom chevron. */
+/* .episodes-tool is also used on buttons — only selects need chevron clearance. */
 select.episodes-tool {
   padding: 0 30px 0 10px;
 }
@@ -4632,7 +4632,7 @@ select.episodes-tool {
   transition: border-color 150ms ease;
 }
 
-/* Select variant (enum skill params): room for the inset custom chevron. */
+/* .skill-input is also used on text fields — only selects need chevron clearance. */
 select.skill-input {
   padding: 0 30px 0 10px;
 }

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -102,7 +102,7 @@ button {
 select.episodes-tool {
   -webkit-appearance: none;
   appearance: none;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%23e7e7ea' stroke-width='1.4'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%238a8a93' stroke-width='1.4'/></svg>");
   background-repeat: no-repeat;
   background-position: right 10px center;
   overflow: hidden;

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -97,9 +97,11 @@ button {
 .agent-directive,
 .log-select,
 .modal-select,
+.prof-select,
 .record-skill,
 .set-ctl > select.set-text,
-select.episodes-tool {
+select.episodes-tool,
+select.skill-input {
   -webkit-appearance: none;
   appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%238a8a93' stroke-width='1.4'/></svg>");
@@ -4048,10 +4050,10 @@ select.episodes-tool {
   color: var(--danger);
 }
 .prof-select {
-  background: transparent;
+  background-color: transparent;
   border: 1px solid var(--hairline-strong);
   border-radius: 8px;
-  padding: 6px 8px;
+  padding: 6px 30px 6px 10px;
   font: inherit;
   font-size: 12px;
   color: var(--text);
@@ -4624,10 +4626,15 @@ select.episodes-tool {
   padding: 0 9px;
   font-size: 12px;
   color: var(--text);
-  background: rgb(0 0 0 / 45%);
+  background-color: rgb(0 0 0 / 45%);
   border: 1px solid var(--hairline-strong);
   border-radius: 7px;
   transition: border-color 150ms ease;
+}
+
+/* Select variant (enum skill params): room for the inset custom chevron. */
+select.skill-input {
+  padding: 0 30px 0 10px;
 }
 
 .skill-input:focus {

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -97,7 +97,9 @@ button {
 .agent-directive,
 .record-skill,
 .log-select,
-.set-ctl > select.set-text {
+.set-ctl > select.set-text,
+select.episodes-tool,
+.modal-select {
   -webkit-appearance: none;
   appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%23e7e7ea' stroke-width='1.4'/></svg>");
@@ -2384,11 +2386,16 @@ button {
 .episodes-tool {
   height: 32px;
   padding: 0 12px;
-  background: var(--panel);
+  background-color: var(--panel);
   border: 1px solid var(--hairline);
   border-radius: 8px;
   font-size: 12px;
   color: var(--muted);
+}
+
+/* Select variant (Training filter): room for the inset custom chevron. */
+select.episodes-tool {
+  padding: 0 30px 0 10px;
 }
 
 .episodes-tool:hover {
@@ -3859,13 +3866,17 @@ button {
 
 .modal-select,
 .modal-input {
-  background: var(--bg);
+  background-color: var(--bg);
   border: 1px solid var(--hairline-strong);
   border-radius: 8px;
   padding: 8px 10px;
   font: inherit;
   font-size: 13px;
   color: var(--text);
+}
+
+.modal-select {
+  padding: 8px 30px 8px 10px;
 }
 
 .modal-select:focus,

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -92,6 +92,19 @@ button {
   cursor: pointer;
 }
 
+/* Native select chevron cannot be inset reliably.
+   30px end padding = 10px inset + 10px icon + 10px text gap. */
+.agent-directive,
+.record-skill,
+.log-select,
+.set-ctl > select.set-text {
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%23e7e7ea' stroke-width='1.4'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+
 /* ---- icon rail ---------------------------------------------------------- */
 
 .rail {
@@ -908,10 +921,10 @@ button {
   /* Transparent so the overlay's own glass blur shows through — the dark-grey
      fill read as a heavy block against the rest of the HUD. The open dropdown
      popup is OS-rendered dark via the page's color-scheme: dark. */
-  background: transparent;
+  background-color: transparent;
   border: 1px solid var(--hairline-strong);
   border-radius: 8px;
-  padding: 6px 9px;
+  padding: 6px 30px 6px 10px;
   font: inherit;
   font-size: 12px;
   color: var(--text);
@@ -1825,10 +1838,10 @@ button {
 }
 
 .log-select {
-  background: transparent;
+  background-color: transparent;
   border: 1px solid var(--hairline-strong);
   border-radius: 7px;
-  padding: 5px 8px;
+  padding: 5px 30px 5px 10px;
   font: inherit;
   font-size: 11px;
   color: var(--text);
@@ -5223,10 +5236,10 @@ button {
 .agent-directive {
   flex: 1;
   min-width: 0;
-  padding: 8px 10px;
+  padding: 8px 30px 8px 10px;
   font-size: 12px;
   color: var(--text);
-  background: rgb(0 0 0 / 35%);
+  background-color: rgb(0 0 0 / 35%);
   border: 1px solid var(--hairline-strong);
   border-radius: 9px;
 }

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -103,6 +103,9 @@ button {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%23e7e7ea' stroke-width='1.4'/></svg>");
   background-repeat: no-repeat;
   background-position: right 10px center;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 /* ---- icon rail ---------------------------------------------------------- */

--- a/webapp/js/settings/main.js
+++ b/webapp/js/settings/main.js
@@ -117,9 +117,9 @@ const STYLE = `
 .set-status.err { color: #ff6b6b; }
 .set-status.muted { color: var(--muted, #8a90a0); }
 .set-ctl :is(input, select).set-text { padding: 6px 8px; border-radius: 8px; border: 1px solid var(--hairline, #2a2f3a);
-  background: var(--panel, #111114); color: inherit; font: inherit; }
+  background-color: var(--panel, #111114); color: inherit; font: inherit; }
 .set-ctl > input.set-text { width: 200px; }
-.set-ctl > select.set-text { width: 216px; cursor: pointer; }
+.set-ctl > select.set-text { width: 216px; padding: 6px 30px 6px 10px; cursor: pointer; }
 .set-default { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .set-row-list { flex-direction: column; align-items: stretch; }
 .set-row-list .set-ctl { flex-direction: column; align-items: stretch; gap: 8px; margin-top: 10px; }


### PR DESCRIPTION
Problem: 
* native `<select>` chevron look crammed in the right with spacing that is inconsistent
* label clips if it does not fit within given area

Solution:
* add better padding and don't use native chevron
* truncate labels if they don't fit

## Comparing UI

https://github.com/user-attachments/assets/c338458e-9132-44ce-b40b-29ab22bdfdd2

Why 30px right padding?

* 30 = 10px (icon width) + 10px (icon's edge inset) + 10px (gap between label and icon)
* makes it so the right padding of `<select>` matches the left padding(10px)

Ideally in the future this could have a custom select if it becomes a priority but not within the scope of this PR


<br>

## Truncating label

https://github.com/user-attachments/assets/b674b9d5-1cad-4659-b271-af51a51aa424

