### PR TITLE
fix(sound): silence the engine burst on motor_sound startup

### DIFF
--- a/ros2_ws/src/mars_bot/mars_control/mars_control/motor_sound.py
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/motor_sound.py
@@ -82,10 +82,14 @@ class MotorSoundNode(Node):
         # is what winds the sound down after the last command goes stale.
         self.create_timer(0.1, self._update_drive)
 
+        # Gate the synth before the audio thread exists: _open_stream starts
+        # PortAudio rendering immediately and a fresh MotorSynth is enabled, so
+        # deciding afterwards leaks an idle engine until this call lands — a
+        # click normally, a fifth of a second when a build is eating the CPU.
+        self._update_drive()
         self._stream = self._open_stream(params)
         if self._stream is not None and not self._only_in_mad_mode:
             self._synth.trigger_startup()
-        self._update_drive()
 
     def _declare_parameters(self):
         self.declare_parameters(

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/motor_sound.py
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/motor_sound.py
@@ -82,10 +82,6 @@ class MotorSoundNode(Node):
         # is what winds the sound down after the last command goes stale.
         self.create_timer(0.1, self._update_drive)
 
-        # Gate the synth before the audio thread exists: _open_stream starts
-        # PortAudio rendering immediately and a fresh MotorSynth is enabled, so
-        # deciding afterwards leaks an idle engine until this call lands — a
-        # click normally, a fifth of a second when a build is eating the CPU.
         self._update_drive()
         self._stream = self._open_stream(params)
         if self._stream is not None and not self._only_in_mad_mode:


### PR DESCRIPTION
## What

`motor_sound` plays a short burst of the Mad engine sound every time the node starts. Most audible after `innate build`, which is stop → build → start ([scripts/innate:1160](https://github.com/innate-inc/innate-os/blob/main/scripts/innate#L1160)) — the restart lands while colcon still has every core.

## Why

`MotorSynth.__init__` sets `self.enabled = True`. In `MotorSoundNode.__init__` the order was:

```python
self._stream = self._open_stream(params)   # stream.start() → PortAudio renders NOW
if self._stream is not None and not self._only_in_mad_mode:
    self._synth.trigger_startup()
self._update_drive()                       # → synth.enabled = False
```

PortAudio's callback runs on its own realtime thread from the moment `stream.start()` returns, but nothing silences the synth until `_update_drive()` two lines later. In between it renders the parked idle throb — the only sound this node makes, hence "Mad mode noise".

Normally that window is a block or two (10.7 ms each) and you hear a click. Under a build the main thread gets descheduled while the audio thread keeps its realtime slot, so the window stretches; add the ~200 ms gain ramp-down and it's the ~0.2 s people notice.

## Fix

Decide the gate before the audio thread exists — `_update_drive()` moves above `_open_stream()`. The chirp stays after the stream opens, so `only_in_mad_mode=False` still announces itself.

## Testing

Driving the real `MotorSynth` (no ROS needed):

| | peak amplitude over 0.2 s |
|---|---|
| before (fresh synth, enabled) | **0.0474** (≈ −26 dBFS), audible from the first block |
| after (gated first) | **0.000000** |
| chirp path, `only_in_mad_mode=False` | 0.0129 — still fires |

`ruff check` / `ruff format --check` clean. Not verified through a real audio device — the reasoning is from the code plus the synth-level measurement above.
