### PR TITLE
feat(sim): unify props behind sidecars — one droppable set, two ways to place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ workspace/physical_skills/
 # Runtime start_training resume markers (innate_training_node).
 workspace/.training_pending/
 
+# Per-machine challenge state, written at runtime.
+workspace/challenges.json
+
 # Per-skill persistent key-value stores (Skill.storage, skills/types.py).
 workspace/skill_storage/
 

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -308,7 +308,7 @@ class VirtualMars:
             self.data.qpos[qadr] = home
         mq, _md, source, mult = self._mimic
         self.data.qpos[mq] = mult * ARM_HOME[source]
-        self.props.forget_dropped()  # mj_resetData already re-parked every prop
+        self.props.mark_all_parked()  # mj_resetData already re-parked every prop
         self._cmd_vx = self._cmd_wz = 0.0
         self._cmd_sim_time = -math.inf
         self._hold = None
@@ -725,10 +725,8 @@ class VirtualMars:
         return out
 
     def object_poses(self) -> dict[str, list[float]]:
-        """Ground-truth [x, y, z, qw, qx, qy, qz] per prop actually in the
-        world -- what the viewer draws them from. Props still parked off-map
-        are omitted, not reported at their parking spot, so a viewer never
-        draws one."""
+        """[x, y, z, qw, qx, qy, qz] per prop in world frame. Props parked off-map
+        are omitted."""
         return self.props.poses(self.data)
 
     def prop_manifest(self) -> list[dict]:
@@ -746,34 +744,26 @@ class VirtualMars:
         mujoco.mj_forward(self.model, self.data)
         return True
 
-    def drop_prop_at_robot(self, name: str) -> bool:
+    def place_prop_at_robot(self, name: str) -> bool:
         """Set one prop down in front of the robot WHERE IT IS NOW, at rest,
-        at the prop's own reach offset -- the manipulation props' offsets put
-        them on an arc the arm can reach top-down, so this places rather than
-        drops. Drive somewhere, set a fresh one down, practise grabbing --
-        without resetting the robot's own pose the way reset() does."""
-        if not self.props.drop_at_robot(self.data, name, self.pose()):
+        at a specified reach offset."""
+        if not self.props.place_at_robot(self.data, name, self.pose()):
             return False
         mujoco.mj_forward(self.model, self.data)
         return True
 
-    def drop_group(self, group: str = "manipulation") -> int:
+    def place_group(self, group: str = "manipulation") -> int:
         """Lay out a whole set of props in front of the robot WHERE IT IS NOW,
         each at its own reach offset, and park everything outside the set.
 
         This is the workflow the arm's props exist for: drive somewhere, put a
         fresh set down, practise grabbing -- without resetting the robot's own
         pose the way reset() does. Returns how many landed."""
-        placed = self.props.drop_group(self.data, group, self.pose())
+        placed = self.props.place_group(self.data, group, self.pose())
         mujoco.mj_forward(self.model, self.data)
         return placed
 
-    def drop_objects(self) -> None:
-        """Back-compat alias for the stage's original one-click layout, which
-        has always meant the manipulation set specifically."""
-        self.drop_group("manipulation")
-
-    def remove_objects(self) -> None:
+    def remove_all_props(self) -> None:
         """Send every prop back off-map -- the state the world starts in, and
         what reset() leaves behind. Lets an operator clear the floor without
         resetting the robot's own pose."""

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -22,6 +22,7 @@ from PIL import Image
 
 from . import world
 from .constants import CAMERA_FOVY, CAMERA_HEIGHT, CAMERA_WIDTH, WRIST_CAMERA_FOVY
+from .props import PropRegistry
 from .world import ARM_HOME, SPAWN_X, SPAWN_Y, SPAWN_YAW_DEG
 
 # Stop the base if the last Twist is stale, like a real base watchdog.
@@ -185,11 +186,15 @@ class VirtualMars:
         visual_dir = ASSETS_DIR / "apartment_visual"
         visual_rooms = world.find_visual_rooms(visual_dir) if visual_dir.is_dir() else {}
 
+        # Droppable props: sidecars from the tracked source dir plus any the
+        # asset bundle shipped, each parked off-map until something places it.
+        self.props = PropRegistry.load([world.repo_root() / "sim" / "props", ASSETS_DIR / "props"])
         xml = world.build_world_xml(
             rooms,
             include_placeholder_robot=False,
             visual_rooms=visual_rooms,
             texture_max=_texture_cap(self._render_w),
+            props=self.props,
         )
         # Lidar rays hit only the textured visual meshes (true surfaces, like
         # a real lidar) when available -- without them, fall back to all
@@ -212,6 +217,8 @@ class VirtualMars:
             *(f for pieces in rooms.values() for f in pieces),
             *(p for obj in visual_rooms.values() for p in (obj, obj.with_suffix(".png"))),
             *(f for f in urdf_path.parent.rglob("*") if f.suffix in (".stl", ".dae", ".obj", ".png", ".urdf")),
+            # A prop mesh appearing (or being republished) changes the world.
+            *self.props.asset_files(),
         ]
         cache_path = _model_cache_path(xml, asset_files)
         self.model = None
@@ -276,19 +283,11 @@ class VirtualMars:
         for dadr in (self._joints[mimic_source][1], self._mimic[1]):
             self._servo[dadr] = (KD_GRIPPER, GRIPPER_EFFORT_LIMIT)
 
-        # Manipulation props: parked off-map in the model, so they exist only
-        # once drop_objects places them (and only then does anything report
-        # them). mj_resetData restores the parked pose, so reset() just has to
-        # forget which ones were out.
-        self._dropped: set[str] = set()
-        self._objects = {}  # name -> (body id, freejoint qpos_adr, dof_adr)
-        for obj in world.GRASP_OBJECTS:
-            jid = self.model.joint(f"{obj['name']}_free").id
-            self._objects[obj["name"]] = (
-                self.model.body(obj["name"]).id,
-                self.model.jnt_qposadr[jid],
-                self.model.jnt_dofadr[jid],
-            )
+        # Props are parked off-map in the model, so they exist only once
+        # something places them (and only then does anything report them).
+        # mj_resetData restores the parked pose, so reset() just has to forget
+        # which ones were out.
+        self.props.bind(self.model)
 
         self._renderer: mujoco.Renderer | None = None
         self._depth_renderer: mujoco.Renderer | None = None
@@ -309,7 +308,7 @@ class VirtualMars:
             self.data.qpos[qadr] = home
         mq, _md, source, mult = self._mimic
         self.data.qpos[mq] = mult * ARM_HOME[source]
-        self._dropped.clear()  # mj_resetData already re-parked every prop
+        self.props.forget_dropped()  # mj_resetData already re-parked every prop
         self._cmd_vx = self._cmd_wz = 0.0
         self._cmd_sim_time = -math.inf
         self._hold = None
@@ -726,44 +725,56 @@ class VirtualMars:
         return out
 
     def object_poses(self) -> dict[str, list[float]]:
-        """Ground-truth [x, y, z, qw, qx, qy, qz] per manipulation prop that is
-        actually in the world -- what the viewer draws them from. Empty until
-        drop_objects; props still parked off-map are omitted, not reported at
-        their parking spot, so a viewer never draws one."""
-        return {
-            name: [*map(float, self.data.xpos[bid]), *map(float, self.data.xquat[bid])]
-            for name, (bid, _q, _d) in self._objects.items()
-            if name in self._dropped
-        }
+        """Ground-truth [x, y, z, qw, qx, qy, qz] per prop actually in the
+        world -- what the viewer draws them from. Props still parked off-map
+        are omitted, not reported at their parking spot, so a viewer never
+        draws one."""
+        return self.props.poses(self.data)
 
-    def _place_object(self, obj: dict, x: float, y: float) -> None:
-        """Teleport one prop upright and at rest to (x, y), resting height."""
-        _bid, qadr, dadr = self._objects[obj["name"]]
-        self.data.qpos[qadr : qadr + 7] = [x, y, obj["z"], 1.0, 0.0, 0.0, 0.0]
-        self.data.qvel[dadr : dadr + 6] = 0.0
+    def prop_manifest(self) -> list[dict]:
+        """What every prop is and how to draw it (props.py) -- handed to the
+        viewer so its buttons and models follow the sidecars, not a second
+        hard-coded table."""
+        return self.props.manifest()
+
+    def drop_prop_at(self, name: str, x: float, y: float, yaw: float = 0.0) -> bool:
+        """Release one prop above (x, y), yawed about +z, and let physics
+        settle it onto whatever is below (a floor, a sofa, a table). False if
+        this world has no such prop."""
+        if not self.props.drop_at(self.data, name, x, y, yaw):
+            return False
+        mujoco.mj_forward(self.model, self.data)
+        return True
+
+    def drop_prop_at_robot(self, name: str) -> bool:
+        """Set one prop down in front of the robot WHERE IT IS NOW, at rest,
+        at the prop's own reach offset -- the manipulation props' offsets put
+        them on an arc the arm can reach top-down, so this places rather than
+        drops. Drive somewhere, set a fresh one down, practise grabbing --
+        without resetting the robot's own pose the way reset() does."""
+        if not self.props.drop_at_robot(self.data, name, self.pose()):
+            return False
+        mujoco.mj_forward(self.model, self.data)
+        return True
 
     def drop_objects(self) -> None:
-        """Bring the manipulation props into the world, on the floor in front
-        of the robot WHERE IT IS NOW and at rest (world.GRASP_OBJECTS' robot-
-        frame offsets). They are parked off-map until this is called, so this
-        is the only way they ever appear; calling it again re-lays them.
-        Drive somewhere, drop a fresh set, practise grabbing -- without
-        resetting the robot's own pose the way reset() does."""
-        x, y, yaw = self.pose()
-        cos, sin = math.cos(yaw), math.sin(yaw)
-        for obj in world.GRASP_OBJECTS:
-            forward, lateral = obj["forward"], obj["lateral"]
-            self._place_object(obj, x + cos * forward - sin * lateral, y + sin * forward + cos * lateral)
-        self._dropped.update(obj["name"] for obj in world.GRASP_OBJECTS)
+        """Set down every prop that has a reachable offset, the way the stage's
+        one-click "drop objects" always did."""
+        pose = self.pose()
+        for name in self.props.props:
+            self.props.drop_at_robot(self.data, name, pose)
         mujoco.mj_forward(self.model, self.data)
 
     def remove_objects(self) -> None:
-        """Send the props back off-map to GRASP_PARK_XY -- the state the world
-        starts in, and what reset() leaves behind. The counterpart of
-        drop_objects, so an operator can clear the floor without resetting the
-        robot's own pose."""
-        park_x, park_y = world.GRASP_PARK_XY
-        for i, obj in enumerate(world.GRASP_OBJECTS):
-            self._place_object(obj, park_x + i * world.GRASP_PARK_PITCH, park_y)
-        self._dropped.clear()
+        """Send every prop back off-map -- the state the world starts in, and
+        what reset() leaves behind. Lets an operator clear the floor without
+        resetting the robot's own pose."""
+        self.props.park_all(self.data)
         mujoco.mj_forward(self.model, self.data)
+
+    def remove_prop(self, name: str) -> bool:
+        """Send one prop back off-map."""
+        if not self.props.park(self.data, name):
+            return False
+        mujoco.mj_forward(self.model, self.data)
+        return True

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -757,13 +757,21 @@ class VirtualMars:
         mujoco.mj_forward(self.model, self.data)
         return True
 
-    def drop_objects(self) -> None:
-        """Set down every prop that has a reachable offset, the way the stage's
-        one-click "drop objects" always did."""
-        pose = self.pose()
-        for name in self.props.props:
-            self.props.drop_at_robot(self.data, name, pose)
+    def drop_group(self, group: str = "manipulation") -> int:
+        """Lay out a whole set of props in front of the robot WHERE IT IS NOW,
+        each at its own reach offset, and park everything outside the set.
+
+        This is the workflow the arm's props exist for: drive somewhere, put a
+        fresh set down, practise grabbing -- without resetting the robot's own
+        pose the way reset() does. Returns how many landed."""
+        placed = self.props.drop_group(self.data, group, self.pose())
         mujoco.mj_forward(self.model, self.data)
+        return placed
+
+    def drop_objects(self) -> None:
+        """Back-compat alias for the stage's original one-click layout, which
+        has always meant the manipulation set specifically."""
+        self.drop_group("manipulation")
 
     def remove_objects(self) -> None:
         """Send every prop back off-map -- the state the world starts in, and

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -751,7 +751,8 @@ class VirtualMars:
 
     def place_group(self, group: str = "manipulation") -> int:
         """Set down every prop in `group` at its own reach offset from the
-        robot's current pose, park the rest, and return how many landed."""
+        robot's current pose, and return how many landed. Props outside the
+        group stay where they are -- use remove_all_props() to clear."""
         placed = self.props.place_group(self.data, group, self.pose())
         mujoco.mj_forward(self.model, self.data)
         return placed

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -714,7 +714,7 @@ class VirtualMars:
 
     def encoder_positions(self) -> dict[str, float]:
         """What the real servo encoders would read: link angle plus the
-        structural deflection. The driver publishes THIS on /joint_states --
+        structural deflection due to gravity. The driver publishes THIS on /joint_states --
         real sag happens past the encoders, invisible to FK. The observer
         truth stream keeps joint_positions(), so viewers draw the sag."""
         out = {}
@@ -730,43 +730,35 @@ class VirtualMars:
         return self.props.poses(self.data)
 
     def prop_manifest(self) -> list[dict]:
-        """What every prop is and how to draw it (props.py) -- handed to the
-        viewer so its buttons and models follow the sidecars, not a second
-        hard-coded table."""
+        """What every prop is and how to draw it (props.py), for the viewer."""
         return self.props.manifest()
 
     def drop_prop_at(self, name: str, x: float, y: float, yaw: float = 0.0) -> bool:
-        """Release one prop above (x, y), yawed about +z, and let physics
-        settle it onto whatever is below (a floor, a sofa, a table). False if
-        this world has no such prop."""
+        """Release one prop above (x, y) and let physics settle it onto
+        whatever is below (floor, sofa, table). False when prop does not exist."""
         if not self.props.drop_at(self.data, name, x, y, yaw):
             return False
         mujoco.mj_forward(self.model, self.data)
         return True
 
     def place_prop_at_robot(self, name: str) -> bool:
-        """Set one prop down in front of the robot WHERE IT IS NOW, at rest,
-        at a specified reach offset."""
+        """Set one prop down at rest, at its own reach offset from the robot's
+        current pose. False when prop does not exist."""
         if not self.props.place_at_robot(self.data, name, self.pose()):
             return False
         mujoco.mj_forward(self.model, self.data)
         return True
 
     def place_group(self, group: str = "manipulation") -> int:
-        """Lay out a whole set of props in front of the robot WHERE IT IS NOW,
-        each at its own reach offset, and park everything outside the set.
-
-        This is the workflow the arm's props exist for: drive somewhere, put a
-        fresh set down, practise grabbing -- without resetting the robot's own
-        pose the way reset() does. Returns how many landed."""
+        """Set down every prop in `group` at its own reach offset from the
+        robot's current pose, park the rest, and return how many landed."""
         placed = self.props.place_group(self.data, group, self.pose())
         mujoco.mj_forward(self.model, self.data)
         return placed
 
     def remove_all_props(self) -> None:
         """Send every prop back off-map -- the state the world starts in, and
-        what reset() leaves behind. Lets an operator clear the floor without
-        resetting the robot's own pose."""
+        what reset() leaves behind."""
         self.props.park_all(self.data)
         mujoco.mj_forward(self.model, self.data)
 

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
@@ -48,12 +48,12 @@ class Prop:
     name: str
     label: str = "?"  # one glyph, the viewer's chip for this prop
     title: str = ""  # human-readable name (defaults to name)
-    # Props that get laid out together by one click. The manipulation set is
-    # what the arm practises on, and putting the whole set down at once is the
-    # workflow that matters there: drive somewhere, lay out a fresh set, grab.
-    # Their reach offsets are chosen so a whole group lands side by side
-    # without overlapping.
-    group: str = "scenery"
+    # Props laid out together by one click, or None for a prop that is only
+    # ever placed deliberately. The manipulation set is what the arm practises
+    # on, and putting the whole set down at once is the workflow that matters
+    # there: drive somewhere, lay out a fresh set, grab. A group's reach
+    # offsets have to be chosen so the whole set lands side by side.
+    group: str | None = None
 
     # -- geometry --
     # Mesh path relative to the sidecar. None (or a file that isn't installed)
@@ -347,8 +347,9 @@ class PropRegistry:
         return True
 
     def groups(self) -> list[str]:
-        """Group names in sidecar order, each appearing once."""
-        return list(dict.fromkeys(prop.group for prop in self.props.values()))
+        """Named groups in sidecar order, each appearing once (ungrouped props
+        contribute nothing)."""
+        return list(dict.fromkeys(p.group for p in self.props.values() if p.group))
 
     def drop_group(self, data, group: str, pose: tuple[float, float, float]) -> int:
         """Set down every prop in one group at its own reach offset, and park

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
@@ -1,9 +1,6 @@
-"""Droppable props: one sidecar per prop, discovered from the props roots.
-
-A prop is a free-floating MuJoCo body parked off-map until something places it
--- the manipulation targets the arm practises on (cube, can, sock, bar, ball)
-and the scenery a scenario needs (a person, a soccer ball, a dog) are the same
-kind of thing here, differing only in what their sidecars say.
+"""Droppable props: free-floating MuJoCo bodies parked off-map until something
+places them. Manipulation targets (cube, can, sock, ...) and scenery (a person,
+a dog, ...) differ only in what their sidecars say.
 
 A sidecar is a Python module exporting ``PROP = Prop(...)`` (the same shape as
 sim/challenges/), found under any props root. Python rather than data because
