### PR TITLE
fix(brain): hold a task through skill registration instead of bouncing it

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/core/orchestrator.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/orchestrator.py
@@ -59,6 +59,7 @@ class Orchestrator:
 
         # Set via set_lifecycle() after construction (mutual cycle with BrainLifecycle).
         self.lifecycle = None
+        self.vision_output = None
 
         self._active_inputs_pub = active_inputs_pub
         self._memory_positions_pub = memory_positions_pub
@@ -73,6 +74,12 @@ class Orchestrator:
     def set_lifecycle(self, lifecycle) -> None:
         """Inject BrainLifecycle, which can only be built after this object (mutual cycle)."""
         self.lifecycle = lifecycle
+
+    def set_vision_output(self, vision_output) -> None:
+        """Inject VisionOutputHandler, built after this object. Registration
+        completing is what releases a task it held (see its
+        _defer_until_registered)."""
+        self.vision_output = vision_output
 
     # ================= perception loop =================
     def check_lidar_health(self) -> None:
@@ -111,6 +118,8 @@ class Orchestrator:
             # at 10 Hz, so keep this at debug to avoid flooding the log. Matches
             # the "Brain not active" skip above.
             self._logger.debug("[BrainClient] Primitives not registered. Skipping agent_loop.")
+            if self.vision_output is not None:
+                self.vision_output.expire_deferred()
             return
         if not (self._state.ready_for_image and self._camera.has_image):
             return
@@ -283,6 +292,8 @@ class Orchestrator:
             self._logger.error("Failed to register primitives and/or directive with server")
             return
         self._state.primitives_registered = True
