### PR TITLE
feat(sim): droppable scenario props — human, soccer ball, labrador

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -178,11 +178,17 @@ class VirtualMars:
         visual_dir = ASSETS_DIR / "apartment_visual"
         visual_rooms = world.find_visual_rooms(visual_dir) if visual_dir.is_dir() else {}
 
+        # Prop meshes are optional: older asset bundles lack them (the human
+        # body is then absent; ball/dog fall back to bare primitives).
+        human_obj = ASSETS_DIR / world.HUMAN_MESH
+        object_meshes = {k: p for k, rel in world.OBJECT_MESHES.items() if (p := ASSETS_DIR / rel).exists()}
         xml = world.build_world_xml(
             rooms,
             include_placeholder_robot=False,
             visual_rooms=visual_rooms,
             texture_max=_texture_cap(self._render_w),
+            human_obj=human_obj if human_obj.exists() else None,
+            object_meshes=object_meshes,
         )
         # Lidar rays hit only the textured visual meshes (true surfaces, like
         # a real lidar) when available -- without them, fall back to all
@@ -198,6 +204,9 @@ class VirtualMars:
             *(f for pieces in rooms.values() for f in pieces),
             *(p for obj in visual_rooms.values() for p in (obj, obj.with_suffix(".png"))),
             *(f for f in urdf_path.parent.rglob("*") if f.suffix in (".stl", ".dae", ".obj", ".png", ".urdf")),
+            *((human_obj, human_obj.with_name(f"{human_obj.stem}_basecolor.png")) if human_obj.exists() else ()),
+            *(f for p in object_meshes.values() for f in (p, p.with_name(f"{p.stem}_basecolor.png"))),
+            *(f for p in object_meshes.values() for f in sorted(p.parent.glob(f"{p.stem}_collision_*.obj"))),
         ]
         cache_path = _model_cache_path(xml, asset_files)
         self.model = None
@@ -254,6 +263,17 @@ class VirtualMars:
         jid = self.model.joint(f"robot_{mimic_name}").id
         self._mimic = (self.model.jnt_qposadr[jid], self.model.jnt_dofadr[jid], mimic_source, mimic_mult)
 
+        # Droppable props: freejoint (qpos_adr, dof_adr) per kind (see
+        # world.OBJECT_KINDS). The mesh-backed human is present only when its
+        # asset shipped; the ball and dog primitives are always in the world.
+        self._objects: dict[str, tuple[int, int]] = {}
+        for kind in world.OBJECT_KINDS:
+            if kind == "human" and not human_obj.exists():
+                continue
+            jid = self.model.joint(f"{kind}_free").id
+            self._objects[kind] = (self.model.jnt_qposadr[jid], self.model.jnt_dofadr[jid])
+        self._dropped: set[str] = set()  # kinds placed by drop_object (else parked off-map)
+
         self._renderer: mujoco.Renderer | None = None
         self._depth_renderer: mujoco.Renderer | None = None
         self._cmd_vx = 0.0
@@ -271,9 +291,32 @@ class VirtualMars:
             self.data.qpos[qadr] = home
         mq, _md, source, mult = self._mimic
         self.data.qpos[mq] = mult * ARM_HOME[source]
+        self._dropped.clear()  # mj_resetData re-parked every prop at OBJECT_PARK
         self._cmd_vx = self._cmd_wz = 0.0
         self._cmd_sim_time = -math.inf
         mujoco.mj_forward(self.model, self.data)
+
+    def drop_object(self, kind: str, x: float, y: float, yaw: float) -> bool:
+        """Teleport a scenario prop (see world.OBJECT_KINDS) above (x, y),
+        yawed about +z (the human lands on its back, head along yaw's
+        +y-rotated axis), and let physics settle it onto whatever is below.
+        False if the kind isn't in the world (unknown, or its asset is missing
+        from the bundle)."""
+        obj = self._objects.get(kind)
+        if obj is None:
+            return False
+        qadr, dadr = obj
+        half = yaw / 2
+        self.data.qpos[qadr : qadr + 7] = [x, y, world.OBJECT_DROP_Z[kind], math.cos(half), 0.0, 0.0, math.sin(half)]
+        self.data.qvel[dadr : dadr + 6] = 0.0
+        self._dropped.add(kind)
+        mujoco.mj_forward(self.model, self.data)
+        return True
+
+    def object_poses(self) -> dict[str, list[float]]:
+        """Ground-truth {kind: [x, y, z, qw, qx, qy, qz]} for every prop
+        dropped this session; parked (never-dropped) props are omitted."""
+        return {kind: [*map(float, (b := self.data.body(kind)).xpos), *map(float, b.xquat)] for kind in self._dropped}
 
     def set_cmd_vel(self, vx: float, wz: float) -> None:
         self._cmd_vx = max(-world.MAX_LINEAR, min(world.MAX_LINEAR, vx))

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -34,6 +34,36 @@ MAX_YAW = 1.0
 MAX_BASE_LINEAR_SPEED = 2.0
 MAX_BASE_ANGULAR_SPEED = 6.0
 
+# Scenario props a drop_object command can place (see core.drop_object). Each
+# is a free-floating MuJoCo body parked off-map (OBJECT_PARK) until dropped,
+# released from OBJECT_DROP_Z so it starts clear of furniture. The human is a
+# posed scan (centimeter units, Y-up, feet at origin -- identity quat lies it
+# on its back, head toward +y) that doubles as its own collision hull; the
+# ball and dog collide as primitives (a sphere rolls perfectly; the dog's
+# box can't snag hull seams) with the textured mesh drawn over them (Z-up
+# meters, bbox-centered -- sim/tools/convert_objects.py), so the robot
+# cameras see the same object the browser viewer draws. Meshes are optional:
+# older asset bundles fall back to visible bare primitives.
+HUMAN_MESH = "humans/casual_man.obj"
+OBJECT_MESHES = {
+    "soccer_ball": "objects/soccer_ball.obj",
+    "labrador": "objects/labrador.obj",
+}
+OBJECT_KINDS = ("human", "soccer_ball", "labrador")
+OBJECT_PARK = {
+    "human": (15.0, 15.0),
+    "soccer_ball": (16.5, 15.0),
+    "labrador": (18.0, 15.0),
+}
+# Release heights: high enough that each object's hull starts clear of
+# sofas/beds/tables instead of spawning inside them (the human's lying hull
+# reaches ~0.24m below its body origin).
+OBJECT_DROP_Z = {
+    "human": 1.5,
+    "soccer_ball": 0.6,
+    "labrador": 1.0,
+}
+
 DRIVEN_JOINTS = ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint_head"]
 MIMIC_JOINT = ("joint6M", "joint6", -1.0)  # (name, source, multiplier)
 