@@ -14,16 +11,14 @@ Paths inside a sidecar resolve relative to that sidecar, so a tracked prop can
 point at a bundled mesh (``../assets/humans/casual_man.obj``) and a bundled
 pack can keep everything in its own directory.
 
-Meshes are OPTIONAL at every level: a prop whose mesh is missing from the
-installed asset bundle degrades to its collision primitive, drawn instead of
-hidden, so the world is always complete even when the assets are not.
+Meshes are OPTIONAL at every level: a prop whose mesh the installed bundle
+lacks degrades to its collision primitive, drawn instead of hidden, so the
+world is always complete even when the assets are not.
 
-Geom groups follow the rest of the world (see world.py): group VISUAL_GROUP is
-rendered and is the only thing lidar rays hit (a true surface, like a real
-lidar); group COLLISION_GROUP is physics-only and hidden from every render. A
-primitive-only prop is a single geom in VISUAL_GROUP doing all three jobs; a
-mesh-backed prop splits them -- the textured mesh is what cameras and lidar
-see, the collider underneath is what physics uses.
+Geom groups follow the rest of the world (see world.py): a primitive-only prop
+is one VISUAL_GROUP geom doing render, lidar and physics; a mesh-backed prop
+splits them -- the textured mesh in VISUAL_GROUP, the collider under it in
+COLLISION_GROUP.
 """
 
 import importlib.util
@@ -269,19 +264,9 @@ class PropRegistry:
     """The props in one world: their MJCF, their addresses in the compiled
     model, and which of them are currently out on the floor.
 
-    Two ways a prop gets there, and the verbs are load-bearing:
-
-    * ``drop_*`` RELEASES it from the prop's ``drop_z`` and lets physics settle
-      it onto whatever is below -- the honest answer when nobody knows what is
-      under the spot the user picked.
-    * ``place_*`` sets it down at ``rest_z`` already at rest: no fall, no
-      bounce, no drift off a tuned spot.
-
-    Everything below is one of those two; ``_set_pose`` is the shared write
-    that neither name would fit.
-
-    Parked props are deliberately NOT reported by poses(): a viewer should
-    draw nothing rather than draw a prop sitting in the parking row.
+    The method-name verbs are load-bearing: ``drop_*`` releases from ``drop_z``
+    and lets physics settle the prop onto whatever is below, ``place_*`` sets
+    it down at ``rest_z`` already at rest.
     """
 
     def __init__(self, props: dict[str, Prop]):
@@ -337,8 +322,7 @@ class PropRegistry:
 
     def drop_at(self, data, name: str, x: float, y: float, yaw: float = 0.0) -> bool:
         """Release a prop at its drop_z above (x, y), yawed about +z, and let
-        physics settle it onto whatever is below -- floor, sofa, table, another
-        prop. False if this world has no such prop."""
+        physics settle it onto whatever is below. False when prop does not exist."""
         if name not in self._addr:
             return False
         self._set_pose(data, name, x, y, self.props[name].drop_z, yaw)
@@ -346,9 +330,7 @@ class PropRegistry:
 
     def place_at_robot(self, data, name: str, pose: tuple[float, float, float]) -> bool:
         """Set a prop down at rest_z at its `reach` offset from the robot's
-        current pose. The manipulation props' offsets put them where the arm
-        can actually reach them, so this places rather than drops: no fall, no
-        bounce, no drift off the tuned spot."""
+        current pose. False when prop does not exist."""
         if name not in self._addr:
             return False
         prop = self.props[name]
@@ -366,9 +348,8 @@ class PropRegistry:
         return list(dict.fromkeys(p.group for p in self.props.values() if p.group))
 
     def place_group(self, data, group: str, pose: tuple[float, float, float]) -> int:
-        """Set down every prop in one group at its own reach offset, and park
-        the rest -- so the set that lands is exactly the set asked for, the way
-        the stage's one-click layout always behaved. Returns how many landed."""
+        """Set down every prop in one group at its own reach offset and park
+        the rest, so the set out is exactly `group`. Returns how many landed."""
         placed = 0
         for name, prop in self.props.items():
             if prop.group == group:
@@ -391,8 +372,8 @@ class PropRegistry:
             self.park(data, name)
 
     def mark_all_parked(self) -> None:
-        """After mj_resetData: every prop is back at its parked pose already,
-        so the registry only has to catch its bookkeeping up."""
+        """Catch the bookkeeping up after mj_resetData, which has already
+        restored every prop to its parked pose."""
         self.out.clear()
 
     # -- readout --

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
@@ -83,7 +83,7 @@ class Prop:
     # to clear furniture, then physics settles it).
     rest_z: float = 0.02
     drop_z: float | None = None
-    # Where the robot puts this prop when asked to drop it in front of itself:
+    # Where the robot puts this prop when asked to place it in front of itself:
     # robot-frame metres. The manipulation props' values place them on an arc
     # the arm can reach top-down -- do NOT round them off.
     reach: tuple[float, float] = (0.6, 0.0)
@@ -269,6 +269,17 @@ class PropRegistry:
     """The props in one world: their MJCF, their addresses in the compiled
     model, and which of them are currently out on the floor.
 
+    Two ways a prop gets there, and the verbs are load-bearing:
+
+    * ``drop_*`` RELEASES it from the prop's ``drop_z`` and lets physics settle
+      it onto whatever is below -- the honest answer when nobody knows what is
+      under the spot the user picked.
+    * ``place_*`` sets it down at ``rest_z`` already at rest: no fall, no
+      bounce, no drift off a tuned spot.
+
+    Everything below is one of those two; ``_set_pose`` is the shared write
+    that neither name would fit.
+
     Parked props are deliberately NOT reported by poses(): a viewer should
     draw nothing rather than draw a prop sitting in the parking row.
     """
@@ -276,7 +287,7 @@ class PropRegistry:
     def __init__(self, props: dict[str, Prop]):
         self.props = props
         self._addr: dict[str, tuple[int, int, int]] = {}  # name -> (body id, qpos adr, dof adr)
-        self.dropped: set[str] = set()
+        self.out: set[str] = set()  # on the floor rather than parked off-map
 
     @classmethod
     def load(cls, roots: list[Path]) -> "PropRegistry":
@@ -315,24 +326,27 @@ class PropRegistry:
 
     # -- placement (callers hold the sim lock) --
 
-    def _place(self, data, name: str, x: float, y: float, z: float, yaw: float) -> None:
+    def _set_pose(self, data, name: str, x: float, y: float, z: float, yaw: float) -> None:
+        """Write one prop's pose and zero its velocity. The z is the caller's
+        choice of drop_z or rest_z -- that choice IS drop-vs-place."""
         _bid, qadr, dadr = self._addr[name]
         half = yaw / 2
         data.qpos[qadr : qadr + 7] = [x, y, z, math.cos(half), 0.0, 0.0, math.sin(half)]
         data.qvel[dadr : dadr + 6] = 0.0
-        self.dropped.add(name)
+        self.out.add(name)
 
     def drop_at(self, data, name: str, x: float, y: float, yaw: float = 0.0) -> bool:
-        """Release a prop above (x, y) yawed about +z and let physics settle it
-        onto whatever is below. False if this world has no such prop."""
+        """Release a prop at its drop_z above (x, y), yawed about +z, and let
+        physics settle it onto whatever is below -- floor, sofa, table, another
+        prop. False if this world has no such prop."""
         if name not in self._addr:
             return False
-        self._place(data, name, x, y, self.props[name].drop_z, yaw)
+        self._set_pose(data, name, x, y, self.props[name].drop_z, yaw)
         return True
 
-    def drop_at_robot(self, data, name: str, pose: tuple[float, float, float]) -> bool:
-        """Set a prop down at rest at its `reach` offset from the robot's
-        current pose -- the manipulation props' offsets put them where the arm
+    def place_at_robot(self, data, name: str, pose: tuple[float, float, float]) -> bool:
+        """Set a prop down at rest_z at its `reach` offset from the robot's
+        current pose. The manipulation props' offsets put them where the arm
         can actually reach them, so this places rather than drops: no fall, no
         bounce, no drift off the tuned spot."""
         if name not in self._addr:
@@ -343,7 +357,7 @@ class PropRegistry:
         cos, sin = math.cos(ryaw), math.sin(ryaw)
         x = rx + cos * forward - sin * lateral
         y = ry + sin * forward + cos * lateral
-        self._place(data, name, x, y, prop.rest_z, 0.0)
+        self._set_pose(data, name, x, y, prop.rest_z, 0.0)
         return True
 
     def groups(self) -> list[str]:
@@ -351,14 +365,14 @@ class PropRegistry:
         contribute nothing)."""
         return list(dict.fromkeys(p.group for p in self.props.values() if p.group))
 
-    def drop_group(self, data, group: str, pose: tuple[float, float, float]) -> int:
+    def place_group(self, data, group: str, pose: tuple[float, float, float]) -> int:
         """Set down every prop in one group at its own reach offset, and park
         the rest -- so the set that lands is exactly the set asked for, the way
         the stage's one-click layout always behaved. Returns how many landed."""
         placed = 0
         for name, prop in self.props.items():
             if prop.group == group:
-                placed += bool(self.drop_at_robot(data, name, pose))
+                placed += bool(self.place_at_robot(data, name, pose))
             else:
                 self.park(data, name)
         return placed
@@ -368,18 +382,18 @@ class PropRegistry:
         if name not in self._addr:
             return False
         park_x, park_y = self.park_xy(name)
-        self._place(data, name, park_x, park_y, self.props[name].rest_z, 0.0)
-        self.dropped.discard(name)
+        self._set_pose(data, name, park_x, park_y, self.props[name].rest_z, 0.0)
+        self.out.discard(name)
         return True
 
     def park_all(self, data) -> None:
         for name in list(self.props):
             self.park(data, name)
 
