### PR TITLE
feat(teleop): confirm before engaging above-cap (Mad) speed mode

### DIFF
--- a/webapp/js/nav/confirm.js
+++ b/webapp/js/nav/confirm.js
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
 // Promise-based confirm dialog on the app's .modal design (the same classes
-// collect/training hand-roll), replacing window.confirm for the Nav page's
-// destructive actions. Escape, backdrop, and ✕ all cancel; for dangerous
-// actions the cancel button takes initial focus so a stray Enter can't
-// delete anything.
+// collect/training hand-roll), replacing window.confirm for destructive
+// actions (Nav page, teleop speed picker). Escape, backdrop, and ✕ all
+// cancel; for dangerous actions the cancel button takes initial focus so a
+// stray Enter can't delete anything.
 
 /** Open dialogs' settle functions, so page teardown can sweep strays. */
 /** @type {Set<(result: boolean) => void>} */
@@ -21,7 +21,7 @@ export function dismissAllConfirms() {
 }
 
 /**
- * @param {{ title: string, body: string, confirmLabel: string, danger?: boolean }} opts
+ * @param {{ title: string, body: string, confirmLabel: string, cancelLabel?: string, danger?: boolean }} opts
  * @returns {Promise<boolean>}
  */
 export function confirmDialog(opts) {
@@ -53,7 +53,7 @@ export function confirmDialog(opts) {
     const cancel = document.createElement("button");
     cancel.type = "button";
     cancel.className = "confirm-btn";
-    cancel.textContent = "Cancel";
+    cancel.textContent = opts.cancelLabel ?? "Cancel";
     const ok = document.createElement("button");
     ok.type = "button";
     ok.className = `confirm-btn confirm-primary${opts.danger ? " danger" : ""}`;

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -27,6 +27,7 @@ import { createArmPanel } from "./armPanel.js";
 import { createProfilingPanel } from "./profilingPanel.js";
 import { createSkillsMenu } from "./skillsMenu.js";
 import { createCameraSwitch } from "./cameraSwitch.js";
+import { dismissAllConfirms } from "../nav/confirm.js";
 
 // Runtime feature flags (config.json, served static). Sim-only debug controls are
 // off unless a deployment opts in. Fetched once when this module first loads (the
@@ -102,6 +103,9 @@ function buildCockpit(root) {
   return {
     destroy() {
       drive.haltAll();
+      // Confirm dialogs (speed picker) live on document.body — sweep them so
+      // navigating away doesn't leave one floating over the next page.
+      dismissAllConfirms();
       for (const part of parts) part.destroy();
       session.destroy();
       root.innerHTML = "";

--- a/webapp/js/teleop/speedModes.js
+++ b/webapp/js/teleop/speedModes.js
@@ -117,7 +117,7 @@ export function createSpeedModes(parent, rosClient) {
       if (
         mode.scale > 1.0 &&
         !window.confirm(
-          `Engage ${mode.label} mode? Beyond full speed, the arm loses every argument it starts with furniture — one high-speed collision can break it. Go mad, but drive like you want to keep the arm.`,
+          `Engage ${mode.label} mode? Beyond full speed, one high-speed collision can break the arm of the robot. Go mad, but with great power comes great responsibility.`,
         )
       ) {
         return;

--- a/webapp/js/teleop/speedModes.js
+++ b/webapp/js/teleop/speedModes.js
@@ -110,6 +110,18 @@ export function createSpeedModes(parent, rosClient) {
     button.setAttribute("aria-checked", "false");
     button.addEventListener("click", () => {
       if (mode.id === selectedId) return;
+      // Above 1.0 the mode exceeds the robot's configured caps (that's what "Mad"
+      // is) — at those speeds a collision can break the arm, so the operator has
+      // to say they mean it. Gate on scale, not id, so any future above-cap mode
+      // the robot publishes gets the same warning.
+      if (
+        mode.scale > 1.0 &&
+        !window.confirm(
+          `Engage ${mode.label} mode? Beyond full speed, the arm loses every argument it starts with furniture — one high-speed collision can break it. Go mad, but drive like you want to keep the arm.`,
+        )
+      ) {
+        return;
+      }
       const previousId = selectedId;
       paint(mode.id);
       optimisticUntil = performance.now() + OPTIMISTIC_HOLD_MS;

--- a/webapp/js/teleop/speedModes.js
+++ b/webapp/js/teleop/speedModes.js
@@ -17,6 +17,7 @@ import {
   PARAMETER_DOUBLE,
   SPEED_MODES,
 } from "../constants.js";
+import { confirmDialog } from "../nav/confirm.js";
 
 // A click's optimistic paint has to survive long enough for the robot to apply the
 // parameter and emit a fresh /robot/info (published at 1 Hz), or the picker would
@@ -108,19 +109,23 @@ export function createSpeedModes(parent, rosClient) {
     button.textContent = mode.label;
     button.setAttribute("role", "radio");
     button.setAttribute("aria-checked", "false");
-    button.addEventListener("click", () => {
+    button.addEventListener("click", async () => {
       if (mode.id === selectedId) return;
       // Above 1.0 the mode exceeds the robot's configured caps (that's what "Mad"
       // is) — at those speeds a collision can break the arm, so the operator has
       // to say they mean it. Gate on scale, not id, so any future above-cap mode
       // the robot publishes gets the same warning.
-      if (
-        mode.scale > 1.0 &&
-        !window.confirm(
-          `Engage ${mode.label} mode? Beyond full speed, one high-speed collision can break the arm of the robot. Go mad, but with great power comes great responsibility.`,
-        )
-      ) {
-        return;
+      if (mode.scale > 1.0) {
+        const ok = await confirmDialog({
+          title: `Engage ${mode.label} mode?`,
+          body: "Beyond full speed, one high-speed collision can break the arm of the robot. Go mad, but with great power comes great responsibility.",
+          confirmLabel: "Yes I am ready to handle the heat.",
+          cancelLabel: "No I wanna go back to my safe space.",
+          danger: true,
+        });
+        // Re-check after the await: a /robot/info update while the dialog was
+        // open may have already landed the picker on this mode.
+        if (!ok || mode.id === selectedId) return;
       }
       const previousId = selectedId;
       paint(mode.id);


### PR DESCRIPTION
## What

Clicking **Mad** in the webapp's speed picker now pops a styled confirm dialog before the mode is applied:

> **Engage Mad mode?**
> Beyond full speed, one high-speed collision can break the arm of the robot. Go mad, but with great power comes great responsibility.
>
> [No I wanna go back to my safe space.] [Yes I am ready to handle the heat.]

Declining (button, ✕, Escape, or backdrop click) leaves the current mode untouched; nothing is sent to the robot until the operator confirms.

## Why

Mad runs at 2.0x scale — beyond the configured motion caps — and a collision at that speed can break the arm. The other modes stay one-click.

## How

- Reuses the Nav page's `confirmDialog` (the app's `.modal` design), which grows an optional `cancelLabel` so both buttons carry custom text. `danger: true` gives the confirm button the red treatment and puts initial focus on cancel.
- Gate in the click handler of `webapp/js/teleop/speedModes.js`, before the optimistic paint and the `set_parameters` call; the mode is re-checked after the dialog resolves in case a `/robot/info` update landed meanwhile.
- Triggered by `mode.scale > 1.0` (exceeds configured caps) rather than the `"mad"` id, so any future above-cap mode the robot publishes in `drive_speed_modes` gets the same warning.
- The teleop page's destroy now calls `dismissAllConfirms()` (same as Nav) so navigating away can't leave a dialog floating over the next page.

Companion PR adds the same confirm to the mobile app's speed picker: innate-inc/innate-controller-app#238.