@@ -161,9 +191,14 @@ def build_world_xml(
     include_placeholder_robot: bool = True,
     visual_rooms: dict[str, Path] | None = None,
     texture_max: int | None = None,
+    human_obj: Path | None = None,
+    object_meshes: dict[str, Path] | None = None,
 ) -> str:
     """The apartment environment MJCF (floor plane + decomposed room hulls,
-    optionally the textured visual rooms in their own geom group).
+    optionally the textured visual rooms in their own geom group) plus the
+    droppable scenario props parked off-map (see OBJECT_KINDS; the human body
+    is included only when human_obj is given, and object_meshes supplies the
+    optional textured visuals for the primitive-collision props).
     texture_max caps the visual textures' resolution (see capped_texture_path)."""
     collision_group = COLLISION_GROUP if visual_rooms else 0
 
@@ -196,6 +231,91 @@ def build_world_xml(
             f'contype="0" conaffinity="0" group="{VISUAL_GROUP}"/>'
         )
 
+    # Droppable props (see OBJECT_KINDS): the human is mesh-backed and optional;
+    # the ball and dog are primitives, always present. Each body carries a
+    # freejoint "{kind}_free" and is parked at OBJECT_PARK[kind].
+    object_assets = ""
+    object_bodies = []
+
+    if human_obj is not None:
+        png = human_obj.with_name(f"{human_obj.stem}_basecolor.png")
+        object_assets += f"""
+    <mesh name="human" file="{human_obj.resolve()}" scale="0.01 0.01 0.01"/>
+    <texture name="tex_human" type="2d" file="{png.resolve()}"/>
+    <material name="mat_human" texture="tex_human" specular="0.1" shininess="0.1"/>"""
+        hx, hy = OBJECT_PARK["human"]
+        # Visual mesh carries no mass/contacts; the auto convex hull collides
+        # (density gives ~70kg) so a dropped body settles on floor/furniture.
+        object_bodies.append(f"""
+    <body name="human" pos="{hx} {hy} 0.3">
+      <freejoint name="human_free"/>
+      <geom name="human_visual" mesh="human" type="mesh" material="mat_human"
+            contype="0" conaffinity="0" group="{VISUAL_GROUP}" density="0"/>
+      <geom name="human_collision" mesh="human" type="mesh" friction="0.9 0.01 0.001"
+            condim="3" margin="0.007" solref="0.02 1" density="500" group="{COLLISION_GROUP}"/>
+    </body>""")
+
+    def prop_visual(kind: str, fallback_rgba: str) -> tuple[str, str, str]:
+        """(assets, visual geom, collision extras) for a primitive-collision
+        prop: with a converted mesh (see convert_objects.py) the textured mesh
+        is the visible surface and the primitive hides in COLLISION_GROUP;
+        without one the primitive itself stays visible."""
+        mesh = (object_meshes or {}).get(kind)
+        if mesh is None:
+            return "", "", f' rgba="{fallback_rgba}"'
+        png = mesh.with_name(f"{mesh.stem}_basecolor.png")
+        assets = f"""
+    <mesh name="{kind}" file="{mesh.resolve()}"/>
+    <texture name="tex_{kind}" type="2d" file="{png.resolve()}"/>
+    <material name="mat_{kind}" texture="tex_{kind}" specular="0.1" shininess="0.1"/>"""
+        visual = f"""
+      <geom name="{kind}_visual" mesh="{kind}" type="mesh" material="mat_{kind}"
+            contype="0" conaffinity="0" group="{VISUAL_GROUP}" density="0"/>"""
+        return assets, visual, f' group="{COLLISION_GROUP}"'
+
+    # Soccer ball: a physics sphere (regulation ~0.11m radius, ~0.43kg via
+    # density). condim 6 adds rolling friction so a kicked ball rolls and
+    # gently stops instead of rolling forever.
+    assets, visual, extras = prop_visual("soccer_ball", "0.9 0.9 0.9 1")
+    object_assets += assets
+    bx, by = OBJECT_PARK["soccer_ball"]
+    object_bodies.append(f"""
+    <body name="soccer_ball" pos="{bx} {by} 0.3">
+      <freejoint name="soccer_ball_free"/>{visual}
+      <geom name="soccer_ball_geom" type="sphere" size="0.11"
+            friction="0.7 0.01 0.002" condim="6" margin="0.007" solref="0.02 1" density="80"{extras}/>
+    </body>""")
+
+    # Labrador: collides as its real shape via CoACD convex pieces (see
+    # convert_objects.py DECOMPOSE) when the bundle ships them -- legs, head
+    # and the gap under the belly are all live; density ~ flesh gives a
+    # realistic ~30kg. Falls back to a bbox box stand-in (~34kg) otherwise.
+    assets, visual, extras = prop_visual("labrador", "0.82 0.68 0.44 1")
+    object_assets += assets
+    dog_mesh = (object_meshes or {}).get("labrador")
+    dog_pieces = sorted(dog_mesh.parent.glob("labrador_collision_*.obj")) if dog_mesh else []
+    if dog_pieces:
+        for i, piece in enumerate(dog_pieces):
+            object_assets += f'\n    <mesh name="labrador_col{i}" file="{piece.resolve()}"/>'
+        dog_collision = "".join(
+            f"""
+      <geom name="labrador_col{i}" mesh="labrador_col{i}" type="mesh" friction="0.9 0.01 0.001"
+            condim="4" margin="0.007" solref="0.02 1" density="1000" group="{COLLISION_GROUP}"/>"""
+            for i in range(len(dog_pieces))
+        )
+    else:
+        dog_collision = f"""
+      <geom name="labrador_geom" type="box" size="0.124 0.5 0.256"
+            friction="0.9 0.01 0.001" condim="4" margin="0.007" solref="0.02 1"
+            density="250"{extras}/>"""
+    dgx, dgy = OBJECT_PARK["labrador"]
+    object_bodies.append(f"""
+    <body name="labrador" pos="{dgx} {dgy} 0.4">
+      <freejoint name="labrador_free"/>{visual}{dog_collision}
+    </body>""")
+
+    object_body_xml = "".join(object_bodies)
+
     robot_body = (
         """
     <body name="robot_base" pos="0 0 0">
@@ -221,7 +341,7 @@ def build_world_xml(
   <statistic center="{lx} {ly} {lz}" extent="{extent}"/>
   <asset>
 {chr(10).join(mesh_lines)}
-{chr(10).join(visual_mesh_lines)}
+{chr(10).join(visual_mesh_lines)}{object_assets}
   </asset>
   <worldbody>
     <light pos="4 -3 6" dir="-4 3 -6" diffuse="1 1 1"/>
@@ -231,7 +351,7 @@ def build_world_xml(
     <body name="apartment" quat="0.7071068 0.7071068 0 0">
 {chr(10).join(geom_lines)}
 {chr(10).join(visual_geom_lines)}
-    </body>{robot_body}
+    </body>{object_body_xml}{robot_body}
   </worldbody>
 </mujoco>
 """

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -127,9 +127,18 @@ class WorldServer:
         with self.lock:
             x, y, yaw = self.sim.pose()
             joints = self.sim.joint_positions()
+            objects = self.sim.object_poses()
             sim_time = float(self.sim.data.time)
         # t = sim clock (playback timeline); wall = shared clock for lag HUDs.
-        payload = json.dumps({"t": sim_time, "wall": time.time(), "pose": [x, y, yaw], "joints": joints})
+        payload = json.dumps(
+            {
+                "t": sim_time,
+                "wall": time.time(),
+                "pose": [x, y, yaw],
+                "joints": joints,
+                "objects": objects,
+            }
+        )
         with self.state_cond:
             self.state_payload = payload
             self.state_seq += 1
@@ -137,16 +146,40 @@ class WorldServer:
 
     def serve_state(self, ws) -> None:
         """One observer connection: push each new state, latest-wins (a slow
-        client skips states instead of queueing lag)."""
-        last_seq = -1
+        client skips states instead of queueing lag). The receive side takes
+        scenario commands ({"op": "drop_object", ...}) -- world manipulation
+        stays on the observer channel, never in the robot's RPC surface."""
+
+        def push() -> None:
+            last_seq = -1
+            try:
+                while True:
+                    with self.state_cond:
+                        self.state_cond.wait_for(lambda seen=last_seq: self.state_seq != seen)
+                        payload, last_seq = self.state_payload, self.state_seq
+                    ws.send(payload)
+            except Exception:  # noqa: BLE001,S110 -- client gone; the stream just ends
+                pass
+
+        threading.Thread(target=push, daemon=True).start()
         try:
-            while True:
-                with self.state_cond:
-                    self.state_cond.wait_for(lambda seen=last_seq: self.state_seq != seen)
-                    payload, last_seq = self.state_payload, self.state_seq
-                ws.send(payload)
-        except Exception:  # noqa: BLE001,S110 -- client gone; the stream just ends
+            for message in ws:
+                self.handle_observer_command(json.loads(message))
+        except Exception:  # noqa: BLE001,S110 -- client gone or bad JSON; drop the connection
             pass
+
+    def handle_observer_command(self, cmd: dict) -> None:
+        op = cmd.get("op")
+        if op == "drop_object":
+            kind = str(cmd.get("kind", "human"))
+            with self.lock:
+                ok = self.sim.drop_object(kind, float(cmd["x"]), float(cmd["y"]), float(cmd["yaw"]))
+            if not ok:
+                print(
+                    f"[world-server] drop_object ignored: '{kind}' not in the world (unknown or asset missing)",
+                    flush=True,
+                )
+            self.publish_state()
 
     # --- renders (main thread only: macOS GL is main-thread-sensitive) ---
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -343,3 +343,5 @@ as-is.
 ### Credits
 
 The apartment environment is derived from ["Appartement"](https://sketchfab.com/3d-models/appartement-6a7a5fe208344b2e8123a88923dbd5b3) by [SrMonteiro](https://sketchfab.com/crispimrafael), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Changes were made: split per room, convex-decomposed for collision, re-exported for rendering (GLB/MuJoCo meshes), and rasterized into a navigation map.
+
+The scenario human is derived from ["Casual Man In Navy T-shirt And Jeans"](https://sketchfab.com/3d-models/casual-man-in-navy-t-shirt-and-jeans-bddc55b5a9d4406b982ec6de9b99531b) by [restore50](https://sketchfab.com/restore50), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Changes were made: converted to a normalized MuJoCo OBJ (y-up centimeters, feet at origin) with the basecolor texture extracted.

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -1256,12 +1256,15 @@ def health_score(level: str) -> float:
 # Directories wholly owned by the published asset bundle: each is replaced
 # atomically on refresh. work/* land under sim/assets/, viewer/* under
 # sim/viewer/. Must stay in sync with sim/tools/publish_assets.py's layout.
+# Keep the work/ entries in sync with publish_assets.py's WORK_DIRS: a dir
+# missing here downloads fine but is silently dropped at extraction.
 SIM_ASSET_UNITS = [
     "work/apartment_split",
     "work/apartment_split_v2",
     "work/apartment_visual",
     "work/sdf_shells",
     "work/map",
+    "work/humans",
     # (The bundle's viewer/public/physics/apartment_sdf is demo-only and not
     # extracted; the hulls feed the webapp's "collisions" overlay.)
     "viewer/public/physics/apartment_collisions_v2",

--- a/sim/sim-assets.lock
+++ b/sim/sim-assets.lock
@@ -1,5 +1,5 @@
 {
-  "tag": "sim-assets-097aa85b3b53",
-  "url": "https://github.com/innate-inc/innate-sim-assets/releases/download/sim-assets-097aa85b3b53/innate-sim-assets-097aa85b3b53.tar.gz",
-  "sha256": "097aa85b3b533fd4fab8bf3f2694b00cfdf579d994016038b968a857ea09f2d8"
+  "tag": "sim-assets-ed27954801fd",
+  "url": "https://github.com/innate-inc/innate-sim-assets/releases/download/sim-assets-ed27954801fd/innate-sim-assets-ed27954801fd.tar.gz",
+  "sha256": "ed27954801fdb0c1375a7db9ce8d183d5560b3893c57757fd894f58cf4f69102"
 }

--- a/sim/tools/convert_objects.py
+++ b/sim/tools/convert_objects.py
@@ -1,0 +1,150 @@
+"""Convert Blender-exported scenario prop OBJs into the MuJoCo convention the
+driver loads (see world.py OBJECT_KINDS): Z-up meters, centered on the bbox
+center, resized to the real-world size below. The basecolor texture is pulled
+out of the matching viewer GLB (Blender's OBJ export writes no textures), so
+the robot cameras see the same object the browser viewer draws.
+
+Kinds listed in DECOMPOSE also get CoACD convex-decomposed collision pieces
+({kind}_collision_*.obj, same body frame) so they collide as their real shape
+rather than a bounding primitive, plus a {kind}_hulls.f32 triangle soup
+written next to the viewer GLBs for the browser's collision overlay (the same
+format as the apartment's hulls.f32; public/models ships wholesale in the
+asset bundle, so it needs no extra staging).
+
+Inputs: a Blender OBJ export (default Y-up / -Z-forward) per prop from the
+source-asset checkout next to this repo (../assets/objects, like the human's
+../assets/humans), plus the viewer GLB in sim/viewer/public/models/. Outputs
+land in sim/assets/objects/ (bundled by publish_assets.py, like humans/).
+
+The Blender scene, its OBJ export, and the viewer GLB must be the SAME
+geometry: the OBJ's bbox defines the physics frame and scene.ts normalizes
+the GLB by its own bbox, so any geometry present in only one of them (e.g.
+deleted scan debris) shifts the two out of alignment.
+
+Usage: cd sim && uv run tools/convert_objects.py
+"""
+
+import io
+import json
+import struct
+import sys
+from pathlib import Path
+
+SIM = Path(__file__).resolve().parent.parent
+SRC_DIR = SIM.parent.parent / "assets" / "objects"
+OUT_DIR = SIM / "assets" / "objects"
+VIEWER_MODELS = SIM / "viewer" / "public" / "models"
+
+# kind -> (blender OBJ, viewer GLB, real-world size in meters of the LONGEST
+# bbox side). Sizes must match world.py's collision primitives and the
+# viewer's scene.ts OBJECTS fitSizeM.
+PROPS = {
+    "soccer_ball": (SRC_DIR / "soccer_ball.obj", VIEWER_MODELS / "soccer_ball.glb", 0.22),
+    "labrador": (SRC_DIR / "dog_fixed.obj", VIEWER_MODELS / "labrador.glb", 1.0),
+}
+
+# kind -> CoACD real-metric concavity threshold (m). The ball stays a sphere
+# primitive (exact and it rolls); the dog gets its true shape -- legs, head,
+# the gap under the belly.
+DECOMPOSE = {"labrador": 0.03}
+
+
+def extract_basecolor(glb_path: Path, out_png: Path) -> None:
+    """Write material 0's baseColor image from a GLB as PNG (MuJoCo textures
+    are PNG-only, so JPEG payloads are converted)."""
+    data = glb_path.read_bytes()
+    assert data[:4] == b"glTF", f"{glb_path} is not a GLB"
+    json_len = struct.unpack("<I", data[12:16])[0]
+    gltf = json.loads(data[20 : 20 + json_len])
+    bin_start = 20 + json_len + 8  # skip the BIN chunk header
+    material = gltf["materials"][0]
+    image_index = gltf["textures"][material["pbrMetallicRoughness"]["baseColorTexture"]["index"]]["source"]
+    image = gltf["images"][image_index]
+    view = gltf["bufferViews"][image["bufferView"]]
+    payload = data[bin_start + view.get("byteOffset", 0) :][: view["byteLength"]]
+
+    if image["mimeType"] == "image/png":
+        out_png.write_bytes(payload)
+    else:
+        from PIL import Image
+
+        Image.open(io.BytesIO(payload)).convert("RGB").save(out_png)
+
+
+def convert_obj(src: Path, dst: Path, size_m: float) -> tuple[float, float, float]:
+    """Rewrite a Blender OBJ (Y-up) as Z-up meters, longest side = size_m,
+    bbox-centered; returns the final (x, y, z) extents for the collision
+    primitive in world.py. Vertices and normals rotate Y-up -> Z-up
+    ((x, y, z) -> (x, -z, y)); texcoords and faces pass through. Object/group/
+    material lines are DROPPED to merge everything into one shape: MuJoCo's
+    OBJ loader keeps only the first object, silently discarding the rest."""
+    verts: list[tuple[float, float, float]] = []
+    lines = src.read_text().splitlines()
+    for line in lines:
+        if line.startswith("v "):
+            x, y, z = (float(c) for c in line.split()[1:4])
+            verts.append((x, -z, y))
+    lo = [min(v[i] for v in verts) for i in range(3)]
+    hi = [max(v[i] for v in verts) for i in range(3)]
+    scale = size_m / max(h - lo_i for h, lo_i in zip(hi, lo, strict=True))
+    center = [(h + lo_i) / 2 for h, lo_i in zip(hi, lo, strict=True)]
+
+    out = [f"# {src.name} converted to sim prop convention (z-up meters, bbox-centered)"]
+    vi = 0
+    for line in lines:
+        if line.startswith("v "):
+            v = [(verts[vi][i] - center[i]) * scale for i in range(3)]
+            vi += 1
+            out.append(f"v {v[0]:.6f} {v[1]:.6f} {v[2]:.6f}")
+        elif line.startswith("vn "):
+            x, y, z = (float(c) for c in line.split()[1:4])
+            out.append(f"vn {x:.4f} {-z:.4f} {y:.4f}")
+        elif line.startswith(("vt ", "f ")):
+            out.append(line)
+    dst.write_text("\n".join(out) + "\n")
+    return tuple((h - lo_i) * scale for h, lo_i in zip(hi, lo, strict=True))  # type: ignore[return-value]
+
+
+def decompose(kind: str, mesh_obj: Path, threshold_m: float) -> int:
+    """CoACD the converted mesh into convex collision pieces (driver side)
+    and one wireframe triangle soup (viewer side); returns the piece count."""
+    import coacd
+    import numpy as np
+    import trimesh
+
+    # preprocess_resolution as in decompose_rooms.py: the default (50) remeshes
+    # a ~1m prop with ~2cm voxels, aliasing thin parts (paws, tail) into
+    # detached junk fragments.
+    mesh = trimesh.load(mesh_obj, process=False, force="mesh")
+    parts = coacd.run_coacd(
+        coacd.Mesh(mesh.vertices, mesh.faces),
+        threshold=threshold_m,
+        real_metric=True,
+        preprocess_resolution=200,
+    )
+
+    for old in OUT_DIR.glob(f"{kind}_collision_*.obj"):
+        old.unlink()
+    soup = []
+    for i, (verts, faces) in enumerate(parts):
+        piece = trimesh.Trimesh(vertices=verts, faces=faces, process=False)
+        piece.export(OUT_DIR / f"{kind}_collision_{i}.obj")
+        soup.append(piece.vertices[piece.faces].reshape(-1, 3))
+    (VIEWER_MODELS / f"{kind}_hulls.f32").write_bytes(np.concatenate(soup).astype(np.float32).tobytes())
+    return len(parts)
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    for kind, (obj_path, glb_path, size_m) in PROPS.items():
+        if not obj_path.exists():
+            sys.exit(f"missing {obj_path} -- export it from Blender first")
+        png = OUT_DIR / f"{kind}_basecolor.png"
+        extract_basecolor(glb_path, png)
+        extents = convert_obj(obj_path, OUT_DIR / f"{kind}.obj", size_m)
+        hulls = f", {decompose(kind, OUT_DIR / f'{kind}.obj', DECOMPOSE[kind])} hulls" if kind in DECOMPOSE else ""
+        print(f"{kind}: extents ({extents[0]:.3f}, {extents[1]:.3f}, {extents[2]:.3f}) m, texture {png.name}{hulls}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/tools/publish_assets.py
+++ b/sim/tools/publish_assets.py
@@ -40,12 +40,13 @@ REPO = (
     "innate-inc/innate-sim-assets"  # dedicated repo: keeps asset tags out of innate-os (robots version-check its tags)
 )
 
-WORK_DIRS = ["apartment_split", "apartment_split_v2", "apartment_visual", "sdf_shells", "map"]
+WORK_DIRS = ["apartment_split", "apartment_split_v2", "apartment_visual", "sdf_shells", "map", "humans", "objects"]
 
 # Kept in sync with sim/README.md's Credits section.
 ATTRIBUTION = (
     "# Attribution\n\n"
-    + 'The apartment environment is derived from ["Appartement"](https://sketchfab.com/3d-models/appartement-6a7a5fe208344b2e8123a88923dbd5b3) by [SrMonteiro](https://sketchfab.com/crispimrafael), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Changes were made: split per room, convex-decomposed for collision, re-exported for rendering (GLB/MuJoCo meshes), and rasterized into a navigation map.'
+    + 'The apartment environment is derived from ["Appartement"](https://sketchfab.com/3d-models/appartement-6a7a5fe208344b2e8123a88923dbd5b3) by [SrMonteiro](https://sketchfab.com/crispimrafael), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Changes were made: split per room, convex-decomposed for collision, re-exported for rendering (GLB/MuJoCo meshes), and rasterized into a navigation map.\n\n'
+    + 'The scenario human is derived from ["Casual Man In Navy T-shirt And Jeans"](https://sketchfab.com/3d-models/casual-man-in-navy-t-shirt-and-jeans-bddc55b5a9d4406b982ec6de9b99531b) by [restore50](https://sketchfab.com/restore50), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Changes were made: converted to a normalized MuJoCo OBJ (y-up centimeters, feet at origin) with the basecolor texture extracted.'
 )
 VIEWER_CARRYOVER = ["public/models", "public/robot", "assets/apartment_obj"]
 
@@ -188,7 +189,8 @@ def main() -> None:
                     f"Sim asset bundle ({n_files} files). Fetched by the launcher via sim/sim-assets.lock; "
                     f"regenerate with sim/tools/ (see sandbox/README.md), republish with tools/publish_assets.py. "
                     f"Apartment model: 'Appartement' by SrMonteiro (sketchfab.com/crispimrafael), CC BY 4.0; "
-                    f"see ATTRIBUTION.md in the bundle.",
+                    f"human model: 'Casual Man In Navy T-shirt And Jeans' by restore50 (sketchfab.com/restore50), "
+                    f"CC BY 4.0; see ATTRIBUTION.md in the bundle.",
                 ],
                 check=True,
             )

--- a/sim/viewer/src/physics/worldStateController.ts
+++ b/sim/viewer/src/physics/worldStateController.ts
@@ -12,6 +12,9 @@ export interface WorldState {
   y: number;
   yaw: number;
   joints: Record<string, number>;
+  /** Ground truth of every dropped scenario prop, keyed by kind (human,
+   * soccer_ball, labrador): [x, y, z, qw, qx, qy, qz]. Empty until a drop. */
+  objects: Record<string, number[]>;
 }
 
 export class WorldStateController {
@@ -61,6 +64,12 @@ export class WorldStateController {
     await this.#open;
   }
 
+  /** Send a scenario command up the observer socket (e.g. drop_object);
+   * dropped silently while the socket is (re)connecting. */
+  send(cmd: object): void {
+    if (this.#ws.readyState === WebSocket.OPEN) this.#ws.send(JSON.stringify(cmd));
+  }
+
   dispose(): void {
     this.#disposed = true;
     this.#ws.close();
@@ -72,10 +81,19 @@ export class WorldStateController {
       wall: number;
       pose: [number, number, number];
       joints: Record<string, number>;
+      objects?: Record<string, number[]> | null;
     };
     const joints = msg.joints;
     // joint6M: the gripper's mirrored finger (URDF mimic of joint6, x-1).
     joints["joint6M"] = -(joints["joint6"] ?? 0);
-    this.onState?.({ t: msg.t, wall: msg.wall, x: msg.pose[0], y: msg.pose[1], yaw: msg.pose[2], joints });
+    this.onState?.({
+      t: msg.t,
+      wall: msg.wall,
+      x: msg.pose[0],
+      y: msg.pose[1],
+      yaw: msg.pose[2],
+      joints,
+      objects: msg.objects ?? {},
+    });
   }
 }

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -18,6 +18,53 @@ const APARTMENT_URL = "/models/appartement.glb";
 const APARTMENT_MANIFEST_URL = "/models/apartment/manifest.json";
 const ROBOT_URDF_URL = "/robot/mars.urdf";
 
+// Droppable scenario props (world.py OBJECT_KINDS / core.drop_object): the
+// browser draws a GLB for each at its MuJoCo body's ground-truth pose. Each
+// model is normalized into the SAME local frame its physics body uses, so the
+// one pose quaternion orients both identically:
+//   - human: MuJoCo loads its OBJ Y-up with feet at the origin; the GLB shares
+//     that convention, so it is NOT rotated Y-up->Z-up and its feet sit at the
+//     origin (identity quat -> lying on its back).
+//   - ball/dog: their MuJoCo geoms are primitives centered on the body origin,
+//     so the GLB is rotated Y-up->Z-up (standard glTF) and centered; sizes
+//     match the sphere diameter / box footprint in world.py.
+interface ObjectDef {
+  url: string;
+  rotateToZUp: boolean; // standard glTF Y-up -> scene Z-up (false for the human)
+  fitSizeM: number; // rescale so fitDim spans this many meters
+  fitDim: "height" | "max"; // "height" = up-axis extent (human); "max" = largest bbox side
+  origin: "base" | "center"; // where the body origin sits: feet-down vs geometric center
+  /** The prop's MuJoCo collision shape (world.py's geoms, body frame), drawn
+   * as a wireframe when the collision overlay is on: a primitive, or a "soup"
+   * of CoACD hull triangles (float32 xyz, written by convert_objects.py next
+   * to the GLBs). The human has none here: it collides as the convex hull of
+   * its visual mesh. */
+  collision?:
+    | { type: "sphere"; radius: number }
+    | { type: "box"; size: [number, number, number] }
+    | { type: "soup"; url: string };
+}
+
+const OBJECTS: Record<string, ObjectDef> = {
+  human: { url: "/models/human.glb", rotateToZUp: false, fitSizeM: 1.727, fitDim: "height", origin: "base" },
+  soccer_ball: {
+    url: "/models/soccer_ball.glb",
+    rotateToZUp: true,
+    fitSizeM: 0.22,
+    fitDim: "max",
+    origin: "center",
+    collision: { type: "sphere", radius: 0.11 },
+  },
+  labrador: {
+    url: "/models/labrador.glb",
+    rotateToZUp: true,
+    fitSizeM: 1.0,
+    fitDim: "max",
+    origin: "center",
+    collision: { type: "soup", url: "/models/labrador_hulls.f32" },
+  },
+};
+
 /** Per-room split written by tools/split-apartment.mjs. bbox is in the glb's
  * Y-up frame (the whole apartment is rotated Y-up -> Z-up on load). */
 interface ApartmentManifest {
@@ -115,6 +162,17 @@ export class SimScene {
   // Set by the first spawnAt: after that the camera belongs to the robot, and
   // the layout overview framing must not yank it away.
   private spawned = false;
+  // One posed GLB per dropped prop (see OBJECTS); each loads lazily on its
+  // first real pose. The collision wireframes ride along under the same
+  // roots, toggled with the apartment hull overlay.
+  private objectRoots = new Map<string, THREE.Group>();
+  private objectPromises = new Map<string, Promise<void>>();
+  private objectHulls: THREE.Mesh[] = [];
+  private hullMaterial = new THREE.MeshBasicMaterial({ color: 0x00ff88, wireframe: true });
+
+  /** While true the orbit controls stay off even in the orbit view -- a
+   * placement drag (drop-object picker) owns the pointer. */
+  placementMode = false;
 
   /** Fixed render size (offscreen use, e.g. SimSession); null = track the window. */
   private fixedSize: { width: number; height: number } | null = null;
@@ -234,13 +292,14 @@ export class SimScene {
       });
     }
     if (this.hullsGroup) this.hullsGroup.visible = visible;
+    for (const hull of this.objectHulls) hull.visible = visible;
   }
 
   private async loadCollisionHulls(): Promise<void> {
     const group = new THREE.Group();
     group.rotation.x = Math.PI / 2;
     const baseUrl = "/physics/apartment_collisions_v2/";
-    const material = new THREE.MeshBasicMaterial({ color: 0x00ff88, wireframe: true });
+    const material = this.hullMaterial;
 
     // Fast path: one binary triangle soup (float32 xyz), one fetch, no
     // parsing -- publish_assets writes it next to the per-hull OBJs.
@@ -531,12 +590,124 @@ export class SimScene {
    * Falls back to orbit if the requested view's frame wasn't in the URDF. */
   setView(view: CameraView): void {
     this.activeView = view === "orbit" || this.robotCameras.has(view) ? view : "orbit";
-    this.controls.enabled = this.activeView === "orbit";
+    this.controls.enabled = this.activeView === "orbit" && !this.placementMode;
   }
 
   /** Drive the URDF's arm/head joints to match physics-simulated angles (radians). */
   setJointAngles(joints: Record<string, number>): void {
     this.robot?.setJointValues(joints);
+  }
+
+  /** Mirror every dropped scenario prop from ground truth, keyed by kind
+   * ({kind: [x, y, z, qw, qx, qy, qz]}, the same quat MuJoCo applies to each
+   * body). Kinds absent from the map are hidden; each GLB loads lazily on its
+   * first real pose. */
+  setObjectPoses(poses: Record<string, number[]>): void {
+    for (const kind of Object.keys(OBJECTS)) {
+      const pose = poses[kind];
+      if (!pose) {
+        const root = this.objectRoots.get(kind);
+        if (root) root.visible = false;
+        continue;
+      }
+      if (!this.objectPromises.has(kind)) {
+        this.objectPromises.set(
+          kind,
+          this.loadObject(kind).catch((err) => console.error(`[sim-viewer] object '${kind}' failed to load:`, err)),
+        );
+      }
+      const root = this.objectRoots.get(kind);
+      if (!root) continue; // still loading; the next state places it
+      root.visible = true;
+      root.position.set(pose[0], pose[1], pose[2]);
+      root.quaternion.set(pose[4], pose[5], pose[6], pose[3]);
+    }
+  }
+
+  private async loadObject(kind: string): Promise<void> {
+    const def = OBJECTS[kind];
+    const gltf = await new GLTFLoader().loadAsync(def.url);
+    this.normalizeModel(gltf.scene, def);
+    gltf.scene.traverse((obj) => {
+      if (obj instanceof THREE.Mesh) {
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+      }
+    });
+    const root = new THREE.Group();
+    root.visible = false;
+    root.add(gltf.scene);
+    if (def.collision) {
+      let geometry: THREE.BufferGeometry | null = null;
+      if (def.collision.type === "sphere") {
+        geometry = new THREE.SphereGeometry(def.collision.radius, 16, 12);
+      } else if (def.collision.type === "box") {
+        geometry = new THREE.BoxGeometry(...(def.collision.size.map((s) => s * 2) as [number, number, number]));
+      } else {
+        // CoACD hull soup, already in the body frame (see convert_objects.py).
+        const res = await fetch(def.collision.url);
+        if (res.ok) {
+          geometry = new THREE.BufferGeometry();
+          geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(await res.arrayBuffer()), 3));
+        } else {
+          console.warn(`[sim-viewer] collision soup missing for '${kind}' (${res.status}); overlay skipped`);
+        }
+      }
+      if (geometry) {
+        const hull = new THREE.Mesh(geometry, this.hullMaterial);
+        hull.visible = this.hullsVisible; // honor a toggle made before the drop
+        this.objectHulls.push(hull);
+        root.add(hull);
+      }
+    }
+    this.objectRoots.set(kind, root);
+    this.scene.add(root);
+  }
+
+  /** Rescale + re-origin a raw GLB into its MuJoCo body's local frame (GLB
+   * exports bake arbitrary origins, orientations, and unit scales). See
+   * OBJECTS for each kind's convention. */
+  private normalizeModel(scene: THREE.Object3D, def: ObjectDef): void {
+    if (def.rotateToZUp) scene.rotation.x = Math.PI / 2; // glTF Y-up -> scene Z-up
+    scene.updateMatrixWorld(true);
+    const box = new THREE.Box3().setFromObject(scene);
+    const size = box.getSize(new THREE.Vector3());
+    const upExtent = def.rotateToZUp ? size.z : size.y;
+    const span = def.fitDim === "max" ? Math.max(size.x, size.y, size.z) : upExtent;
+    scene.scale.multiplyScalar(def.fitSizeM / span);
+
+    // Re-measure post-scale to place the origin.
+    scene.updateMatrixWorld(true);
+    const scaled = new THREE.Box3().setFromObject(scene);
+    const center = scaled.getCenter(new THREE.Vector3());
+    if (def.origin === "center") {
+      scene.position.sub(center);
+    } else {
+      // base: centered in the ground plane, up-axis min sitting at the origin.
+      scene.position.x -= center.x;
+      if (def.rotateToZUp) {
+        scene.position.y -= center.y;
+        scene.position.z -= scaled.min.z;
+      } else {
+        scene.position.z -= center.z;
+        scene.position.y -= scaled.min.y;
+      }
+    }
+  }
+
+  /** Intersect a canvas pointer position with the floor plane (z=0) through
+   * the active view's camera; null when it points above the horizon. */
+  screenToFloor(clientX: number, clientY: number): THREE.Vector3 | null {
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    const ndc = new THREE.Vector2(
+      ((clientX - rect.left) / rect.width) * 2 - 1,
+      -((clientY - rect.top) / rect.height) * 2 + 1,
+    );
+    const cam = (this.activeView !== "orbit" ? this.robotCameras.get(this.activeView) : undefined) ?? this.camera;
+    const raycaster = new THREE.Raycaster();
+    raycaster.setFromCamera(ndc, cam);
+    const hit = new THREE.Vector3();
+    return raycaster.ray.intersectPlane(new THREE.Plane(new THREE.Vector3(0, 0, 1), 0), hit) ? hit : null;
   }
 
   // Orange accent for the arm links (see ORANGE_LINKS). Cached so every mesh

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -67,7 +67,14 @@ export class SimSession {
   #stageReady = false;
 
   // Ground-truth snapshots on the sim clock.
-  #samples: { t: number; x: number; y: number; yaw: number; joints: Record<string, number> }[] = [];
+  #samples: {
+    t: number;
+    x: number;
+    y: number;
+    yaw: number;
+    joints: Record<string, number>;
+    objects: Record<string, number[]>;
+  }[] = [];
   #gaps: number[] = []; // recent inter-arrival gaps: sizes the playback delay
   #lastArrival = 0;
   // Playback position on the sim clock (see tick).
@@ -157,11 +164,11 @@ export class SimSession {
 
       const last = this.#samples[this.#samples.length - 1];
       if (last === undefined || s.t > last.t) {
-        this.#samples.push({ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints });
+        this.#samples.push({ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints, objects: s.objects });
         if (this.#samples.length > 60) this.#samples.shift();
       } else if (s.t < last.t - 0.5) {
         // Sim clock jumped backwards (world-server restart): restart playback.
-        this.#samples = [{ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints }];
+        this.#samples = [{ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints, objects: s.objects }];
         this.#playT = null;
       }
       this.#live = true;
@@ -217,6 +224,13 @@ export class SimSession {
   setCollisionHullsVisible(on: boolean): void {
     this.#hullsOn = on;
     this.#overlaysDirty = true;
+  }
+
+  /** Drop a scenario prop (see scene.ts OBJECTS: human, soccer_ball,
+   * labrador) above (x, y), yawed about +z; the world server's physics settles
+   * it onto whatever is below (stage "drop object" picker). */
+  dropObject(kind: string, x: number, y: number, yaw: number): void {
+    this.#controller?.send({ op: "drop_object", kind, x, y, yaw });
   }
 
   // WebRTC-specific surface: harmless no-ops in sim.
@@ -293,6 +307,9 @@ export class SimSession {
       joints[name] = va + (vb - va) * u;
     }
     scene.setJointAngles(joints);
+    // No interpolation for the props: 75Hz raw samples are smooth enough even
+    // during a fall, and they're static almost all the time.
+    scene.setObjectPoses(b.objects);
 
     if (this.#overlaysDirty) {
       this.#overlaysDirty = false;

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -4,6 +4,7 @@
 // full-res every frame, PiP thumbnails scissor-rendered from the same GL
 // context and blitted out.
 
+import * as THREE from "three";
 import { SimScene, type CameraView } from "./scene";
 import { LoadQueue } from "./loadQueue";
 import { THUMB_H, THUMB_W, type SimSession } from "./simSession";
@@ -17,6 +18,14 @@ const THUMB_FRAME_DIV = 2;
 const MIN_FRAME_MS = 1000 / 62;
 
 const VIEW_FOR: Record<string, CameraView> = { main: "main", arm: "arm", orbit: "orbit" };
+
+// Droppable props offered by the placement picker; kind matches world.py
+// OBJECT_KINDS and scene.ts OBJECTS.
+const DROP_KINDS: { kind: string; label: string }[] = [
+  { kind: "human", label: "🧍" },
+  { kind: "soccer_ball", label: "⚽" },
+  { kind: "labrador", label: "🐕" },
+];
 
 export function createSimStage(parent: HTMLElement, session: SimSession): { audioEl: null; destroy: () => void } {
   const wrap = document.createElement("div");
@@ -41,7 +50,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   chips.style.cssText = "display:flex;gap:6px;";
   const OFF_BG = "rgba(0,0,0,.45)";
   const ON_BG = "rgba(0,255,136,.22)";
-  const addChip = (label: string, onToggle: (on: boolean) => void) => {
+  const addChip = (label: string, onToggle: (on: boolean) => void): ((on: boolean) => void) => {
     const b = document.createElement("button");
     b.type = "button";
     b.textContent = label;
@@ -50,16 +59,34 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
       `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
       "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
     let on = false;
-    b.onclick = () => {
-      on = !on;
+    const set = (next: boolean) => {
+      on = next;
       b.style.background = on ? ON_BG : OFF_BG;
       b.style.color = on ? "#7dffc4" : "rgba(255,255,255,.75)";
+    };
+    b.onclick = () => {
+      set(!on);
       onToggle(on);
     };
     chips.appendChild(b);
+    return set;
   };
   addChip("lidar", (on) => session.setLidarVisible(on));
   addChip("collisions", (on) => session.setCollisionHullsVisible(on));
+  // Drop-object picker: one chip per prop (world.py OBJECT_KINDS). Selecting a
+  // kind arms placement for it; the others disarm (mutually exclusive). A
+  // stepping stone toward per-challenge UI -- for now it just seeds the world.
+  const dropLabel = document.createElement("span");
+  dropLabel.textContent = "drop";
+  dropLabel.style.cssText = "align-self:center;color:rgba(255,255,255,.5);font:500 11px system-ui;margin-left:4px;";
+  chips.appendChild(dropLabel);
+  const dropChipSetters = new Map<string, (on: boolean) => void>();
+  for (const { kind, label } of DROP_KINDS) {
+    dropChipSetters.set(
+      kind,
+      addChip(label, (on) => armDrop(on ? kind : null)),
+    );
+  }
   debugStack.appendChild(chips);
 
   // Loading indicator: a compact pill holding a progress bar, centered just
@@ -143,6 +170,54 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
 
   const scene = new SimScene(canvas, { fixedSize: { width: parent.clientWidth || 1280, height: parent.clientHeight || 720 } });
   scene.followCamera = true;
+
+  // Drop-object placement: while a kind is armed the orbit controls are paused
+  // -- press marks the spot on the floor, drag points the yaw (arrow preview,
+  // the human's head), release drops that body there and physics settles it.
+  let armedKind: string | null = null;
+  let dropStart: THREE.Vector3 | null = null;
+  let dropArrow: THREE.ArrowHelper | null = null;
+  const clearDropDrag = () => {
+    dropStart = null;
+    if (dropArrow) {
+      scene.scene.remove(dropArrow);
+      dropArrow.dispose();
+      dropArrow = null;
+    }
+  };
+  const armDrop = (kind: string | null) => {
+    armedKind = kind;
+    scene.placementMode = kind !== null;
+    canvas.style.cursor = kind !== null ? "crosshair" : "";
+    for (const [k, set] of dropChipSetters) set(k === kind); // reflect the armed kind, disarm the rest
+    if (kind === null) clearDropDrag();
+  };
+  canvas.addEventListener("pointerdown", (e) => {
+    if (armedKind === null || e.button !== 0) return;
+    dropStart = scene.screenToFloor(e.clientX, e.clientY);
+  });
+  canvas.addEventListener("pointermove", (e) => {
+    if (!dropStart) return;
+    const cur = scene.screenToFloor(e.clientX, e.clientY);
+    if (!cur) return;
+    const drag = cur.sub(dropStart).setZ(0);
+    if (drag.length() < 0.05) return;
+    if (!dropArrow) {
+      dropArrow = new THREE.ArrowHelper(drag.clone().normalize(), dropStart.clone().setZ(0.05), 1, 0xff8800, 0.25, 0.15);
+      scene.scene.add(dropArrow);
+    }
+    dropArrow.setDirection(drag.clone().normalize());
+    dropArrow.setLength(Math.max(drag.length(), 0.4), 0.25, 0.15);
+  });
+  canvas.addEventListener("pointerup", (e) => {
+    if (armedKind === null || !dropStart) return;
+    const end = scene.screenToFloor(e.clientX, e.clientY);
+    const drag = end ? end.sub(dropStart).setZ(0) : new THREE.Vector3();
+    // An identity drop faces +y (the human's head); the drag vector is that direction.
+    const yaw = drag.length() > 0.2 ? Math.atan2(drag.y, drag.x) - Math.PI / 2 : 0;
+    session.dropObject(armedKind, dropStart.x, dropStart.y, yaw);
+    armDrop(null);
+  });
 
   const resize = () => {
     const w = wrap.clientWidth;


### PR DESCRIPTION
## Summary

Split out of #601 (part 1 of 3). Adds three free-jointed props to the apartment world and a way to place them, with **no challenge/judging layer** on top — that lands in the stacked follow-up.

**Driver**
- `world.py`: `OBJECT_KINDS`/`OBJECT_MESHES`/`OBJECT_PARK`/`OBJECT_DROP_Z`, one body per prop in `build_world_xml`, parked off-map until dropped. The human is a posed scan colliding as its own convex hull; the ball is a sphere primitive (`condim 6`, so a kicked ball rolls and settles) and the dog collides via CoACD pieces — both with the textured mesh drawn over them, so the robot cameras see what the viewer draws.
- `core.drop_object()` teleports a prop above `(x, y)` with a yaw and lets physics settle it; `object_poses()` publishes ground truth for everything dropped. Meshes are optional — older asset bundles fall back to bare primitives.
- `world_server` publishes `objects` in the observer state stream, and `serve_state`'s receive side now takes scenario commands (`{"op": "drop_object", ...}`). World manipulation stays on the observer channel and out of the robot's RPC surface.

**Assets**
- `sim/tools/convert_objects.py` converts the Blender exports to the MuJoCo convention (Z-up meters, bbox-centered), pulls the basecolor out of the viewer GLB, and CoACD-decomposes the dog into collision pieces plus a wireframe soup for the browser overlay.
- `publish_assets.py` bundles `humans/` and `objects/`; lock repinned; the human model is credited per CC BY 4.0.

**Viewer**
- `scene.ts` draws a GLB per dropped prop at its MuJoCo pose, normalized into the same body frame physics uses, with collision wireframes on the existing "collisions" toggle.
- `simStage.ts` gains a drop picker: pick a kind, press to mark the spot, drag to point the yaw, release to drop.

## Stack

1. **this PR** — props + drop command
2. #604 — challenge engine (based on this branch)
3. #603 — unrelated dev-experience docs, independent

Based on the same commit as #601 (`504f0d0b`), so the diff is exactly the prop half of that PR. `origin/main` has since merged #577, which touches the same sim files — a rebase is still needed and is not part of this split.

## Known open review items (carried over from #601, deliberately not fixed here)

- [ ] `SIM_ASSET_UNITS` in `sim/launcher/runtime.py` gains `work/humans` but **not** `work/objects`, while `publish_assets.py` publishes both. `ensure_sim_assets` only moves listed units out of staging, so the ball/dog meshes and collision pieces are silently discarded — MuJoCo falls back to a bare sphere/box while the browser still draws the real GLBs.
- [ ] `scene.placementMode` is assigned by `armDrop()` but only read inside `setView()`, so orbit controls are never actually paused during a placement drag (and can get stuck disabled if the view changes while armed).

## Validation

- [x] `ruff check` / `ruff format --check` clean (three E741s in `convert_objects.py` fixed — they were failing `format` on #601).
- [x] `tsc --noEmit` clean in `sim/viewer`.
- [ ] Not yet run against a live `./innate-sim up`.