-    def forget_dropped(self) -> None:
+    def mark_all_parked(self) -> None:
         """After mj_resetData: every prop is back at its parked pose already,
-        so the registry only has to forget which ones were out."""
-        self.dropped.clear()
+        so the registry only has to catch its bookkeeping up."""
+        self.out.clear()
 
     # -- readout --
 
@@ -389,13 +403,14 @@ class PropRegistry:
         return {
             name: [*map(float, data.xpos[bid]), *map(float, data.xquat[bid])]
             for name, (bid, _q, _d) in self._addr.items()
-            if name in self.dropped
+            if name in self.out
         }
 
     def center_xy(self, data, name: str) -> tuple[float, float] | None:
-        """xy of a dropped prop's visual centre, correcting for an off-centre
-        body origin (the human stands feet-at-origin). None while parked."""
-        if name not in self.dropped or name not in self._addr:
+        """xy of a prop's visual centre while it is out, correcting for an
+        off-centre body origin (the human stands feet-at-origin). None while
+        parked."""
+        if name not in self.out or name not in self._addr:
             return None
         bid, _q, _d = self._addr[name]
         ox, oy, oz = self.props[name].center_offset

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
@@ -1,0 +1,388 @@
+"""Droppable props: one sidecar per prop, discovered from the props roots.
+
+A prop is a free-floating MuJoCo body parked off-map until something places it
+-- the manipulation targets the arm practises on (cube, can, sock, bar, ball)
+and the scenery a scenario needs (a person, a soccer ball, a dog) are the same
+kind of thing here, differing only in what their sidecars say.
+
+A sidecar is a Python module exporting ``PROP = Prop(...)`` (the same shape as
+sim/challenges/), found under any props root. Python rather than data because
+the tuning behind these numbers is the valuable part of them and only a comment
+can carry it -- see the sock's grasp band or the ball's density.
+
+Paths inside a sidecar resolve relative to that sidecar, so a tracked prop can
+point at a bundled mesh (``../assets/humans/casual_man.obj``) and a bundled
+pack can keep everything in its own directory.
+
+Meshes are OPTIONAL at every level: a prop whose mesh is missing from the
+installed asset bundle degrades to its collision primitive, drawn instead of
+hidden, so the world is always complete even when the assets are not.
+
+Geom groups follow the rest of the world (see world.py): group VISUAL_GROUP is
+rendered and is the only thing lidar rays hit (a true surface, like a real
+lidar); group COLLISION_GROUP is physics-only and hidden from every render. A
+primitive-only prop is a single geom in VISUAL_GROUP doing all three jobs; a
+mesh-backed prop splits them -- the textured mesh is what cameras and lidar
+see, the collider underneath is what physics uses.
+"""
+
+import importlib.util
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Parking row for undropped props: far off-map, spaced wide enough that the
+# biggest prop (a 1.7m human lying down) cannot touch its neighbours. Bodies
+# still exist in the model while parked -- mj_resetData restores exactly this
+# pose, which is what makes reset() re-parking free.
+PARK_X0 = 15.0
+PARK_Y = 15.0
+PARK_PITCH = 2.0
+
+
+@dataclass
+class Prop:
+    """One droppable prop. Field defaults are the "small rigid object" case;
+    a sidecar overrides only what it cares about."""
+
+    name: str
+    label: str = "?"  # one glyph, the viewer's chip for this prop
+    title: str = ""  # human-readable name (defaults to name)
+
+    # -- geometry --
+    # Mesh path relative to the sidecar. None (or a file that isn't installed)
+    # leaves the prop as its bare primitive.
+    mesh: str | None = None
+    mesh_scale: float = 1.0  # 0.01 for a centimetre-unit scan
+    texture: str | None = None  # defaults to "<mesh stem>_basecolor.png"
+    # How the prop collides: a primitive ("box"/"sphere"/"cylinder", sized by
+    # `size`), "hull" (the visual mesh's own convex hull), or "pieces" (the
+    # convex decomposition sitting next to the mesh as <stem>_collision_*.obj).
+    collision: str = "box"
+    size: tuple[float, ...] = (0.02, 0.02, 0.02)
+
+    # -- contact model --
+    density: float = 700.0
+    condim: int = 4
+    friction: tuple[float, float, float] = (1.0, 0.02, 0.001)
+    solref: tuple[float, float] = (0.01, 1.0)
+    solimp: tuple[float, ...] | None = None
+    priority: int | None = None
+    margin: float | None = None
+    rgba: tuple[float, float, float, float] = (0.8, 0.8, 0.8, 1.0)
+
+    # -- placement --
+    # Height of the body origin when the prop is set down at rest, and the
+    # height it is RELEASED from when dropped onto unknown ground (high enough
+    # to clear furniture, then physics settles it).
+    rest_z: float = 0.02
+    drop_z: float | None = None
+    # Where the robot puts this prop when asked to drop it in front of itself:
+    # robot-frame metres. The manipulation props' values place them on an arc
+    # the arm can reach top-down -- do NOT round them off.
+    reach: tuple[float, float] = (0.6, 0.0)
+    # Body-frame offset from the free-joint origin to the visual CENTRE. Only
+    # non-zero for a mesh whose origin is not its middle (the human scan stands
+    # feet-at-origin), so distances to it mean what a reader expects.
+    center_offset: tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+    # -- browser view (see sim/viewer/src/props.ts) --
+    # Passed through to the viewer verbatim; an absent or unfetchable glb makes
+    # the browser build the same primitive physics uses.
+    viewer: dict = field(default_factory=dict)
+
+    # Directory the sidecar came from; every relative path above resolves
+    # against it. Set by the loader, never by a sidecar.
+    root: Path | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.title:
+            self.title = self.name.replace("_", " ").capitalize()
+        if self.drop_z is None:
+            self.drop_z = self.rest_z
+
+    # -- resolved asset paths --
+
+    @property
+    def mesh_path(self) -> Path | None:
+        """The installed mesh, or None when this prop has no mesh or the asset
+        bundle did not ship it."""
+        if self.mesh is None or self.root is None:
+            return None
+        path = (self.root / self.mesh).resolve()
+        return path if path.is_file() else None
+
+    @property
+    def texture_path(self) -> Path | None:
+        mesh = self.mesh_path
+        if mesh is None:
+            return None
+        name = self.texture or f"{mesh.stem}_basecolor.png"
+        path = (mesh.parent / name).resolve()
+        return path if path.is_file() else None
+
+    @property
+    def collision_pieces(self) -> list[Path]:
+        """Convex decomposition next to the mesh, in the mesh's body frame."""
+        mesh = self.mesh_path
+        if mesh is None or self.collision != "pieces":
+            return []
+        return sorted(mesh.parent.glob(f"{mesh.stem}_collision_*.obj"))
+
+    def asset_files(self) -> list[Path]:
+        """Everything on disk that shapes this prop's MJCF -- the model cache
+        key has to see all of it or a re-published mesh won't take effect."""
+        return [p for p in (self.mesh_path, self.texture_path) if p is not None] + self.collision_pieces
+
+    # -- MJCF --
+
+    # MuJoCo primitive standing in for a mesh collider, keyed by how many
+    # numbers `size` carries -- "hull"/"pieces" name a mesh, not a shape, so a
+    # prop whose mesh never shipped still needs something real to be.
+    _PRIMITIVE_FOR_SIZE = {1: "sphere", 2: "cylinder", 3: "box"}
+
+    def _primitive_geom(self, name: str, group: int, physical: bool) -> str:
+        shape = self.collision
+        if shape not in ("box", "sphere", "cylinder"):
+            shape = self._PRIMITIVE_FOR_SIZE.get(len(self.size), "box")
+        size = " ".join(f"{s:g}" for s in self.size)
+        return self._geom(name, f'type="{shape}" size="{size}"', group, physical)
+
+    def _geom(self, name: str, shape: str, group: int, physical: bool) -> str:
+        """One geom. `physical` false makes it a pure visual surface: no
+        contacts, no mass, so the collider underneath owns the dynamics."""
+        friction = " ".join(f"{f:g}" for f in self.friction)
+        solref = " ".join(f"{s:g}" for s in self.solref)
+        extra = ""
+        if not physical:
+            extra += ' contype="0" conaffinity="0" density="0"'
+        else:
+            extra += f' density="{self.density:g}" condim="{self.condim}"'
+            extra += f' friction="{friction}" solref="{solref}"'
+            if self.solimp is not None:
+                extra += f' solimp="{" ".join(f"{s:g}" for s in self.solimp)}"'
+            if self.priority is not None:
+                extra += f' priority="{self.priority}"'
+            if self.margin is not None:
+                extra += f' margin="{self.margin:g}"'
+        return f'\n      <geom name="{name}" {shape}{extra}{{fill}}/>'.replace("{fill}", self._fill(group))
+
+    def _fill(self, group: int) -> str:
+        return f' rgba="{" ".join(f"{c:g}" for c in self.rgba)}" group="{group}"'
+
+    def assets_xml(self, visual_group: int) -> str:
+        """<asset> entries for this prop (nothing at all without a mesh)."""
+        mesh, texture = self.mesh_path, self.texture_path
+        if mesh is None:
+            return ""
+        scale = (
+            f' scale="{self.mesh_scale:g} {self.mesh_scale:g} {self.mesh_scale:g}"' if self.mesh_scale != 1.0 else ""
+        )
+        out = f'\n    <mesh name="{self.name}" file="{mesh}"{scale}/>'
+        if texture is not None:
+            out += f'\n    <texture name="tex_{self.name}" type="2d" file="{texture}"/>'
+            out += f'\n    <material name="mat_{self.name}" texture="tex_{self.name}" specular="0.1" shininess="0.1"/>'
+        for i, piece in enumerate(self.collision_pieces):
+            out += f'\n    <mesh name="{self.name}_col{i}" file="{piece}"/>'
+        return out
+
+    def body_xml(self, park_x: float, park_y: float, visual_group: int, collision_group: int) -> str:
+        """The prop's free body, parked at (park_x, park_y)."""
+        mesh = self.mesh_path
+        if mesh is None:
+            # No mesh installed: the primitive IS the prop -- visible, lidar-
+            # visible and collidable, all from one geom.
+            geoms = self._primitive_geom(f"{self.name}_geom", visual_group, physical=True)
+        else:
+            material = f' material="mat_{self.name}"' if self.texture_path is not None else self._fill(visual_group)
+            geoms = (
+                f'\n      <geom name="{self.name}_visual" mesh="{self.name}" type="mesh"{material}'
+                f' contype="0" conaffinity="0" density="0" group="{visual_group}"/>'
+            )
+            pieces = self.collision_pieces
+            if pieces:
+                for i in range(len(pieces)):
+                    geoms += self._geom(
+                        f"{self.name}_col{i}", f'mesh="{self.name}_col{i}" type="mesh"', collision_group, physical=True
+                    )
+            elif self.collision == "hull" or self.collision == "pieces":
+                # "pieces" with none installed degrades to the mesh's own hull.
+                geoms += self._geom(
+                    f"{self.name}_collision", f'mesh="{self.name}" type="mesh"', collision_group, physical=True
+                )
+            else:
+                geoms += self._primitive_geom(f"{self.name}_geom", collision_group, physical=True)
+        return f"""
+    <body name="{self.name}" pos="{park_x:.4f} {park_y:.4f} {self.rest_z:g}">
+      <freejoint name="{self.name}_free"/>{geoms}
+    </body>"""
+
+    # -- what the browser needs to draw and offer this prop --
+
+    def manifest(self) -> dict:
+        return {
+            "name": self.name,
+            "label": self.label,
+            "title": self.title,
+            "collision": self.collision,
+            "size": list(self.size),
+            "rgba": list(self.rgba),
+            "viewer": self.viewer,
+        }
+
+
+# --- loading ---
+
+
+def load_props(roots: list[Path]) -> dict[str, Prop]:
+    """Every prop under `roots`, later roots overriding earlier ones by name.
+    A broken sidecar is skipped with a warning -- one bad prop must not take
+    out the world."""
+    found: dict[str, Prop] = {}
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.glob("*.py")):
+            if path.name.startswith("_"):
+                continue
+            try:
+                spec = importlib.util.spec_from_file_location(f"sim_prop_{path.stem}", path)
+                assert spec and spec.loader
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                prop: Prop = module.PROP
+                prop.root = path.parent
+                found[prop.name] = prop
+            except Exception as exc:  # noqa: BLE001 -- a bad sidecar loses its prop, nothing else
+                print(f"[props] skipping {path.name}: {exc!r}", flush=True)
+    return found
+
+
+class PropRegistry:
+    """The props in one world: their MJCF, their addresses in the compiled
+    model, and which of them are currently out on the floor.
+
+    Parked props are deliberately NOT reported by poses(): a viewer should
+    draw nothing rather than draw a prop sitting in the parking row.
+    """
+
+    def __init__(self, props: dict[str, Prop]):
+        self.props = props
+        self._addr: dict[str, tuple[int, int, int]] = {}  # name -> (body id, qpos adr, dof adr)
+        self.dropped: set[str] = set()
+
+    @classmethod
+    def load(cls, roots: list[Path]) -> "PropRegistry":
+        registry = cls(load_props(roots))
+        if registry.props:
+            print(f"[props] loaded: {', '.join(registry.props)}", flush=True)
+        return registry
+
+    def park_xy(self, name: str) -> tuple[float, float]:
+        return PARK_X0 + list(self.props).index(name) * PARK_PITCH, PARK_Y
+
+    def asset_files(self) -> list[Path]:
+        return [f for prop in self.props.values() for f in prop.asset_files()]
+
+    # -- MJCF --
+
+    def assets_xml(self, visual_group: int) -> str:
+        return "".join(prop.assets_xml(visual_group) for prop in self.props.values())
+
+    def bodies_xml(self, visual_group: int, collision_group: int) -> str:
+        out = []
+        for name, prop in self.props.items():
+            park_x, park_y = self.park_xy(name)
+            out.append(prop.body_xml(park_x, park_y, visual_group, collision_group))
+        return "".join(out)
+
+    # -- model binding --
+
+    def bind(self, model) -> None:
+        """Resolve each prop's addresses in the compiled model. Called once
+        after the model is built (or loaded from cache)."""
+        self._addr.clear()
+        for name in self.props:
+            jid = model.joint(f"{name}_free").id
+            self._addr[name] = (model.body(name).id, model.jnt_qposadr[jid], model.jnt_dofadr[jid])
+
+    # -- placement (callers hold the sim lock) --
+
+    def _place(self, data, name: str, x: float, y: float, z: float, yaw: float) -> None:
+        _bid, qadr, dadr = self._addr[name]
+        half = yaw / 2
+        data.qpos[qadr : qadr + 7] = [x, y, z, math.cos(half), 0.0, 0.0, math.sin(half)]
+        data.qvel[dadr : dadr + 6] = 0.0
+        self.dropped.add(name)
+
+    def drop_at(self, data, name: str, x: float, y: float, yaw: float = 0.0) -> bool:
+        """Release a prop above (x, y) yawed about +z and let physics settle it
+        onto whatever is below. False if this world has no such prop."""
+        if name not in self._addr:
+            return False
+        self._place(data, name, x, y, self.props[name].drop_z, yaw)
+        return True
+
+    def drop_at_robot(self, data, name: str, pose: tuple[float, float, float]) -> bool:
+        """Set a prop down at rest at its `reach` offset from the robot's
+        current pose -- the manipulation props' offsets put them where the arm
+        can actually reach them, so this places rather than drops: no fall, no
+        bounce, no drift off the tuned spot."""
+        if name not in self._addr:
+            return False
+        prop = self.props[name]
+        rx, ry, ryaw = pose
+        forward, lateral = prop.reach
+        cos, sin = math.cos(ryaw), math.sin(ryaw)
+        x = rx + cos * forward - sin * lateral
+        y = ry + sin * forward + cos * lateral
+        self._place(data, name, x, y, prop.rest_z, 0.0)
+        return True
+
+    def park(self, data, name: str) -> bool:
+        """Send one prop back off-map."""
+        if name not in self._addr:
+            return False
+        park_x, park_y = self.park_xy(name)
+        self._place(data, name, park_x, park_y, self.props[name].rest_z, 0.0)
+        self.dropped.discard(name)
+        return True
+
+    def park_all(self, data) -> None:
+        for name in list(self.props):
+            self.park(data, name)
+
+    def forget_dropped(self) -> None:
+        """After mj_resetData: every prop is back at its parked pose already,
+        so the registry only has to forget which ones were out."""
+        self.dropped.clear()
+
+    # -- readout --
+
+    def poses(self, data) -> dict[str, list[float]]:
+        """Ground-truth {name: [x, y, z, qw, qx, qy, qz]} for props on the
+        floor. Parked props are omitted, not reported at their parking spot."""
+        return {
+            name: [*map(float, data.xpos[bid]), *map(float, data.xquat[bid])]
+            for name, (bid, _q, _d) in self._addr.items()
+            if name in self.dropped
+        }
+
+    def center_xy(self, data, name: str) -> tuple[float, float] | None:
+        """xy of a dropped prop's visual centre, correcting for an off-centre
+        body origin (the human stands feet-at-origin). None while parked."""
+        if name not in self.dropped or name not in self._addr:
+            return None
+        bid, _q, _d = self._addr[name]
+        ox, oy, oz = self.props[name].center_offset
+        if ox == oy == oz == 0.0:
+            return float(data.xpos[bid][0]), float(data.xpos[bid][1])
+        w, qx, qy, qz = (float(v) for v in data.xquat[bid])
+        # Rows 0/1 of the quaternion rotation matrix; z is irrelevant for xy.
+        rx = (1 - 2 * (qy * qy + qz * qz)) * ox + 2 * (qx * qy - w * qz) * oy + 2 * (qx * qz + w * qy) * oz
+        ry = 2 * (qx * qy + w * qz) * ox + (1 - 2 * (qx * qx + qz * qz)) * oy + 2 * (qy * qz - w * qx) * oz
+        return float(data.xpos[bid][0]) + rx, float(data.xpos[bid][1]) + ry
+
+    def manifest(self) -> list[dict]:
+        """What the viewer needs to draw every prop and offer it as a button."""
+        return [prop.manifest() for prop in self.props.values()]

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
@@ -348,14 +348,12 @@ class PropRegistry:
         return list(dict.fromkeys(p.group for p in self.props.values() if p.group))
 
     def place_group(self, data, group: str, pose: tuple[float, float, float]) -> int:
-        """Set down every prop in one group at its own reach offset and park
-        the rest, so the set out is exactly `group`. Returns how many landed."""
+        """Set down every prop in one group at its own reach offset, leaving
+        every other prop where it is. Returns how many landed."""
         placed = 0
         for name, prop in self.props.items():
             if prop.group == group:
                 placed += bool(self.place_at_robot(data, name, pose))
-            else:
-                self.park(data, name)
         return placed
 
     def park(self, data, name: str) -> bool:

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
@@ -48,6 +48,12 @@ class Prop:
     name: str
     label: str = "?"  # one glyph, the viewer's chip for this prop
     title: str = ""  # human-readable name (defaults to name)
+    # Props that get laid out together by one click. The manipulation set is
+    # what the arm practises on, and putting the whole set down at once is the
+    # workflow that matters there: drive somewhere, lay out a fresh set, grab.
+    # Their reach offsets are chosen so a whole group lands side by side
+    # without overlapping.
+    group: str = "scenery"
 
     # -- geometry --
     # Mesh path relative to the sidecar. None (or a file that isn't installed)
@@ -224,6 +230,7 @@ class Prop:
             "name": self.name,
             "label": self.label,
             "title": self.title,
+            "group": self.group,
             "collision": self.collision,
             "size": list(self.size),
             "rgba": list(self.rgba),
@@ -338,6 +345,22 @@ class PropRegistry:
         y = ry + sin * forward + cos * lateral
         self._place(data, name, x, y, prop.rest_z, 0.0)
         return True
+
+    def groups(self) -> list[str]:
+        """Group names in sidecar order, each appearing once."""
+        return list(dict.fromkeys(prop.group for prop in self.props.values()))
+
+    def drop_group(self, data, group: str, pose: tuple[float, float, float]) -> int:
+        """Set down every prop in one group at its own reach offset, and park
+        the rest -- so the set that lands is exactly the set asked for, the way
+        the stage's one-click layout always behaved. Returns how many landed."""
+        placed = 0
+        for name, prop in self.props.items():
+            if prop.group == group:
+                placed += bool(self.drop_at_robot(data, name, pose))
+            else:
+                self.park(data, name)
+        return placed
 
     def park(self, data, name: str) -> bool:
         """Send one prop back off-map."""

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -10,6 +10,7 @@ from VIRTUAL_MARS_ASSETS (default: <repo>/sim/assets in a dev checkout).
 import math
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import mujoco
 
@@ -83,103 +84,6 @@ STRUCT_STIFFNESS = 25.0  # N*m/rad, per arm joint
 ARM_BACKLASH_RAD = 0.055
 BACKLASH_TANH_NM = 0.05  # torque scale over which the play takes up
 
