### PR TITLE
docs(sim): everyday commands + innate CLI tab completions in the container

### DIFF
--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -122,10 +122,16 @@ export PATH="/root/innate-os/scripts:$PATH"  # put the `innate` developer CLI on
 # into the developer's checkout). This block runs after oh-my-zsh's compinit, so
 # re-run it to pick up the completions dir added to fpath.
 fpath=("/root/.zsh/completions" $fpath)
-if [ -f /root/innate-os/scripts/innate ] && [ ! -s /root/.zsh/completions/_innate ]; then
+# Regenerate when the cached file is missing/empty, or older than the CLI it was
+# generated from: `innate update` and plain `git pull` both rewrite scripts/innate
+# through the bind mount, and a pure existence guard would serve its stale
+# completions for the rest of the container's life.
+if [ -f /root/innate-os/scripts/innate ] && \
+   { [ ! -s /root/.zsh/completions/_innate ] || \
+     [ /root/innate-os/scripts/innate -nt /root/.zsh/completions/_innate ]; }; then
     mkdir -p /root/.zsh/completions
     # Generate through a temp file so an interrupted or failing run leaves no
-    # partial _innate behind — the guard above would treat it as done and no
+    # partial _innate behind — the guard above would treat it as current and no
     # later shell would retry.
     innate_comp_tmp=$(mktemp /root/.zsh/completions/innate-completions.XXXXXX)
     if /root/innate-os/scripts/innate completions > "$innate_comp_tmp" 2>/dev/null && [ -s "$innate_comp_tmp" ]; then

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -113,6 +113,17 @@ RUN cat >> /root/.zshrc <<'EOF'
 export INNATE_OS_ROOT=/root/innate-os
 export CCACHE_DIR=/root/.cache/ccache
 export PATH="/root/innate-os/scripts:$PATH"  # put the `innate` developer CLI on PATH
+
+# Tab completions for the `innate` CLI (mirrors scripts/update/post_update.sh).
+# scripts/ is bind-mounted at runtime, so generate on first login rather than at
+# build time. This block runs after oh-my-zsh's compinit, so re-run it to pick up
+# the completions dir added to fpath.
+fpath=("/root/innate-os/scripts/build/completions" $fpath)
+if [ -f /root/innate-os/scripts/innate ] && [ ! -f /root/innate-os/scripts/build/completions/_innate ]; then
+    mkdir -p /root/innate-os/scripts/build/completions
+    /root/innate-os/scripts/innate completions > /root/innate-os/scripts/build/completions/_innate 2>/dev/null
+fi
+autoload -Uz compinit && compinit
 EOF
 
 WORKDIR /root/innate-os

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -124,23 +124,17 @@ export PATH="/root/innate-os/scripts:$PATH"  # put the `innate` developer CLI on
 # exist at image build time, so this runs on login, not in a RUN layer. It lands
 # after oh-my-zsh's compinit, hence the second compinit to pick up the new fpath.
 fpath=("/root/.zsh/completions" $fpath)
-# Regenerate when the cached file is missing/empty, or older than the CLI it was
-# generated from: `innate update` and plain `git pull` both rewrite scripts/innate
-# through the bind mount, and a pure existence guard would serve its stale
-# completions for the rest of the container's life.
-if [ -f /root/innate-os/scripts/innate ] && \
-   { [ ! -s /root/.zsh/completions/_innate ] || \
-     [ /root/innate-os/scripts/innate -nt /root/.zsh/completions/_innate ]; }; then
+# Generation costs ~60ms, so just regenerate every shell instead of tracking
+# whether scripts/innate has outrun the cached file. Written through a temp
+# file and renamed into place because the sim's tmux session opens nine windows
+# at once and every one of them sources this: a plain `>` would let them
+# truncate the file out from under each other's compinit. Capped at 3s (50x the
+# nominal cost) and stderr to a log -- this is in the login path of every shell
+# now, so a wedged generator must not be able to wedge the shell with it.
+if [ -f /root/innate-os/scripts/innate ]; then
     mkdir -p /root/.zsh/completions
-    # Generate through a temp file so an interrupted or failing run leaves no
-    # partial _innate behind — the guard above would treat it as current and no
-    # later shell would retry.
     innate_comp_tmp=$(mktemp /root/.zsh/completions/innate-completions.XXXXXX)
-    # Time-capped because this sits in the login path: a hung generator would
-    # otherwise hang every new shell. Stderr goes to a log next to the output
-    # rather than the terminal -- failing silently with no breadcrumb is worse
-    # than a file nobody reads.
-    if timeout 30 /root/innate-os/scripts/innate completions \
+    if timeout 3 /root/innate-os/scripts/innate completions \
            > "$innate_comp_tmp" 2>/root/.zsh/innate-completions.log \
        && [ -s "$innate_comp_tmp" ]; then
         mv "$innate_comp_tmp" /root/.zsh/completions/_innate

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -116,12 +116,24 @@ export PATH="/root/innate-os/scripts:$PATH"  # put the `innate` developer CLI on
 
 # Tab completions for the `innate` CLI (mirrors scripts/update/post_update.sh).
 # scripts/ is bind-mounted at runtime, so generate on first login rather than at