+        if self.vision_output is not None:
+            self.vision_output.replay_deferred()
         self._logger.info(
             f"Successfully registered {msg.payload.get('count', 0)} primitives and directive: "
             f"{msg.payload.get('directive_registered', False)}"

--- a/ros2_ws/src/brain/brain_client/brain_client/core/vision_output.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/vision_output.py
@@ -11,12 +11,21 @@ from __future__ import annotations
 
 import json
 import math
+import threading
+import time
 import traceback
 
 from brain_client.perception import pose as pose_math
 from brain_client.transport.messages import VisionAgentOutput
 
 _NAV_TO_POSITION = "innate-os/navigate_to_position"
+
+# How long a task may wait for a registration round trip before the cloud is
+# told the robot dropped it. Registration is a single request/ack the robot
+# itself initiates, so this is generous; the cap exists only so a registration
+# that never completes cannot pin the agent on a tool call forever -- the exact
+# failure _bounce_dropped_task was written to prevent.
+DEFERRED_TASK_TIMEOUT_S = 20.0
 
 
 class VisionOutputHandler:
@@ -27,6 +36,11 @@ class VisionOutputHandler:
         self._chat = chat
         self._gaze = gaze
         self._pose = pose_tracker
+        # A task that arrived mid-registration, waiting for it to finish.
+        # (message, deadline); guarded because it is set on the websocket
+        # handler thread and read from the agent loop's timer thread.
+        self._deferred = None
+        self._deferred_lock = threading.Lock()
 
     def handle_message(self, msg) -> None:
         """ws handler entry point: validate, optionally log, then dispatch."""
@@ -37,8 +51,8 @@ class VisionOutputHandler:
                 self._bounce_dropped_task(msg.payload, "the brain is not active")
                 return
             if not self._state.primitives_registered:
-                self._logger.warn("[BrainClient] Primitives not registered. Skipping VisionAgentOutput.")
-                self._bounce_dropped_task(msg.payload, "skills were mid (re-)registration")
+                self._logger.warn("[BrainClient] Primitives not registered. Holding task until registration completes.")
+                self._defer_until_registered(msg)
                 return
 
             # HOTFIX: accept next_task with a "name" field by aliasing it to "type".
@@ -55,6 +69,48 @@ class VisionOutputHandler:
             self._handle_output(payload)
         except Exception as e:
             self._logger.error(f"Error processing vision output: {e}. Traceback: {traceback.format_exc()}")
+
+    def _defer_until_registered(self, msg) -> None:
+        """Hold a task that landed during a registration round trip.
+
+        A task arriving inside that window is not one the robot cannot run --
+        it is one the robot is not ready for YET, and registration is a round
+        trip the robot itself started. Bouncing it made the cloud record a
+        failure for a skill that would have succeeded moments later, which is
+        what test_dispatched_primitive_completes_rather_than_failing caught.
+
+        Latest wins: the cloud runs one task at a time, so a held task that a
+        newer one supersedes is already stale -- but it still gets an answer,
+        because the cloud marks a primitive running when it SENDS it and only a
+        terminal message clears that.
+        """
+        with self._deferred_lock:
+            previous = self._deferred[0] if self._deferred else None
+            self._deferred = (msg, time.monotonic() + DEFERRED_TASK_TIMEOUT_S)
+        if previous is not None:
+            self._bounce_dropped_task(previous.payload, "a newer task replaced it while skills were registering")
+
+    def replay_deferred(self) -> None:
+        """Run a task held through registration. Called once registration
+        completes (Orchestrator.handle_registered)."""
+        with self._deferred_lock:
+            held = self._deferred[0] if self._deferred else None
+            self._deferred = None
+        if held is not None:
+            self._logger.info("[BrainClient] Registration complete; running the task held during it.")
+            self.handle_message(held)
+
+    def expire_deferred(self) -> None:
+        """Answer a held task whose registration never completed. Polled from
+        the agent loop so a stuck registration still gets the cloud a terminal
+        message instead of silence."""
+        with self._deferred_lock:
+            if not self._deferred or time.monotonic() < self._deferred[1]:
+                return
+            held = self._deferred[0]
+            self._deferred = None
+        self._logger.warn("[BrainClient] Held task timed out waiting for registration; reporting it dropped.")
+        self._bounce_dropped_task(held.payload, "skills did not finish (re-)registering in time")
 
     def _bounce_dropped_task(self, raw_payload, why: str) -> None:
         """A dropped trigger must never be dropped SILENTLY: the cloud marks

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -236,6 +236,9 @@ class BrainClientNode(Node):
         self.vision_output = VisionOutputHandler(
             self, state, runner=self.runner, chat=self.chat, gaze=self.gaze, pose_tracker=self.pose_tracker
         )
+        # The other half of that cycle: registration completing is what lets a
+        # task held through it finally run.
+        self.orchestrator.set_vision_output(self.vision_output)
         self.reload = ReloadCoordinator(
             self,
             state,

--- a/ros2_ws/src/brain/brain_client/test/test_fake_cloud_loop.launch.py
+++ b/ros2_ws/src/brain/brain_client/test/test_fake_cloud_loop.launch.py
@@ -76,6 +76,12 @@ SCRIPTED_INPUTS = {
 }
 TEST_DIRECTIVE = "security_guard_agent"
 
+# How many times test_loop_continues_after_completion replaces a primitive that
+# failed instead of completing. Bounded, not unlimited: the continuation path
+# is what it measures, so a run that only ever makes progress by redispatching
+# should still be reported as broken.
+MAX_REDISPATCHES = 3
+
 IMAGE_TOPIC = "/test/camera/compressed"
 
 # FakeCloud is started in generate_test_description (before the nodes connect) and
@@ -319,17 +325,75 @@ class TestFakeCloudLoop(unittest.TestCase):
             f"Expected primitive_completed, got {terminal[0].get('type')}: {terminal[0].get('payload')}",
         )
 
+    def test_dispatched_primitive_completes_rather_than_failing(self):
+        """A dispatched primitive reports completion, not failure.
+
+        Split out of test_loop_continues_after_completion, which used to carry
+        both this and the continuation path and so reported an intermittent
+        failure as "the loop stopped". They are separate claims: this one owns
+        the failure itself.
+
+        send_email needs no external creds and succeeds headlessly (see
+        test_scripted_primitive_runs_to_completion), so a failure here is a
+        real defect. Assert WITH the reason the skills server attached -- a
+        module load error, an in-training checkpoint, or the skill's own
+        message (skills_server._abort_result via catalog.unavailable_reason) --
+        because a list of message types cannot say why, and that "why" is the
+        whole diagnosis.
+        """
+        self._activate_test_directive()
+        before = len(FAKE.transcript)
+        FAKE.script_task(SCRIPTED_SKILL, SCRIPTED_INPUTS)
+        done = self._feed_until(
+            lambda: bool(self._since(before, "primitive_completed", "primitive_failed")),
+            timeout=45.0,
+        )
+        self.assertTrue(done, f"No terminal result for {SCRIPTED_SKILL}. Types: {FAKE.received_types()}")
+        terminal = self._since(before, "primitive_completed", "primitive_failed")[0]
+        payload = terminal.get("payload") or {}
+        self.assertEqual(
+            terminal.get("type"),
+            "primitive_completed",
+            f"{SCRIPTED_SKILL} failed instead of completing. reason={payload.get('reason')!r} payload={payload}",
+        )
+
     def test_loop_continues_after_completion(self):
         """After one primitive completes the brain requests and runs the next -
-        the post-completion continuation path. Scripts two of its own tasks."""
+        the post-completion continuation path. Scripts two of its own tasks.
+
+        Redispatches around an intermittent primitive failure, which is
+        test_dispatched_primitive_completes_rather_than_failing's subject, not
+        this one's. It has to: the fake cloud pops its queue on dispatch and
+        never requeues (fake_cloud._handle_perception), so one failure leaves
+        this test asking for two completions from a single remaining task --
+        unsatisfiable, and it burns the whole timeout streaming perception
+        rather than failing on the thing that actually went wrong.
+        """
         self._activate_test_directive()
         before = len(FAKE.transcript)
         FAKE.script_task(SCRIPTED_SKILL, SCRIPTED_INPUTS)
         FAKE.script_task(SCRIPTED_SKILL, SCRIPTED_INPUTS)
-        done = self._feed_until(lambda: len(self._since(before, "primitive_completed")) >= 2, timeout=45.0)
-        self.assertTrue(
-            done,
-            f"Loop did not complete two primitives. Types: {FAKE.received_types()}",
+
+        completed = failures = 0
+        for _ in range(MAX_REDISPATCHES + 1):
+            seen_failures = failures
+            self._feed_until(
+                lambda seen=seen_failures: (
+                    len(self._since(before, "primitive_completed")) >= 2
+                    or len(self._since(before, "primitive_failed")) > seen
+                ),
+                timeout=45.0,
+            )
+            completed = len(self._since(before, "primitive_completed"))
+            failures = len(self._since(before, "primitive_failed"))
+            if completed >= 2:
+                return
+            if failures == seen_failures:
+                break  # neither completed nor failed: a genuine stall, not the flake
+            FAKE.script_task(SCRIPTED_SKILL, SCRIPTED_INPUTS)  # replace the consumed slot
+        self.fail(
+            f"Loop did not complete two primitives: {completed} completed, {failures} failed, "
+            f"after up to {MAX_REDISPATCHES} redispatches. Types: {FAKE.received_types()}"
         )
 
     def test_chat_in_is_forwarded_to_cloud(self):


### PR DESCRIPTION
## The symptom

`test_fake_cloud_loop`'s `test_loop_continues_after_completion` failed intermittently with:

```
AssertionError: Loop did not complete two primitives.
Types: [... 'primitive_failed', 'pose_image', 'primitive_activated',
        'primitive_feedback', 'primitive_completed', 'pose_image' x ~90]
```

Two things were wrong with that, before anything about the brain.

It is **the wrong diagnosis**: the loop did not stop. One of the two primitives came back `primitive_failed`, and the test counted only completions.

And it **discarded the evidence**. The reason lived in `payload["reason"]`; the assertion printed a list of message types, which cannot say why anything failed.

It also burned the full 45 s doing it. A failure is unrecoverable here — the fake cloud pops its queue on dispatch and never requeues (`fake_cloud._handle_perception:265`), so one failure left the test asking for two completions from a single remaining task. The assertion became unsatisfiable and the robot streamed perception until the deadline. That is the tail of ~90 `pose_image` frames, and it reads as a hang in the continuation path while being nothing of the sort.

## What the split found

Splitting the one test into its two actual claims, and asserting *with* the payload, produced the cause on the first failing run:

```
FAIL: test_dispatched_primitive_completes_rather_than_failing
AssertionError: 'primitive_failed' != 'primitive_completed'
 : innate-os/send_email failed instead of completing.
   reason='The robot dropped this task: skills were mid (re-)registration.'
```

- **`test_dispatched_primitive_completes_rather_than_failing`** (new) owns the failure and asserts with the reason the skills server attached.
- **`test_loop_continues_after_completion`** keeps its own subject and redispatches around a failure, bounded at `MAX_REDISPATCHES = 3`, so it measures continuation and fails for its own reasons. It passed in the failing run — the other half of the point.

## The cause

`vision_output.handle_message` answered any task landing inside a registration round trip with a terminal failure:

```python
if not self._state.primitives_registered:
    self._bounce_dropped_task(msg.payload, "skills were mid (re-)registration")
    return
```

Worth recording what this is *not*, because it is the plausible-looking answer: the skill catalog is never the gate. `catalog.reload_all` builds the new dicts outside the lock and swaps them inside it, so a lookup during a reload sees the complete old dict. The gate is the brain's own `primitives_registered` flag.

## The fix

A task arriving mid-registration is not one the robot *cannot* run — it is one the robot is not ready for **yet**, and the round trip is one the robot itself started. The cloud was being told a skill failed when it would have succeeded moments later.

It is now held and run once registration completes (`Orchestrator.handle_registered` → `replay_deferred`), for at most `DEFERRED_TASK_TIMEOUT_S`, polled from the agent loop, after which it bounces exactly as before.

That cap is load-bearing rather than defensive garnish: the cloud marks a primitive running when it *sends* it, and only a terminal message clears that, so silence would pin the agent on a tool call forever — precisely the failure `_bounce_dropped_task` was written to prevent. Latest-wins while holding (the cloud runs one task at a time), and a superseded task still gets its terminal message rather than being dropped silently.

## Evidence

| commit | integration runs | result |
|---|---|---|
| `cf294a07` (tests only) | 2 | **1 failure** (the trace above), 1 pass |
| `76f13a43` (+ fix) | 4 | **4 passes** |

Reproduced within two runs before the fix; four consecutive green after, via `workflow_dispatch`.

This is not proof. It is a race, absence of a flake is weak evidence, and four runs is a small sample. What changed is that the mechanism is now identified from a real trace instead of inferred from message ordering, and the fix addresses that mechanism directly. More dispatches before merge are cheap if you want a larger sample.

## Known limitation

`expire_deferred` is polled from `agent_loop`, which early-returns while the brain is inactive. If the brain goes inactive while a task is held, nothing expires it until the loop resumes — bounded in practice, but not by construction.

## Validation

- [x] `ruff check` + `ruff format --check` clean across `brain_client` (caught a late-binding closure in the retry loop; the predicate binds `seen_failures` explicitly).
- [x] Integration tests: 4/4 green on the fix commit, against a failure that reproduced within 2 runs before it.
- [ ] Not exercised on hardware; the race is in the brain, which is shared, so behavior should be identical.