-# --- manipulation props --------------------------------------------------
-#
-# Graspable free bodies for core.drop_objects (the viewer's "drop objects"
-# button), parked off-map at GRASP_PARK_XY until dropped; a reset re-parks
-# them. forward/lateral are robot-frame metres from the robot at drop time,
-# on a 0.22m arc around the arm's shoulder so each is reachable top-down.
-# Densities are real materials'; do NOT lighten them -- at 20-40g a prop
-# skitters metres off the lightest graze.
-GRASP_PARK_XY = (15.0, 15.0)
-GRASP_PARK_PITCH = 0.5
-
-GRASP_OBJECTS = (
-    {
-        "name": "cube",
-        "forward": 0.227,
-        "lateral": 0.116,
-        "z": 0.02,  # resting height of the body origin = half the footprint
-        "geom": 'type="box" size="0.02 0.02 0.02"',
-        "density": 700,
-        "condim": 4,
-        "rgba": "0.85 0.28 0.24 1",
-    },
-    {
-        "name": "can",
-        "forward": 0.296,
-        "lateral": 0.011,
-        # 40mm across: 50mm pinches at the fingertip and rolls out. 60mm
-        # tall: taller fills pick_any_object's optical-flow window with
-        # featureless colour and positioning livelocks.
-        "z": 0.03,
-        "geom": 'type="cylinder" size="0.020 0.03"',
-        "density": 1050,
-        "roll": 0.005,  # rolling resistance on the floor
-        "condim": 4,
-        "rgba": "0.25 0.55 0.85 1",
-    },
-    {
-        # pick_any_object's design target: its default prompt is "the sock",
-        # and its grasp band sits HIGH -- the shipped constants close the jaws
-        # with the pad centre ~50mm off a hard floor (floor_z is an ee target,
-        # the pads ride ~10mm above it, close_lift adds 10mm more). A sock is
-        # a 60-80mm lump you pinch by the top; the 40mm cube is below that
-        # band and is the HARD case on real hardware too. This prop is what
-        # "the skill works" should be measured against: a rolled-sock-sized,
-        # sock-weight box (65g of fabric).
-        "name": "sock",
-        "forward": 0.161,
-        "lateral": 0.154,
-        "z": 0.03,
-        # 60mm tall (the skill's closing band lands on its upper third);
-        # 40x40 so the worst-case diagonal clears the 81mm jaw at any yaw.
-        # Grey, not white: white on pale parquet starves the flow tracker.
-        "geom": 'type="box" size="0.020 0.020 0.030"',
-        "density": 450,
-        "condim": 6,
-        "rgba": "0.45 0.46 0.50 1",
-    },
-    {
-        "name": "bar",
-        "forward": 0.296,
-        "lateral": -0.117,
-        "z": 0.015,
-        "geom": 'type="box" size="0.015 0.05 0.015"',
-        "density": 700,
-        "condim": 4,
-        # Deep orange: yellow on pale parquet starves the flow tracker.
-        "rgba": "0.80 0.33 0.10 1",
-    },
-    {
-        # 40mm, the same width as the cube and can: a 50mm sphere left only
-        # 15mm of jaw clearance per side, so the descending blade grazed its
-        # flank on ordinary aim error, stalled the descent high, and the jaws
-        # closed over the top cap without ever moving the ball (measured: pad
-        # centre 31mm above ball centre at the close, ball displaced 4mm total,
-        # 0/4). A sphere needs the pads at its equator -- it is the least
-        # forgiving shape in the roster, so it gets the friendliest width.
-        # Density is a dense rubber ball's: at the sphere's tiny volume the
-        # real bouncy-ball ~1100 lands at 37g, inside the skitter zone the
-        # header comment warns about.
-        "name": "ball",
-        "forward": 0.227,
-        "lateral": -0.221,
-        "z": 0.0225,
-        "geom": 'type="sphere" size="0.0225"',
-        "density": 1000,
-        "condim": 6,
-        # Foam stress ball: a hard sphere is unpickable (the contact rolls
-        # around the curve and the arm rides up over it). ~3mm of dent stops
-        # the roll; much softer slips. Priority beats the fingers' pad model.
-        "priority": 4,
-        "friction": "2.0 0.4 0.1",
-        "solref": "0.012 1",
-        "solimp": "0.9 0.97 0.003",
-        "rgba": "0.4 0.8 0.45 1",
-    },
-)
-
 # Matches the webapp's ARM_HOME_POSITIONS.
 ARM_HOME = {
     "joint1": 1.445009902188274,
@@ -208,6 +112,10 @@ _PALETTE = [
     "0.2 0.9 0.7 1",
     "0.6 0.6 0.9 1",
 ]
+
+
+if TYPE_CHECKING:
+    from .props import PropRegistry
 
 
 def repo_root() -> Path:
@@ -299,41 +207,19 @@ def capped_texture_path(png_path: Path, texture_max: int) -> Path:
     return cached
 
 
-def grasp_object_bodies() -> str:
-    """MJCF for the manipulation props (see GRASP_OBJECTS), each a free body
-    parked off-map. core.drop_objects brings them into the apartment; the
-    parked pose is also what mj_resetData restores them to."""
-    park_x, park_y = GRASP_PARK_XY
-    bodies = []
-    for i, obj in enumerate(GRASP_OBJECTS):
-        # Per-object contact overrides (the sock): friction/solref/solimp
-        # default to the rigid-prop values, priority is emitted only if set.
-        friction = obj.get("friction", f"1.0 0.02 {obj.get('roll', 0.001)}")
-        solref = obj.get("solref", "0.01 1")
-        extra = ""
-        if "priority" in obj:
-            extra += f' priority="{obj["priority"]}"'
-        if "solimp" in obj:
-            extra += f' solimp="{obj["solimp"]}"'
-        bodies.append(f"""
-    <body name="{obj["name"]}" pos="{park_x + i * GRASP_PARK_PITCH:.4f} {park_y:.4f} {obj["z"]}">
-      <freejoint name="{obj["name"]}_free"/>
-      <geom name="{obj["name"]}_geom" {obj["geom"]} density="{obj["density"]}" condim="{obj["condim"]}"
-            friction="{friction}" solref="{solref}"{extra} rgba="{obj["rgba"]}" group="{VISUAL_GROUP}"/>
-    </body>""")
-    return "".join(bodies)
-
-
 def build_world_xml(
     rooms: dict[str, list[Path]],
     include_placeholder_robot: bool = True,
     visual_rooms: dict[str, Path] | None = None,
     texture_max: int | None = None,
+    props: "PropRegistry | None" = None,
 ) -> str:
     """The apartment environment MJCF (floor plane + decomposed room hulls,
-    optionally the textured visual rooms in their own geom group, plus the
-    graspable props in front of the spawn).
+    optionally the textured visual rooms in their own geom group, plus every
+    droppable prop parked off-map -- see props.py).
     texture_max caps the visual textures' resolution (see capped_texture_path)."""
+    prop_assets = props.assets_xml(VISUAL_GROUP) if props else ""
+    prop_bodies = props.bodies_xml(VISUAL_GROUP, COLLISION_GROUP) if props else ""
     collision_group = COLLISION_GROUP if visual_rooms else 0
 
     mesh_lines = []
@@ -390,7 +276,7 @@ def build_world_xml(
   <statistic center="{lx} {ly} {lz}" extent="{extent}"/>
   <asset>
 {chr(10).join(mesh_lines)}
-{chr(10).join(visual_mesh_lines)}
+{chr(10).join(visual_mesh_lines)}{prop_assets}
   </asset>
   <worldbody>
     <light pos="4 -3 6" dir="-4 3 -6" diffuse="1 1 1"/>
@@ -400,7 +286,7 @@ def build_world_xml(
     <body name="apartment" quat="0.7071068 0.7071068 0 0">
 {chr(10).join(geom_lines)}
 {chr(10).join(visual_geom_lines)}
-    </body>{grasp_object_bodies()}{robot_body}
+    </body>{prop_bodies}{robot_body}
   </worldbody>
 </mujoco>
 """

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -174,6 +174,10 @@ class WorldServer:
             name = str(cmd["name"])
             with self.lock:
                 ok = self.sim.remove_prop(name)
+        elif op == "drop_group":  # a whole set at once, each at its own offset
+            with self.lock:
+                self.sim.drop_group(str(cmd.get("group", "manipulation")))
+            ok = True
         elif op in ("drop_objects", "remove_objects"):  # whole-set shortcuts
             with self.lock:
                 getattr(self.sim, op)()

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -166,21 +166,21 @@ class WorldServer:
             yaw = float(cmd.get("yaw", 0.0))
             with self.lock:
                 ok = self.sim.drop_prop_at(name, x, y, yaw)
-        elif op == "drop_prop_at_robot":  # the prop's own reach offset
+        elif op == "place_prop_at_robot":  # at rest, at the prop's own reach offset
             name = str(cmd["name"])
             with self.lock:
-                ok = self.sim.drop_prop_at_robot(name)
+                ok = self.sim.place_prop_at_robot(name)
         elif op == "remove_prop":
             name = str(cmd["name"])
             with self.lock:
                 ok = self.sim.remove_prop(name)
-        elif op == "drop_group":  # a whole set at once, each at its own offset
+        elif op == "place_group":  # a whole set at once, each at its own offset
             with self.lock:
-                self.sim.drop_group(str(cmd.get("group", "manipulation")))
+                self.sim.place_group(str(cmd.get("group", "manipulation")))
             ok = True
-        elif op in ("drop_objects", "remove_objects"):  # whole-set shortcuts
+        elif op == "remove_all_props":  # the stage's "clear" chip
             with self.lock:
-                getattr(self.sim, op)()
+                self.sim.remove_all_props()
             ok = True
         else:
             return

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -6,7 +6,7 @@ sim/README.md "world_server.py"):
   then one binary frame iff the JSON says "blob": <nbytes>.
 - observer state stream (--state-port): a WebSocket broadcasting ground
   truth ({t, wall, pose, joints, objects}) after every physics slice, and
-  accepting stage commands ({"op": "drop_objects"}) back. Ground truth and
+  accepting stage commands ({"op": "drop_prop_at", ...}) back. Ground truth and
   scenery only -- robot software must never consume or drive it.
 
 Always runs on the host (the launcher starts it via uv): in-container
@@ -18,6 +18,7 @@ reads take the physics lock directly.
 """
 
 import argparse
+import contextlib
 import json
 import os
 import socket
@@ -141,23 +142,58 @@ class WorldServer:
 
     def _serve_scenario_commands(self, ws) -> None:
         """Read the observer socket for stage commands. This is the sim's own
-        scenery, not robot control: the ops lay the manipulation props out in
-        front of the robot and take them away again (see core.drop_objects),
-        so an operator can practise grabbing without a full reset."""
+        scenery, not robot control: the ops place props (see props.py) and take
+        them away again, so an operator can set a scene up -- or practise
+        grabbing -- without a full reset.
+
+        A prop can be put down two ways: at the robot, which uses the prop's
+        own reach offset so it lands where the arm can actually get at it, or
+        at a spot the user picked, which releases it there and lets physics
+        settle it onto whatever is below."""
         try:
             for raw in ws:
-                op = json.loads(raw).get("op")
-                if op in ("drop_objects", "remove_objects"):  # allowlist: it names the method
-                    with self.lock:
-                        getattr(self.sim, op)()
+                try:
+                    self._run_scenario_command(json.loads(raw))
+                except Exception as exc:  # noqa: BLE001 -- one bad command must not drop the connection
+                    print(f"[world-server] ignoring stage command: {exc!r}", flush=True)
         except Exception:  # noqa: BLE001,S110 -- client gone, or junk on the wire
             pass
+
+    def _run_scenario_command(self, cmd: dict) -> None:
+        op = cmd.get("op")
+        if op == "drop_prop_at":  # user picked the spot: release + settle
+            name, x, y = str(cmd["name"]), float(cmd["x"]), float(cmd["y"])
+            yaw = float(cmd.get("yaw", 0.0))
+            with self.lock:
+                ok = self.sim.drop_prop_at(name, x, y, yaw)
+        elif op == "drop_prop_at_robot":  # the prop's own reach offset
+            name = str(cmd["name"])
+            with self.lock:
+                ok = self.sim.drop_prop_at_robot(name)
+        elif op == "remove_prop":
+            name = str(cmd["name"])
+            with self.lock:
+                ok = self.sim.remove_prop(name)
+        elif op in ("drop_objects", "remove_objects"):  # whole-set shortcuts
+            with self.lock:
+                getattr(self.sim, op)()
+            ok = True
+        else:
+            return
+        if not ok:
+            print(f"[world-server] {op} ignored: no prop {cmd.get('name')!r} in this world", flush=True)
+        self.publish_state()
 
     def serve_state(self, ws) -> None:
         """One observer connection: push each new state, latest-wins (a slow
         client skips states instead of queueing lag), and accept the stage
         commands above on the way back."""
         threading.Thread(target=self._serve_scenario_commands, args=(ws,), daemon=True).start()
+        # The prop roster (props.py sidecars) never changes while the server
+        # runs, so it goes out once per connection instead of riding every
+        # state broadcast. The viewer builds its models and buttons from it.
+        with contextlib.suppress(Exception):  # noqa: BLE001 -- client gone before the first frame
+            ws.send(json.dumps({"props": self.sim.prop_manifest()}))
         last_seq = -1
         try:
             while True:

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -143,13 +143,7 @@ class WorldServer:
     def _serve_scenario_commands(self, ws) -> None:
         """Read the observer socket for stage commands. This is the sim's own
         scenery, not robot control: the ops place props (see props.py) and take
-        them away again, so an operator can set a scene up -- or practise
-        grabbing -- without a full reset.
-
-        A prop can be put down two ways: at the robot, which uses the prop's
-        own reach offset so it lands where the arm can actually get at it, or
-        at a spot the user picked, which releases it there and lets physics
-        settle it onto whatever is below."""
+        them away again, without a full reset."""
         try:
             for raw in ws:
                 try:

--- a/sim/README.md
+++ b/sim/README.md
@@ -326,9 +326,12 @@ robot adapter; humans and tools see it only through the observer stream):
 - **observer stream** (WebSocket, port 8800; the webapp proxies it at
   `/worldstate`) — ground truth `{t, wall, pose, joints, objects}` pushed after
   every physics slice (~75Hz), latest-wins per client, and stage commands
-  (`{"op": "drop_objects"}` / `{"op": "remove_objects"}`, the viewer's
-  drop/remove button -- the manipulation props are parked off-map until asked
-  for) accepted back on the same socket. Scenery, never robot control. The 3D view consumes this;
+  (the viewer's prop chips: `drop_prop_at` releases a prop over a spot you
+  picked and lets physics settle it, `place_prop_at_robot` / `place_group` set
+  props down at rest at their own reach offsets, `remove_prop` /
+  `remove_all_props` send them back off-map, which is where every prop starts)
+  accepted back on the same socket.
+  Scenery, never robot control. The 3D view consumes this;
   future challenge UIs/graders are just more clients.
 
 Physics steps against the wall clock in <=25ms slices (a stall replays as

--- a/sim/props/10_cube.py
+++ b/sim/props/10_cube.py
@@ -1,0 +1,20 @@
+"""Cube: the plain rigid manipulation target."""
+
+from mars_sim_driver.props import Prop
+
+# Densities are real materials'; do NOT lighten them -- at 20-40g a prop
+# skitters metres off the lightest graze.
+PROP = Prop(
+    name="cube",
+    label="🧊",
+    title="Cube",
+    collision="box",
+    size=(0.02, 0.02, 0.02),
+    density=700,
+    condim=4,
+    rgba=(0.85, 0.28, 0.24, 1.0),
+    rest_z=0.02,  # resting height of the body origin = half the footprint
+    # Robot-frame metres, on a 0.22m arc around the arm's shoulder so the prop
+    # lands where the arm can reach it top-down.
+    reach=(0.227, 0.116),
+)

--- a/sim/props/10_cube.py
+++ b/sim/props/10_cube.py
@@ -7,6 +7,7 @@ from mars_sim_driver.props import Prop
 PROP = Prop(
     name="cube",
     label="🧊",
+    group="manipulation",
     title="Cube",
     collision="box",
     size=(0.02, 0.02, 0.02),

--- a/sim/props/11_can.py
+++ b/sim/props/11_can.py
@@ -5,6 +5,7 @@ from mars_sim_driver.props import Prop
 PROP = Prop(
     name="can",
     label="🥫",
+    group="manipulation",
     title="Can",
     collision="cylinder",
     # 40mm across: 50mm pinches at the fingertip and rolls out. 60mm

--- a/sim/props/11_can.py
+++ b/sim/props/11_can.py
@@ -1,0 +1,20 @@
+"""Can: the cylindrical manipulation target."""
+
+from mars_sim_driver.props import Prop
+
+PROP = Prop(
+    name="can",
+    label="🥫",
+    title="Can",
+    collision="cylinder",
+    # 40mm across: 50mm pinches at the fingertip and rolls out. 60mm
+    # tall: taller fills pick_any_object's optical-flow window with
+    # featureless colour and positioning livelocks.
+    size=(0.020, 0.03),
+    density=1050,
+    condim=4,
+    friction=(1.0, 0.02, 0.005),  # the third term is rolling resistance on the floor
+    rgba=(0.25, 0.55, 0.85, 1.0),
+    rest_z=0.03,
+    reach=(0.296, 0.011),
+)

--- a/sim/props/12_sock.py
+++ b/sim/props/12_sock.py
@@ -12,6 +12,7 @@ from mars_sim_driver.props import Prop
 PROP = Prop(
     name="sock",
     label="🧦",
+    group="manipulation",
     title="Sock",
     collision="box",
     # 60mm tall (the skill's closing band lands on its upper third);

--- a/sim/props/12_sock.py
+++ b/sim/props/12_sock.py
@@ -1,0 +1,26 @@
+"""Sock: pick_any_object's design target -- the prop the skill is measured against."""
+
+from mars_sim_driver.props import Prop
+
+# pick_any_object's design target: its default prompt is "the sock", and its
+# grasp band sits HIGH -- the shipped constants close the jaws with the pad
+# centre ~50mm off a hard floor (floor_z is an ee target, the pads ride ~10mm
+# above it, close_lift adds 10mm more). A sock is a 60-80mm lump you pinch by
+# the top; the 40mm cube is below that band and is the HARD case on real
+# hardware too. This prop is what "the skill works" should be measured
+# against: a rolled-sock-sized, sock-weight box (65g of fabric).
+PROP = Prop(
+    name="sock",
+    label="🧦",
+    title="Sock",
+    collision="box",
+    # 60mm tall (the skill's closing band lands on its upper third);
+    # 40x40 so the worst-case diagonal clears the 81mm jaw at any yaw.
+    # Grey, not white: white on pale parquet starves the flow tracker.
+    size=(0.020, 0.020, 0.030),
+    density=450,
+    condim=6,
+    rgba=(0.45, 0.46, 0.50, 1.0),
+    rest_z=0.03,
+    reach=(0.161, 0.154),
+)

--- a/sim/props/13_bar.py
+++ b/sim/props/13_bar.py
@@ -1,0 +1,17 @@
+"""Bar: the long, thin manipulation target (yaw matters to the grasp)."""
+
+from mars_sim_driver.props import Prop
+
+PROP = Prop(
+    name="bar",
+    label="🍫",
+    title="Bar",
+    collision="box",
+    size=(0.015, 0.05, 0.015),
+    density=700,
+    condim=4,
+    # Deep orange: yellow on pale parquet starves the flow tracker.
+    rgba=(0.80, 0.33, 0.10, 1.0),
+    rest_z=0.015,
+    reach=(0.296, -0.117),
+)

--- a/sim/props/13_bar.py
+++ b/sim/props/13_bar.py
@@ -5,6 +5,7 @@ from mars_sim_driver.props import Prop
 PROP = Prop(
     name="bar",
     label="🍫",
+    group="manipulation",
     title="Bar",
     collision="box",
     size=(0.015, 0.05, 0.015),

--- a/sim/props/14_ball.py
+++ b/sim/props/14_ball.py
@@ -12,7 +12,7 @@ from mars_sim_driver.props import Prop
 # bouncy-ball ~1100 lands at 37g, inside the skitter zone props.py warns about.
 PROP = Prop(
     name="ball",
-    label="🟢",
+    label="🎾",
     group="manipulation",
     title="Stress ball",
     collision="sphere",

--- a/sim/props/14_ball.py
+++ b/sim/props/14_ball.py
@@ -1,0 +1,31 @@
+"""Stress ball: the least forgiving manipulation target."""
+
+from mars_sim_driver.props import Prop
+
+# 40mm, the same width as the cube and can: a 50mm sphere left only 15mm of jaw
+# clearance per side, so the descending blade grazed its flank on ordinary aim
+# error, stalled the descent high, and the jaws closed over the top cap without
+# ever moving the ball (measured: pad centre 31mm above ball centre at the
+# close, ball displaced 4mm total, 0/4). A sphere needs the pads at its equator
+# -- it is the least forgiving shape in the roster, so it gets the friendliest
+# width. Density is a dense rubber ball's: at the sphere's tiny volume the real
+# bouncy-ball ~1100 lands at 37g, inside the skitter zone props.py warns about.
+PROP = Prop(
+    name="ball",
+    label="🟢",
+    title="Stress ball",
+    collision="sphere",
+    size=(0.0225,),
+    density=1000,
+    condim=6,
+    # Foam stress ball: a hard sphere is unpickable (the contact rolls around
+    # the curve and the arm rides up over it). ~3mm of dent stops the roll;
+    # much softer slips. Priority beats the fingers' pad model.
+    priority=4,
+    friction=(2.0, 0.4, 0.1),
+    solref=(0.012, 1.0),
+    solimp=(0.9, 0.97, 0.003),
+    rgba=(0.4, 0.8, 0.45, 1.0),
+    rest_z=0.0225,
+    reach=(0.227, -0.221),
+)

--- a/sim/props/14_ball.py
+++ b/sim/props/14_ball.py
@@ -12,7 +12,7 @@ from mars_sim_driver.props import Prop
 # bouncy-ball ~1100 lands at 37g, inside the skitter zone props.py warns about.
 PROP = Prop(
     name="ball",
-    label="🎾",
+    label="🟢",
     group="manipulation",
     title="Stress ball",
     collision="sphere",

--- a/sim/props/14_ball.py
+++ b/sim/props/14_ball.py
@@ -13,6 +13,7 @@ from mars_sim_driver.props import Prop
 PROP = Prop(
     name="ball",
     label="🟢",
+    group="manipulation",
     title="Stress ball",
     collision="sphere",
     size=(0.0225,),

--- a/sim/props/20_human.py
+++ b/sim/props/20_human.py
@@ -1,0 +1,42 @@
+"""A person: scenery for rescue/assistance scenarios, not a grasp target."""
+
+from mars_sim_driver.props import Prop
+
+# A posed scan in centimetre units, Y-up, feet at the origin -- so an identity
+# quaternion lays it on its back with the head toward +y, and a yaw rotates
+# that head direction. It doubles as its own collision hull (MuJoCo convexifies
+# a mesh geom), which is coarse but right for a body lying on a floor.
+PROP = Prop(
+    name="human",
+    label="🧍",
+    title="Person",
+    mesh="../assets/humans/casual_man.obj",
+    mesh_scale=0.01,
+    collision="hull",
+    # Bare fallback when the asset bundle ships no human: a body-sized box, so
+    # the scenario still has something to find.
+    size=(0.25, 0.85, 0.15),
+    density=500,  # ~70kg over the hull's volume
+    condim=3,
+    friction=(0.9, 0.01, 0.001),
+    solref=(0.02, 1.0),
+    margin=0.007,
+    rgba=(0.65, 0.6, 0.55, 1.0),
+    rest_z=0.3,
+    # Released high enough that the lying hull (which reaches ~0.24m below the
+    # body origin) starts clear of sofas and beds instead of inside them.
+    drop_z=1.5,
+    reach=(1.5, 0.0),
+    # The scan's origin is at the FEET; without this a Near() against it would
+    # measure to the feet of a 1.7m body.
+    center_offset=(0.0, 0.864, 0.0),
+    viewer={
+        "glb": "/models/human.glb",
+        # NOT rotated Y-up -> Z-up: the glb shares the OBJ's convention, so the
+        # one pose quaternion orients mesh and body identically.
+        "rotateToZUp": False,
+        "fitSizeM": 1.727,
+        "fitDim": "height",
+        "origin": "base",
+    },
+)

--- a/sim/props/21_soccer_ball.py
+++ b/sim/props/21_soccer_ball.py
@@ -20,7 +20,7 @@ PROP = Prop(
     rgba=(0.9, 0.9, 0.9, 1.0),
     rest_z=0.11,
     drop_z=0.6,
-    reach=(1.0, 0.0),
+    reach=(1.2, -0.8),  # offset laterally so a whole-group drop lands them side by side
     viewer={
         "glb": "/models/soccer_ball.glb",
         "rotateToZUp": True,

--- a/sim/props/21_soccer_ball.py
+++ b/sim/props/21_soccer_ball.py
@@ -20,7 +20,7 @@ PROP = Prop(
     rgba=(0.9, 0.9, 0.9, 1.0),
     rest_z=0.11,
     drop_z=0.6,
-    reach=(1.2, -0.8),  # offset laterally so a whole-group drop lands them side by side
+    reach=(1.2, 0.0),
     viewer={
         "glb": "/models/soccer_ball.glb",
         "rotateToZUp": True,

--- a/sim/props/21_soccer_ball.py
+++ b/sim/props/21_soccer_ball.py
@@ -1,0 +1,31 @@
+"""Soccer ball: scenery the robot pushes around (not the arm's stress ball)."""
+
+from mars_sim_driver.props import Prop
+
+# Collides as a sphere primitive rather than its mesh: a sphere rolls exactly
+# right and a convexified mesh does not. condim 6 adds rolling friction, so a
+# nudged ball rolls and gently stops instead of rolling forever.
+PROP = Prop(
+    name="soccer_ball",
+    label="⚽",
+    title="Soccer ball",
+    mesh="../assets/objects/soccer_ball.obj",
+    collision="sphere",
+    size=(0.11,),  # regulation
+    density=80,  # ~0.43kg at that radius
+    condim=6,
+    friction=(0.7, 0.01, 0.002),
+    solref=(0.02, 1.0),
+    margin=0.007,
+    rgba=(0.9, 0.9, 0.9, 1.0),
+    rest_z=0.11,
+    drop_z=0.6,
+    reach=(1.0, 0.0),
+    viewer={
+        "glb": "/models/soccer_ball.glb",
+        "rotateToZUp": True,
+        "fitSizeM": 0.22,
+        "fitDim": "max",
+        "origin": "center",
+    },
+)

--- a/sim/props/22_labrador.py
+++ b/sim/props/22_labrador.py
@@ -21,7 +21,7 @@ PROP = Prop(
     rgba=(0.82, 0.68, 0.44, 1.0),
     rest_z=0.256,
     drop_z=1.0,
-    reach=(1.2, 0.8),  # offset laterally so a whole-group drop lands them side by side
+    reach=(1.2, 0.0),
     viewer={
         "glb": "/models/labrador.glb",
         "rotateToZUp": True,

--- a/sim/props/22_labrador.py
+++ b/sim/props/22_labrador.py
@@ -1,0 +1,35 @@
+"""Labrador: scenery with a real silhouette -- legs, head, and a gap underneath."""
+
+from mars_sim_driver.props import Prop
+
+# Collides as its true shape via the CoACD pieces the asset pipeline writes
+# next to the mesh, so the legs and the gap under the belly are all live. With
+# no pieces installed it degrades to the mesh's own convex hull, and with no
+# mesh at all to the bbox box below (~34kg).
+PROP = Prop(
+    name="labrador",
+    label="🐕",
+    title="Dog",
+    mesh="../assets/objects/labrador.obj",
+    collision="pieces",
+    size=(0.124, 0.5, 0.256),
+    density=1000,  # flesh; ~30kg over the decomposed volume
+    condim=4,
+    friction=(0.9, 0.01, 0.001),
+    solref=(0.02, 1.0),
+    margin=0.007,
+    rgba=(0.82, 0.68, 0.44, 1.0),
+    rest_z=0.256,
+    drop_z=1.0,
+    reach=(1.2, 0.0),
+    viewer={
+        "glb": "/models/labrador.glb",
+        "rotateToZUp": True,
+        "fitSizeM": 1.0,
+        "fitDim": "max",
+        "origin": "center",
+        # CoACD hull soup (float32 xyz) in the same body frame, for the
+        # "collisions" overlay.
+        "hulls": "/models/labrador_hulls.f32",
+    },
+)

--- a/sim/props/22_labrador.py
+++ b/sim/props/22_labrador.py
@@ -21,7 +21,7 @@ PROP = Prop(
     rgba=(0.82, 0.68, 0.44, 1.0),
     rest_z=0.256,
     drop_z=1.0,
-    reach=(1.2, 0.0),
+    reach=(1.2, 0.8),  # offset laterally so a whole-group drop lands them side by side
     viewer={
         "glb": "/models/labrador.glb",
         "rotateToZUp": True,

--- a/sim/viewer/README.md
+++ b/sim/viewer/README.md
@@ -17,12 +17,16 @@ The stage has sim-only chips: **lidar** (live `/scan` hit points),
 **collisions** (wireframe of everything the driver collides against, for
 physics-vs-visual alignment checks: the apartment hull set plus the robot's
 own `<collision>` primitives, which urdf-loader parses out of mars.urdf and
-hangs off each link so they track the joints), and **drop objects** / **remove objects**. The
-apartment has no props in it by default; the button lays a set out on the floor
-in front of the robot wherever it currently is, so you can drive somewhere,
-drop them, and practise grabbing -- then flips to "remove objects" to clear
-them away. It reads the world rather than remembering its own presses, so a sim
-reset (which also clears them) leaves it labelled correctly.
+hangs off each link so they track the joints), and a **prop** row per set.
+
+The apartment has no props in it by default -- every one of them starts parked
+off-map. A prop chip puts one in the world, and the **drop | at robot** switch
+says how: "at robot" sets it down at rest at its own tuned reach offset (drive
+somewhere, lay a set out, practise grabbing), while "drop" takes over the
+pointer so you click a spot and drag a heading, and the prop falls onto
+whatever is under it. A set chip (`+manipulation`) lays out a whole group at
+once. **clear** sends every prop back off-map, which is also what a sim reset
+leaves behind.
 
 The render assets (`public/models` glb, `public/physics` hulls) are not in
 git: `./innate-sim up` extracts them from the published bundle (see

--- a/sim/viewer/src/physics/worldStateController.ts
+++ b/sim/viewer/src/physics/worldStateController.ts
@@ -3,6 +3,8 @@
 // (proxied at /worldstate) -- the 3D view's only state source. See
 // world_server.py "two interfaces".
 
+import type { PropInfo } from "../props";
+
 export interface WorldState {
   /** Sim clock (s) -- the playback timeline. */
   t: number;
@@ -19,6 +21,8 @@ export interface WorldState {
 
 export class WorldStateController {
   onState?: (state: WorldState) => void;
+  /** The prop roster, sent once per connection (props.py sidecars). */
+  onProps?: (props: PropInfo[]) => void;
 
   #url: string;
   #ws!: WebSocket;
@@ -77,7 +81,14 @@ export class WorldStateController {
   }
 
   #onMessage(raw: string): void {
-    const msg = JSON.parse(raw) as {
+    const parsed = JSON.parse(raw) as { props?: PropInfo[] };
+    if (parsed.props) {
+      // Roster frame, not a state frame: it has no clock and arrives once,
+      // ahead of the stream (see world_server.serve_state).
+      this.onProps?.(parsed.props);
+      return;
+    }
+    const msg = parsed as unknown as {
       t: number;
       wall: number;
       pose: [number, number, number];

--- a/sim/viewer/src/physics/worldStateController.ts
+++ b/sim/viewer/src/physics/worldStateController.ts
@@ -68,7 +68,7 @@ export class WorldStateController {
     await this.#open;
   }
 
-  /** Send a stage command (e.g. drop_objects) back up the observer socket.
+  /** Send a stage command (e.g. place_group) back up the observer socket.
    * Dropped silently while the socket is (re)connecting -- it is a button
    * press, not something worth queueing. */
   send(cmd: object): void {

--- a/sim/viewer/src/props.ts
+++ b/sim/viewer/src/props.ts
@@ -37,8 +37,9 @@ export interface PropInfo {
   name: string;
   label: string;
   title: string;
-  /** Props laid out together by one click (props.py `group`). */
-  group: string;
+  /** Props laid out together by one click, or null for a prop that is only
+   * ever placed deliberately (props.py `group`). */
+  group: string | null;
   collision: string;
   size: number[];
   rgba: number[];

--- a/sim/viewer/src/props.ts
+++ b/sim/viewer/src/props.ts
@@ -37,6 +37,8 @@ export interface PropInfo {
   name: string;
   label: string;
   title: string;
+  /** Props laid out together by one click (props.py `group`). */
+  group: string;
   collision: string;
   size: number[];
   rgba: number[];

--- a/sim/viewer/src/props.ts
+++ b/sim/viewer/src/props.ts
@@ -1,0 +1,236 @@
+// Droppable props in the browser: one class covering both kinds the world
+// server serves (see mars_sim_driver/props.py).
+//
+// The server sends a roster once per observer connection -- name, label, and
+// how to draw each prop -- so adding a prop is a sidecar in sim/props/ and
+// nothing here. Two ways a prop gets a body:
+//
+//   - a glb named by its sidecar's `viewer.glb`, normalized into the SAME
+//     local frame its MuJoCo body uses so one pose quaternion orients both;
+//   - otherwise (no glb, or the asset bundle never shipped it) the same
+//     primitive physics is using, built from `collision`/`size`/`rgba`.
+//
+// The second is not a degraded path to apologise for: most props ARE
+// primitives, and a prop whose mesh is missing still has to be visible or the
+// 3D view disagrees with what the robot's cameras see.
+
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+
+/** How the browser should place a prop's glb into its MuJoCo body frame. */
+export interface PropViewerDef {
+  glb?: string;
+  /** Standard glTF Y-up -> scene Z-up. False for a model already authored Z-up. */
+  rotateToZUp?: boolean;
+  /** Rescale so fitDim spans this many metres. */
+  fitSizeM?: number;
+  /** "height" = up-axis extent; "max" = largest bbox side. */
+  fitDim?: "height" | "max";
+  /** Where the body origin sits: feet-down vs geometric centre. */
+  origin?: "base" | "center";
+  /** CoACD hull soup (float32 xyz) in the body frame, for the collision overlay. */
+  hulls?: string;
+}
+
+/** One prop as the world server describes it (props.py Prop.manifest). */
+export interface PropInfo {
+  name: string;
+  label: string;
+  title: string;
+  collision: string;
+  size: number[];
+  rgba: number[];
+  viewer: PropViewerDef;
+}
+
+/** Build the primitive MuJoCo is colliding with. Mirrors props.py's
+ * _PRIMITIVE_FOR_SIZE: "hull"/"pieces" name a mesh rather than a shape, so a
+ * prop whose mesh is absent falls back on what its `size` implies. */
+function primitiveGeometry(info: PropInfo): THREE.BufferGeometry {
+  const s = info.size;
+  let shape = info.collision;
+  if (shape !== "box" && shape !== "sphere" && shape !== "cylinder") {
+    shape = s.length === 1 ? "sphere" : s.length === 2 ? "cylinder" : "box";
+  }
+  if (shape === "sphere") {
+    // Finely tessellated: a coarse sphere casts a visibly polygonal shadow
+    // right where it meets the floor, which is where the eye checks contact.
+    return new THREE.SphereGeometry(s[0], 32, 24);
+  }
+  if (shape === "cylinder") {
+    // MuJoCo sizes a cylinder (radius, half-length) and stands it on +z;
+    // THREE's is (radius, radius, length) and Y-up.
+    return new THREE.CylinderGeometry(s[0], s[0], s[1] * 2, 40).rotateX(Math.PI / 2);
+  }
+  // MuJoCo box sizes are half-extents.
+  return new THREE.BoxGeometry(s[0] * 2, s[1] * 2, s[2] * 2);
+}
+
+/** Rescale + re-origin a raw glb into its MuJoCo body's local frame (glb
+ * exports bake arbitrary origins, orientations and unit scales). */
+function normalizeModel(scene: THREE.Object3D, def: PropViewerDef): void {
+  if (def.rotateToZUp !== false) scene.rotation.x = Math.PI / 2; // glTF Y-up -> scene Z-up
+  scene.updateMatrixWorld(true);
+  const size = new THREE.Box3().setFromObject(scene).getSize(new THREE.Vector3());
+  const upExtent = def.rotateToZUp !== false ? size.z : size.y;
+  const span = def.fitDim === "height" ? upExtent : Math.max(size.x, size.y, size.z);
+  if (def.fitSizeM && span > 0) scene.scale.multiplyScalar(def.fitSizeM / span);
+
+  // Re-measure post-scale to place the origin.
+  scene.updateMatrixWorld(true);
+  const scaled = new THREE.Box3().setFromObject(scene);
+  const center = scaled.getCenter(new THREE.Vector3());
+  if (def.origin !== "base") {
+    scene.position.sub(center);
+    return;
+  }
+  // base: centred in the ground plane, up-axis min sitting at the origin.
+  scene.position.x -= center.x;
+  if (def.rotateToZUp !== false) {
+    scene.position.y -= center.y;
+    scene.position.z -= scaled.min.z;
+  } else {
+    scene.position.z -= center.z;
+    scene.position.y -= scaled.min.y;
+  }
+}
+
+/**
+ * Every prop's body in the scene, driven by ground-truth poses.
+ *
+ * Each prop's root is built on first sight and then reused: a prop that is
+ * taken away and put back down reappears rather than staying invisible.
+ */
+export class PropLibrary {
+  /** Roster from the server, by name. Empty until the first manifest lands. */
+  private info = new Map<string, PropInfo>();
+  private roots = new Map<string, THREE.Group>();
+  private loading = new Set<string>();
+  private hulls: THREE.Mesh[] = [];
+  private hullsVisible = false;
+
+  constructor(
+    private scene: THREE.Scene,
+    private material: THREE.MeshBasicMaterial,
+    /** Called when a prop's body first enters the scene (shadow box refit). */
+    private onChanged: () => void = () => {},
+  ) {}
+
+  /** Adopt the server's roster. Props that vanish from it lose their bodies. */
+  setManifest(props: PropInfo[]): void {
+    this.info = new Map(props.map((p) => [p.name, p]));
+    for (const [name, root] of this.roots) {
+      if (!this.info.has(name)) {
+        this.scene.remove(root);
+        this.roots.delete(name);
+      }
+    }
+  }
+
+  get manifest(): PropInfo[] {
+    return [...this.info.values()];
+  }
+
+  /** Mirror ground truth: {name: [x, y, z, qw, qx, qy, qz]}. A prop the block
+   * stops naming has left the world (parked, or never dropped) and is hidden
+   * rather than left behind at its last pose. */
+  setPoses(poses: Record<string, number[]>): void {
+    for (const [name, root] of this.roots) {
+      if (!poses[name]) root.visible = false;
+    }
+    for (const [name, pose] of Object.entries(poses)) {
+      const root = this.ensure(name);
+      if (!root) continue; // unknown prop, or its glb is still loading
+      // Explicitly, not just on creation: a prop that was removed and put down
+      // again reuses its hidden root and would otherwise stay invisible.
+      root.visible = true;
+      root.position.set(pose[0], pose[1], pose[2]);
+      root.quaternion.set(pose[4], pose[5], pose[6], pose[3]);
+    }
+  }
+
+  setHullsVisible(visible: boolean): void {
+    this.hullsVisible = visible;
+    for (const hull of this.hulls) hull.visible = visible;
+  }
+
+  /** Every prop body currently in the world (shadow-box fitting). */
+  get visibleRoots(): THREE.Object3D[] {
+    return [...this.roots.values()].filter((r) => r.visible);
+  }
+
+  private ensure(name: string): THREE.Group | undefined {
+    const existing = this.roots.get(name);
+    if (existing) return existing;
+    const info = this.info.get(name);
+    if (!info) return undefined; // a prop this build was never told about
+
+    const root = new THREE.Group();
+    this.roots.set(name, root);
+    this.scene.add(root);
+    if (info.viewer.hulls) void this.loadHullSoup(info, root);
+
+    if (!info.viewer.glb) {
+      root.add(this.primitiveMesh(info));
+      this.onChanged();
+      return root;
+    }
+    // Show the primitive immediately, then swap in the glb once it arrives --
+    // so a prop is never invisible, whether the mesh is slow or absent.
+    const placeholder = this.primitiveMesh(info);
+    root.add(placeholder);
+    if (!this.loading.has(name)) {
+      this.loading.add(name);
+      void this.loadGlb(info, root, placeholder);
+    }
+    this.onChanged();
+    return root;
+  }
+
+  private primitiveMesh(info: PropInfo): THREE.Mesh {
+    const [r, g, b] = info.rgba;
+    const mesh = new THREE.Mesh(
+      primitiveGeometry(info),
+      new THREE.MeshStandardMaterial({ color: new THREE.Color(r, g, b), roughness: 0.7 }),
+    );
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    return mesh;
+  }
+
+  private async loadGlb(info: PropInfo, root: THREE.Group, placeholder: THREE.Mesh): Promise<void> {
+    try {
+      const gltf = await new GLTFLoader().loadAsync(info.viewer.glb!);
+      normalizeModel(gltf.scene, info.viewer);
+      gltf.scene.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          obj.castShadow = true;
+          obj.receiveShadow = true;
+        }
+      });
+      root.remove(placeholder);
+      placeholder.geometry.dispose();
+      root.add(gltf.scene);
+      this.onChanged();
+    } catch (err) {
+      // Expected whenever the asset bundle predates this prop: keep the
+      // primitive, which is what physics is using anyway.
+      console.warn(`[sim-viewer] prop '${info.name}' has no model (${info.viewer.glb}); drawing its primitive`, err);
+    }
+  }
+
+  private async loadHullSoup(info: PropInfo, root: THREE.Group): Promise<void> {
+    try {
+      const res = await fetch(info.viewer.hulls!);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(await res.arrayBuffer()), 3));
+      const hull = new THREE.Mesh(geometry, this.material);
+      hull.visible = this.hullsVisible; // honour a toggle made before the drop
+      this.hulls.push(hull);
+      root.add(hull);
+    } catch (err) {
+      console.warn(`[sim-viewer] collision soup missing for '${info.name}'; overlay skipped`, err);
+    }
+  }
+}

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -13,6 +13,7 @@ import { LineMaterial } from "three/addons/lines/LineMaterial.js";
 import URDFLoader from "urdf-loader";
 import type { URDFRobot } from "urdf-loader";
 import { LoadQueue, queuedGLB } from "./loadQueue";
+import { PropLibrary, type PropInfo } from "./props";
 
 const APARTMENT_URL = "/models/appartement.glb";
 const APARTMENT_MANIFEST_URL = "/models/apartment/manifest.json";
@@ -40,23 +41,6 @@ export interface ApartmentLayout {
   /** No manifest: streamApartment falls back to the monolith glb. */
   monolith: boolean;
 }
-// The manipulation props (world.py GRASP_OBJECTS). They are MuJoCo primitives,
-// so the browser rebuilds them here rather than loading a mesh -- keep the
-// dimensions and colours in step with world.py. THREE's cylinder is Y-up while
-// MuJoCo's is Z-up, hence the rotated geometry.
-const GRASP_OBJECT_SHAPES: Record<string, { geometry: () => THREE.BufferGeometry; color: number }> = {
-  cube: { geometry: () => new THREE.BoxGeometry(0.04, 0.04, 0.04), color: 0xd94739 },
-  sock: { geometry: () => new THREE.BoxGeometry(0.04, 0.04, 0.06), color: 0x73757f },
-  can: {
-    geometry: () => new THREE.CylinderGeometry(0.02, 0.02, 0.06, 40).rotateX(Math.PI / 2),
-    color: 0x408cd9,
-  },
-  bar: { geometry: () => new THREE.BoxGeometry(0.03, 0.1, 0.03), color: 0xcc541a },
-  // Finely tessellated: a coarse sphere casts a visibly polygonal shadow right
-  // where it meets the floor, which is the one place the eye checks for contact.
-  ball: { geometry: () => new THREE.SphereGeometry(0.0225, 32, 24), color: 0x66cc73 },
-};
-
 // These URDF links carry no real body geometry — just small marker spheres
 // used to visualize the end-effector / camera optical frames (e.g. in
 // RViz). Hide them here rather than in the URDF itself, since that file is
@@ -159,8 +143,10 @@ export class SimScene {
   // the robot's own graph, so they follow the joints for free.
   private robotColliders: THREE.Object3D[] = [];
   private hullMaterial = new THREE.MeshBasicMaterial({ color: 0x00ff88, wireframe: true });
-  // One mesh per manipulation prop, built on the first state that names it.
-  private objectMeshes = new Map<string, THREE.Mesh>();
+  // Every prop in the world, built from the server's roster (props.ts).
+  private props: PropLibrary;
+  // While true a placement drag owns the pointer and orbit stays off.
+  private placementMode = false;
 
   /** Fixed render size (offscreen use, e.g. SimSession); null = track the window. */
   private fixedSize: { width: number; height: number } | null = null;
@@ -180,6 +166,10 @@ export class SimScene {
 
     this.scene.background = new THREE.Color(0x14161a);
     this.scene.fog = new THREE.FogExp2(0x14161a, 0.035);
+
+    // Props share the apartment's hull wireframe material, so one "collisions"
+    // toggle covers both. A prop entering the world refits the shadow box.
+    this.props = new PropLibrary(this.scene, this.hullMaterial, () => this.updateShadowVolume());
 
     this.camera = new THREE.PerspectiveCamera(55, w / h, 0.05, 200);
     this.camera.up.set(0, 0, 1);
@@ -336,6 +326,7 @@ export class SimScene {
    */
   setCollisionHullsVisible(visible: boolean): void {
     this.hullsVisible = visible;
+    this.props.setHullsVisible(visible);
     if (visible && !this.hullsPromise) {
       // ~1300 OBJ fetches; takes seconds on first show. A failure resets the
       // promise so toggling again retries instead of staying dead forever.
@@ -673,11 +664,10 @@ export class SimScene {
     // two would push the robot itself out of its own shadow box.
     const reach = SHADOW_BOX_MAX_M - SHADOW_MARGIN_M;
     const points: Array<[number, number]> = [this.robotXY];
-    for (const mesh of this.objectMeshes.values()) {
-      if (!mesh.visible) continue;
-      const dx = mesh.position.x - this.robotXY[0];
-      const dy = mesh.position.y - this.robotXY[1];
-      if (Math.hypot(dx, dy) <= reach) points.push([mesh.position.x, mesh.position.y]);
+    for (const root of this.props.visibleRoots) {
+      const dx = root.position.x - this.robotXY[0];
+      const dy = root.position.y - this.robotXY[1];
+      if (Math.hypot(dx, dy) <= reach) points.push([root.position.x, root.position.y]);
     }
     const xs = points.map((pt) => pt[0]);
     const ys = points.map((pt) => pt[1]);
@@ -721,7 +711,35 @@ export class SimScene {
    * Falls back to orbit if the requested view's frame wasn't in the URDF. */
   setView(view: CameraView): void {
     this.activeView = view === "orbit" || this.robotCameras.has(view) ? view : "orbit";
-    this.controls.enabled = this.activeView === "orbit";
+    this.applyControlsEnabled();
+  }
+
+  /** While a placement drag owns the pointer the orbit controls stay off,
+   * even in the orbit view -- otherwise aiming a prop also spins the camera.
+   * Applied immediately: a flag that is only consulted by setView() would not
+   * take effect until the user happened to switch views. */
+  setPlacementMode(on: boolean): void {
+    this.placementMode = on;
+    this.applyControlsEnabled();
+  }
+
+  private applyControlsEnabled(): void {
+    this.controls.enabled = this.activeView === "orbit" && !this.placementMode;
+  }
+
+  /** Intersect a canvas pointer position with the floor plane (z=0) through
+   * the active view's camera; null when it points above the horizon. */
+  screenToFloor(clientX: number, clientY: number): THREE.Vector3 | null {
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    const ndc = new THREE.Vector2(
+      ((clientX - rect.left) / rect.width) * 2 - 1,
+      -((clientY - rect.top) / rect.height) * 2 + 1,
+    );
+    const cam = (this.activeView !== "orbit" ? this.robotCameras.get(this.activeView) : undefined) ?? this.camera;
+    const raycaster = new THREE.Raycaster();
+    raycaster.setFromCamera(ndc, cam);
+    const hit = new THREE.Vector3();
+    return raycaster.ray.intersectPlane(new THREE.Plane(new THREE.Vector3(0, 0, 1), 0), hit) ? hit : null;
   }
 
   /** Drive the URDF's arm/head joints to match physics-simulated angles (radians). */
@@ -729,33 +747,18 @@ export class SimScene {
     this.robot?.setJointValues(joints);
   }
 
-  /** Mirror the manipulation props from ground truth, keyed by name
+  /** Adopt the world server's prop roster (props.py sidecars): what exists,
+   * what to call it, and how to draw it. Sent once per observer connection. */
+  setPropManifest(props: PropInfo[]): void {
+    this.props.setManifest(props);
+  }
+
+  /** Mirror every prop in the world from ground truth, keyed by name
    * ({name: [x, y, z, qw, qx, qy, qz]} -- world_server's "objects" block).
-   * Each mesh is built on first sight from GRASP_OBJECT_SHAPES; a prop the
-   * block stops naming has left the world (parked, or never dropped) and is
-   * hidden rather than left behind at its last pose. */
+   * A prop the block stops naming has left the world and is hidden rather
+   * than left behind at its last pose. */
   setObjectPoses(poses: Record<string, number[]>): void {
-    for (const [name, mesh] of this.objectMeshes) {
-      if (!poses[name]) mesh.visible = false;
-    }
-    for (const [name, pose] of Object.entries(poses)) {
-      let mesh = this.objectMeshes.get(name);
-      if (!mesh) {
-        const shape = GRASP_OBJECT_SHAPES[name];
-        if (!shape) continue; // a prop this build doesn't know how to draw
-        mesh = new THREE.Mesh(shape.geometry(), new THREE.MeshStandardMaterial({ color: shape.color, roughness: 0.7 }));
-        mesh.castShadow = true;
-        mesh.receiveShadow = true;
-        this.objectMeshes.set(name, mesh);
-        this.scene.add(mesh);
-      }
-      // Explicitly, not just on creation: a prop that was removed and dropped
-      // again reuses its hidden mesh, and would otherwise stay invisible until
-      // a page reload rebuilt it.
-      mesh.visible = true;
-      mesh.position.set(pose[0], pose[1], pose[2]);
-      mesh.quaternion.set(pose[4], pose[5], pose[6], pose[3]);
-    }
+    this.props.setPoses(poses);
     this.updateShadowVolume(); // the props moved; the box may need to grow or shrink
   }
 

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -239,28 +239,22 @@ export class SimSession {
     this.#overlaysDirty = true;
   }
 
-  /** Lay the manipulation props out on the floor in front of the robot,
-   * wherever it currently is (stage "drop objects" button). */
-  dropObjects(): void {
-    this.#controller?.send({ op: "drop_objects" });
+  /** Send every prop back off-map (stage "clear" chip). */
+  removeAllProps(): void {
+    this.#controller?.send({ op: "remove_all_props" });
   }
 
-  /** Send every prop back off-map (stage "clear" button). */
-  removeObjects(): void {
-    this.#controller?.send({ op: "remove_objects" });
-  }
-
-  /** Lay a whole set of props out in front of the robot at once, each at its
+  /** Set a whole set of props down in front of the robot at once, each at its
    * own reach offset (props.py `group`), parking everything outside the set. */
-  dropPropGroup(group: string): void {
-    this.#controller?.send({ op: "drop_group", group });
+  placePropGroup(group: string): void {
+    this.#controller?.send({ op: "place_group", group });
   }
 
-  /** Put one prop down in front of the robot, at the prop's own reach offset
-   * -- for the manipulation props that is an arc the arm can reach top-down,
-   * so it is placed at rest rather than dropped. */
-  dropPropAtRobot(name: string): void {
-    this.#controller?.send({ op: "drop_prop_at_robot", name });
+  /** Set one prop down in front of the robot at the prop's own reach offset --
+   * for the manipulation props that is an arc the arm can reach top-down, so
+   * it lands at rest rather than falling. */
+  placePropAtRobot(name: string): void {
+    this.#controller?.send({ op: "place_prop_at_robot", name });
   }
 
   /** Release one prop above a spot the user picked, yawed about +z; the world

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -7,6 +7,7 @@
 import type { SimScene } from "./scene";
 import { RosbridgePhysicsController } from "./physics/rosbridgeController";
 import { WorldStateController } from "./physics/worldStateController";
+import type { PropInfo } from "./props";
 
 /** PiP tile render size; square to match the webapp's .cam-tile. */
 export const THUMB_W = 240;
@@ -93,6 +94,13 @@ export class SimSession {
   #hullsOn = false;
   #overlaysDirty = false;
 
+  // The prop roster, relayed from the world server once per connection
+  // (props.py sidecars). The stage builds its buttons from it and the scene
+  // builds its models; both key off this rather than a second local table.
+  #props: PropInfo[] = [];
+  #propListeners = new Set<(props: PropInfo[]) => void>();
+  #propsDirty = false;
+
   #stateUrls: string[];
   #rosUrl: string;
 
@@ -149,6 +157,11 @@ export class SimSession {
   #connectState(i: number): void {
     const url = this.#stateUrls[i];
     this.#controller = new WorldStateController(url);
+    this.#controller.onProps = (props) => {
+      this.#props = props;
+      this.#propsDirty = true; // handed to the scene on the next tick
+      for (const cb of this.#propListeners) cb(props);
+    };
     this.#controller.onState = (s) => {
       const lag = Date.now() / 1000 - s.wall;
       if (lag < this.#lagMinS) this.#lagMinS = lag;
@@ -232,9 +245,35 @@ export class SimSession {
     this.#controller?.send({ op: "drop_objects" });
   }
 
-  /** Send the props back off-map (stage "remove objects" button). */
+  /** Send every prop back off-map (stage "clear" button). */
   removeObjects(): void {
     this.#controller?.send({ op: "remove_objects" });
+  }
+
+  /** Put one prop down in front of the robot, at the prop's own reach offset
+   * -- for the manipulation props that is an arc the arm can reach top-down,
+   * so it is placed at rest rather than dropped. */
+  dropPropAtRobot(name: string): void {
+    this.#controller?.send({ op: "drop_prop_at_robot", name });
+  }
+
+  /** Release one prop above a spot the user picked, yawed about +z; the world
+   * server's physics settles it onto whatever is below. */
+  dropPropAt(name: string, x: number, y: number, yaw: number): void {
+    this.#controller?.send({ op: "drop_prop_at", name, x, y, yaw });
+  }
+
+  /** Send one prop back off-map. */
+  removeProp(name: string): void {
+    this.#controller?.send({ op: "remove_prop", name });
+  }
+
+  /** Subscribe to the prop roster (props.py sidecars); fires immediately if it
+   * has already arrived. The stage builds its buttons from this. */
+  onProps(cb: (props: PropInfo[]) => void): () => void {
+    this.#propListeners.add(cb);
+    if (this.#props.length) cb(this.#props);
+    return () => this.#propListeners.delete(cb);
   }
 
   /** Whether any manipulation prop is currently in the world. Read from
@@ -340,6 +379,10 @@ export class SimSession {
         pa[2] + (pb[2] - pa[2]) * u,
         ...q.map((v) => v / norm),
       ];
+    }
+    if (this.#propsDirty) {
+      this.#propsDirty = false;
+      scene.setPropManifest(this.#props);
     }
     scene.setObjectPoses(objects);
 

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -250,6 +250,12 @@ export class SimSession {
     this.#controller?.send({ op: "remove_objects" });
   }
 
+  /** Lay a whole set of props out in front of the robot at once, each at its
+   * own reach offset (props.py `group`), parking everything outside the set. */
+  dropPropGroup(group: string): void {
+    this.#controller?.send({ op: "drop_group", group });
+  }
+
   /** Put one prop down in front of the robot, at the prop's own reach offset
    * -- for the manipulation props that is an arc the arm can reach top-down,
    * so it is placed at rest rather than dropped. */

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -6,6 +6,7 @@
 
 import * as THREE from "three";
 import { SimScene, type CameraView } from "./scene";
+import type { PropInfo } from "./props";
 import { LoadQueue } from "./loadQueue";
 import { THUMB_H, THUMB_W, type SimSession } from "./simSession";
 
@@ -104,9 +105,33 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
 
   // Rebuilt whenever the roster arrives (once per observer connection).
   const propChips = new Map<string, HTMLButtonElement>();
-  const unsubscribeProps = session.onProps((props: { name: string; label: string; title: string }[]) => {
+  const groupChips: HTMLButtonElement[] = [];
+  const unsubscribeProps = session.onProps((props: PropInfo[]) => {
     for (const chip of propChips.values()) chip.remove();
+    for (const chip of groupChips) chip.remove();
     propChips.clear();
+    groupChips.length = 0;
+    // One chip per set, before the individual props: putting a whole set down
+    // at once is the workflow the arm's props exist for, and clicking five
+    // chips is not it. Sets come from the roster, so a new group in a sidecar
+    // gets its button for free.
+    for (const group of [...new Set(props.map((p) => p.group))]) {
+      const members = props.filter((p) => p.group === group);
+      if (members.length < 2) continue; // a set of one is just the prop's own chip
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.textContent = `+${group}`;
+      chip.title = `Set down all ${members.length} ${group} props in front of the robot`;
+      chip.style.cssText =
+        `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
+        "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
+      chip.onclick = () => {
+        armDrop(null);
+        session.dropPropGroup(group);
+      };
+      groupChips.push(chip);
+      propRow.appendChild(chip);
+    }
     for (const prop of props) {
       const chip = document.createElement("button");
       chip.type = "button";

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -46,14 +46,29 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   propControls.style.cssText = "display:flex;gap:6px;align-items:center;flex-wrap:wrap;";
   const OFF_BG = "rgba(0,0,0,.45)";
   const ON_BG = "rgba(0,255,136,.22)";
-  const newChip = (label: string) => {
+  const ON_FG = "#7dffc4";
+  const OFF_FG = "rgba(255,255,255,.75)";
+  /** The one place a chip's lit/unlit look is decided. Every chip goes through
+   * it, so the toggles and an armed prop can never drift apart. */
+  const setChipOn = (el: HTMLElement, on: boolean) => {
+    el.style.background = on ? ON_BG : OFF_BG;
+    el.style.color = on ? ON_FG : OFF_FG;
+  };
+  // No backdrop-filter: re-blurring over an animated canvas costs fps.
+  const CHIP_CSS =
+    "padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);" +
+    "font:500 11px system-ui;cursor:pointer;line-height:1;";
+  const makeChip = (label: string, title?: string) => {
     const b = document.createElement("button");
     b.type = "button";
     b.textContent = label;
-    b.style.cssText =
-      // No backdrop-filter: re-blurring over an animated canvas costs fps.
-      `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
-      "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
+    if (title) b.title = title;
+    b.style.cssText = CHIP_CSS;
+    setChipOn(b, false);
+    return b;
+  };
+  const newChip = (label: string) => {
+    const b = makeChip(label);
     propControls.appendChild(b);
     return b;
   };
@@ -62,8 +77,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
     let on = false;
     b.onclick = () => {
       on = !on;
-      b.style.background = on ? ON_BG : OFF_BG;
-      b.style.color = on ? "#7dffc4" : "rgba(255,255,255,.75)";
+      setChipOn(b, on);
       onToggle(on);
     };
   };
@@ -90,25 +104,30 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   modeSwitch.type = "button";
   modeSwitch.title = "How clicking a prop places it";
   modeSwitch.style.cssText =
-    "position:relative;display:inline-flex;padding:2px;border-radius:999px;" +
-    `border:1px solid rgba(255,255,255,.25);background:${OFF_BG};cursor:pointer;` +
-    "font:500 11px system-ui;line-height:1;";
+    // Equal grid columns, so the half-width knob lands exactly on a label
+    // whatever the two words measure.
+    "position:relative;display:inline-grid;grid-auto-flow:column;grid-auto-columns:1fr;" +
+    "padding:2px;border-radius:999px;border:1px solid rgba(255,255,255,.28);" +
+    // Darker than a chip: the 3D scene behind this is often bright wall or
+    // floor, where 45% black leaves the inactive label unreadable.
+    "background:rgba(0,0,0,.62);cursor:pointer;font:500 11px system-ui;line-height:1;";
   const knob = document.createElement("span");
   knob.style.cssText =
-    `position:absolute;top:2px;bottom:2px;left:2px;width:calc(50% - 2px);border-radius:999px;background:${ON_BG};` +
-    "transition:transform .15s ease;pointer-events:none;";
+    "position:absolute;top:2px;bottom:2px;left:2px;width:calc(50% - 2px);border-radius:999px;" +
+    "background:rgba(0,255,136,.28);transition:transform .15s ease;pointer-events:none;";
   const placeLabel = document.createElement("span");
   const robotLabel = document.createElement("span");
   placeLabel.textContent = "place";
   robotLabel.textContent = "at robot";
   for (const label of [placeLabel, robotLabel]) {
-    label.style.cssText = "position:relative;z-index:1;padding:4px 10px;transition:color .15s ease;";
+    label.style.cssText =
+      "position:relative;z-index:1;padding:4px 12px;text-align:center;white-space:nowrap;transition:color .15s ease;";
   }
   modeSwitch.append(knob, placeLabel, robotLabel);
   const refreshModeSwitch = () => {
     knob.style.transform = placeMode ? "translateX(0)" : "translateX(100%)";
-    placeLabel.style.color = placeMode ? "#7dffc4" : "rgba(255,255,255,.55)";
-    robotLabel.style.color = placeMode ? "rgba(255,255,255,.55)" : "#7dffc4";
+    placeLabel.style.color = placeMode ? ON_FG : OFF_FG;
+    robotLabel.style.color = placeMode ? OFF_FG : ON_FG;
   };
   modeSwitch.onclick = () => {
     placeMode = !placeMode;
@@ -118,13 +137,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   refreshModeSwitch();
   propControls.appendChild(modeSwitch);
 
-  const clearChip = document.createElement("button");
-  clearChip.type = "button";
-  clearChip.textContent = "clear";
-  clearChip.title = "Send every prop back off-map";
-  clearChip.style.cssText =
-    `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
-    "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
+  const clearChip = makeChip("clear", "Send every prop back off-map");
   clearChip.onclick = () => {
     armDrop(null);
     session.removeObjects();
@@ -163,13 +176,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
       row.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;align-items:center;";
       // A set of one is just the prop's own chip, so it gets no set chip.
       if (group && members.length > 1) {
-        const chip = document.createElement("button");
-        chip.type = "button";
-        chip.textContent = `+${group}`;
-        chip.title = `Set down all ${members.length} ${group} props in front of the robot`;
-        chip.style.cssText =
-          `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
-          "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
+        const chip = makeChip(`+${group}`, `Set down all ${members.length} ${group} props in front of the robot`);
         chip.onclick = () => {
           armDrop(null);
           session.dropPropGroup(group);
@@ -177,13 +184,10 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
         row.appendChild(chip);
       }
       for (const prop of members) {
-        const chip = document.createElement("button");
-        chip.type = "button";
-        chip.textContent = prop.label;
-        chip.title = prop.title;
-        chip.style.cssText =
-          `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
-          "color:rgba(255,255,255,.75);font:500 13px system-ui;cursor:pointer;line-height:1;";
+        const chip = makeChip(prop.label, prop.title);
+        chip.style.fontSize = "13px"; // emoji read small at the chip's 11px
+        // A roster can arrive mid-drag; keep whatever was armed looking armed.
+        setChipOn(chip, prop.name === armedProp);
         chip.onclick = () => {
           if (placeMode) armDrop(armedProp === prop.name ? null : prop.name);
           else session.dropPropAtRobot(prop.name);
@@ -297,8 +301,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
     canvas.style.cursor = name !== null ? "crosshair" : "";
     for (const [propName, chip] of propChips) {
       const on = propName === name;
-      chip.style.background = on ? ON_BG : OFF_BG;
-      chip.style.color = on ? "#7dffc4" : "rgba(255,255,255,.75)";
+      setChipOn(chip, on);
     }
     if (name === null) clearDropDrag();
   }

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -68,10 +68,12 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   addChip("collisions", (on) => session.setCollisionHullsVisible(on));
   debugStack.appendChild(chips);
 
-  // Prop row: one chip per prop the world server offers (props.py sidecars,
-  // relayed by session.onProps), so adding a prop is a sidecar and nothing
-  // here. Two ways to put one down, chosen by the mode chip:
+  // Props, in two rows: the objects themselves, and under them the controls
+  // that say what a click on one does. One chip per prop the world server
+  // offers (props.py sidecars, relayed by session.onProps), so adding a prop
+  // is a sidecar and nothing here.
   //
+  // The switch picks between the two ways to put a prop down:
   //   at robot -- one click, using the prop's own reach offset. The
   //     manipulation props' offsets put them on an arc the arm can reach
   //     top-down, so this is the one that matters for practising grabs.
@@ -80,28 +82,58 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   const propRow = document.createElement("div");
   propRow.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;align-items:center;";
   debugStack.appendChild(propRow);
+  const propControls = document.createElement("div");
+  propControls.style.cssText = "display:flex;gap:6px;align-items:center;";
+  debugStack.appendChild(propControls);
 
+  // Slide switch: place | at robot. Defaults to "at robot" -- that is the
+  // one-click layout the props have always had, and the destructive-feeling
+  // one (taking over the pointer) is the one you opt into.
   let placeMode = false;
-  const modeChip = document.createElement("button");
-  modeChip.type = "button";
-  modeChip.style.cssText =
+  const modeSwitch = document.createElement("button");
+  modeSwitch.type = "button";
+  modeSwitch.title = "How clicking a prop places it";
+  modeSwitch.style.cssText =
+    "position:relative;display:inline-flex;padding:2px;border-radius:999px;" +
+    `border:1px solid rgba(255,255,255,.25);background:${OFF_BG};cursor:pointer;` +
+    "font:500 11px system-ui;line-height:1;";
+  const knob = document.createElement("span");
+  knob.style.cssText =
+    `position:absolute;top:2px;bottom:2px;left:2px;width:calc(50% - 2px);border-radius:999px;background:${ON_BG};` +
+    "transition:transform .15s ease;pointer-events:none;";
+  const placeLabel = document.createElement("span");
+  const robotLabel = document.createElement("span");
+  placeLabel.textContent = "place";
+  robotLabel.textContent = "at robot";
+  for (const label of [placeLabel, robotLabel]) {
+    label.style.cssText = "position:relative;z-index:1;padding:4px 10px;transition:color .15s ease;";
+  }
+  modeSwitch.append(knob, placeLabel, robotLabel);
+  const refreshModeSwitch = () => {
+    knob.style.transform = placeMode ? "translateX(0)" : "translateX(100%)";
+    placeLabel.style.color = placeMode ? "#7dffc4" : "rgba(255,255,255,.55)";
+    robotLabel.style.color = placeMode ? "rgba(255,255,255,.55)" : "#7dffc4";
+  };
+  modeSwitch.onclick = () => {
+    placeMode = !placeMode;
+    if (!placeMode) armDrop(null); // leaving place mode disarms whatever was armed
+    refreshModeSwitch();
+  };
+  refreshModeSwitch();
+  propControls.appendChild(modeSwitch);
+
+  const clearChip = document.createElement("button");
+  clearChip.type = "button";
+  clearChip.textContent = "clear";
+  clearChip.title = "Send every prop back off-map";
+  clearChip.style.cssText =
     `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
     "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
-  const refreshModeChip = () => {
-    modeChip.textContent = placeMode ? "place" : "at robot";
-    modeChip.title = placeMode
-      ? "Click a prop, then click the floor and drag to aim it"
-      : "Click a prop to set it down in front of the robot, where the arm can reach it";
-    modeChip.style.background = placeMode ? ON_BG : OFF_BG;
-    modeChip.style.color = placeMode ? "#7dffc4" : "rgba(255,255,255,.75)";
+  clearChip.onclick = () => {
+    armDrop(null);
+    session.removeObjects();
   };
-  modeChip.onclick = () => {
-    placeMode = !placeMode;
-    if (!placeMode) armDrop(null);
-    refreshModeChip();
-  };
-  refreshModeChip();
-  propRow.appendChild(modeChip);
+  propControls.appendChild(clearChip);
 
   // Rebuilt whenever the roster arrives (once per observer connection).
   const propChips = new Map<string, HTMLButtonElement>();
@@ -111,11 +143,11 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
     for (const chip of groupChips) chip.remove();
     propChips.clear();
     groupChips.length = 0;
-    // One chip per set, before the individual props: putting a whole set down
-    // at once is the workflow the arm's props exist for, and clicking five
-    // chips is not it. Sets come from the roster, so a new group in a sidecar
-    // gets its button for free.
-    for (const group of [...new Set(props.map((p) => p.group))]) {
+    // A set chip ahead of the props it contains: putting a whole set down at
+    // once is the workflow the arm's props exist for, and clicking five chips
+    // is not it. Only props that name a group get one, so scenery -- which is
+    // placed deliberately, one piece at a time -- has none.
+    for (const group of [...new Set(props.map((p) => p.group).filter(Boolean))]) {
       const members = props.filter((p) => p.group === group);
       if (members.length < 2) continue; // a set of one is just the prop's own chip
       const chip = document.createElement("button");
@@ -127,7 +159,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
         "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
       chip.onclick = () => {
         armDrop(null);
-        session.dropPropGroup(group);
+        session.dropPropGroup(group as string);
       };
       groupChips.push(chip);
       propRow.appendChild(chip);
@@ -148,19 +180,6 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
       propRow.appendChild(chip);
     }
   });
-
-  const clearChip = document.createElement("button");
-  clearChip.type = "button";
-  clearChip.textContent = "clear";
-  clearChip.title = "Send every prop back off-map";
-  clearChip.style.cssText =
-    `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
-    "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
-  clearChip.onclick = () => {
-    armDrop(null);
-    session.removeObjects();
-  };
-  propRow.appendChild(clearChip);
 
   // Loading indicator: a compact pill holding a progress bar, centered just
   // below the camera thumbnail strip (webapp's .cam-strip pins tiles at the top

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -39,8 +39,11 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   debugStack.style.cssText =
     "position:absolute;left:14px;bottom:132px;display:flex;flex-direction:column;gap:8px;z-index:5;";
   wrap.appendChild(debugStack);
-  const chips = document.createElement("div");
-  chips.style.cssText = "display:flex;gap:6px;";
+  // One controls row, built here because newChip fills it but appended after
+  // the prop rows so it sits beneath them: what a prop click does, then the
+  // view overlays. Four stacked rows crowded the WASD overlay underneath.
+  const propControls = document.createElement("div");
+  propControls.style.cssText = "display:flex;gap:6px;align-items:center;flex-wrap:wrap;";
   const OFF_BG = "rgba(0,0,0,.45)";
   const ON_BG = "rgba(0,255,136,.22)";
   const newChip = (label: string) => {
@@ -51,7 +54,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
       // No backdrop-filter: re-blurring over an animated canvas costs fps.
       `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
       "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
-    chips.appendChild(b);
+    propControls.appendChild(b);
     return b;
   };
   const addChip = (label: string, onToggle: (on: boolean) => void) => {
@@ -64,10 +67,6 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
       onToggle(on);
     };
   };
-  addChip("lidar", (on) => session.setLidarVisible(on));
-  addChip("collisions", (on) => session.setCollisionHullsVisible(on));
-  debugStack.appendChild(chips);
-
   // Props, in two rows: the objects themselves, and under them the controls
   // that say what a click on one does. One chip per prop the world server
   // offers (props.py sidecars, relayed by session.onProps), so adding a prop
@@ -82,9 +81,6 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   const propRows = document.createElement("div");
   propRows.style.cssText = "display:flex;flex-direction:column;gap:6px;align-items:flex-start;";
   debugStack.appendChild(propRows);
-  const propControls = document.createElement("div");
-  propControls.style.cssText = "display:flex;gap:6px;align-items:center;";
-  debugStack.appendChild(propControls);
 
   // Slide switch: place | at robot. Defaults to "at robot" -- that is the
   // one-click layout the props have always had, and the destructive-feeling
@@ -134,6 +130,15 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
     session.removeObjects();
   };
   propControls.appendChild(clearChip);
+
+  // Hairline between what places props and what draws overlays -- same row,
+  // different jobs.
+  const divider = document.createElement("span");
+  divider.style.cssText = "width:1px;align-self:stretch;margin:2px 2px;background:rgba(255,255,255,.18);";
+  propControls.appendChild(divider);
+  addChip("lidar", (on) => session.setLidarVisible(on));
+  addChip("collisions", (on) => session.setCollisionHullsVisible(on));
+  debugStack.appendChild(propControls);
 
   // Rebuilt whenever the roster arrives (once per observer connection).
   //

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -4,6 +4,7 @@
 // full-res every frame, PiP thumbnails scissor-rendered from the same GL
 // context and blitted out.
 
+import * as THREE from "three";
 import { SimScene, type CameraView } from "./scene";
 import { LoadQueue } from "./loadQueue";
 import { THUMB_H, THUMB_W, type SimSession } from "./simSession";
@@ -64,24 +65,77 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   };
   addChip("lidar", (on) => session.setLidarVisible(on));
   addChip("collisions", (on) => session.setCollisionHullsVisible(on));
-  // Not a toggle with its own memory: the label follows the world, so a sim
-  // reset (which takes the props away) or another viewer's drop leaves this
-  // reading correctly. refreshObjectChip runs from the render loop.
-  const objectChip = newChip("drop objects");
-  let objectChipShowsRemove: boolean | null = null;
-  const refreshObjectChip = () => {
-    const present = session.objectsPresent;
-    if (present === objectChipShowsRemove) return;
-    objectChipShowsRemove = present;
-    objectChip.textContent = present ? "remove objects" : "drop objects";
-    objectChip.style.background = present ? ON_BG : OFF_BG;
-    objectChip.style.color = present ? "#7dffc4" : "rgba(255,255,255,.75)";
-  };
-  objectChip.onclick = () => {
-    if (session.objectsPresent) session.removeObjects();
-    else session.dropObjects();
-  };
   debugStack.appendChild(chips);
+
+  // Prop row: one chip per prop the world server offers (props.py sidecars,
+  // relayed by session.onProps), so adding a prop is a sidecar and nothing
+  // here. Two ways to put one down, chosen by the mode chip:
+  //
+  //   at robot -- one click, using the prop's own reach offset. The
+  //     manipulation props' offsets put them on an arc the arm can reach
+  //     top-down, so this is the one that matters for practising grabs.
+  //   place    -- click the floor to mark the spot, drag to point the yaw,
+  //     release; physics settles it onto whatever is under it.
+  const propRow = document.createElement("div");
+  propRow.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;align-items:center;";
+  debugStack.appendChild(propRow);
+
+  let placeMode = false;
+  const modeChip = document.createElement("button");
+  modeChip.type = "button";
+  modeChip.style.cssText =
+    `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
+    "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
+  const refreshModeChip = () => {
+    modeChip.textContent = placeMode ? "place" : "at robot";
+    modeChip.title = placeMode
+      ? "Click a prop, then click the floor and drag to aim it"
+      : "Click a prop to set it down in front of the robot, where the arm can reach it";
+    modeChip.style.background = placeMode ? ON_BG : OFF_BG;
+    modeChip.style.color = placeMode ? "#7dffc4" : "rgba(255,255,255,.75)";
+  };
+  modeChip.onclick = () => {
+    placeMode = !placeMode;
+    if (!placeMode) armDrop(null);
+    refreshModeChip();
+  };
+  refreshModeChip();
+  propRow.appendChild(modeChip);
+
+  // Rebuilt whenever the roster arrives (once per observer connection).
+  const propChips = new Map<string, HTMLButtonElement>();
+  const unsubscribeProps = session.onProps((props: { name: string; label: string; title: string }[]) => {
+    for (const chip of propChips.values()) chip.remove();
+    propChips.clear();
+    for (const prop of props) {
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.textContent = prop.label;
+      chip.title = prop.title;
+      chip.style.cssText =
+        `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
+        "color:rgba(255,255,255,.75);font:500 13px system-ui;cursor:pointer;line-height:1;";
+      chip.onclick = () => {
+        if (placeMode) armDrop(armedProp === prop.name ? null : prop.name);
+        else session.dropPropAtRobot(prop.name);
+      };
+      propChips.set(prop.name, chip);
+      propRow.appendChild(chip);
+    }
+  });
+
+  const clearChip = document.createElement("button");
+  clearChip.type = "button";
+  clearChip.textContent = "clear";
+  clearChip.title = "Send every prop back off-map";
+  clearChip.style.cssText =
+    `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
+    "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
+  clearChip.onclick = () => {
+    armDrop(null);
+    session.removeObjects();
+  };
+  propRow.appendChild(clearChip);
 
   // Loading indicator: a compact pill holding a progress bar, centered just
   // below the camera thumbnail strip (webapp's .cam-strip pins tiles at the top
@@ -165,6 +219,61 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   const scene = new SimScene(canvas, { fixedSize: { width: parent.clientWidth || 1280, height: parent.clientHeight || 720 } });
   scene.followCamera = true;
 
+  // Placement drag (mode "place"): while a prop is armed the orbit controls
+  // are off -- press marks the spot on the floor, drag points the yaw (arrow
+  // preview), release drops it there and physics settles it.
+  let armedProp: string | null = null;
+  let dropStart: THREE.Vector3 | null = null;
+  let dropArrow: THREE.ArrowHelper | null = null;
+  const clearDropDrag = () => {
+    dropStart = null;
+    if (dropArrow) {
+      scene.scene.remove(dropArrow);
+      dropArrow.dispose();
+      dropArrow = null;
+    }
+  };
+  function armDrop(name: string | null): void {
+    armedProp = name;
+    scene.setPlacementMode(name !== null);
+    canvas.style.cursor = name !== null ? "crosshair" : "";
+    for (const [propName, chip] of propChips) {
+      const on = propName === name;
+      chip.style.background = on ? ON_BG : OFF_BG;
+      chip.style.color = on ? "#7dffc4" : "rgba(255,255,255,.75)";
+    }
+    if (name === null) clearDropDrag();
+  }
+  canvas.addEventListener("pointerdown", (e) => {
+    if (armedProp === null || e.button !== 0) return;
+    dropStart = scene.screenToFloor(e.clientX, e.clientY);
+  });
+  canvas.addEventListener("pointermove", (e) => {
+    if (!dropStart) return;
+    const cur = scene.screenToFloor(e.clientX, e.clientY);
+    if (!cur) return;
+    const drag = cur.sub(dropStart).setZ(0);
+    if (drag.length() < 0.05) return;
+    if (!dropArrow) {
+      dropArrow = new THREE.ArrowHelper(drag.clone().normalize(), dropStart.clone().setZ(0.05), 1, 0xff8800, 0.25, 0.15);
+      scene.scene.add(dropArrow);
+    }
+    dropArrow.setDirection(drag.clone().normalize());
+    dropArrow.setLength(Math.max(drag.length(), 0.4), 0.25, 0.15);
+  });
+  // On window, not canvas: releasing outside the canvas must still finish (or
+  // cancel) the drag rather than leaving the prop armed and the arrow behind.
+  window.addEventListener("pointerup", (e) => {
+    if (armedProp === null || !dropStart) return;
+    const end = scene.screenToFloor(e.clientX, e.clientY);
+    const drag = end ? end.sub(dropStart).setZ(0) : new THREE.Vector3();
+    // An identity drop faces +y (the human's head); the drag vector is that
+    // direction, so subtract the quarter turn between them.
+    const yaw = drag.length() > 0.2 ? Math.atan2(drag.y, drag.x) - Math.PI / 2 : 0;
+    session.dropPropAt(armedProp, dropStart.x, dropStart.y, yaw);
+    armDrop(null);
+  });
+
   const resize = () => {
     const w = wrap.clientWidth;
     const h = wrap.clientHeight;
@@ -187,7 +296,6 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
     const dt = Math.min((now - lastTime) / 1000, 0.1);
     lastTime = now;
     session.tick(scene, dt);
-    refreshObjectChip();
 
     // Thumbnails first (scissor corner renders, blitted out), one tile per
     // slot -- see THUMB_FRAME_DIV.
@@ -269,6 +377,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
       disposed = true;
       queue.cancel(); // stop pulling new downloads for a stage that's gone
       unsubscribe();
+      unsubscribeProps();
       cancelAnimationFrame(raf);
       observer.disconnect();
       longTaskObserver?.disconnect();

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -96,13 +96,16 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   propRows.style.cssText = "display:flex;flex-direction:column;gap:6px;align-items:flex-start;";
   debugStack.appendChild(propRows);
 
-  // Slide switch: place | at robot. Defaults to "at robot" -- that is the
-  // one-click layout the props have always had, and the destructive-feeling
-  // one (taking over the pointer) is the one you opt into.
-  let placeMode = false;
+  // Slide switch: drop | at robot -- the two verbs props.py uses, so what the
+  // chip does is what the switch says. "drop" takes over the pointer and lets
+  // the prop fall onto whatever you aimed at; "at robot" sets it down at rest
+  // at its own reach offset. Defaults to "at robot": that is the one-click
+  // layout the props have always had, and the pointer-grabbing mode is the one
+  // you opt into.
+  let dropMode = false;
   const modeSwitch = document.createElement("button");
   modeSwitch.type = "button";
-  modeSwitch.title = "How clicking a prop places it";
+  modeSwitch.title = "Where clicking a prop puts it";
   modeSwitch.style.cssText =
     // Equal grid columns, so the half-width knob lands exactly on a label
     // whatever the two words measure.
@@ -115,23 +118,23 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   knob.style.cssText =
     "position:absolute;top:2px;bottom:2px;left:2px;width:calc(50% - 2px);border-radius:999px;" +
     "background:rgba(0,255,136,.28);transition:transform .15s ease;pointer-events:none;";
-  const placeLabel = document.createElement("span");
+  const dropLabel = document.createElement("span");
   const robotLabel = document.createElement("span");
-  placeLabel.textContent = "place";
+  dropLabel.textContent = "drop";
   robotLabel.textContent = "at robot";
-  for (const label of [placeLabel, robotLabel]) {
+  for (const label of [dropLabel, robotLabel]) {
     label.style.cssText =
       "position:relative;z-index:1;padding:4px 12px;text-align:center;white-space:nowrap;transition:color .15s ease;";
   }
-  modeSwitch.append(knob, placeLabel, robotLabel);
+  modeSwitch.append(knob, dropLabel, robotLabel);
   const refreshModeSwitch = () => {
-    knob.style.transform = placeMode ? "translateX(0)" : "translateX(100%)";
-    placeLabel.style.color = placeMode ? ON_FG : OFF_FG;
-    robotLabel.style.color = placeMode ? OFF_FG : ON_FG;
+    knob.style.transform = dropMode ? "translateX(0)" : "translateX(100%)";
+    dropLabel.style.color = dropMode ? ON_FG : OFF_FG;
+    robotLabel.style.color = dropMode ? OFF_FG : ON_FG;
   };
   modeSwitch.onclick = () => {
-    placeMode = !placeMode;
-    if (!placeMode) armDrop(null); // leaving place mode disarms whatever was armed
+    dropMode = !dropMode;
+    if (!dropMode) armDrop(null); // leaving drop mode disarms whatever was armed
     refreshModeSwitch();
   };
   refreshModeSwitch();
@@ -140,7 +143,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   const clearChip = makeChip("clear", "Send every prop back off-map");
   clearChip.onclick = () => {
     armDrop(null);
-    session.removeObjects();
+    session.removeAllProps();
   };
   propControls.appendChild(clearChip);
 
@@ -179,7 +182,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
         const chip = makeChip(`+${group}`, `Set down all ${members.length} ${group} props in front of the robot`);
         chip.onclick = () => {
           armDrop(null);
-          session.dropPropGroup(group);
+          session.placePropGroup(group);
         };
         row.appendChild(chip);
       }
@@ -189,8 +192,8 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
         // A roster can arrive mid-drag; keep whatever was armed looking armed.
         setChipOn(chip, prop.name === armedProp);
         chip.onclick = () => {
-          if (placeMode) armDrop(armedProp === prop.name ? null : prop.name);
-          else session.dropPropAtRobot(prop.name);
+          if (dropMode) armDrop(armedProp === prop.name ? null : prop.name);
+          else session.placePropAtRobot(prop.name);
         };
         propChips.set(prop.name, chip);
         row.appendChild(chip);

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -79,9 +79,9 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   //     top-down, so this is the one that matters for practising grabs.
   //   place    -- click the floor to mark the spot, drag to point the yaw,
   //     release; physics settles it onto whatever is under it.
-  const propRow = document.createElement("div");
-  propRow.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;align-items:center;";
-  debugStack.appendChild(propRow);
+  const propRows = document.createElement("div");
+  propRows.style.cssText = "display:flex;flex-direction:column;gap:6px;align-items:flex-start;";
+  debugStack.appendChild(propRows);
   const propControls = document.createElement("div");
   propControls.style.cssText = "display:flex;gap:6px;align-items:center;";
   debugStack.appendChild(propControls);
@@ -136,48 +136,57 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   propControls.appendChild(clearChip);
 
   // Rebuilt whenever the roster arrives (once per observer connection).
+  //
+  // One row per group, headed by that group's set chip, then a loose row for
+  // the props that belong to no set. A set chip floating in a row of everything
+  // says nothing about WHICH props it lays out; heading its own row, it does.
   const propChips = new Map<string, HTMLButtonElement>();
-  const groupChips: HTMLButtonElement[] = [];
   const unsubscribeProps = session.onProps((props: PropInfo[]) => {
-    for (const chip of propChips.values()) chip.remove();
-    for (const chip of groupChips) chip.remove();
+    propRows.replaceChildren();
     propChips.clear();
-    groupChips.length = 0;
-    // A set chip ahead of the props it contains: putting a whole set down at
-    // once is the workflow the arm's props exist for, and clicking five chips
-    // is not it. Only props that name a group get one, so scenery -- which is
-    // placed deliberately, one piece at a time -- has none.
-    for (const group of [...new Set(props.map((p) => p.group).filter(Boolean))]) {
-      const members = props.filter((p) => p.group === group);
-      if (members.length < 2) continue; // a set of one is just the prop's own chip
-      const chip = document.createElement("button");
-      chip.type = "button";
-      chip.textContent = `+${group}`;
-      chip.title = `Set down all ${members.length} ${group} props in front of the robot`;
-      chip.style.cssText =
-        `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
-        "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
-      chip.onclick = () => {
-        armDrop(null);
-        session.dropPropGroup(group as string);
-      };
-      groupChips.push(chip);
-      propRow.appendChild(chip);
-    }
+
+    const buckets = new Map<string | null, PropInfo[]>();
     for (const prop of props) {
-      const chip = document.createElement("button");
-      chip.type = "button";
-      chip.textContent = prop.label;
-      chip.title = prop.title;
-      chip.style.cssText =
-        `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
-        "color:rgba(255,255,255,.75);font:500 13px system-ui;cursor:pointer;line-height:1;";
-      chip.onclick = () => {
-        if (placeMode) armDrop(armedProp === prop.name ? null : prop.name);
-        else session.dropPropAtRobot(prop.name);
-      };
-      propChips.set(prop.name, chip);
-      propRow.appendChild(chip);
+      const key = prop.group || null;
+      const bucket = buckets.get(key);
+      if (bucket) bucket.push(prop);
+      else buckets.set(key, [prop]);
+    }
+
+    for (const [group, members] of buckets) {
+      const row = document.createElement("div");
+      row.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;align-items:center;";
+      // A set of one is just the prop's own chip, so it gets no set chip.
+      if (group && members.length > 1) {
+        const chip = document.createElement("button");
+        chip.type = "button";
+        chip.textContent = `+${group}`;
+        chip.title = `Set down all ${members.length} ${group} props in front of the robot`;
+        chip.style.cssText =
+          `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
+          "color:rgba(255,255,255,.75);font:500 11px system-ui;cursor:pointer;";
+        chip.onclick = () => {
+          armDrop(null);
+          session.dropPropGroup(group);
+        };
+        row.appendChild(chip);
+      }
+      for (const prop of members) {
+        const chip = document.createElement("button");
+        chip.type = "button";
+        chip.textContent = prop.label;
+        chip.title = prop.title;
+        chip.style.cssText =
+          `padding:4px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.25);background:${OFF_BG};` +
+          "color:rgba(255,255,255,.75);font:500 13px system-ui;cursor:pointer;line-height:1;";
+        chip.onclick = () => {
+          if (placeMode) armDrop(armedProp === prop.name ? null : prop.name);
+          else session.dropPropAtRobot(prop.name);
+        };
+        propChips.set(prop.name, chip);
+        row.appendChild(chip);
+      }
+      propRows.appendChild(row);
     }
   });
 


### PR DESCRIPTION
## Summary

Branched off current `main`, so it already includes #577 — no rebase needed.

The manipulation targets the arm practises on (cube, can, sock, bar, ball) and the scenery a scenario needs (a person, a soccer ball, a dog) were heading for two parallel implementations of the same mechanism. They are one thing now, described by data rather than code.

A prop is a sidecar in `sim/props/` exporting `PROP = Prop(...)` — the same shape as `sim/challenges/`. Python rather than JSON because the tuning behind these numbers is the valuable part of them and only a comment can carry it: the sock's grasp band, the ball's density and priority, the can's width all keep the notes that explain them. Paths resolve relative to the sidecar, so a tracked prop can point at a bundled mesh and a generated asset pack can describe itself from inside its own directory (`sim/assets/props/` is a second root).

`props.py` owns the whole lifecycle: `Prop` emits its own MJCF, `PropRegistry` binds to the compiled model and does placement, parking and ground-truth readout. `world.py` and `core.py` lose their hard-coded tables entirely (`world.py` is −138 lines).

### Two ways to put a prop down

They answer different questions, so both are one click:

- **at the robot**, using the prop's own `reach` offset. The manipulation props' offsets put them on an arc the arm can reach top-down, so this places *at rest* — no fall, no bounce, no drift off the tuned spot. This is what the old one-click "drop objects" did, preserved exactly.
- **at a spot you picked**: click the floor, drag to point the yaw, release; physics settles it onto whatever is below (a floor, a sofa, a table).

### Meshes are optional at every level

A prop whose mesh the asset bundle never shipped degrades to its collision primitive — and the browser draws that same primitive rather than nothing, so the 3D view never disagrees with what the robot's cameras see. Today only the human's mesh is published; the ball and dog render as primitives until an asset pack ships them, and no code changes when it does.

### The viewer follows the same data

The world server sends its prop roster once per observer connection, and `PropLibrary` (`props.ts`) builds both the models and the stage's buttons from it — so adding a prop needs no browser code at all. One class replaces `GRASP_OBJECT_SHAPES` and the parallel mesh maps.

## Two bugs fixed on the way

- `collision="pieces"` with no mesh installed emitted `type="pieces"`, which is not a MuJoCo primitive — **the world failed to compile**. The fallback now derives a real shape from `size`.
- `placementMode` is a setter that applies `controls.enabled` immediately. As a plain field consulted only inside `setView()` it never actually paused the orbit controls, so a placement drag also spun the camera.

## Validation

- [x] 8 props load; world compiles (1317 geoms); parked props report nothing.
- [x] `drop_at_robot("cube")` lands on exactly its tuned reach offset from the robot pose.
- [x] The human's feet-origin `center_offset` correction computes correctly under a −90° yaw.
- [x] A dropped human settles 1.5m → 0.170 onto the floor; `park`/`park_all` round-trip.
- [x] `ruff check` + `ruff format --check` clean; `tsc --noEmit` clean; `npm run build:lib` succeeds.
- [ ] Not yet driven through a live `./innate-sim up` — the stage UI has not been clicked.

## Relationship to the other open PRs

- Supersedes #602, which is the same work from before `main` merged #577. Left open rather than closed because #604 is stacked on its branch.
- #604 (challenge engine) is untouched and stays as it is. It calls the older prop API, so if it lands after this, `drop_object` → `drop_prop_at` and its local `OBJECT_CENTER_OFFSET`/`_center_xy` can drop in favour of `PropRegistry.center_xy`.
- #603 (dev docs) is unrelated either way.