-# build time. This block runs after oh-my-zsh's compinit, so re-run it to pick up
-# the completions dir added to fpath.
-fpath=("/root/innate-os/scripts/build/completions" $fpath)
-if [ -f /root/innate-os/scripts/innate ] && [ ! -f /root/innate-os/scripts/build/completions/_innate ]; then
-    mkdir -p /root/innate-os/scripts/build/completions
-    /root/innate-os/scripts/innate completions > /root/innate-os/scripts/build/completions/_innate 2>/dev/null
+# build time. The generated file lives under /root rather than in the bind mount:
+# the mount carries the host user's ownership, and compinit's security audit
+# rejects an fpath entry root doesn't own (and we'd be dropping root-owned files
+# into the developer's checkout). This block runs after oh-my-zsh's compinit, so
+# re-run it to pick up the completions dir added to fpath.
+fpath=("/root/.zsh/completions" $fpath)
+if [ -f /root/innate-os/scripts/innate ] && [ ! -s /root/.zsh/completions/_innate ]; then
+    mkdir -p /root/.zsh/completions
+    # Generate through a temp file so an interrupted or failing run leaves no
+    # partial _innate behind — the guard above would treat it as done and no
+    # later shell would retry.
+    innate_comp_tmp=$(mktemp /root/.zsh/completions/innate-completions.XXXXXX)
+    if /root/innate-os/scripts/innate completions > "$innate_comp_tmp" 2>/dev/null && [ -s "$innate_comp_tmp" ]; then
+        mv "$innate_comp_tmp" /root/.zsh/completions/_innate
+    else
+        rm -f "$innate_comp_tmp"
+    fi
+    unset innate_comp_tmp
 fi
 autoload -Uz compinit && compinit
 EOF

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -114,13 +114,15 @@ export INNATE_OS_ROOT=/root/innate-os
 export CCACHE_DIR=/root/.cache/ccache
 export PATH="/root/innate-os/scripts:$PATH"  # put the `innate` developer CLI on PATH
 
-# Tab completions for the `innate` CLI (mirrors scripts/update/post_update.sh).
-# scripts/ is bind-mounted at runtime, so generate on first login rather than at
-# build time. The generated file lives under /root rather than in the bind mount:
-# the mount carries the host user's ownership, and compinit's security audit
-# rejects an fpath entry root doesn't own (and we'd be dropping root-owned files
-# into the developer's checkout). This block runs after oh-my-zsh's compinit, so
-# re-run it to pick up the completions dir added to fpath.
+# Tab completions for the `innate` CLI — the container's answer to what
+# scripts/update/post_update.sh does on a physical robot, but deliberately NOT
+# to the same path: post_update writes scripts/build/completions, and here
+# scripts/ is a bind mount carrying the host user's ownership, which compinit's
+# security audit rejects for an fpath entry root doesn't own (and generating
+# there would drop root-owned files into the developer's checkout). So the file
+# lives under /root instead. The bind mount also means scripts/innate does not
+# exist at image build time, so this runs on login, not in a RUN layer. It lands
+# after oh-my-zsh's compinit, hence the second compinit to pick up the new fpath.
 fpath=("/root/.zsh/completions" $fpath)
 # Regenerate when the cached file is missing/empty, or older than the CLI it was
 # generated from: `innate update` and plain `git pull` both rewrite scripts/innate
@@ -134,7 +136,13 @@ if [ -f /root/innate-os/scripts/innate ] && \
     # partial _innate behind — the guard above would treat it as current and no
     # later shell would retry.
     innate_comp_tmp=$(mktemp /root/.zsh/completions/innate-completions.XXXXXX)
-    if /root/innate-os/scripts/innate completions > "$innate_comp_tmp" 2>/dev/null && [ -s "$innate_comp_tmp" ]; then
+    # Time-capped because this sits in the login path: a hung generator would
+    # otherwise hang every new shell. Stderr goes to a log next to the output
+    # rather than the terminal -- failing silently with no breadcrumb is worse
+    # than a file nobody reads.
+    if timeout 30 /root/innate-os/scripts/innate completions \
+           > "$innate_comp_tmp" 2>/root/.zsh/innate-completions.log \
+       && [ -s "$innate_comp_tmp" ]; then
         mv "$innate_comp_tmp" /root/.zsh/completions/_innate
     else
         rm -f "$innate_comp_tmp"

