### PR TITLE
feat(teleop): copy leader joint positions to the clipboard

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1609,6 +1609,29 @@ button {
   color: var(--accent);
 }
 
+/* Engage sits next to a small icon button that copies the joint ticks. */
+.arm-engage-row {
+  display: flex;
+  gap: 8px;
+}
+
+.arm-engage-row .arm-engage {
+  flex: 1;
+}
+
+.arm-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7px 9px;
+  color: var(--muted);
+}
+
+.arm-copy.copied {
+  border-color: var(--ok);
+  color: var(--ok);
+}
+
 .arm-note {
   font-size: 9px;
 }

--- a/webapp/js/teleop/armPanel.js
+++ b/webapp/js/teleop/armPanel.js
@@ -13,6 +13,7 @@
 // or serial failure.
 
 import { DynamixelLeader } from "../dynamixel.js";
+import { copyToButton, ICON_COPY } from "../clipboard.js";
 import {
   LEADER_POSITIONS_TOPIC,
   ARM_REBOOT_SERVICE,
@@ -140,10 +141,24 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   engageBtn.className = "arm-button arm-engage";
   engageBtn.type = "button";
 
+  // Copy the live joint ticks — handy for pasting a pose into a skill.
+  const copyBtn = document.createElement("button");
+  copyBtn.className = "arm-button arm-copy";
+  copyBtn.type = "button";
+  copyBtn.title = "Copy joint positions";
+  copyBtn.setAttribute("aria-label", "Copy joint positions");
+  copyBtn.innerHTML = ICON_COPY;
+
+  // Engage + copy share a row; the row (not the button) is what hides when
+  // there's nothing to read.
+  const engageRow = document.createElement("div");
+  engageRow.className = "arm-engage-row";
+  engageRow.append(engageBtn, copyBtn);
+
   const note = document.createElement("p");
   note.className = "arm-note microlabel";
 
-  wrap.append(status, joints, connectBtn, engageBtn, note, ...(armSvc ? [divider(), armSvc.el] : []));
+  wrap.append(status, joints, connectBtn, engageRow, note, ...(armSvc ? [divider(), armSvc.el] : []));
 
   // ---- state ------------------------------------------------------------
 
@@ -197,7 +212,7 @@ export function createArmPanel(parent, rosClient, opts = {}) {
     connectBtn.disabled = false;
     connectBtn.textContent = state.error ? "Reconnect arm" : "Connect arm";
 
-    engageBtn.hidden = !reading;
+    engageRow.hidden = !reading;
     engageBtn.textContent = engaged ? "Live — click to stop" : "Engage follow";
     engageBtn.classList.toggle("active", engaged);
 
@@ -238,6 +253,12 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   });
 
   engageBtn.addEventListener("click", () => setEngaged(!engaged));
+
+  copyBtn.addEventListener("click", () => {
+    const positions = leader.state.positions;
+    if (!positions) return; // row is hidden without a read, but be safe
+    void copyToButton(`[${positions.join(", ")}]`, copyBtn, "copied");
+  });
 
   const unsubLeader = leader.onChange((state) => {
     if (destroyed) return;


### PR DESCRIPTION
## What

Adds a small copy icon button next to **Engage follow** in the teleop arm panel. Clicking it copies the six live leader-arm joint ticks to the clipboard as `[2048, 1024, ...]` — the shape you paste into a skill when scripting a pose.

## Details

- Uses the existing `copyToButton` / `ICON_COPY` helpers from `webapp/js/clipboard.js`, so it flashes a check on success (✕ on failure) and falls back to the legacy textarea path on insecure origins (`http://<robot-ip>`).
- Engage and the copy button now share an `.arm-engage-row`; the row is what hides when the leader arm isn't reading, so the copy button is only offered when there are positions to copy.

## Testing

`tsc --noEmit` over `webapp/` reports no new errors (`armPanel.js` and `clipboard.js` clean; the remaining errors are pre-existing in other files). Not exercised on hardware — the row only appears with a leader arm connected over WebSerial.