### PR TITLE
feat(teleop): title the speed warning "Engage Mad MARS mode?"

### DIFF
--- a/webapp/js/teleop/speedModes.js
+++ b/webapp/js/teleop/speedModes.js
@@ -117,7 +117,7 @@ export function createSpeedModes(parent, rosClient) {
       // the robot publishes gets the same warning.
       if (mode.scale > 1.0) {
         const ok = await confirmDialog({
-          title: `Engage ${mode.label} mode?`,
+          title: `Engage ${mode.label} MARS mode?`,
           body: "Beyond full speed, one high-speed collision can break the arm of the robot. Go mad, but with great power comes great responsibility.",
           confirmLabel: "Yes I am ready to handle the heat.",
           cancelLabel: "No I wanna go back to my safe space.",


### PR DESCRIPTION
Copy tweak on top of #593: the confirm dialog's title now names the robot.

> **Engage Mad MARS mode?**
> Beyond full speed, one high-speed collision can break the arm of the robot. Go mad, but with great power comes great responsibility.
>
> [No I wanna go back to my safe space.] [Yes I am ready to handle the heat.]

The label stays interpolated (`Engage ${mode.label} MARS mode?`), so an above-cap mode the robot publishes under a different name still reads correctly. Body text and buttons are unchanged.

Companion PR does the same on mobile: innate-inc/innate-controller-app#240.