--- a/sim/README.md
+++ b/sim/README.md
@@ -254,10 +254,10 @@ and restarts in one step.
 
 The trap is the simulated world itself — `mars_sim_driver`'s `world.py`,
 `core.py` and `world_server.py`. That process runs on the **host**, outside
-the container, on every platform (in-container rendering was far too slow to
-be usable), importing straight from your checkout. `innate build` rebuilds
-the container's copy, but the world server never loads it. Restart that one
-from the host: `./innate-sim down && ./innate-sim up`.
+the container, on every platform, importing straight from your checkout.
+`innate build` rebuilds the container's copy, but the world server never
+loads it. Restart that one from the host:
+`./innate-sim down && ./innate-sim up`.
 
 `innate view` is the fastest way to see why a node is unhappy: the tmux
 session has one window per subsystem (zenoh, rosbridge-app, sim-driver,

--- a/sim/README.md
+++ b/sim/README.md
@@ -226,8 +226,54 @@ robot on Wi-Fi**, where those topics are too large to stream smoothly; there you
 use the lighter `/mars/main_camera/remote/*` topics instead. See
 [Foxglove](../README.md#foxglove) in the main README for that case.
 
-Prefer your own ROS tooling? A rosbridge server is also available at
-`ws://localhost:9090`.
+### Everyday commands
+
+```bash
+./innate-sim status      # startup checks + health snapshot
+./innate-sim logs        # startup logs; `logs os` / `logs agent` follow live
+./innate-sim sh          # shell into the container (see next section)
+./innate-sim down        # stop
+./innate-sim clean       # remove containers/volumes (keeps .env + config)
+```
+
+### Working on the robot code
+
+`./innate-sim sh` drops you into the container, where the same `innate` CLI
+as on a real robot manages the ROS stack. Your checkout is bind-mounted into
+it (`ros2_ws/`, `workspace/`, `scripts/`, `config/`), so files you edit on
+the host are immediately visible inside — you only choose how to reload them:
+
+```bash
+innate                   # status: mode, node health, command hints
+innate view              # attach the tmux session running the stack (Ctrl-b d to detach)
+innate restart           # stop + relaunch all ROS nodes (no rebuild)
+innate build             # stop nodes, colcon-build ros2_ws, restart
+innate build <pkg…>      # same, but only the named packages (faster)
+innate build release     # optimized build (CMAKE_BUILD_TYPE=Release)
+innate skill list        # skills the brain currently offers
+innate skill run <id> @param=value   # trigger a skill from the shell
+```
+
+Which one you need depends on what you changed:
+
+- **`workspace/` agents & skills, `config/` parameters** — not compiled;
+  `innate restart` is enough.
+- **`ros2_ws/` packages** (nodes, messages, drivers) — `colcon` installs a
+  copy, so edits need `innate build` (which restarts for you). Passing the
+  package name (`innate build mars_nav`) keeps the cycle short.
+- **The simulated world itself** (`mars_sim_driver`'s `world.py` / `core.py` /
+  `world_server.py`) — on macOS the physics/render process runs on the
+  *host*, outside the container, importing straight from your checkout.
+  `innate build` doesn't touch it; restart it from the host instead:
+  `pkill -f mars_sim_driver.world_server && ./innate-sim up`.
+
+`innate view` is the fastest way to see why a node is unhappy: the tmux
+session has one window per subsystem (zenoh, rosbridge, sim-driver,
+nav-brain, behavior, arm-ik, vision-nav, console-webapp), each showing that
+process's live output.
+
+Prefer Foxglove? Open a Rosbridge connection to `ws://localhost:9090` for
+TF, `/scan`, `/mars/main_camera/points`, camera topics and `/cmd_vel` teleop.
 
 ### Configuration
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -122,7 +122,7 @@ If something stops you anyway, we want to hear about it —
 
 ```bash
 ./innate-sim status      # startup checks + health snapshot
-./innate-sim logs        # startup logs; `logs os` / `logs agent` follow live
+./innate-sim logs startup   # startup logs; `logs brain` / `logs cloud-agent` for the running stack
 ./innate-sim sh          # shell into the container; `innate build` rebuilds ros2_ws
 ./innate-sim down        # stop the container + world server (keeps data)
 ./innate-sim clean       # remove containers/volumes (keeps .env + config)
@@ -144,13 +144,15 @@ real robot runs — develop here, deploy there. Start with the docs:
 | You edited | What to do |
 |---|---|
 | skills or agents in `workspace/` | **nothing** — they hot-reload on save (fallback: `ros2 service call /brain/reload std_srvs/srv/Trigger` in the container) |
-| ROS code in `ros2_ws/src/` | inside the container: `innate build` then `innate restart` |
+| parameters in `config/` | inside the container: `innate restart` |
+| ROS code in `ros2_ws/src/` | inside the container: `innate build` (it stops the nodes, builds, and restarts them) |
 | the simulated world (`mars_sim_driver/` world/server) | `./innate-sim down && ./innate-sim up` — this part runs on the host |
 | launcher / webapp files | just rerun `./innate-sim up` / reload the browser |
 
 The container's ROS session lives in tmux (`./innate-sim sh`, then
-`tmux attach -t innate`): one window per subsystem (zenoh, rosbridge,
-sim-driver, nav-brain, behavior, arm-ik, vision-nav, console-webapp).
+`tmux attach -t innate`): one window per subsystem (zenoh, rosbridge-app,
+sim-driver, nav-brain, behavior, arm-ik, vision-nav, console-webapp,
+foxglove).
 
 ---
 
@@ -226,16 +228,6 @@ robot on Wi-Fi**, where those topics are too large to stream smoothly; there you
 use the lighter `/mars/main_camera/remote/*` topics instead. See
 [Foxglove](../README.md#foxglove) in the main README for that case.
 
-### Everyday commands
-
-```bash
-./innate-sim status      # startup checks + health snapshot
-./innate-sim logs        # startup logs; `logs os` / `logs agent` follow live
-./innate-sim sh          # shell into the container (see next section)
-./innate-sim down        # stop
-./innate-sim clean       # remove containers/volumes (keeps .env + config)
-```
-
 ### Working on the robot code
 
 `./innate-sim sh` drops you into the container, where the same `innate` CLI
@@ -254,26 +246,26 @@ innate skill list        # skills the brain currently offers
 innate skill run <id> @param=value   # trigger a skill from the shell
 ```
 
-Which one you need depends on what you changed:
+[When do changes take effect?](#when-do-changes-take-effect) above has the
+answer for each kind of edit. `ros2_ws/` is the one worth knowing by heart:
+`colcon` installs a *copy*, so editing a node and restarting is not enough —
+`innate build mars_nav` (naming the package keeps the cycle short) rebuilds
+and restarts in one step.
 
-- **`workspace/` agents & skills, `config/` parameters** — not compiled;
-  `innate restart` is enough.
-- **`ros2_ws/` packages** (nodes, messages, drivers) — `colcon` installs a
-  copy, so edits need `innate build` (which restarts for you). Passing the
-  package name (`innate build mars_nav`) keeps the cycle short.
-- **The simulated world itself** (`mars_sim_driver`'s `world.py` / `core.py` /
-  `world_server.py`) — on macOS the physics/render process runs on the
-  *host*, outside the container, importing straight from your checkout.
-  `innate build` doesn't touch it; restart it from the host instead:
-  `pkill -f mars_sim_driver.world_server && ./innate-sim up`.
+The trap is the simulated world itself — `mars_sim_driver`'s `world.py`,
+`core.py` and `world_server.py`. That process runs on the **host**, outside
+the container, on every platform (in-container rendering was far too slow to
+be usable), importing straight from your checkout. `innate build` rebuilds
+the container's copy, but the world server never loads it. Restart that one
+from the host: `./innate-sim down && ./innate-sim up`.
 
 `innate view` is the fastest way to see why a node is unhappy: the tmux
-session has one window per subsystem (zenoh, rosbridge, sim-driver,
-nav-brain, behavior, arm-ik, vision-nav, console-webapp), each showing that
-process's live output.
+session has one window per subsystem (zenoh, rosbridge-app, sim-driver,
+nav-brain, behavior, arm-ik, vision-nav, console-webapp, foxglove), each
+showing that process's live output.
 
-Prefer Foxglove? Open a Rosbridge connection to `ws://localhost:9090` for
-TF, `/scan`, `/mars/main_camera/points`, camera topics and `/cmd_vel` teleop.
+Prefer your own ROS tooling? A rosbridge server is also available at
+`ws://localhost:9090`.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

Split out of #601 (part 3 of 3). Two developer-experience changes that rode along on that branch but are independent of the prop/challenge work — no code paths in common, reviewable on their own.

- `sim/README.md` gains **Everyday commands** and **Working on the robot code**: which reload each kind of edit needs (`innate restart` for `workspace/`+`config/`, `innate build` for `ros2_ws/` packages), and why the macOS world server needs a host-side restart instead of either.
- `sim/Dockerfile` generates the `innate` zsh completions on first login — `scripts/` is bind-mounted at runtime, so this can't happen at build time — and re-runs `compinit` to pick up the new `fpath` entry. Mirrors `scripts/update/post_update.sh`.

Docs and shell config only; no runtime behavior change.

## Stack

Independent of #602 (props) and its challenge-engine follow-up; merge in any order.

Based on the same commit as #601 (`504f0d0b`).

## Validation

- [x] Docs/Dockerfile only — nothing to run.
- [ ] Completion generation not yet exercised in a fresh container.