### PR TITLE
feat(brain): local spatial memory — recorded on tour, visible on the map, recallable as a skill, Gemini-cached

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/README.md
+++ b/ros2_ws/src/brain/brain_client/brain_client/README.md
@@ -6,9 +6,10 @@ code, start from what it *does*:
 | Folder | What lives here |
 |---|---|
 | `nodes/` | The runnable ROS entry points (the only files with `main()`). Thin composition roots — they build collaborators, wire them, and spin. No behaviour. |
-| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), and the system `prompt`. |
+| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached), and the system `prompt`. |
 | `core/` | The activate/deactivate/reset state machine and directive switching (`lifecycle`), typed `config`, and the shared `state`. |
 | `perception/` | Turning sensors into what the agent sees: `camera`, `pose`/`pose_tracking`, `scan_health`, `gaze`. |
+| `memory/` | Persistent per-map spatial memory: `store` (JSON index + JPEGs on disk), pure `selection` (which viewpoints earn a slot), `recorder` (the always-on ROS adapter that captures them). |
 | `skills/` | The skill system: `registry`, `roster` (available + directive-active sets), `runner` (action lifecycle), `loader`, `hot_reload`, and the public `types` SDK base classes. |
 | `agents/` | Directives/behaviours: `loader`, `initializer`, and the public `types` SDK base class. |
 | `inputs/` | Input-device subsystem and its public `types` SDK base class. |
@@ -21,7 +22,7 @@ code, start from what it *does*:
 **1. Dependency direction is one-way.**
 
 ```
-nodes  ->  {brain, core}  ->  {perception, skills, agents, inputs, transport, robot}  ->  common
+nodes  ->  {brain, core}  ->  {perception, memory, skills, agents, inputs, transport, robot}  ->  common
 ```
 
 A module never imports "upward" (e.g. `perception` never imports `core`).

--- a/ros2_ws/src/brain/brain_client/brain_client/README.md
+++ b/ros2_ws/src/brain/brain_client/brain_client/README.md
@@ -6,7 +6,7 @@ code, start from what it *does*:
 | Folder | What lives here |
 |---|---|
 | `nodes/` | The runnable ROS entry points (the only files with `main()`). Thin composition roots — they build collaborators, wire them, and spin. No behaviour. |
-| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached), and the system `prompt`. |
+| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached) + `search_server` (the `/brain/search_memory` action skills call), and the system `prompt`. |
 | `core/` | The activate/deactivate/reset state machine and directive switching (`lifecycle`), typed `config`, and the shared `state`. |
 | `perception/` | Turning sensors into what the agent sees: `camera`, `pose`/`pose_tracking`, `scan_health`, `gaze`. |
 | `memory/` | Persistent per-map spatial memory: `store` (JSON index + JPEGs on disk), pure `selection` (which viewpoints earn a slot), `recorder` (the always-on ROS adapter that captures them). |

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -31,15 +31,9 @@ from typing import TYPE_CHECKING
 from brain_client.brain import grounding
 from brain_client.brain.context import Decision, GeminiContext, ToolCall
 from brain_client.brain.loop import LoopThread
+from brain_client.brain.memory_search import verdict_text
 from brain_client.brain.prompt import build_system_prompt
-from brain_client.brain.tools import (
-    GO_TO_POINT_IN_VIEW,
-    SEARCH_MEMORY,
-    STOP_SKILL,
-    WAIT,
-    assign_tool_names,
-    build_tools,
-)
+from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
 from brain_client.brain.transport import pick_transport
 from brain_client.brain.utils import (
     Event,
@@ -60,7 +54,7 @@ if TYPE_CHECKING:
 
     from rclpy.node import Node
 
-    from brain_client.brain.memory_search import MemorySearch
+    from brain_client.brain.memory_search import MemorySearch, SearchVerdict
     from brain_client.core.config import BrainConfig
     from brain_client.core.state import BrainState, RunningSkill
     from brain_client.perception.camera import CameraCapture
@@ -74,6 +68,7 @@ if TYPE_CHECKING:
     from innate_proxy import ProxyClient
 
 _NAV_TO_POSITION = "innate-os/navigate_to_position"
+_SEARCH_MEMORY = "innate-os/search_memory"
 _FRESH_FRAME_SEC = 3.0  # an older camera frame means the feed is broken; don't think blind
 _MAX_EVENTS_QUEUED = 30  # the oldest beyond this are dropped as stale stimuli
 _MAX_EVENT_IMAGES = 4  # newest event images sent per turn; older ones arrive as text only
@@ -448,12 +443,7 @@ class BrainAgent:
         # the name the model calls always resolves to the skill it was declared for.
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
-        return build_tools(
-            named,
-            None,
-            can_go_to_point_in_view=_NAV_TO_POSITION in active_ids,
-            can_search_memory=self._memory is not None and self._memory.frame_count > 0,
-        )
+        return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
 
     # ================= act =================
     def _act(self, decision: Decision, speaker: SpeechStreamer, context: GeminiContext) -> list[tuple[ToolCall, str]]:
@@ -510,17 +500,19 @@ class BrainAgent:
             # (a goal that slips through anyway is cancelled by the runner's
             # generation bump, but this keeps the robot from twitching first).
             return "rejected — the brain is deactivating"
-        if call.name == SEARCH_MEMORY:
-            return self._search_memory(call.args)
-        if self._state.primitive_running is not None:
-            return "rejected — another skill is already running; stop it first"
-        if call.name == GO_TO_POINT_IN_VIEW:
-            return self._go_to_point_in_view(call.args)
         # Only names declared this turn resolve: falling back to the full
         # registry would let a hallucinated call bypass the active-skill allowlist.
         # The map can outlive a roster change (it isn't rebuilt while a skill
         # runs), so the resolved id is re-checked against the live active set.
         skill_id = self._tool_map.get(call.name)
+        if skill_id == _SEARCH_MEMORY and skill_id in self._roster.active_skill_ids():
+            # Recall is a query, not an act: it occupies no skill slot, so it
+            # resolves before the one-skill-at-a-time gate.
+            return self._search_memory(call.args)
+        if self._state.primitive_running is not None:
+            return "rejected — another skill is already running; stop it first"
+        if call.name == GO_TO_POINT_IN_VIEW:
+            return self._go_to_point_in_view(call.args)
         if skill_id is None:
             return f"unknown skill '{call.name}'"
         if skill_id not in self._roster.active_skill_ids():
@@ -578,18 +570,25 @@ class BrainAgent:
         )
 
     def _search_memory(self, args: dict) -> str:
-        """Fire a spatial-memory search; the loop must not block, so the result is an event."""
-        if self._memory is None or self._memory.frame_count == 0:
-            return "rejected — no places remembered on this map yet"
+        """Fire a spatial-memory search; the loop must not block, so the verdict is an event.
+
+        The brain hosts MemorySearch itself, so its own calls skip the
+        /brain/search_memory action the skill rides — same search, same cache,
+        one less hop.
+        """
+        if self._memory is None:
+            return "rejected — memory search is unavailable (no Gemini access)"
         query = str(args.get("query") or "").strip()
         if not query:
             return "rejected — give a query describing what to find"
-        self._memory.begin_search(query, self._on_memory_result)
+        if self._memory.frame_count == 0:
+            return "rejected — no places remembered on this map yet"
+        self._memory.begin_search(query, self._on_memory_verdict)
         return "searching memory — the result arrives as an event"
 
-    def _on_memory_result(self, text: str, image: bytes | None) -> None:
-        """Search thread: the result (and the matched frame) becomes the next turn's event."""
-        self.add_event(text, image=image, kind=EventKind.MEMORY)
+    def _on_memory_verdict(self, verdict: SearchVerdict) -> None:
+        """Search thread: the verdict (and its matched frame) becomes the next turn's event."""
+        self.add_event(verdict_text(verdict), image=verdict.image, kind=EventKind.MEMORY)
 
     def _start_skill(self, skill_id: str, inputs: dict) -> None:
         self._gaze.pause()
@@ -630,11 +629,13 @@ class BrainAgent:
         device = data.get("input_device", "unknown")
         self.add_event(f"Input from {device}: {json.dumps(data)}")
 
-    def on_skill_event(self, status: str, skill_name: str, detail: str | None = None) -> None:
+    def on_skill_event(
+        self, status: str, skill_name: str, detail: str | None = None, image: bytes | None = None
+    ) -> None:
         line = f"Skill {skill_name} {status}"
         if detail:
             line += f": {detail}"
-        self.add_event(line)
+        self.add_event(line, image=image)
 
     def on_skill_feedback(self, skill_name: str, feedback: str, image: bytes | None = None) -> None:
         self.add_event(f"Update from running skill {skill_name}: {feedback}", image=image)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -435,14 +435,17 @@ class BrainAgent:
     def _build_tools(self, events: list[Event]) -> list[dict]:
         running = self._state.primitive_running
         user_spoke = any(event.kind == EventKind.USER for event in events)
-        if running is not None:
-            return build_tools([], running.primitive_name, user_spoke=user_spoke)
         active_ids = set(self._roster.active_skill_ids())
         skills = [meta for meta in self._state.registry.metadata if meta["id"] in active_ids]
         # One naming pass feeds both the declarations and the dispatch map, so
         # the name the model calls always resolves to the skill it was declared for.
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
+        if running is not None:
+            # Recall occupies no skill slot (see _dispatch), so it stays
+            # declared while a skill runs — search-while-driving is the point.
+            queries = [(name, meta) for name, meta in named if meta["id"] == _SEARCH_MEMORY]
+            return build_tools(queries, running.primitive_name, user_spoke=user_spoke)
         return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
 
     # ================= act =================
@@ -502,8 +505,8 @@ class BrainAgent:
             return "rejected — the brain is deactivating"
         # Only names declared this turn resolve: falling back to the full
         # registry would let a hallucinated call bypass the active-skill allowlist.
-        # The map can outlive a roster change (it isn't rebuilt while a skill
-        # runs), so the resolved id is re-checked against the live active set.
+        # The map is a turn old by now and the roster can change under it, so
+        # the resolved id is re-checked against the live active set.
         skill_id = self._tool_map.get(call.name)
         if skill_id == _SEARCH_MEMORY and skill_id in self._roster.active_skill_ids():
             # Recall is a query, not an act: it occupies no skill slot, so it

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -32,7 +32,14 @@ from brain_client.brain import grounding
 from brain_client.brain.context import Decision, GeminiContext, ToolCall
 from brain_client.brain.loop import LoopThread
 from brain_client.brain.prompt import build_system_prompt
-from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
+from brain_client.brain.tools import (
+    GO_TO_POINT_IN_VIEW,
+    SEARCH_MEMORY,
+    STOP_SKILL,
+    WAIT,
+    assign_tool_names,
+    build_tools,
+)
 from brain_client.brain.transport import pick_transport
 from brain_client.brain.utils import (
     Event,
@@ -53,6 +60,7 @@ if TYPE_CHECKING:
 
     from rclpy.node import Node
 
+    from brain_client.brain.memory_search import MemorySearch
     from brain_client.core.config import BrainConfig
     from brain_client.core.state import BrainState, RunningSkill
     from brain_client.perception.camera import CameraCapture
@@ -89,6 +97,7 @@ class BrainAgent:
         gaze: GazeController,
         proxy: ProxyClient | None = None,
         scan_health: ScanHealthMonitor | None = None,
+        memory: MemorySearch | None = None,
         trace: Callable[[str], None] | None = None,
     ):
         self._logger = node.get_logger()
@@ -100,6 +109,7 @@ class BrainAgent:
         self._roster = roster
         self._chat = chat
         self._gaze = gaze
+        self._memory = memory
         self._trace_sink = trace  # publishes one JSON string per event on /brain/trace
         self._lidar = ScanHealthReporter(
             scan_health, pose_tracker, chat, self._logger, enabled=not config.simulator_mode
@@ -438,7 +448,12 @@ class BrainAgent:
         # the name the model calls always resolves to the skill it was declared for.
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
-        return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
+        return build_tools(
+            named,
+            None,
+            can_go_to_point_in_view=_NAV_TO_POSITION in active_ids,
+            can_search_memory=self._memory is not None and self._memory.frame_count > 0,
+        )
 
     # ================= act =================
     def _act(self, decision: Decision, speaker: SpeechStreamer, context: GeminiContext) -> list[tuple[ToolCall, str]]:
@@ -495,6 +510,8 @@ class BrainAgent:
             # (a goal that slips through anyway is cancelled by the runner's
             # generation bump, but this keeps the robot from twitching first).
             return "rejected — the brain is deactivating"
+        if call.name == SEARCH_MEMORY:
+            return self._search_memory(call.args)
         if self._state.primitive_running is not None:
             return "rejected — another skill is already running; stop it first"
         if call.name == GO_TO_POINT_IN_VIEW:
@@ -559,6 +576,20 @@ class BrainAgent:
             f"driving to the floor point {math.hypot(*floor):.1f}m away (stopping ~{grounding.STANDOFF_M}m short) "
             "— you will get an event when it finishes"
         )
+
+    def _search_memory(self, args: dict) -> str:
+        """Fire a spatial-memory search; the loop must not block, so the result is an event."""
+        if self._memory is None or self._memory.frame_count == 0:
+            return "rejected — no places remembered on this map yet"
+        query = str(args.get("query") or "").strip()
+        if not query:
+            return "rejected — give a query describing what to find"
+        self._memory.begin_search(query, self._on_memory_result)
+        return "searching memory — the result arrives as an event"
+
+    def _on_memory_result(self, text: str, image: bytes | None) -> None:
+        """Search thread: the result (and the matched frame) becomes the next turn's event."""
+        self.add_event(text, image=image, kind=EventKind.MEMORY)
 
     def _start_skill(self, skill_id: str, inputs: dict) -> None:
         self._gaze.pause()

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -31,7 +31,6 @@ from typing import TYPE_CHECKING
 from brain_client.brain import grounding
 from brain_client.brain.context import Decision, GeminiContext, ToolCall
 from brain_client.brain.loop import LoopThread
-from brain_client.brain.memory_search import verdict_text
 from brain_client.brain.prompt import build_system_prompt
 from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
 from brain_client.brain.transport import pick_transport
@@ -54,7 +53,6 @@ if TYPE_CHECKING:
 
     from rclpy.node import Node
 
-    from brain_client.brain.memory_search import MemorySearch, SearchVerdict
     from brain_client.core.config import BrainConfig
     from brain_client.core.state import BrainState, RunningSkill
     from brain_client.perception.camera import CameraCapture
@@ -68,7 +66,6 @@ if TYPE_CHECKING:
     from innate_proxy import ProxyClient
 
 _NAV_TO_POSITION = "innate-os/navigate_to_position"
-_SEARCH_MEMORY = "innate-os/search_memory"
 _FRESH_FRAME_SEC = 3.0  # an older camera frame means the feed is broken; don't think blind
 _MAX_EVENTS_QUEUED = 30  # the oldest beyond this are dropped as stale stimuli
 _MAX_EVENT_IMAGES = 4  # newest event images sent per turn; older ones arrive as text only
@@ -92,7 +89,6 @@ class BrainAgent:
         gaze: GazeController,
         proxy: ProxyClient | None = None,
         scan_health: ScanHealthMonitor | None = None,
-        memory: MemorySearch | None = None,
         trace: Callable[[str], None] | None = None,
     ):
         self._logger = node.get_logger()
@@ -104,7 +100,6 @@ class BrainAgent:
         self._roster = roster
         self._chat = chat
         self._gaze = gaze
-        self._memory = memory
         self._trace_sink = trace  # publishes one JSON string per event on /brain/trace
         self._lidar = ScanHealthReporter(
             scan_health, pose_tracker, chat, self._logger, enabled=not config.simulator_mode
@@ -442,10 +437,7 @@ class BrainAgent:
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
         if running is not None:
-            # Recall occupies no skill slot (see _dispatch), so it stays
-            # declared while a skill runs — search-while-driving is the point.
-            queries = [(name, meta) for name, meta in named if meta["id"] == _SEARCH_MEMORY]
-            return build_tools(queries, running.primitive_name, user_spoke=user_spoke)
+            return build_tools([], running.primitive_name, user_spoke=user_spoke)
         return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
 
     # ================= act =================
@@ -508,10 +500,6 @@ class BrainAgent:
         # The map is a turn old by now and the roster can change under it, so
         # the resolved id is re-checked against the live active set.
         skill_id = self._tool_map.get(call.name)
-        if skill_id == _SEARCH_MEMORY and skill_id in self._roster.active_skill_ids():
-            # Recall is a query, not an act: it occupies no skill slot, so it
-            # resolves before the one-skill-at-a-time gate.
-            return self._search_memory(call.args)
         if self._state.primitive_running is not None:
             return "rejected — another skill is already running; stop it first"
         if call.name == GO_TO_POINT_IN_VIEW:
@@ -571,27 +559,6 @@ class BrainAgent:
             f"driving to the floor point {math.hypot(*floor):.1f}m away (stopping ~{grounding.STANDOFF_M}m short) "
             "— you will get an event when it finishes"
         )
-
-    def _search_memory(self, args: dict) -> str:
-        """Fire a spatial-memory search; the loop must not block, so the verdict is an event.
-
-        The brain hosts MemorySearch itself, so its own calls skip the
-        /brain/search_memory action the skill rides — same search, same cache,
-        one less hop.
-        """
-        if self._memory is None:
-            return "rejected — memory search is unavailable (no Gemini access)"
-        query = str(args.get("query") or "").strip()
-        if not query:
-            return "rejected — give a query describing what to find"
-        if self._memory.frame_count == 0:
-            return "rejected — no places remembered on this map yet"
-        self._memory.begin_search(query, self._on_memory_verdict)
-        return "searching memory — the result arrives as an event"
-
-    def _on_memory_verdict(self, verdict: SearchVerdict) -> None:
-        """Search thread: the verdict (and its matched frame) becomes the next turn's event."""
-        self.add_event(verdict_text(verdict), image=verdict.image, kind=EventKind.MEMORY)
 
     def _start_skill(self, skill_id: str, inputs: dict) -> None:
         self._gaze.pause()

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
@@ -17,6 +17,7 @@ without the upload endpoint latches the tier off for the process.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import threading
@@ -78,6 +79,23 @@ class FrameFiles:
         if time.time() - record.uploaded_at > _USABLE_FOR_SEC:
             return None
         return record
+
+    def purge(self) -> None:
+        """Forget every registered upload and best-effort delete the server-side
+        copies — the store's wipe already removed the sidecar; without this the
+        forgotten frames would linger on Gemini until their 48 h expiry."""
+        with self._lock:
+            self._sync_map_locked()
+            records, self._records = dict(self._records), {}
+        if not records:
+            return
+
+        def run() -> None:
+            for record in records.values():
+                with contextlib.suppress(Exception):  # a 404 must not stop the rest
+                    self._rest.delete("/v1beta/files/" + record.uri.rsplit("/", 1)[-1])
+
+        threading.Thread(target=run, name="memory-file-purge", daemon=True).start()
 
     def maintain(self) -> None:
         """Upload new/refreshed/aging frames in the background; returns immediately."""
@@ -188,8 +206,8 @@ class FrameFiles:
                 )
                 for memory_id, entry in data.get("files", {}).items()
             }
-        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
-            return {}  # unreadable registry = nothing uploaded; the chore rebuilds it
+        except (OSError, json.JSONDecodeError, AttributeError, KeyError, TypeError, ValueError):
+            return {}  # unreadable or wrong-shaped registry = nothing uploaded; the chore rebuilds it
 
     def _save_locked(self) -> None:
         path = self._store.files_index_path()

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
@@ -29,12 +29,14 @@ from brain_client.brain.transport import FILES_UPLOAD_PATH, UNSUPPORTED_ENDPOINT
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from rclpy.impl.rcutils_logger import RcutilsLogger
+
     from brain_client.brain.transport import GeminiRest
     from brain_client.memory.store import Memory, MemoryStore
 
-_FILE_LIFETIME_SEC = 48 * 3600  # Gemini deletes uploads after this
-_USABLE_FOR_SEC = 47 * 3600  # stop referencing this long after upload (margin under the deletion)
+_USABLE_FOR_SEC = 47 * 3600  # Gemini deletes uploads at 48 h; stop referencing an hour early
 _REUPLOAD_AFTER_SEC = 40 * 3600  # the background chore refreshes an upload past this age
+_RETRY_DELAY_SEC = 30.0  # after a failed round — the 1 Hz tick must not hammer a broken endpoint
 
 
 @dataclass(frozen=True)
@@ -45,18 +47,29 @@ class _FileRecord:
 
 
 class FrameFiles:
-    def __init__(self, store: MemoryStore, rest: GeminiRest, logger):
+    def __init__(self, store: MemoryStore, rest: GeminiRest, logger: RcutilsLogger):
         self._store = store
         self._rest = rest
         self._logger = logger
         self.unsupported = False  # latched: the backend has no upload passthrough
         self._lock = threading.Lock()  # registry map + sidecar IO
         self._busy = threading.Lock()  # at most one maintenance thread
+        self._retry_at = 0.0  # monotonic; a failed round backs off until then
         self._dir: Path | None = None  # which map's registry is loaded
         self._records: dict[int, _FileRecord] = {}
 
     def uri_for(self, memory: Memory) -> str | None:
         """A live server-side URI for exactly this frame, or None (ride inline)."""
+        record = self._live_record(memory)
+        return record.uri if record is not None else None
+
+    def usable_until(self, memory: Memory) -> float | None:
+        """Epoch seconds until this frame's live URI stops being referenced —
+        a context cache embedding it must not outlive this. None = inline."""
+        record = self._live_record(memory)
+        return record.uploaded_at + _USABLE_FOR_SEC if record is not None else None
+
+    def _live_record(self, memory: Memory) -> _FileRecord | None:
         with self._lock:
             self._sync_map_locked()
             record = self._records.get(memory.id)
@@ -64,77 +77,96 @@ class FrameFiles:
             return None
         if time.time() - record.uploaded_at > _USABLE_FOR_SEC:
             return None
-        return record.uri
+        return record
 
     def maintain(self) -> None:
         """Upload new/refreshed/aging frames in the background; returns immediately."""
-        if self.unsupported:
+        if self.unsupported or time.monotonic() < self._retry_at:
             return
-        pending = self._pending()
-        if not pending:
+        pending, scanned_dir = self._pending()
+        if not pending or scanned_dir is None:
             return
         if not self._busy.acquire(blocking=False):
             return  # a maintenance round is already running
 
         def run() -> None:
             try:
-                self._upload(pending)
+                self._upload(pending, scanned_dir)
             finally:
                 self._busy.release()
 
         threading.Thread(target=run, name="memory-file-upload", daemon=True).start()
 
-    def _pending(self) -> list[Memory]:
+    def _pending(self) -> tuple[list[Memory], Path | None]:
+        """Frames needing upload, and the registry dir they were scanned against."""
         snapshot = self._store.snapshot()
         now = time.time()
         with self._lock:
             self._sync_map_locked()
             if self._dir is None:
-                return []
+                return [], None
+            scanned_dir = self._dir
             records = dict(self._records)
         pending = []
         for memory in snapshot.memories:
             record = records.get(memory.id)
             if record is None or record.image_stamp != memory.stamp or now - record.uploaded_at > _REUPLOAD_AFTER_SEC:
                 pending.append(memory)
-        return pending
+        return pending, scanned_dir
 
-    def _upload(self, pending: list[Memory]) -> None:
-        """One maintenance round. A transient failure ends the round (the next
-        tick retries); an unsupported-endpoint answer latches the tier off."""
-        uploaded_into = self._dir  # a map switch mid-round orphans these uploads
-        for memory in pending:
-            path = self._store.image_path(memory.id)
-            if path is None:
-                return
-            try:
-                data = path.read_bytes()
-            except OSError:
-                continue  # evicted between the scan and now
-            try:
-                response = self._rest.upload(FILES_UPLOAD_PATH, data, "image/jpeg")
-            except GeminiHttpError as error:
-                if error.status in UNSUPPORTED_ENDPOINT_STATUSES:
-                    self.unsupported = True
+    def _upload(self, pending: list[Memory], uploaded_into: Path) -> None:
+        """One maintenance round. A transient failure ends the round (retried
+        after a backoff); an unsupported-endpoint answer latches the tier off.
+        The registry is saved once per round, not per frame.
+
+        ``uploaded_into`` is the dir the pending scan ran against — any other
+        map loaded by the time a result lands means these uploads are orphans
+        (never recorded into the new map's registry, whose ids collide).
+        """
+        try:
+            for memory in pending:
+                path = self._store.image_path(memory.id)
+                if path is None:
+                    return
+                try:
+                    data = path.read_bytes()
+                except OSError:
+                    continue  # evicted between the scan and now
+                try:
+                    response = self._rest.upload(FILES_UPLOAD_PATH, data, "image/jpeg")
+                except GeminiHttpError as error:
+                    if error.status in UNSUPPORTED_ENDPOINT_STATUSES:
+                        self.unsupported = True
+                        self._logger.warn(
+                            f"[Memory] backend has no file-upload endpoint (HTTP {error.status}); frames ride inline"
+                        )
+                    else:
+                        self._retry_at = time.monotonic() + _RETRY_DELAY_SEC
+                        self._logger.warn(
+                            f"[Memory] frame upload failed ({error}); retrying in {_RETRY_DELAY_SEC:.0f}s"
+                        )
+                    return
+                except Exception as error:  # noqa: BLE001 — network trouble ends the round, never the process
+                    self._retry_at = time.monotonic() + _RETRY_DELAY_SEC
+                    self._logger.warn(f"[Memory] frame upload failed ({error!r}); retrying in {_RETRY_DELAY_SEC:.0f}s")
+                    return
+                uri = str((response.get("file") or {}).get("uri") or "")
+                if not uri:
+                    self._retry_at = time.monotonic() + _RETRY_DELAY_SEC
                     self._logger.warn(
-                        f"[Memory] backend has no file-upload endpoint (HTTP {error.status}); frames ride inline"
+                        f"[Memory] frame upload returned no file uri; retrying in {_RETRY_DELAY_SEC:.0f}s"
                     )
-                else:
-                    self._logger.warn(f"[Memory] frame upload failed ({error}); retrying next tick")
-                return
-            except Exception as error:  # noqa: BLE001 — network trouble ends the round, never the process
-                self._logger.warn(f"[Memory] frame upload failed ({error!r}); retrying next tick")
-                return
-            uri = str((response.get("file") or {}).get("uri") or "")
-            if not uri:
-                self._logger.warn("[Memory] frame upload returned no file uri; retrying next tick")
-                return
+                    return
+                with self._lock:
+                    self._sync_map_locked()
+                    if self._dir != uploaded_into:
+                        return  # the map switched mid-round; these frames are gone
+                    self._records[memory.id] = _FileRecord(uri=uri, uploaded_at=time.time(), image_stamp=memory.stamp)
+        finally:
             with self._lock:
                 self._sync_map_locked()
-                if self._dir != uploaded_into:
-                    return  # the map switched mid-round; these frames are gone
-                self._records[memory.id] = _FileRecord(uri=uri, uploaded_at=time.time(), image_stamp=memory.stamp)
-                self._save_locked()
+                if self._dir == uploaded_into and self._dir is not None:
+                    self._save_locked()
 
     # --- registry persistence (under self._lock) ---
     def _sync_map_locked(self) -> None:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
@@ -179,7 +179,13 @@ class FrameFiles:
                     self._sync_map_locked()
                     if self._dir != uploaded_into:
                         return  # the map switched mid-round; these frames are gone
+                    superseded = self._records.get(memory.id)
                     self._records[memory.id] = _FileRecord(uri=uri, uploaded_at=time.time(), image_stamp=memory.stamp)
+                # A refreshed frame's old upload would otherwise linger until
+                # Gemini's 48 h expiry — at the refresh cadence that piles up.
+                if superseded is not None and superseded.uri != uri:
+                    with contextlib.suppress(Exception):  # best effort; expiry is the backstop
+                        self._rest.delete("/v1beta/files/" + superseded.uri.rsplit("/", 1)[-1])
         finally:
             with self._lock:
                 self._sync_map_locked()

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Server-side copies of the remembered frames — the Gemini Files API tier.
+
+Each recorded JPEG is uploaded once, in the background, and referenced in
+requests as ``fileData``: a frame's bytes cross the network at record time and
+never again. The registry is a sidecar beside the store's images, so a restart
+re-uploads nothing; an entry is trusted only while its stamp matches the live
+memory, so a wiped-and-recreated id can never resolve to an old upload. Files
+expire server-side after 48 h — :meth:`maintain` (driven by the recorder's
+1 Hz tick via ``MemorySearch.warm``) re-uploads well before that.
+
+The whole tier is a pure optimization: a missing, expired, or failed upload
+just means that frame rides ``inlineData`` in the next request, and a backend
+without the upload endpoint latches the tier off for the process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from brain_client.brain.transport import FILES_UPLOAD_PATH, UNSUPPORTED_ENDPOINT_STATUSES, GeminiHttpError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from brain_client.brain.transport import GeminiRest
+    from brain_client.memory.store import Memory, MemoryStore
+
+_FILE_LIFETIME_SEC = 48 * 3600  # Gemini deletes uploads after this
+_USABLE_FOR_SEC = 47 * 3600  # stop referencing this long after upload (margin under the deletion)
+_REUPLOAD_AFTER_SEC = 40 * 3600  # the background chore refreshes an upload past this age
+
+
+@dataclass(frozen=True)
+class _FileRecord:
+    uri: str
+    uploaded_at: float  # epoch seconds
+    image_stamp: float  # the memory's stamp at upload — a mismatch means the frame changed
+
+
+class FrameFiles:
+    def __init__(self, store: MemoryStore, rest: GeminiRest, logger):
+        self._store = store
+        self._rest = rest
+        self._logger = logger
+        self.unsupported = False  # latched: the backend has no upload passthrough
+        self._lock = threading.Lock()  # registry map + sidecar IO
+        self._busy = threading.Lock()  # at most one maintenance thread
+        self._dir: Path | None = None  # which map's registry is loaded
+        self._records: dict[int, _FileRecord] = {}
+
+    def uri_for(self, memory: Memory) -> str | None:
+        """A live server-side URI for exactly this frame, or None (ride inline)."""
+        with self._lock:
+            self._sync_map_locked()
+            record = self._records.get(memory.id)
+        if record is None or record.image_stamp != memory.stamp:
+            return None
+        if time.time() - record.uploaded_at > _USABLE_FOR_SEC:
+            return None
+        return record.uri
+
+    def maintain(self) -> None:
+        """Upload new/refreshed/aging frames in the background; returns immediately."""
+        if self.unsupported:
+            return
+        pending = self._pending()
+        if not pending:
+            return
+        if not self._busy.acquire(blocking=False):
+            return  # a maintenance round is already running
+
+        def run() -> None:
+            try:
+                self._upload(pending)
+            finally:
+                self._busy.release()
+
+        threading.Thread(target=run, name="memory-file-upload", daemon=True).start()
+
+    def _pending(self) -> list[Memory]:
+        snapshot = self._store.snapshot()
+        now = time.time()
+        with self._lock:
+            self._sync_map_locked()
+            if self._dir is None:
+                return []
+            records = dict(self._records)
+        pending = []
+        for memory in snapshot.memories:
+            record = records.get(memory.id)
+            if record is None or record.image_stamp != memory.stamp or now - record.uploaded_at > _REUPLOAD_AFTER_SEC:
+                pending.append(memory)
+        return pending
+
+    def _upload(self, pending: list[Memory]) -> None:
+        """One maintenance round. A transient failure ends the round (the next
+        tick retries); an unsupported-endpoint answer latches the tier off."""
+        uploaded_into = self._dir  # a map switch mid-round orphans these uploads
+        for memory in pending:
+            path = self._store.image_path(memory.id)
+            if path is None:
+                return
+            try:
+                data = path.read_bytes()
+            except OSError:
+                continue  # evicted between the scan and now
+            try:
+                response = self._rest.upload(FILES_UPLOAD_PATH, data, "image/jpeg")
+            except GeminiHttpError as error:
+                if error.status in UNSUPPORTED_ENDPOINT_STATUSES:
+                    self.unsupported = True
+                    self._logger.warn(
+                        f"[Memory] backend has no file-upload endpoint (HTTP {error.status}); frames ride inline"
+                    )
+                else:
+                    self._logger.warn(f"[Memory] frame upload failed ({error}); retrying next tick")
+                return
+            except Exception as error:  # noqa: BLE001 — network trouble ends the round, never the process
+                self._logger.warn(f"[Memory] frame upload failed ({error!r}); retrying next tick")
+                return
+            uri = str((response.get("file") or {}).get("uri") or "")
+            if not uri:
+                self._logger.warn("[Memory] frame upload returned no file uri; retrying next tick")
+                return
+            with self._lock:
+                self._sync_map_locked()
+                if self._dir != uploaded_into:
+                    return  # the map switched mid-round; these frames are gone
+                self._records[memory.id] = _FileRecord(uri=uri, uploaded_at=time.time(), image_stamp=memory.stamp)
+                self._save_locked()
+
+    # --- registry persistence (under self._lock) ---
+    def _sync_map_locked(self) -> None:
+        path = self._store.files_index_path()
+        target = path.parent if path is not None else None
+        if target == self._dir:
+            return
+        self._dir = target
+        self._records = self._load(path) if path is not None else {}
+
+    def _load(self, path: Path) -> dict[int, _FileRecord]:
+        try:
+            data = json.loads(path.read_text())
+            return {
+                int(memory_id): _FileRecord(
+                    uri=str(entry["uri"]),
+                    uploaded_at=float(entry["uploaded_at"]),
+                    image_stamp=float(entry["image_stamp"]),
+                )
+                for memory_id, entry in data.get("files", {}).items()
+            }
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return {}  # unreadable registry = nothing uploaded; the chore rebuilds it
+
+    def _save_locked(self) -> None:
+        path = self._store.files_index_path()
+        if path is None:
+            return
+        live_ids = {memory.id for memory in self._store.snapshot().memories}
+        self._records = {memory_id: record for memory_id, record in self._records.items() if memory_id in live_ids}
+        index = {
+            "version": 1,
+            "files": {
+                str(memory_id): {
+                    "uri": record.uri,
+                    "uploaded_at": record.uploaded_at,
+                    "image_stamp": record.image_stamp,
+                }
+                for memory_id, record in self._records.items()
+            },
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(index))
+        os.replace(tmp, path)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -91,10 +91,22 @@ class MemorySearch:
         self._cache_unsupported = False
         self._failed_revision: int | None = None  # cache creation failed for exactly this content; don't hammer
         self._flight = threading.Lock()  # one network operation at a time (a search or a warm)
+        # UI mirror, set by the composition root: every finished search's verdict
+        # as a JSON-able dict (query, found, pose, explanation, latency, cached).
+        self.on_result: Callable[[dict], None] | None = None
 
     @property
     def frame_count(self) -> int:
         return len(self._store.snapshot().memories)
+
+    def cache_state(self) -> str:
+        """How the next search will run: warm | cold | inline | unsupported."""
+        if self._cache_unsupported:
+            return "unsupported"
+        snapshot = self._store.snapshot()
+        if len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
+            return "inline"  # under the cache floor — always answered inline, still quick
+        return "warm" if self._cache_matches(snapshot) else "cold"
 
     def begin_search(self, query: str, on_done: Callable[[str, bytes | None], None]) -> None:
         """Run a search on a daemon thread; the outcome (text, matched jpeg) hits ``on_done``."""
@@ -104,6 +116,7 @@ class MemorySearch:
                 text, image = self.search(query)
             except Exception as error:  # noqa: BLE001 — a failed search must report back, not vanish
                 self._logger.error(f"[Memory] search failed: {error!r}")
+                self._report({"query": query, "found": False, "error": str(error)})
                 text, image = f'Memory search for "{query}" failed: {error}', None
             on_done(text, image)
 
@@ -112,6 +125,7 @@ class MemorySearch:
     def search(self, query: str) -> tuple[str, bytes | None]:
         """Blocking: ask Gemini which remembered frame serves the query."""
         with self._flight:
+            started = time.monotonic()
             snapshot = self._store.snapshot()
             if not snapshot.memories:
                 return (
@@ -127,7 +141,7 @@ class MemorySearch:
                 }
                 try:
                     response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-                    return self._conclude(query, response, cache.memories)
+                    return self._conclude(query, response, cache.memories, started, cached=True)
                 except GeminiHttpError as error:
                     if error.status >= 500:
                         raise
@@ -142,7 +156,7 @@ class MemorySearch:
                 "generationConfig": _GENERATION_CONFIG,
             }
             response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-            return self._conclude(query, response, tuple(memory for memory, _ in frames))
+            return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
 
     def warm(self) -> None:
         """Refresh the context cache in the background once the memory has settled.
@@ -238,15 +252,36 @@ class MemorySearch:
         return self._cache
 
     # --- request assembly / response handling ---
-    def _conclude(self, query: str, response: dict, memories: tuple[Memory, ...]) -> tuple[str, bytes | None]:
+    def _conclude(
+        self, query: str, response: dict, memories: tuple[Memory, ...], started: float, *, cached: bool
+    ) -> tuple[str, bytes | None]:
+        latency = round(time.monotonic() - started, 2)
         verdict = _parse_verdict(response)
         if verdict is None:
+            self._report({"query": query, "found": False, "error": "unreadable answer"})
             return f'Memory search for "{query}" returned an unreadable answer — try again.', None
         found, frame, explanation = verdict
         if not found or not 1 <= frame <= len(memories):
+            self._report(
+                {"query": query, "found": False, "explanation": explanation, "latency_sec": latency, "cached": cached}
+            )
             return f'Memory search for "{query}": nothing in the remembered views matches. {explanation}', None
         memory = memories[frame - 1]
         jpeg = self._read_image(memory)
+        self._report(
+            {
+                "query": query,
+                "found": True,
+                "id": memory.id,
+                "x": round(memory.x, 3),
+                "y": round(memory.y, 3),
+                "theta": round(memory.theta, 4),
+                "seen_stamp": memory.stamp,
+                "explanation": explanation,
+                "latency_sec": latency,
+                "cached": cached,
+            }
+        )
         return (
             f'Memory search for "{query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago at '
             f"map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
@@ -256,6 +291,15 @@ class MemorySearch:
             f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false).",
             jpeg,
         )
+
+    def _report(self, payload: dict) -> None:
+        """Mirror a search verdict to the UI; best-effort — it must never break a search."""
+        if self.on_result is None:
+            return
+        try:
+            self.on_result({**payload, "stamp": time.time()})
+        except Exception as error:  # noqa: BLE001 — the UI mirror must not break the search
+            self._logger.warn(f"[Memory] search result mirror failed: {error!r}")
 
     def _load_frames(self, memories: tuple[Memory, ...]) -> list[tuple[Memory, bytes]]:
         frames = []

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -11,9 +11,11 @@ changes, expires, or the process restarts, and :meth:`warm` refreshes it in
 the background so the first search stays fast. A backend without the
 cachedContents endpoint falls back to inline frames — slower, same answers.
 
-Searches run on a daemon thread and report through a callback: the agent loop
-must never block on the network, so a search is dispatched fire-and-forget and
-its result arrives as a new event.
+Every search concludes in a :class:`SearchVerdict` — one structured outcome
+for every consumer: the agent's fire-and-forget event path (the loop must
+never block on the network), the ``/brain/search_memory`` action server that
+skills call, and the webapp mirror. :func:`verdict_text` renders the one
+model-facing sentence for all of them.
 """
 
 from __future__ import annotations
@@ -81,6 +83,22 @@ class _CacheHandle:
     expires_monotonic: float
 
 
+@dataclass(frozen=True)
+class SearchVerdict:
+    """One search's structured outcome. ``error`` non-empty means the search
+    itself failed (transport, unreadable answer) — distinct from a clean
+    no-match, which is ``found=False`` with an explanation."""
+
+    query: str
+    found: bool
+    explanation: str = ""
+    error: str = ""
+    memory: Memory | None = None
+    image: bytes | None = None
+    latency_sec: float = 0.0
+    cached: bool = False
+
+
 class MemorySearch:
     def __init__(self, store: MemoryStore, rest: GeminiRest, *, model: str, logger):
         self._store = store
@@ -108,55 +126,66 @@ class MemorySearch:
             return "inline"  # under the cache floor — always answered inline, still quick
         return "warm" if self._cache_matches(snapshot) else "cold"
 
-    def begin_search(self, query: str, on_done: Callable[[str, bytes | None], None]) -> None:
-        """Run a search on a daemon thread; the outcome (text, matched jpeg) hits ``on_done``."""
+    def begin_search(self, query: str, on_done: Callable[[SearchVerdict], None]) -> None:
+        """Run a search on a daemon thread; the verdict hits ``on_done`` when it lands."""
 
         def run() -> None:
             try:
-                text, image = self.search(query)
-            except Exception as error:  # noqa: BLE001 — a failed search must report back, not vanish
-                self._logger.error(f"[Memory] search failed: {error!r}")
-                self._report({"query": query, "found": False, "error": str(error)})
-                text, image = f'Memory search for "{query}" failed: {error}', None
-            on_done(text, image)
+                on_done(self.search(query))
+            except Exception as error:  # noqa: BLE001 — a broken consumer must not kill the thread silently
+                self._logger.error(f"[Memory] search callback failed: {error!r}")
 
         threading.Thread(target=run, name="memory-search", daemon=True).start()
 
-    def search(self, query: str) -> tuple[str, bytes | None]:
-        """Blocking: ask Gemini which remembered frame serves the query."""
+    def search(self, query: str) -> SearchVerdict:
+        """Blocking: ask Gemini which remembered frame serves the query.
+
+        Never raises — failures come back as an ``error`` verdict every
+        consumer (agent event, action result, webapp card) can render.
+        """
         with self._flight:
             started = time.monotonic()
-            snapshot = self._store.snapshot()
-            if not snapshot.memories:
-                return (
-                    "The robot has no memories of this map yet — drive around in navigation mode to build them.",
-                    None,
-                )
-            cache = self._ensure_cache(snapshot)
-            if cache is not None:
-                body = {
-                    "cachedContent": cache.name,
-                    "contents": [_user([{"text": _question(query)}])],
-                    "generationConfig": _GENERATION_CONFIG,
-                }
-                try:
-                    response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-                    return self._conclude(query, response, cache.memories, started, cached=True)
-                except GeminiHttpError as error:
-                    if error.status >= 500:
-                        raise
-                    # The cache died server-side (expired early, deleted, rejected):
-                    # forget it and answer inline; the next warm rebuilds it.
-                    self._cache = None
-                    self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
-            frames = self._load_frames(snapshot.memories)
+            try:
+                verdict = self._search_locked(query, started)
+            except Exception as error:  # noqa: BLE001 — transport failures become a typed error verdict
+                self._logger.error(f"[Memory] search failed: {error!r}")
+                verdict = SearchVerdict(query=query, found=False, error=str(error))
+        self._report(verdict)
+        return verdict
+
+    def _search_locked(self, query: str, started: float) -> SearchVerdict:
+        snapshot = self._store.snapshot()
+        if not snapshot.memories:
+            return SearchVerdict(
+                query=query,
+                found=False,
+                explanation="The robot has no memories of this map yet — drive around in navigation mode to build them.",
+            )
+        cache = self._ensure_cache(snapshot)
+        if cache is not None:
             body = {
-                "systemInstruction": {"parts": [{"text": _SYSTEM}]},
-                "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+                "cachedContent": cache.name,
+                "contents": [_user([{"text": _question(query)}])],
                 "generationConfig": _GENERATION_CONFIG,
             }
-            response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-            return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
+            try:
+                response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
+                return self._conclude(query, response, cache.memories, started, cached=True)
+            except GeminiHttpError as error:
+                if error.status >= 500:
+                    raise
+                # The cache died server-side (expired early, deleted, rejected):
+                # forget it and answer inline; the next warm rebuilds it.
+                self._cache = None
+                self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
+        frames = self._load_frames(snapshot.memories)
+        body = {
+            "systemInstruction": {"parts": [{"text": _SYSTEM}]},
+            "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+            "generationConfig": _GENERATION_CONFIG,
+        }
+        response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
+        return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
 
     def warm(self) -> None:
         """Refresh the context cache in the background once the memory has settled.
@@ -254,50 +283,51 @@ class MemorySearch:
     # --- request assembly / response handling ---
     def _conclude(
         self, query: str, response: dict, memories: tuple[Memory, ...], started: float, *, cached: bool
-    ) -> tuple[str, bytes | None]:
+    ) -> SearchVerdict:
         latency = round(time.monotonic() - started, 2)
-        verdict = _parse_verdict(response)
-        if verdict is None:
-            self._report({"query": query, "found": False, "error": "unreadable answer"})
-            return f'Memory search for "{query}" returned an unreadable answer — try again.', None
-        found, frame, explanation = verdict
-        if not found or not 1 <= frame <= len(memories):
-            self._report(
-                {"query": query, "found": False, "explanation": explanation, "latency_sec": latency, "cached": cached}
+        parsed = _parse_verdict(response)
+        if parsed is None:
+            return SearchVerdict(
+                query=query, found=False, error="unreadable answer", latency_sec=latency, cached=cached
             )
-            return f'Memory search for "{query}": nothing in the remembered views matches. {explanation}', None
+        found, frame, explanation = parsed
+        if not found or not 1 <= frame <= len(memories):
+            return SearchVerdict(query=query, found=False, explanation=explanation, latency_sec=latency, cached=cached)
         memory = memories[frame - 1]
-        jpeg = self._read_image(memory)
-        self._report(
-            {
-                "query": query,
-                "found": True,
+        return SearchVerdict(
+            query=query,
+            found=True,
+            explanation=explanation,
+            memory=memory,
+            image=self._read_image(memory),
+            latency_sec=latency,
+            cached=cached,
+        )
+
+    def _report(self, verdict: SearchVerdict) -> None:
+        """Mirror a verdict to the UI topic; best-effort — it must never break a search."""
+        if self.on_result is None:
+            return
+        payload: dict = {"query": verdict.query, "found": verdict.found, "stamp": time.time()}
+        if verdict.error:
+            payload["error"] = verdict.error
+        else:
+            payload |= {
+                "explanation": verdict.explanation,
+                "latency_sec": verdict.latency_sec,
+                "cached": verdict.cached,
+            }
+        if verdict.memory is not None:
+            memory = verdict.memory
+            payload |= {
                 "id": memory.id,
                 "x": round(memory.x, 3),
                 "y": round(memory.y, 3),
                 "theta": round(memory.theta, 4),
                 "seen_stamp": memory.stamp,
-                "explanation": explanation,
-                "latency_sec": latency,
-                "cached": cached,
             }
-        )
-        return (
-            f'Memory search for "{query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago at '
-            f"map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
-            f"{explanation} "
-            + ("The attached image is that memory. " if jpeg else "")
-            + f"To go there: navigate_to_position(x={memory.x:.2f}, y={memory.y:.2f}, "
-            f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false).",
-            jpeg,
-        )
-
-    def _report(self, payload: dict) -> None:
-        """Mirror a search verdict to the UI; best-effort — it must never break a search."""
-        if self.on_result is None:
-            return
         try:
-            self.on_result({**payload, "stamp": time.time()})
+            self.on_result(payload)
         except Exception as error:  # noqa: BLE001 — the UI mirror must not break the search
             self._logger.warn(f"[Memory] search result mirror failed: {error!r}")
 
@@ -315,6 +345,25 @@ class MemorySearch:
             return path.read_bytes() if path is not None else None
         except OSError:
             return None
+
+
+def verdict_text(verdict: SearchVerdict) -> str:
+    """The one model-facing sentence for a verdict — shared by the agent's
+    event path and the search skill, so the model reads the same thing
+    whichever door the search came through."""
+    if verdict.error:
+        return f'Memory search for "{verdict.query}" failed: {verdict.error}'
+    if verdict.memory is None:
+        return f'Memory search for "{verdict.query}": nothing in the remembered views matches. {verdict.explanation}'
+    memory = verdict.memory
+    return (
+        f'Memory search for "{verdict.query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago '
+        f"at map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
+        f"{verdict.explanation} "
+        + ("The attached image is that memory. " if verdict.image else "")
+        + f"To go there: navigate_to_position(x={memory.x:.2f}, y={memory.y:.2f}, "
+        f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false)."
+    )
 
 
 def _user(parts: list[dict]) -> dict:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -58,6 +58,11 @@ _TTL_SAFETY_SEC = 120  # treat the cache as gone this long before Gemini actuall
 _MIN_FRAMES_TO_CACHE = 6  # fewer frames sit under the API's minimum cache size (and upload fast anyway)
 _WARM_AFTER_QUIET_SEC = 30.0  # let a recording burst settle before rebuilding the cache
 _MAX_STALE_FRAMES = 10  # a delta this big rides every search — rebuild even mid-burst
+_WARM_RETRY_SEC = 30.0  # after a transient cache-build failure — warm() rides a 1 Hz tick
+# How long a new search waits for the lock. An abandoned goal (the skill's
+# timeout fired; cancels are rejected) can hold it for the transport's full
+# timeout — parking every executor thread behind it would wedge the server.
+_BUSY_WAIT_SEC = 5.0
 
 _SYSTEM = (
     "You are the spatial memory of a small home robot. You hold snapshots the robot remembered "
@@ -124,7 +129,8 @@ class MemorySearch:
         self._files = FrameFiles(store, rest, logger)
         self._cache: _CacheHandle | None = None
         self._cache_unsupported = False
-        self._failed_revision: int | None = None  # cache creation failed for exactly this content; don't hammer
+        self._failed_revision: int | None = None  # the backend refused exactly this content (4xx); don't hammer
+        self._retry_at = 0.0  # monotonic; transient build failures back off until then
         self._flight = threading.Lock()  # searches run one at a time
         # Maintenance never holds _flight: a search must proceed mid-rebuild
         # (it rides the old handle — the swap is a single reference write).
@@ -152,13 +158,17 @@ class MemorySearch:
         Never raises — failures come back as an ``error`` verdict every
         consumer (action result, webapp card) can render.
         """
-        with self._flight:
+        if not self._flight.acquire(timeout=_BUSY_WAIT_SEC):
+            verdict = SearchVerdict(query=query, found=False, error="another memory search is still running")
+        else:
             started = time.monotonic()
             try:
                 verdict = self._search_locked(query, started)
             except Exception as error:  # noqa: BLE001 — transport failures become a typed error verdict
                 self._logger.error(f"[Memory] search failed: {error!r}")
                 verdict = SearchVerdict(query=query, found=False, error=str(error))
+            finally:
+                self._flight.release()
         self._report(verdict)
         return verdict
 
@@ -221,13 +231,29 @@ class MemorySearch:
 
         def run() -> None:
             try:
-                self._ensure_cache(self._store.snapshot())
-            except Exception as error:  # noqa: BLE001 — warming is opportunistic; the search path degrades
-                self._logger.warn(f"[Memory] cache warm failed: {error!r}")
+                fresh = self._store.snapshot()
+                if self._should_warm(fresh):
+                    self._create_cache(fresh)
             finally:
                 self._warming.release()
 
         threading.Thread(target=run, name="memory-warm", daemon=True).start()
+
+    def forget(self) -> None:
+        """The user forgot this map's memories: drop the cache handle and the
+        uploaded frames so the forgotten views stop being served — server-side
+        deletion is best effort, in the background."""
+        cache, self._cache = self._cache, None
+        self._failed_revision = None
+        self._files.purge()
+        if cache is None:
+            return
+
+        def run() -> None:
+            with contextlib.suppress(Exception):
+                self._rest.delete(f"/v1beta/{cache.name}")
+
+        threading.Thread(target=run, name="memory-cache-forget", daemon=True).start()
 
     # --- cache management (under _flight, except the read-only probes) ---
     def _cache_matches(self, snapshot: MemorySnapshot) -> bool:
@@ -257,20 +283,13 @@ class MemorySearch:
         return sum(1 for memory in snapshot.memories if cached.get(memory.id) != memory.stamp)
 
     def _should_warm(self, snapshot: MemorySnapshot) -> bool:
+        """The one gate for cache rebuilds — warm() checks it before spawning
+        the thread and again on the fresh snapshot inside it."""
         if self._cache_unsupported or len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
             return False
-        if self._failed_revision == snapshot.revision:
+        if self._failed_revision == snapshot.revision or time.monotonic() < self._retry_at:
             return False
         return not self._cache_matches(snapshot)
-
-    def _ensure_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
-        if self._cache_unsupported or len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
-            return None
-        if self._cache_matches(snapshot):
-            return self._cache
-        if self._failed_revision == snapshot.revision:
-            return None
-        return self._create_cache(snapshot)
 
     def _create_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
         started = time.monotonic()
@@ -304,9 +323,20 @@ class MemorySearch:
                 self._logger.warn(
                     f"[Memory] backend has no context-cache endpoint (HTTP {error.status}); searches run uncached"
                 )
-            else:
+            elif error.status < 500:
+                # The backend refused this content — identical retries can't
+                # succeed; wait for the memory to change.
                 self._failed_revision = snapshot.revision
                 self._logger.warn(f"[Memory] context cache creation failed: {error}")
+            else:
+                self._retry_at = time.monotonic() + _WARM_RETRY_SEC
+                self._logger.warn(
+                    f"[Memory] context cache creation failed ({error}); retrying in {_WARM_RETRY_SEC:.0f}s"
+                )
+            return None
+        except Exception as error:  # noqa: BLE001 — network trouble backs off; warm() rides a 1 Hz tick
+            self._retry_at = time.monotonic() + _WARM_RETRY_SEC
+            self._logger.warn(f"[Memory] context cache creation failed ({error!r}); retrying in {_WARM_RETRY_SEC:.0f}s")
             return None
         if not name:
             self._failed_revision = snapshot.revision

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Recall over the spatial memory: which remembered view answers a request.
+
+Mobility-VLA-style retrieval: every remembered frame goes to Gemini, labeled
+with its number, capture time, and map pose, and the model picks the one that
+best serves the query — directly ("the kitchen") or by reasoning ("I am
+hungry"). The frames ride in an explicit Gemini context cache, so a search
+uploads only the question; the cache is rebuilt lazily whenever the memory
+changes, expires, or the process restarts, and :meth:`warm` refreshes it in
+the background so the first search stays fast. A backend without the
+cachedContents endpoint falls back to inline frames — slower, same answers.
+
+Searches run on a daemon thread and report through a callback: the agent loop
+must never block on the network, so a search is dispatched fire-and-forget and
+its result arrives as a new event.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import json
+import math
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from brain_client.brain.transport import CACHED_CONTENTS_PATH, GENERATE_PATH, GeminiHttpError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from brain_client.brain.transport import GeminiRest
+    from brain_client.memory.store import Memory, MemorySnapshot, MemoryStore
+
+_TTL_SEC = 12 * 3600  # ~20k-token cache: 12h of storage costs ~$0.24, cheap insurance against cold starts
+_TTL_SAFETY_SEC = 120  # treat the cache as gone this long before Gemini actually expires it
+_MIN_FRAMES_TO_CACHE = 6  # fewer frames sit under the API's minimum cache size (and upload fast anyway)
+_WARM_AFTER_QUIET_SEC = 30.0  # let a recording burst settle before re-uploading every frame
+_UNSUPPORTED_STATUSES = (404, 405, 501)  # the backend has no cachedContents passthrough
+
+_SYSTEM = (
+    "You are the spatial memory of a small home robot. You hold snapshots the robot remembered "
+    "while driving around its current map; each frame is labeled with its number, when it was "
+    "recorded, and the map pose it was taken from. Given what the robot needs, pick the single "
+    "frame whose view best serves it — the place itself, or where the needed thing was last "
+    'seen. Needs may be indirect: "I am hungry" points at food or the kitchen, "exit the '
+    'room" at a doorway. Prefer the most recent frame among equals. If no remembered view '
+    "plausibly helps, be honest and report no match."
+)
+
+_RESPONSE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "found": {"type": "BOOLEAN"},
+        "frame": {"type": "INTEGER", "description": "number of the best frame, 0 when found is false"},
+        "explanation": {
+            "type": "STRING",
+            "description": "one sentence: what the frame shows and why it serves the need",
+        },
+    },
+    "required": ["found", "frame", "explanation"],
+}
+
+_GENERATION_CONFIG = {
+    "responseMimeType": "application/json",
+    "responseSchema": _RESPONSE_SCHEMA,
+    "thinkingConfig": {"thinkingLevel": "low"},
+}
+
+
+@dataclass(frozen=True)
+class _CacheHandle:
+    name: str  # "cachedContents/…"
+    revision: int
+    map_name: str | None
+    memories: tuple[Memory, ...]  # frame numbers resolve against what was cached, not the live store
+    expires_monotonic: float
+
+
+class MemorySearch:
+    def __init__(self, store: MemoryStore, rest: GeminiRest, *, model: str, logger):
+        self._store = store
+        self._rest = rest
+        self._model = model
+        self._logger = logger
+        self._cache: _CacheHandle | None = None
+        self._cache_unsupported = False
+        self._failed_revision: int | None = None  # cache creation failed for exactly this content; don't hammer
+        self._flight = threading.Lock()  # one network operation at a time (a search or a warm)
+
+    @property
+    def frame_count(self) -> int:
+        return len(self._store.snapshot().memories)
+
+    def begin_search(self, query: str, on_done: Callable[[str, bytes | None], None]) -> None:
+        """Run a search on a daemon thread; the outcome (text, matched jpeg) hits ``on_done``."""
+
+        def run() -> None:
+            try:
+                text, image = self.search(query)
+            except Exception as error:  # noqa: BLE001 — a failed search must report back, not vanish
+                self._logger.error(f"[Memory] search failed: {error!r}")
+                text, image = f'Memory search for "{query}" failed: {error}', None
+            on_done(text, image)
+
+        threading.Thread(target=run, name="memory-search", daemon=True).start()
+
+    def search(self, query: str) -> tuple[str, bytes | None]:
+        """Blocking: ask Gemini which remembered frame serves the query."""
+        with self._flight:
+            snapshot = self._store.snapshot()
+            if not snapshot.memories:
+                return (
+                    "The robot has no memories of this map yet — drive around in navigation mode to build them.",
+                    None,
+                )
+            cache = self._ensure_cache(snapshot)
+            if cache is not None:
+                body = {
+                    "cachedContent": cache.name,
+                    "contents": [_user([{"text": _question(query)}])],
+                    "generationConfig": _GENERATION_CONFIG,
+                }
+                try:
+                    response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
+                    return self._conclude(query, response, cache.memories)
+                except GeminiHttpError as error:
+                    if error.status >= 500:
+                        raise
+                    # The cache died server-side (expired early, deleted, rejected):
+                    # forget it and answer inline; the next warm rebuilds it.
+                    self._cache = None
+                    self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
+            frames = self._load_frames(snapshot.memories)
+            body = {
+                "systemInstruction": {"parts": [{"text": _SYSTEM}]},
+                "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+                "generationConfig": _GENERATION_CONFIG,
+            }
+            response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
+            return self._conclude(query, response, tuple(memory for memory, _ in frames))
+
+    def warm(self) -> None:
+        """Refresh the context cache in the background once the memory has settled.
+
+        Called from the recorder's tick; returns immediately. Keeps the first
+        search after a boot or a recording burst from paying the frame upload.
+        """
+        snapshot = self._store.snapshot()
+        if not self._should_warm(snapshot):
+            return
+        if time.monotonic() - self._store.last_change_monotonic < _WARM_AFTER_QUIET_SEC:
+            return
+        if not self._flight.acquire(blocking=False):
+            return  # a search or another warm is already on the wire
+
+        def run() -> None:
+            try:
+                self._ensure_cache(self._store.snapshot())
+            except Exception as error:  # noqa: BLE001 — warming is opportunistic; the search path retries
+                self._logger.warn(f"[Memory] cache warm failed: {error!r}")
+            finally:
+                self._flight.release()
+
+        threading.Thread(target=run, name="memory-warm", daemon=True).start()
+
+    # --- cache management (under _flight, except the read-only probes) ---
+    def _cache_matches(self, snapshot: MemorySnapshot) -> bool:
+        cache = self._cache
+        return (
+            cache is not None
+            and cache.revision == snapshot.revision
+            and cache.map_name == snapshot.map_name
+            and time.monotonic() < cache.expires_monotonic
+        )
+
+    def _should_warm(self, snapshot: MemorySnapshot) -> bool:
+        if self._cache_unsupported or len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
+            return False
+        if self._failed_revision == snapshot.revision:
+            return False
+        return not self._cache_matches(snapshot)
+
+    def _ensure_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
+        if self._cache_unsupported or len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
+            return None
+        if self._cache_matches(snapshot):
+            return self._cache
+        if self._failed_revision == snapshot.revision:
+            return None
+        return self._create_cache(snapshot)
+
+    def _create_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
+        frames = self._load_frames(snapshot.memories)
+        if len(frames) < _MIN_FRAMES_TO_CACHE:
+            return None
+        body = {
+            "model": f"models/{self._model}",
+            "systemInstruction": {"parts": [{"text": _SYSTEM}]},
+            "contents": [_user(_frame_parts(frames))],
+            "ttl": f"{_TTL_SEC}s",
+            "displayName": f"mars-spatial-memory-{snapshot.map_name or 'unknown'}",
+        }
+        started = time.monotonic()
+        try:
+            name = str(self._rest.post(CACHED_CONTENTS_PATH, body).get("name") or "")
+        except GeminiHttpError as error:
+            if error.status in _UNSUPPORTED_STATUSES:
+                self._cache_unsupported = True
+                self._logger.warn(
+                    f"[Memory] backend has no context-cache endpoint (HTTP {error.status}); searches run uncached"
+                )
+            else:
+                self._failed_revision = snapshot.revision
+                self._logger.warn(f"[Memory] context cache creation failed: {error}")
+            return None
+        if not name:
+            self._failed_revision = snapshot.revision
+            return None
+        old, self._cache = (
+            self._cache,
+            _CacheHandle(
+                name=name,
+                revision=snapshot.revision,
+                map_name=snapshot.map_name,
+                memories=tuple(memory for memory, _ in frames),
+                expires_monotonic=started + _TTL_SEC - _TTL_SAFETY_SEC,
+            ),
+        )
+        if old is not None:
+            with contextlib.suppress(Exception):
+                self._rest.delete(f"/v1beta/{old.name}")
+        self._logger.info(f"[Memory] cached {len(frames)} frames for search in {time.monotonic() - started:.1f}s")
+        return self._cache
+
+    # --- request assembly / response handling ---
+    def _conclude(self, query: str, response: dict, memories: tuple[Memory, ...]) -> tuple[str, bytes | None]:
+        verdict = _parse_verdict(response)
+        if verdict is None:
+            return f'Memory search for "{query}" returned an unreadable answer — try again.', None
+        found, frame, explanation = verdict
+        if not found or not 1 <= frame <= len(memories):
+            return f'Memory search for "{query}": nothing in the remembered views matches. {explanation}', None
+        memory = memories[frame - 1]
+        jpeg = self._read_image(memory)
+        return (
+            f'Memory search for "{query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago at '
+            f"map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
+            f"{explanation} "
+            + ("The attached image is that memory. " if jpeg else "")
+            + f"To go there: navigate_to_position(x={memory.x:.2f}, y={memory.y:.2f}, "
+            f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false).",
+            jpeg,
+        )
+
+    def _load_frames(self, memories: tuple[Memory, ...]) -> list[tuple[Memory, bytes]]:
+        frames = []
+        for memory in memories:
+            jpeg = self._read_image(memory)
+            if jpeg:  # evicted between snapshot and read: the frame just drops out
+                frames.append((memory, jpeg))
+        return frames
+
+    def _read_image(self, memory: Memory) -> bytes | None:
+        path = self._store.image_path(memory.id)
+        try:
+            return path.read_bytes() if path is not None else None
+        except OSError:
+            return None
+
+
+def _user(parts: list[dict]) -> dict:
+    return {"role": "user", "parts": parts}
+
+
+def _frame_parts(frames: list[tuple[Memory, bytes]]) -> list[dict]:
+    parts: list[dict] = []
+    for number, (memory, jpeg) in enumerate(frames, start=1):
+        parts.append({"inlineData": {"mimeType": "image/jpeg", "data": base64.b64encode(jpeg).decode()}})
+        parts.append({"text": _frame_label(number, memory)})
+    return parts
+
+
+def _frame_label(number: int, memory: Memory) -> str:
+    when = datetime.fromtimestamp(memory.stamp).strftime("%Y-%m-%d %H:%M")
+    return (
+        f"Frame {number} — recorded {when}, from map position x={memory.x:.2f}m y={memory.y:.2f}m "
+        f"heading={math.degrees(memory.theta):.0f}°"
+    )
+
+
+def _question(query: str) -> str:
+    return f'The robot needs: "{query}". Which frame best serves this?'
+
+
+def _parse_verdict(response: dict) -> tuple[bool, int, str] | None:
+    try:
+        parts = response["candidates"][0]["content"]["parts"]
+        text = next(part["text"] for part in parts if part.get("text") and not part.get("thought"))
+        data = json.loads(text)
+        return bool(data["found"]), int(data["frame"]), str(data.get("explanation", ""))
+    except (KeyError, IndexError, TypeError, ValueError, StopIteration):
+        return None
+
+
+def _age_text(seconds: float) -> str:
+    if seconds < 90:
+        return f"{max(round(seconds), 0)}s"
+    if seconds < 90 * 60:
+        return f"{round(seconds / 60)}min"
+    if seconds < 36 * 3600:
+        return f"{round(seconds / 3600)}h"
+    return f"{round(seconds / 86400)}d"

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -3,13 +3,21 @@
 """Recall over the spatial memory: which remembered view answers a request.
 
 Mobility-VLA-style retrieval: every remembered frame goes to Gemini, labeled
-with its number, capture time, and map pose, and the model picks the one that
+with its id, capture time, and map pose, and the model picks the one that
 best serves the query — directly ("the kitchen") or by reasoning ("I am
-hungry"). The frames ride in an explicit Gemini context cache, so a search
-uploads only the question; the cache is rebuilt lazily whenever the memory
-changes, expires, or the process restarts, and :meth:`warm` refreshes it in
-the background so the first search stays fast. A backend without the
-cachedContents endpoint falls back to inline frames — slower, same answers.
+hungry").
+
+Bandwidth is tiered, and every tier is a pure optimization that degrades
+without changing answers. Each frame's bytes cross the network once, at
+record time — a background chore (:mod:`frame_files`) uploads them to the
+Gemini Files API and requests reference them as ``fileData``. On top rides an
+explicit context cache: fresh → the search sends only the question; stale →
+the search *still* uses it and appends the delta (added/refreshed frames plus
+short supersede/retire notes) — a search is always exactly one round trip and
+never waits for maintenance (cache builds happen only in :meth:`warm`'s
+background thread). A frame not yet uploaded rides ``inlineData``; a backend
+without an endpoint latches that tier off, bottoming out at today's
+all-inline behavior.
 
 Every search concludes in a :class:`SearchVerdict` — one structured outcome
 for every consumer: the agent's fire-and-forget event path (the loop must
@@ -30,7 +38,13 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from brain_client.brain.transport import CACHED_CONTENTS_PATH, GENERATE_PATH, GeminiHttpError
+from brain_client.brain.frame_files import FrameFiles
+from brain_client.brain.transport import (
+    CACHED_CONTENTS_PATH,
+    GENERATE_PATH,
+    UNSUPPORTED_ENDPOINT_STATUSES,
+    GeminiHttpError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -41,24 +55,24 @@ if TYPE_CHECKING:
 _TTL_SEC = 12 * 3600  # ~20k-token cache: 12h of storage costs ~$0.24, cheap insurance against cold starts
 _TTL_SAFETY_SEC = 120  # treat the cache as gone this long before Gemini actually expires it
 _MIN_FRAMES_TO_CACHE = 6  # fewer frames sit under the API's minimum cache size (and upload fast anyway)
-_WARM_AFTER_QUIET_SEC = 30.0  # let a recording burst settle before re-uploading every frame
-_UNSUPPORTED_STATUSES = (404, 405, 501)  # the backend has no cachedContents passthrough
+_WARM_AFTER_QUIET_SEC = 30.0  # let a recording burst settle before rebuilding the cache
 
 _SYSTEM = (
     "You are the spatial memory of a small home robot. You hold snapshots the robot remembered "
-    "while driving around its current map; each frame is labeled with its number, when it was "
-    "recorded, and the map pose it was taken from. Given what the robot needs, pick the single "
-    "frame whose view best serves it — the place itself, or where the needed thing was last "
-    'seen. Needs may be indirect: "I am hungry" points at food or the kitchen, "exit the '
-    'room" at a doorway. Prefer the most recent frame among equals. If no remembered view '
-    "plausibly helps, be honest and report no match."
+    "while driving around its current map; each frame is labeled with its id number, when it was "
+    "recorded, and the map pose it was taken from. Later messages may add frames, supersede one "
+    "with a newer view, or retire one — always honor the latest state. Given what the robot "
+    "needs, pick the single frame whose view best serves it — the place itself, or where the "
+    'needed thing was last seen. Needs may be indirect: "I am hungry" points at food or the '
+    'kitchen, "exit the room" at a doorway. Prefer the most recent frame among equals. If no '
+    "remembered view plausibly helps, be honest and report no match."
 )
 
 _RESPONSE_SCHEMA = {
     "type": "OBJECT",
     "properties": {
         "found": {"type": "BOOLEAN"},
-        "frame": {"type": "INTEGER", "description": "number of the best frame, 0 when found is false"},
+        "frame": {"type": "INTEGER", "description": "id number of the best frame, 0 when found is false"},
         "explanation": {
             "type": "STRING",
             "description": "one sentence: what the frame shows and why it serves the need",
@@ -105,10 +119,14 @@ class MemorySearch:
         self._rest = rest
         self._model = model
         self._logger = logger
+        self._files = FrameFiles(store, rest, logger)
         self._cache: _CacheHandle | None = None
         self._cache_unsupported = False
         self._failed_revision: int | None = None  # cache creation failed for exactly this content; don't hammer
-        self._flight = threading.Lock()  # one network operation at a time (a search or a warm)
+        self._flight = threading.Lock()  # searches run one at a time
+        # Maintenance never holds _flight: a search must proceed mid-rebuild
+        # (it rides the old handle — the swap is a single reference write).
+        self._warming = threading.Lock()  # at most one cache rebuild
         # UI mirror, set by the composition root: every finished search's verdict
         # as a JSON-able dict (query, found, pose, explanation, latency, cached).
         self.on_result: Callable[[dict], None] | None = None
@@ -118,13 +136,17 @@ class MemorySearch:
         return len(self._store.snapshot().memories)
 
     def cache_state(self) -> str:
-        """How the next search will run: warm | cold | inline | unsupported."""
+        """How the next search will run: warm | cold | inline | unsupported.
+
+        A stale-but-usable cache reports warm — the search rides it with a
+        delta, so recall is still instant (rebuilds are warm()'s business).
+        """
         if self._cache_unsupported:
             return "unsupported"
         snapshot = self._store.snapshot()
         if len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
-            return "inline"  # under the cache floor — always answered inline, still quick
-        return "warm" if self._cache_matches(snapshot) else "cold"
+            return "inline"  # under the cache floor — always answered from frames, still quick
+        return "warm" if self._usable_cache(snapshot) is not None else "cold"
 
     def begin_search(self, query: str, on_done: Callable[[SearchVerdict], None]) -> None:
         """Run a search on a daemon thread; the verdict hits ``on_done`` when it lands."""
@@ -154,6 +176,8 @@ class MemorySearch:
         return verdict
 
     def _search_locked(self, query: str, started: float) -> SearchVerdict:
+        """One round trip from the best context available NOW — a search never
+        builds a cache and never waits for an upload (that's warm()'s job)."""
         snapshot = self._store.snapshot()
         if not snapshot.memories:
             return SearchVerdict(
@@ -161,53 +185,55 @@ class MemorySearch:
                 found=False,
                 explanation="The robot has no memories of this map yet — drive around in navigation mode to build them.",
             )
-        cache = self._ensure_cache(snapshot)
+        cache = self._usable_cache(snapshot)
         if cache is not None:
+            # A stale cache still serves: the delta (new/refreshed frames plus
+            # supersede/retire notes) rides alongside the question.
             body = {
                 "cachedContent": cache.name,
-                "contents": [_user([{"text": _question(query)}])],
+                "contents": [_user([*self._delta_parts(cache, snapshot), {"text": _question(query)}])],
                 "generationConfig": _GENERATION_CONFIG,
             }
             try:
                 response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-                return self._conclude(query, response, cache.memories, started, cached=True)
+                return self._conclude(query, response, snapshot.memories, started, cached=True)
             except GeminiHttpError as error:
                 if error.status >= 500:
                     raise
                 # The cache died server-side (expired early, deleted, rejected):
-                # forget it and answer inline; the next warm rebuilds it.
+                # forget it and answer from frames; the next warm rebuilds it.
                 self._cache = None
-                self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
-        frames = self._load_frames(snapshot.memories)
+                self._logger.warn(f"[Memory] cached search failed ({error}); retrying without it")
+        parts, _included = self._frame_parts(snapshot.memories)
         body = {
             "systemInstruction": {"parts": [{"text": _SYSTEM}]},
-            "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+            "contents": [_user([*parts, {"text": _question(query)}])],
             "generationConfig": _GENERATION_CONFIG,
         }
         response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-        return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
+        return self._conclude(query, response, snapshot.memories, started, cached=False)
 
     def warm(self) -> None:
-        """Refresh the context cache in the background once the memory has settled.
-
-        Called from the recorder's tick; returns immediately. Keeps the first
-        search after a boot or a recording burst from paying the frame upload.
+        """All background maintenance, driven by the recorder's 1 Hz tick:
+        upload new/aging frames server-side, and rebuild the context cache once
+        the memory has settled. Returns immediately; searches never wait on it.
         """
+        self._files.maintain()
         snapshot = self._store.snapshot()
         if not self._should_warm(snapshot):
             return
         if time.monotonic() - self._store.last_change_monotonic < _WARM_AFTER_QUIET_SEC:
             return
-        if not self._flight.acquire(blocking=False):
-            return  # a search or another warm is already on the wire
+        if not self._warming.acquire(blocking=False):
+            return  # a rebuild is already on the wire
 
         def run() -> None:
             try:
                 self._ensure_cache(self._store.snapshot())
-            except Exception as error:  # noqa: BLE001 — warming is opportunistic; the search path retries
+            except Exception as error:  # noqa: BLE001 — warming is opportunistic; the search path degrades
                 self._logger.warn(f"[Memory] cache warm failed: {error!r}")
             finally:
-                self._flight.release()
+                self._warming.release()
 
         threading.Thread(target=run, name="memory-warm", daemon=True).start()
 
@@ -220,6 +246,14 @@ class MemorySearch:
             and cache.map_name == snapshot.map_name
             and time.monotonic() < cache.expires_monotonic
         )
+
+    def _usable_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
+        """The handle a search may ride right now — fresh OR stale (the delta
+        covers staleness); only the wrong map or expiry disqualifies it."""
+        cache = self._cache
+        if cache is None or cache.map_name != snapshot.map_name:
+            return None
+        return cache if time.monotonic() < cache.expires_monotonic else None
 
     def _should_warm(self, snapshot: MemorySnapshot) -> bool:
         if self._cache_unsupported or len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
@@ -238,13 +272,13 @@ class MemorySearch:
         return self._create_cache(snapshot)
 
     def _create_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
-        frames = self._load_frames(snapshot.memories)
-        if len(frames) < _MIN_FRAMES_TO_CACHE:
+        parts, included = self._frame_parts(snapshot.memories)
+        if len(included) < _MIN_FRAMES_TO_CACHE:
             return None
         body = {
             "model": f"models/{self._model}",
             "systemInstruction": {"parts": [{"text": _SYSTEM}]},
-            "contents": [_user(_frame_parts(frames))],
+            "contents": [_user(parts)],
             "ttl": f"{_TTL_SEC}s",
             "displayName": f"mars-spatial-memory-{snapshot.map_name or 'unknown'}",
         }
@@ -252,7 +286,7 @@ class MemorySearch:
         try:
             name = str(self._rest.post(CACHED_CONTENTS_PATH, body).get("name") or "")
         except GeminiHttpError as error:
-            if error.status in _UNSUPPORTED_STATUSES:
+            if error.status in UNSUPPORTED_ENDPOINT_STATUSES:
                 self._cache_unsupported = True
                 self._logger.warn(
                     f"[Memory] backend has no context-cache endpoint (HTTP {error.status}); searches run uncached"
@@ -270,14 +304,14 @@ class MemorySearch:
                 name=name,
                 revision=snapshot.revision,
                 map_name=snapshot.map_name,
-                memories=tuple(memory for memory, _ in frames),
+                memories=included,
                 expires_monotonic=started + _TTL_SEC - _TTL_SAFETY_SEC,
             ),
         )
         if old is not None:
             with contextlib.suppress(Exception):
                 self._rest.delete(f"/v1beta/{old.name}")
-        self._logger.info(f"[Memory] cached {len(frames)} frames for search in {time.monotonic() - started:.1f}s")
+        self._logger.info(f"[Memory] cached {len(included)} frames for search in {time.monotonic() - started:.1f}s")
         return self._cache
 
     # --- request assembly / response handling ---
@@ -290,10 +324,12 @@ class MemorySearch:
             return SearchVerdict(
                 query=query, found=False, error="unreadable answer", latency_sec=latency, cached=cached
             )
-        found, frame, explanation = parsed
-        if not found or not 1 <= frame <= len(memories):
+        found, frame_id, explanation = parsed
+        # Frames are labeled by stable store id, so the answer resolves against
+        # the CURRENT snapshot — a cached-but-since-evicted id cleanly misses.
+        memory = next((m for m in memories if m.id == frame_id), None)
+        if not found or memory is None:
             return SearchVerdict(query=query, found=False, explanation=explanation, latency_sec=latency, cached=cached)
-        memory = memories[frame - 1]
         return SearchVerdict(
             query=query,
             found=True,
@@ -331,13 +367,52 @@ class MemorySearch:
         except Exception as error:  # noqa: BLE001 — the UI mirror must not break the search
             self._logger.warn(f"[Memory] search result mirror failed: {error!r}")
 
-    def _load_frames(self, memories: tuple[Memory, ...]) -> list[tuple[Memory, bytes]]:
-        frames = []
+    def _frame_parts(self, memories: tuple[Memory, ...]) -> tuple[list[dict], tuple[Memory, ...]]:
+        """Request parts for these frames, and which memories made it in
+        (an evicted-mid-read frame just drops out)."""
+        parts: list[dict] = []
+        included: list[Memory] = []
         for memory in memories:
+            frame = self._frame_part(memory)
+            if frame is None:
+                continue
+            parts.extend(frame)
+            included.append(memory)
+        return parts, tuple(included)
+
+    def _frame_part(self, memory: Memory) -> list[dict] | None:
+        """One frame as [image part, label part] — a server-side fileData
+        reference when the upload tier has one, inline bytes otherwise."""
+        uri = self._files.uri_for(memory)
+        if uri is not None:
+            image: dict = {"fileData": {"mimeType": "image/jpeg", "fileUri": uri}}
+        else:
             jpeg = self._read_image(memory)
-            if jpeg:  # evicted between snapshot and read: the frame just drops out
-                frames.append((memory, jpeg))
-        return frames
+            if not jpeg:
+                return None
+            image = {"inlineData": {"mimeType": "image/jpeg", "data": base64.b64encode(jpeg).decode()}}
+        return [image, {"text": _frame_label(memory)}]
+
+    def _delta_parts(self, cache: _CacheHandle, snapshot: MemorySnapshot) -> list[dict]:
+        """What changed since the cache was built: new frames, re-captured
+        frames with a supersede note, and retire notes for evicted ids.
+        Empty exactly when the cache is fresh."""
+        cached = {memory.id: memory for memory in cache.memories}
+        parts: list[dict] = []
+        for memory in snapshot.memories:
+            old = cached.get(memory.id)
+            if old is not None and old.stamp == memory.stamp:
+                continue
+            frame = self._frame_part(memory)
+            if frame is None:
+                continue
+            if old is not None:
+                parts.append({"text": f"Frame {memory.id} was re-captured — this newer view supersedes it:"})
+            parts.extend(frame)
+        current_ids = {memory.id for memory in snapshot.memories}
+        for gone in sorted(cached.keys() - current_ids):
+            parts.append({"text": f"Frame {gone} no longer exists — ignore it."})
+        return parts
 
     def _read_image(self, memory: Memory) -> bytes | None:
         path = self._store.image_path(memory.id)
@@ -370,18 +445,12 @@ def _user(parts: list[dict]) -> dict:
     return {"role": "user", "parts": parts}
 
 
-def _frame_parts(frames: list[tuple[Memory, bytes]]) -> list[dict]:
-    parts: list[dict] = []
-    for number, (memory, jpeg) in enumerate(frames, start=1):
-        parts.append({"inlineData": {"mimeType": "image/jpeg", "data": base64.b64encode(jpeg).decode()}})
-        parts.append({"text": _frame_label(number, memory)})
-    return parts
-
-
-def _frame_label(number: int, memory: Memory) -> str:
+def _frame_label(memory: Memory) -> str:
+    # Labeled by the stable store id (not enumeration position), so delta
+    # notes and verdicts stay valid across additions, refreshes, and evictions.
     when = datetime.fromtimestamp(memory.stamp).strftime("%Y-%m-%d %H:%M")
     return (
-        f"Frame {number} — recorded {when}, from map position x={memory.x:.2f}m y={memory.y:.2f}m "
+        f"Frame {memory.id} — recorded {when}, from map position x={memory.x:.2f}m y={memory.y:.2f}m "
         f"heading={math.degrees(memory.theta):.0f}°"
     )
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -20,9 +20,8 @@ without an endpoint latches that tier off, bottoming out at today's
 all-inline behavior.
 
 Every search concludes in a :class:`SearchVerdict` — one structured outcome
-for every consumer: the agent's fire-and-forget event path (the loop must
-never block on the network), the ``/brain/search_memory`` action server that
-skills call, and the webapp mirror. :func:`verdict_text` renders the one
+for every consumer: the ``/brain/search_memory`` action server that skills
+call, and the webapp mirror. :func:`verdict_text` renders the one
 model-facing sentence for all of them.
 """
 
@@ -134,10 +133,6 @@ class MemorySearch:
         # as a JSON-able dict (query, found, pose, explanation, latency, cached).
         self.on_result: Callable[[dict], None] | None = None
 
-    @property
-    def frame_count(self) -> int:
-        return len(self._store.snapshot().memories)
-
     def cache_state(self) -> str:
         """How the next search will run: warm | cold | inline | unsupported.
 
@@ -151,22 +146,11 @@ class MemorySearch:
             return "inline"  # under the cache floor — always answered from frames, still quick
         return "warm" if self._usable_cache(snapshot) is not None else "cold"
 
-    def begin_search(self, query: str, on_done: Callable[[SearchVerdict], None]) -> None:
-        """Run a search on a daemon thread; the verdict hits ``on_done`` when it lands."""
-
-        def run() -> None:
-            try:
-                on_done(self.search(query))
-            except Exception as error:  # noqa: BLE001 — a broken consumer must not kill the thread silently
-                self._logger.error(f"[Memory] search callback failed: {error!r}")
-
-        threading.Thread(target=run, name="memory-search", daemon=True).start()
-
     def search(self, query: str) -> SearchVerdict:
         """Blocking: ask Gemini which remembered frame serves the query.
 
         Never raises — failures come back as an ``error`` verdict every
-        consumer (agent event, action result, webapp card) can render.
+        consumer (action result, webapp card) can render.
         """
         with self._flight:
             started = time.monotonic()

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -49,6 +49,8 @@ from brain_client.brain.transport import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from rclpy.impl.rcutils_logger import RcutilsLogger
+
     from brain_client.brain.transport import GeminiRest
     from brain_client.memory.store import Memory, MemorySnapshot, MemoryStore
 
@@ -56,6 +58,7 @@ _TTL_SEC = 12 * 3600  # ~20k-token cache: 12h of storage costs ~$0.24, cheap ins
 _TTL_SAFETY_SEC = 120  # treat the cache as gone this long before Gemini actually expires it
 _MIN_FRAMES_TO_CACHE = 6  # fewer frames sit under the API's minimum cache size (and upload fast anyway)
 _WARM_AFTER_QUIET_SEC = 30.0  # let a recording burst settle before rebuilding the cache
+_MAX_STALE_FRAMES = 10  # a delta this big rides every search — rebuild even mid-burst
 
 _SYSTEM = (
     "You are the spatial memory of a small home robot. You hold snapshots the robot remembered "
@@ -114,7 +117,7 @@ class SearchVerdict:
 
 
 class MemorySearch:
-    def __init__(self, store: MemoryStore, rest: GeminiRest, *, model: str, logger):
+    def __init__(self, store: MemoryStore, rest: GeminiRest, *, model: str, logger: RcutilsLogger):
         self._store = store
         self._rest = rest
         self._model = model
@@ -196,13 +199,15 @@ class MemorySearch:
             }
             try:
                 response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-                return self._conclude(query, response, snapshot.memories, started, cached=True)
+                return self._conclude(query, response, snapshot, started, cached=True)
             except GeminiHttpError as error:
                 if error.status >= 500:
                     raise
-                # The cache died server-side (expired early, deleted, rejected):
-                # forget it and answer from frames; the next warm rebuilds it.
-                self._cache = None
+                # The cache died server-side (expired early, deleted — including
+                # by warm() swapping in a successor and deleting this handle
+                # mid-flight): forget the handle that failed, never a newer one.
+                if self._cache is cache:
+                    self._cache = None
                 self._logger.warn(f"[Memory] cached search failed ({error}); retrying without it")
         parts, _included = self._frame_parts(snapshot.memories)
         body = {
@@ -211,7 +216,7 @@ class MemorySearch:
             "generationConfig": _GENERATION_CONFIG,
         }
         response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-        return self._conclude(query, response, snapshot.memories, started, cached=False)
+        return self._conclude(query, response, snapshot, started, cached=False)
 
     def warm(self) -> None:
         """All background maintenance, driven by the recorder's 1 Hz tick:
@@ -222,8 +227,11 @@ class MemorySearch:
         snapshot = self._store.snapshot()
         if not self._should_warm(snapshot):
             return
-        if time.monotonic() - self._store.last_change_monotonic < _WARM_AFTER_QUIET_SEC:
-            return
+        if (
+            time.monotonic() - self._store.last_change_monotonic < _WARM_AFTER_QUIET_SEC
+            and self._staleness(snapshot) < _MAX_STALE_FRAMES
+        ):
+            return  # let the burst settle — unless the delta already rides every search too heavy
         if not self._warming.acquire(blocking=False):
             return  # a rebuild is already on the wire
 
@@ -255,6 +263,15 @@ class MemorySearch:
             return None
         return cache if time.monotonic() < cache.expires_monotonic else None
 
+    def _staleness(self, snapshot: MemorySnapshot) -> int:
+        """How many frames the next search's delta must carry (0 = fresh, or no
+        cache to be stale against)."""
+        cache = self._usable_cache(snapshot)
+        if cache is None:
+            return 0
+        cached = {memory.id: memory.stamp for memory in cache.memories}
+        return sum(1 for memory in snapshot.memories if cached.get(memory.id) != memory.stamp)
+
     def _should_warm(self, snapshot: MemorySnapshot) -> bool:
         if self._cache_unsupported or len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
             return False
@@ -272,6 +289,19 @@ class MemorySearch:
         return self._create_cache(snapshot)
 
     def _create_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
+        started = time.monotonic()
+        # A cache built from fileData must not outlive the uploads it embeds
+        # (Gemini deletes them at 48 h): cap its life at the earliest
+        # referenced file's usable deadline, so warm() rebuilds in time — and
+        # when that deadline is already at hand, don't build at all (the handle
+        # would arrive expired and every warm would pay for another).
+        expires = started + _TTL_SEC - _TTL_SAFETY_SEC
+        for memory in snapshot.memories:
+            until = self._files.usable_until(memory)
+            if until is not None:
+                expires = min(expires, started + (until - time.time()) - _TTL_SAFETY_SEC)
+        if expires <= started:
+            return None
         parts, included = self._frame_parts(snapshot.memories)
         if len(included) < _MIN_FRAMES_TO_CACHE:
             return None
@@ -282,7 +312,6 @@ class MemorySearch:
             "ttl": f"{_TTL_SEC}s",
             "displayName": f"mars-spatial-memory-{snapshot.map_name or 'unknown'}",
         }
-        started = time.monotonic()
         try:
             name = str(self._rest.post(CACHED_CONTENTS_PATH, body).get("name") or "")
         except GeminiHttpError as error:
@@ -305,7 +334,7 @@ class MemorySearch:
                 revision=snapshot.revision,
                 map_name=snapshot.map_name,
                 memories=included,
-                expires_monotonic=started + _TTL_SEC - _TTL_SAFETY_SEC,
+                expires_monotonic=expires,
             ),
         )
         if old is not None:
@@ -316,7 +345,7 @@ class MemorySearch:
 
     # --- request assembly / response handling ---
     def _conclude(
-        self, query: str, response: dict, memories: tuple[Memory, ...], started: float, *, cached: bool
+        self, query: str, response: dict, snapshot: MemorySnapshot, started: float, *, cached: bool
     ) -> SearchVerdict:
         latency = round(time.monotonic() - started, 2)
         parsed = _parse_verdict(response)
@@ -325,9 +354,22 @@ class MemorySearch:
                 query=query, found=False, error="unreadable answer", latency_sec=latency, cached=cached
             )
         found, frame_id, explanation = parsed
+        # The coordinates only mean anything on the map the frames came from —
+        # a map switched mid-flight voids the verdict rather than steering the
+        # robot toward another map's frame.
+        live = self._store.snapshot()
+        if live.map_name != snapshot.map_name:
+            return SearchVerdict(
+                query=query,
+                found=False,
+                error="the active map changed during the search",
+                latency_sec=latency,
+                cached=cached,
+            )
         # Frames are labeled by stable store id, so the answer resolves against
-        # the CURRENT snapshot — a cached-but-since-evicted id cleanly misses.
-        memory = next((m for m in memories if m.id == frame_id), None)
+        # the LIVE snapshot — an id evicted mid-search cleanly misses, a
+        # refreshed one serves its newest pose.
+        memory = next((m for m in live.memories if m.id == frame_id), None)
         if not found or memory is None:
             return SearchVerdict(query=query, found=False, explanation=explanation, latency_sec=latency, cached=cached)
         return SearchVerdict(

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
@@ -14,7 +14,9 @@ app chat.
 Rules:
 - Only one skill runs at a time. After starting one, wait for its result event; while it runs \
 you can still talk, and you can abort it with stop_current_skill. If the user speaks to you \
-while a skill runs, answer them — a running skill is never a reason to ignore the user.
+while a skill runs, answer them — a running skill is never a reason to ignore the user. Never \
+assert the outcome of a skill you just started — its result event is the only source of what \
+it found or did.
 - Plain text is speech: conversational and SHORT — usually one brief sentence; speaking takes \
 real time, and long replies talk over the conversation. When there is nothing to do or say, \
 call the wait tool if it is offered and write no text — never emit placeholder text of any \

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
@@ -30,9 +30,6 @@ you have failed to complete the action and think trying again might succeed.
 capability you don't have, briefly say you can't. Never write tool-call syntax in your text \
 (e.g. "Calling tool ...") — text is only ever speech.
 - Distances are meters, angles are degrees. The robot's forward axis is +x; +y is to its left.
-- search_memory (when offered) is your recall of places this robot has seen on its map. When \
-asked to find or go to something not in view, search first and navigate to the match — don't \
-wander. If the search finds nothing, say so and only then explore.
 - You keep receiving updates while idle. Stay quiet and idle unless something relevant changes \
 (the user speaking to you is always relevant) or your directive tells you to act. Never invent tasks or goals of your own: only your \
 directive and the user's requests drive action — noticing an object is not a reason to act.

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
@@ -30,6 +30,9 @@ you have failed to complete the action and think trying again might succeed.
 capability you don't have, briefly say you can't. Never write tool-call syntax in your text \
 (e.g. "Calling tool ...") — text is only ever speech.
 - Distances are meters, angles are degrees. The robot's forward axis is +x; +y is to its left.
+- search_memory (when offered) is your recall of places this robot has seen on its map. When \
+asked to find or go to something not in view, search first and navigate to the match — don't \
+wander. If the search finds nothing, say so and only then explore.
 - You keep receiving updates while idle. Stay quiet and idle unless something relevant changes \
 (the user speaking to you is always relevant) or your directive tells you to act. Never invent tasks or goals of your own: only your \
 directive and the user's requests drive action — noticing an object is not a reason to act.

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/search_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/search_server.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The ``/brain/search_memory`` action: spatial-memory recall as a capability.
+
+The capability server pattern (arm_sdk_server, the nav stack): the state that
+makes search fast and safe — the Gemini context cache, the transport, the
+credentials — stays in the brain process with :class:`MemorySearch`; skills
+and SDK users reach it through this action and never see any of it.
+
+Runs on its own node and spin thread because a search blocks for seconds and
+the brain node is spun single-threaded — recall must never stall a turn.
+Cancellation is rejected by design: the network call can't be unwound, so a
+caller that stops waiting simply abandons the goal and the verdict is dropped
+(the skill layer's Stop already works exactly that way).
+"""
+
+from __future__ import annotations
+
+import base64
+import threading
+from typing import TYPE_CHECKING
+
+import rclpy
+from brain_messages.action import SearchMemory
+from rclpy.action import ActionServer, CancelResponse
+from rclpy.executors import SingleThreadedExecutor
+
+from brain_client.brain.memory_search import verdict_text
+
+if TYPE_CHECKING:
+    from brain_client.brain.memory_search import MemorySearch, SearchVerdict
+
+
+class MemorySearchServer:
+    def __init__(self, search: MemorySearch):
+        self._search = search
+        self._node = rclpy.create_node("memory_search_server")
+        self._server = ActionServer(
+            self._node,
+            SearchMemory,
+            "/brain/search_memory",
+            execute_callback=self._execute,
+            cancel_callback=lambda _: CancelResponse.REJECT,
+        )
+        self._executor = SingleThreadedExecutor()
+        self._executor.add_node(self._node)
+        self._thread = threading.Thread(target=self._executor.spin, name="memory-search-server", daemon=True)
+        self._thread.start()
+
+    def _execute(self, goal_handle) -> SearchMemory.Result:
+        verdict = self._search.search(str(goal_handle.request.query))  # never raises: errors are verdicts
+        goal_handle.succeed()
+        return _to_result(verdict)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(timeout_sec=2.0)
+        self._node.destroy_node()
+
+
+def _to_result(verdict: SearchVerdict) -> SearchMemory.Result:
+    result = SearchMemory.Result()
+    result.found = verdict.found
+    result.message = verdict_text(verdict)
+    result.explanation = verdict.explanation
+    result.error = verdict.error
+    result.latency_sec = float(verdict.latency_sec)
+    result.cached = verdict.cached
+    if verdict.memory is not None:
+        result.x = verdict.memory.x
+        result.y = verdict.memory.y
+        result.theta = verdict.memory.theta
+        result.seen_stamp = verdict.memory.stamp
+    if verdict.image:
+        result.image_b64 = base64.b64encode(verdict.image).decode()
+    return result

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/search_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/search_server.py
@@ -23,11 +23,14 @@ from typing import TYPE_CHECKING
 import rclpy
 from brain_messages.action import SearchMemory
 from rclpy.action import ActionServer, CancelResponse
-from rclpy.executors import SingleThreadedExecutor
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
 
 from brain_client.brain.memory_search import verdict_text
 
 if TYPE_CHECKING:
+    from rclpy.action.server import ServerGoalHandle
+
     from brain_client.brain.memory_search import MemorySearch, SearchVerdict
 
 
@@ -35,25 +38,35 @@ class MemorySearchServer:
     def __init__(self, search: MemorySearch):
         self._search = search
         self._node = rclpy.create_node("memory_search_server")
+        # Reentrant + multithreaded (the arm_sdk_server pattern): an execute
+        # callback blocks its thread for the whole search, and goal/result
+        # requests from other callers must still be serviced meanwhile.
         self._server = ActionServer(
             self._node,
             SearchMemory,
             "/brain/search_memory",
             execute_callback=self._execute,
             cancel_callback=lambda _: CancelResponse.REJECT,
+            callback_group=ReentrantCallbackGroup(),
         )
-        self._executor = SingleThreadedExecutor()
+        self._executor = MultiThreadedExecutor(num_threads=4)
         self._executor.add_node(self._node)
         self._thread = threading.Thread(target=self._executor.spin, name="memory-search-server", daemon=True)
         self._thread.start()
 
-    def _execute(self, goal_handle) -> SearchMemory.Result:
+    def _execute(self, goal_handle: ServerGoalHandle) -> SearchMemory.Result:
         verdict = self._search.search(str(goal_handle.request.query))  # never raises: errors are verdicts
         goal_handle.succeed()
         return _to_result(verdict)
 
     def shutdown(self) -> None:
         self._executor.shutdown(timeout_sec=2.0)
+        self._thread.join(timeout=2.0)
+        if self._thread.is_alive():
+            # A search is still concluding on the spin thread; destroying the
+            # node under it is the InvalidHandle → SIGABRT race. The daemon
+            # thread dies with the process — leak the node instead.
+            return
         self._node.destroy_node()
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -93,10 +93,11 @@ def build_tools(
     its dispatch map from the same pairs, so the declared names and the
     dispatched names can never diverge.
 
-    While a skill runs, the robot's only action is stopping it, so the
-    declarations collapse. The shape depends on whether the user just spoke:
-    offered any no-op tool, the model calls it and goes silent, so a turn
-    carrying a user message gets stop_current_skill ALONE — plain text becomes
+    While a skill runs, the robot's only *act* is stopping it, so the caller
+    passes only its non-occupying query skills (memory recall) and the
+    declarations collapse to stop + those. The shape depends on whether the
+    user just spoke: offered any no-op tool, the model calls it and goes
+    silent, so a turn carrying a user message drops wait — plain text becomes
     the reply channel, and the description steers stop away from questions.
     """
     if running_skill_name is not None:
@@ -111,7 +112,10 @@ def build_tools(
                 else "Use when it is clearly failing, no longer makes sense, or the user asks for something else."
             ),
         }
-        return [{"functionDeclarations": [stop] if user_spoke else [stop, _WAIT_DECLARATION]}]
+        declarations = [stop, *(_declaration(name, meta) for name, meta in named_skills)]
+        if not user_spoke:
+            declarations.append(_WAIT_DECLARATION)
+        return [{"functionDeclarations": declarations}]
     declarations = [_declaration(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -11,6 +11,7 @@ from brain_client.skills.registry import SkillMeta
 STOP_SKILL = "stop_current_skill"
 WAIT = "wait"
 GO_TO_POINT_IN_VIEW = "go_to_point_in_view"
+SEARCH_MEMORY = "search_memory"
 
 # An explicit no-op keeps idle turns clean: without it, models tend to emit
 # placeholder text ("[]", "Empty response") rather than returning nothing.
@@ -41,6 +42,24 @@ _GO_TO_POINT_IN_VIEW_DECLARATION = {
     },
 }
 
+# Recall over the robot's persistent spatial memory (brain/memory_search.py).
+# Declared only while the memory holds at least one frame for the current map.
+_SEARCH_MEMORY_DECLARATION = {
+    "name": SEARCH_MEMORY,
+    "description": (
+        "Search the robot's long-term memory of places it has seen on this map. Describe the place "
+        "or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my "
+        "airpods'); a vision model reviews every remembered view and an event brings back the best "
+        "match — its image, map coordinates, and when it was seen. Use it to find anything not in "
+        "the current camera view, then drive there with navigate_to_position (local_frame=false)."
+    ),
+    "parameters": {
+        "type": "OBJECT",
+        "properties": {"query": {"type": "STRING", "description": "what to look for, with any helpful context"}},
+        "required": ["query"],
+    },
+}
+
 # Skill input "type" strings (python annotation names from skill introspection)
 # -> Gemini schema types. Anything else is passed as a string with the expected
 # type noted in the description.
@@ -66,7 +85,7 @@ def assign_tool_names(skills: list[SkillMeta]) -> list[tuple[str, SkillMeta]]:
     shadow a built-in tool); colliding names get a numeric suffix so a call
     never silently dispatches to the wrong skill.
     """
-    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW}
+    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW, SEARCH_MEMORY}
     named: list[tuple[str, SkillMeta]] = []
     for meta in skills:
         base = name = tool_name(meta["name"])
@@ -85,6 +104,7 @@ def build_tools(
     running_skill_name: str | None,
     *,
     can_go_to_point_in_view: bool = False,
+    can_search_memory: bool = False,
     user_spoke: bool = False,
 ) -> list[dict]:
     """One function declaration per available skill, in a native tools block.
@@ -115,6 +135,8 @@ def build_tools(
     declarations = [_declaration(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)
+    if can_search_memory:
+        declarations.append(_SEARCH_MEMORY_DECLARATION)
     declarations.append(_WAIT_DECLARATION)
     return [{"functionDeclarations": declarations}]
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -93,11 +93,10 @@ def build_tools(
     its dispatch map from the same pairs, so the declared names and the
     dispatched names can never diverge.
 
-    While a skill runs, the robot's only *act* is stopping it, so the caller
-    passes only its non-occupying query skills (memory recall) and the
-    declarations collapse to stop + those. The shape depends on whether the
-    user just spoke: offered any no-op tool, the model calls it and goes
-    silent, so a turn carrying a user message drops wait — plain text becomes
+    While a skill runs, the robot's only action is stopping it, so the
+    declarations collapse. The shape depends on whether the user just spoke:
+    offered any no-op tool, the model calls it and goes silent, so a turn
+    carrying a user message gets stop_current_skill ALONE — plain text becomes
     the reply channel, and the description steers stop away from questions.
     """
     if running_skill_name is not None:
@@ -112,10 +111,7 @@ def build_tools(
                 else "Use when it is clearly failing, no longer makes sense, or the user asks for something else."
             ),
         }
-        declarations = [stop, *(_declaration(name, meta) for name, meta in named_skills)]
-        if not user_spoke:
-            declarations.append(_WAIT_DECLARATION)
-        return [{"functionDeclarations": declarations}]
+        return [{"functionDeclarations": [stop] if user_spoke else [stop, _WAIT_DECLARATION]}]
     declarations = [_declaration(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -11,7 +11,6 @@ from brain_client.skills.registry import SkillMeta
 STOP_SKILL = "stop_current_skill"
 WAIT = "wait"
 GO_TO_POINT_IN_VIEW = "go_to_point_in_view"
-SEARCH_MEMORY = "search_memory"
 
 # An explicit no-op keeps idle turns clean: without it, models tend to emit
 # placeholder text ("[]", "Empty response") rather than returning nothing.
@@ -42,24 +41,6 @@ _GO_TO_POINT_IN_VIEW_DECLARATION = {
     },
 }
 
-# Recall over the robot's persistent spatial memory (brain/memory_search.py).
-# Declared only while the memory holds at least one frame for the current map.
-_SEARCH_MEMORY_DECLARATION = {
-    "name": SEARCH_MEMORY,
-    "description": (
-        "Search the robot's long-term memory of places it has seen on this map. Describe the place "
-        "or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my "
-        "airpods'); a vision model reviews every remembered view and an event brings back the best "
-        "match — its image, map coordinates, and when it was seen. Use it to find anything not in "
-        "the current camera view, then drive there with navigate_to_position (local_frame=false)."
-    ),
-    "parameters": {
-        "type": "OBJECT",
-        "properties": {"query": {"type": "STRING", "description": "what to look for, with any helpful context"}},
-        "required": ["query"],
-    },
-}
-
 # Skill input "type" strings (python annotation names from skill introspection)
 # -> Gemini schema types. Anything else is passed as a string with the expected
 # type noted in the description.
@@ -85,7 +66,7 @@ def assign_tool_names(skills: list[SkillMeta]) -> list[tuple[str, SkillMeta]]:
     shadow a built-in tool); colliding names get a numeric suffix so a call
     never silently dispatches to the wrong skill.
     """
-    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW, SEARCH_MEMORY}
+    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW}
     named: list[tuple[str, SkillMeta]] = []
     for meta in skills:
         base = name = tool_name(meta["name"])
@@ -104,7 +85,6 @@ def build_tools(
     running_skill_name: str | None,
     *,
     can_go_to_point_in_view: bool = False,
-    can_search_memory: bool = False,
     user_spoke: bool = False,
 ) -> list[dict]:
     """One function declaration per available skill, in a native tools block.
@@ -135,8 +115,6 @@ def build_tools(
     declarations = [_declaration(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)
-    if can_search_memory:
-        declarations.append(_SEARCH_MEMORY_DECLARATION)
     declarations.append(_WAIT_DECLARATION)
     return [{"functionDeclarations": declarations}]
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
@@ -2,10 +2,11 @@
 # Copyright (c) 2026 Innate Inc
 """How the brain reaches Gemini: the Innate proxy (managed) or GEMINI_API_KEY (dev).
 
-The proxy holds the upstream key and passes native ``:streamGenerateContent``
-calls through untouched (the robot authenticates with its service key); the
-direct path talks to ``generativelanguage.googleapis.com``. Both speak the same
-wire format — a transport only moves chunks and never interprets them.
+The proxy holds the upstream key and passes native Gemini calls — the turn
+stream and the memory search's blocking generate / context-cache management —
+through untouched (the robot authenticates with its service key); the direct
+path talks to ``generativelanguage.googleapis.com``. Both speak the same wire
+format — a transport only moves payloads and never interprets them.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import httpx
@@ -25,9 +27,27 @@ if TYPE_CHECKING:
 PROXY_SERVICE = "gemini"
 DIRECT_BASE_URL = "https://generativelanguage.googleapis.com"
 STREAM_PATH = "/v1beta/models/{model}:streamGenerateContent?alt=sse"
+GENERATE_PATH = "/v1beta/models/{model}:generateContent"
+CACHED_CONTENTS_PATH = "/v1beta/cachedContents"
 
 Transport = Callable[[str, dict], Iterator[dict]]
 """(model, request body) -> streamed response chunks."""
+
+
+class GeminiHttpError(RuntimeError):
+    """A non-200 from the Gemini API, keeping the status for policy decisions."""
+
+    def __init__(self, status: int, detail: str):
+        super().__init__(f"HTTP {status}: {detail}")
+        self.status = status
+
+
+@dataclass(frozen=True)
+class GeminiRest:
+    """Blocking JSON calls against the same backend the stream uses."""
+
+    post: Callable[[str, dict], dict]  # (api path, body) -> parsed response; raises GeminiHttpError on non-200
+    delete: Callable[[str], dict]  # api path -> parsed response (usually empty)
 
 
 class Backend(StrEnum):
@@ -77,6 +97,50 @@ def direct_transport(api_key: str) -> Transport:
             yield from _sse_chunks(resp.iter_lines())
 
     return stream
+
+
+def pick_rest(proxy: ProxyClient | None) -> GeminiRest | None:
+    """Blocking-call access to Gemini, chosen the same way as :func:`pick_transport`."""
+    if proxy is not None and proxy.is_available():
+        return proxy_rest(proxy)
+    api_key = os.environ.get("GEMINI_API_KEY", "").strip()
+    if api_key:
+        return direct_rest(api_key)
+    return None
+
+
+def proxy_rest(proxy: ProxyClient) -> GeminiRest:
+    """Non-streaming Gemini calls through the proxy (same service passthrough as the stream)."""
+
+    def request(method: str, path: str, body: dict | None = None) -> dict:
+        with proxy.request_stream(PROXY_SERVICE, path, method=method, json=body) as resp:
+            data = resp.read()
+            if resp.status_code != 200:
+                raise GeminiHttpError(resp.status_code, data[:200].decode(errors="replace"))
+            return json.loads(data) if data else {}
+
+    return GeminiRest(
+        post=lambda path, body: request("POST", path, body),
+        delete=lambda path: request("DELETE", path),
+    )
+
+
+def direct_rest(api_key: str) -> GeminiRest:
+    """Non-streaming Gemini calls directly against Google with GEMINI_API_KEY."""
+    # Own client: a context-cache upload carries a few MB of frames and needs a
+    # longer timeout than the per-chunk streaming client.
+    client = httpx.Client(headers={"x-goog-api-key": api_key}, timeout=120.0)
+
+    def request(method: str, path: str, body: dict | None = None) -> dict:
+        resp = client.request(method, DIRECT_BASE_URL + path, json=body)
+        if resp.status_code != 200:
+            raise GeminiHttpError(resp.status_code, resp.text[:200])
+        return resp.json() if resp.content else {}
+
+    return GeminiRest(
+        post=lambda path, body: request("POST", path, body),
+        delete=lambda path: request("DELETE", path),
+    )
 
 
 def _sse_chunks(lines: Iterable[str]) -> Iterator[dict]:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
@@ -29,6 +29,11 @@ DIRECT_BASE_URL = "https://generativelanguage.googleapis.com"
 STREAM_PATH = "/v1beta/models/{model}:streamGenerateContent?alt=sse"
 GENERATE_PATH = "/v1beta/models/{model}:generateContent"
 CACHED_CONTENTS_PATH = "/v1beta/cachedContents"
+FILES_UPLOAD_PATH = "/upload/v1beta/files"
+
+# The backend has no passthrough for this endpoint at all — callers latch the
+# feature off permanently rather than retry (shared by the cache and files tiers).
+UNSUPPORTED_ENDPOINT_STATUSES = (404, 405, 501)
 
 Transport = Callable[[str, dict], Iterator[dict]]
 """(model, request body) -> streamed response chunks."""
@@ -44,10 +49,11 @@ class GeminiHttpError(RuntimeError):
 
 @dataclass(frozen=True)
 class GeminiRest:
-    """Blocking JSON calls against the same backend the stream uses."""
+    """Blocking JSON + media calls against the same backend the stream uses."""
 
     post: Callable[[str, dict], dict]  # (api path, body) -> parsed response; raises GeminiHttpError on non-200
     delete: Callable[[str], dict]  # api path -> parsed response (usually empty)
+    upload: Callable[[str, bytes, str], dict]  # (api path, raw bytes, mime type) -> parsed response
 
 
 class Backend(StrEnum):
@@ -112,16 +118,20 @@ def pick_rest(proxy: ProxyClient | None) -> GeminiRest | None:
 def proxy_rest(proxy: ProxyClient) -> GeminiRest:
     """Non-streaming Gemini calls through the proxy (same service passthrough as the stream)."""
 
-    def request(method: str, path: str, body: dict | None = None) -> dict:
-        with proxy.request_stream(PROXY_SERVICE, path, method=method, json=body) as resp:
-            data = resp.read()
+    def request(method: str, path: str, body: dict | None = None, data: bytes | None = None) -> dict:
+        with proxy.request_stream(PROXY_SERVICE, path, method=method, json=body, data=data) as resp:
+            payload = resp.read()
             if resp.status_code != 200:
-                raise GeminiHttpError(resp.status_code, data[:200].decode(errors="replace"))
-            return json.loads(data) if data else {}
+                raise GeminiHttpError(resp.status_code, payload[:200].decode(errors="replace"))
+            return json.loads(payload) if payload else {}
 
+    # The proxy client cannot attach the raw-upload protocol headers; a
+    # passthrough that requires them answers non-200 and the caller latches
+    # the files tier off (frames ride inline — today's behavior).
     return GeminiRest(
         post=lambda path, body: request("POST", path, body),
         delete=lambda path: request("DELETE", path),
+        upload=lambda path, data, mime: request("POST", path, data=data),
     )
 
 
@@ -137,9 +147,20 @@ def direct_rest(api_key: str) -> GeminiRest:
             raise GeminiHttpError(resp.status_code, resp.text[:200])
         return resp.json() if resp.content else {}
 
+    def upload(path: str, data: bytes, mime: str) -> dict:
+        resp = client.post(
+            DIRECT_BASE_URL + path,
+            content=data,
+            headers={"X-Goog-Upload-Protocol": "raw", "Content-Type": mime},
+        )
+        if resp.status_code != 200:
+            raise GeminiHttpError(resp.status_code, resp.text[:200])
+        return resp.json() if resp.content else {}
+
     return GeminiRest(
         post=lambda path, body: request("POST", path, body),
         delete=lambda path: request("DELETE", path),
+        upload=upload,
     )
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
@@ -18,7 +18,6 @@ class EventKind(StrEnum):
     INFO = "info"
     USER = "user"
     MOTION = "motion"
-    MEMORY = "memory"
 
 
 @dataclass(frozen=True)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
@@ -18,6 +18,7 @@ class EventKind(StrEnum):
     INFO = "info"
     USER = "user"
     MOTION = "motion"
+    MEMORY = "memory"
 
 
 @dataclass(frozen=True)

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -24,6 +24,8 @@ class BrainConfig:
     arm_camera_image_topic: str
     odom_topic: str
     current_nav_mode_topic: str
+    current_map_topic: str
+    amcl_pose_topic: str
     scan_topic: str
 
     # --- Feature flags ---
@@ -82,6 +84,8 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "arm_camera_image_topic": "/mars/arm/image_raw/compressed",
     "odom_topic": "/odom",
     "current_nav_mode_topic": "/nav/current_mode",
+    "current_map_topic": "/nav/current_map",
+    "amcl_pose_topic": "/amcl_pose",
     "scan_topic": "/scan",
     # --- Feature flags ---
     "send_arm_camera_image": True,

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/__init__.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/coverage.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/coverage.py
@@ -33,6 +33,12 @@ OCCUPIED_THRESHOLD = 50  # nav grid: -1 unknown, 0 free, 100 occupied
 _CAMERA_FOV_RAD = math.radians(128.0)
 _PAINT_RANGE_M = 4.0  # beyond this the picture stops carrying useful floor detail
 _RAY_COUNT = 96
+# Paint this old no longer vouches for the scene: a stale area reads as
+# unpainted, so a revisit records anew — from whatever angle the robot happens
+# to look — while the old straight-on shot keeps its slot until eviction.
+# Must stay above selection's _REFRESH_AGE_SEC: an aligned dwell then renews
+# its stamp in place before its own paint expires, instead of minting twins.
+PAINT_FRESH_SEC = 20.0
 
 
 @dataclass(frozen=True)
@@ -51,8 +57,10 @@ class Coverage:
         self._grid: Map | None = None
         self._masks: dict[tuple[int, float], np.ndarray] = {}
 
-    def assess(self, memories: Sequence[Memory], grid: Map, x: float, y: float, theta: float) -> CoverageView | None:
-        """This pose's wedge against the union of kept paint; None when the
+    def assess(
+        self, memories: Sequence[Memory], grid: Map, x: float, y: float, theta: float, now: float
+    ) -> CoverageView | None:
+        """This pose's wedge against the union of FRESH paint; None when the
         grid is unreadable. A pose that sees nothing reads as fully painted —
         a blind spot earns no slot."""
         wedge = wedge_mask(grid, x, y, theta)
@@ -61,7 +69,9 @@ class Coverage:
         visible = int(wedge.sum())
         if visible == 0:
             return CoverageView(painted_fraction=1.0, visible_m2=0.0)
-        painted = self._union(memories, grid)
+        self._prune({(m.id, m.stamp) for m in memories})
+        fresh = [m for m in memories if now - m.stamp <= PAINT_FRESH_SEC]
+        painted = self._union(fresh, grid)
         if painted is None:
             return None
         fraction = float((wedge & painted).sum()) / visible
@@ -90,10 +100,11 @@ class Coverage:
                 cheapest, cheapest_cost = memory, cost
         return cheapest
 
-    def _union(self, memories: Sequence[Memory], grid: Map) -> np.ndarray | None:
-        live = {(m.id, m.stamp) for m in memories}
+    def _prune(self, live: set[tuple[int, float]]) -> None:
         for stale in [key for key in self._masks if key not in live]:
             del self._masks[stale]
+
+    def _union(self, memories: Sequence[Memory], grid: Map) -> np.ndarray | None:
         union = np.zeros((grid.height, grid.width), dtype=bool)
         for memory in memories:
             mask = self._mask(memory, grid)

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/coverage.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/coverage.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Visibility paint over the occupancy grid. Pure: no ROS, no I/O.
+
+Every kept memory "paints" the floor its camera saw — a field-of-view wedge
+raycast from its pose until walls (or unknown, or range) stop each ray. The
+union of that paint is what the robot's memory can vouch for, and coverage —
+not pose arithmetic — is the ground truth for novelty: a picture is worth
+taking when the wedge in front of the camera is mostly unpainted, and the
+memories worth keeping are the ones whose paint nothing else replaces.
+
+Masks are cached per memory keyed by (id, stamp), pruned to the live set, and
+rebuilt when the grid object changes; the steady-state cost per assessment is
+one wedge raster and one masked count.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import cv2
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from brain_client.memory.store import Memory
+    from brain_client.state.map import Map
+
+OCCUPIED_THRESHOLD = 50  # nav grid: -1 unknown, 0 free, 100 occupied
+_CAMERA_FOV_RAD = math.radians(128.0)
+_PAINT_RANGE_M = 4.0  # beyond this the picture stops carrying useful floor detail
+_RAY_COUNT = 96
+
+
+@dataclass(frozen=True)
+class CoverageView:
+    """What one pose's camera wedge amounts to against the kept paint."""
+
+    painted_fraction: float  # how much of the wedge the memories already show
+    visible_m2: float  # how much floor the wedge paints at all
+
+
+class Coverage:
+    """Paint bookkeeping over the live memory set. Owned by the recorder;
+    everything here is derived — forgetting a memory un-paints it."""
+
+    def __init__(self) -> None:
+        self._grid: Map | None = None
+        self._masks: dict[tuple[int, float], np.ndarray] = {}
+
+    def assess(self, memories: Sequence[Memory], grid: Map, x: float, y: float, theta: float) -> CoverageView | None:
+        """This pose's wedge against the union of kept paint; None when the
+        grid is unreadable. A pose that sees nothing reads as fully painted —
+        a blind spot earns no slot."""
+        wedge = wedge_mask(grid, x, y, theta)
+        if wedge is None:
+            return None
+        visible = int(wedge.sum())
+        if visible == 0:
+            return CoverageView(painted_fraction=1.0, visible_m2=0.0)
+        painted = self._union(memories, grid)
+        if painted is None:
+            return None
+        fraction = float((wedge & painted).sum()) / visible
+        return CoverageView(painted_fraction=fraction, visible_m2=visible * grid.resolution**2)
+
+    def least_unique(self, memories: Sequence[Memory], grid: Map) -> Memory | None:
+        """The memory whose paint is most replaceable — evicting it loses the
+        least coverage; None when any mask is unavailable. Ties break toward
+        the smaller view, so the further-back shot that shows the same floor
+        outlives the close-ups it subsumes."""
+        masks: list[tuple[Memory, np.ndarray]] = []
+        for memory in memories:
+            mask = self._mask(memory, grid)
+            if mask is None:
+                return None
+            masks.append((memory, mask))
+        cheapest: Memory | None = None
+        cheapest_cost = (0, 0)
+        for memory, mask in masks:
+            others = np.zeros_like(mask)
+            for other, other_mask in masks:
+                if other.id != memory.id:
+                    others |= other_mask
+            cost = (int((mask & ~others).sum()), int(mask.sum()))
+            if cheapest is None or cost < cheapest_cost:
+                cheapest, cheapest_cost = memory, cost
+        return cheapest
+
+    def _union(self, memories: Sequence[Memory], grid: Map) -> np.ndarray | None:
+        live = {(m.id, m.stamp) for m in memories}
+        for stale in [key for key in self._masks if key not in live]:
+            del self._masks[stale]
+        union = np.zeros((grid.height, grid.width), dtype=bool)
+        for memory in memories:
+            mask = self._mask(memory, grid)
+            if mask is None:
+                return None
+            union |= mask
+        return union
+
+    def _mask(self, memory: Memory, grid: Map) -> np.ndarray | None:
+        if grid is not self._grid:  # a new map message repaints the world
+            self._grid = grid
+            self._masks.clear()
+        key = (memory.id, memory.stamp)
+        mask = self._masks.get(key)
+        if mask is None:
+            mask = wedge_mask(grid, memory.x, memory.y, memory.theta)
+            if mask is not None:
+                self._masks[key] = mask
+        return mask
+
+
+def wedge_mask(grid: Map, x: float, y: float, theta: float) -> np.ndarray | None:
+    """The known-free cells this pose's camera sees, as a boolean grid mask —
+    rays fan across the FOV and stop at occupied, unknown, out-of-map, or
+    range; the swept wedge is filled between the origin and the ray ends."""
+    cells = grid.grid
+    if cells is None:
+        return None
+    points = [_to_cell(grid, x, y)]
+    for i in range(_RAY_COUNT):
+        angle = theta - _CAMERA_FOV_RAD / 2 + _CAMERA_FOV_RAD * i / (_RAY_COUNT - 1)
+        points.append(_ray_end(grid, cells, x, y, angle))
+    mask = np.zeros((grid.height, grid.width), dtype=np.uint8)
+    cv2.fillPoly(mask, [np.array(points, dtype=np.int32)], (1.0,))
+    free = (cells >= 0) & (cells < OCCUPIED_THRESHOLD)
+    return mask.astype(bool) & free
+
+
+def _ray_end(grid: Map, cells: np.ndarray, x: float, y: float, angle: float) -> tuple[int, int]:
+    """The last known-free cell along the ray before something stops it."""
+    step = grid.resolution
+    cos_a, sin_a = math.cos(angle), math.sin(angle)
+    end = _to_cell(grid, x, y)
+    for i in range(1, int(_PAINT_RANGE_M / step) + 1):
+        col, row = _to_cell(grid, x + cos_a * step * i, y + sin_a * step * i)
+        if not (0 <= row < grid.height and 0 <= col < grid.width):
+            break
+        value = int(cells[row, col])
+        if value < 0 or value >= OCCUPIED_THRESHOLD:
+            break
+        end = (col, row)
+    return end
+
+
+def _to_cell(grid: Map, x: float, y: float) -> tuple[int, int]:
+    return int((x - grid.origin_x) / grid.resolution), int((y - grid.origin_y) / grid.resolution)

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/quality.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/quality.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Whether a camera frame is worth remembering. Pure: no ROS, no I/O.
+
+A refresh overwrites a viewpoint's only image, so one bad frame — mid-turn
+motion blur, a lights-off room, a lens against a blank surface — must not
+clobber a good view. These checks judge the frame, not the scene: too dark to
+show anything, or too little detail to be anything.
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+_ANALYSIS_WIDTH = 320  # thresholds are calibrated at this scale; camera resolution must not move them
+_MIN_MEAN_BRIGHTNESS = 15.0  # of 255
+_MIN_SHARPNESS = 25.0  # variance of the Laplacian; below is heavy blur or a featureless close-up
+
+
+def frame_worth_keeping(jpeg: bytes) -> bool:
+    gray = cv2.imdecode(np.frombuffer(jpeg, np.uint8), cv2.IMREAD_GRAYSCALE)
+    if gray is None:
+        return False
+    if gray.shape[1] != _ANALYSIS_WIDTH:
+        height = max(1, round(gray.shape[0] * _ANALYSIS_WIDTH / gray.shape[1]))
+        gray = cv2.resize(gray, (_ANALYSIS_WIDTH, height), interpolation=cv2.INTER_AREA)
+    if float(gray.mean()) < _MIN_MEAN_BRIGHTNESS:
+        return False
+    return float(cv2.Laplacian(gray, cv2.CV_64F).var()) >= _MIN_SHARPNESS

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/quality.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/quality.py
@@ -15,16 +15,24 @@ import numpy as np
 
 _ANALYSIS_WIDTH = 320  # thresholds are calibrated at this scale; camera resolution must not move them
 _MIN_MEAN_BRIGHTNESS = 15.0  # of 255
-_MIN_SHARPNESS = 25.0  # variance of the Laplacian; below is heavy blur or a featureless close-up
+MIN_SHARPNESS = 25.0  # variance of the Laplacian; below is heavy blur or a featureless close-up
 
 
-def frame_worth_keeping(jpeg: bytes) -> bool:
+def frame_sharpness(jpeg: bytes) -> float | None:
+    """Sharpness score for ranking frames against each other, or None when the
+    frame is unusable regardless (undecodable, or too dark to show anything).
+    A keepable frame scores at least MIN_SHARPNESS."""
     gray = cv2.imdecode(np.frombuffer(jpeg, np.uint8), cv2.IMREAD_GRAYSCALE)
     if gray is None:
-        return False
+        return None
     if gray.shape[1] != _ANALYSIS_WIDTH:
         height = max(1, round(gray.shape[0] * _ANALYSIS_WIDTH / gray.shape[1]))
         gray = cv2.resize(gray, (_ANALYSIS_WIDTH, height), interpolation=cv2.INTER_AREA)
     if float(gray.mean()) < _MIN_MEAN_BRIGHTNESS:
-        return False
-    return float(cv2.Laplacian(gray, cv2.CV_64F).var()) >= _MIN_SHARPNESS
+        return None
+    return float(cv2.Laplacian(gray, cv2.CV_64F).var())
+
+
+def frame_worth_keeping(jpeg: bytes) -> bool:
+    sharpness = frame_sharpness(jpeg)
+    return sharpness is not None and sharpness >= MIN_SHARPNESS

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Builds the spatial memory while the robot drives around a mapped area.
+
+Always on, independent of brain activation: a webapp teleop tour must build
+memories too, so the recorder owns its own lightweight subscriptions instead
+of borrowing the brain's activation-gated sensors. One rule governs capture —
+record only what a well-localized robot saw: AMCL's covariance must hold below
+the webapp's "confident" thresholds for a few seconds straight, then the
+admission policy (memory/selection.py) decides novelty, refresh, and eviction.
+
+Also republishes the memory positions at 1 Hz on ``/brain/memory_positions``
+(the topic the mobile app's map overlay watches) and nudges the search's
+context cache to re-warm once recording quiets down.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from std_msgs.msg import String
+
+from brain_client.memory.selection import plan_admission
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from rclpy.node import Node
+    from rclpy.publisher import Publisher
+
+    from brain_client.core.config import BrainConfig
+    from brain_client.memory.store import MemoryStore
+    from brain_client.perception.pose_tracking import PoseTracker
+
+_TICK_SEC = 1.0
+_POSITION_VAR_MAX = 0.10  # m² — the webapp's "confident" localization threshold
+_YAW_VAR_MAX = 0.18  # rad² — from the cloud-era pose graph gate
+_CONFIDENT_FOR_SEC = 3.0  # covariance must hold below the thresholds this long before recording
+_FRESH_FRAME_SEC = 2.5  # the compressed feed runs ~7.5 Hz; older means it died
+_MIN_HEAD_PITCH_DEG = -25.0  # looking further down films the floor, not the room
+
+
+class MemoryRecorder:
+    def __init__(
+        self,
+        node: Node,
+        config: BrainConfig,
+        *,
+        store: MemoryStore,
+        pose_tracker: PoseTracker,
+        warm_search: Callable[[], None] | None,
+        positions_pub: Publisher,
+    ):
+        self._logger = node.get_logger()
+        self._store = store
+        self._pose = pose_tracker
+        self._warm_search = warm_search
+        self._positions_pub = positions_pub
+
+        self._frame: tuple[float, bytes] | None = None  # (monotonic arrival, jpeg)
+        self._nav_mode: str | None = None
+        self._map_name = ""
+        self._covariance: tuple[float, float, float] | None = None  # (var x, var y, var yaw)
+        self._head_pitch = 0.0
+        self._confident_since: float | None = None
+
+        image_qos = QoSProfile(
+            reliability=QoSReliabilityPolicy.BEST_EFFORT, history=QoSHistoryPolicy.KEEP_LAST, depth=1
+        )
+        # The forked AMCL latches its pose; matching TRANSIENT_LOCAL hands a
+        # late-joining recorder the last covariance instead of silence.
+        amcl_qos = QoSProfile(
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            depth=1,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        node.create_subscription(CompressedImage, config.image_topic, self._on_image, image_qos)
+        node.create_subscription(String, config.current_nav_mode_topic, self._on_nav_mode, 10)
+        node.create_subscription(String, config.current_map_topic, self._on_current_map, 10)
+        node.create_subscription(PoseWithCovarianceStamped, config.amcl_pose_topic, self._on_amcl_pose, amcl_qos)
+        node.create_subscription(String, "/mars/head/current_position", self._on_head, 10)
+        node.create_timer(_TICK_SEC, self.tick)
+
+    # --- callbacks ---
+    def _on_image(self, msg: CompressedImage) -> None:
+        if msg.data:
+            self._frame = (time.monotonic(), bytes(msg.data))
+
+    def _on_nav_mode(self, msg: String) -> None:
+        self._nav_mode = msg.data
+
+    def _on_current_map(self, msg: String) -> None:
+        self._map_name = msg.data
+
+    def _on_amcl_pose(self, msg: PoseWithCovarianceStamped) -> None:
+        covariance = msg.pose.covariance
+        self._covariance = (covariance[0], covariance[7], covariance[35])
+
+    def _on_head(self, msg: String) -> None:
+        try:
+            self._head_pitch = float(json.loads(msg.data)["current_position"])
+        except (json.JSONDecodeError, TypeError, ValueError, KeyError):
+            pass  # keep the last known pitch; one corrupt message must not flip the gate
+
+    # --- the 1 Hz tick ---
+    def tick(self) -> None:
+        self._store.switch_map(self._map_name or None)
+        self._maybe_record()
+        self._publish_positions()
+        if self._warm_search is not None:
+            self._warm_search()
+
+    def _maybe_record(self) -> None:
+        if not self._localized_long_enough():
+            return
+        jpeg = self._fresh_jpeg()
+        pose = self._pose.map_pose_xyt()
+        if jpeg is None or pose is None or self._head_pitch < _MIN_HEAD_PITCH_DEG:
+            return
+        self._record(*pose, jpeg)
+
+    def _localized_long_enough(self) -> bool:
+        if self._nav_mode != "navigation" or not self._map_name or not self._confident():
+            self._confident_since = None
+            return False
+        now = time.monotonic()
+        if self._confident_since is None:
+            self._confident_since = now
+        return now - self._confident_since >= _CONFIDENT_FOR_SEC
+
+    def _confident(self) -> bool:
+        if self._covariance is None:
+            return False
+        var_x, var_y, var_yaw = self._covariance
+        return max(var_x, var_y) <= _POSITION_VAR_MAX and var_yaw <= _YAW_VAR_MAX
+
+    def _fresh_jpeg(self) -> bytes | None:
+        frame = self._frame
+        if frame is None or time.monotonic() - frame[0] > _FRESH_FRAME_SEC:
+            return None
+        return frame[1]
+
+    def _record(self, x: float, y: float, theta: float, jpeg: bytes) -> None:
+        plan = plan_admission(self._store.snapshot().memories, x, y, theta, time.time())
+        if not plan.record:
+            return
+        if plan.replace is not None:
+            self._store.replace(plan.replace, x, y, theta, time.time(), jpeg)
+            self._logger.info(f"[Memory] refreshed viewpoint {plan.replace.id} at ({x:.2f}, {y:.2f})")
+            return
+        if plan.evict is not None:
+            self._store.evict(plan.evict)
+        memory = self._store.add(x, y, theta, time.time(), jpeg)
+        if memory is not None:
+            evicted = f", evicted {plan.evict.id}" if plan.evict is not None else ""
+            self._logger.info(f"[Memory] recorded viewpoint {memory.id} at ({x:.2f}, {y:.2f}){evicted}")
+
+    def _publish_positions(self) -> None:
+        payload = {"map": self._map_name, "positions": self._store.positions()}
+        self._positions_pub.publish(String(data=json.dumps(payload)))

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -7,7 +7,12 @@ memories too, so the recorder owns its own lightweight subscriptions instead
 of borrowing the brain's activation-gated sensors. One rule governs capture —
 record only what a well-localized robot saw: AMCL's covariance must hold below
 the webapp's "confident" thresholds for a few seconds straight, then the
-admission policy (memory/selection.py) decides novelty, refresh, and eviction.
+admission policy (memory/selection.py) decides novelty, refresh, and eviction —
+a kept viewpoint's picture refreshes only from a frame aimed the same way with
+a clear sight line between the capture points, so an oblique, mid-turn, or
+behind-a-wall frame never overwrites a straight-on view. Every stored
+frame must first pass the quality gates (memory/quality.py); a bad frame never
+clobbers a good view.
 
 Also republishes the memory positions at 1 Hz on ``/brain/memory_positions``
 (the topic the mobile app's map overlay watches) and nudges the search's
@@ -21,11 +26,15 @@ import time
 from typing import TYPE_CHECKING
 
 from geometry_msgs.msg import PoseWithCovarianceStamped
+from nav_msgs.msg import OccupancyGrid
 from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
 from sensor_msgs.msg import CompressedImage
 from std_msgs.msg import String
 
+from brain_client.common.geometry import quaternion_to_yaw
+from brain_client.memory.quality import frame_worth_keeping
 from brain_client.memory.selection import plan_admission
+from brain_client.state.map import Map
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -70,13 +79,15 @@ class MemoryRecorder:
         self._covariance: tuple[float, float, float] | None = None  # (var x, var y, var yaw)
         self._head_pitch = 0.0
         self._confident_since: float | None = None
+        self._grid: Map | None = None  # sight-line truth for same-view refreshes
 
         image_qos = QoSProfile(
             reliability=QoSReliabilityPolicy.BEST_EFFORT, history=QoSHistoryPolicy.KEEP_LAST, depth=1
         )
-        # The forked AMCL latches its pose; matching TRANSIENT_LOCAL hands a
-        # late-joining recorder the last covariance instead of silence.
-        amcl_qos = QoSProfile(
+        # The forked AMCL latches its pose (and map_server its grid); matching
+        # TRANSIENT_LOCAL hands a late-joining recorder the last message
+        # instead of silence.
+        latched_qos = QoSProfile(
             reliability=QoSReliabilityPolicy.RELIABLE,
             history=QoSHistoryPolicy.KEEP_LAST,
             depth=1,
@@ -85,7 +96,8 @@ class MemoryRecorder:
         node.create_subscription(CompressedImage, config.image_topic, self._on_image, image_qos)
         node.create_subscription(String, config.current_nav_mode_topic, self._on_nav_mode, 10)
         node.create_subscription(String, config.current_map_topic, self._on_current_map, 10)
-        node.create_subscription(PoseWithCovarianceStamped, config.amcl_pose_topic, self._on_amcl_pose, amcl_qos)
+        node.create_subscription(PoseWithCovarianceStamped, config.amcl_pose_topic, self._on_amcl_pose, latched_qos)
+        node.create_subscription(OccupancyGrid, "/map", self._on_map, latched_qos)
         node.create_subscription(String, "/mars/head/current_position", self._on_head, 10)
         node.create_timer(_TICK_SEC, self.tick)
 
@@ -103,6 +115,17 @@ class MemoryRecorder:
     def _on_amcl_pose(self, msg: PoseWithCovarianceStamped) -> None:
         covariance = msg.pose.covariance
         self._covariance = (covariance[0], covariance[7], covariance[35])
+
+    def _on_map(self, msg: OccupancyGrid) -> None:
+        self._grid = Map(
+            resolution=msg.info.resolution,
+            width=msg.info.width,
+            height=msg.info.height,
+            origin_x=msg.info.origin.position.x,
+            origin_y=msg.info.origin.position.y,
+            origin_theta=quaternion_to_yaw(msg.info.origin.orientation),
+            raw_source=msg,
+        )
 
     def _on_head(self, msg: String) -> None:
         try:
@@ -152,8 +175,8 @@ class MemoryRecorder:
         return frame[1]
 
     def _record(self, x: float, y: float, theta: float, jpeg: bytes) -> None:
-        plan = plan_admission(self._store.snapshot().memories, x, y, theta, time.time())
-        if not plan.record:
+        plan = plan_admission(self._store.snapshot().memories, x, y, theta, time.time(), self._grid)
+        if not plan.record or not frame_worth_keeping(jpeg):
             return
         if plan.replace is not None:
             self._store.replace(plan.replace, x, y, theta, time.time(), jpeg)

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -7,12 +7,19 @@ memories too, so the recorder owns its own lightweight subscriptions instead
 of borrowing the brain's activation-gated sensors. One rule governs capture —
 record only what a well-localized robot saw: AMCL's covariance must hold below
 the webapp's "confident" thresholds for a few seconds straight, then the
-admission policy (memory/selection.py) decides novelty, refresh, and eviction —
-a kept viewpoint's picture refreshes only from a frame aimed the same way with
+admission policy (memory/selection.py) decides novelty, refresh, and eviction.
+Novelty is visibility paint: each memory paints the floor its camera saw, and
+a new picture is taken while the wedge ahead is mostly unpainted. A kept
+viewpoint's picture refreshes only from a frame aimed the same way with
 a clear sight line between the capture points, so an oblique, mid-turn, or
 behind-a-wall frame never overwrites a straight-on view. Every stored
 frame must first pass the quality gates (memory/quality.py); a bad frame never
 clobbers a good view.
+
+Each tick records the SHARPEST keepable frame seen since the last one, paired
+with the pose at that frame's capture moment — not whatever the feed holds at
+tick time. During a quick turn the blurred sweep loses to the crisp instant at
+a pause, and that instant keeps its own heading even though the tick is 1 Hz.
 
 Also republishes the memory positions at 1 Hz on ``/brain/memory_positions``
 (the topic the mobile app's map overlay watches) and nudges the search's
@@ -23,6 +30,7 @@ from __future__ import annotations
 
 import json
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from geometry_msgs.msg import PoseWithCovarianceStamped
@@ -32,7 +40,8 @@ from sensor_msgs.msg import CompressedImage
 from std_msgs.msg import String
 
 from brain_client.common.geometry import quaternion_to_yaw
-from brain_client.memory.quality import frame_worth_keeping
+from brain_client.memory.coverage import Coverage
+from brain_client.memory.quality import MIN_SHARPNESS, frame_sharpness
 from brain_client.memory.selection import plan_admission
 from brain_client.state.map import Map
 
@@ -54,6 +63,19 @@ _FRESH_FRAME_SEC = 2.5  # the compressed feed runs ~7.5 Hz; older means it died
 _MIN_HEAD_PITCH_DEG = -25.0  # looking further down films the floor, not the room
 
 
+@dataclass(frozen=True)
+class _Candidate:
+    """The sharpest keepable frame of the current tick window, with the pose
+    it was captured from."""
+
+    arrived: float  # monotonic
+    x: float
+    y: float
+    theta: float
+    sharpness: float
+    jpeg: bytes
+
+
 class MemoryRecorder:
     def __init__(
         self,
@@ -73,13 +95,14 @@ class MemoryRecorder:
         self._cache_state = cache_state
         self._positions_pub = positions_pub
 
-        self._frame: tuple[float, bytes] | None = None  # (monotonic arrival, jpeg)
+        self._candidate: _Candidate | None = None
         self._nav_mode: str | None = None
         self._map_name = ""
         self._covariance: tuple[float, float, float] | None = None  # (var x, var y, var yaw)
         self._head_pitch = 0.0
         self._confident_since: float | None = None
-        self._grid: Map | None = None  # sight-line truth for same-view refreshes
+        self._grid: Map | None = None  # sight-line + paint truth for admissions and refreshes
+        self._coverage = Coverage()
 
         image_qos = QoSProfile(
             reliability=QoSReliabilityPolicy.BEST_EFFORT, history=QoSHistoryPolicy.KEEP_LAST, depth=1
@@ -103,8 +126,24 @@ class MemoryRecorder:
 
     # --- callbacks ---
     def _on_image(self, msg: CompressedImage) -> None:
-        if msg.data:
-            self._frame = (time.monotonic(), bytes(msg.data))
+        """Keep the sharpest keepable frame of the tick window. Scoring costs a
+        JPEG decode per frame (~7.5 Hz), so it runs only while a record could
+        actually happen."""
+        if not msg.data or not self._recordable_moment():
+            return
+        pose = self._pose.map_pose_xyt()
+        if pose is None:
+            return
+        jpeg = bytes(msg.data)
+        sharpness = frame_sharpness(jpeg)
+        if sharpness is None or sharpness < MIN_SHARPNESS:
+            return
+        best = self._candidate
+        if best is None or sharpness > best.sharpness:
+            self._candidate = _Candidate(time.monotonic(), *pose, sharpness, jpeg)
+
+    def _recordable_moment(self) -> bool:
+        return self._nav_mode == "navigation" and bool(self._map_name) and self._confident()
 
     def _on_nav_mode(self, msg: String) -> None:
         self._nav_mode = msg.data
@@ -145,13 +184,12 @@ class MemoryRecorder:
             self._logger.error(f"[Memory] tick failed: {error!r}")
 
     def _maybe_record(self) -> None:
-        if not self._localized_long_enough():
+        candidate, self._candidate = self._candidate, None  # each tick starts a fresh window
+        if not self._localized_long_enough() or candidate is None:
             return
-        jpeg = self._fresh_jpeg()
-        pose = self._pose.map_pose_xyt()
-        if jpeg is None or pose is None or self._head_pitch < _MIN_HEAD_PITCH_DEG:
+        if time.monotonic() - candidate.arrived > _FRESH_FRAME_SEC or self._head_pitch < _MIN_HEAD_PITCH_DEG:
             return
-        self._record(*pose, jpeg)
+        self._record(candidate.x, candidate.y, candidate.theta, candidate.jpeg)
 
     def _localized_long_enough(self) -> bool:
         if self._nav_mode != "navigation" or not self._map_name or not self._confident():
@@ -168,15 +206,9 @@ class MemoryRecorder:
         var_x, var_y, var_yaw = self._covariance
         return max(var_x, var_y) <= _POSITION_VAR_MAX and var_yaw <= _YAW_VAR_MAX
 
-    def _fresh_jpeg(self) -> bytes | None:
-        frame = self._frame
-        if frame is None or time.monotonic() - frame[0] > _FRESH_FRAME_SEC:
-            return None
-        return frame[1]
-
     def _record(self, x: float, y: float, theta: float, jpeg: bytes) -> None:
-        plan = plan_admission(self._store.snapshot().memories, x, y, theta, time.time(), self._grid)
-        if not plan.record or not frame_worth_keeping(jpeg):
+        plan = plan_admission(self._store.snapshot().memories, x, y, theta, time.time(), self._grid, self._coverage)
+        if not plan.record:
             return
         if plan.replace is not None:
             self._store.replace(plan.replace, x, y, theta, time.time(), jpeg)

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -112,11 +112,14 @@ class MemoryRecorder:
 
     # --- the 1 Hz tick ---
     def tick(self) -> None:
-        self._store.switch_map(self._map_name or None)
-        self._maybe_record()
-        self._publish_positions()
-        if self._warm_search is not None:
-            self._warm_search()
+        try:
+            self._store.switch_map(self._map_name or None)
+            self._maybe_record()
+            self._publish_positions()
+            if self._warm_search is not None:
+                self._warm_search()
+        except Exception as error:  # noqa: BLE001 — a full disk must not take the brain node down
+            self._logger.error(f"[Memory] tick failed: {error!r}")
 
     def _maybe_record(self) -> None:
         if not self._localized_long_enough():
@@ -166,6 +169,10 @@ class MemoryRecorder:
     def _publish_positions(self) -> None:
         payload = {
             "map": self._map_name,
+            # The webapp keys its per-map state on map+fingerprint: a same-name
+            # re-map wipes the store and restarts ids, and only the fingerprint
+            # betrays that to a client watching the name.
+            "fingerprint": self._store.fingerprint[:12],
             "cache": self._cache_state() if self._cache_state is not None else "off",
             "positions": self._store.positions(),
         }

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -60,6 +60,10 @@ _POSITION_VAR_MAX = 0.10  # m² — the webapp's "confident" localization thresh
 _YAW_VAR_MAX = 0.18  # rad² — from the cloud-era pose graph gate
 _CONFIDENT_FOR_SEC = 3.0  # covariance must hold below the thresholds this long before recording
 _FRESH_FRAME_SEC = 2.5  # the compressed feed runs ~7.5 Hz; older means it died
+# Our AMCL runs update_min_* = 0 (amcl.yaml): it publishes every scan while
+# alive. Older means AMCL died — TF keeps composing odom motion while the last
+# good covariance stays latched, and those poses are vouched for by nothing.
+_COVARIANCE_FRESH_SEC = 5.0
 _MIN_HEAD_PITCH_DEG = -25.0  # looking further down films the floor, not the room
 
 
@@ -99,6 +103,7 @@ class MemoryRecorder:
         self._nav_mode: str | None = None
         self._map_name = ""
         self._covariance: tuple[float, float, float] | None = None  # (var x, var y, var yaw)
+        self._covariance_at = 0.0  # monotonic arrival of the last AMCL message
         self._head_pitch = 0.0
         self._confident_since: float | None = None
         self._grid: Map | None = None  # sight-line + paint truth for admissions and refreshes
@@ -154,6 +159,7 @@ class MemoryRecorder:
     def _on_amcl_pose(self, msg: PoseWithCovarianceStamped) -> None:
         covariance = msg.pose.covariance
         self._covariance = (covariance[0], covariance[7], covariance[35])
+        self._covariance_at = time.monotonic()
 
     def _on_map(self, msg: OccupancyGrid) -> None:
         self._grid = Map(
@@ -201,7 +207,7 @@ class MemoryRecorder:
         return now - self._confident_since >= _CONFIDENT_FOR_SEC
 
     def _confident(self) -> bool:
-        if self._covariance is None:
+        if self._covariance is None or time.monotonic() - self._covariance_at > _COVARIANCE_FRESH_SEC:
             return False
         var_x, var_y, var_yaw = self._covariance
         return max(var_x, var_y) <= _POSITION_VAR_MAX and var_yaw <= _YAW_VAR_MAX
@@ -229,6 +235,9 @@ class MemoryRecorder:
             # betrays that to a client watching the name.
             "fingerprint": self._store.fingerprint[:12],
             "cache": self._cache_state() if self._cache_state is not None else "off",
+            # The robot's clock, so clients age the stamps against it — a robot
+            # without NTP can sit hours from the browser's clock.
+            "now": time.time(),
             "positions": self._store.positions(),
         }
         self._positions_pub.publish(String(data=json.dumps(payload)))

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -54,12 +54,14 @@ class MemoryRecorder:
         store: MemoryStore,
         pose_tracker: PoseTracker,
         warm_search: Callable[[], None] | None,
+        cache_state: Callable[[], str] | None,
         positions_pub: Publisher,
     ):
         self._logger = node.get_logger()
         self._store = store
         self._pose = pose_tracker
         self._warm_search = warm_search
+        self._cache_state = cache_state
         self._positions_pub = positions_pub
 
         self._frame: tuple[float, bytes] | None = None  # (monotonic arrival, jpeg)
@@ -162,5 +164,9 @@ class MemoryRecorder:
             self._logger.info(f"[Memory] recorded viewpoint {memory.id} at ({x:.2f}, {y:.2f}){evicted}")
 
     def _publish_positions(self) -> None:
-        payload = {"map": self._map_name, "positions": self._store.positions()}
+        payload = {
+            "map": self._map_name,
+            "cache": self._cache_state() if self._cache_state is not None else "off",
+            "positions": self._store.positions(),
+        }
         self._positions_pub.publish(String(data=json.dumps(payload)))

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -21,9 +21,10 @@ with the pose at that frame's capture moment — not whatever the feed holds at
 tick time. During a quick turn the blurred sweep loses to the crisp instant at
 a pause, and that instant keeps its own heading even though the tick is 1 Hz.
 
-Also republishes the memory positions at 1 Hz on ``/brain/memory_positions``
-(the topic the mobile app's map overlay watches) and nudges the search's
-context cache to re-warm once recording quiets down.
+Also mirrors the memory positions on the latched ``/brain/memory_positions``
+(the topic the webapp and mobile map overlays watch) — published only when the
+payload changes, so an idle robot costs one replayed message, not 6 KB/s —
+and nudges the search's context cache to re-warm once recording quiets down.
 """
 
 from __future__ import annotations
@@ -100,6 +101,7 @@ class MemoryRecorder:
         self._positions_pub = positions_pub
 
         self._candidate: _Candidate | None = None
+        self._last_published: dict | None = None
         self._nav_mode: str | None = None
         self._map_name = ""
         self._covariance: tuple[float, float, float] | None = None  # (var x, var y, var yaw)
@@ -235,9 +237,11 @@ class MemoryRecorder:
             # betrays that to a client watching the name.
             "fingerprint": self._store.fingerprint[:12],
             "cache": self._cache_state() if self._cache_state is not None else "off",
-            # The robot's clock, so clients age the stamps against it — a robot
-            # without NTP can sit hours from the browser's clock.
-            "now": time.time(),
             "positions": self._store.positions(),
         }
+        # Gate on the whole payload, not store.revision: `cache` flips by wall
+        # clock (a warm() completing, a handle expiring) without a store change.
+        if payload == self._last_published:
+            return
+        self._last_published = payload
         self._positions_pub.publish(String(data=json.dumps(payload)))

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/selection.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/selection.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Which viewpoints earn a slot in the spatial memory. Pure: no ROS, no I/O.
+
+A memory earns its place by showing something no kept frame shows. Two
+viewpoints are redundant only when they are both close AND similarly oriented —
+either gap alone (same spot facing away, same heading across the room) makes a
+genuinely different view. Capacity is bounded; at the cap, the older half of
+the most redundant pair makes room.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from brain_client.memory.store import Memory
+
+MAX_MEMORIES = 50
+_REDUNDANT_DISTANCE_M = 1.0
+_REDUNDANT_ANGLE_RAD = math.radians(100.0)  # most of the camera's 128 deg FOV still overlaps within this
+_REFRESH_AGE_SEC = 30 * 60.0  # a revisited viewpoint older than this gets a fresh image
+
+
+@dataclass(frozen=True)
+class Admission:
+    """What to do with a candidate viewpoint; replace/evict name existing memories."""
+
+    record: bool
+    replace: Memory | None = None  # same viewpoint, stale image: overwrite in place
+    evict: Memory | None = None  # at capacity: remove this one to make room
+
+
+_SKIP = Admission(record=False)
+
+
+def plan_admission(memories: Sequence[Memory], x: float, y: float, theta: float, stamp: float) -> Admission:
+    nearest = min(memories, key=lambda m: redundancy(m, x, y, theta), default=None)
+    if nearest is not None and redundancy(nearest, x, y, theta) < 1.0:
+        if stamp - nearest.stamp < _REFRESH_AGE_SEC:
+            return _SKIP
+        return Admission(record=True, replace=nearest)
+    if len(memories) < MAX_MEMORIES:
+        return Admission(record=True)
+    return Admission(record=True, evict=_most_redundant(memories))
+
+
+def redundancy(memory: Memory, x: float, y: float, theta: float) -> float:
+    """How interchangeable a memory is with this viewpoint; < 1 means redundant.
+
+    The max of the normalized position and heading gaps: both must be small
+    for the views to overlap, so either being large keeps the pair distinct.
+    """
+    position = math.hypot(memory.x - x, memory.y - y) / _REDUNDANT_DISTANCE_M
+    heading = _angle_diff(memory.theta, theta) / _REDUNDANT_ANGLE_RAD
+    return max(position, heading)
+
+
+def _most_redundant(memories: Sequence[Memory]) -> Memory:
+    """The older half of the closest pair — evicting it costs the least coverage."""
+    closest = min(
+        ((a, b) for i, a in enumerate(memories) for b in memories[i + 1 :]),
+        key=lambda pair: redundancy(pair[0], pair[1].x, pair[1].y, pair[1].theta),
+    )
+    return min(closest, key=lambda m: m.stamp)
+
+
+def _angle_diff(a: float, b: float) -> float:
+    diff = abs(a - b) % (2 * math.pi)
+    return min(diff, 2 * math.pi - diff)

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/selection.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/selection.py
@@ -7,15 +7,17 @@ novelty is visibility paint (memory/coverage.py) — record while the wedge in
 front of the camera is under the coverage threshold, and overlap is welcome
 (rather too many pictures than too few). The demand scales with the view: a
 roomy wedge tolerates overlap, while a cramped one (nose to a wall) must be
-nearly all new — important things hang on walls, so a close-up of an unknown
+mostly new — important things hang on walls, so a close-up of an unknown
 wall earns a slot, but sliding along a known one does not. Without a grid,
 pose redundancy stands in: two viewpoints are interchangeable only when both
 close AND similarly oriented. Capacity is bounded; at the cap, the memory
 whose paint is most replaceable makes room, and the further-back shot outlives
-the close-ups it subsumes.
+the close-ups it subsumes. Paint also ages: a wedge painted long ago no longer
+vouches for the scene, so a stale area records anew — from whatever angle the
+robot happens to look — while the old shot keeps its slot until eviction.
 
 A kept viewpoint's picture refreshes only from a frame that shows the same
-information, and at most once a minute. Heading is what decides that: two
+information, and at most every ten seconds. Heading is what decides that: two
 frames aimed the same way, displaced along that very axis, with nothing but
 free space between their capture points show the same scene — one merely a
 step closer. So refresh needs a near-identical heading, a displacement riding
@@ -45,10 +47,12 @@ _REDUNDANT_DISTANCE_M = 1.0
 _REDUNDANT_ANGLE_RAD = math.radians(100.0)  # most of the camera's 128 deg FOV still overlaps within this
 _SAME_VIEW_DISTANCE_M = 0.3  # lateral drift bound off the view axis, and the gridless fallback radius
 _SAME_VIEW_ANGLE_RAD = math.radians(20.0)
-_REFRESH_AGE_SEC = 60.0
+_REFRESH_AGE_SEC = (
+    10.0  # dwelling refreshes the picture this often; superseded uploads are deleted, so churn stays cheap
+)
 _COVERAGE_THRESHOLD = 0.8  # a roomy view records until this much of its wedge is painted — overlap is welcome
 _WIDE_VIEW_M2 = 1.0  # below this the view is a close-up
-_CLOSEUP_THRESHOLD = 0.2  # a close-up must be nearly all new — wall detail matters, wall spam does not
+_CLOSEUP_THRESHOLD = 0.28  # a close-up must be mostly new — 0.2 starved small rooms, where every view is cramped
 
 
 @dataclass(frozen=True)
@@ -80,7 +84,7 @@ def plan_admission(
         and _same_view(nearest, x, y, theta, grid)
     ):
         return Admission(record=True, replace=nearest)
-    if not _worth_a_slot(memories, x, y, theta, grid, coverage, nearest):
+    if not _worth_a_slot(memories, x, y, theta, stamp, grid, coverage, nearest):
         return _SKIP
     if len(memories) < MAX_MEMORIES:
         return Admission(record=True)
@@ -93,6 +97,7 @@ def _worth_a_slot(
     x: float,
     y: float,
     theta: float,
+    stamp: float,
     grid: Map | None,
     coverage: Coverage | None,
     nearest: Memory | None,
@@ -100,7 +105,7 @@ def _worth_a_slot(
     """Novelty: with a grid, whether enough of the wedge ahead is unpainted —
     the smaller the view, the newer it must be; without one, pose redundancy."""
     if coverage is not None and grid is not None:
-        view = coverage.assess(memories, grid, x, y, theta)
+        view = coverage.assess(memories, grid, x, y, theta, stamp)
         if view is not None:
             threshold = _COVERAGE_THRESHOLD if view.visible_m2 >= _WIDE_VIEW_M2 else _CLOSEUP_THRESHOLD
             return view.painted_fraction < threshold

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/selection.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/selection.py
@@ -2,11 +2,17 @@
 # Copyright (c) 2026 Innate Inc
 """Which viewpoints earn a slot in the spatial memory. Pure: no ROS, no I/O.
 
-A memory earns its place by showing something no kept frame shows. Two
-viewpoints are redundant only when they are both close AND similarly oriented —
-either gap alone (same spot facing away, same heading across the room) makes a
-genuinely different view. Capacity is bounded; at the cap, the older half of
-the most redundant pair makes room.
+A memory earns its place by showing floor the kept frames don't: with a grid,
+novelty is visibility paint (memory/coverage.py) — record while the wedge in
+front of the camera is under the coverage threshold, and overlap is welcome
+(rather too many pictures than too few). The demand scales with the view: a
+roomy wedge tolerates overlap, while a cramped one (nose to a wall) must be
+nearly all new — important things hang on walls, so a close-up of an unknown
+wall earns a slot, but sliding along a known one does not. Without a grid,
+pose redundancy stands in: two viewpoints are interchangeable only when both
+close AND similarly oriented. Capacity is bounded; at the cap, the memory
+whose paint is most replaceable makes room, and the further-back shot outlives
+the close-ups it subsumes.
 
 A kept viewpoint's picture refreshes only from a frame that shows the same
 information, and at most once a minute. Heading is what decides that: two
@@ -16,7 +22,8 @@ step closer. So refresh needs a near-identical heading, a displacement riding
 the view axis (a lateral step slides different information into frame), and a
 clear line of sight on the occupancy grid (without a grid, a tight distance
 stands in). An oblique, mid-turn, side-stepped, or behind-a-wall take never
-overwrites a straight-on view.
+overwrites a straight-on view — it becomes a new viewpoint instead, once
+enough of its wedge is unpainted.
 """
 
 from __future__ import annotations
@@ -24,9 +31,14 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
+from brain_client.memory.coverage import OCCUPIED_THRESHOLD
 from brain_client.memory.store import Memory
 from brain_client.state.map import Map
+
+if TYPE_CHECKING:
+    from brain_client.memory.coverage import Coverage
 
 MAX_MEMORIES = 50
 _REDUNDANT_DISTANCE_M = 1.0
@@ -34,7 +46,9 @@ _REDUNDANT_ANGLE_RAD = math.radians(100.0)  # most of the camera's 128 deg FOV s
 _SAME_VIEW_DISTANCE_M = 0.3  # lateral drift bound off the view axis, and the gridless fallback radius
 _SAME_VIEW_ANGLE_RAD = math.radians(20.0)
 _REFRESH_AGE_SEC = 60.0
-_OCCUPIED_THRESHOLD = 50  # nav grid: -1 unknown, 0 free, 100 occupied
+_COVERAGE_THRESHOLD = 0.8  # a roomy view records until this much of its wedge is painted — overlap is welcome
+_WIDE_VIEW_M2 = 1.0  # below this the view is a close-up
+_CLOSEUP_THRESHOLD = 0.2  # a close-up must be nearly all new — wall detail matters, wall spam does not
 
 
 @dataclass(frozen=True)
@@ -50,16 +64,47 @@ _SKIP = Admission(record=False)
 
 
 def plan_admission(
-    memories: Sequence[Memory], x: float, y: float, theta: float, stamp: float, grid: Map | None = None
+    memories: Sequence[Memory],
+    x: float,
+    y: float,
+    theta: float,
+    stamp: float,
+    grid: Map | None = None,
+    coverage: Coverage | None = None,
 ) -> Admission:
     nearest = min(memories, key=lambda m: redundancy(m, x, y, theta), default=None)
-    if nearest is not None and redundancy(nearest, x, y, theta) < 1.0:
-        if stamp - nearest.stamp >= _REFRESH_AGE_SEC and _same_view(nearest, x, y, theta, grid):
-            return Admission(record=True, replace=nearest)
+    if (
+        nearest is not None
+        and redundancy(nearest, x, y, theta) < 1.0
+        and stamp - nearest.stamp >= _REFRESH_AGE_SEC
+        and _same_view(nearest, x, y, theta, grid)
+    ):
+        return Admission(record=True, replace=nearest)
+    if not _worth_a_slot(memories, x, y, theta, grid, coverage, nearest):
         return _SKIP
     if len(memories) < MAX_MEMORIES:
         return Admission(record=True)
-    return Admission(record=True, evict=_most_redundant(memories))
+    evict = coverage.least_unique(memories, grid) if coverage is not None and grid is not None else None
+    return Admission(record=True, evict=evict if evict is not None else _most_redundant(memories))
+
+
+def _worth_a_slot(
+    memories: Sequence[Memory],
+    x: float,
+    y: float,
+    theta: float,
+    grid: Map | None,
+    coverage: Coverage | None,
+    nearest: Memory | None,
+) -> bool:
+    """Novelty: with a grid, whether enough of the wedge ahead is unpainted —
+    the smaller the view, the newer it must be; without one, pose redundancy."""
+    if coverage is not None and grid is not None:
+        view = coverage.assess(memories, grid, x, y, theta)
+        if view is not None:
+            threshold = _COVERAGE_THRESHOLD if view.visible_m2 >= _WIDE_VIEW_M2 else _CLOSEUP_THRESHOLD
+            return view.painted_fraction < threshold
+    return nearest is None or redundancy(nearest, x, y, theta) >= 1.0
 
 
 def _same_view(memory: Memory, x: float, y: float, theta: float, grid: Map | None) -> bool:
@@ -94,7 +139,7 @@ def _clear_line(grid: Map, ax: float, ay: float, bx: float, by: float) -> bool:
         if not (0 <= row < grid.height and 0 <= col < grid.width):
             return False
         value = int(cells[row, col])
-        if value < 0 or value >= _OCCUPIED_THRESHOLD:
+        if value < 0 or value >= OCCUPIED_THRESHOLD:
             return False
     return True
 

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/selection.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/selection.py
@@ -7,6 +7,16 @@ viewpoints are redundant only when they are both close AND similarly oriented �
 either gap alone (same spot facing away, same heading across the room) makes a
 genuinely different view. Capacity is bounded; at the cap, the older half of
 the most redundant pair makes room.
+
+A kept viewpoint's picture refreshes only from a frame that shows the same
+information, and at most once a minute. Heading is what decides that: two
+frames aimed the same way, displaced along that very axis, with nothing but
+free space between their capture points show the same scene — one merely a
+step closer. So refresh needs a near-identical heading, a displacement riding
+the view axis (a lateral step slides different information into frame), and a
+clear line of sight on the occupancy grid (without a grid, a tight distance
+stands in). An oblique, mid-turn, side-stepped, or behind-a-wall take never
+overwrites a straight-on view.
 """
 
 from __future__ import annotations
@@ -16,11 +26,15 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from brain_client.memory.store import Memory
+from brain_client.state.map import Map
 
 MAX_MEMORIES = 50
 _REDUNDANT_DISTANCE_M = 1.0
 _REDUNDANT_ANGLE_RAD = math.radians(100.0)  # most of the camera's 128 deg FOV still overlaps within this
-_REFRESH_AGE_SEC = 30 * 60.0  # a revisited viewpoint older than this gets a fresh image
+_SAME_VIEW_DISTANCE_M = 0.3  # lateral drift bound off the view axis, and the gridless fallback radius
+_SAME_VIEW_ANGLE_RAD = math.radians(20.0)
+_REFRESH_AGE_SEC = 60.0
+_OCCUPIED_THRESHOLD = 50  # nav grid: -1 unknown, 0 free, 100 occupied
 
 
 @dataclass(frozen=True)
@@ -28,22 +42,61 @@ class Admission:
     """What to do with a candidate viewpoint; replace/evict name existing memories."""
 
     record: bool
-    replace: Memory | None = None  # same viewpoint, stale image: overwrite in place
+    replace: Memory | None = None  # same view, aged picture: overwrite in place
     evict: Memory | None = None  # at capacity: remove this one to make room
 
 
 _SKIP = Admission(record=False)
 
 
-def plan_admission(memories: Sequence[Memory], x: float, y: float, theta: float, stamp: float) -> Admission:
+def plan_admission(
+    memories: Sequence[Memory], x: float, y: float, theta: float, stamp: float, grid: Map | None = None
+) -> Admission:
     nearest = min(memories, key=lambda m: redundancy(m, x, y, theta), default=None)
     if nearest is not None and redundancy(nearest, x, y, theta) < 1.0:
-        if stamp - nearest.stamp < _REFRESH_AGE_SEC:
-            return _SKIP
-        return Admission(record=True, replace=nearest)
+        if stamp - nearest.stamp >= _REFRESH_AGE_SEC and _same_view(nearest, x, y, theta, grid):
+            return Admission(record=True, replace=nearest)
+        return _SKIP
     if len(memories) < MAX_MEMORIES:
         return Admission(record=True)
     return Admission(record=True, evict=_most_redundant(memories))
+
+
+def _same_view(memory: Memory, x: float, y: float, theta: float, grid: Map | None) -> bool:
+    """The same picture — only such a frame may overwrite the stored one.
+    Heading decides; the displacement may only ride the view axis (ahead or
+    behind — a lateral step frames different information), and the sight line
+    must be clear. Distance is capped implicitly: the caller consults this
+    inside the redundancy disc, so a same-heading frame beyond
+    _REDUNDANT_DISTANCE_M is a new viewpoint, never a refresh."""
+    if _angle_diff(memory.theta, theta) >= _SAME_VIEW_ANGLE_RAD:
+        return False
+    dx, dy = x - memory.x, y - memory.y
+    if abs(dy * math.cos(memory.theta) - dx * math.sin(memory.theta)) > _SAME_VIEW_DISTANCE_M:
+        return False
+    if grid is None:
+        return math.hypot(dx, dy) <= _SAME_VIEW_DISTANCE_M
+    return _clear_line(grid, memory.x, memory.y, x, y)
+
+
+def _clear_line(grid: Map, ax: float, ay: float, bx: float, by: float) -> bool:
+    """Nothing but known-free cells on the segment — the two endpoints see the
+    same scene. Unknown or out-of-map counts as blocked: what the map cannot
+    vouch for must not justify an overwrite."""
+    cells = grid.grid
+    if cells is None:
+        return False
+    steps = max(1, math.ceil(math.hypot(bx - ax, by - ay) / (grid.resolution / 2)))
+    for i in range(steps + 1):
+        t = i / steps
+        col = int((ax + (bx - ax) * t - grid.origin_x) / grid.resolution)
+        row = int((ay + (by - ay) * t - grid.origin_y) / grid.resolution)
+        if not (0 <= row < grid.height and 0 <= col < grid.width):
+            return False
+        value = int(cells[row, col])
+        if value < 0 or value >= _OCCUPIED_THRESHOLD:
+            return False
+    return True
 
 
 def redundancy(memory: Memory, x: float, y: float, theta: float) -> float:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -101,9 +101,19 @@ class MemoryStore:
             return self._fingerprint
 
     def positions(self) -> list[dict]:
-        """The webapp mirror payload: one ``{id, x, y, theta, stamp}`` per memory."""
+        """The webapp mirror payload: one ``{id, x, y, theta, stamp}`` per memory,
+        rounded to display precision — full floats bloat the JSON by half."""
         with self._lock:
-            return [{"id": m.id, "x": m.x, "y": m.y, "theta": m.theta, "stamp": m.stamp} for m in self._memories]
+            return [
+                {
+                    "id": m.id,
+                    "x": round(m.x, 3),
+                    "y": round(m.y, 3),
+                    "theta": round(m.theta, 4),
+                    "stamp": round(m.stamp, 1),
+                }
+                for m in self._memories
+            ]
 
     def image_path(self, memory_id: int) -> Path | None:
         with self._lock:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -85,9 +85,9 @@ class MemoryStore:
             return MemorySnapshot(self._map_name, self._revision, tuple(self._memories))
 
     def positions(self) -> list[dict]:
-        """The webapp mirror payload: one ``{x, y, theta}`` per memory."""
+        """The webapp mirror payload: one ``{id, x, y, theta, stamp}`` per memory."""
         with self._lock:
-            return [{"x": m.x, "y": m.y, "theta": m.theta} for m in self._memories]
+            return [{"id": m.id, "x": m.x, "y": m.y, "theta": m.theta, "stamp": m.stamp} for m in self._memories]
 
     def image_path(self, memory_id: int) -> Path | None:
         with self._lock:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -93,6 +93,11 @@ class MemoryStore:
         with self._lock:
             return self._dir / f"{memory_id}.jpg" if self._dir is not None else None
 
+    def files_index_path(self) -> Path | None:
+        """Where the current map's server-side-upload registry lives (brain/frame_files.py)."""
+        with self._lock:
+            return self._dir / "files.json" if self._dir is not None else None
+
     def add(self, x: float, y: float, theta: float, stamp: float, jpeg: bytes) -> Memory | None:
         """Record a new memory; None when no map is loaded."""
         with self._lock:
@@ -144,6 +149,7 @@ class MemoryStore:
             for stale in self._dir.glob("*.jpg"):
                 stale.unlink(missing_ok=True)
             (self._dir / "index.json").unlink(missing_ok=True)
+            (self._dir / "files.json").unlink(missing_ok=True)
         self._memories = []
         self._next_id = 1
 

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -132,6 +132,17 @@ class MemoryStore:
             self._memories = [memory if m.id == old.id else m for m in self._memories]
             self._commit_locked()
 
+    def clear(self) -> int:
+        """Forget every memory on the current map — images, index, and upload
+        registry — returning how many were forgotten."""
+        with self._lock:
+            if self._dir is None or not self._memories:
+                return 0
+            cleared = len(self._memories)
+            self._wipe_locked()
+            self._commit_locked()
+            return cleared
+
     def evict(self, memory: Memory) -> None:
         with self._lock:
             if self._dir is None or all(m.id != memory.id for m in self._memories):

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Persistent per-map spatial memory: a JSON index plus one JPEG per memory.
+
+Lives under ``data/spatial_memory/<map>/`` beside the maps it describes and
+survives restarts. Memories only mean anything in the coordinate frame of the
+map they were recorded on, so each map gets its own directory, and the index
+carries a fingerprint of the map file — re-mapping under the same name yields
+a new frame, and the stale memories are wiped rather than trusted.
+
+Thread contract: mutations come from the recorder's timer (executor thread);
+:meth:`snapshot` serves readers on the agent loop and search threads. Every
+index access takes the store lock; image files are read without it, so a
+concurrently evicted file reads as missing — callers tolerate that.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from threading import Lock
+
+_INDEX_VERSION = 1
+
+
+@dataclass(frozen=True)
+class Memory:
+    """One remembered viewpoint: where the robot stood and when it looked."""
+
+    id: int
+    x: float
+    y: float
+    theta: float
+    stamp: float  # epoch seconds at capture
+
+
+@dataclass(frozen=True)
+class MemorySnapshot:
+    """An immutable view of the store for readers on other threads."""
+
+    map_name: str | None
+    revision: int
+    memories: tuple[Memory, ...]
+
+
+class MemoryStore:
+    def __init__(self, data_dir: Path):
+        self._maps_dir = data_dir / "maps"
+        self._root = data_dir / "spatial_memory"
+        self._lock = Lock()
+        self._map_name: str | None = None
+        self._dir: Path | None = None
+        self._memories: list[Memory] = []
+        self._next_id = 1
+        self._fingerprint = ""
+        self._revision = 0
+        self.last_change_monotonic = 0.0
+
+    def switch_map(self, map_name: str | None) -> None:
+        """Point the store at a map's memories, loading them from disk.
+
+        Idempotent per name — the fingerprint check (file I/O) runs only when
+        the name actually changes, so calling this every tick is free.
+        """
+        if map_name == self._map_name:
+            return
+        fingerprint = _map_fingerprint(self._maps_dir, map_name) if map_name else ""
+        with self._lock:
+            self._map_name = map_name
+            self._dir = self._root / Path(map_name).stem if map_name else None
+            self._memories = []
+            self._next_id = 1
+            self._fingerprint = fingerprint
+            self._revision += 1
+            self.last_change_monotonic = time.monotonic()
+            if self._dir is not None:
+                self._load_locked()
+
+    def snapshot(self) -> MemorySnapshot:
+        with self._lock:
+            return MemorySnapshot(self._map_name, self._revision, tuple(self._memories))
+
+    def positions(self) -> list[dict]:
+        """The webapp mirror payload: one ``{x, y, theta}`` per memory."""
+        with self._lock:
+            return [{"x": m.x, "y": m.y, "theta": m.theta} for m in self._memories]
+
+    def image_path(self, memory_id: int) -> Path | None:
+        with self._lock:
+            return self._dir / f"{memory_id}.jpg" if self._dir is not None else None
+
+    def add(self, x: float, y: float, theta: float, stamp: float, jpeg: bytes) -> Memory | None:
+        """Record a new memory; None when no map is loaded."""
+        with self._lock:
+            if self._dir is None:
+                return None
+            memory = Memory(self._next_id, x, y, theta, stamp)
+            self._next_id += 1
+            self._write_image_locked(memory.id, jpeg)
+            self._memories.append(memory)
+            self._commit_locked()
+            return memory
+
+    def replace(self, old: Memory, x: float, y: float, theta: float, stamp: float, jpeg: bytes) -> None:
+        """Overwrite a memory in place — same slot, fresh view of the same spot."""
+        with self._lock:
+            if self._dir is None or all(m.id != old.id for m in self._memories):
+                return
+            memory = Memory(old.id, x, y, theta, stamp)
+            self._write_image_locked(memory.id, jpeg)
+            self._memories = [memory if m.id == old.id else m for m in self._memories]
+            self._commit_locked()
+
+    def evict(self, memory: Memory) -> None:
+        with self._lock:
+            if self._dir is None or all(m.id != memory.id for m in self._memories):
+                return
+            self._memories = [m for m in self._memories if m.id != memory.id]
+            (self._dir / f"{memory.id}.jpg").unlink(missing_ok=True)
+            self._commit_locked()
+
+    # --- locked internals ---
+    def _load_locked(self) -> None:
+        assert self._dir is not None
+        try:
+            index = json.loads((self._dir / "index.json").read_text())
+            stale = index.get("version") != _INDEX_VERSION or index.get("fingerprint") != self._fingerprint
+        except (OSError, json.JSONDecodeError, TypeError):
+            index, stale = {}, True
+        if stale:
+            self._wipe_locked()
+            return
+        self._memories = [Memory(**entry) for entry in index.get("memories", [])]
+        self._next_id = int(index.get("next_id", 1))
+
+    def _wipe_locked(self) -> None:
+        """The map was re-made (or the index is unreadable): the coordinates lie."""
+        assert self._dir is not None
+        if self._dir.is_dir():
+            for stale in self._dir.glob("*.jpg"):
+                stale.unlink(missing_ok=True)
+            (self._dir / "index.json").unlink(missing_ok=True)
+        self._memories = []
+        self._next_id = 1
+
+    def _write_image_locked(self, memory_id: int, jpeg: bytes) -> None:
+        assert self._dir is not None
+        self._dir.mkdir(parents=True, exist_ok=True)
+        (self._dir / f"{memory_id}.jpg").write_bytes(jpeg)
+
+    def _commit_locked(self) -> None:
+        assert self._dir is not None
+        index = {
+            "version": _INDEX_VERSION,
+            "map": self._map_name,
+            "fingerprint": self._fingerprint,
+            "next_id": self._next_id,
+            "memories": [asdict(m) for m in self._memories],
+        }
+        self._dir.mkdir(parents=True, exist_ok=True)
+        tmp = self._dir / "index.json.tmp"
+        tmp.write_text(json.dumps(index))
+        os.replace(tmp, self._dir / "index.json")
+        self._revision += 1
+        self.last_change_monotonic = time.monotonic()
+
+
+def _map_fingerprint(maps_dir: Path, map_name: str) -> str:
+    """Identity of the map's content, not its name — a re-mapped room must not match."""
+    pgm = maps_dir / (Path(map_name).stem + ".pgm")
+    source = pgm if pgm.exists() else maps_dir / map_name
+    try:
+        return hashlib.sha256(source.read_bytes()).hexdigest()
+    except OSError:
+        return ""

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -57,19 +57,25 @@ class MemoryStore:
         self._memories: list[Memory] = []
         self._next_id = 1
         self._fingerprint = ""
+        self._stat_sig: tuple[int, int] | None = None
         self._revision = 0
         self.last_change_monotonic = 0.0
 
     def switch_map(self, map_name: str | None) -> None:
         """Point the store at a map's memories, loading them from disk.
 
-        Idempotent per name — the fingerprint check (file I/O) runs only when
-        the name actually changes, so calling this every tick is free.
+        Called every tick: same name + unchanged file stat is a cheap no-op,
+        and hashing runs only when the name or the map file changes — so
+        re-mapping over the active map's own name is caught within a tick.
         """
-        if map_name == self._map_name:
+        stat_sig = _map_stat(self._maps_dir, map_name) if map_name else None
+        if map_name == self._map_name and stat_sig == self._stat_sig:
             return
         fingerprint = _map_fingerprint(self._maps_dir, map_name) if map_name else ""
         with self._lock:
+            self._stat_sig = stat_sig
+            if map_name == self._map_name and fingerprint == self._fingerprint:
+                return  # the file was touched, not re-made
             self._map_name = map_name
             self._dir = self._root / Path(map_name).stem if map_name else None
             self._memories = []
@@ -83,6 +89,12 @@ class MemoryStore:
     def snapshot(self) -> MemorySnapshot:
         with self._lock:
             return MemorySnapshot(self._map_name, self._revision, tuple(self._memories))
+
+    @property
+    def fingerprint(self) -> str:
+        """Identity of the loaded map's content — changes exactly when the memories wipe."""
+        with self._lock:
+            return self._fingerprint
 
     def positions(self) -> list[dict]:
         """The webapp mirror payload: one ``{id, x, y, theta, stamp}`` per memory."""
@@ -133,14 +145,18 @@ class MemoryStore:
         assert self._dir is not None
         try:
             index = json.loads((self._dir / "index.json").read_text())
-            stale = index.get("version") != _INDEX_VERSION or index.get("fingerprint") != self._fingerprint
-        except (OSError, json.JSONDecodeError, TypeError):
-            index, stale = {}, True
-        if stale:
-            self._wipe_locked()
-            return
-        self._memories = [Memory(**entry) for entry in index.get("memories", [])]
-        self._next_id = int(index.get("next_id", 1))
+            fresh = (
+                isinstance(index, dict)
+                and index.get("version") == _INDEX_VERSION
+                and index.get("fingerprint") == self._fingerprint
+            )
+            if fresh:
+                self._memories = [Memory(**entry) for entry in index.get("memories", [])]
+                self._next_id = int(index.get("next_id", 1))
+                return
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            pass  # a wrong-shaped index is as stale as a wrong fingerprint
+        self._wipe_locked()
 
     def _wipe_locked(self) -> None:
         """The map was re-made (or the index is unreadable): the coordinates lie."""
@@ -175,11 +191,22 @@ class MemoryStore:
         self.last_change_monotonic = time.monotonic()
 
 
+def _map_source(maps_dir: Path, map_name: str) -> Path:
+    pgm = maps_dir / (Path(map_name).stem + ".pgm")
+    return pgm if pgm.exists() else maps_dir / map_name
+
+
+def _map_stat(maps_dir: Path, map_name: str) -> tuple[int, int] | None:
+    try:
+        stat = _map_source(maps_dir, map_name).stat()
+    except OSError:
+        return None
+    return stat.st_mtime_ns, stat.st_size
+
+
 def _map_fingerprint(maps_dir: Path, map_name: str) -> str:
     """Identity of the map's content, not its name — a re-mapped room must not match."""
-    pgm = maps_dir / (Path(map_name).stem + ".pgm")
-    source = pgm if pgm.exists() else maps_dir / map_name
     try:
-        return hashlib.sha256(source.read_bytes()).hexdigest()
+        return hashlib.sha256(_map_source(maps_dir, map_name).read_bytes()).hexdigest()
     except OSError:
         return ""

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -72,6 +72,10 @@ class MemoryStore:
         if map_name == self._map_name and stat_sig == self._stat_sig:
             return
         fingerprint = _map_fingerprint(self._maps_dir, map_name) if map_name else ""
+        if map_name is not None and not fingerprint:
+            # The map file is unreadable this tick (being rewritten, transient
+            # IO error). "Can't verify" must never wipe — retry next tick.
+            return
         with self._lock:
             self._stat_sig = stat_sig
             if map_name == self._map_name and fingerprint == self._fingerprint:
@@ -173,7 +177,7 @@ class MemoryStore:
         """The map was re-made (or the index is unreadable): the coordinates lie."""
         assert self._dir is not None
         if self._dir.is_dir():
-            for stale in self._dir.glob("*.jpg"):
+            for stale in self._dir.glob("*.jpg*"):  # images and any crash-orphaned .jpg.tmp
                 stale.unlink(missing_ok=True)
             (self._dir / "index.json").unlink(missing_ok=True)
             (self._dir / "files.json").unlink(missing_ok=True)
@@ -181,9 +185,13 @@ class MemoryStore:
         self._next_id = 1
 
     def _write_image_locked(self, memory_id: int, jpeg: bytes) -> None:
+        # tmp + replace like the index: the proxy and upload threads read these
+        # files without the lock and must never see a torn frame.
         assert self._dir is not None
         self._dir.mkdir(parents=True, exist_ok=True)
-        (self._dir / f"{memory_id}.jpg").write_bytes(jpeg)
+        tmp = self._dir / f"{memory_id}.jpg.tmp"
+        tmp.write_bytes(jpeg)
+        os.replace(tmp, self._dir / f"{memory_id}.jpg")
 
     def _commit_locked(self) -> None:
         assert self._dir is not None

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -141,7 +141,8 @@ class BrainClientNode(Node):
         self.pose_tracker = PoseTracker(self, odom_topic=cfg.odom_topic, nav_mode_topic=cfg.current_nav_mode_topic)
         self.scan_health = ScanHealthMonitor(self, scan_topic=cfg.scan_topic, stale_after_sec=cfg.scan_stale_after_sec)
         # Spatial memory: the recorder builds it whenever the robot drives well-
-        # localized (brain active or not); search recalls over it for the agent.
+        # localized (brain active or not); skills recall over it through the
+        # /brain/search_memory action — the agent itself knows nothing of it.
         self.memory_store = MemoryStore(get_innate_os_root() / "data")
         rest = pick_rest(self._proxy)
         self.memory_search = (
@@ -190,7 +191,6 @@ class BrainClientNode(Node):
             gaze=self.gaze,
             proxy=self._proxy,
             scan_health=self.scan_health,
-            memory=self.memory_search,
             trace=lambda payload: self.brain_trace_pub.publish(String(data=payload)),
         )
         # Heavy traces (request bodies, frames — hundreds of KB per turn) are

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -154,8 +154,16 @@ class BrainClientNode(Node):
             store=self.memory_store,
             pose_tracker=self.pose_tracker,
             warm_search=self.memory_search.warm if self.memory_search is not None else None,
+            cache_state=self.memory_search.cache_state if self.memory_search is not None else None,
             positions_pub=self.create_publisher(String, "/brain/memory_positions", 10),
         )
+        # Search verdicts for the webapp's map (latched: a page opened after the
+        # search still sees the last one; clients gate on the payload's stamp).
+        self.memory_search_pub = self.create_publisher(String, "/brain/memory_search", LATCHED_QOS)
+        if self.memory_search is not None:
+            self.memory_search.on_result = lambda payload: self.memory_search_pub.publish(
+                String(data=json.dumps(payload))
+            )
         self.gaze = GazeController(self, state)
         self.runner = PrimitiveRunner(
             self,

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -25,10 +25,15 @@ from std_srvs.srv import SetBool, Trigger
 
 from brain_client.agents.initializer import initialize_agents
 from brain_client.brain.agent import BrainAgent
+from brain_client.brain.memory_search import MemorySearch
+from brain_client.brain.transport import pick_rest
 from brain_client.brain.utils import EventKind
+from brain_client.common.script_paths import get_innate_os_root
 from brain_client.core.config import BrainConfig
 from brain_client.core.lifecycle import BrainLifecycle
 from brain_client.core.state import BrainState
+from brain_client.memory.recorder import MemoryRecorder
+from brain_client.memory.store import MemoryStore
 from brain_client.perception.camera import CameraCapture
 from brain_client.perception.gaze_control import GazeController
 from brain_client.perception.pose_tracking import PoseTracker
@@ -134,6 +139,23 @@ class BrainClientNode(Node):
         self.camera = CameraCapture(self, cfg)
         self.pose_tracker = PoseTracker(self, odom_topic=cfg.odom_topic, nav_mode_topic=cfg.current_nav_mode_topic)
         self.scan_health = ScanHealthMonitor(self, scan_topic=cfg.scan_topic, stale_after_sec=cfg.scan_stale_after_sec)
+        # Spatial memory: the recorder builds it whenever the robot drives well-
+        # localized (brain active or not); search recalls over it for the agent.
+        self.memory_store = MemoryStore(get_innate_os_root() / "data")
+        rest = pick_rest(self._proxy)
+        self.memory_search = (
+            MemorySearch(self.memory_store, rest, model=cfg.gemini_model, logger=self.get_logger())
+            if rest is not None
+            else None
+        )
+        self.memory_recorder = MemoryRecorder(
+            self,
+            cfg,
+            store=self.memory_store,
+            pose_tracker=self.pose_tracker,
+            warm_search=self.memory_search.warm if self.memory_search is not None else None,
+            positions_pub=self.create_publisher(String, "/brain/memory_positions", 10),
+        )
         self.gaze = GazeController(self, state)
         self.runner = PrimitiveRunner(
             self,
@@ -155,6 +177,7 @@ class BrainClientNode(Node):
             gaze=self.gaze,
             proxy=self._proxy,
             scan_health=self.scan_health,
+            memory=self.memory_search,
             trace=lambda payload: self.brain_trace_pub.publish(String(data=payload)),
         )
         # Heavy traces (request bodies, frames — hundreds of KB per turn) are

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -481,8 +481,13 @@ class BrainClientNode(Node):
         response.success = True
         return response
 
-    def _svc_clear_memories(self, request, response):
+    def _svc_clear_memories(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         cleared = self.memory_store.clear()
+        if self.memory_search is not None:
+            # Forgetting must reach the server-side copies too: the context
+            # cache and the uploaded frames would otherwise keep serving the
+            # forgotten views until their own expiry.
+            self.memory_search.forget()
         self.get_logger().info(f"[BrainClient] Cleared {cleared} spatial memories on user request")
         response.success = True
         response.message = f"Forgot {cleared} remembered views"

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -157,7 +157,7 @@ class BrainClientNode(Node):
             pose_tracker=self.pose_tracker,
             warm_search=self.memory_search.warm if self.memory_search is not None else None,
             cache_state=self.memory_search.cache_state if self.memory_search is not None else None,
-            positions_pub=self.create_publisher(String, "/brain/memory_positions", 10),
+            positions_pub=self.create_publisher(String, "/brain/memory_positions", LATCHED_QOS),
         )
         # Search verdicts for the webapp's map (latched: a page opened after the
         # search still sees the last one; clients gate on the payload's stamp).

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -242,6 +242,7 @@ class BrainClientNode(Node):
         self.create_service(ResetBrain, "/brain/reset_brain", self._svc_reset_brain)
         self.create_service(SetBool, "/brain/set_brain_active", self._svc_set_brain_active)
         self.create_service(Trigger, "/brain/reload", self._svc_reload)
+        self.create_service(Trigger, "/brain/clear_memories", self._svc_clear_memories)
         self.create_service(ReloadSkillsAgents, "/brain/reload_skills_agents", self._svc_reload_skills_agents)
         self.create_service(GetAvailableDirectives, "/brain/get_available_directives", self._svc_get_directives)
 
@@ -478,6 +479,13 @@ class BrainClientNode(Node):
                 self.lifecycle.deactivate_brain()
                 response.message = "Brain deactivated."
         response.success = True
+        return response
+
+    def _svc_clear_memories(self, request, response):
+        cleared = self.memory_store.clear()
+        self.get_logger().info(f"[BrainClient] Cleared {cleared} spatial memories on user request")
+        response.success = True
+        response.message = f"Forgot {cleared} remembered views"
         return response
 
     def _svc_reload(self, request, response):

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -26,6 +26,7 @@ from std_srvs.srv import SetBool, Trigger
 from brain_client.agents.initializer import initialize_agents
 from brain_client.brain.agent import BrainAgent
 from brain_client.brain.memory_search import MemorySearch
+from brain_client.brain.search_server import MemorySearchServer
 from brain_client.brain.transport import pick_rest
 from brain_client.brain.utils import EventKind
 from brain_client.common.script_paths import get_innate_os_root
@@ -160,10 +161,14 @@ class BrainClientNode(Node):
         # Search verdicts for the webapp's map (latched: a page opened after the
         # search still sees the last one; clients gate on the payload's stamp).
         self.memory_search_pub = self.create_publisher(String, "/brain/memory_search", LATCHED_QOS)
+        self.memory_search_server = None
         if self.memory_search is not None:
             self.memory_search.on_result = lambda payload: self.memory_search_pub.publish(
                 String(data=json.dumps(payload))
             )
+            # Recall as a capability: skills reach the same cache-backed search
+            # through /brain/search_memory (see brain/search_server.py).
+            self.memory_search_server = MemorySearchServer(self.memory_search)
         self.gaze = GazeController(self, state)
         self.runner = PrimitiveRunner(
             self,
@@ -552,6 +557,8 @@ class BrainClientNode(Node):
     def destroy_node(self):
         self.exit_event.set()
         self.brain.shutdown()
+        if self.memory_search_server is not None:
+            self.memory_search_server.shutdown()
         if self._agent_status_heartbeat is not None and not self._agent_status_heartbeat.is_canceled():
             self._agent_status_heartbeat.cancel()
         self.reload.stop_watcher()

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -9,6 +9,7 @@ skills.robot_state. This node wires those together and owns the action server.
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import threading
@@ -30,6 +31,7 @@ from brain_client.perception.camera_provider import CameraProvider
 from brain_client.robot.head import Head
 from brain_client.robot.manipulation import Manipulation
 from brain_client.robot.mobility import Mobility
+from brain_client.robot.spatial_memory import SpatialMemory
 from brain_client.skills.catalog import SkillRepository
 from brain_client.skills.cli_bridge import SkillCliBridge, SkillCliGoalHandle
 from brain_client.skills.invoker import SkillInvoker
@@ -83,6 +85,7 @@ class SkillsActionServer(Node):
         self.manipulation = Manipulation(self, self.get_logger(), lazy=True)
         self.mobility = Mobility(self, self.get_logger(), self.cmd_vel_topic)
         self.head = Head(self, self.get_logger(), self.head_position_topic)
+        self.spatial_memory = SpatialMemory(self, self.get_logger())
 
         self.robot_state = RobotStateProvider(
             self,
@@ -90,6 +93,7 @@ class SkillsActionServer(Node):
             manipulation=self.manipulation,
             mobility=self.mobility,
             head=self.head,
+            memory=self.spatial_memory,
             head_current_position_topic=self.head_current_position_topic,
         )
 
@@ -408,7 +412,11 @@ class SkillsActionServer(Node):
             finalize, success = _FINALIZE[output.status]
             getattr(goal_handle, finalize)()
             return ExecuteSkill.Result(
-                success=success, message=output.message, skill_type=skill_type, success_type=output.status.value
+                success=success,
+                message=output.message,
+                skill_type=skill_type,
+                success_type=output.status.value,
+                image_b64=base64.b64encode(output.image).decode() if output.image else "",
             )
         except Exception as e:
             self.get_logger().error(f"Error executing skill: {str(e)}")

--- a/ros2_ws/src/brain/brain_client/brain_client/perception/pose_tracking.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/perception/pose_tracking.py
@@ -72,23 +72,26 @@ class PoseTracker:
     # --- pose queries ---
     def current_pose_xyt(self) -> Pose | None:
         """Current robot pose as (x, y, theta); None if unavailable."""
-        try:
-            if self.is_mapfree and self.last_odom is not None:
-                pos = self.last_odom.pose.pose.position
-                ori = self.last_odom.pose.pose.orientation
-            else:
-                # No timeout: this runs on the agent's loop thread (twice per
-                # turn), and tf2's timeout is a sleep-poll — waiting 0.5s here
-                # whenever the map frame is missing stalls turns and telemetry.
-                # The listener keeps the buffer warm; if the transform isn't
-                # there yet, None now beats a pose half a second late.
-                transform = self.tf_buffer.lookup_transform(
-                    target_frame="map",
-                    source_frame="base_link",
-                    time=Time(),
-                )
-                pos = transform.transform.translation
-                ori = transform.transform.rotation
+        if self.is_mapfree and self.last_odom is not None:
+            pos = self.last_odom.pose.pose.position
+            ori = self.last_odom.pose.pose.orientation
             return (pos.x, pos.y, quaternion_to_yaw(ori))
+        return self.map_pose_xyt()
+
+    def map_pose_xyt(self) -> Pose | None:
+        """The map->base_link pose from TF, regardless of nav mode; None if unavailable."""
+        try:
+            # No timeout: this runs on the agent's loop thread (twice per
+            # turn), and tf2's timeout is a sleep-poll — waiting 0.5s here
+            # whenever the map frame is missing stalls turns and telemetry.
+            # The listener keeps the buffer warm; if the transform isn't
+            # there yet, None now beats a pose half a second late.
+            transform = self.tf_buffer.lookup_transform(
+                target_frame="map",
+                source_frame="base_link",
+                time=Time(),
+            )
         except Exception:
             return None
+        pos = transform.transform.translation
+        return (pos.x, pos.y, quaternion_to_yaw(transform.transform.rotation))

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Skill-facing recall over the robot's spatial memory.
+
+A thin client of the brain's ``/brain/search_memory`` action — the Gemini
+context cache, transport, and credentials all live server-side; a skill only
+ever sees a typed :class:`RecallVerdict`. Declared like any interface::
+
+    memory: SpatialMemory
+
+    def execute(self, query: str):
+        recall = self.memory.begin(query)
+        verdict = self.wait_for(recall, timeout=60.0)
+
+``begin`` returns a zero-arg reader that stays None until the verdict lands,
+so the wait runs through ``self.wait_for`` — cancel-aware like every blocking
+framework call. A skill that stops waiting simply abandons the goal; the
+search concludes server-side and its verdict is dropped.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from brain_messages.action import SearchMemory
+from rclpy.action import ActionClient
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class RecallVerdict:
+    """One memory search's outcome. ``error`` non-empty means the search
+    itself failed — distinct from a clean no-match (``found=False`` with an
+    explanation). ``message`` is the model-ready sentence; the pose fields
+    chain directly into navigation."""
+
+    found: bool
+    message: str
+    explanation: str = ""
+    error: str = ""
+    x: float = 0.0
+    y: float = 0.0
+    theta: float = 0.0
+    seen_stamp: float = 0.0
+    image: bytes | None = None
+    latency_sec: float = 0.0
+    cached: bool = False
+
+
+class SpatialMemory:
+    def __init__(self, node, logger):
+        self._logger = logger
+        self._client = ActionClient(node, SearchMemory, "/brain/search_memory")
+
+    def begin(self, query: str) -> Callable[[], RecallVerdict | None]:
+        """Start a search; hand the returned reader to ``self.wait_for``."""
+        holder: list[RecallVerdict | None] = [None]
+
+        def conclude(verdict: RecallVerdict) -> None:
+            holder[0] = verdict
+
+        if not self._client.wait_for_server(timeout_sec=2.0):
+            conclude(_error_verdict("memory search unavailable — is the brain node running?"))
+            return lambda: holder[0]
+
+        def on_result(future) -> None:
+            try:
+                conclude(_from_result(future.result().result))
+            except Exception as error:  # noqa: BLE001 — a lost result must still unblock the waiter
+                conclude(_error_verdict(f"memory search result lost: {error}"))
+
+        def on_goal(future) -> None:
+            try:
+                handle = future.result()
+            except Exception as error:  # noqa: BLE001 — same: the waiter needs an answer, not a hang
+                conclude(_error_verdict(f"memory search goal failed: {error}"))
+                return
+            if handle is None or not handle.accepted:
+                conclude(_error_verdict("memory search goal rejected"))
+                return
+            handle.get_result_async().add_done_callback(on_result)
+
+        goal = SearchMemory.Goal()
+        goal.query = str(query)
+        self._client.send_goal_async(goal).add_done_callback(on_goal)
+        return lambda: holder[0]
+
+
+def _error_verdict(error: str) -> RecallVerdict:
+    return RecallVerdict(found=False, message=f"Memory search failed: {error}", error=error)
+
+
+def _from_result(result) -> RecallVerdict:
+    return RecallVerdict(
+        found=result.found,
+        message=result.message,
+        explanation=result.explanation,
+        error=result.error,
+        x=result.x,
+        y=result.y,
+        theta=result.theta,
+        seen_stamp=result.seen_stamp,
+        image=base64.b64decode(result.image_b64) if result.image_b64 else None,
+        latency_sec=result.latency_sec,
+        cached=result.cached,
+    )

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
@@ -21,14 +21,23 @@ search concludes server-side and its verdict is dropped.
 from __future__ import annotations
 
 import base64
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from brain_messages.action import SearchMemory
 from rclpy.action import ActionClient
 
+from brain_client.skills.types import cancellable_sleep
+
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from rclpy.impl.rcutils_logger import RcutilsLogger
+    from rclpy.node import Node
+    from rclpy.task import Future
+
+_SERVER_WAIT_SEC = 2.0  # how long begin() waits for /brain/search_memory to exist
 
 
 @dataclass(frozen=True)
@@ -52,7 +61,7 @@ class RecallVerdict:
 
 
 class SpatialMemory:
-    def __init__(self, node, logger):
+    def __init__(self, node: Node, logger: RcutilsLogger):
         self._logger = logger
         self._client = ActionClient(node, SearchMemory, "/brain/search_memory")
 
@@ -63,17 +72,23 @@ class SpatialMemory:
         def conclude(verdict: RecallVerdict) -> None:
             holder[0] = verdict
 
-        if not self._client.wait_for_server(timeout_sec=2.0):
-            conclude(_error_verdict("memory search unavailable — is the brain node running?"))
-            return lambda: holder[0]
+        # rclpy's wait_for_server is a time.sleep poll — sliced here so a Stop
+        # pressed while the server is absent unwinds instead of blocking out
+        # the whole timeout (cancellable_sleep raises SkillCancelled).
+        deadline = time.monotonic() + _SERVER_WAIT_SEC
+        while not self._client.wait_for_server(timeout_sec=0.0):
+            if time.monotonic() >= deadline:
+                conclude(_error_verdict("memory search unavailable — is the brain node running?"))
+                return lambda: holder[0]
+            cancellable_sleep(0.1)
 
-        def on_result(future) -> None:
+        def on_result(future: Future) -> None:
             try:
                 conclude(_from_result(future.result().result))
             except Exception as error:  # noqa: BLE001 — a lost result must still unblock the waiter
                 conclude(_error_verdict(f"memory search result lost: {error}"))
 
-        def on_goal(future) -> None:
+        def on_goal(future: Future) -> None:
             try:
                 handle = future.result()
             except Exception as error:  # noqa: BLE001 — same: the waiter needs an answer, not a hang
@@ -94,7 +109,7 @@ def _error_verdict(error: str) -> RecallVerdict:
     return RecallVerdict(found=False, message=f"Memory search failed: {error}", error=error)
 
 
-def _from_result(result) -> RecallVerdict:
+def _from_result(result: SearchMemory.Result) -> RecallVerdict:
     return RecallVerdict(
         found=result.found,
         message=result.message,

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
@@ -84,7 +84,10 @@ class SpatialMemory:
 
         def on_result(future: Future) -> None:
             try:
-                conclude(_from_result(future.result().result))
+                response = future.result()
+                if response is None:
+                    raise RuntimeError("empty result")
+                conclude(_from_result(response.result))
             except Exception as error:  # noqa: BLE001 — a lost result must still unblock the waiter
                 conclude(_error_verdict(f"memory search result lost: {error}"))
 

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
@@ -32,13 +32,14 @@ from brain_client.state.pose import Pose
 
 
 class RobotStateProvider:
-    def __init__(self, node, camera_node, *, manipulation, mobility, head, head_current_position_topic: str):
+    def __init__(self, node, camera_node, *, manipulation, mobility, head, memory, head_current_position_topic: str):
         self._node = node
         self._logger = node.get_logger()
         self._camera = camera_node
         self._manipulation = manipulation
         self._mobility = mobility
         self._head = head
+        self._memory = memory
         self._head_current_position_topic = head_current_position_topic
 
         self.last_odom = None
@@ -107,6 +108,8 @@ class RobotStateProvider:
                 skill.inject_interface(interface_type, self._mobility)
             elif interface_type == InterfaceType.HEAD:
                 skill.inject_interface(interface_type, self._head)
+            elif interface_type == InterfaceType.MEMORY:
+                skill.inject_interface(interface_type, self._memory)
 
     # --- subscriptions ---
     def start_subscriptions(self) -> None:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
@@ -10,6 +10,7 @@ import json
 import threading
 import time
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from nav_msgs.msg import OccupancyGrid
@@ -30,9 +31,22 @@ from brain_client.state.map import Map
 from brain_client.state.odometry import Odometry
 from brain_client.state.pose import Pose
 
+if TYPE_CHECKING:
+    from brain_client.robot.spatial_memory import SpatialMemory
+
 
 class RobotStateProvider:
-    def __init__(self, node, camera_node, *, manipulation, mobility, head, memory, head_current_position_topic: str):
+    def __init__(
+        self,
+        node,
+        camera_node,
+        *,
+        manipulation,
+        mobility,
+        head,
+        memory: SpatialMemory,
+        head_current_position_topic: str,
+    ):
         self._node = node
         self._logger = node.get_logger()
         self._camera = camera_node

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -34,7 +34,7 @@ class PrimitiveRunner:
         self._on_task_finished = on_task_finished
 
         # Bound late by the node (mutual cycle: the brain needs the runner too).
-        self.on_event = lambda status, skill_name, detail=None: None
+        self.on_event = lambda status, skill_name, detail=None, image=None: None
         self.on_feedback = lambda skill_name, feedback, image=None: None
 
         self.action_client = ActionClient(node, ExecuteSkill, "execute_skill")
@@ -353,7 +353,8 @@ class PrimitiveRunner:
         # client's job.
         status, detail = self._classify_result(result, is_code)
         if status is not None:
-            self.on_event(status, primitive_name, detail)
+            image = base64.b64decode(result.image_b64) if result.image_b64 else None
+            self.on_event(status, primitive_name, detail, image=image)
         self._emit_skill_output(result, is_code)
 
     def _is_code_skill(self, skill_id: str) -> bool:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -82,19 +82,25 @@ def cancellable_sleep(seconds: float) -> None:
 
 class SkillOutput:
     """The result of a skill run: the message, the status (a SkillResult, not
-    a string), and an optional structured payload for chaining callers.
+    a string), an optional structured payload for chaining callers, and an
+    optional evidence image (JPEG bytes) that travels with the result — the
+    agent sees it in the completion event, so a skill can show what it found,
+    not just say it (``return SkillOutput("found it", image=jpeg)``).
 
     ``str(output)`` and f-strings give the message; ``output.ok`` is the
     success check. Unpacking as the legacy ``(message, status)`` tuple still
     works but is deprecated.
     """
 
-    __slots__ = ("message", "data", "status")
+    __slots__ = ("message", "data", "status", "image")
 
-    def __init__(self, message: str, data: Any = None, status: "SkillResult" = SkillResult.SUCCESS):
+    def __init__(
+        self, message: str, data: Any = None, status: "SkillResult" = SkillResult.SUCCESS, image: bytes | None = None
+    ):
         self.message = str(message)
         self.data = data
         self.status = status
+        self.image = image
 
     @property
     def ok(self) -> bool:
@@ -180,6 +186,7 @@ class InterfaceType(Enum):
     MANIPULATION = "manipulation"
     MOBILITY = "mobility"
     HEAD = "head"
+    MEMORY = "memory"
 
 
 class SkillStorage:
@@ -501,6 +508,7 @@ def _feed_specs() -> "tuple[_FeedSpec, ...]":
     from brain_client.robot.head import Head
     from brain_client.robot.manipulation import Manipulation
     from brain_client.robot.mobility import Mobility
+    from brain_client.robot.spatial_memory import SpatialMemory
     from brain_client.state.arm import Arm
     from brain_client.state.battery import Battery
     from brain_client.state.head import HeadState
@@ -517,6 +525,7 @@ def _feed_specs() -> "tuple[_FeedSpec, ...]":
         _FeedSpec(Manipulation, Interface, InterfaceType.MANIPULATION, "Manipulation", ("manipulation",)),
         _FeedSpec(Mobility, Interface, InterfaceType.MOBILITY, "Mobility", ("mobility",)),
         _FeedSpec(Head, Interface, InterfaceType.HEAD, "Head", ("head",)),
+        _FeedSpec(SpatialMemory, Interface, InterfaceType.MEMORY, "SpatialMemory", ("memory",)),
         # cameras start per run (and sim renders on demand) — longer grace
         _FeedSpec(MainImage, Camera, main, "MainImage", ("image", "main_image"), "main camera", grace_s=3.0),
         _FeedSpec(WristImage, Camera, wrist, "WristImage", ("wrist_image",), "wrist camera", grace_s=3.0),

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -27,7 +27,8 @@ One rule covers interfaces, cameras and robot state: annotate what you read.
 ``battery: Battery``, ``odom: Odometry``, ``pose: Pose``, ``lidar: Lidar``,
 ``arm: Arm``, ``map: Map``, ``joint_states: JointStates``,
 ``head_position: HeadState``, ``image: MainImage`` / ``WristImage`` /
-``DepthMap``, ``mobility: Mobility``, ``head: Head``. A plain annotation is
+``DepthMap``, ``mobility: Mobility``, ``head: Head``,
+``memory: SpatialMemory`` (recall over the robot's spatial memory). A plain annotation is
 guaranteed inside execute() — the server waits for the first value and fails
 the run up front if none arrives — so no None guards are needed; ``| None``
 (``head: Head | None``) makes it best effort instead, injected when available
@@ -36,7 +37,9 @@ it before you ship.
 
 execute() returns the run's result: the message str, or
 ``SkillOutput(message, data)`` to attach a structured payload for chaining
-callers, or None. Call ``self.fail(message)`` to end the run as a failure.
+callers (``image=jpeg_bytes`` attaches an evidence image the agent sees in
+the completion event), or None. Call ``self.fail(message)`` to end the run
+as a failure.
 Callers of other skills get that SkillOutput back — ``out = self.turn(...)``
 then ``out.message`` / ``out.data`` / ``out.ok``, with ``out.status`` a
 SkillResult enum, never a bare string. (Legacy ``(message, SkillResult)``
@@ -106,6 +109,7 @@ __all__ = [
     "Mobility",
     "Odometry",
     "Pose",
+    "RecallVerdict",
     "Skill",
     "SkillCancelled",
     "SkillFailed",
@@ -113,6 +117,7 @@ __all__ = [
     "SkillRef",
     "SkillResult",
     "SkillReturn",
+    "SpatialMemory",
     "TrainedSkill",
     "Waypoint",
     "WristImage",
@@ -126,12 +131,15 @@ if TYPE_CHECKING:
     from brain_client.robot.head import Head
     from brain_client.robot.manipulation import Manipulation, Waypoint
     from brain_client.robot.mobility import Mobility
+    from brain_client.robot.spatial_memory import RecallVerdict, SpatialMemory
 
 _LAZY_INTERFACES = {
     "Mobility": ("brain_client.robot.mobility", "Mobility"),
     "Manipulation": ("brain_client.robot.manipulation", "Manipulation"),
     "Head": ("brain_client.robot.head", "Head"),
     "Waypoint": ("brain_client.robot.manipulation", "Waypoint"),
+    "SpatialMemory": ("brain_client.robot.spatial_memory", "SpatialMemory"),
+    "RecallVerdict": ("brain_client.robot.spatial_memory", "RecallVerdict"),
 }
 
 

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -1077,51 +1077,91 @@ def test_trace_reports_the_turn_lifecycle(agent_factory, monkeypatch):
     assert snapshot["active"] is False and snapshot["backend"] == "gemini-direct" and snapshot["history"] == 3
 
 
-# ---------- spatial memory tool ----------
+# ---------- spatial memory (the search_memory skill's non-occupying dispatch) ----------
 
 from brain_client.brain.context import ToolCall  # noqa: E402
+from brain_client.brain.memory_search import SearchVerdict  # noqa: E402
+from brain_client.memory.store import Memory  # noqa: E402
+from brain_client.skills.registry import SkillRegistry  # noqa: E402
+
+SEARCH_SKILL = {
+    "id": "innate-os/search_memory",
+    "name": "search_memory",
+    "type": "code",
+    "guidelines": "Search the robot's memory of this map.",
+    "inputs": {"query": {"type": "str", "required": True}},
+}
+
+FOUND_VERDICT = SearchVerdict(
+    query="banana",
+    found=True,
+    explanation="a banana on the counter",
+    memory=Memory(id=2, x=1.5, y=0.5, theta=0.0, stamp=1000.0),
+    image=JPEG,
+    latency_sec=1.2,
+    cached=True,
+)
 
 
-def declared_tool_names(agent) -> list[str]:
-    return [d["name"] for d in agent._build_tools([])[0]["functionDeclarations"]]
+def arm_search_skill(agent) -> None:
+    """Put the search skill in the registry + active roster, like a directive would."""
+    agent._state.registry = SkillRegistry.from_metadata([SEARCH_SKILL])
+    agent._roster = SimpleNamespace(active_skill_ids=lambda: ["innate-os/search_memory"])
 
 
-def test_search_memory_is_declared_only_while_frames_exist(agent_factory):
-    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
-    assert "search_memory" not in declared_tool_names(agent)
-    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=3))
-    assert "search_memory" in declared_tool_names(agent)
-    agent, _ = agent_factory()  # no memory subsystem (no Gemini access at all)
-    assert "search_memory" not in declared_tool_names(agent)
-
-
-def test_search_memory_result_returns_as_an_event_with_the_matched_frame(agent_factory):
+def test_search_memory_skill_dispatches_without_occupying_the_slot(agent_factory):
     searches = []
     memory = SimpleNamespace(
         frame_count=3,
-        begin_search=lambda query, on_done: (searches.append(query), on_done("Memory search: found it", JPEG)),
+        begin_search=lambda query, on_done: (searches.append(query), on_done(FOUND_VERDICT)),
     )
-    agent, _ = agent_factory(memory=memory)
+    agent, state = agent_factory(memory=memory)
+    arm_search_skill(agent)
     agent._context._transport = lambda model, body: [model_response(call_part("search_memory", {"query": "banana"}))]
     run_turn(agent)
 
     assert searches == ["banana"]
+    assert state.primitive_running is None  # a query, not an act: the slot stays free
     # The call was answered immediately (started, not blocked on)...
     outcome = agent._context._history[-1]["parts"][0]["functionResponse"]["response"]["outcome"]
     assert outcome == "searching memory — the result arrives as an event"
-    # ...and the result waits in the queue as a MEMORY event carrying the frame.
+    # ...and the verdict waits in the queue as a MEMORY event carrying the frame.
     (event,) = agent._events
-    assert event.kind == EventKind.MEMORY and event.image == JPEG and "found it" in event.text
+    assert event.kind == EventKind.MEMORY and event.image == JPEG
+    assert "banana on the counter" in event.text and "x=1.50m" in event.text
+
+
+def test_search_memory_runs_even_while_another_skill_occupies_the_slot(agent_factory):
+    # Recall is a query: unlike every actuator skill, it must not be blocked by
+    # one-skill-at-a-time (search while driving is a deliberate property).
+    memory = SimpleNamespace(frame_count=3, begin_search=lambda query, on_done: on_done(FOUND_VERDICT))
+    agent, state = agent_factory(memory=memory)
+    arm_search_skill(agent)
+    state.primitive_running = RunningSkill(primitive_name="navigate", skill_id="innate-os/navigate_to_position")
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
+    outcome = agent._execute(ToolCall("search_memory", {"query": "keys"}))
+    assert outcome == "searching memory — the result arrives as an event"
 
 
 def test_search_memory_rejects_an_empty_memory_and_a_missing_query(agent_factory):
     agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
+    arm_search_skill(agent)
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
     assert (
         agent._execute(ToolCall("search_memory", {"query": "keys"}))
         == "rejected — no places remembered on this map yet"
     )
     agent, _ = agent_factory(memory=SimpleNamespace(frame_count=2))
+    arm_search_skill(agent)
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
     assert agent._execute(ToolCall("search_memory", {})) == "rejected — give a query describing what to find"
+
+
+def test_skill_completion_event_carries_the_result_image(agent_factory):
+    agent, _ = agent_factory()
+    agent.on_skill_event("completed", "inspect_shelf", "found the mug", image=JPEG)
+    (event,) = agent._events
+    assert event.image == JPEG and "found the mug" in event.text
 
 
 # ---------- prompt ----------

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -462,7 +462,7 @@ def agent_factory(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "test-key")  # gives the agent a swappable transport
     created = []
 
-    def make(trace=None) -> tuple[BrainAgent, BrainState]:
+    def make(trace=None, memory=None) -> tuple[BrainAgent, BrainState]:
         logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
         node = SimpleNamespace(get_logger=lambda: logger)
         config = SimpleNamespace(
@@ -503,6 +503,7 @@ def agent_factory(monkeypatch):
             roster=SimpleNamespace(active_skill_ids=lambda: []),
             chat=chat,
             gaze=SimpleNamespace(pause=lambda: None),
+            memory=memory,
             trace=trace,
         )
         created.append(agent)
@@ -1074,6 +1075,53 @@ def test_trace_reports_the_turn_lifecycle(agent_factory, monkeypatch):
     snapshot = traces[7]
     # History: the user turn, the model turn, and the wait call's functionResponse.
     assert snapshot["active"] is False and snapshot["backend"] == "gemini-direct" and snapshot["history"] == 3
+
+
+# ---------- spatial memory tool ----------
+
+from brain_client.brain.context import ToolCall  # noqa: E402
+
+
+def declared_tool_names(agent) -> list[str]:
+    return [d["name"] for d in agent._build_tools([])[0]["functionDeclarations"]]
+
+
+def test_search_memory_is_declared_only_while_frames_exist(agent_factory):
+    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
+    assert "search_memory" not in declared_tool_names(agent)
+    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=3))
+    assert "search_memory" in declared_tool_names(agent)
+    agent, _ = agent_factory()  # no memory subsystem (no Gemini access at all)
+    assert "search_memory" not in declared_tool_names(agent)
+
+
+def test_search_memory_result_returns_as_an_event_with_the_matched_frame(agent_factory):
+    searches = []
+    memory = SimpleNamespace(
+        frame_count=3,
+        begin_search=lambda query, on_done: (searches.append(query), on_done("Memory search: found it", JPEG)),
+    )
+    agent, _ = agent_factory(memory=memory)
+    agent._context._transport = lambda model, body: [model_response(call_part("search_memory", {"query": "banana"}))]
+    run_turn(agent)
+
+    assert searches == ["banana"]
+    # The call was answered immediately (started, not blocked on)...
+    outcome = agent._context._history[-1]["parts"][0]["functionResponse"]["response"]["outcome"]
+    assert outcome == "searching memory — the result arrives as an event"
+    # ...and the result waits in the queue as a MEMORY event carrying the frame.
+    (event,) = agent._events
+    assert event.kind == EventKind.MEMORY and event.image == JPEG and "found it" in event.text
+
+
+def test_search_memory_rejects_an_empty_memory_and_a_missing_query(agent_factory):
+    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
+    assert (
+        agent._execute(ToolCall("search_memory", {"query": "keys"}))
+        == "rejected — no places remembered on this map yet"
+    )
+    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=2))
+    assert agent._execute(ToolCall("search_memory", {})) == "rejected — give a query describing what to find"
 
 
 # ---------- prompt ----------

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -462,7 +462,7 @@ def agent_factory(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "test-key")  # gives the agent a swappable transport
     created = []
 
-    def make(trace=None, memory=None) -> tuple[BrainAgent, BrainState]:
+    def make(trace=None) -> tuple[BrainAgent, BrainState]:
         logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
         node = SimpleNamespace(get_logger=lambda: logger)
         config = SimpleNamespace(
@@ -503,7 +503,6 @@ def agent_factory(monkeypatch):
             roster=SimpleNamespace(active_skill_ids=lambda: []),
             chat=chat,
             gaze=SimpleNamespace(pause=lambda: None),
-            memory=memory,
             trace=trace,
         )
         created.append(agent)
@@ -1074,95 +1073,7 @@ def test_trace_reports_the_turn_lifecycle(agent_factory, monkeypatch):
     assert snapshot["active"] is False and snapshot["backend"] == "gemini-direct" and snapshot["history"] == 3
 
 
-# ---------- spatial memory (the search_memory skill's non-occupying dispatch) ----------
-
-from brain_client.brain.context import ToolCall  # noqa: E402
-from brain_client.brain.memory_search import SearchVerdict  # noqa: E402
-from brain_client.memory.store import Memory  # noqa: E402
-from brain_client.skills.registry import SkillRegistry  # noqa: E402
-
-SEARCH_SKILL = {
-    "id": "innate-os/search_memory",
-    "name": "search_memory",
-    "type": "code",
-    "guidelines": "Search the robot's memory of this map.",
-    "inputs": {"query": {"type": "str", "required": True}},
-}
-
-FOUND_VERDICT = SearchVerdict(
-    query="banana",
-    found=True,
-    explanation="a banana on the counter",
-    memory=Memory(id=2, x=1.5, y=0.5, theta=0.0, stamp=1000.0),
-    image=JPEG,
-    latency_sec=1.2,
-    cached=True,
-)
-
-
-def arm_search_skill(agent) -> None:
-    """Put the search skill in the registry + active roster, like a directive would."""
-    agent._state.registry = SkillRegistry.from_metadata([SEARCH_SKILL])
-    agent._roster = SimpleNamespace(active_skill_ids=lambda: ["innate-os/search_memory"])
-
-
-def test_search_memory_skill_dispatches_without_occupying_the_slot(agent_factory):
-    searches = []
-    memory = SimpleNamespace(
-        frame_count=3,
-        begin_search=lambda query, on_done: (searches.append(query), on_done(FOUND_VERDICT)),
-    )
-    agent, state = agent_factory(memory=memory)
-    arm_search_skill(agent)
-    agent._context._transport = lambda model, body: [model_response(call_part("search_memory", {"query": "banana"}))]
-    run_turn(agent)
-
-    assert searches == ["banana"]
-    assert state.primitive_running is None  # a query, not an act: the slot stays free
-    # The call was answered immediately (started, not blocked on)...
-    outcome = agent._context._history[-1]["parts"][0]["functionResponse"]["response"]["outcome"]
-    assert outcome == "searching memory — the result arrives as an event"
-    # ...and the verdict waits in the queue as a MEMORY event carrying the frame.
-    (event,) = agent._events
-    assert event.kind == EventKind.MEMORY and event.image == JPEG
-    assert "banana on the counter" in event.text and "x=1.50m" in event.text
-
-
-def test_search_memory_runs_even_while_another_skill_occupies_the_slot(agent_factory):
-    # Recall is a query: unlike every actuator skill, it must not be blocked by
-    # one-skill-at-a-time (search while driving is a deliberate property).
-    memory = SimpleNamespace(frame_count=3, begin_search=lambda query, on_done: on_done(FOUND_VERDICT))
-    agent, state = agent_factory(memory=memory)
-    arm_search_skill(agent)
-    state.primitive_running = RunningSkill(primitive_name="navigate", skill_id="innate-os/navigate_to_position")
-    agent._tool_map = {"search_memory": "innate-os/search_memory"}
-    outcome = agent._execute(ToolCall("search_memory", {"query": "keys"}))
-    assert outcome == "searching memory — the result arrives as an event"
-
-
-def test_search_memory_stays_declared_while_a_skill_runs(agent_factory):
-    # Dispatch alone is not enough: the model can only search while driving if
-    # the tool is still OFFERED while the slot is occupied.
-    agent, state = agent_factory(memory=SimpleNamespace(frame_count=3))
-    arm_search_skill(agent)
-    state.primitive_running = RunningSkill(primitive_name="navigate", skill_id="innate-os/navigate_to_position")
-    declarations = agent._build_tools([])[0]["functionDeclarations"]
-    assert [d["name"] for d in declarations] == [STOP_SKILL, "search_memory", "wait"]
-    assert agent._tool_map["search_memory"] == "innate-os/search_memory"
-
-
-def test_search_memory_rejects_an_empty_memory_and_a_missing_query(agent_factory):
-    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
-    arm_search_skill(agent)
-    agent._tool_map = {"search_memory": "innate-os/search_memory"}
-    assert (
-        agent._execute(ToolCall("search_memory", {"query": "keys"}))
-        == "rejected — no places remembered on this map yet"
-    )
-    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=2))
-    arm_search_skill(agent)
-    agent._tool_map = {"search_memory": "innate-os/search_memory"}
-    assert agent._execute(ToolCall("search_memory", {})) == "rejected — give a query describing what to find"
+# ---------- skill events ----------
 
 
 def test_skill_completion_event_carries_the_result_image(agent_factory):

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -611,9 +611,9 @@ def test_a_call_outside_the_active_skill_set_is_rejected(agent_factory):
 
 
 def test_a_stale_tool_name_is_rechecked_against_the_live_active_set(agent_factory):
-    # The dispatch map is not rebuilt while a skill runs, so it can outlive a
-    # roster change: a name resolved through it must still clear the live
-    # active set before dispatch.
+    # The dispatch map is built at the top of the turn, so it can outlive a
+    # roster change that lands while the model is thinking: a name resolved
+    # through it must still clear the live active set before dispatch.
     from brain_client.skills.registry import SkillRegistry
 
     agent, state = agent_factory()
@@ -625,13 +625,10 @@ def test_a_stale_tool_name_is_rechecked_against_the_live_active_set(agent_factor
     run_turn(agent)  # populates the dispatch map with wave
     assert len(started) == 1
 
-    # Next turn: a skill is running (map kept stale), wave gets deactivated,
-    # and the skill ends while the model is thinking.
-    state.primitive_running = RunningSkill(primitive_name="other", skill_id="local/other")
-    agent._roster.active_skill_ids = lambda: []
-
+    # Next turn: wave is deactivated while the model is thinking — after the
+    # dispatch map was built from the roster that still held it.
     def transport(model, body):
-        state.primitive_running = None
+        agent._roster.active_skill_ids = lambda: []
         return [model_response(call_part("wave", {}))]
 
     agent._context._transport = transport
@@ -1141,6 +1138,17 @@ def test_search_memory_runs_even_while_another_skill_occupies_the_slot(agent_fac
     agent._tool_map = {"search_memory": "innate-os/search_memory"}
     outcome = agent._execute(ToolCall("search_memory", {"query": "keys"}))
     assert outcome == "searching memory — the result arrives as an event"
+
+
+def test_search_memory_stays_declared_while_a_skill_runs(agent_factory):
+    # Dispatch alone is not enough: the model can only search while driving if
+    # the tool is still OFFERED while the slot is occupied.
+    agent, state = agent_factory(memory=SimpleNamespace(frame_count=3))
+    arm_search_skill(agent)
+    state.primitive_running = RunningSkill(primitive_name="navigate", skill_id="innate-os/navigate_to_position")
+    declarations = agent._build_tools([])[0]["functionDeclarations"]
+    assert [d["name"] for d in declarations] == [STOP_SKILL, "search_memory", "wait"]
+    assert agent._tool_map["search_memory"] == "innate-os/search_memory"
 
 
 def test_search_memory_rejects_an_empty_memory_and_a_missing_query(agent_factory):

--- a/ros2_ws/src/brain/brain_client/test/test_memory_skill.py
+++ b/ros2_ws/src/brain/brain_client/test/test_memory_skill.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Memory recall as a capability: the SearchMemory action mapping, the SDK
+accessor's begin/wait contract, and the result-image channel that carries a
+skill's evidence frame back into the agent's events."""
+
+from __future__ import annotations
+
+import base64
+import threading
+from types import SimpleNamespace
+
+from brain_client.brain.memory_search import SearchVerdict, verdict_text
+from brain_client.brain.search_server import _to_result
+from brain_client.core.state import BrainState, RunningSkill
+from brain_client.memory.store import Memory
+from brain_client.robot.spatial_memory import SpatialMemory
+from brain_client.skills.registry import SkillRegistry
+from brain_client.skills.runner import PrimitiveRunner
+from brain_client.skills.types import SkillOutput, SkillResult
+
+JPEG = b"\xff\xd8\xff\xe0fakejpegbytes"
+
+FOUND = SearchVerdict(
+    query="the kitchen",
+    found=True,
+    explanation="counter with a kettle",
+    memory=Memory(id=3, x=1.5, y=-0.5, theta=1.57, stamp=1000.0),
+    image=JPEG,
+    latency_sec=1.2,
+    cached=True,
+)
+
+
+# ---------- action result mapping ----------
+
+
+def test_to_result_maps_a_found_verdict_completely():
+    result = _to_result(FOUND)
+    assert result.found and result.cached and result.error == ""
+    assert (result.x, result.y, result.theta, result.seen_stamp) == (1.5, -0.5, 1.57, 1000.0)
+    assert base64.b64decode(result.image_b64) == JPEG
+    assert result.message == verdict_text(FOUND)
+    assert "navigate_to_position" in result.message
+
+
+def test_to_result_maps_errors_and_no_match():
+    error = _to_result(SearchVerdict(query="x", found=False, error="network down"))
+    assert not error.found and error.error == "network down" and error.image_b64 == ""
+    assert "failed" in error.message
+    no_match = _to_result(SearchVerdict(query="x", found=False, explanation="nothing like that"))
+    assert not no_match.found and no_match.error == "" and no_match.seen_stamp == 0.0
+    assert "nothing in the remembered views matches" in no_match.message
+
+
+# ---------- the SDK accessor ----------
+
+
+class FakeFuture:
+    """A future whose callback fires immediately — the whole chain runs inline."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def result(self):
+        return self._value
+
+    def add_done_callback(self, callback):
+        callback(self)
+
+
+def make_accessor(result_msg=None, *, accepted=True, server_up=True):
+    accessor = SpatialMemory.__new__(SpatialMemory)
+    accessor._logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
+    handle = SimpleNamespace(accepted=accepted, get_result_async=lambda: FakeFuture(SimpleNamespace(result=result_msg)))
+    accessor._client = SimpleNamespace(
+        wait_for_server=lambda timeout_sec: server_up,
+        send_goal_async=lambda goal: FakeFuture(handle),
+    )
+    return accessor
+
+
+def test_begin_delivers_a_typed_verdict_through_the_reader():
+    result_msg = SimpleNamespace(
+        found=True,
+        message="Found it.",
+        explanation="the counter",
+        error="",
+        x=1.5,
+        y=-0.5,
+        theta=1.57,
+        seen_stamp=1000.0,
+        image_b64=base64.b64encode(JPEG).decode(),
+        latency_sec=1.2,
+        cached=True,
+    )
+    reader = make_accessor(result_msg).begin("the kitchen")
+    verdict = reader()
+    assert verdict is not None and verdict.found and verdict.image == JPEG
+    assert verdict.x == 1.5 and verdict.cached and verdict.message == "Found it."
+
+
+def test_begin_unblocks_the_waiter_on_every_failure_path():
+    rejected = make_accessor(accepted=False).begin("x")()
+    assert rejected is not None and rejected.error == "memory search goal rejected"
+    down = make_accessor(server_up=False).begin("x")()
+    assert down is not None and "is the brain node running" in down.error
+    # A reader with no verdict yet reads None — wait_for's contract.
+    pending = SpatialMemory.__new__(SpatialMemory)
+    pending._logger = SimpleNamespace(error=lambda *a: None)
+    pending._client = SimpleNamespace(
+        wait_for_server=lambda timeout_sec: True,
+        send_goal_async=lambda goal: SimpleNamespace(add_done_callback=lambda cb: None),  # never resolves
+    )
+    assert pending.begin("x")() is None
+
+
+# ---------- the result-image channel ----------
+
+
+def test_skill_output_carries_an_optional_image():
+    assert SkillOutput("done").image is None
+    assert SkillOutput("found it", image=JPEG).image == JPEG
+
+
+def make_runner(events: list):
+    runner = PrimitiveRunner.__new__(PrimitiveRunner)
+    state = BrainState()
+    state.registry = SkillRegistry.from_metadata(
+        [{"id": "innate-os/search_memory", "name": "search_memory", "type": "code"}]
+    )
+    state.primitive_running = RunningSkill(primitive_name="search_memory", skill_id="innate-os/search_memory")
+    runner._state = state
+    runner._goal_handle = SimpleNamespace()
+    runner._generation = 0
+    runner._slot_lock = threading.Lock()
+    runner._logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
+    runner._stop_robot = lambda: None
+    runner._on_task_finished = lambda: None
+    runner._chat = SimpleNamespace(publish_task_status=lambda **kwargs: None, emit=lambda *a, **k: None)
+    runner.on_event = lambda status, name, detail=None, image=None: events.append((status, name, detail, image))
+    return runner
+
+
+def test_runner_decodes_the_result_image_into_the_brain_event():
+    events: list = []
+    runner = make_runner(events)
+    result = SimpleNamespace(
+        success=True,
+        success_type=SkillResult.SUCCESS.value,
+        skill_type="innate-os/search_memory",
+        message="Found it.",
+        image_b64=base64.b64encode(JPEG).decode(),
+    )
+    runner._on_result(SimpleNamespace(result=lambda: SimpleNamespace(result=result)), generation=0)
+    ((status, name, detail, image),) = events
+    assert status == "completed" and image == JPEG and detail == "Found it."
+
+
+def test_runner_passes_no_image_when_the_result_has_none():
+    events: list = []
+    runner = make_runner(events)
+    result = SimpleNamespace(
+        success=True,
+        success_type=SkillResult.SUCCESS.value,
+        skill_type="innate-os/search_memory",
+        message="nothing matched",
+        image_b64="",
+    )
+    runner._on_result(SimpleNamespace(result=lambda: SimpleNamespace(result=result)), generation=0)
+    ((status, _, _, image),) = events
+    assert status == "completed" and image is None

--- a/ros2_ws/src/brain/brain_client/test/test_runner_deactivation.py
+++ b/ros2_ws/src/brain/brain_client/test/test_runner_deactivation.py
@@ -25,7 +25,7 @@ def make_runner(running: RunningSkill | None, goal_handle=None):
     runner._stop_robot = lambda: None
     runner._on_task_finished = lambda: None
     runner._chat = SimpleNamespace(publish_task_status=lambda **kwargs: None)
-    runner.on_event = lambda status, name, detail=None: None
+    runner.on_event = lambda status, name, detail=None, image=None: None
     return runner, state
 
 

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
-"""Spatial memory: admission policy, the on-disk store, the recorder's gates,
-and the Gemini search with its context-cache lifecycle."""
+"""Spatial memory: admission policy, visit tracking, frame quality, the
+on-disk store, the recorder's gates, and the Gemini search with its
+context-cache lifecycle."""
 
 from __future__ import annotations
 
@@ -12,20 +13,54 @@ import time
 from dataclasses import replace
 from types import SimpleNamespace
 
+import cv2
+import numpy as np
 import pytest
 
 from brain_client.brain.memory_search import MemorySearch, verdict_text
 from brain_client.brain.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
 from brain_client.memory import recorder as recorder_module
+from brain_client.memory.quality import frame_worth_keeping
 from brain_client.memory.recorder import MemoryRecorder
 from brain_client.memory.selection import MAX_MEMORIES, plan_admission
 from brain_client.memory.store import Memory, MemoryStore
+from brain_client.state.map import Map
 
-JPEG = b"\xff\xd8\xff\xe0fakejpegbytes"
+
+def encoded(image: np.ndarray) -> bytes:
+    ok, buffer = cv2.imencode(".jpg", image)
+    assert ok
+    return buffer.tobytes()
+
+
+def frame(seed: int) -> bytes:
+    """A distinct, deterministic frame that passes the quality gates."""
+    rng = np.random.default_rng(seed)
+    return encoded(rng.integers(0, 255, size=(240, 320), dtype=np.uint8))
+
+
+GOOD_JPEG = frame(0)
+DARK_JPEG = encoded(np.full((240, 320), 5, dtype=np.uint8))
 
 
 def memory(id_: int, x: float, y: float = 0.0, theta: float = 0.0, stamp: float = 1000.0) -> Memory:
     return Memory(id=id_, x=x, y=y, theta=theta, stamp=stamp)
+
+
+def grid_of(cells: np.ndarray, resolution: float = 0.1) -> Map:
+    """A Map over a raw cell array; world (0,0) at the grid corner."""
+    return Map(
+        resolution=resolution,
+        width=cells.shape[1],
+        height=cells.shape[0],
+        origin_x=0.0,
+        origin_y=0.0,
+        raw_source=SimpleNamespace(data=cells.flatten().tolist()),
+    )
+
+
+def open_room(size: int = 30) -> np.ndarray:
+    return np.zeros((size, size), dtype=np.int8)
 
 
 # ================= admission policy =================
@@ -51,10 +86,62 @@ def test_distance_alone_makes_a_new_view():
     assert plan.record and plan.replace is None
 
 
-def test_stale_viewpoint_is_refreshed_in_place():
+def test_the_same_view_refreshes_once_aged():
     old = memory(1, 0.0, 0.0, stamp=1000.0)
-    plan = plan_admission([old], 0.1, 0.0, 0.05, stamp=1000.0 + 31 * 60)
+    plan = plan_admission([old], 0.1, 0.05, math.radians(8), stamp=1070.0)
     assert plan.record and plan.replace == old and plan.evict is None
+
+
+def test_a_recent_picture_is_not_rewritten():
+    old = memory(1, 0.0, 0.0, stamp=1000.0)
+    plan = plan_admission([old], 0.1, 0.05, math.radians(8), stamp=1030.0)
+    assert not plan.record
+
+
+def test_an_oblique_frame_never_replaces_a_straight_on_view():
+    # The mid-turn case: still redundant with the memory (heading < 100 deg),
+    # but no longer the same picture — skip, never overwrite.
+    old = memory(1, 0.5, 0.5, stamp=1000.0)
+    plan = plan_admission([old], 0.5, 0.5, math.radians(40), stamp=2000.0, grid=grid_of(open_room()))
+    assert not plan.record
+
+
+def test_a_same_heading_frame_with_clear_sight_refreshes_from_a_step_back():
+    # Same aim, displaced along it, free space between the capture points: the
+    # same information, one frame merely a bit further away — it may update.
+    old = memory(1, 0.5, 0.5, stamp=1000.0)
+    plan = plan_admission([old], 1.3, 0.5, math.radians(5), stamp=2000.0, grid=grid_of(open_room()))
+    assert plan.record and plan.replace == old
+
+
+def test_a_side_step_off_the_view_axis_never_refreshes():
+    # Same aim, but displaced ACROSS it: the frame slides new information into
+    # view even though both cameras point the same way.
+    old = memory(1, 0.5, 0.5, theta=0.0, stamp=1000.0)
+    plan = plan_admission([old], 0.5, 1.3, math.radians(5), stamp=2000.0, grid=grid_of(open_room()))
+    assert not plan.record
+
+
+def test_a_wall_between_the_capture_points_blocks_the_refresh():
+    cells = open_room()
+    cells[:, 9] = 100  # a wall at world x = 0.9-1.0
+    old = memory(1, 0.5, 0.5, stamp=1000.0)
+    plan = plan_admission([old], 1.3, 0.5, math.radians(5), stamp=2000.0, grid=grid_of(cells))
+    assert not plan.record
+
+
+def test_unknown_cells_between_the_capture_points_block_the_refresh():
+    cells = open_room()
+    cells[:, 9] = -1  # the map cannot vouch for what is here
+    old = memory(1, 0.5, 0.5, stamp=1000.0)
+    plan = plan_admission([old], 1.3, 0.5, math.radians(5), stamp=2000.0, grid=grid_of(cells))
+    assert not plan.record
+
+
+def test_without_a_grid_only_a_tight_pose_match_refreshes():
+    old = memory(1, 0.0, 0.0, stamp=1000.0)
+    assert not plan_admission([old], 0.6, 0.0, 0.0, stamp=2000.0).record
+    assert plan_admission([old], 0.2, 0.0, 0.0, stamp=2000.0).replace == old
 
 
 def test_at_capacity_evicts_the_older_of_the_closest_pair():
@@ -63,6 +150,31 @@ def test_at_capacity_evicts_the_older_of_the_closest_pair():
     newer_twin = memory(91, x=200.4, stamp=200.0)
     plan = plan_admission([*spread, older_twin, newer_twin], -5.0, 0.0, 0.0, stamp=1000.0)
     assert plan.record and plan.evict == older_twin
+
+
+# ================= frame quality =================
+
+
+def test_a_textured_bright_frame_is_kept():
+    assert frame_worth_keeping(GOOD_JPEG)
+
+
+def test_a_dark_frame_is_rejected():
+    assert not frame_worth_keeping(DARK_JPEG)
+
+
+def test_a_featureless_frame_is_rejected():
+    assert not frame_worth_keeping(encoded(np.full((240, 320), 128, dtype=np.uint8)))
+
+
+def test_a_blurred_frame_is_rejected():
+    rng = np.random.default_rng(3)
+    noise = rng.integers(0, 255, size=(240, 320), dtype=np.uint8)
+    assert not frame_worth_keeping(encoded(cv2.GaussianBlur(noise, (31, 31), 0)))
+
+
+def test_undecodable_bytes_are_rejected():
+    assert not frame_worth_keeping(b"\xff\xd8not-a-jpeg")
 
 
 # ================= store =================
@@ -159,6 +271,28 @@ def test_replace_keeps_the_slot_and_updates_everything_else(data_dir):
     assert path is not None and path.read_bytes() == b"jpg-new"
 
 
+def test_clear_forgets_the_map_for_good(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.add(4.0, 2.0, 0.5, 1001.0, b"jpg-two")
+    assert store.clear() == 2
+    assert store.snapshot().memories == ()
+    assert list((data_dir / "spatial_memory" / "A").glob("*.jpg")) == []
+
+    reloaded = MemoryStore(data_dir)
+    reloaded.switch_map("A.yaml")
+    assert reloaded.snapshot().memories == ()  # the wipe was committed, not just in-memory
+    fresh = reloaded.add(1.0, 2.0, 0.5, 2000.0, b"jpg-new")
+    assert fresh is not None and fresh.id == 1  # ids restart with the fresh memory
+
+
+def test_clear_without_a_map_is_a_noop(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map(None)
+    assert store.clear() == 0
+
+
 def test_without_a_map_nothing_is_recorded(data_dir):
     store = MemoryStore(data_dir)
     store.switch_map(None)
@@ -184,10 +318,11 @@ def test_corrupt_index_resets_cleanly(data_dir):
 def clock(monkeypatch):
     state = SimpleNamespace(now=1000.0)
     monkeypatch.setattr(recorder_module.time, "monotonic", lambda: state.now)
+    monkeypatch.setattr(recorder_module.time, "time", lambda: state.now)  # stamps drive the refresh age gate
     return state
 
 
-def make_recorder(data_dir, published: list | None = None):
+def make_recorder(data_dir, published: list | None = None, pose: SimpleNamespace | None = None):
     logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
     node = SimpleNamespace(
         get_logger=lambda: logger,
@@ -200,12 +335,13 @@ def make_recorder(data_dir, published: list | None = None):
         current_map_topic="/nav/current_map",
         amcl_pose_topic="/amcl_pose",
     )
+    pose = pose if pose is not None else SimpleNamespace(xyt=(1.0, 2.0, 0.5))
     store = MemoryStore(data_dir)
     recorder = MemoryRecorder(
         node,
         config,
         store=store,
-        pose_tracker=SimpleNamespace(map_pose_xyt=lambda: (1.0, 2.0, 0.5)),
+        pose_tracker=SimpleNamespace(map_pose_xyt=lambda: pose.xyt),
         warm_search=None,
         cache_state=lambda: "warm",
         positions_pub=SimpleNamespace(publish=(published if published is not None else []).append),
@@ -218,8 +354,21 @@ def see_confident_world(recorder, clock):
     recorder._on_current_map(SimpleNamespace(data="A.yaml"))
     recorder._on_nav_mode(SimpleNamespace(data="navigation"))
     recorder._on_amcl_pose(SimpleNamespace(pose=SimpleNamespace(covariance=_covariance(0.02, 0.02, 0.05))))
-    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
     recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -10.0})))
+
+
+def observe(recorder, clock, jpeg: bytes, advance: float = 1.0):
+    """One recorder tick seeing this frame, the clock advanced past the last."""
+    clock.now += advance
+    recorder._on_image(SimpleNamespace(data=jpeg))
+    recorder.tick()
+
+
+def stored_image(store: MemoryStore, memory_id: int) -> bytes:
+    path = store.image_path(memory_id)
+    assert path is not None
+    return path.read_bytes()
 
 
 def _covariance(var_x: float, var_y: float, var_yaw: float) -> list[float]:
@@ -234,7 +383,7 @@ def test_confidence_must_hold_before_recording(data_dir, clock):
     recorder.tick()  # starts the confidence clock
     assert store.snapshot().memories == ()
     clock.now += 3.1
-    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
     recorder.tick()
     assert len(store.snapshot().memories) == 1
 
@@ -249,11 +398,11 @@ def test_a_covariance_spike_resets_the_clock(data_dir, clock):
     recorder._on_amcl_pose(SimpleNamespace(pose=SimpleNamespace(covariance=_covariance(0.02, 0.02, 0.05))))
     recorder.tick()  # confident again: the clock restarts here, 2s in
     clock.now += 2.9
-    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
     recorder.tick()
     assert store.snapshot().memories == ()
     clock.now += 0.3
-    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
     recorder.tick()
     assert len(store.snapshot().memories) == 1
 
@@ -265,7 +414,7 @@ def test_only_navigation_mode_records(data_dir, clock):
     for _ in range(5):
         recorder.tick()
         clock.now += 2.0
-        recorder._on_image(SimpleNamespace(data=b"live-frame"))
+        recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
     assert store.snapshot().memories == ()
 
 
@@ -275,7 +424,7 @@ def test_looking_at_the_floor_blocks_capture(data_dir, clock):
     recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -45.0})))
     recorder.tick()
     clock.now += 3.1
-    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
     recorder.tick()
     assert store.snapshot().memories == ()
 
@@ -295,13 +444,98 @@ def test_positions_mirror_publishes_map_poses_and_cache_state(data_dir, clock):
     see_confident_world(recorder, clock)
     recorder.tick()
     clock.now += 3.1
-    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
     recorder.tick()
     payload = json.loads(published[-1].data)
     assert payload["map"] == "A.yaml" and payload["cache"] == "warm"
     (position,) = payload["positions"]
     assert position["id"] == 1 and position["x"] == 1.0 and position["y"] == 2.0 and position["theta"] == 0.5
     assert position["stamp"] > 0
+
+
+def settled_recorder(data_dir, clock, pose: SimpleNamespace):
+    """A recorder past the confidence hold, its first viewpoint just recorded with frame(1)."""
+    recorder, store = make_recorder(data_dir, pose=pose)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    clock.now += 3.1
+    observe(recorder, clock, frame(1), advance=0.0)
+    assert len(store.snapshot().memories) == 1
+    return recorder, store
+
+
+def test_a_new_viewpoint_needs_a_keepable_frame(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    clock.now += 3.1
+    observe(recorder, clock, DARK_JPEG, advance=0.0)
+    assert store.snapshot().memories == ()
+    observe(recorder, clock, frame(1))
+    assert len(store.snapshot().memories) == 1
+
+
+def test_dwelling_rewrites_nothing_within_the_refresh_window(data_dir, clock):
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.5))
+    recorder, store = settled_recorder(data_dir, clock, pose)
+    observe(recorder, clock, frame(2))
+    observe(recorder, clock, frame(3))
+    assert stored_image(store, 1) == frame(1)
+
+
+def test_an_aged_same_view_refreshes_with_the_current_frame(data_dir, clock):
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.5))
+    recorder, store = settled_recorder(data_dir, clock, pose)
+    observe(recorder, clock, frame(2), advance=61.0)  # staring at the same spot a minute later
+    assert stored_image(store, 1) == frame(2)
+    assert len(store.snapshot().memories) == 1
+
+
+def test_a_turned_away_frame_never_overwrites(data_dir, clock):
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.5))
+    recorder, store = settled_recorder(data_dir, clock, pose)
+    pose.xyt = (1.0, 2.0, 0.5 + math.radians(40))  # mid-turn: redundant, but a different picture
+    observe(recorder, clock, frame(2), advance=61.0)
+    assert stored_image(store, 1) == frame(1)
+    assert len(store.snapshot().memories) == 1
+
+
+def grid_msg(cells: np.ndarray, resolution: float = 0.1):
+    identity = SimpleNamespace(w=1.0, x=0.0, y=0.0, z=0.0)
+    origin = SimpleNamespace(position=SimpleNamespace(x=0.0, y=0.0), orientation=identity)
+    info = SimpleNamespace(resolution=resolution, width=cells.shape[1], height=cells.shape[0], origin=origin)
+    return SimpleNamespace(info=info, data=cells.flatten().tolist())
+
+
+def test_the_grid_widens_the_refresh_to_clear_sight_lines(data_dir, clock):
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.0))
+    recorder, store = settled_recorder(data_dir, clock, pose)
+    recorder._on_map(grid_msg(open_room(40)))
+    pose.xyt = (1.8, 2.0, 0.0)  # a step along the aim, nothing in between
+    observe(recorder, clock, frame(2), advance=61.0)
+    assert stored_image(store, 1) == frame(2)
+    assert len(store.snapshot().memories) == 1
+
+
+def test_a_wall_on_the_sight_line_blocks_the_refresh(data_dir, clock):
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.0))
+    recorder, store = settled_recorder(data_dir, clock, pose)
+    cells = open_room(40)
+    cells[:, 14] = 100  # a wall at world x = 1.4-1.5
+    recorder._on_map(grid_msg(cells))
+    pose.xyt = (1.8, 2.0, 0.0)
+    observe(recorder, clock, frame(2), advance=61.0)
+    assert stored_image(store, 1) == frame(1)
+    assert len(store.snapshot().memories) == 1
+
+
+def test_bad_frames_never_overwrite_a_view(data_dir, clock):
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.5))
+    recorder, store = settled_recorder(data_dir, clock, pose)
+    observe(recorder, clock, DARK_JPEG, advance=61.0)  # refresh is due, but the lights are off
+    assert stored_image(store, 1) == frame(1)
+    observe(recorder, clock, frame(2))  # the first keepable frame lands it
+    assert stored_image(store, 1) == frame(2)
 
 
 # ================= memory search =================

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -184,6 +184,7 @@ def make_recorder(data_dir, published: list | None = None):
         store=store,
         pose_tracker=SimpleNamespace(map_pose_xyt=lambda: (1.0, 2.0, 0.5)),
         warm_search=None,
+        cache_state=lambda: "warm",
         positions_pub=SimpleNamespace(publish=(published if published is not None else []).append),
     )
     return recorder, store
@@ -265,7 +266,7 @@ def test_a_stale_frame_blocks_capture(data_dir, clock):
     assert store.snapshot().memories == ()
 
 
-def test_positions_mirror_publishes_map_and_poses(data_dir, clock):
+def test_positions_mirror_publishes_map_poses_and_cache_state(data_dir, clock):
     published: list = []
     recorder, store = make_recorder(data_dir, published)
     see_confident_world(recorder, clock)
@@ -274,8 +275,10 @@ def test_positions_mirror_publishes_map_and_poses(data_dir, clock):
     recorder._on_image(SimpleNamespace(data=b"live-frame"))
     recorder.tick()
     payload = json.loads(published[-1].data)
-    assert payload["map"] == "A.yaml"
-    assert payload["positions"] == [{"x": 1.0, "y": 2.0, "theta": 0.5}]
+    assert payload["map"] == "A.yaml" and payload["cache"] == "warm"
+    (position,) = payload["positions"]
+    assert position["id"] == 1 and position["x"] == 1.0 and position["y"] == 2.0 and position["theta"] == 0.5
+    assert position["stamp"] > 0
 
 
 # ================= memory search =================
@@ -423,3 +426,53 @@ def test_warm_waits_for_recording_to_settle(data_dir):
     search.warm()
     time.sleep(0.05)
     assert fake.creates == []
+
+
+def test_search_mirrors_verdicts_to_the_ui(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "kitchen"})
+    reports: list[dict] = []
+    search.on_result = reports.append
+    search.search("the kitchen")
+    (report,) = reports
+    assert report["found"] and report["id"] == 2 and report["x"] == 3.0 and report["cached"]
+    assert report["query"] == "the kitchen" and report["explanation"] == "kitchen"
+    assert report["latency_sec"] >= 0 and report["stamp"] > 0 and report["seen_stamp"] == 1001.0
+
+    fake.verdict = {"found": False, "frame": 0, "explanation": "no such view"}
+    search.search("a unicorn")
+    assert reports[-1] == {
+        "query": "a unicorn",
+        "found": False,
+        "explanation": "no such view",
+        "latency_sec": reports[-1]["latency_sec"],
+        "cached": True,
+        "stamp": reports[-1]["stamp"],
+    }
+
+
+def test_a_broken_ui_mirror_does_not_break_the_search(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+
+    def explode(payload: dict) -> None:
+        raise RuntimeError("publisher gone")
+
+    search.on_result = explode
+    text, image = search.search("anything")
+    assert image == b"jpg-1"  # the search itself still succeeded
+
+
+def test_cache_state_reflects_the_lifecycle(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    assert search.cache_state() == "cold"
+    search.search("first")
+    assert search.cache_state() == "warm"
+    store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
+    assert search.cache_state() == "cold"
+
+    small, _, _ = make_search(data_dir / "small", frames=0)
+    assert small.cache_state() == "inline"
+
+    unsupported, fake2, _ = make_search(data_dir / "unsup", frames=6)
+    fake2.create_error = GeminiHttpError(404, "no endpoint")
+    unsupported.search("first")
+    assert unsupported.cache_state() == "unsupported"

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -104,6 +104,27 @@ def test_remapping_under_the_same_name_wipes_stale_memories(data_dir):
     assert list((data_dir / "spatial_memory" / "A").glob("*.jpg")) == []
 
 
+def test_a_same_name_remap_is_caught_without_a_map_switch(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.switch_map("A.yaml")  # the every-tick call: a no-op while the file is unchanged
+    assert len(store.snapshot().memories) == 1
+
+    (data_dir / "maps" / "A.pgm").write_bytes(b"remapped-content")
+    store.switch_map("A.yaml")
+    assert store.snapshot().memories == ()
+
+
+def test_a_touched_but_identical_map_keeps_memories(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    (data_dir / "maps" / "A.pgm").write_bytes(b"map-A-content")
+    store.switch_map("A.yaml")
+    assert len(store.snapshot().memories) == 1
+
+
 def test_maps_have_isolated_memories(data_dir):
     store = MemoryStore(data_dir)
     store.switch_map("A.yaml")
@@ -346,7 +367,9 @@ def build_cache(search: MemorySearch) -> None:
 
 def upload_frames(search: MemorySearch) -> None:
     """Synchronous stand-in for maintain()'s background upload round."""
-    search._files._upload(search._files._pending())
+    pending, scanned_dir = search._files._pending()
+    if scanned_dir is not None:
+        search._files._upload(pending, scanned_dir)
 
 
 def part_kinds(body: dict) -> list[str]:
@@ -510,6 +533,21 @@ def test_warm_waits_for_recording_to_settle(data_dir):
     assert fake.creates == []
 
 
+def test_warm_rebuilds_mid_burst_once_the_delta_grows_too_big(data_dir):
+    # The quiet window must not let the stale-cache delta grow without bound
+    # during a long recording tour — past the threshold, rebuild anyway.
+    search, fake, store = make_search(data_dir, frames=6)
+    build_cache(search)
+    for i in range(10):
+        store.add(40.0 + i, 0.0, 0.0, 3000.0 + i, b"jpg-burst")
+    assert time.monotonic() - store.last_change_monotonic < 1.0  # mid-burst
+    search.warm()
+    deadline = time.time() + 2.0
+    while len(fake.creates) < 2 and time.time() < deadline:
+        time.sleep(0.01)
+    assert len(fake.creates) == 2
+
+
 def test_search_mirrors_verdicts_to_the_ui(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "kitchen"})
     build_cache(search)
@@ -636,6 +674,35 @@ def test_a_transient_upload_failure_retries_next_round(data_dir):
     assert len(fake.uploads) == 3
 
 
+def test_a_failed_round_backs_off_before_retrying(data_dir):
+    # The 1 Hz tick must not re-POST a full frame every second against a
+    # broken endpoint — a failed round arms a cooldown that maintain() honors.
+    search, fake, _ = make_search(data_dir, frames=3)
+    fake.upload_error = GeminiHttpError(500, "hiccup")
+    upload_frames(search)  # fails, arms the cooldown
+    fake.upload_error = None
+    search._files.maintain()  # inside the cooldown: returns before spawning
+    assert fake.uploads == []
+    search._files._retry_at = 0.0  # cooldown over
+    upload_frames(search)
+    assert len(fake.uploads) == 3
+
+
+def test_a_cache_built_from_references_expires_with_its_files(data_dir):
+    # A cache embedding fileData must not outlive the uploads it references —
+    # its expiry is capped by the oldest file, not the 12 h cache TTL.
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    files = search._files
+    with files._lock:
+        files._records = {i: replace(r, uploaded_at=r.uploaded_at - 46 * 3600) for i, r in files._records.items()}
+    build_cache(search)
+    cache = search._cache
+    assert cache is not None
+    remaining = cache.expires_monotonic - time.monotonic()
+    assert 0 < remaining < 3600  # ~1 h of file life left, minus the safety margin
+
+
 def test_the_cache_builds_from_file_references(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     upload_frames(search)
@@ -676,3 +743,29 @@ def test_labels_and_verdicts_use_stable_store_ids(data_dir):
     labels = [part["text"] for part in parts if "text" in part][:-1]  # the last text part is the question
     assert labels[0].startswith("Frame 2 ")  # ids, not positions, after the eviction
     assert verdict.found and verdict.memory is not None and verdict.memory.id == 5
+
+
+def mutate_after_generate(search: MemorySearch, fake: FakeGemini, mutate) -> None:
+    """Rewire the search's transport so the store mutates while the answer is in flight."""
+    inner = fake.rest.post
+
+    def post_then_mutate(path: str, body: dict) -> dict:
+        response = inner(path, body)
+        mutate()
+        return response
+
+    search._rest = GeminiRest(post=post_then_mutate, delete=fake.rest.delete, upload=fake.rest.upload)
+
+
+def test_a_map_switch_mid_search_voids_the_verdict(data_dir):
+    search, fake, store = make_search(data_dir, frames=2)
+    mutate_after_generate(search, fake, lambda: store.switch_map("B.yaml"))
+    verdict = search.search("the kitchen")
+    assert not verdict.found and "map changed" in verdict.error
+
+
+def test_an_eviction_mid_search_misses_cleanly(data_dir):
+    search, fake, store = make_search(data_dir, frames=2)  # the fake's verdict picks frame 1
+    mutate_after_generate(search, fake, lambda: store.evict(memory_with_id(store, 1)))
+    verdict = search.search("the kitchen")
+    assert not verdict.found and not verdict.error

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import json
 import math
+import threading
 import time
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -295,10 +297,13 @@ class FakeGemini:
         self.creates: list[dict] = []
         self.generates: list[dict] = []
         self.deletes: list[str] = []
+        self.uploads: list[bytes] = []
         self.create_error: GeminiHttpError | None = None
         self.cached_generate_error: GeminiHttpError | None = None
+        self.upload_error: GeminiHttpError | None = None
+        self.upload_gate: threading.Event | None = None  # when set, uploads block on it
         self.verdict = verdict if verdict is not None else {"found": True, "frame": 1, "explanation": "matches"}
-        self.rest = GeminiRest(post=self._post, delete=self._delete)
+        self.rest = GeminiRest(post=self._post, delete=self._delete, upload=self._upload)
 
     def _post(self, path: str, body: dict) -> dict:
         if path == CACHED_CONTENTS_PATH:
@@ -315,6 +320,14 @@ class FakeGemini:
         self.deletes.append(path)
         return {}
 
+    def _upload(self, path: str, data: bytes, mime: str) -> dict:
+        if self.upload_gate is not None:
+            self.upload_gate.wait(timeout=5)
+        if self.upload_error is not None:
+            raise self.upload_error
+        self.uploads.append(data)
+        return {"file": {"name": f"files/f{len(self.uploads)}", "uri": f"https://files/f{len(self.uploads)}"}}
+
 
 def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[MemorySearch, FakeGemini, MemoryStore]:
     store = MemoryStore(data_dir)
@@ -326,28 +339,81 @@ def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[Mem
     return MemorySearch(store, fake.rest, model="test-model", logger=logger), fake, store
 
 
-def test_cache_is_created_once_and_reused(data_dir):
+def build_cache(search: MemorySearch) -> None:
+    """Synchronous stand-in for warm()'s background cache rebuild."""
+    search._ensure_cache(search._store.snapshot())
+
+
+def upload_frames(search: MemorySearch) -> None:
+    """Synchronous stand-in for maintain()'s background upload round."""
+    search._files._upload(search._files._pending())
+
+
+def part_kinds(body: dict) -> list[str]:
+    return [next(iter(part)) for part in body["contents"][0]["parts"]]
+
+
+def memory_with_id(store: MemoryStore, memory_id: int):
+    (memory,) = [m for m in store.snapshot().memories if m.id == memory_id]
+    return memory
+
+
+def test_search_rides_a_fresh_cache_with_only_the_question(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "the kitchen"})
+    build_cache(search)
     verdict = search.search("the kitchen")
     search.search("the kitchen again")
     assert len(fake.creates) == 1
     assert [body.get("cachedContent") for body in fake.generates] == ["cachedContents/c1", "cachedContents/c1"]
+    assert part_kinds(fake.generates[0]) == ["text"]  # fresh cache: no frame bytes at all
     assert verdict.found and verdict.cached and verdict.image == b"jpg-2"
     assert verdict.memory is not None and verdict.memory.x == 3.0
-    assert "x=3.00m" in verdict_text(verdict) and "the kitchen" in verdict_text(verdict)
-    assert "navigate_to_position" in verdict_text(verdict)
+    assert "x=3.00m" in verdict_text(verdict) and "navigate_to_position" in verdict_text(verdict)
 
 
-def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
+def test_a_search_never_builds_the_cache(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    search.search("anything")
+    assert fake.creates == []  # a cold search answers from frames; rebuilds belong to warm()
+
+
+def test_a_stale_cache_serves_with_a_delta_of_new_frames(data_dir):
+    search, fake, store = make_search(data_dir, frames=6, verdict={"found": True, "frame": 7, "explanation": "new"})
+    build_cache(search)
+    store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")  # id 7
+    verdict = search.search("the new spot")
+    assert len(fake.creates) == 1  # the search path never rebuilds
+    body = fake.generates[-1]
+    assert body["cachedContent"] == "cachedContents/c1"
+    assert part_kinds(body) == ["inlineData", "text", "text"]  # the new frame, its label, the question
+    assert "Frame 7" in body["contents"][0]["parts"][1]["text"]
+    assert verdict.found and verdict.cached
+    assert verdict.memory is not None and verdict.memory.id == 7 and verdict.image == b"jpg-late"
+
+
+def test_delta_notes_supersede_and_retire_frames(data_dir):
     search, fake, store = make_search(data_dir, frames=6)
-    search.search("first")
+    build_cache(search)
+    store.replace(memory_with_id(store, 2), 3.0, 0.0, 0.0, 5000.0, b"jpg-2-new")
+    store.evict(memory_with_id(store, 3))
+    search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    texts = [part["text"] for part in parts if "text" in part]
+    assert any("Frame 2 was re-captured" in text for text in texts)
+    assert any("Frame 3 no longer exists" in text for text in texts)
+    assert sum("inlineData" in part for part in parts) == 1  # only the re-captured frame's bytes travel
+
+
+def test_warm_rebuilds_a_stale_cache_and_deletes_the_old(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    build_cache(search)
     store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
-    search.search("second")
+    build_cache(search)
     assert len(fake.creates) == 2
     assert fake.deletes == ["/v1beta/cachedContents/c1"]
 
 
-def test_few_frames_answer_inline_without_caching(data_dir):
+def test_few_frames_answer_from_frames_without_caching(data_dir):
     search, fake, _ = make_search(data_dir, frames=3)
     verdict = search.search("anything")
     assert fake.creates == []
@@ -360,35 +426,36 @@ def test_few_frames_answer_inline_without_caching(data_dir):
 def test_unsupported_backend_disables_caching_permanently(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     fake.create_error = GeminiHttpError(404, "no such endpoint")
+    build_cache(search)
+    build_cache(search)
+    assert len(fake.creates) == 1  # latched after the first answer
     verdict = search.search("first")
-    search.search("second")
-    assert len(fake.creates) == 1  # never attempted again
-    assert all("cachedContent" not in body for body in fake.generates)
+    assert "cachedContent" not in fake.generates[-1]
     assert verdict.image == b"jpg-1"
 
 
 def test_failed_cache_creation_retries_only_after_the_memory_changes(data_dir):
     search, fake, store = make_search(data_dir, frames=6)
     fake.create_error = GeminiHttpError(400, "cache too small")
-    search.search("first")
-    search.search("second")
+    build_cache(search)
+    build_cache(search)
     assert len(fake.creates) == 1
     fake.create_error = None
     store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
-    search.search("third")
+    build_cache(search)
     assert len(fake.creates) == 2
 
 
-def test_a_dead_cache_falls_back_inline_and_is_forgotten(data_dir):
+def test_a_dead_cache_falls_back_and_is_forgotten(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
-    search.search("first")
+    build_cache(search)
     fake.cached_generate_error = GeminiHttpError(403, "cache expired")
     verdict = search.search("second")
     assert verdict.image == b"jpg-1" and not verdict.cached
-    assert "cachedContent" not in fake.generates[-1]  # answered inline
+    assert "cachedContent" not in fake.generates[-1]  # answered from frames within the same search
     fake.cached_generate_error = None
-    search.search("third")
-    assert len(fake.creates) == 2  # the dead handle was dropped, a fresh cache built
+    build_cache(search)
+    assert len(fake.creates) == 2  # the dead handle was dropped; warm rebuilt
 
 
 def test_no_match_is_a_clean_verdict_not_an_error(data_dir):
@@ -412,7 +479,7 @@ def test_a_transport_crash_becomes_an_error_verdict_not_an_exception(data_dir):
     def explode(path: str, body: dict) -> dict:
         raise RuntimeError("network down")
 
-    search._rest = GeminiRest(post=explode, delete=lambda path: {})
+    search._rest = GeminiRest(post=explode, delete=lambda path: {}, upload=lambda path, data, mime: {})
     verdict = search.search("anything")
     assert not verdict.found and "network down" in verdict.error
 
@@ -445,6 +512,7 @@ def test_warm_waits_for_recording_to_settle(data_dir):
 
 def test_search_mirrors_verdicts_to_the_ui(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "kitchen"})
+    build_cache(search)
     reports: list[dict] = []
     search.on_result = reports.append
     search.search("the kitchen")
@@ -479,15 +547,132 @@ def test_a_broken_ui_mirror_does_not_break_the_search(data_dir):
 def test_cache_state_reflects_the_lifecycle(data_dir):
     search, fake, store = make_search(data_dir, frames=6)
     assert search.cache_state() == "cold"
-    search.search("first")
+    build_cache(search)
     assert search.cache_state() == "warm"
     store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
-    assert search.cache_state() == "cold"
+    assert search.cache_state() == "warm"  # stale-but-usable: the delta keeps recall instant
 
     small, _, _ = make_search(data_dir / "small", frames=0)
     assert small.cache_state() == "inline"
 
     unsupported, fake2, _ = make_search(data_dir / "unsup", frames=6)
     fake2.create_error = GeminiHttpError(404, "no endpoint")
-    unsupported.search("first")
+    build_cache(unsupported)
     assert unsupported.cache_state() == "unsupported"
+
+
+# ================= files tier =================
+
+
+def test_frames_upload_once_and_ride_as_file_references(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    assert len(fake.uploads) == 6
+    upload_frames(search)
+    assert len(fake.uploads) == 6  # nothing left to do
+    search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    file_parts = [part for part in parts if "fileData" in part]
+    assert len(file_parts) == 6 and not any("inlineData" in part for part in parts)
+    assert file_parts[0]["fileData"]["fileUri"].startswith("https://files/")
+
+
+def test_the_upload_registry_survives_a_restart(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    reborn, fake2, _ = make_search(data_dir, frames=0)  # same map dir, fresh process
+    upload_frames(reborn)
+    assert fake2.uploads == []  # every frame is already server-side
+
+
+def test_an_aging_upload_is_refreshed_before_server_expiry(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    files = search._files
+    with files._lock:
+        files._records = {i: replace(r, uploaded_at=r.uploaded_at - 41 * 3600) for i, r in files._records.items()}
+    upload_frames(search)
+    assert len(fake.uploads) == 12
+
+
+def test_an_expired_reference_rides_inline_instead(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+    upload_frames(search)
+    files = search._files
+    with files._lock:
+        files._records = {i: replace(r, uploaded_at=r.uploaded_at - 47.5 * 3600) for i, r in files._records.items()}
+    search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    assert not any("fileData" in part for part in parts)  # too old to trust server-side
+    assert sum("inlineData" in part for part in parts) == 3
+
+
+def test_a_refreshed_frame_invalidates_its_upload(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    upload_frames(search)
+    store.replace(memory_with_id(store, 2), 3.0, 0.0, 0.0, 5000.0, b"jpg-2-new")
+    upload_frames(search)
+    assert len(fake.uploads) == 7 and fake.uploads[-1] == b"jpg-2-new"
+
+
+def test_upload_latch_on_unsupported_backend(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    fake.upload_error = GeminiHttpError(404, "no upload passthrough")
+    upload_frames(search)
+    assert search._files.unsupported and fake.uploads == []
+    search._files.maintain()  # latched: no thread is even spawned
+    search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    assert sum("inlineData" in part for part in parts) == 6  # exactly the pre-files behavior
+
+
+def test_a_transient_upload_failure_retries_next_round(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+    fake.upload_error = GeminiHttpError(500, "hiccup")
+    upload_frames(search)
+    assert not search._files.unsupported and fake.uploads == []
+    fake.upload_error = None
+    upload_frames(search)
+    assert len(fake.uploads) == 3
+
+
+def test_the_cache_builds_from_file_references(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    build_cache(search)
+    (create,) = fake.creates
+    parts = create["contents"][0]["parts"]
+    assert sum("fileData" in part for part in parts) == 6 and not any("inlineData" in part for part in parts)
+
+
+def test_a_not_yet_uploaded_frame_rides_inline_beside_references(data_dir):
+    search, fake, store = make_search(data_dir, frames=3)
+    upload_frames(search)
+    store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
+    search.search("anything")  # before any maintenance round reaches the new frame
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    assert sum("fileData" in part for part in parts) == 3
+    assert sum("inlineData" in part for part in parts) == 1
+
+
+def test_search_never_waits_for_maintenance(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    fake.upload_gate = threading.Event()
+    search._files.maintain()  # the background round is now stuck on the gate
+    try:
+        verdict = search.search("anything")  # must conclude while the upload hangs
+        assert verdict.found
+    finally:
+        fake.upload_gate.set()
+    assert search._files._busy.acquire(timeout=2)  # the round finishes once released
+    search._files._busy.release()
+
+
+def test_labels_and_verdicts_use_stable_store_ids(data_dir):
+    search, fake, store = make_search(data_dir, frames=6, verdict={"found": True, "frame": 5, "explanation": "there"})
+    store.evict(memory_with_id(store, 1))
+    verdict = search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    labels = [part["text"] for part in parts if "text" in part][:-1]  # the last text part is the question
+    assert labels[0].startswith("Frame 2 ")  # ids, not positions, after the eviction
+    assert verdict.found and verdict.memory is not None and verdict.memory.id == 5

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -17,6 +17,7 @@ import cv2
 import numpy as np
 import pytest
 
+from brain_client.brain import memory_search as memory_search_module
 from brain_client.brain.memory_search import MemorySearch, verdict_text
 from brain_client.brain.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
 from brain_client.memory import recorder as recorder_module
@@ -173,11 +174,35 @@ def test_a_fully_painted_wedge_is_skipped():
     assert not plan.record
 
 
-def test_a_pose_that_paints_nothing_earns_no_slot():
+def test_a_wall_closeup_earns_a_slot_where_the_wall_is_unknown():
     cells = open_room()
     cells[:, :2] = 100  # a wall along world x < 0.2
     plan = plan_admission([], 0.35, 1.5, math.pi, stamp=1000.0, grid=grid_of(cells), coverage=Coverage())
-    assert not plan.record  # unpainted, but nose against the wall: almost no floor in view
+    assert plan.record  # cramped, but nothing shows this wall yet — a closeup beats nothing
+
+
+def test_wall_closeups_do_not_pile_up():
+    cells = open_room()
+    cells[:, :2] = 100
+    seen = memory(1, 0.35, 1.5, theta=math.pi, stamp=1000.0)
+    plan = plan_admission([seen], 0.35, 1.5, math.pi, stamp=1010.0, grid=grid_of(cells), coverage=Coverage())
+    assert not plan.record  # the wall is known: a cramped view must be nearly all new
+
+
+def test_a_blind_pose_earns_no_slot():
+    cells = open_room()
+    cells[:, 10:] = 100  # solid mass from x = 1.0
+    plan = plan_admission([], 1.05, 1.5, 0.0, stamp=1000.0, grid=grid_of(cells), coverage=Coverage())
+    assert not plan.record
+
+
+def test_the_further_back_shot_outlives_the_closeups_it_subsumes():
+    cells = open_room(60)
+    cells[:, 35] = 100  # a wall at world x = 3.5
+    wide = memory(1, 1.0, 3.0, theta=0.0)
+    twin = memory(2, 1.0, 3.0, theta=0.0)  # zeroes the wide view's unique paint, like the closeup's
+    closeup = memory(3, 3.0, 3.0, theta=0.0)  # against the wall, inside the wide view
+    assert Coverage().least_unique([wide, twin, closeup], grid_of(cells)) == closeup
 
 
 def test_at_capacity_the_most_replaceable_paint_makes_room(monkeypatch):
@@ -346,6 +371,19 @@ def test_without_a_map_nothing_is_recorded(data_dir):
     assert store.snapshot().memories == ()
 
 
+def test_a_transiently_unreadable_map_file_never_wipes(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(1.0, 2.0, 0.5, 1000.0, GOOD_JPEG)
+    (data_dir / "maps" / "A.pgm").unlink()  # a rewrite window or IO hiccup, not a re-map
+    store.switch_map("A.yaml")
+    (data_dir / "maps" / "A.pgm").write_bytes(b"map-A-content")
+    store.switch_map("A.yaml")
+    (memory,) = store.snapshot().memories
+    path = store.image_path(memory.id)
+    assert path is not None and path.read_bytes() == GOOD_JPEG
+
+
 def test_corrupt_index_resets_cleanly(data_dir):
     memory_dir = data_dir / "spatial_memory" / "A"
     memory_dir.mkdir(parents=True)
@@ -405,8 +443,11 @@ def see_confident_world(recorder, clock):
 
 
 def observe(recorder, clock, jpeg: bytes, advance: float = 1.0):
-    """One recorder tick seeing this frame, the clock advanced past the last."""
+    """One recorder tick seeing this frame, the clock advanced past the last.
+    Re-feeds AMCL like the live one does (update_min_* = 0: it publishes every
+    scan), so covariance freshness holds across any advance."""
     clock.now += advance
+    recorder._on_amcl_pose(SimpleNamespace(pose=SimpleNamespace(covariance=_covariance(0.02, 0.02, 0.05))))
     recorder._on_image(SimpleNamespace(data=jpeg))
     recorder.tick()
 
@@ -453,6 +494,19 @@ def test_a_covariance_spike_resets_the_clock(data_dir, clock):
     assert len(store.snapshot().memories) == 1
 
 
+def test_a_silent_amcl_stops_recording(data_dir, clock):
+    # AMCL publishes every scan while alive (update_min_* = 0). When it dies
+    # mid-drive, TF keeps composing odom motion under the latched confident
+    # covariance — those unvouched poses must not become memories.
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.5))
+    recorder, store = settled_recorder(data_dir, clock, pose)
+    pose.xyt = (4.0, 2.0, 0.5)  # still "driving" — but AMCL has gone quiet
+    clock.now += 6.0
+    recorder._on_image(SimpleNamespace(data=frame(2)))
+    recorder.tick()
+    assert len(store.snapshot().memories) == 1  # only the pre-death viewpoint
+
+
 def test_only_navigation_mode_records(data_dir, clock):
     recorder, store = make_recorder(data_dir)
     see_confident_world(recorder, clock)
@@ -494,6 +548,7 @@ def test_positions_mirror_publishes_map_poses_and_cache_state(data_dir, clock):
     recorder.tick()
     payload = json.loads(published[-1].data)
     assert payload["map"] == "A.yaml" and payload["cache"] == "warm"
+    assert payload["now"] == clock.now  # the robot's clock, for client-side age math
     (position,) = payload["positions"]
     assert position["id"] == 1 and position["x"] == 1.0 and position["y"] == 2.0 and position["theta"] == 0.5
     assert position["stamp"] > 0
@@ -682,6 +737,10 @@ class FakeGemini:
 
 
 def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[MemorySearch, FakeGemini, MemoryStore]:
+    (data_dir / "maps").mkdir(parents=True, exist_ok=True)
+    map_file = data_dir / "maps" / "A.pgm"
+    if not map_file.exists():
+        map_file.write_bytes(b"map-A-content")  # the store refuses a map it cannot fingerprint
     store = MemoryStore(data_dir)
     store.switch_map("A.yaml")
     for i in range(frames):
@@ -693,7 +752,9 @@ def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[Mem
 
 def build_cache(search: MemorySearch) -> None:
     """Synchronous stand-in for warm()'s background cache rebuild."""
-    search._ensure_cache(search._store.snapshot())
+    snapshot = search._store.snapshot()
+    if search._should_warm(snapshot):
+        search._create_cache(snapshot)
 
 
 def upload_frames(search: MemorySearch) -> None:
@@ -798,6 +859,57 @@ def test_failed_cache_creation_retries_only_after_the_memory_changes(data_dir):
     store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
     build_cache(search)
     assert len(fake.creates) == 2
+
+
+def test_a_transient_cache_failure_backs_off_instead_of_latching(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    fake.create_error = GeminiHttpError(503, "overloaded")
+    build_cache(search)
+    build_cache(search)
+    assert len(fake.creates) == 1  # backed off — warm() rides a 1 Hz tick
+    assert search._failed_revision is None  # a 5xx is the backend's fault, not this content's
+    fake.create_error = None
+    search._retry_at = 0.0  # the backoff window elapses
+    build_cache(search)
+    assert len(fake.creates) == 2  # same content retries once the backend recovers
+
+
+def test_a_network_error_during_warm_backs_off_instead_of_raising(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+
+    def explode(path: str, body: dict) -> dict:
+        raise RuntimeError("connection reset")
+
+    search._rest = GeminiRest(post=explode, delete=lambda path: {}, upload=lambda path, data, mime: {})
+    build_cache(search)
+    assert search._retry_at > time.monotonic() and search._failed_revision is None
+
+
+def test_a_busy_search_returns_a_typed_verdict_instead_of_queuing(data_dir, monkeypatch):
+    search, fake, _ = make_search(data_dir, frames=3)
+    monkeypatch.setattr(memory_search_module, "_BUSY_WAIT_SEC", 0.05)
+    search._flight.acquire()  # an abandoned goal (cancels are rejected) still holds the lock
+    try:
+        verdict = search.search("anything")
+    finally:
+        search._flight.release()
+    assert not verdict.found and "still running" in verdict.error
+    assert fake.generates == []  # never reached the network
+
+
+def test_forget_drops_the_cache_and_purges_the_uploads(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    upload_frames(search)
+    build_cache(search)
+    assert search._cache is not None
+    store.clear()
+    search.forget()
+    assert search._cache is None and search._files._records == {}
+    deadline = time.time() + 2.0
+    while len(fake.deletes) < 7 and time.time() < deadline:
+        time.sleep(0.01)
+    assert "/v1beta/cachedContents/c1" in fake.deletes
+    assert sum(1 for path in fake.deletes if path.startswith("/v1beta/files/")) == 6
 
 
 def test_a_dead_cache_falls_back_and_is_forgotten(data_dir):

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -97,7 +97,7 @@ def test_the_same_view_refreshes_once_aged():
 
 def test_a_recent_picture_is_not_rewritten():
     old = memory(1, 0.0, 0.0, stamp=1000.0)
-    plan = plan_admission([old], 0.1, 0.05, math.radians(8), stamp=1030.0)
+    plan = plan_admission([old], 0.1, 0.05, math.radians(8), stamp=1005.0)
     assert not plan.record
 
 
@@ -162,14 +162,14 @@ def test_the_wedge_stops_at_walls():
 def test_a_quarter_turn_at_a_painted_spot_is_novel():
     # The old 100-degree rule skipped this; paint says ~70% of the wedge is new.
     old = memory(1, 1.5, 1.5, theta=0.0, stamp=1000.0)
-    plan = plan_admission([old], 1.5, 1.5, math.pi / 2, stamp=1010.0, grid=grid_of(open_room()), coverage=Coverage())
+    plan = plan_admission([old], 1.5, 1.5, math.pi / 2, stamp=1005.0, grid=grid_of(open_room()), coverage=Coverage())
     assert plan.record and plan.replace is None
 
 
 def test_a_fully_painted_wedge_is_skipped():
     old = memory(1, 1.5, 1.5, theta=0.0, stamp=1000.0)
     plan = plan_admission(
-        [old], 1.5, 1.5, math.radians(5), stamp=1010.0, grid=grid_of(open_room()), coverage=Coverage()
+        [old], 1.5, 1.5, math.radians(5), stamp=1005.0, grid=grid_of(open_room()), coverage=Coverage()
     )
     assert not plan.record
 
@@ -185,8 +185,20 @@ def test_wall_closeups_do_not_pile_up():
     cells = open_room()
     cells[:, :2] = 100
     seen = memory(1, 0.35, 1.5, theta=math.pi, stamp=1000.0)
-    plan = plan_admission([seen], 0.35, 1.5, math.pi, stamp=1010.0, grid=grid_of(cells), coverage=Coverage())
+    plan = plan_admission([seen], 0.35, 1.5, math.pi, stamp=1005.0, grid=grid_of(cells), coverage=Coverage())
     assert not plan.record  # the wall is known: a cramped view must be nearly all new
+
+
+def test_stale_paint_no_longer_vouches_for_the_scene():
+    # Side-stepped off the view axis: the same-view refresh can't fire, and
+    # fresh paint reads the wedge as covered — but once the paint ages out,
+    # the area records anew without touching the old shot's slot.
+    old = memory(1, 1.5, 1.5, theta=0.0, stamp=1000.0)
+    grid = grid_of(open_room())
+    fresh = plan_admission([old], 1.5, 1.9, 0.0, stamp=1005.0, grid=grid, coverage=Coverage())
+    assert not fresh.record
+    stale = plan_admission([old], 1.5, 1.9, 0.0, stamp=1400.0, grid=grid, coverage=Coverage())
+    assert stale.record and stale.replace is None
 
 
 def test_a_blind_pose_earns_no_slot():
@@ -406,7 +418,12 @@ def clock(monkeypatch):
     return state
 
 
-def make_recorder(data_dir, published: list | None = None, pose: SimpleNamespace | None = None):
+def make_recorder(
+    data_dir,
+    published: list | None = None,
+    pose: SimpleNamespace | None = None,
+    cache: SimpleNamespace | None = None,
+):
     logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
     node = SimpleNamespace(
         get_logger=lambda: logger,
@@ -420,6 +437,7 @@ def make_recorder(data_dir, published: list | None = None, pose: SimpleNamespace
         amcl_pose_topic="/amcl_pose",
     )
     pose = pose if pose is not None else SimpleNamespace(xyt=(1.0, 2.0, 0.5))
+    cache = cache if cache is not None else SimpleNamespace(state="warm")
     store = MemoryStore(data_dir)
     recorder = MemoryRecorder(
         node,
@@ -427,7 +445,7 @@ def make_recorder(data_dir, published: list | None = None, pose: SimpleNamespace
         store=store,
         pose_tracker=SimpleNamespace(map_pose_xyt=lambda: pose.xyt),
         warm_search=None,
-        cache_state=lambda: "warm",
+        cache_state=lambda: cache.state,
         positions_pub=SimpleNamespace(publish=(published if published is not None else []).append),
     )
     return recorder, store
@@ -540,7 +558,8 @@ def test_a_stale_frame_blocks_capture(data_dir, clock):
 
 def test_positions_mirror_publishes_map_poses_and_cache_state(data_dir, clock):
     published: list = []
-    recorder, store = make_recorder(data_dir, published)
+    pose = SimpleNamespace(xyt=(1.23456789, -2.98765432, 0.87654321))
+    recorder, store = make_recorder(data_dir, published, pose=pose)
     see_confident_world(recorder, clock)
     recorder.tick()
     clock.now += 3.1
@@ -548,10 +567,31 @@ def test_positions_mirror_publishes_map_poses_and_cache_state(data_dir, clock):
     recorder.tick()
     payload = json.loads(published[-1].data)
     assert payload["map"] == "A.yaml" and payload["cache"] == "warm"
-    assert payload["now"] == clock.now  # the robot's clock, for client-side age math
     (position,) = payload["positions"]
-    assert position["id"] == 1 and position["x"] == 1.0 and position["y"] == 2.0 and position["theta"] == 0.5
-    assert position["stamp"] > 0
+    assert position["id"] == 1
+    # Display precision, not the store's: full floats bloat the JSON by half.
+    assert position["x"] == 1.235 and position["y"] == -2.988 and position["theta"] == 0.8765
+    assert position["stamp"] == round(clock.now, 1)
+
+
+def test_positions_mirror_republishes_only_on_change(data_dir, clock):
+    published: list = []
+    cache = SimpleNamespace(state="warm")
+    recorder, store = make_recorder(data_dir, published, cache=cache)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    quiet = len(published)
+    for _ in range(3):  # nothing changes — the latch alone serves late joiners
+        clock.now += 1.0
+        recorder._on_amcl_pose(SimpleNamespace(pose=SimpleNamespace(covariance=_covariance(0.02, 0.02, 0.05))))
+        recorder.tick()
+    assert len(published) == quiet
+    observe(recorder, clock, GOOD_JPEG)  # a recorded viewpoint changes the payload
+    assert len(published) == quiet + 1
+    cache.state = "cold"  # flips by wall clock, without a store change — the gate must see it
+    clock.now += 1.0
+    recorder.tick()
+    assert len(published) == quiet + 2 and json.loads(published[-1].data)["cache"] == "cold"
 
 
 def settled_recorder(data_dir, clock, pose: SimpleNamespace):
@@ -1094,6 +1134,9 @@ def test_a_refreshed_frame_invalidates_its_upload(data_dir):
     store.replace(memory_with_id(store, 2), 3.0, 0.0, 0.0, 5000.0, b"jpg-2-new")
     upload_frames(search)
     assert len(fake.uploads) == 7 and fake.uploads[-1] == b"jpg-2-new"
+    # The superseded upload is deleted, not left to Gemini's 48 h expiry — at
+    # the 10 s refresh cadence a dwelled-on viewpoint would pile files up fast.
+    assert any(path.endswith("/files/f2") for path in fake.deletes)
 
 
 def test_upload_latch_on_unsupported_backend(data_dir):

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Spatial memory: admission policy, the on-disk store, the recorder's gates,
+and the Gemini search with its context-cache lifecycle."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from brain_client.brain.memory_search import MemorySearch
+from brain_client.brain.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
+from brain_client.memory import recorder as recorder_module
+from brain_client.memory.recorder import MemoryRecorder
+from brain_client.memory.selection import MAX_MEMORIES, plan_admission
+from brain_client.memory.store import Memory, MemoryStore
+
+JPEG = b"\xff\xd8\xff\xe0fakejpegbytes"
+
+
+def memory(id_: int, x: float, y: float = 0.0, theta: float = 0.0, stamp: float = 1000.0) -> Memory:
+    return Memory(id=id_, x=x, y=y, theta=theta, stamp=stamp)
+
+
+# ================= admission policy =================
+
+
+def test_first_viewpoint_is_recorded():
+    plan = plan_admission([], 0.0, 0.0, 0.0, stamp=1000.0)
+    assert plan.record and plan.replace is None and plan.evict is None
+
+
+def test_near_duplicate_viewpoint_is_skipped():
+    plan = plan_admission([memory(1, 0.0, 0.0)], 0.3, 0.2, 0.2, stamp=1010.0)
+    assert not plan.record
+
+
+def test_same_spot_facing_elsewhere_is_a_new_view():
+    plan = plan_admission([memory(1, 0.0, 0.0, theta=0.0)], 0.0, 0.0, math.radians(120), stamp=1010.0)
+    assert plan.record and plan.replace is None
+
+
+def test_distance_alone_makes_a_new_view():
+    plan = plan_admission([memory(1, 0.0, 0.0)], 1.5, 0.0, 0.0, stamp=1010.0)
+    assert plan.record and plan.replace is None
+
+
+def test_stale_viewpoint_is_refreshed_in_place():
+    old = memory(1, 0.0, 0.0, stamp=1000.0)
+    plan = plan_admission([old], 0.1, 0.0, 0.05, stamp=1000.0 + 31 * 60)
+    assert plan.record and plan.replace == old and plan.evict is None
+
+
+def test_at_capacity_evicts_the_older_of_the_closest_pair():
+    spread = [memory(i, x=3.0 * i, stamp=500.0 + i) for i in range(MAX_MEMORIES - 2)]
+    older_twin = memory(90, x=200.0, stamp=100.0)
+    newer_twin = memory(91, x=200.4, stamp=200.0)
+    plan = plan_admission([*spread, older_twin, newer_twin], -5.0, 0.0, 0.0, stamp=1000.0)
+    assert plan.record and plan.evict == older_twin
+
+
+# ================= store =================
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    (tmp_path / "maps").mkdir()
+    (tmp_path / "maps" / "A.pgm").write_bytes(b"map-A-content")
+    (tmp_path / "maps" / "B.pgm").write_bytes(b"map-B-content")
+    return tmp_path
+
+
+def test_store_round_trips_across_instances(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    first = store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.add(4.0, 2.0, 0.5, 1001.0, b"jpg-two")
+    assert first is not None
+
+    reloaded = MemoryStore(data_dir)
+    reloaded.switch_map("A.yaml")
+    snapshot = reloaded.snapshot()
+    assert [m.id for m in snapshot.memories] == [1, 2]
+    assert snapshot.memories[0] == first
+    path = reloaded.image_path(1)
+    assert path is not None and path.read_bytes() == b"jpg-one"
+
+
+def test_remapping_under_the_same_name_wipes_stale_memories(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+
+    (data_dir / "maps" / "A.pgm").write_bytes(b"remapped-content")
+    reloaded = MemoryStore(data_dir)
+    reloaded.switch_map("A.yaml")
+    assert reloaded.snapshot().memories == ()
+    assert list((data_dir / "spatial_memory" / "A").glob("*.jpg")) == []
+
+
+def test_maps_have_isolated_memories(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.switch_map("B.yaml")
+    assert store.snapshot().memories == ()
+    store.switch_map("A.yaml")
+    assert len(store.snapshot().memories) == 1
+
+
+def test_eviction_removes_the_image_file(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    added = store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    assert added is not None
+    path = store.image_path(added.id)
+    assert path is not None and path.exists()
+    store.evict(added)
+    assert not path.exists()
+    assert store.snapshot().memories == ()
+
+
+def test_replace_keeps_the_slot_and_updates_everything_else(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    added = store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-old")
+    assert added is not None
+    store.replace(added, 1.1, 2.1, 0.6, 2000.0, b"jpg-new")
+    (kept,) = store.snapshot().memories
+    assert kept.id == added.id and kept.stamp == 2000.0 and kept.x == 1.1
+    path = store.image_path(kept.id)
+    assert path is not None and path.read_bytes() == b"jpg-new"
+
+
+def test_without_a_map_nothing_is_recorded(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map(None)
+    assert store.add(1.0, 2.0, 0.5, 1000.0, b"jpg") is None
+    assert store.snapshot().memories == ()
+
+
+def test_corrupt_index_resets_cleanly(data_dir):
+    memory_dir = data_dir / "spatial_memory" / "A"
+    memory_dir.mkdir(parents=True)
+    (memory_dir / "index.json").write_text("{not json")
+    (memory_dir / "7.jpg").write_bytes(b"orphan")
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    assert store.snapshot().memories == ()
+    assert not (memory_dir / "7.jpg").exists()  # orphaned images have no poses; they are wiped with the index
+
+
+# ================= recorder =================
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    state = SimpleNamespace(now=1000.0)
+    monkeypatch.setattr(recorder_module.time, "monotonic", lambda: state.now)
+    return state
+
+
+def make_recorder(data_dir, published: list | None = None):
+    logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
+    node = SimpleNamespace(
+        get_logger=lambda: logger,
+        create_subscription=lambda *a, **k: None,
+        create_timer=lambda *a, **k: None,
+    )
+    config = SimpleNamespace(
+        image_topic="/img",
+        current_nav_mode_topic="/nav/current_mode",
+        current_map_topic="/nav/current_map",
+        amcl_pose_topic="/amcl_pose",
+    )
+    store = MemoryStore(data_dir)
+    recorder = MemoryRecorder(
+        node,
+        config,
+        store=store,
+        pose_tracker=SimpleNamespace(map_pose_xyt=lambda: (1.0, 2.0, 0.5)),
+        warm_search=None,
+        positions_pub=SimpleNamespace(publish=(published if published is not None else []).append),
+    )
+    return recorder, store
+
+
+def see_confident_world(recorder, clock):
+    """Feed the recorder everything a recordable moment needs."""
+    recorder._on_current_map(SimpleNamespace(data="A.yaml"))
+    recorder._on_nav_mode(SimpleNamespace(data="navigation"))
+    recorder._on_amcl_pose(SimpleNamespace(pose=SimpleNamespace(covariance=_covariance(0.02, 0.02, 0.05))))
+    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -10.0})))
+
+
+def _covariance(var_x: float, var_y: float, var_yaw: float) -> list[float]:
+    covariance = [0.0] * 36
+    covariance[0], covariance[7], covariance[35] = var_x, var_y, var_yaw
+    return covariance
+
+
+def test_confidence_must_hold_before_recording(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_confident_world(recorder, clock)
+    recorder.tick()  # starts the confidence clock
+    assert store.snapshot().memories == ()
+    clock.now += 3.1
+    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder.tick()
+    assert len(store.snapshot().memories) == 1
+
+
+def test_a_covariance_spike_resets_the_clock(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    clock.now += 2.0
+    recorder._on_amcl_pose(SimpleNamespace(pose=SimpleNamespace(covariance=_covariance(0.9, 0.9, 0.5))))
+    recorder.tick()  # lost: the clock resets
+    recorder._on_amcl_pose(SimpleNamespace(pose=SimpleNamespace(covariance=_covariance(0.02, 0.02, 0.05))))
+    recorder.tick()  # confident again: the clock restarts here, 2s in
+    clock.now += 2.9
+    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder.tick()
+    assert store.snapshot().memories == ()
+    clock.now += 0.3
+    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder.tick()
+    assert len(store.snapshot().memories) == 1
+
+
+def test_only_navigation_mode_records(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_confident_world(recorder, clock)
+    recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    for _ in range(5):
+        recorder.tick()
+        clock.now += 2.0
+        recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    assert store.snapshot().memories == ()
+
+
+def test_looking_at_the_floor_blocks_capture(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_confident_world(recorder, clock)
+    recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -45.0})))
+    recorder.tick()
+    clock.now += 3.1
+    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder.tick()
+    assert store.snapshot().memories == ()
+
+
+def test_a_stale_frame_blocks_capture(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    clock.now += 3.1  # the frame from see_confident_world is now 3.1s old
+    recorder.tick()
+    assert store.snapshot().memories == ()
+
+
+def test_positions_mirror_publishes_map_and_poses(data_dir, clock):
+    published: list = []
+    recorder, store = make_recorder(data_dir, published)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    clock.now += 3.1
+    recorder._on_image(SimpleNamespace(data=b"live-frame"))
+    recorder.tick()
+    payload = json.loads(published[-1].data)
+    assert payload["map"] == "A.yaml"
+    assert payload["positions"] == [{"x": 1.0, "y": 2.0, "theta": 0.5}]
+
+
+# ================= memory search =================
+
+
+def gemini_json(payload: dict) -> dict:
+    return {"candidates": [{"content": {"role": "model", "parts": [{"text": json.dumps(payload)}]}}]}
+
+
+class FakeGemini:
+    """A scriptable GeminiRest: records every call, answers by path."""
+
+    def __init__(self, verdict: dict | None = None):
+        self.creates: list[dict] = []
+        self.generates: list[dict] = []
+        self.deletes: list[str] = []
+        self.create_error: GeminiHttpError | None = None
+        self.cached_generate_error: GeminiHttpError | None = None
+        self.verdict = verdict if verdict is not None else {"found": True, "frame": 1, "explanation": "matches"}
+        self.rest = GeminiRest(post=self._post, delete=self._delete)
+
+    def _post(self, path: str, body: dict) -> dict:
+        if path == CACHED_CONTENTS_PATH:
+            self.creates.append(body)
+            if self.create_error is not None:
+                raise self.create_error
+            return {"name": f"cachedContents/c{len(self.creates)}"}
+        self.generates.append(body)
+        if "cachedContent" in body and self.cached_generate_error is not None:
+            raise self.cached_generate_error
+        return gemini_json(self.verdict)
+
+    def _delete(self, path: str) -> dict:
+        self.deletes.append(path)
+        return {}
+
+
+def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[MemorySearch, FakeGemini, MemoryStore]:
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    for i in range(frames):
+        store.add(float(3 * i), 0.0, 0.0, 1000.0 + i, f"jpg-{i + 1}".encode())
+    fake = FakeGemini(verdict)
+    logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
+    return MemorySearch(store, fake.rest, model="test-model", logger=logger), fake, store
+
+
+def test_cache_is_created_once_and_reused(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "the kitchen"})
+    text, image = search.search("the kitchen")
+    search.search("the kitchen again")
+    assert len(fake.creates) == 1
+    assert [body.get("cachedContent") for body in fake.generates] == ["cachedContents/c1", "cachedContents/c1"]
+    assert "x=3.00m" in text and "the kitchen" in text
+    assert image == b"jpg-2"
+
+
+def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    search.search("first")
+    store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
+    search.search("second")
+    assert len(fake.creates) == 2
+    assert fake.deletes == ["/v1beta/cachedContents/c1"]
+
+
+def test_few_frames_answer_inline_without_caching(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+    text, image = search.search("anything")
+    assert fake.creates == []
+    (body,) = fake.generates
+    assert "systemInstruction" in body and "cachedContent" not in body
+    assert sum("inlineData" in part for part in body["contents"][0]["parts"]) == 3
+    assert image == b"jpg-1"
+
+
+def test_unsupported_backend_disables_caching_permanently(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    fake.create_error = GeminiHttpError(404, "no such endpoint")
+    _, image = search.search("first")
+    search.search("second")
+    assert len(fake.creates) == 1  # never attempted again
+    assert all("cachedContent" not in body for body in fake.generates)
+    assert image == b"jpg-1"
+
+
+def test_failed_cache_creation_retries_only_after_the_memory_changes(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    fake.create_error = GeminiHttpError(400, "cache too small")
+    search.search("first")
+    search.search("second")
+    assert len(fake.creates) == 1
+    fake.create_error = None
+    store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
+    search.search("third")
+    assert len(fake.creates) == 2
+
+
+def test_a_dead_cache_falls_back_inline_and_is_forgotten(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    search.search("first")
+    fake.cached_generate_error = GeminiHttpError(403, "cache expired")
+    text, image = search.search("second")
+    assert image == b"jpg-1"
+    assert "cachedContent" not in fake.generates[-1]  # answered inline
+    fake.cached_generate_error = None
+    search.search("third")
+    assert len(fake.creates) == 2  # the dead handle was dropped, a fresh cache built
+
+
+def test_no_match_returns_text_only(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6, verdict={"found": False, "frame": 0, "explanation": "no kitchen"})
+    text, image = search.search("the kitchen")
+    assert image is None and "nothing in the remembered views matches" in text
+
+
+def test_unreadable_answer_reports_gracefully(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+    fake.verdict = None  # type: ignore[assignment] — json.dumps(None) is valid JSON but not a verdict
+    text, image = search.search("anything")
+    assert image is None and "unreadable" in text
+
+
+def test_empty_memory_answers_without_the_network(data_dir):
+    search, fake, _ = make_search(data_dir, frames=0)
+    text, image = search.search("anything")
+    assert fake.generates == [] and image is None
+    assert "no memories" in text
+
+
+def test_warm_builds_the_cache_in_the_background(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    store.last_change_monotonic = time.monotonic() - 60.0
+    search.warm()
+    deadline = time.time() + 2.0
+    while search._cache is None and time.time() < deadline:
+        time.sleep(0.01)
+    assert search._cache is not None and len(fake.creates) == 1
+    assert fake.generates == []  # warming never asks a question
+
+
+def test_warm_waits_for_recording_to_settle(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    store.last_change_monotonic = time.monotonic()  # just changed
+    search.warm()
+    time.sleep(0.05)
+    assert fake.creates == []

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from brain_client.brain.memory_search import MemorySearch
+from brain_client.brain.memory_search import MemorySearch, verdict_text
 from brain_client.brain.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
 from brain_client.memory import recorder as recorder_module
 from brain_client.memory.recorder import MemoryRecorder
@@ -328,12 +328,14 @@ def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[Mem
 
 def test_cache_is_created_once_and_reused(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "the kitchen"})
-    text, image = search.search("the kitchen")
+    verdict = search.search("the kitchen")
     search.search("the kitchen again")
     assert len(fake.creates) == 1
     assert [body.get("cachedContent") for body in fake.generates] == ["cachedContents/c1", "cachedContents/c1"]
-    assert "x=3.00m" in text and "the kitchen" in text
-    assert image == b"jpg-2"
+    assert verdict.found and verdict.cached and verdict.image == b"jpg-2"
+    assert verdict.memory is not None and verdict.memory.x == 3.0
+    assert "x=3.00m" in verdict_text(verdict) and "the kitchen" in verdict_text(verdict)
+    assert "navigate_to_position" in verdict_text(verdict)
 
 
 def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
@@ -347,22 +349,22 @@ def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
 
 def test_few_frames_answer_inline_without_caching(data_dir):
     search, fake, _ = make_search(data_dir, frames=3)
-    text, image = search.search("anything")
+    verdict = search.search("anything")
     assert fake.creates == []
     (body,) = fake.generates
     assert "systemInstruction" in body and "cachedContent" not in body
     assert sum("inlineData" in part for part in body["contents"][0]["parts"]) == 3
-    assert image == b"jpg-1"
+    assert verdict.image == b"jpg-1" and not verdict.cached
 
 
 def test_unsupported_backend_disables_caching_permanently(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     fake.create_error = GeminiHttpError(404, "no such endpoint")
-    _, image = search.search("first")
+    verdict = search.search("first")
     search.search("second")
     assert len(fake.creates) == 1  # never attempted again
     assert all("cachedContent" not in body for body in fake.generates)
-    assert image == b"jpg-1"
+    assert verdict.image == b"jpg-1"
 
 
 def test_failed_cache_creation_retries_only_after_the_memory_changes(data_dir):
@@ -381,32 +383,45 @@ def test_a_dead_cache_falls_back_inline_and_is_forgotten(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     search.search("first")
     fake.cached_generate_error = GeminiHttpError(403, "cache expired")
-    text, image = search.search("second")
-    assert image == b"jpg-1"
+    verdict = search.search("second")
+    assert verdict.image == b"jpg-1" and not verdict.cached
     assert "cachedContent" not in fake.generates[-1]  # answered inline
     fake.cached_generate_error = None
     search.search("third")
     assert len(fake.creates) == 2  # the dead handle was dropped, a fresh cache built
 
 
-def test_no_match_returns_text_only(data_dir):
+def test_no_match_is_a_clean_verdict_not_an_error(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": False, "frame": 0, "explanation": "no kitchen"})
-    text, image = search.search("the kitchen")
-    assert image is None and "nothing in the remembered views matches" in text
+    verdict = search.search("the kitchen")
+    assert not verdict.found and verdict.image is None and verdict.error == ""
+    assert "nothing in the remembered views matches" in verdict_text(verdict)
 
 
-def test_unreadable_answer_reports_gracefully(data_dir):
+def test_unreadable_answer_becomes_an_error_verdict(data_dir):
     search, fake, _ = make_search(data_dir, frames=3)
     fake.verdict = None  # type: ignore[assignment] — json.dumps(None) is valid JSON but not a verdict
-    text, image = search.search("anything")
-    assert image is None and "unreadable" in text
+    verdict = search.search("anything")
+    assert verdict.error == "unreadable answer" and verdict.image is None
+    assert "failed" in verdict_text(verdict)
+
+
+def test_a_transport_crash_becomes_an_error_verdict_not_an_exception(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+
+    def explode(path: str, body: dict) -> dict:
+        raise RuntimeError("network down")
+
+    search._rest = GeminiRest(post=explode, delete=lambda path: {})
+    verdict = search.search("anything")
+    assert not verdict.found and "network down" in verdict.error
 
 
 def test_empty_memory_answers_without_the_network(data_dir):
     search, fake, _ = make_search(data_dir, frames=0)
-    text, image = search.search("anything")
-    assert fake.generates == [] and image is None
-    assert "no memories" in text
+    verdict = search.search("anything")
+    assert fake.generates == [] and verdict.image is None and not verdict.found
+    assert "no memories" in verdict_text(verdict)
 
 
 def test_warm_builds_the_cache_in_the_background(data_dir):
@@ -457,8 +472,8 @@ def test_a_broken_ui_mirror_does_not_break_the_search(data_dir):
         raise RuntimeError("publisher gone")
 
     search.on_result = explode
-    text, image = search.search("anything")
-    assert image == b"jpg-1"  # the search itself still succeeded
+    verdict = search.search("anything")
+    assert verdict.image == b"jpg-1"  # the search itself still succeeded
 
 
 def test_cache_state_reflects_the_lifecycle(data_dir):

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -20,7 +20,9 @@ import pytest
 from brain_client.brain.memory_search import MemorySearch, verdict_text
 from brain_client.brain.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
 from brain_client.memory import recorder as recorder_module
-from brain_client.memory.quality import frame_worth_keeping
+from brain_client.memory import selection as selection_module
+from brain_client.memory.coverage import Coverage, wedge_mask
+from brain_client.memory.quality import MIN_SHARPNESS, frame_sharpness, frame_worth_keeping
 from brain_client.memory.recorder import MemoryRecorder
 from brain_client.memory.selection import MAX_MEMORIES, plan_admission
 from brain_client.memory.store import Memory, MemoryStore
@@ -142,6 +144,50 @@ def test_without_a_grid_only_a_tight_pose_match_refreshes():
     old = memory(1, 0.0, 0.0, stamp=1000.0)
     assert not plan_admission([old], 0.6, 0.0, 0.0, stamp=2000.0).record
     assert plan_admission([old], 0.2, 0.0, 0.0, stamp=2000.0).replace == old
+
+
+# ================= visibility paint =================
+
+
+def test_the_wedge_stops_at_walls():
+    cells = open_room()
+    cells[:, 20] = 100  # a wall at world x = 2.0-2.1
+    mask = wedge_mask(grid_of(cells), 1.5, 1.5, 0.0)
+    assert mask is not None
+    assert mask[15, 16]  # free floor ahead, before the wall
+    assert not mask[:, 21:].any()  # nothing painted beyond it
+
+
+def test_a_quarter_turn_at_a_painted_spot_is_novel():
+    # The old 100-degree rule skipped this; paint says ~70% of the wedge is new.
+    old = memory(1, 1.5, 1.5, theta=0.0, stamp=1000.0)
+    plan = plan_admission([old], 1.5, 1.5, math.pi / 2, stamp=1010.0, grid=grid_of(open_room()), coverage=Coverage())
+    assert plan.record and plan.replace is None
+
+
+def test_a_fully_painted_wedge_is_skipped():
+    old = memory(1, 1.5, 1.5, theta=0.0, stamp=1000.0)
+    plan = plan_admission(
+        [old], 1.5, 1.5, math.radians(5), stamp=1010.0, grid=grid_of(open_room()), coverage=Coverage()
+    )
+    assert not plan.record
+
+
+def test_a_pose_that_paints_nothing_earns_no_slot():
+    cells = open_room()
+    cells[:, :2] = 100  # a wall along world x < 0.2
+    plan = plan_admission([], 0.35, 1.5, math.pi, stamp=1000.0, grid=grid_of(cells), coverage=Coverage())
+    assert not plan.record  # unpainted, but nose against the wall: almost no floor in view
+
+
+def test_at_capacity_the_most_replaceable_paint_makes_room(monkeypatch):
+    monkeypatch.setattr(selection_module, "MAX_MEMORIES", 3)
+    twins = [memory(1, 1.0, 3.0, theta=0.0), memory(2, 1.0, 3.0, theta=0.0)]
+    distinct = memory(3, 4.0, 3.0, theta=0.0)
+    plan = plan_admission(
+        [*twins, distinct], 2.0, 3.0, math.pi, stamp=2000.0, grid=grid_of(open_room(60)), coverage=Coverage()
+    )
+    assert plan.record and plan.evict is not None and plan.evict.id in (1, 2)  # never the lone wide view
 
 
 def test_at_capacity_evicts_the_older_of_the_closest_pair():
@@ -464,6 +510,46 @@ def settled_recorder(data_dir, clock, pose: SimpleNamespace):
     return recorder, store
 
 
+def test_the_sharpest_frame_of_the_window_wins_with_its_own_pose(data_dir, clock):
+    # A quick turn: the tick records the crispest instant of the last second,
+    # at the heading it was seen from — not whatever the feed holds at tick time.
+    rng = np.random.default_rng(11)
+    noise = rng.integers(0, 255, size=(240, 320), dtype=np.uint8)
+    sharp, soft = encoded(noise), encoded(cv2.GaussianBlur(noise, (5, 5), 0))
+    scores = (frame_sharpness(soft), frame_sharpness(sharp))
+    assert scores[0] is not None and scores[1] is not None and MIN_SHARPNESS <= scores[0] < scores[1]
+
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.0))
+    recorder, store = make_recorder(data_dir, pose=pose)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    clock.now += 3.1
+    recorder._on_image(SimpleNamespace(data=soft))
+    pose.xyt = (1.0, 2.0, 2.5)
+    recorder._on_image(SimpleNamespace(data=sharp))
+    pose.xyt = (1.0, 2.0, 3.0)
+    recorder._on_image(SimpleNamespace(data=DARK_JPEG))  # what the feed holds at tick time
+    recorder.tick()
+    (m,) = store.snapshot().memories
+    assert m.theta == 2.5 and stored_image(store, m.id) == sharp
+
+
+def test_a_mid_turn_blur_never_becomes_the_candidate(data_dir, clock):
+    rng = np.random.default_rng(12)
+    blurred = encoded(cv2.GaussianBlur(rng.integers(0, 255, size=(240, 320), dtype=np.uint8), (31, 31), 0))
+    pose = SimpleNamespace(xyt=(1.0, 2.0, 0.0))
+    recorder, store = make_recorder(data_dir, pose=pose)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    clock.now += 3.1
+    recorder._on_image(SimpleNamespace(data=blurred))  # sweeping past this heading
+    pose.xyt = (1.0, 2.0, 2.0)
+    recorder._on_image(SimpleNamespace(data=frame(4)))  # the pause at the end of the turn
+    recorder.tick()
+    (m,) = store.snapshot().memories
+    assert m.theta == 2.0 and stored_image(store, m.id) == frame(4)
+
+
 def test_a_new_viewpoint_needs_a_keepable_frame(data_dir, clock):
     recorder, store = make_recorder(data_dir)
     see_confident_world(recorder, clock)
@@ -525,8 +611,19 @@ def test_a_wall_on_the_sight_line_blocks_the_refresh(data_dir, clock):
     recorder._on_map(grid_msg(cells))
     pose.xyt = (1.8, 2.0, 0.0)
     observe(recorder, clock, frame(2), advance=61.0)
-    assert stored_image(store, 1) == frame(1)
-    assert len(store.snapshot().memories) == 1
+    assert stored_image(store, 1) == frame(1)  # the old view survives behind the wall...
+    (kept, minted) = store.snapshot().memories
+    assert stored_image(store, minted.id) == frame(2)  # ...and the unseen floor ahead earns its own slot
+
+
+def test_a_quarter_turn_with_a_grid_mints_a_second_viewpoint(data_dir, clock):
+    pose = SimpleNamespace(xyt=(2.0, 2.0, 0.0))
+    recorder, store = settled_recorder(data_dir, clock, pose)
+    recorder._on_map(grid_msg(open_room(40)))
+    pose.xyt = (2.0, 2.0, math.pi / 2)  # the old 100-degree rule would skip this turn
+    observe(recorder, clock, frame(2))
+    memories = store.snapshot().memories
+    assert len(memories) == 2 and memories[1].theta == math.pi / 2
 
 
 def test_bad_frames_never_overwrite_a_view(data_dir, clock):

--- a/ros2_ws/src/brain/brain_messages/CMakeLists.txt
+++ b/ros2_ws/src/brain/brain_messages/CMakeLists.txt
@@ -50,6 +50,7 @@ set(action_files
   "action/ExecutePolicy.action"
   "action/ExecuteBehavior.action"
   "action/ExecuteArmCommand.action"
+  "action/SearchMemory.action"
 )
 
 if(BUILD_TESTING)

--- a/ros2_ws/src/brain/brain_messages/action/ExecuteSkill.action
+++ b/ros2_ws/src/brain/brain_messages/action/ExecuteSkill.action
@@ -7,6 +7,7 @@ bool success
 string message
 string skill_type
 string success_type  # One of: "success", "cancelled", "failure"
+string image_b64     # optional evidence image the skill attached to its result
 ---
 # Feedback definition
 string skill_type

--- a/ros2_ws/src/brain/brain_messages/action/SearchMemory.action
+++ b/ros2_ws/src/brain/brain_messages/action/SearchMemory.action
@@ -1,0 +1,17 @@
+# Goal definition
+string query
+---
+# Result definition
+bool found
+string message      # model-ready verdict text (coordinates, age, explanation, navigation hint)
+string explanation  # the vision model's one-line reasoning
+string error        # non-empty when the search itself failed (transport, unreadable answer)
+float64 x           # map-frame pose of the matched viewpoint (0 when not found)
+float64 y
+float64 theta
+float64 seen_stamp  # epoch seconds when the matched view was recorded (0 when none)
+string image_b64    # the matched remembered frame ("" when none)
+float64 latency_sec
+bool cached         # answered from the Gemini context cache
+---
+# Feedback definition

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -7265,6 +7265,27 @@ select.skill-input {
   border-color: rgb(232 163 61 / 40%);
 }
 
+.mem-panel-clear {
+  padding: 2px 8px;
+  font-size: 10px;
+  color: var(--muted);
+  cursor: pointer;
+  background: none;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 999px;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.mem-panel-clear:hover:not(:disabled) {
+  color: var(--danger);
+  border-color: rgb(217 106 90 / 45%);
+}
+
+.mem-panel-clear:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .mem-panel-empty {
   font-size: 12px;
   line-height: 1.5;

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1290,6 +1290,7 @@ select.skill-input {
 }
 
 .cam-map-host {
+  position: relative; /* the memory cards anchor to the map, not the tile */
   width: 100%;
   height: 100%;
 }
@@ -1300,6 +1301,13 @@ select.skill-input {
 
 /* The map's Locate / Go To controls only make sense at full size. */
 .cam-map-host:not(.big) .map-controls {
+  display: none;
+}
+
+/* Same for the memory cards: in the PiP thumbnail they would outsize and
+   clip against the tile's overflow — the pulsing marks alone tell the story. */
+.cam-map-host:not(.big) .mem-card,
+.cam-map-host:not(.big) .mem-search-card {
   display: none;
 }
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -6963,6 +6963,267 @@ select.skill-input {
   opacity: 0.45;
 }
 
+/* ---- Spatial memory (map layer cards + sidebar reel) ----------------------
+   The layer's violet (#b48cff) is deliberately distinct from every other map
+   mark; the cards share the scene's glass language (legend, status). */
+
+.mem-card {
+  position: absolute;
+  z-index: 5;
+  padding: 6px;
+  background: rgb(10 10 12 / 88%);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgb(0 0 0 / 45%);
+}
+
+/* The hover thumbnail is read-only — it must never steal the canvas's cursor. */
+.mem-card-hover {
+  pointer-events: none;
+}
+
+.mem-card-img {
+  display: block;
+  width: 180px;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 6px;
+  background: rgb(255 255 255 / 4%);
+}
+
+.mem-card-img-lg {
+  width: 248px;
+}
+
+.mem-card-meta {
+  padding-top: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.mem-card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.mem-card-btn {
+  flex: 1;
+  padding: 6px 12px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ctl-text);
+  background: var(--ctl-glass);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 7px;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.mem-card-btn:hover {
+  color: var(--text);
+  border-color: rgb(255 255 255 / 30%);
+}
+
+.mem-card-btn-go {
+  color: #cbaefc;
+  border-color: rgb(180 140 255 / 45%);
+}
+
+.mem-card-btn-go:hover {
+  color: #e2d2ff;
+  border-color: rgb(180 140 255 / 80%);
+}
+
+/* The recall verdict — floats in from the top of the scene, dismisses itself. */
+.mem-search-card {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  z-index: 6;
+  width: min(430px, calc(100% - 24px));
+  padding: 10px 12px;
+  background: rgb(10 10 12 / 90%);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgb(0 0 0 / 50%);
+  opacity: 0;
+  transform: translate(-50%, -10px);
+  transition: opacity 260ms ease, transform 260ms ease;
+}
+
+.mem-search-card.is-in {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.mem-search-card.is-found {
+  border-color: rgb(180 140 255 / 45%);
+  box-shadow: 0 8px 30px rgb(0 0 0 / 50%), 0 0 26px rgb(180 140 255 / 14%);
+}
+
+.mem-search-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.mem-search-head .microlabel {
+  margin: 0;
+  flex: none;
+  color: #cbaefc;
+}
+
+.mem-search-query {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 13px;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mem-search-chip {
+  flex: none;
+  padding: 2px 8px;
+  font-size: 10px;
+  color: #cbaefc;
+  background: rgb(180 140 255 / 12%);
+  border: 1px solid rgb(180 140 255 / 35%);
+  border-radius: 999px;
+}
+
+.mem-search-close {
+  flex: none;
+  margin-left: auto;
+  padding: 0 4px;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--muted);
+  background: none;
+  border: none;
+}
+
+.mem-search-close:hover {
+  color: var(--text);
+}
+
+.mem-search-body {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin-top: 8px;
+}
+
+.mem-search-img {
+  flex: none;
+  width: 132px;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 6px;
+  background: rgb(255 255 255 / 4%);
+}
+
+.mem-search-text {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+/* Sidebar panel: count + cache chip + the reel of remembered views. */
+.mem-panel-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.mem-panel-head .microlabel {
+  margin-bottom: 8px;
+}
+
+.mem-panel-count {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.mem-panel-chip {
+  margin-left: auto;
+  padding: 2px 8px;
+  font-size: 10px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 999px;
+  color: var(--muted);
+}
+
+.mem-panel-chip[data-kind="ok"] {
+  color: var(--ok);
+  border-color: rgb(86 194 140 / 40%);
+}
+
+.mem-panel-chip[data-kind="warn"] {
+  color: var(--ctl-accent);
+  border-color: rgb(232 163 61 / 40%);
+}
+
+.mem-panel-empty {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.mem-reel {
+  display: flex;
+  gap: 8px;
+  padding-bottom: 4px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.mem-thumb {
+  position: relative;
+  flex: none;
+  padding: 0;
+  overflow: hidden;
+  background: none;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 8px;
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.mem-thumb:hover {
+  border-color: rgb(180 140 255 / 70%);
+  transform: translateY(-1px);
+}
+
+.mem-thumb-img {
+  display: block;
+  width: 96px;
+  height: 72px;
+  object-fit: cover;
+}
+
+.mem-thumb-age {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 2px 5px;
+  font-size: 9px;
+  color: #ddd;
+  text-align: left;
+  background: linear-gradient(transparent, rgb(0 0 0 / 78%));
+}
+
+.mem-panel-search {
+  margin-top: 8px;
+  overflow: hidden;
+  font-size: 10px;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Phones: scene on top, telemetry scrolling beneath it. */
 @media (max-width: 700px) {
   .nav-grid {

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -429,6 +429,7 @@ select.skill-input {
   border-radius: 10px;
   background: var(--ctl-glass);
   box-shadow: var(--ctl-sheen);
+  backdrop-filter: blur(6px);
   color: var(--text);
   text-align: left;
   transition: border-color 150ms ease, color 150ms ease, background 150ms ease;
@@ -437,6 +438,10 @@ select.skill-input {
 .map-btn:hover:not(:disabled) {
   border-color: var(--ctl-edge-accent);
   background: var(--ctl-glass-hover);
+}
+
+.map-btn:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .map-btn:disabled {
@@ -457,6 +462,16 @@ select.skill-input {
   height: 24px;
   border: 1px solid var(--hairline-strong);
   border-radius: 50%;
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+.map-btn:hover:not(:disabled) .map-btn-icon {
+  border-color: var(--ctl-edge-accent);
+}
+
+.map-btn.is-active .map-btn-icon {
+  border-color: var(--ctl-edge-accent-hover);
+  background: var(--accent-faint);
 }
 
 .map-btn-icon svg {
@@ -493,8 +508,10 @@ select.skill-input {
 .map-status {
   max-width: 340px;
   padding: 4px 10px;
+  border: 1px solid var(--hairline);
   border-radius: 8px;
-  background: rgba(10, 10, 12, 0.7);
+  background: var(--ctl-glass);
+  backdrop-filter: blur(6px);
   font-size: 12px;
   line-height: 1.4;
   color: var(--muted);
@@ -2287,6 +2304,20 @@ select.skill-input {
   margin: 0;
   font-size: 19px;
   font-weight: 600;
+}
+
+/* Title with a leading identity glyph (Nav wears the mobile app's map pin). */
+.page-title-iconed {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.page-title-iconed svg {
+  flex: none;
+  width: 19px;
+  height: 19px;
+  color: var(--muted);
 }
 
 .log-main {
@@ -6523,14 +6554,57 @@ select.skill-input {
   bottom: 12px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 8px 10px;
+  gap: 5px;
+  padding: 9px 12px;
   font-size: 11px;
   color: var(--muted);
-  background: rgb(10 10 12 / 72%);
+  background: var(--ctl-glass);
+  backdrop-filter: blur(6px);
   border: 1px solid var(--hairline);
-  border-radius: 8px;
+  border-radius: 10px;
   pointer-events: none;
+}
+
+/* Current-map pill (bottom-left) — the mobile app's map-name pill, same
+   glyph; the pin lights amber only while a map is actually loaded. */
+.map-name-pill {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: min(46%, 260px);
+  padding: 5px 12px 5px 10px;
+  font-size: 11px;
+  color: var(--ctl-text);
+  background: var(--ctl-glass);
+  box-shadow: var(--ctl-sheen);
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+.map-name-pill svg {
+  flex: none;
+  width: 13px;
+  height: 13px;
+  color: var(--ctl-accent);
+}
+
+.map-name-pill span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.map-name-pill.is-empty {
+  color: var(--ctl-text-off);
+}
+
+.map-name-pill.is-empty svg {
+  color: var(--ctl-text-off);
 }
 
 .legend-row {
@@ -6628,6 +6702,11 @@ select.skill-input {
   color: var(--accent);
   border: 1px solid var(--accent-dim);
   border-radius: 999px;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.maps-new:hover:not(:disabled) {
+  background: var(--accent-faint);
 }
 
 .maps-new:disabled {
@@ -6654,6 +6733,7 @@ select.skill-input {
   padding: 5px 6px;
   border-radius: 6px;
   text-align: left;
+  transition: background 120ms ease;
 }
 
 .maps-pick:hover:not(:disabled) {
@@ -6695,8 +6775,9 @@ select.skill-input {
   color: var(--muted);
   text-align: center;
   background: rgb(10 10 12 / 92%);
-  border: 1px solid var(--hairline);
-  border-radius: 8px;
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 10px;
   pointer-events: none;
 }
 
@@ -6955,9 +7036,15 @@ select.skill-input {
   transition: color 150ms ease, border-color 150ms ease, background 150ms ease;
 }
 
+.layer-chip:not(.is-on):hover:not(:disabled) {
+  color: var(--text);
+  border-color: rgb(255 255 255 / 26%);
+}
+
 .layer-chip.is-on {
   color: var(--ctl-accent);
   border-color: var(--ctl-edge-accent);
+  background: linear-gradient(var(--accent-faint), var(--accent-faint)), var(--ctl-glass);
 }
 
 /* Momentary action chip (never .is-on) — reads as a button, not a toggle. */
@@ -7007,6 +7094,10 @@ select.skill-input {
   padding-top: 6px;
   font-size: 11px;
   color: var(--muted);
+  /* Never wider than the thumbnail: a long meta line otherwise stretches the
+     card past the image and leaves a dead bar beside it — wrap instead. */
+  width: 0;
+  min-width: 100%;
 }
 
 .mem-card-actions {

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -7100,6 +7100,56 @@ select.skill-input {
   min-width: 100%;
 }
 
+.mem-card-popup .mem-card-img {
+  cursor: zoom-in;
+}
+
+/* Full-screen viewer for a remembered image (the popup's photo opens it). */
+.mem-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 10px;
+  background: rgb(10 10 12 / 82%);
+  backdrop-filter: blur(6px);
+}
+
+.mem-lightbox-img {
+  max-width: min(90vw, 1400px);
+  max-height: 80vh;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 12px;
+  background: rgb(255 255 255 / 4%);
+}
+
+.mem-lightbox-cap {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.mem-lightbox-close {
+  position: fixed;
+  top: 14px;
+  right: 18px;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  font-size: 15px;
+  color: var(--muted);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 50%;
+  background: var(--ctl-glass);
+}
+
+.mem-lightbox-close:hover {
+  color: var(--text);
+  border-color: rgb(255 255 255 / 30%);
+}
+
 .mem-card-actions {
   display: flex;
   gap: 8px;

--- a/webapp/debug/map-preview.html
+++ b/webapp/debug/map-preview.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright (c) 2026 Innate Inc -->
+<!-- Nav page preview — the whole navigation view (map widget, chips, legend,
+     maps roster, plots) rendered against synthetic data, no robot needed.
+     For iterating on map styling: serve the webapp directory
+     (`python3 -m http.server -d webapp 8123`) and open /debug/map-preview.html.
+     The rosClient singleton is stubbed before the page mounts, then a fake
+     apartment map, driving robot, plan, scan, costmap, and memories are fed
+     straight into the subscribers' callbacks. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>nav preview</title>
+  <link rel="stylesheet" href="/css/app.css" />
+  <style>
+    body { display: block; }
+    .preview-stage { position: fixed; inset: 0; }
+  </style>
+</head>
+<body>
+  <main class="stage preview-stage" id="stage"></main>
+  <script type="module">
+    import { ros } from "/js/rosClient.js";
+
+    // ---- stub the shared client before anything subscribes ------------------
+    const subs = new Map(); // topic -> Set<cb>
+    ros.subscribe = (topic, cb) => {
+      if (!subs.has(topic)) subs.set(topic, new Set());
+      subs.get(topic).add(cb);
+      return () => subs.get(topic)?.delete(cb);
+    };
+    const publish = (topic, msg) => {
+      for (const cb of subs.get(topic) ?? []) cb(msg);
+    };
+    ros.callService = async () => ({ success: true, message: "ok (stubbed)" });
+    ros.sendActionGoal = () => ({ promise: new Promise(() => {}) });
+    ros.connect = () => {};
+    ros.onStateChange = (cb) => {
+      cb("connected", "preview");
+      return () => {};
+    };
+
+    const { mount } = await import("/js/nav/main.js");
+    mount(document.getElementById("stage"));
+
+    // ?empty previews the waiting-for-map state: mount the page, feed nothing.
+    if (new URLSearchParams(location.search).has("empty")) throw new Error("preview: empty state, publishing skipped");
+
+    // ---- synthetic apartment grid: -1 unknown, 0 free, 100 wall -------------
+    const W = 260, H = 200, RES = 0.05, OX = -6, OY = -5;
+    const cells = new Int8Array(W * H).fill(-1);
+    const rect = (c0, r0, c1, r1, v) => {
+      for (let r = r0; r <= r1; r++) for (let c = c0; c <= c1; c++) cells[r * W + c] = v;
+    };
+    rect(20, 20, 240, 180, 0);                       // floor
+    rect(20, 20, 240, 22, 100); rect(20, 178, 240, 180, 100);   // outer walls
+    rect(20, 20, 22, 180, 100); rect(238, 20, 240, 180, 100);
+    rect(120, 20, 122, 100, 100); rect(120, 130, 122, 180, 100); // wall + door
+    rect(120, 100, 190, 102, 100); rect(214, 100, 240, 102, 100);
+    rect(60, 120, 80, 140, 100);                     // an island (sofa)
+    rect(170, 40, 185, 55, 100);                     // a table
+    const gridMsg = {
+      info: { width: W, height: H, resolution: RES, origin: { position: { x: OX, y: OY } } },
+      data: Array.from(cells),
+    };
+
+    // Costmap: walls lethal, one-cell ring inscribed, soft inflation beyond.
+    const cost = new Int8Array(W * H).fill(0);
+    for (let r = 0; r < H; r++) for (let c = 0; c < W; c++) {
+      if (cells[r * W + c] !== 100) continue;
+      for (let dr = -6; dr <= 6; dr++) for (let dc = -6; dc <= 6; dc++) {
+        const rr = r + dr, cc = c + dc;
+        if (rr < 0 || rr >= H || cc < 0 || cc >= W || cells[rr * W + cc] !== 0) continue;
+        const d = Math.hypot(dr, dc);
+        const v = d <= 1.5 ? 100 : d <= 3 ? 99 : Math.max(0, Math.round(98 * (1 - (d - 3) / 4)));
+        const i = rr * W + cc;
+        if (v > cost[i]) cost[i] = v;
+      }
+    }
+    const costMsg = {
+      info: { width: W, height: H, resolution: RES, origin: { position: { x: OX, y: OY } } },
+      data: Array.from(cost),
+    };
+
+    const quat = (yaw) => ({ x: 0, y: 0, z: Math.sin(yaw / 2), w: Math.cos(yaw / 2) });
+    const odom = (x, y, yaw) => ({ pose: { pose: { position: { x, y }, orientation: quat(yaw) } } });
+
+    publish("/nav/current_mode", { data: "navigation" });
+    publish("/nav/current_map", { data: "apartment.yaml" });
+    publish("/nav/available_maps", { data: JSON.stringify({ available_maps: ["apartment.yaml", "office.yaml", "warehouse.yaml"] }) });
+    publish("/map", gridMsg);
+    publish("/navigation/global_costmap/costmap", costMsg);
+    publish("/brain/memory_positions", {
+      data: JSON.stringify({
+        map: "apartment", fingerprint: "f1", cache: "warm",
+        positions: [
+          { id: 1, x: 1.5, y: -0.7, theta: 1.5708, stamp: Date.now() / 1000 - 300 },  // faces the interior wall 0.7 m away
+          { id: 2, x: -1.6, y: 1.55, theta: 3.1416, stamp: Date.now() / 1000 - 5000 }, // faces the sofa island 0.4 m away
+          { id: 3, x: 3.4, y: -3.0, theta: 0.6, stamp: Date.now() / 1000 - 60 },       // open room, full cone
+        ],
+      }),
+    });
+
+    // Robot drives a slow loop; the goal + plan point at the far room.
+    const goal = { x: 4.1, y: 2.9, yaw: 0.9 };
+    publish("/nav/commanded_goal", {
+      header: { frame_id: "map" },
+      pose: { position: { x: goal.x, y: goal.y }, orientation: quat(goal.yaw) },
+    });
+
+    // ?static freezes the robot near the memories — stable framing for
+    // styling screenshots.
+    if (new URLSearchParams(location.search).has("static")) {
+      const sp = { x: -0.9, y: -1.6, yaw: 1.2 };
+      publish("/odom", odom(sp.x, sp.y, sp.yaw));
+      publish("/amcl_pose", odom(sp.x, sp.y, sp.yaw));
+      const pts = [];
+      for (let i = 0; i <= 24; i++) {
+        const u = i / 24;
+        pts.push({ pose: { position: { x: sp.x + (goal.x - sp.x) * u, y: sp.y + (goal.y - sp.y) * u + Math.sin(u * Math.PI) * 1.1 }, orientation: quat(goal.yaw) } });
+      }
+      publish("/navigation/plan", { poses: pts });
+      const ranges = [];
+      for (let i = 0; i < 360; i++) ranges.push(2.2 + Math.sin(i * 0.15) * 0.5);
+      publish("/scan", { ranges, angle_min: -Math.PI, angle_increment: Math.PI / 180, range_min: 0.1, range_max: 8 });
+      // Keep the route alive past the widget's stale-plan expiry.
+      setInterval(() => publish("/navigation/plan", { poses: pts }), 2000);
+      throw new Error("preview: static scene, no motion loop");
+    }
+
+    let t = 0;
+    setInterval(() => {
+      t += 0.05;
+      const x = -1.5 + Math.cos(t * 0.4) * 1.6;
+      const y = -0.5 + Math.sin(t * 0.4) * 1.2;
+      const yaw = t * 0.4 + Math.PI / 2;
+      publish("/odom", odom(x, y, yaw));
+      if (t < 0.1) publish("/amcl_pose", odom(x, y, yaw));
+      const pts = [];
+      for (let i = 0; i <= 24; i++) {
+        const u = i / 24;
+        pts.push({ pose: { position: { x: x + (goal.x - x) * u, y: y + (goal.y - y) * u + Math.sin(u * Math.PI) * 1.1 }, orientation: quat(goal.yaw) } });
+      }
+      publish("/navigation/plan", { poses: pts });
+      const ranges = [];
+      const n = 360;
+      for (let i = 0; i < n; i++) ranges.push(2.2 + Math.sin(i * 0.15 + t) * 0.5 + Math.random() * 0.05);
+      publish("/scan", { ranges, angle_min: -Math.PI, angle_increment: (2 * Math.PI) / n, range_min: 0.1, range_max: 8 });
+    }, 100);
+  </script>
+</body>
+</html>

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -14,7 +14,16 @@
 // (it originated in the old teleop chat pane, since removed).
 
 import { copyText } from "../clipboard.js";
-import { CHAT_IN_TOPIC, CHAT_OUT_TOPIC, GET_CHAT_HISTORY_SERVICE, SKILL_STATUS_UPDATE_TOPIC } from "../constants.js";
+import {
+  AGENT_STATUS_TOPIC,
+  CHAT_IN_TOPIC,
+  CHAT_OUT_TOPIC,
+  GET_AVAILABLE_DIRECTIVES_SERVICE,
+  GET_CHAT_HISTORY_SERVICE,
+  RESET_BRAIN_SERVICE,
+  SET_BRAIN_ACTIVE_SERVICE,
+  SKILL_STATUS_UPDATE_TOPIC,
+} from "../constants.js";
 
 /**
  * @param {HTMLElement} root cockpit root — the panel mounts as a right-edge overlay.
@@ -36,6 +45,7 @@ export function createAgentPanel(root, rosClient, agentState) {
   titleEl.textContent = "Agent";
   const stateDot = document.createElement("span");
   stateDot.className = "agent-state-dot";
+  stateDot.title = `green while the brain is active — ${AGENT_STATUS_TOPIC}`;
   // Phones dock the panel as a bottom sheet (CSS); this expands it upward.
   const expandBtn = document.createElement("button");
   expandBtn.type = "button";
@@ -56,15 +66,17 @@ export function createAgentPanel(root, rosClient, agentState) {
   const directiveSelect = document.createElement("select");
   directiveSelect.className = "agent-directive mono";
   directiveSelect.setAttribute("aria-label", "Directive");
+  directiveSelect.title = `Pick the directive to run — ${GET_AVAILABLE_DIRECTIVES_SERVICE}`;
 
   const toggleBtn = document.createElement("button");
   toggleBtn.type = "button";
   toggleBtn.className = "agent-toggle";
+  toggleBtn.title = SET_BRAIN_ACTIVE_SERVICE;
 
   const resetBtn = document.createElement("button");
   resetBtn.type = "button";
   resetBtn.className = "agent-reset";
-  resetBtn.title = "Reset the agent's brain / working memory";
+  resetBtn.title = `Reset the agent's brain / working memory — ${RESET_BRAIN_SERVICE}`;
   resetBtn.textContent = "Reset";
 
   controls.append(directiveSelect, toggleBtn, resetBtn);
@@ -78,12 +90,14 @@ export function createAgentPanel(root, rosClient, agentState) {
   const activeSkillName = document.createElement("span");
   activeSkillName.className = "agent-activeskill-name mono";
   activeSkillName.textContent = "—";
+  activeSkill.title = `the skill the brain is executing right now — ${SKILL_STATUS_UPDATE_TOPIC}`;
   activeSkill.append(activeSkillLabel, activeSkillName);
 
   // ---- live stream (thoughts + chat + skill runs) -------------------------
   const streamLabel = document.createElement("p");
   streamLabel.className = "microlabel agent-stream-label";
   streamLabel.textContent = "AI thoughts";
+  streamLabel.title = `the brain's thoughts, chat, and skill runs — ${CHAT_OUT_TOPIC}`;
 
   const stream = document.createElement("div");
   stream.className = "agent-stream";
@@ -99,6 +113,7 @@ export function createAgentPanel(root, rosClient, agentState) {
   send.type = "submit";
   send.className = "agent-compose-send";
   send.textContent = "Send";
+  send.title = CHAT_IN_TOPIC;
   form.append(input, send);
 
   panel.append(head, controls, activeSkill, streamLabel, stream, form);
@@ -263,6 +278,7 @@ export function createAgentPanel(root, rosClient, agentState) {
       const toggle = document.createElement("button");
       toggle.type = "button";
       toggle.className = "chat-thoughts-toggle";
+      toggle.title = "The model's internal reasoning for this turn — click to expand";
       const label = document.createElement("span");
       label.className = "chat-thoughts-label";
       label.textContent = "Thoughts";
@@ -346,6 +362,7 @@ export function createAgentPanel(root, rosClient, agentState) {
       nameEl.textContent = name.replace(/_/g, " ");
       const statusEl = document.createElement("span");
       statusEl.className = "chat-skill-status mono";
+      statusEl.title = SKILL_STATUS_UPDATE_TOPIC;
       head.append(tag, nameEl, statusEl);
       wrap.append(head);
       stream.appendChild(wrap);
@@ -361,6 +378,7 @@ export function createAgentPanel(root, rosClient, agentState) {
     if (cls === "failed" && reason && !run.hasDetail) {
       run.hasDetail = true;
       run.wrap.classList.add("has-detail", "open");
+      run.head.title = "Click to show/hide the failure reason";
       const chevron = document.createElement("span");
       chevron.className = "chat-skill-chevron mono";
       chevron.textContent = "▴";

--- a/webapp/js/agent/challengeIntro.js
+++ b/webapp/js/agent/challengeIntro.js
@@ -44,6 +44,7 @@ export function showChallengeIntro() {
   close.type = "button";
   close.className = "challenge-intro-close";
   close.textContent = "✕";
+  close.title = "Dismiss";
   close.setAttribute("aria-label", "Dismiss");
   close.addEventListener("click", dismiss);
 
@@ -72,6 +73,7 @@ export function showChallengeIntro() {
   const figure = document.createElement("a");
   figure.className = "challenge-intro-figure";
   figure.href = TUTORIAL_URL;
+  figure.title = TUTORIAL_URL;
   figure.target = "_blank";
   figure.rel = "noopener noreferrer";
   const shot = document.createElement("img");

--- a/webapp/js/agent/challengePanel.js
+++ b/webapp/js/agent/challengePanel.js
@@ -96,6 +96,7 @@ export function createChallengePanel(container, session) {
       item.className = "challenge-item";
       const dot = document.createElement("span");
       dot.className = `challenge-dot${c.passed ? " passed" : ""}`;
+      dot.title = c.passed ? "Passed at least once" : "Not passed yet";
       const text = document.createElement("div");
       text.className = "challenge-item-text";
       const name = document.createElement("div");
@@ -137,6 +138,7 @@ export function createChallengePanel(container, session) {
     timerEl = document.createElement("span");
     timerEl.className = `challenge-timer${active.state !== "running" ? " final" : ""}`;
     timerEl.textContent = timerText(active);
+    timerEl.title = active.state === "running" ? "Time remaining before the challenge fails" : "Final run time";
     titleRow.append(name, timerEl);
     wrap.append(titleRow);
 
@@ -170,11 +172,11 @@ export function createChallengePanel(container, session) {
     const actions = document.createElement("div");
     actions.className = "challenge-actions";
     if (active.state === "running") {
-      actions.append(actionButton("Abort", () => session.abortChallenge()));
+      actions.append(actionButton("Abort", () => session.abortChallenge(), "Stop the run and return to the challenge list"));
     } else {
       actions.append(
-        actionButton("Retry", () => session.startChallenge(active.id)),
-        actionButton("Done", () => session.abortChallenge()),
+        actionButton("Retry", () => session.startChallenge(active.id), "Start the same challenge again"),
+        actionButton("Done", () => session.abortChallenge(), "Dismiss the result and return to the list"),
       );
     }
     wrap.append(actions);
@@ -184,12 +186,14 @@ export function createChallengePanel(container, session) {
   /**
    * @param {string} label
    * @param {() => void} onClick
+   * @param {string} [title]
    */
-  function actionButton(label, onClick) {
+  function actionButton(label, onClick, title = "") {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "challenge-action";
     btn.textContent = label;
+    if (title) btn.title = title;
     btn.addEventListener("click", onClick);
     return btn;
   }

--- a/webapp/js/agentIndicator.js
+++ b/webapp/js/agentIndicator.js
@@ -13,6 +13,7 @@ export function createAgentIndicator(agentState, agentHref) {
   pill.className = "agent-indicator";
   pill.href = agentHref;
   pill.hidden = true;
+  pill.title = "The autonomous brain is running — open the Agent page to take control";
 
   const dot = document.createElement("span");
   dot.className = "agent-indicator-dot";
@@ -22,6 +23,7 @@ export function createAgentIndicator(agentState, agentHref) {
   stop.type = "button";
   stop.className = "agent-indicator-stop";
   stop.textContent = "Stop";
+  stop.title = "Deactivate the brain — /brain/set_brain_active";
   pill.append(dot, label, stop);
   document.body.appendChild(pill);
 

--- a/webapp/js/appPromo.js
+++ b/webapp/js/appPromo.js
@@ -41,6 +41,7 @@ export function maybeShowAppPromo(root) {
   close.type = "button";
   close.className = "app-promo-close";
   close.textContent = "✕";
+  close.title = "Dismiss";
   close.setAttribute("aria-label", "Dismiss");
   close.addEventListener("click", dismiss);
 
@@ -68,6 +69,7 @@ export function maybeShowAppPromo(root) {
     cta.rel = "noopener noreferrer";
   }
   cta.textContent = platform === "ios" ? "Download for iOS" : "Download for Android";
+  cta.title = platform === "ios" ? "Opens TestFlight" : "Downloads the .apk";
   cta.addEventListener("click", dismiss); // they've got the message — don't ask again
 
   const stay = document.createElement("button");

--- a/webapp/js/armAlert.js
+++ b/webapp/js/armAlert.js
@@ -29,6 +29,7 @@ export function createArmAlert(rosClient) {
   const title = document.createElement("span");
   title.className = "microlabel";
   title.textContent = "servo protection";
+  title.title = ARM_STATUS_TOPIC;
   const dismissBtn = document.createElement("button");
   dismissBtn.type = "button";
   dismissBtn.className = "arm-alert-dismiss";
@@ -43,6 +44,7 @@ export function createArmAlert(rosClient) {
   const rebootBtn = document.createElement("button");
   rebootBtn.type = "button";
   rebootBtn.className = "arm-button";
+  rebootBtn.title = "Reboot the arm's servos, then torque back on";
 
   card.append(head, text, rebootBtn);
   document.body.appendChild(card);

--- a/webapp/js/armsdk/main.js
+++ b/webapp/js/armsdk/main.js
@@ -146,14 +146,14 @@ const PAGE_HTML = `
     robot connection lost — commands and the live view pause until it returns
   </p>
   <div class="armsdk-toolbar">
-    <span class="armsdk-pill" data-el="torque">torque ?</span>
-    <span class="armsdk-pill" data-el="moving">idle</span>
-    <button class="armsdk-go" data-cmd="torque_on">Torque on</button>
-    <button class="armsdk-warn" data-cmd="torque_off">Torque off</button>
-    <button data-cmd="rest">Rest</button>
-    <button class="armsdk-warn" data-el="rebootBtn">⟳ Reboot arm</button>
+    <span class="armsdk-pill" data-el="torque" title="servo torque state — /mars/arm/status">torque ?</span>
+    <span class="armsdk-pill" data-el="moving" title="whether an arm command is in flight">idle</span>
+    <button class="armsdk-go" data-cmd="torque_on" title="Stiffen the servos so the arm holds and accepts moves">Torque on</button>
+    <button class="armsdk-warn" data-cmd="torque_off" title="Go limp — also the abort path; fires mid-motion">Torque off</button>
+    <button data-cmd="rest" title="Move to the SDK rest pose">Rest</button>
+    <button class="armsdk-warn" data-el="rebootBtn" title="recover() — reboot the servos, settle, torque back on">⟳ Reboot arm</button>
     <span class="spacer"></span>
-    <label>speed cap <input type="number" data-el="speedcap" value="0.20" step="0.05" min="0.05"> m/s</label>
+    <label title="max_ee_speed — end-effector speed cap applied to every move">speed cap <input type="number" data-el="speedcap" value="0.20" step="0.05" min="0.05"> m/s</label>
     <label title="After each cartesian move the SDK FK-checks the settled pose against the target (5 cm xy / 10 cm z). A miss triggers recover() — servo reboot + torque on — then one retry before raising ArmUnhealthy. Off = moves are unverified; you just see the error here.">
       <input type="checkbox" data-el="verify"> verified moves</label>
   </div>
@@ -166,10 +166,10 @@ const PAGE_HTML = `
       <span class="armsdk-viz-hint">grab the amber handle to move the arm · drag to orbit · scroll to zoom</span>
       <div class="armsdk-viz-loading" data-el="vizLoading">loading model…</div>
       <div class="armsdk-pose">
-        <span><b>xyz</b><span class="num" data-el="pxyz">—</span></span>
-        <span><b>rpy</b><span class="num" data-el="prpy">—</span></span>
-        <span><b>grip</b><span class="num" data-el="pg">—</span> / <span class="num" data-el="gt">—</span> tgt</span>
-        <span hidden data-el="dragChip"><b>target</b><span class="num" data-el="dragXyz">—</span></span>
+        <span title="end-effector position in base_link (m) — /fk_pose"><b>xyz</b><span class="num" data-el="pxyz">—</span></span>
+        <span title="end-effector roll/pitch/yaw (degrees)"><b>rpy</b><span class="num" data-el="prpy">—</span></span>
+        <span title="measured gripper joint / commanded grip target"><b>grip</b><span class="num" data-el="pg">—</span> / <span class="num" data-el="gt">—</span> tgt</span>
+        <span hidden data-el="dragChip" title="where the 3D drag handle will send the arm on release"><b>target</b><span class="num" data-el="dragXyz">—</span></span>
         <button class="armsdk-copy" data-el="copyPose" title="Copy pose (x y z rpy)">${ICON_COPY}</button>
       </div>
     </div>
@@ -183,7 +183,7 @@ const PAGE_HTML = `
               <option value="0.01">1 cm</option><option value="0.02" selected>2 cm</option><option value="0.05">5 cm</option>
             </select></label>
           <label>rot <select data-el="rstep"><option value="5">5°</option><option value="15" selected>15°</option></select></label>
-          <label>dur <input type="number" data-el="jogdur" value="0.8" step="0.2" min="0.2"> s</label>
+          <label title="duration passed to move_by">dur <input type="number" data-el="jogdur" value="0.8" step="0.2" min="0.2"> s</label>
         </div>
         <div class="armsdk-jog">
           <button data-jog="dx,1" data-key="w" title="Keyboard: W — nudge +x (forward)">+x fwd <kbd>W</kbd></button>
@@ -213,21 +213,21 @@ const PAGE_HTML = `
           <label>r° <input type="number" data-el="ar" value="0" step="5"></label>
           <label>p° <input type="number" data-el="ap" value="0" step="5"></label>
           <label>y° <input type="number" data-el="aw" value="0" step="5"></label>
-          <label>dur <input type="number" data-el="adur" value="1.5" step="0.5" min="0.5"> s</label>
+          <label title="duration passed to move_to">dur <input type="number" data-el="adur" value="1.5" step="0.5" min="0.5"> s</label>
         </div>
         <div class="armsdk-row">
-          <button class="armsdk-go" data-el="goBtn">Go</button>
-          <button data-el="fillBtn">← from current</button>
+          <button class="armsdk-go" data-el="goBtn" title="move_to — absolute cartesian move to these fields">Go</button>
+          <button data-el="fillBtn" title="Fill the fields from the live pose">← from current</button>
         </div>
       </div>
 
       <div class="armsdk-card">
         <h2>Gripper</h2>
         <div class="armsdk-row">
-          <button class="armsdk-go" data-el="open100">Open</button>
-          <button data-el="open50">Open 50%</button>
-          <button class="armsdk-warn" data-el="closeBtn">Close</button>
-          <label>strength <input type="number" data-el="grip" value="0.2" step="0.1" min="0" max="0.6"> rad</label>
+          <button class="armsdk-go" data-el="open100" title="gripper_open percent=100">Open</button>
+          <button data-el="open50" title="gripper_open percent=50">Open 50%</button>
+          <button class="armsdk-warn" data-el="closeBtn" title="gripper_close at the strength beside">Close</button>
+          <label title="grip preload in rad — higher grips harder">strength <input type="number" data-el="grip" value="0.2" step="0.1" min="0" max="0.6"> rad</label>
         </div>
       </div>
     </div>
@@ -237,11 +237,11 @@ const PAGE_HTML = `
     <div class="armsdk-card">
       <h2>Joints · stream_joints (rad)
         <button class="armsdk-copy" data-el="copyJoints" title="Copy measured joint positions">${ICON_COPY}</button>
-        <span class="armsdk-dirty" data-el="jdirty" hidden>driving live — sync paused</span></h2>
+        <span class="armsdk-dirty" data-el="jdirty" hidden title="sliders are streaming joints; live sync resumes once the arm settles">driving live — sync paused</span></h2>
       <div data-el="sliders"></div>
       <div class="armsdk-row">
-        <button data-el="syncBtn">Sync from measured</button>
-        <button data-cmd="zero">Zero pose</button>
+        <button data-el="syncBtn" title="Snap the sliders back to the measured arm state">Sync from measured</button>
+        <button data-cmd="zero" title="Drive every joint to 0 rad">Zero pose</button>
       </div>
       <div class="armsdk-hint">sliders drive the arm live as you drag; they resume tracking the arm once it settles</div>
     </div>

--- a/webapp/js/brain/main.js
+++ b/webapp/js/brain/main.js
@@ -303,13 +303,13 @@ function buildView(root) {
                 .join(" ") +
               ")"
             : "";
-        const title = esc(c.outcome || "");
+        const title = esc(c.outcome || `${c.name} — no outcome reported`);
         return `<span class="br-call ${bad ? "bad" : quiet ? "quiet" : "go"}" title="${title}">${esc(c.name)}${esc(trunc(args, 46))}</span>`;
       })
       .join("");
     div.innerHTML =
       `<div class="head"><b>turn ${d.turn}</b><span>${(d.calls || []).length ? "" : "observed"}</span>` +
-      `<span class="lat">${d.latency.toFixed(1)}s think</span></div>` +
+      `<span class="lat" title="Model inference latency for this turn">${d.latency.toFixed(1)}s think</span></div>` +
       (calls ? `<div class="calls">${calls}</div>` : "");
     prepend(".br-actions", div);
   }
@@ -333,6 +333,7 @@ function buildView(root) {
       if (skillRows.size > 40) skillRows.delete(/** @type {string} */ (skillRows.keys().next().value));
     }
     row.className = "br-skill-row " + d.status;
+    row.title = "/brain/skill_status_update";
     row.innerHTML =
       `<span class="st"></span><span>${esc(d.skill_name || d.primitive_name)}</span>` +
       (d.reason ? `<span class="reason">${esc(trunc(d.reason, 60))}</span>` : "") +
@@ -343,6 +344,7 @@ function buildView(root) {
   function addQueueCard(kind, text) {
     const div = document.createElement("div");
     div.className = "br-qcard " + (kind === "user" ? "user" : "");
+    div.title = "Queued for the next look — the model sees it next turn";
     div.innerHTML = `<div class="k">${kind}</div><div class="t"></div>`;
     /** @type {HTMLElement} */ (div.querySelector(".t")).textContent = trunc(text, 160);
     prepend(".br-queue", div, 20);
@@ -445,6 +447,7 @@ function buildView(root) {
       b.innerHTML = `<img alt=""><span></span>`;
       /** @type {HTMLImageElement} */ (b.querySelector("img")).src = "data:image/jpeg;base64," + fr.jpeg;
       /** @type {HTMLElement} */ (b.querySelector("span")).textContent = fr.label;
+      b.title = `${fr.label} — click to inspect`;
       b.addEventListener("click", () => showTurn(turn, i));
       film.append(b);
     });
@@ -796,33 +799,33 @@ function template() {
   <div class="br-head">
     <h1 class="page-title">Brain</h1>
     <div class="br-chips">
-      <div class="br-chip br-chip-active"><span class="led"></span><span>brain <b>—</b></span></div>
-      <div class="br-chip br-chip-directive"><span>directive</span><b>—</b></div>
-      <div class="br-chip br-chip-backend"><span>backend</span><b>—</b></div>
-      <div class="br-chip br-chip-model"><span>model</span><b>—</b></div>
-      <div class="br-chip br-chip-voice"><span class="led"></span><span>voice</span></div>
+      <div class="br-chip br-chip-active" title="/brain/agent_status"><span class="led"></span><span>brain <b>—</b></span></div>
+      <div class="br-chip br-chip-directive" title="current directive — /brain/agent_status"><span>directive</span><b>—</b></div>
+      <div class="br-chip br-chip-backend" title="inference backend — /brain/trace, falling back to /brain/websocket_status"><span>backend</span><b>—</b></div>
+      <div class="br-chip br-chip-model" title="model in use — /brain/trace"><span>model</span><b>—</b></div>
+      <div class="br-chip br-chip-voice" title="pulses while the robot speaks — /tts/is_playing"><span class="led"></span><span>voice</span></div>
     </div>
   </div>
   <div class="br-grid">
     <section class="br-panel br-panel-loop">
-      <h2>The agent loop <span class="sub br-tools"></span></h2>
+      <h2>The agent loop <span class="sub br-tools" title="Tools the model may call this turn"></span></h2>
       <svg class="br-loop-svg" viewBox="0 0 300 300">
         <circle class="br-ring-base" cx="150" cy="150" r="${RING_R}"/>
         <circle class="br-ring-count" cx="150" cy="150" r="${RING_R}"/>
         <circle class="br-trail t2" r="2.5"/>
         <circle class="br-trail t1" r="3.5"/>
         <circle class="br-comet" r="5"/>
-        <g class="br-node look"><circle r="27"/><text dy="4">LOOK</text></g>
-        <g class="br-node think"><circle r="27"/><text dy="4">THINK</text></g>
-        <g class="br-node act"><circle r="27"/><text dy="4">ACT</text></g>
+        <g class="br-node look"><title>Capture the camera frames sent to the model</title><circle r="27"/><text dy="4">LOOK</text></g>
+        <g class="br-node think"><title>Waiting on model inference</title><circle r="27"/><text dy="4">THINK</text></g>
+        <g class="br-node act"><title>Executing the tool calls the model returned</title><circle r="27"/><text dy="4">ACT</text></g>
         <g class="br-center">
           <text class="br-phase" x="150" y="130">OFFLINE</text>
-          <text class="br-timer" x="150" y="168">—</text>
+          <text class="br-timer" x="150" y="168"><title>seconds spent thinking, or the countdown to the next look</title>—</text>
           <text class="br-turn"  x="150" y="192">TURN 0</text>
         </g>
       </svg>
       <div class="br-loop-sub"></div>
-      <div class="br-streak"></div>
+      <div class="br-streak" title="Consecutive inference failures"></div>
     </section>
 
     <section class="br-panel br-panel-vision">
@@ -831,14 +834,14 @@ function template() {
         <img class="br-frame" alt="">
         <div class="br-stage-idle">NO SIGNAL</div>
         <div class="br-scan"></div>
-        <div class="br-motion-tag">◉ motion</div>
-        <div class="br-ping"><span class="ringA"></span><span class="ringB"></span><span class="cross"></span></div>
+        <div class="br-motion-tag" title="Motion woke the brain early — see the event queue">◉ motion</div>
+        <div class="br-ping" title="Where the model asked the robot to drive (go_to_point)"><span class="ringA"></span><span class="ringB"></span><span class="cross"></span></div>
       </div>
       <div class="br-film"></div>
       <div class="br-vision-cap">
         <span class="br-frame-cap"></span>
         <button class="br-inspect-btn" hidden title="Everything the model received and returned this turn">inspect turn</button>
-        <span class="br-pose-strip">
+        <span class="br-pose-strip" title="robot pose — /odom">
           <svg class="br-heading" viewBox="0 0 16 16"><polygon class="br-needle" points="8,1.5 11,12 8,9.5 5,12"/></svg>
           <span class="br-pose-txt">pose —</span>
         </span>
@@ -863,10 +866,10 @@ function template() {
     <section class="br-panel br-panel-vitals">
       <h2>Vitals <span class="sub">think latency · s</span></h2>
       <div class="br-tiles">
-        <div class="br-tile"><div class="v br-tile-turns">0</div><div class="l">turns</div></div>
-        <div class="br-tile"><div class="v br-tile-last">—</div><div class="l">last think</div></div>
-        <div class="br-tile"><div class="v br-tile-avg">—</div><div class="l">avg think</div></div>
-        <div class="br-tile"><div class="v br-tile-up">—</div><div class="l">uptime</div></div>
+        <div class="br-tile" title="Loop turns since the brain started"><div class="v br-tile-turns">0</div><div class="l">turns</div></div>
+        <div class="br-tile" title="Latest model inference latency"><div class="v br-tile-last">—</div><div class="l">last think</div></div>
+        <div class="br-tile" title="Average model inference latency this session"><div class="v br-tile-avg">—</div><div class="l">avg think</div></div>
+        <div class="br-tile" title="How long the brain loop has been running"><div class="v br-tile-up">—</div><div class="l">uptime</div></div>
       </div>
       <div class="br-spark-wrap">
         <svg class="br-spark" viewBox="0 0 400 88" preserveAspectRatio="none"></svg>
@@ -874,7 +877,7 @@ function template() {
       </div>
       <div class="br-gauge">
         <div class="bar"><div class="fill br-hist-fill"></div></div>
-        <div class="lab"><span>conversation history</span><span class="br-hist-txt">0 / ${HIST_MAX}</span></div>
+        <div class="lab" title="Entries in the rolling conversation history the model sees"><span>conversation history</span><span class="br-hist-txt">0 / ${HIST_MAX}</span></div>
       </div>
     </section>
   </div>
@@ -883,7 +886,7 @@ function template() {
     <div class="br-inspect-card">
       <div class="br-i-head">
         <b class="br-i-title">turn</b><span class="br-i-meta"></span>
-        <button class="br-i-close" aria-label="Close">✕</button>
+        <button class="br-i-close" aria-label="Close" title="Close">✕</button>
       </div>
       <div class="br-i-body">
         <h3>new images this turn</h3>

--- a/webapp/js/calibration/main.js
+++ b/webapp/js/calibration/main.js
@@ -75,6 +75,7 @@ function buildView(root) {
   const fileStatus = document.createElement("span");
   fileStatus.className = "calib-file-status microlabel";
   fileStatus.textContent = "Calibration file: checking…";
+  fileStatus.title = `Inferred from ${MAIN_CAMERA_DEPTH_TOPIC} — depth frames only flow once a valid calibration is loaded`;
   head.append(title, fileStatus);
 
   // ---- grid: live feed | controls & feedback ---------------------------
@@ -141,14 +142,17 @@ function buildView(root) {
   startBtn.type = "button";
   startBtn.className = "calib-btn calib-btn-primary";
   startBtn.textContent = "Start Calibration";
+  startBtn.title = RUN_STEREO_CALIBRATION_ACTION;
   const captureBtn = document.createElement("button");
   captureBtn.type = "button";
   captureBtn.className = "calib-btn";
   captureBtn.textContent = "Capture";
+  captureBtn.title = STEREO_CALIB_CAPTURE_TOPIC;
   const stopBtn = document.createElement("button");
   stopBtn.type = "button";
   stopBtn.className = "calib-btn calib-btn-stop";
   stopBtn.textContent = "Stop";
+  stopBtn.title = "Cancel the calibration run";
   actionRow.append(startBtn, captureBtn, stopBtn);
 
   const statusLine = document.createElement("p");
@@ -412,9 +416,9 @@ function buildView(root) {
       };
       stats.append(
         stat("Images captured", String(r.imagesCaptured)),
-        stat("Left RMS", r.leftRms.toFixed(4)),
-        stat("Right RMS", r.rightRms.toFixed(4)),
-        stat("Stereo RMS", r.stereoRms.toFixed(4)),
+        Object.assign(stat("Left RMS", r.leftRms.toFixed(4)), { title: "Reprojection RMS error in pixels — lower is better" }),
+        Object.assign(stat("Right RMS", r.rightRms.toFixed(4)), { title: "Reprojection RMS error in pixels — lower is better" }),
+        Object.assign(stat("Stereo RMS", r.stereoRms.toFixed(4)), { title: "Stereo-pair reprojection RMS in pixels — lower is better" }),
       );
 
       if (r.quality) {

--- a/webapp/js/collect/recordPanel.js
+++ b/webapp/js/collect/recordPanel.js
@@ -61,9 +61,11 @@ export function createRecordPanel(parent, ros, opts = {}) {
   const sel = document.createElement("select");
   sel.className = "record-skill";
   sel.setAttribute("aria-label", "Skill to record into");
+  sel.title = "The dataset new episodes are saved into";
 
   const count = document.createElement("span");
   count.className = "record-count mono";
+  count.title = "Episodes saved into this dataset";
 
   const link = document.createElement("a");
   link.className = "record-link";
@@ -77,9 +79,13 @@ export function createRecordPanel(parent, ros, opts = {}) {
   const controls = document.createElement("div");
   controls.className = "record-controls";
   const startBtn = button("record-start", "● Record");
+  startBtn.title = RECORDER_NEW_EPISODE_SERVICE;
   const stopBtn = button("record-stop", "■ Stop");
+  stopBtn.title = RECORDER_STOP_EPISODE_SERVICE;
   const saveBtn = button("record-save", "Save");
+  saveBtn.title = RECORDER_SAVE_EPISODE_SERVICE;
   const discardBtn = button("record-discard", "Discard");
+  discardBtn.title = RECORDER_CANCEL_EPISODE_SERVICE;
   controls.append(startBtn, stopBtn, saveBtn, discardBtn);
 
   const hint = document.createElement("p");
@@ -97,6 +103,7 @@ export function createRecordPanel(parent, ros, opts = {}) {
   const orphanMsg = document.createElement("span");
   orphanMsg.className = "record-orphan-msg";
   const orphanDiscard = button("record-orphan-discard", "Discard recording");
+  orphanDiscard.title = RECORDER_CANCEL_EPISODE_SERVICE;
   const orphanDismiss = button("record-orphan-dismiss", "✕");
   orphanDismiss.title = "Dismiss";
   orphanBar.append(orphanMsg, orphanDiscard, orphanDismiss);
@@ -293,6 +300,7 @@ export function createRecordPanel(parent, ros, opts = {}) {
     close.type = "button";
     close.className = "modal-close";
     close.textContent = "✕";
+    close.title = "Close";
     close.addEventListener("click", closeModal);
     head.append(title, close);
 
@@ -374,6 +382,7 @@ export function createRecordPanel(parent, ros, opts = {}) {
       submitBtn.type = "button";
       submitBtn.className = "modal-start";
       submitBtn.textContent = kind === "replay" ? "Set up recording" : "Create skill";
+      submitBtn.title = CREATE_PHYSICAL_SKILL_SERVICE;
       children.push(warn, submitBtn);
 
       function submit() {

--- a/webapp/js/collect/replayWizard.js
+++ b/webapp/js/collect/replayWizard.js
@@ -42,15 +42,20 @@ export function createReplayWizard(host, ros, opts) {
   cancelBtn.type = "button";
   cancelBtn.className = "record-wizard-cancel";
   cancelBtn.textContent = "Cancel";
+  cancelBtn.title = "Abandon this draft skill";
   head.append(nameEl, cancelBtn);
 
   // ---- controls (phase-dependent) -----------------------------------------
   const controls = document.createElement("div");
   controls.className = "record-controls";
   const recordBtn = button("record-start", "● Record");
+  recordBtn.title = RECORDER_NEW_EPISODE_SERVICE;
   const stopBtn = button("record-stop", "■ Stop");
+  stopBtn.title = `${RECORDER_STOP_EPISODE_SERVICE} · ${RECORDER_SAVE_EPISODE_SERVICE}`;
   const reRecordBtn = button("record-discard", "Re-record");
+  reRecordBtn.title = "Discard this take and record another — the latest take wins";
   const saveBtn = button("record-save", "✓ Save skill");
+  saveBtn.title = SAVE_AS_REPLAY_SKILL_SERVICE;
   controls.append(recordBtn, stopBtn, reRecordBtn, saveBtn);
 
   const hint = document.createElement("p");

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -128,8 +128,9 @@ export const MAPPING_POSE_TOPIC = "/mapping_pose";
 
 // ---- Spatial memory ---------------------------------------------------------
 // The robot's per-map visual memory (brain_client/memory): places it remembered
-// while driving well-localized. Positions mirror at 1 Hz (std_msgs/String JSON
-// {map, cache: warm|cold|inline|unsupported|off, positions:[{id,x,y,theta,stamp}]});
+// while driving well-localized. Positions mirror latched, published on change
+// (std_msgs/String JSON {map, fingerprint,
+// cache: warm|cold|inline|unsupported|off, positions:[{id,x,y,theta,stamp}]});
 // the JPEG behind each entry is served same-origin by the front door at
 // /memory/image?map=…&id=… (webapp/proxy/media_routes.py).
 export const MEMORY_POSITIONS_TOPIC = "/brain/memory_positions";

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -133,6 +133,7 @@ export const MAPPING_POSE_TOPIC = "/mapping_pose";
 // the JPEG behind each entry is served same-origin by the front door at
 // /memory/image?map=…&id=… (webapp/proxy/media_routes.py).
 export const MEMORY_POSITIONS_TOPIC = "/brain/memory_positions";
+export const CLEAR_MEMORIES_SERVICE = "/brain/clear_memories";
 // One latched message per finished memory search (std_msgs/String JSON:
 // {query, found, id?, x?, y?, theta?, seen_stamp?, explanation?, error?,
 // latency_sec?, cached?, stamp}). Latched so a page opened just after the

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -126,6 +126,19 @@ export const NAV_DELETE_MAP_SERVICE = "/nav/delete_map";
 // stale from navigation mode.
 export const MAPPING_POSE_TOPIC = "/mapping_pose";
 
+// ---- Spatial memory ---------------------------------------------------------
+// The robot's per-map visual memory (brain_client/memory): places it remembered
+// while driving well-localized. Positions mirror at 1 Hz (std_msgs/String JSON
+// {map, cache: warm|cold|inline|unsupported|off, positions:[{id,x,y,theta,stamp}]});
+// the JPEG behind each entry is served same-origin by the front door at
+// /memory/image?map=…&id=… (webapp/proxy/media_routes.py).
+export const MEMORY_POSITIONS_TOPIC = "/brain/memory_positions";
+// One latched message per finished memory search (std_msgs/String JSON:
+// {query, found, id?, x?, y?, theta?, seen_stamp?, explanation?, error?,
+// latency_sec?, cached?, stamp}). Latched so a page opened just after the
+// search still sees it; clients gate the animation on the payload's stamp.
+export const MEMORY_SEARCH_TOPIC = "/brain/memory_search";
+
 // Skill-execution status (std_msgs/String JSON: {primitive_name|skill_name,
 // status: running|completed|failed|interrupted, primitive_id, ...}), published
 // as the agent runs primitives. Separate from chat_out — the chat surfaces it so

--- a/webapp/js/datasets/episodeList.js
+++ b/webapp/js/datasets/episodeList.js
@@ -76,6 +76,7 @@ export function createEpisodeList(parent, ros, opts) {
   const sortBtn = document.createElement("button");
   sortBtn.type = "button";
   sortBtn.className = "episodes-tool";
+  sortBtn.title = "Order episodes by recording time";
   const refreshBtn = document.createElement("button");
   refreshBtn.type = "button";
   refreshBtn.className = "episodes-tool";
@@ -281,7 +282,7 @@ export function createEpisodeList(parent, ros, opts) {
       const preparingCount = n - readyCount;
       sub.append(
         document.createTextNode(`${n} episode${n === 1 ? "" : "s"} · `),
-        spanText(`${readyCount} ready`, "episodes-ready"),
+        Object.assign(spanText(`${readyCount} ready`, "episodes-ready"), { title: "Encoded to H.264 — click a row to replay" }),
       );
       if (preparingCount > 0) {
         sub.append(document.createTextNode(" · "), spanText(`${preparingCount} preparing`, "episodes-preparing"));
@@ -415,6 +416,7 @@ export function createEpisodeList(parent, ros, opts) {
     const recCol = document.createElement("span");
     recCol.className = "ep-recorded";
     recCol.textContent = formatRecorded(ep.start_time);
+    recCol.title = ep.start_time || "";
     const durCol = document.createElement("span");
     durCol.className = "ep-duration mono";
     durCol.textContent = formatDuration(ep, dataFreq);
@@ -518,6 +520,7 @@ export function createEpisodeList(parent, ros, opts) {
     const cell = document.createElement("div");
     cell.className = "ep-result";
     const sel = document.createElement("select");
+    sel.title = `Judge this rollout — ${SET_EPISODE_OUTCOME_SERVICE}`;
     const stateOfOutcome = () => (ep.outcome === "success" ? "is-success" : ep.outcome === "failure" ? "is-fail" : "is-unlabeled");
     const applyClass = () => (sel.className = `ep-label-select ${stateOfOutcome()}`);
     for (const [val, text] of [
@@ -565,6 +568,7 @@ export function createEpisodeList(parent, ros, opts) {
     const cell = document.createElement("div");
     cell.className = "ep-label";
     const sel = document.createElement("select");
+    sel.title = `Label this demonstration — ${SET_EPISODE_OUTCOME_SERVICE}`;
     const applyClass = (/** @type {boolean} */ fail) =>
       (sel.className = `ep-label-select ${fail ? "is-fail" : "is-success"}`);
     applyClass(ep.outcome === "failure");

--- a/webapp/js/datasets/episodeMenu.js
+++ b/webapp/js/datasets/episodeMenu.js
@@ -74,10 +74,12 @@ export function openEpisodeMenu(opts) {
   const head = document.createElement("p");
   head.className = "ctx-head microlabel";
   head.textContent = "add to training dataset";
+  head.title = "Copies the episode's files into the chosen dataset; the eval run stays here";
   menu.appendChild(head);
   if (opts.targets.length) {
     for (const target of opts.targets) {
-      item(target.name, () => copyTo(opts, target), "ctx-target");
+      const b = item(target.name, () => copyTo(opts, target), "ctx-target");
+      if (target.directory) b.title = target.directory;
     }
   } else {
     const none = document.createElement("p");

--- a/webapp/js/datasets/episodePlayer.js
+++ b/webapp/js/datasets/episodePlayer.js
@@ -78,13 +78,13 @@ export function createEpisodePlayer(parent, ros, skill, episode, opts) {
   // demonstration — say so right next to the episode name, with the driving
   // policy and any failure-mode tags from review.
   if (episode.source === "rollout") {
-    subrow.insertBefore(chip("policy rollout", "prov-chip rollout"), nav);
+    subrow.insertBefore(chip("policy rollout", "prov-chip rollout", "Recorded during a policy rollout — not an operator demonstration"), nav);
     if (episode.policy) {
       subrow.insertBefore(chip(episode.policy, "prov-chip policy mono", `Driven by policy ${episode.policy}`), nav);
     }
-    for (const t of episode.tags || []) subrow.insertBefore(chip(t, "prov-chip tag"), nav);
+    for (const t of episode.tags || []) subrow.insertBefore(chip(t, "prov-chip tag", "Failure-mode tag set during rollout review"), nav);
   } else if (episode.source === "replay") {
-    subrow.insertBefore(chip("replay", "prov-chip"), nav);
+    subrow.insertBefore(chip("replay", "prov-chip", "Recorded by replaying a saved trajectory"), nav);
   }
   headinfo.append(titleBtn, subrow);
 
@@ -92,6 +92,7 @@ export function createEpisodePlayer(parent, ros, skill, episode, opts) {
   const actions = document.createElement("div");
   actions.className = "player-actions";
   const label = document.createElement("select");
+  label.title = `Label the episode's outcome — ${SET_EPISODE_OUTCOME_SERVICE}`;
   const isEvalRun = skill.type === "eval";
   const classOf = (/** @type {string | undefined} */ outcome) =>
     outcome === "failure" ? "is-fail" : outcome === "success" || !isEvalRun ? "is-success" : "is-unlabeled";
@@ -135,6 +136,7 @@ export function createEpisodePlayer(parent, ros, skill, episode, opts) {
   const del = document.createElement("button");
   del.type = "button";
   del.className = "player-delete";
+  del.title = `Delete this episode's video and data — ${DELETE_EPISODE_SERVICE}`;
   del.innerHTML =
     '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16"/><path d="M10 11v6M14 11v6"/><path d="M6 7l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12"/><path d="M9 7V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3"/></svg><span>Delete</span>';
   del.addEventListener("click", () => {
@@ -157,6 +159,7 @@ export function createEpisodePlayer(parent, ros, skill, episode, opts) {
     add.type = "button";
     add.className = "player-add";
     add.textContent = "+ Add to training dataset";
+    add.title = "Copy this run's files into a training dataset";
     add.addEventListener("click", () => {
       const r = add.getBoundingClientRect();
       openEpisodeMenu({
@@ -243,6 +246,7 @@ export function createEpisodePlayer(parent, ros, skill, episode, opts) {
   const telLabel = document.createElement("span");
   telLabel.className = "microlabel";
   telLabel.textContent = "telemetry";
+  telLabel.title = "Recorded joint positions (qpos) for this episode";
   const legend = document.createElement("div");
   legend.className = "telemetry-legend";
   telHead.append(telLabel, legend);
@@ -440,6 +444,7 @@ export function createEpisodePlayer(parent, ros, skill, episode, opts) {
       dot.style.background = JOINT_COLORS[j % JOINT_COLORS.length];
       const lbl = document.createElement("span");
       lbl.textContent = `J${j + 1}`;
+      item.title = `Joint ${j + 1}`;
       item.append(dot, lbl);
       legendFrag.appendChild(item);
     }

--- a/webapp/js/datasets/skillList.js
+++ b/webapp/js/datasets/skillList.js
@@ -35,6 +35,7 @@ export function createSkillList(parent, ros, opts) {
   const title = document.createElement("p");
   title.className = "microlabel";
   title.textContent = "datasets";
+  title.title = "Datasets with a recording directory";
   const tally = document.createElement("span");
   tally.className = "skillpanel-count";
   head.append(title, tally);
@@ -82,6 +83,9 @@ export function createSkillList(parent, ros, opts) {
   function sectionHead(label, icon, isEval) {
     const p = document.createElement("p");
     p.className = "skillpanel-group microlabel" + (isEval ? " eval" : "");
+    p.title = isEval
+      ? "Judged policy rollouts — never used for training"
+      : "Operator demonstrations — what the robot trains on";
     p.innerHTML = icon;
     p.appendChild(document.createTextNode(label));
     return p;

--- a/webapp/js/logging/logStream.js
+++ b/webapp/js/logging/logStream.js
@@ -46,13 +46,16 @@ export function createLogStream(parent, source, opts) {
   crumb.className = "logs-crumb";
   const scopeLabel = document.createElement("span");
   scopeLabel.className = "log-scope mono";
+  scopeLabel.title = "Log lines are filtered to this source";
   const errBadge = document.createElement("span");
   errBadge.className = "logs-errbadge";
+  errBadge.title = "Errors in the selected source, ignoring the level filter";
   errBadge.hidden = true;
   crumb.append(scopeLabel, errBadge);
 
   const sevSel = document.createElement("select");
   sevSel.className = "log-select";
+  sevSel.title = "Minimum severity to show";
   for (const [v, label] of [["all", "All levels"], ["info", "Info+"], ["warn", "Warn+"], ["error", "Errors"]]) {
     const o = document.createElement("option");
     o.value = v; o.textContent = label; sevSel.appendChild(o);
@@ -63,6 +66,7 @@ export function createLogStream(parent, source, opts) {
   search.className = "log-search mono";
   search.type = "text";
   search.placeholder = "filter…";
+  search.title = "Filter by node, process, launch file, or message text";
   search.spellcheck = false;
   search.addEventListener("input", () => { filter.text = search.value.trim().toLowerCase(); rerender(); });
 
@@ -71,21 +75,25 @@ export function createLogStream(parent, source, opts) {
 
   const count = document.createElement("span");
   count.className = "log-count microlabel";
+  count.title = "Lines shown / lines buffered";
 
   const rawBtn = document.createElement("button");
   rawBtn.className = "log-btn";
   rawBtn.type = "button";
+  rawBtn.title = "Show the raw line as the process printed it, instead of the parsed message";
   rawBtn.addEventListener("click", () => { raw = !raw; syncRaw(); rerender(); });
 
   const pauseBtn = document.createElement("button");
   pauseBtn.className = "log-btn";
   pauseBtn.type = "button";
+  pauseBtn.title = "Pause autoscroll — new lines keep buffering";
   pauseBtn.addEventListener("click", () => { paused = !paused; if (!paused) scrollToEnd(); syncPause(); });
 
   const clearBtn = document.createElement("button");
   clearBtn.className = "log-btn";
   clearBtn.type = "button";
   clearBtn.textContent = "Clear";
+  clearBtn.title = "Clear the buffer in this browser — the robot's log is untouched";
   clearBtn.addEventListener("click", () => { buffer = []; list.replaceChildren(); updateCount(); });
 
   const copyBtn = document.createElement("button");

--- a/webapp/js/logging/main.js
+++ b/webapp/js/logging/main.js
@@ -35,6 +35,7 @@ function buildView(root) {
   sourcesToggle.type = "button";
   sourcesToggle.className = "sources-toggle";
   sourcesToggle.textContent = "Sources";
+  sourcesToggle.title = "Show the log sources tree";
   head.appendChild(sourcesToggle);
 
   const grid = document.createElement("div");

--- a/webapp/js/logging/sources.js
+++ b/webapp/js/logging/sources.js
@@ -63,10 +63,17 @@ export function createSources(parent, source, ros, opts) {
   modeRow.className = "sources-modes";
   /** @type {Record<string, HTMLButtonElement>} */
   const modeBtns = {};
+  /** @type {Record<string, string>} */
+  const MODE_HINTS = {
+    launch: "Group logs by the launch file that started each process",
+    proc: "Group logs by OS process",
+    node: "Flat list of ROS nodes and loggers, merged across launch files",
+  };
   for (const [m, label, ic] of [["launch", "Launch file", "file"], ["proc", "Process", "process"], ["node", "Node / Logger", "node"]]) {
     const b = document.createElement("button");
     b.type = "button";
     b.className = "sources-mode";
+    b.title = MODE_HINTS[m];
     b.innerHTML = `${icon(ic)}<span>${label}</span>`;
     b.addEventListener("click", () => setMode(m));
     modeBtns[m] = b;
@@ -77,6 +84,7 @@ export function createSources(parent, source, ros, opts) {
   filterInput.className = "sources-filter mono";
   filterInput.type = "text";
   filterInput.placeholder = "filter sources…";
+  filterInput.title = "Filter the tree — a branch is kept if it or any child matches";
   filterInput.spellcheck = false;
   filterInput.addEventListener("input", () => { filterText = filterInput.value.trim().toLowerCase(); render(); });
 

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -47,13 +47,31 @@ export const MAP_COLORS = {
 // in costmap.yaml), so the dot covers what the robot covers at every zoom.
 const ROBOT_RADIUS_M = 0.18;
 
+// The mobile app's destination pin (CrosshairIcon) as a canvas path — the
+// goal marker here is the same mark "Go To" plants on the phone. Tip at
+// (12,22) of the 24×24 box; the hole is punched in the page background color.
+const PIN_PATH = new Path2D("M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z");
+const PIN_TIP_X = 12;
+const PIN_TIP_Y = 22;
+const PIN_HOLE_Y = 9;
+const PIN_HOLE_R = 2.5;
+const PIN_SCALE_CSS = 1.2; // 24-unit glyph → ~29 css px tall, screen-sized at any zoom
+
+// Occupancy colormap — dark like the rest of the app (and the mobile app's
+// map): explored floor is a dark slab, walls are bright, unknown stays
+// transparent so the dotted backdrop reads as "nowhere".
+const GRID_FREE_RGB = [21, 21, 26];
+const GRID_WALL_RGB = [223, 225, 234];
+
 // /localize scan-matches for up to ~30 s before answering.
 const LOCALIZE_TIMEOUT_MS = 40_000;
 
-// Wheel-zoom bounds (metres of real-world width shown).
+// Wheel-zoom bounds (metres of real-world width shown). The factor scales
+// with the actual scroll delta: a trackpad's stream of small deltas zooms
+// smoothly and fine-grained, a mouse's ~100 px notch steps ~10%.
 const MIN_ZOOM_M = 1;
 const MAX_ZOOM_M = 60;
-const ZOOM_STEP = 1.15; // per wheel notch
+const ZOOM_PER_WHEEL_PX = 0.001; // exp() rate per wheel-delta pixel
 
 // Odometry breadcrumb trail: drop a point every few cm, keep the last N.
 const TRAIL_MIN_STEP_M = 0.03;
@@ -70,9 +88,17 @@ const TRAIL_JUMP_M = 1;
 // ---- spatial-memory layer tuning -------------------------------------------
 // A stylized view cone per remembered frame: wide enough to read as "the robot
 // looked this way", far narrower than the camera's real 128° FOV (which would
-// wash the map in overlapping wedges).
+// wash the map in overlapping wedges). The cone is cut by line-of-sight
+// against the grid — a remembered view never shines through a wall.
 const MEM_WEDGE_HALF_RAD = (28 * Math.PI) / 180;
 const MEM_WEDGE_RANGE_M = 1.15;
+// A cell at or above this occupancy blocks sight (Nav2's occupied threshold).
+const OCC_THRESH = 65;
+// Robot marker: the mobile app's robot drawing, rendered at the true hardware
+// width (RobotSprite.tsx's ROBOT_WIDTH_M) with the drawing's +X as forward.
+// Below a legibility floor the marker falls back to dot + wedge.
+const ROBOT_SPRITE_URL = "/public/robot-drawing.svg";
+const ROBOT_SPRITE_W_M = 0.297;
 const MEM_HIT_PX = 16; // hover/click hit radius around a memory dot (css px)
 const MEM_PULSE_MS = 1200; // ring animation when a new memory is recorded
 const MEM_SEARCH_GLOW_MS = 18_000; // how long the recalled spot keeps breathing
@@ -210,6 +236,9 @@ export function createMap(root, opts = {}) {
 
   /** @type {{ width: number, height: number, resolution: number, originX: number, originY: number } | null} */
   let grid = null;
+  /** @type {number[] | null} raw occupancy cells (row-major from the origin) for line-of-sight tests */
+  let gridCells = null;
+  let gridRev = 0; // bumped per /map message — invalidates cached sight shapes
   /** @type {{ x: number, y: number, yaw: number } | null} displayed robot pose (map frame) */
   let pose = null;
   // Robot marker in the MAP frame: anchor at the last /amcl_pose fix and add
@@ -332,6 +361,11 @@ export function createMap(root, opts = {}) {
       }
     }
     memState = next;
+    // Sight-fan cache: entries self-invalidate on grid/pose mismatch; this
+    // just drops fans whose memory no longer exists.
+    for (const id of [...memPolyCache.keys()]) {
+      if (!next.memories.some((m) => m.id === id)) memPolyCache.delete(id);
+    }
     if (memHover && !next.memories.some((m) => m.id === memHover?.id)) setMemHover(null);
     if (memPopupFor !== null && !next.memories.some((m) => m.id === memPopupFor)) closeMemPopup();
     kickMemAnim();
@@ -719,15 +753,17 @@ export function createMap(root, opts = {}) {
   /** @param {any} msg nav_msgs/OccupancyGrid */
   function onMap(msg) {
     const g = rasterizeGrid(msg, off, offCtx, (v, px, di) => {
-      // Unknown = translucent gray; occupancy shades white (free) → black (wall).
-      const shade = v < 0 ? 105 : 255 - Math.round((Math.max(0, Math.min(100, v)) / 100) * 255);
-      px[di] = shade;
-      px[di + 1] = shade;
-      px[di + 2] = shade;
-      px[di + 3] = v < 0 ? 200 : 255;
+      if (v < 0) return; // unknown stays transparent — the backdrop shows through
+      const t = Math.max(0, Math.min(100, v)) / 100;
+      px[di] = GRID_FREE_RGB[0] + Math.round((GRID_WALL_RGB[0] - GRID_FREE_RGB[0]) * t);
+      px[di + 1] = GRID_FREE_RGB[1] + Math.round((GRID_WALL_RGB[1] - GRID_FREE_RGB[1]) * t);
+      px[di + 2] = GRID_FREE_RGB[2] + Math.round((GRID_WALL_RGB[2] - GRID_FREE_RGB[2]) * t);
+      px[di + 3] = 255;
     });
     if (!g) return;
     grid = g;
+    gridCells = msg.data;
+    gridRev++;
     draw();
   }
 
@@ -840,16 +876,76 @@ export function createMap(root, opts = {}) {
     draw();
   }
 
+  // Faint dot lattice behind (and around) the grid — gives the void a surface
+  // so the dark map reads as a slab floating on it. Cached per dpr as a
+  // repeating pattern tile: one fillRect per frame, not thousands of arcs.
+  /** @type {CanvasPattern | null} */
+  let dotPattern = null;
+  let dotPatternDpr = 0;
+  function backdropPattern() {
+    const d = dpr();
+    if (dotPattern && dotPatternDpr === d) return dotPattern;
+    const tile = document.createElement("canvas");
+    const step = Math.max(8, Math.round(22 * d));
+    tile.width = step;
+    tile.height = step;
+    const tctx = tile.getContext("2d");
+    if (!tctx || !ctx) return null;
+    tctx.fillStyle = "rgb(255 255 255 / 5%)";
+    tctx.beginPath();
+    tctx.arc(step / 2, step / 2, Math.max(1, 0.8 * d), 0, Math.PI * 2);
+    tctx.fill();
+    dotPattern = ctx.createPattern(tile, "repeat");
+    dotPatternDpr = d;
+    return dotPattern;
+  }
+
+  // The mobile app's robot drawing (RobotSprite.tsx renders the same file):
+  // browser-cached, so every widget instance shares one fetch.
+  const robotImg = new Image();
+  robotImg.addEventListener("load", () => draw());
+  robotImg.src = ROBOT_SPRITE_URL;
+
+  /** The mobile app's destination pin, tip anchored at (px, py).
+   * @param {number} px @param {number} py @param {string} color @param {number} [alpha] */
+  function drawPin(px, py, color, alpha = 1) {
+    if (!ctx) return;
+    const s = PIN_SCALE_CSS * dpr();
+    ctx.save();
+    ctx.globalAlpha = alpha;
+    ctx.translate(px - PIN_TIP_X * s, py - PIN_TIP_Y * s);
+    ctx.scale(s, s);
+    ctx.strokeStyle = "rgb(10 10 12 / 55%)"; // seats the pin on bright walls
+    ctx.lineWidth = 1.5 / s;
+    ctx.stroke(PIN_PATH);
+    ctx.fillStyle = color;
+    ctx.fill(PIN_PATH);
+    ctx.fillStyle = "#0a0a0c";
+    ctx.beginPath();
+    ctx.arc(PIN_TIP_X, PIN_HOLE_Y, PIN_HOLE_R, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
+
   function draw() {
     if (!ctx) return;
     ctx.fillStyle = "#0a0a0c";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const pat = backdropPattern();
+    if (pat) {
+      ctx.fillStyle = pat;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
 
     if (!grid) {
+      const d = dpr();
+      const cx = canvas.width / 2;
+      const cy = canvas.height / 2;
+      drawPin(cx, cy + 4 * d, "rgb(138 138 147 / 55%)");
       ctx.fillStyle = "#8a8a93";
-      ctx.font = `${14 * dpr()}px ui-monospace, monospace`;
+      ctx.font = `${13 * d}px ui-monospace, monospace`;
       ctx.textAlign = "center";
-      ctx.fillText("waiting for /map…", canvas.width / 2, canvas.height / 2);
+      ctx.fillText("waiting for /map…", cx, cy + 26 * d);
       return;
     }
 
@@ -864,6 +960,12 @@ export function createMap(root, opts = {}) {
       // Fit-the-whole-grid scale (no zoom set, or before the first pose).
       const pad = 16 * dpr();
       scale = Math.min((canvas.width - 2 * pad) / grid.width, (canvas.height - 2 * pad) / grid.height);
+    }
+    if (scale <= 0) {
+      // Degenerate container (mid-layout, collapsed PiP host): nothing fits,
+      // and a negative scale poisons every radius downstream (IndexSizeError).
+      view = null;
+      return;
     }
     if (center) {
       const col = (center.x - grid.originX) / grid.resolution;
@@ -922,6 +1024,7 @@ export function createMap(root, opts = {}) {
       ctx.strokeStyle = MAP_COLORS.trail;
       ctx.lineWidth = 1.5 * dpr();
       ctx.lineJoin = "round";
+      ctx.lineCap = "round";
       ctx.beginPath();
       trail.forEach((p, i) => {
         const { px, py } = worldToCanvas(p.x, p.y);
@@ -932,16 +1035,22 @@ export function createMap(root, opts = {}) {
     }
 
     if (plan && plan.length >= 2) {
-      ctx.strokeStyle = MAP_COLORS.route;
-      ctx.lineWidth = 2 * dpr();
-      ctx.lineJoin = "round";
-      ctx.beginPath();
+      const path = new Path2D();
       plan.forEach((p, i) => {
         const { px, py } = worldToCanvas(p.x, p.y);
-        if (i === 0) ctx.moveTo(px, py);
-        else ctx.lineTo(px, py);
+        if (i === 0) path.moveTo(px, py);
+        else path.lineTo(px, py);
       });
-      ctx.stroke();
+      ctx.lineJoin = "round";
+      ctx.lineCap = "round";
+      // Robot-width corridor under the crisp line: the translucent band covers
+      // the floor the robot will actually sweep, at every zoom.
+      ctx.strokeStyle = withAlpha(MAP_COLORS.route, 0.2);
+      ctx.lineWidth = Math.max(3 * dpr(), (ROBOT_SPRITE_W_M / grid.resolution) * scale);
+      ctx.stroke(path);
+      ctx.strokeStyle = MAP_COLORS.route;
+      ctx.lineWidth = 2 * dpr();
+      ctx.stroke(path);
     }
 
     // Laser scan, projected from the composed robot pose + the static laser
@@ -1003,19 +1112,52 @@ export function createMap(root, opts = {}) {
 
     if (pose) {
       const { px, py } = worldToCanvas(pose.x, pose.y);
-      // World-sized, not screen-sized: the dot covers the same floor area at
-      // every zoom (scale is px per map cell). Floored so it never vanishes.
+      // World-sized, not screen-sized: the marker covers the same floor area
+      // at every zoom (scale is px per map cell). Floored so it never vanishes.
       const rad = Math.max(3 * dpr(), (ROBOT_RADIUS_M / grid.resolution) * scale);
-      ctx.fillStyle = MAP_COLORS.robot;
+      const d = dpr();
+      const glow = ctx.createRadialGradient(px, py, rad * 0.4, px, py, rad * 3);
+      glow.addColorStop(0, withAlpha(MAP_COLORS.robot, 0.28));
+      glow.addColorStop(1, withAlpha(MAP_COLORS.robot, 0));
+      ctx.fillStyle = glow;
       ctx.beginPath();
-      ctx.arc(px, py, rad, 0, Math.PI * 2);
+      ctx.arc(px, py, rad * 3, 0, Math.PI * 2);
       ctx.fill();
-      ctx.strokeStyle = MAP_COLORS.robot;
-      ctx.lineWidth = 2 * dpr();
-      ctx.beginPath();
-      ctx.moveTo(px, py);
-      ctx.lineTo(px + Math.cos(pose.yaw) * rad * 2.4, py - Math.sin(pose.yaw) * rad * 2.4);
-      ctx.stroke();
+      const spriteW = (ROBOT_SPRITE_W_M / grid.resolution) * scale;
+      const spriteReady = robotImg.complete && robotImg.naturalWidth > 0;
+      if (spriteReady && spriteW >= 16 * d) {
+        const spriteH = spriteW * (robotImg.naturalHeight / robotImg.naturalWidth);
+        ctx.save();
+        ctx.translate(px, py);
+        ctx.rotate(-pose.yaw); // world CCW is canvas CW; the drawing's front is +x
+        ctx.imageSmoothingEnabled = true;
+        // Rim light: the drawing's greys were made for the app's white map —
+        // a silhouette-hugging halo keeps them readable on the dark floor.
+        ctx.shadowColor = "rgb(255 255 255 / 80%)";
+        ctx.shadowBlur = 5 * d;
+        ctx.drawImage(robotImg, -spriteW / 2, -spriteH / 2, spriteW, spriteH);
+        ctx.restore();
+      } else {
+        // Too small for the chassis to read — heading wedge + dot + ring.
+        const tipX = px + Math.cos(pose.yaw) * rad * 2.3;
+        const tipY = py - Math.sin(pose.yaw) * rad * 2.3;
+        const w = Math.max(2 * d, rad * 0.55);
+        ctx.fillStyle = MAP_COLORS.robot;
+        ctx.beginPath();
+        ctx.moveTo(tipX, tipY);
+        ctx.lineTo(px + Math.cos(pose.yaw + Math.PI / 2) * w, py - Math.sin(pose.yaw + Math.PI / 2) * w);
+        ctx.lineTo(px + Math.cos(pose.yaw - Math.PI / 2) * w, py - Math.sin(pose.yaw - Math.PI / 2) * w);
+        ctx.closePath();
+        ctx.fill();
+        ctx.beginPath();
+        ctx.arc(px, py, rad, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = "rgb(255 255 255 / 92%)";
+        ctx.lineWidth = Math.max(1, 1.2 * d);
+        ctx.beginPath();
+        ctx.arc(px, py, rad, 0, Math.PI * 2);
+        ctx.stroke();
+      }
     }
 
     // Cards are world-anchored DOM: keep them glued to their memory through
@@ -1034,8 +1176,51 @@ export function createMap(root, opts = {}) {
     }
   }
 
-  /** The remembered viewpoints: one soft view cone + dot each, fading with
-   * age; a white ring blooms once when a memory is first recorded. */
+  /** Occupancy at a world point; unknown/outside counts as free — only walls
+   * cut sight. @param {number} x @param {number} y */
+  function occAt(x, y) {
+    const g = grid;
+    if (!g || !gridCells) return 0;
+    const col = Math.floor((x - g.originX) / g.resolution);
+    const row = Math.floor((y - g.originY) / g.resolution);
+    if (col < 0 || col >= g.width || row < 0 || row >= g.height) return 0;
+    const v = gridCells[row * g.width + col];
+    return v > 0 ? v : 0;
+  }
+
+  /** How far sight reaches from (x0,y0) along `angle` before a wall, capped
+   * at maxR (metres). @param {number} x0 @param {number} y0 @param {number} angle @param {number} maxR */
+  function sightRange(x0, y0, angle, maxR) {
+    const step = (grid?.resolution ?? 0.05) * 0.5;
+    const c = Math.cos(angle);
+    const s = Math.sin(angle);
+    for (let r = step; r <= maxR; r += step) {
+      if (occAt(x0 + r * c, y0 + r * s) >= OCC_THRESH) return Math.max(0, r - step);
+    }
+    return maxR;
+  }
+
+  /** @type {Map<number, { rev: number, x: number, y: number, theta: number, poly: Array<{ x: number, y: number }> }>} */
+  const memPolyCache = new Map();
+  /** The wedge clipped by walls, as a world-space sight fan (cached per grid
+   * revision). @param {import("./memories.js").Memory} m */
+  function memPoly(m) {
+    const hit = memPolyCache.get(m.id);
+    if (hit && hit.rev === gridRev && hit.x === m.x && hit.y === m.y && hit.theta === m.theta) return hit.poly;
+    /** @type {Array<{ x: number, y: number }>} */
+    const poly = [];
+    const K = 28;
+    for (let i = 0; i <= K; i++) {
+      const a = m.theta + MEM_WEDGE_HALF_RAD * ((2 * i) / K - 1);
+      const r = sightRange(m.x, m.y, a, MEM_WEDGE_RANGE_M);
+      poly.push({ x: m.x + r * Math.cos(a), y: m.y + r * Math.sin(a) });
+    }
+    memPolyCache.set(m.id, { rev: gridRev, x: m.x, y: m.y, theta: m.theta, poly });
+    return poly;
+  }
+
+  /** The remembered viewpoints: one wall-clipped view cone + dot each, fading
+   * with age; a white ring blooms once when a memory is first recorded. */
   function drawMemories() {
     if (!ctx || !grid || !view || !layers.memories || !memState?.memories.length) return;
     const nowS = Date.now() / 1000;
@@ -1043,20 +1228,23 @@ export function createMap(root, opts = {}) {
     const d = dpr();
     const g = /** @type {NonNullable<typeof grid>} */ (grid);
     const v = /** @type {NonNullable<typeof view>} */ (view);
-    const range = (MEM_WEDGE_RANGE_M / g.resolution) * v.scale;
     const searchHit = memSearch?.found && nowMs < memSearchUntil ? memSearch.id : null;
     for (const m of memState.memories) {
       const { px, py } = worldToCanvas(m.x, m.y);
       const active = memHover?.id === m.id || memHighlight === m.id || memPopupFor === m.id || searchHit === m.id;
       const alpha = active ? 1 : ageAlpha(m.stamp, nowS);
-      // The view cone (canvas y is down, so world angles negate).
+      // The view cone: the original soft gradient, clipped by line of sight.
+      const range = (MEM_WEDGE_RANGE_M / g.resolution) * v.scale;
       const grad = ctx.createRadialGradient(px, py, 0, px, py, range);
       grad.addColorStop(0, withAlpha(MEMORY_COLOR, (active ? 0.5 : 0.3) * alpha));
       grad.addColorStop(1, withAlpha(MEMORY_COLOR, 0));
       ctx.fillStyle = grad;
       ctx.beginPath();
       ctx.moveTo(px, py);
-      ctx.arc(px, py, range, -m.theta - MEM_WEDGE_HALF_RAD, -m.theta + MEM_WEDGE_HALF_RAD);
+      for (const p of memPoly(m)) {
+        const c = worldToCanvas(p.x, p.y);
+        ctx.lineTo(c.px, c.py);
+      }
       ctx.closePath();
       ctx.fill();
       // The dot.
@@ -1352,7 +1540,9 @@ export function createMap(root, opts = {}) {
   function onWheel(e) {
     if (!zoomMeters) return; // fit-whole mode (standalone page) doesn't zoom
     e.preventDefault();
-    const next = zoomMeters * (e.deltaY > 0 ? ZOOM_STEP : 1 / ZOOM_STEP);
+    // deltaMode: line/page deltas (Firefox mouse wheels) normalized to pixels.
+    const deltaPx = e.deltaY * (e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 100 : 1);
+    const next = zoomMeters * Math.exp(deltaPx * ZOOM_PER_WHEEL_PX);
     zoomMeters = Math.min(MAX_ZOOM_M, Math.max(MIN_ZOOM_M, next));
     draw();
     opts.onZoomChange?.(zoomMeters);

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -2,11 +2,11 @@
 // Reusable nav-map widget — a plain 2D <canvas> rendering the occupancy grid
 // (/map), robot pose (/odom), planner route (/plan), and click-to-navigate
 // (sends a NavigateToPose goal via the router), plus opt-in overlay layers
-// (lidar scan / global costmap / local costmap / odometry trail) for the Nav page.
-// Sizes itself to its container via a ResizeObserver, so
-// it can be the standalone Map page OR a teleop PiP tile that reparents between
-// a small thumbnail and the full stage. No three.js — a canvas + putImageData
-// is all a 2D map needs.
+// (lidar scan / global costmap / local costmap / odometry trail / spatial
+// memories) for the Nav page. Sizes itself to its container via a
+// ResizeObserver, so it can be the standalone Map page OR a teleop PiP tile
+// that reparents between a small thumbnail and the full stage. No three.js —
+// a canvas + putImageData is all a 2D map needs.
 
 import { ros } from "../rosClient.js";
 import {
@@ -23,7 +23,10 @@ import {
   LOCAL_COSTMAP_TOPIC,
   TF_STATIC_TOPIC,
   MAPPING_POSE_TOPIC,
+  MEMORY_POSITIONS_TOPIC,
+  MEMORY_SEARCH_TOPIC,
 } from "../constants.js";
+import { MEMORY_COLOR, ageAlpha, ageText, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
 
 // Overlay palette — exported so the Nav page legend shows the same colors.
 // The robot is deliberately far from the costmap ramp (blue → amber → red):
@@ -34,6 +37,7 @@ export const MAP_COLORS = {
   goal: "#00ff88",
   route: "#00b7ff",
   scan: "#d96a5a",
+  memory: MEMORY_COLOR,
   costLethal: "rgb(217 106 90 / 82%)",
   costInscribed: "rgb(232 163 61 / 75%)",
   costInflation: "rgb(77 124 254 / 45%)",
@@ -60,8 +64,21 @@ const TRAIL_MAX_POINTS = 600;
 const TRAIL_JUMP_M = 1;
 
 /**
- * @typedef {"scan" | "costmap" | "local" | "trail"} LayerName
+ * @typedef {"scan" | "costmap" | "local" | "trail" | "memories"} LayerName
  */
+
+// ---- spatial-memory layer tuning -------------------------------------------
+// A stylized view cone per remembered frame: wide enough to read as "the robot
+// looked this way", far narrower than the camera's real 128° FOV (which would
+// wash the map in overlapping wedges).
+const MEM_WEDGE_HALF_RAD = (28 * Math.PI) / 180;
+const MEM_WEDGE_RANGE_M = 1.15;
+const MEM_HIT_PX = 16; // hover/click hit radius around a memory dot (css px)
+const MEM_PULSE_MS = 1200; // ring animation when a new memory is recorded
+// A latched search verdict older than this is history, not news — show nothing.
+const MEM_SEARCH_FRESH_S = 20;
+const MEM_SEARCH_GLOW_MS = 18_000; // how long the recalled spot keeps breathing
+const MEM_SEARCH_CARD_MS = 14_000; // the verdict card auto-dismisses
 
 /**
  * Rasterize a nav_msgs/OccupancyGrid into `canvas` at 1px per cell, flipped
@@ -108,7 +125,7 @@ function rasterizeGrid(msg, canvas, ctx, paint) {
  *   small); enables scroll-to-zoom. Omit to fit the whole grid (the standalone page). onZoomChange
  *   fires after each wheel-zoom. layers turns on optional overlays (Nav page): live lidar scan,
  *   global/local costmaps, odometry trail — each adds its subscription only while enabled.
- * @returns {{ destroy: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void }}
+ * @returns {{ destroy: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void, highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void }}
  */
 export function createMap(root, opts = {}) {
   let zoomMeters = opts.zoom;
@@ -237,7 +254,7 @@ export function createMap(root, opts = {}) {
 
   // ---- optional overlay layers (Nav page) ---------------------------------
   /** @type {Record<LayerName, boolean>} */
-  const layers = { scan: false, costmap: false, local: false, trail: false, ...opts.layers };
+  const layers = { scan: false, costmap: false, local: false, trail: false, memories: false, ...opts.layers };
   /** @type {any} latest sensor_msgs/LaserScan */
   let scanMsg = null;
   // base_link -> base_laser from /tf_static (URDF); zero until it arrives.
@@ -254,8 +271,255 @@ export function createMap(root, opts = {}) {
   let localGrid = null;
   /** @type {Array<{ x: number, y: number }>} map-frame breadcrumb trail */
   const trail = [];
-  /** @type {Partial<Record<"scan" | "costmap" | "local" | "tf", () => void>>} live layer subscriptions */
+  /** @type {Partial<Record<"scan" | "costmap" | "local" | "tf" | "memories" | "memsearch", () => void>>} live layer subscriptions */
   const layerUnsubs = {};
+
+  // ---- spatial-memory layer state -----------------------------------------
+  /** @type {import("./memories.js").MemoryState | null} */
+  let memState = null;
+  /** @type {Set<number> | null} ids seen so far; null until the first payload
+   * (which adopts everything silently — a page load must not pulse the world) */
+  let memKnown = null;
+  /** @type {Map<number, number>} memory id -> performance.now() of its pulse-in */
+  const memPulses = new Map();
+  /** @type {import("./memories.js").Memory | null} memory under the cursor */
+  let memHover = null;
+  /** @type {number | null} memory highlighted from outside (gallery hover) */
+  let memHighlight = null;
+  /** @type {number | null} memory whose popup card is open */
+  let memPopupFor = null;
+  /** @type {ReturnType<typeof parseSearch>} latest fresh search verdict */
+  let memSearch = null;
+  let memSearchUntil = 0; // performance.now() deadline for the recalled-spot glow
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let memSearchCardTimer;
+
+  // The three DOM overlays: a hover thumbnail, a pinned popup (Go here), and
+  // the search-verdict card. All positioned within `root` over the canvas.
+  const memHoverCard = document.createElement("div");
+  memHoverCard.className = "mem-card mem-card-hover";
+  memHoverCard.hidden = true;
+  root.appendChild(memHoverCard);
+  const memPopup = document.createElement("div");
+  memPopup.className = "mem-card mem-card-popup";
+  memPopup.hidden = true;
+  root.appendChild(memPopup);
+  const memSearchCard = document.createElement("div");
+  memSearchCard.className = "mem-search-card";
+  memSearchCard.hidden = true;
+  root.appendChild(memSearchCard);
+
+  /** @param {any} msg std_msgs/String — /brain/memory_positions */
+  function onMemories(msg) {
+    const next = parseMemories(msg);
+    if (!next) return;
+    if (memKnown === null || (memState && memState.map !== next.map)) {
+      memKnown = new Set(next.memories.map((m) => m.id));
+      memPulses.clear();
+      closeMemPopup();
+    } else {
+      for (const m of next.memories) {
+        if (memKnown.has(m.id)) continue;
+        memKnown.add(m.id);
+        memPulses.set(m.id, performance.now());
+      }
+    }
+    memState = next;
+    if (memHover && !next.memories.some((m) => m.id === memHover?.id)) setMemHover(null);
+    if (memPopupFor !== null && !next.memories.some((m) => m.id === memPopupFor)) closeMemPopup();
+    kickMemAnim();
+    draw();
+  }
+
+  /** @param {any} msg std_msgs/String — /brain/memory_search (latched) */
+  function onMemorySearch(msg) {
+    const verdict = parseSearch(msg);
+    if (!verdict) return;
+    if (Date.now() / 1000 - verdict.stamp > MEM_SEARCH_FRESH_S) return; // stale latched replay
+    memSearch = verdict;
+    memSearchUntil = performance.now() + (verdict.found ? MEM_SEARCH_GLOW_MS : 0);
+    showMemSearchCard(verdict);
+    kickMemAnim();
+    draw();
+  }
+
+  // rAF ticker for the layer's animations (pulse-ins, the recalled-spot glow).
+  // Runs only while something is animating; every other redraw stays event-driven.
+  let memAnimFrame = 0;
+  function memAnimActive() {
+    const now = performance.now();
+    for (const born of memPulses.values()) if (now - born < MEM_PULSE_MS) return true;
+    return Boolean(memSearch?.found) && now < memSearchUntil;
+  }
+  function kickMemAnim() {
+    if (memAnimFrame) return;
+    const step = () => {
+      memAnimFrame = 0;
+      draw();
+      if (memAnimActive()) memAnimFrame = requestAnimationFrame(step);
+    };
+    memAnimFrame = requestAnimationFrame(step);
+  }
+
+  /** Nearest memory within the hit radius of a canvas point, or null.
+   * @param {number} px @param {number} py */
+  function hitMemory(px, py) {
+    if (!layers.memories || !memState || !grid || !view) return null;
+    let best = null;
+    let bestD = MEM_HIT_PX * dpr();
+    for (const m of memState.memories) {
+      const c = worldToCanvas(m.x, m.y);
+      const dist = Math.hypot(c.px - px, c.py - py);
+      if (dist < bestD) {
+        bestD = dist;
+        best = m;
+      }
+    }
+    return best;
+  }
+
+  /** Anchor a card next to a memory's dot, clamped inside the scene.
+   * @param {HTMLElement} el @param {import("./memories.js").Memory} m */
+  function placeMemCard(el, m) {
+    if (!grid || !view) return;
+    const d = dpr();
+    const { px, py } = worldToCanvas(m.x, m.y);
+    const x = px / d;
+    const y = py / d;
+    const left = Math.min(Math.max(8, x + 16), Math.max(8, root.clientWidth - el.offsetWidth - 8));
+    const above = y - el.offsetHeight - 16;
+    el.style.left = `${left}px`;
+    el.style.top = `${above > 8 ? above : Math.min(y + 16, Math.max(8, root.clientHeight - el.offsetHeight - 8))}px`;
+  }
+
+  /** @param {import("./memories.js").Memory | null} m */
+  function setMemHover(m) {
+    if (memHover?.id === m?.id) return;
+    memHover = m;
+    render();
+    if (!m || !memState || memPopupFor !== null) {
+      memHoverCard.hidden = true;
+      draw();
+      return;
+    }
+    memHoverCard.innerHTML = "";
+    const img = new Image();
+    img.className = "mem-card-img";
+    img.alt = "remembered view";
+    img.src = memoryImageUrl(memState.map, m);
+    const meta = document.createElement("div");
+    meta.className = "mem-card-meta mono";
+    meta.textContent = `seen ${ageText(m.stamp)} · click for options`;
+    memHoverCard.append(img, meta);
+    memHoverCard.hidden = false;
+    placeMemCard(memHoverCard, m);
+    draw();
+  }
+
+  /** @param {import("./memories.js").Memory} m */
+  function openMemPopup(m) {
+    if (!memState) return;
+    memPopupFor = m.id;
+    memHoverCard.hidden = true;
+    memPopup.innerHTML = "";
+    const img = new Image();
+    img.className = "mem-card-img mem-card-img-lg";
+    img.alt = "remembered view";
+    img.src = memoryImageUrl(memState.map, m);
+    const meta = document.createElement("div");
+    meta.className = "mem-card-meta mono";
+    meta.textContent = `seen ${ageText(m.stamp)} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
+    const actions = document.createElement("div");
+    actions.className = "mem-card-actions";
+    const goHere = document.createElement("button");
+    goHere.type = "button";
+    goHere.className = "mem-card-btn mem-card-btn-go";
+    goHere.textContent = "Go here";
+    goHere.title = "/navigate_to_pose (action) — drive to this remembered viewpoint";
+    goHere.addEventListener("click", () => {
+      closeMemPopup();
+      publishGoal(m.x, m.y, m.theta);
+    });
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "mem-card-btn";
+    close.textContent = "Close";
+    close.addEventListener("click", closeMemPopup);
+    actions.append(goHere, close);
+    memPopup.append(img, meta, actions);
+    memPopup.hidden = false;
+    placeMemCard(memPopup, m);
+    draw();
+  }
+
+  function closeMemPopup() {
+    if (memPopupFor === null) return;
+    memPopupFor = null;
+    memPopup.hidden = true;
+    draw();
+  }
+
+  /** @param {NonNullable<ReturnType<typeof parseSearch>>} verdict */
+  function showMemSearchCard(verdict) {
+    clearTimeout(memSearchCardTimer);
+    memSearchCard.innerHTML = "";
+    memSearchCard.classList.toggle("is-found", Boolean(verdict.found));
+    const head = document.createElement("div");
+    head.className = "mem-search-head";
+    const label = document.createElement("span");
+    label.className = "microlabel";
+    label.textContent = "memory recall";
+    const query = document.createElement("span");
+    query.className = "mem-search-query";
+    query.textContent = `“${verdict.query}”`;
+    head.append(label, query);
+    if (typeof verdict.latency_sec === "number") {
+      const chip = document.createElement("span");
+      chip.className = "mem-search-chip mono";
+      chip.textContent = `${verdict.latency_sec.toFixed(1)} s${verdict.cached ? " · cached ⚡" : ""}`;
+      head.appendChild(chip);
+    }
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "mem-search-close";
+    closeBtn.textContent = "×";
+    closeBtn.setAttribute("aria-label", "dismiss");
+    closeBtn.addEventListener("click", hideMemSearchCard);
+    head.appendChild(closeBtn);
+    memSearchCard.appendChild(head);
+    const body = document.createElement("div");
+    body.className = "mem-search-body";
+    if (verdict.found && memState) {
+      const match = memState.memories.find((m) => m.id === verdict.id);
+      if (match) {
+        const img = new Image();
+        img.className = "mem-search-img";
+        img.alt = "recalled view";
+        img.src = memoryImageUrl(memState.map, match);
+        body.appendChild(img);
+      }
+    }
+    const text = document.createElement("div");
+    text.className = "mem-search-text";
+    text.textContent = verdict.found
+      ? verdict.explanation || "Found a matching remembered view."
+      : verdict.error
+        ? `Recall failed — ${verdict.error}`
+        : verdict.explanation || "Nothing in the remembered views matches.";
+    body.appendChild(text);
+    memSearchCard.appendChild(body);
+    memSearchCard.hidden = false;
+    // Two frames so the transition runs from the hidden state.
+    memSearchCard.classList.remove("is-in");
+    requestAnimationFrame(() => requestAnimationFrame(() => memSearchCard.classList.add("is-in")));
+    memSearchCardTimer = setTimeout(hideMemSearchCard, MEM_SEARCH_CARD_MS);
+  }
+
+  function hideMemSearchCard() {
+    clearTimeout(memSearchCardTimer);
+    memSearchCard.classList.remove("is-in");
+    memSearchCard.hidden = true;
+  }
 
   /** @param {any} msg sensor_msgs/LaserScan */
   function onScan(msg) {
@@ -346,6 +610,22 @@ export function createMap(root, opts = {}) {
       layerUnsubs.local();
       delete layerUnsubs.local;
       localGrid = null;
+    }
+    if (layers.memories && !layerUnsubs.memories) {
+      layerUnsubs.memories = ros.subscribe(MEMORY_POSITIONS_TOPIC, onMemories, 0, "std_msgs/msg/String");
+      layerUnsubs.memsearch = ros.subscribe(MEMORY_SEARCH_TOPIC, onMemorySearch, 0, "std_msgs/msg/String");
+    } else if (!layers.memories && layerUnsubs.memories) {
+      layerUnsubs.memories();
+      layerUnsubs.memsearch?.();
+      delete layerUnsubs.memories;
+      delete layerUnsubs.memsearch;
+      memState = null;
+      memKnown = null;
+      memPulses.clear();
+      memSearch = null;
+      setMemHover(null);
+      closeMemPopup();
+      hideMemSearchCard();
     }
   }
 
@@ -615,6 +895,8 @@ export function createMap(root, opts = {}) {
       ctx.restore();
     }
 
+    drawMemories();
+
     if (layers.trail && trail.length >= 2) {
       ctx.strokeStyle = MAP_COLORS.trail;
       ctx.lineWidth = 1.5 * dpr();
@@ -660,6 +942,8 @@ export function createMap(root, opts = {}) {
         ctx.fillRect(px - size / 2, py - size / 2, size, size);
       }
     }
+
+    drawMemorySearch();
 
     // Ghost dot under the cursor while manual/goto is armed, until the press
     // starts the real drag.
@@ -712,6 +996,100 @@ export function createMap(root, opts = {}) {
       ctx.lineTo(px + Math.cos(pose.yaw) * rad * 2.4, py - Math.sin(pose.yaw) * rad * 2.4);
       ctx.stroke();
     }
+
+    // Cards are world-anchored DOM: keep them glued to their memory through
+    // every pan/zoom/follow reframe.
+    if (!memHoverCard.hidden && memHover) placeMemCard(memHoverCard, memHover);
+    if (!memPopup.hidden && memPopupFor !== null) {
+      const m = memState?.memories.find((mem) => mem.id === memPopupFor);
+      if (m) placeMemCard(memPopup, m);
+      else closeMemPopup();
+    }
+  }
+
+  /** The remembered viewpoints: one soft view cone + dot each, fading with
+   * age; a white ring blooms once when a memory is first recorded. */
+  function drawMemories() {
+    if (!ctx || !grid || !view || !layers.memories || !memState?.memories.length) return;
+    const nowS = Date.now() / 1000;
+    const nowMs = performance.now();
+    const d = dpr();
+    const g = /** @type {NonNullable<typeof grid>} */ (grid);
+    const v = /** @type {NonNullable<typeof view>} */ (view);
+    const range = (MEM_WEDGE_RANGE_M / g.resolution) * v.scale;
+    const searchHit = memSearch?.found && nowMs < memSearchUntil ? memSearch.id : null;
+    for (const m of memState.memories) {
+      const { px, py } = worldToCanvas(m.x, m.y);
+      const active = memHover?.id === m.id || memHighlight === m.id || memPopupFor === m.id || searchHit === m.id;
+      const alpha = active ? 1 : ageAlpha(m.stamp, nowS);
+      // The view cone (canvas y is down, so world angles negate).
+      const grad = ctx.createRadialGradient(px, py, 0, px, py, range);
+      grad.addColorStop(0, withAlpha(MEMORY_COLOR, (active ? 0.5 : 0.3) * alpha));
+      grad.addColorStop(1, withAlpha(MEMORY_COLOR, 0));
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.moveTo(px, py);
+      ctx.arc(px, py, range, -m.theta - MEM_WEDGE_HALF_RAD, -m.theta + MEM_WEDGE_HALF_RAD);
+      ctx.closePath();
+      ctx.fill();
+      // The dot.
+      ctx.fillStyle = withAlpha(MEMORY_COLOR, active ? 1 : 0.45 + 0.55 * alpha);
+      ctx.beginPath();
+      ctx.arc(px, py, (active ? 4.5 : 3) * d, 0, Math.PI * 2);
+      ctx.fill();
+      if (active) {
+        ctx.strokeStyle = withAlpha("#ffffff", 0.9);
+        ctx.lineWidth = 1.5 * d;
+        ctx.beginPath();
+        ctx.arc(px, py, 6.5 * d, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+      // Pulse-in: a ring blooms outward as the robot commits a new memory.
+      const born = memPulses.get(m.id);
+      if (born !== undefined) {
+        const t = (nowMs - born) / MEM_PULSE_MS;
+        if (t >= 1) memPulses.delete(m.id);
+        else {
+          const ease = 1 - (1 - t) ** 3;
+          ctx.strokeStyle = withAlpha("#ffffff", 0.85 * (1 - t));
+          ctx.lineWidth = 2 * d;
+          ctx.beginPath();
+          ctx.arc(px, py, (6 + 30 * ease) * d, 0, Math.PI * 2);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+
+  /** The recall moment: breathing rings on the matched memory and a drifting
+   * dashed thread from the robot to it — "I remember it's over there". */
+  function drawMemorySearch() {
+    if (!ctx || !grid || !view || !layers.memories) return;
+    if (!memSearch?.found || typeof memSearch.x !== "number" || typeof memSearch.y !== "number") return;
+    if (performance.now() >= memSearchUntil) return;
+    const d = dpr();
+    const t = performance.now() / 1000;
+    const { px, py } = worldToCanvas(memSearch.x, memSearch.y);
+    if (pose) {
+      const from = worldToCanvas(pose.x, pose.y);
+      ctx.strokeStyle = withAlpha(MEMORY_COLOR, 0.75);
+      ctx.lineWidth = 1.5 * d;
+      ctx.setLineDash([6 * d, 6 * d]);
+      ctx.lineDashOffset = -((t * 30 * d) % (12 * d));
+      ctx.beginPath();
+      ctx.moveTo(from.px, from.py);
+      ctx.lineTo(px, py);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+    for (let k = 0; k < 2; k++) {
+      const phase = (t * 0.8 + k * 0.5) % 1;
+      ctx.strokeStyle = withAlpha(MEMORY_COLOR, 0.9 * (1 - phase));
+      ctx.lineWidth = 2 * d;
+      ctx.beginPath();
+      ctx.arc(px, py, (7 + phase * 26) * d, 0, Math.PI * 2);
+      ctx.stroke();
+    }
   }
 
   function render() {
@@ -733,12 +1111,16 @@ export function createMap(root, opts = {}) {
     setHint(goBtn, ui === "goto" ? "click & drag on the map" : "tap a point to navigate");
     stopBtn.hidden = !(ui === "idle" && navActive) || mappingMode;
     centerBtn.hidden = panCenter === null;
-    canvas.style.cursor = ui === "manual" || ui === "goto" ? "crosshair" : "grab";
+    canvas.style.cursor = ui === "manual" || ui === "goto" ? "crosshair" : memHover ? "pointer" : "grab";
   }
 
   /** @param {"idle" | "locate" | "manual" | "goto"} next */
   function setUi(next) {
     ui = next;
+    if (ui !== "idle") {
+      setMemHover(null);
+      closeMemPopup();
+    }
     if ((ui !== "manual" && ui !== "goto") && (goalDrag || hoverPt)) {
       goalDrag = null;
       hoverPt = null;
@@ -888,6 +1270,10 @@ export function createMap(root, opts = {}) {
       draw();
       return;
     }
+    if (!panDrag && ui === "idle") {
+      const { px, py } = eventToCanvas(e);
+      setMemHover(hitMemory(px, py));
+    }
     if (!panDrag || !grid || !view) return;
     const { px, py } = eventToCanvas(e);
     const dx = px - panDrag.px;
@@ -907,8 +1293,15 @@ export function createMap(root, opts = {}) {
   /** @param {PointerEvent} e */
   function onPointerUp(e) {
     if (panDrag) {
+      const clicked = !panDrag.moved;
       panDrag = null;
       render(); // restore the cursor, surface Recenter
+      // A plain click (no pan) opens the memory under the cursor — or lets an
+      // open popup go when the click landed on empty map.
+      if (clicked) {
+        if (memHover) openMemPopup(memHover);
+        else closeMemPopup();
+      }
       return;
     }
     if (!goalDrag) return;
@@ -994,11 +1387,19 @@ export function createMap(root, opts = {}) {
   canvas.addEventListener("pointermove", onPointerMove);
   canvas.addEventListener("pointerup", onPointerUp);
   canvas.addEventListener("pointerleave", () => {
+    setMemHover(null);
     if (!hoverPt) return;
     hoverPt = null;
     draw();
   });
   canvas.addEventListener("wheel", onWheel, { passive: false });
+  /** @param {KeyboardEvent} e */
+  function onKeyDown(e) {
+    if (e.key !== "Escape") return;
+    closeMemPopup();
+    hideMemSearchCard();
+  }
+  document.addEventListener("keydown", onKeyDown);
 
   // Resize with the container, not just the window — covers reparenting between
   // the small PiP tile and the full stage in teleop.
@@ -1040,6 +1441,12 @@ export function createMap(root, opts = {}) {
       if (on) {
         amclPose = null;
         odomAtAmcl = null;
+        // Memory marks are frames of the *finished* map — meaningless against
+        // the one being built.
+        setMemHover(null);
+        closeMemPopup();
+        hideMemSearchCard();
+        memSearch = null;
         unsubMappingPose = ros.subscribe(
           MAPPING_POSE_TOPIC,
           (msg) => {
@@ -1076,7 +1483,27 @@ export function createMap(root, opts = {}) {
       amclPose = null;
       odomAtAmcl = null;
       trail.length = 0;
+      // The memory layer swaps itself when the positions payload names the new
+      // map; the search verdict and popup belong to the old frame — drop now.
+      closeMemPopup();
+      hideMemSearchCard();
+      memSearch = null;
       pose = composedPose();
+      draw();
+    },
+    /** Gallery hover: hold one memory bright without opening anything. @param {number | null} id */
+    highlightMemory(id) {
+      if (memHighlight === id) return;
+      memHighlight = id;
+      draw();
+    },
+    /** Gallery click: centre the view on a memory and open its popup. @param {number} id */
+    focusMemory(id) {
+      const m = memState?.memories.find((mem) => mem.id === id);
+      if (!m) return;
+      panCenter = { x: m.x, y: m.y };
+      render(); // surfaces Recenter, like a hand pan
+      openMemPopup(m);
       draw();
     },
     /** Toggle an overlay layer (subscribes/unsubscribes its topics live).
@@ -1090,6 +1517,9 @@ export function createMap(root, opts = {}) {
     destroy() {
       clearTimeout(navStaleTimer);
       clearTimeout(statusClearTimer);
+      clearTimeout(memSearchCardTimer);
+      cancelAnimationFrame(memAnimFrame);
+      document.removeEventListener("keydown", onKeyDown);
       ro.disconnect();
       unsubMap();
       unsubOdom();
@@ -1100,6 +1530,9 @@ export function createMap(root, opts = {}) {
       for (const unsub of Object.values(layerUnsubs)) unsub();
       canvas.remove();
       controls.remove();
+      memHoverCard.remove();
+      memPopup.remove();
+      memSearchCard.remove();
     },
   };
 }

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -26,7 +26,7 @@ import {
   MEMORY_POSITIONS_TOPIC,
   MEMORY_SEARCH_TOPIC,
 } from "../constants.js";
-import { MEMORY_COLOR, SEARCH_REPLAY_FRESH_S, ageAlpha, ageText, clockSkew, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
+import { MEMORY_COLOR, SEARCH_REPLAY_FRESH_S, ageAlpha, ageText, headerSkew, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
 
 // Overlay palette — exported so the Nav page legend shows the same colors.
 // The robot is deliberately far from the costmap ramp (blue → amber → red):
@@ -149,7 +149,7 @@ function rasterizeGrid(msg, canvas, ctx, paint) {
  *   small); enables scroll-to-zoom. Omit to fit the whole grid (the standalone page). onZoomChange
  *   fires after each wheel-zoom. layers turns on optional overlays (Nav page): live lidar scan,
  *   global/local costmaps, odometry trail — each adds its subscription only while enabled.
- * @returns {{ destroy: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void, highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void }}
+ * @returns {{ destroy: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void, highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void, robotNowS: () => number }}
  */
 export function createMap(root, opts = {}) {
   let zoomMeters = opts.zoom;
@@ -323,7 +323,10 @@ export function createMap(root, opts = {}) {
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let memSearchCardTimer;
   let memCardsViewSig = ""; // the view framing the cards were last placed against
-  let memClockSkew = 0; // robot clock − browser clock, learned from the positions payload
+  // Robot clock − browser clock, learned from odom stamps: odom only flows
+  // live, so the skew is always fresh — the latched memory topics can't teach
+  // it (their replay arrives arbitrarily long after publish).
+  let memClockSkew = 0;
   const robotNowS = () => Date.now() / 1000 + memClockSkew;
 
   // The three DOM overlays: a hover thumbnail, a pinned popup (Go here), and
@@ -381,7 +384,6 @@ export function createMap(root, opts = {}) {
   function onMemories(msg) {
     const next = parseMemories(msg);
     if (!next) return;
-    memClockSkew = clockSkew(next);
     // Keyed on map+fingerprint: a same-name re-map wipes the store and
     // restarts ids at 1 — without the fingerprint those reborn ids would all
     // be "known" and never pulse (and dead-map cards would linger).
@@ -837,6 +839,8 @@ export function createMap(root, opts = {}) {
 
   /** @param {any} msg nav_msgs/Odometry */
   function onOdom(msg) {
+    const skew = headerSkew(msg);
+    if (skew !== null) memClockSkew = skew;
     const p = poseOf(msg);
     if (!p) return;
     odomPose = p;
@@ -1788,6 +1792,9 @@ export function createMap(root, opts = {}) {
       pose = composedPose();
       draw();
     },
+    /** The robot's clock in epoch seconds (see memClockSkew) — memory stamps
+     * are robot time, so hosts age them against this, never the browser's. */
+    robotNowS,
     /** Gallery hover: hold one memory bright without opening anything. @param {number | null} id */
     highlightMemory(id) {
       if (memHighlight === id) return;

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -201,6 +201,7 @@ export function createMap(root, opts = {}) {
   const stopBtn = makeButton(ICONS.stop, "Stop", "cancel navigation");
   stopBtn.title = CANCEL_NAVIGATION_SERVICE;
   const centerBtn = makeButton(ICONS.center, "Recenter", "follow the robot");
+  centerBtn.title = "Recenter the view on the robot (view only — no ROS call)";
   const controlsRow = document.createElement("div");
   controlsRow.className = "map-controls-row";
   for (const btn of [backBtn, locateBtn, autoBtn, manualBtn, goBtn, stopBtn, centerBtn]) controlsRow.appendChild(btn);
@@ -336,6 +337,42 @@ export function createMap(root, opts = {}) {
   memSearchCard.className = "mem-search-card";
   memSearchCard.hidden = true;
   root.appendChild(memSearchCard);
+
+  // Full-screen viewer for a remembered image — opened by clicking the
+  // popup's photo. On document.body (like the confirm dialogs) so it covers
+  // the whole app, not just the scene.
+  const memLightbox = document.createElement("div");
+  memLightbox.className = "mem-lightbox";
+  memLightbox.hidden = true;
+  const memLightboxImg = new Image();
+  memLightboxImg.className = "mem-lightbox-img";
+  memLightboxImg.alt = "remembered view";
+  const memLightboxCap = document.createElement("div");
+  memLightboxCap.className = "mem-lightbox-cap mono";
+  const memLightboxClose = document.createElement("button");
+  memLightboxClose.type = "button";
+  memLightboxClose.className = "mem-lightbox-close";
+  memLightboxClose.textContent = "✕";
+  memLightboxClose.title = "Close";
+  memLightbox.append(memLightboxImg, memLightboxCap, memLightboxClose);
+  memLightbox.addEventListener("click", (e) => {
+    // The backdrop and ✕ close; a click on the photo itself must not.
+    if (e.target === memLightbox || e.target === memLightboxClose) closeMemLightbox();
+  });
+  document.body.appendChild(memLightbox);
+
+  /** @param {import("./memories.js").Memory} m */
+  function openMemLightbox(m) {
+    if (!memState) return;
+    memLightboxImg.src = memoryImageUrl(memState.map, m);
+    memLightboxCap.textContent = `seen ${ageText(m.stamp)} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
+    memLightbox.hidden = false;
+  }
+
+  function closeMemLightbox() {
+    memLightbox.hidden = true;
+    memLightboxImg.removeAttribute("src");
+  }
 
   /** @param {any} msg std_msgs/String — /brain/memory_positions */
   function onMemories(msg) {
@@ -474,6 +511,8 @@ export function createMap(root, opts = {}) {
     img.className = "mem-card-img mem-card-img-lg";
     img.alt = "remembered view";
     img.src = memoryImageUrl(memState.map, m);
+    img.title = "Click to enlarge";
+    img.addEventListener("click", () => openMemLightbox(m));
     const meta = document.createElement("div");
     meta.className = "mem-card-meta mono";
     meta.textContent = `seen ${ageText(m.stamp)} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
@@ -525,12 +564,14 @@ export function createMap(root, opts = {}) {
       const chip = document.createElement("span");
       chip.className = "mem-search-chip mono";
       chip.textContent = `${verdict.latency_sec.toFixed(1)} s${verdict.cached ? " · cached ⚡" : ""}`;
+      chip.title = "Recall latency; cached = answered from the warm memory cache";
       head.appendChild(chip);
     }
     const closeBtn = document.createElement("button");
     closeBtn.type = "button";
     closeBtn.className = "mem-search-close";
     closeBtn.textContent = "×";
+    closeBtn.title = "Dismiss";
     closeBtn.setAttribute("aria-label", "dismiss");
     closeBtn.addEventListener("click", dismissMemSearch);
     head.appendChild(closeBtn);
@@ -1616,6 +1657,11 @@ export function createMap(root, opts = {}) {
   /** @param {KeyboardEvent} e */
   function onKeyDown(e) {
     if (e.key !== "Escape") return;
+    if (!memLightbox.hidden) {
+      // Layered dismissal: the viewer closes first, the popup under it stays.
+      closeMemLightbox();
+      return;
+    }
     closeMemPopup();
     dismissMemSearch();
   }
@@ -1758,6 +1804,7 @@ export function createMap(root, opts = {}) {
       memHoverCard.remove();
       memPopup.remove();
       memSearchCard.remove();
+      memLightbox.remove();
     },
   };
 }

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -26,7 +26,7 @@ import {
   MEMORY_POSITIONS_TOPIC,
   MEMORY_SEARCH_TOPIC,
 } from "../constants.js";
-import { MEMORY_COLOR, ageAlpha, ageText, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
+import { MEMORY_COLOR, SEARCH_REPLAY_FRESH_S, ageAlpha, ageText, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
 
 // Overlay palette — exported so the Nav page legend shows the same colors.
 // The robot is deliberately far from the costmap ramp (blue → amber → red):
@@ -75,8 +75,6 @@ const MEM_WEDGE_HALF_RAD = (28 * Math.PI) / 180;
 const MEM_WEDGE_RANGE_M = 1.15;
 const MEM_HIT_PX = 16; // hover/click hit radius around a memory dot (css px)
 const MEM_PULSE_MS = 1200; // ring animation when a new memory is recorded
-// A latched search verdict older than this is history, not news — show nothing.
-const MEM_SEARCH_FRESH_S = 20;
 const MEM_SEARCH_GLOW_MS = 18_000; // how long the recalled spot keeps breathing
 const MEM_SEARCH_CARD_MS = 14_000; // the verdict card auto-dismisses
 
@@ -271,7 +269,7 @@ export function createMap(root, opts = {}) {
   let localGrid = null;
   /** @type {Array<{ x: number, y: number }>} map-frame breadcrumb trail */
   const trail = [];
-  /** @type {Partial<Record<"scan" | "costmap" | "local" | "tf" | "memories" | "memsearch", () => void>>} live layer subscriptions */
+  /** @type {Partial<Record<"scan" | "costmap" | "local" | "tf" | "memsearch", () => void>>} live layer subscriptions */
   const layerUnsubs = {};
 
   // ---- spatial-memory layer state -----------------------------------------
@@ -293,6 +291,7 @@ export function createMap(root, opts = {}) {
   let memSearchUntil = 0; // performance.now() deadline for the recalled-spot glow
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let memSearchCardTimer;
+  let memCardsViewSig = ""; // the view framing the cards were last placed against
 
   // The three DOM overlays: a hover thumbnail, a pinned popup (Go here), and
   // the search-verdict card. All positioned within `root` over the canvas.
@@ -313,15 +312,23 @@ export function createMap(root, opts = {}) {
   function onMemories(msg) {
     const next = parseMemories(msg);
     if (!next) return;
-    if (memKnown === null || (memState && memState.map !== next.map)) {
+    // Keyed on map+fingerprint: a same-name re-map wipes the store and
+    // restarts ids at 1 — without the fingerprint those reborn ids would all
+    // be "known" and never pulse (and dead-map cards would linger).
+    const swapped = memState && (memState.map !== next.map || memState.fingerprint !== next.fingerprint);
+    if (memKnown === null || swapped) {
       memKnown = new Set(next.memories.map((m) => m.id));
       memPulses.clear();
       closeMemPopup();
+      // A recall verdict belongs to the map it was answered on — a switch
+      // must not leave its glow pointing into the new map's frame.
+      memSearch = null;
+      hideMemSearchCard();
     } else {
       for (const m of next.memories) {
         if (memKnown.has(m.id)) continue;
         memKnown.add(m.id);
-        memPulses.set(m.id, performance.now());
+        if (layers.memories) memPulses.set(m.id, performance.now());
       }
     }
     memState = next;
@@ -331,11 +338,18 @@ export function createMap(root, opts = {}) {
     draw();
   }
 
+  // The first memsearch message after subscribing is the latched replay:
+  // history, shown only while fresh. Later arrivals are live news — never
+  // gated on the stamp, because the robot's wall clock can disagree with the
+  // browser's (no RTC before NTP settles) by more than the freshness window.
+  let memSearchSeen = false;
   /** @param {any} msg std_msgs/String — /brain/memory_search (latched) */
   function onMemorySearch(msg) {
     const verdict = parseSearch(msg);
     if (!verdict) return;
-    if (Date.now() / 1000 - verdict.stamp > MEM_SEARCH_FRESH_S) return; // stale latched replay
+    const replay = !memSearchSeen;
+    memSearchSeen = true;
+    if (replay && Date.now() / 1000 - verdict.stamp > SEARCH_REPLAY_FRESH_S) return; // stale latched replay
     memSearch = verdict;
     memSearchUntil = performance.now() + (verdict.found ? MEM_SEARCH_GLOW_MS : 0);
     showMemSearchCard(verdict);
@@ -484,7 +498,7 @@ export function createMap(root, opts = {}) {
     closeBtn.className = "mem-search-close";
     closeBtn.textContent = "×";
     closeBtn.setAttribute("aria-label", "dismiss");
-    closeBtn.addEventListener("click", hideMemSearchCard);
+    closeBtn.addEventListener("click", dismissMemSearch);
     head.appendChild(closeBtn);
     memSearchCard.appendChild(head);
     const body = document.createElement("div");
@@ -519,6 +533,15 @@ export function createMap(root, opts = {}) {
     clearTimeout(memSearchCardTimer);
     memSearchCard.classList.remove("is-in");
     memSearchCard.hidden = true;
+  }
+
+  /** User dismissal (× or Escape) ends the whole recall moment — card, glow,
+   * and thread. The auto-dismiss timer keeps hideMemSearchCard: there the
+   * glow deliberately outlives the card by a few seconds. */
+  function dismissMemSearch() {
+    memSearchUntil = 0;
+    hideMemSearchCard();
+    draw();
   }
 
   /** @param {any} msg sensor_msgs/LaserScan */
@@ -611,16 +634,14 @@ export function createMap(root, opts = {}) {
       delete layerUnsubs.local;
       localGrid = null;
     }
-    if (layers.memories && !layerUnsubs.memories) {
-      layerUnsubs.memories = ros.subscribe(MEMORY_POSITIONS_TOPIC, onMemories, 0, "std_msgs/msg/String");
+    if (layers.memories && !layerUnsubs.memsearch) {
       layerUnsubs.memsearch = ros.subscribe(MEMORY_SEARCH_TOPIC, onMemorySearch, 0, "std_msgs/msg/String");
-    } else if (!layers.memories && layerUnsubs.memories) {
-      layerUnsubs.memories();
-      layerUnsubs.memsearch?.();
-      delete layerUnsubs.memories;
+    } else if (!layers.memories && layerUnsubs.memsearch) {
+      layerUnsubs.memsearch();
       delete layerUnsubs.memsearch;
-      memState = null;
-      memKnown = null;
+      // memState/memKnown stay: the positions feed is always on (it also
+      // drives the sidebar reel's highlight/focus) — only the marks hide.
+      memSearchSeen = false;
       memPulses.clear();
       memSearch = null;
       setMemHover(null);
@@ -998,12 +1019,18 @@ export function createMap(root, opts = {}) {
     }
 
     // Cards are world-anchored DOM: keep them glued to their memory through
-    // every pan/zoom/follow reframe.
-    if (!memHoverCard.hidden && memHover) placeMemCard(memHoverCard, memHover);
-    if (!memPopup.hidden && memPopupFor !== null) {
-      const m = memState?.memories.find((mem) => mem.id === memPopupFor);
-      if (m) placeMemCard(memPopup, m);
-      else closeMemPopup();
+    // every pan/zoom/follow reframe — but only re-place when the framing
+    // actually changed. placeMemCard reads offsetWidth/clientHeight (a forced
+    // layout), and the recall glow drives draw() at 60 fps for many seconds.
+    const cardsViewSig = view ? `${view.ox}|${view.oy}|${view.scale}` : "";
+    if (cardsViewSig !== memCardsViewSig) {
+      memCardsViewSig = cardsViewSig;
+      if (!memHoverCard.hidden && memHover) placeMemCard(memHoverCard, memHover);
+      if (!memPopup.hidden && memPopupFor !== null) {
+        const m = memState?.memories.find((mem) => mem.id === memPopupFor);
+        if (m) placeMemCard(memPopup, m);
+        else closeMemPopup();
+      }
     }
   }
 
@@ -1296,10 +1323,13 @@ export function createMap(root, opts = {}) {
       const clicked = !panDrag.moved;
       panDrag = null;
       render(); // restore the cursor, surface Recenter
-      // A plain click (no pan) opens the memory under the cursor — or lets an
-      // open popup go when the click landed on empty map.
+      // A plain click (no pan) opens the memory under the pointer — or lets an
+      // open popup go when the click landed on empty map. Hit-test here, not
+      // via memHover: touch has no hover phase before the tap.
       if (clicked) {
-        if (memHover) openMemPopup(memHover);
+        const { px, py } = eventToCanvas(e);
+        const hit = hitMemory(px, py);
+        if (hit) openMemPopup(hit);
         else closeMemPopup();
       }
       return;
@@ -1397,7 +1427,7 @@ export function createMap(root, opts = {}) {
   function onKeyDown(e) {
     if (e.key !== "Escape") return;
     closeMemPopup();
-    hideMemSearchCard();
+    dismissMemSearch();
   }
   document.addEventListener("keydown", onKeyDown);
 
@@ -1414,6 +1444,9 @@ export function createMap(root, opts = {}) {
   const unsubAmcl = ros.subscribe(AMCL_POSE_TOPIC, onAmcl, 0, "geometry_msgs/msg/PoseWithCovarianceStamped");
   const unsubPlans = PLAN_TOPICS.map((topic) => ros.subscribe(topic, (msg) => onPlan(topic, msg), 250, "nav_msgs/msg/Path"));
   const unsubGoal = ros.subscribe(COMMANDED_GOAL_TOPIC, onCommandedGoal, 0, "geometry_msgs/msg/PoseStamped");
+  // Always on (a tiny 1 Hz JSON), not layer-gated: highlightMemory/focusMemory
+  // must keep working from the sidebar reel while the layer chip is off.
+  const unsubMemories = ros.subscribe(MEMORY_POSITIONS_TOPIC, onMemories, 0, "std_msgs/msg/String");
 
   return {
     /** Swap to a saved zoom (e.g. when this widget reparents between thumbnail and full stage). */
@@ -1499,6 +1532,7 @@ export function createMap(root, opts = {}) {
     },
     /** Gallery click: centre the view on a memory and open its popup. @param {number} id */
     focusMemory(id) {
+      if (mappingMode) return; // the coordinates belong to the finished map, and Go-here mid-mapping is wrong
       const m = memState?.memories.find((mem) => mem.id === id);
       if (!m) return;
       panCenter = { x: m.x, y: m.y };
@@ -1526,6 +1560,7 @@ export function createMap(root, opts = {}) {
       unsubAmcl();
       for (const unsub of unsubPlans) unsub();
       unsubGoal();
+      unsubMemories();
       unsubMappingPose?.();
       for (const unsub of Object.values(layerUnsubs)) unsub();
       canvas.remove();

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -26,7 +26,7 @@ import {
   MEMORY_POSITIONS_TOPIC,
   MEMORY_SEARCH_TOPIC,
 } from "../constants.js";
-import { MEMORY_COLOR, SEARCH_REPLAY_FRESH_S, ageAlpha, ageText, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
+import { MEMORY_COLOR, SEARCH_REPLAY_FRESH_S, ageAlpha, ageText, clockSkew, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
 
 // Overlay palette — exported so the Nav page legend shows the same colors.
 // The robot is deliberately far from the costmap ramp (blue → amber → red):
@@ -256,6 +256,7 @@ export function createMap(root, opts = {}) {
   // against the growing grid is mode_manager's /mapping_pose (map frame, from
   // TF): raw odom drifts against it and any AMCL fix predates the map.
   let mappingMode = false;
+  let memoriesBeforeMapping = false; // restore the memories layer when mapping ends
   /** @type {{ x: number, y: number, yaw: number } | null} */
   let mappingPose = null;
   /** @type {(() => void) | null} */
@@ -322,6 +323,8 @@ export function createMap(root, opts = {}) {
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let memSearchCardTimer;
   let memCardsViewSig = ""; // the view framing the cards were last placed against
+  let memClockSkew = 0; // robot clock − browser clock, learned from the positions payload
+  const robotNowS = () => Date.now() / 1000 + memClockSkew;
 
   // The three DOM overlays: a hover thumbnail, a pinned popup (Go here), and
   // the search-verdict card. All positioned within `root` over the canvas.
@@ -365,7 +368,7 @@ export function createMap(root, opts = {}) {
   function openMemLightbox(m) {
     if (!memState) return;
     memLightboxImg.src = memoryImageUrl(memState.map, m);
-    memLightboxCap.textContent = `seen ${ageText(m.stamp)} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
+    memLightboxCap.textContent = `seen ${ageText(m.stamp, robotNowS())} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
     memLightbox.hidden = false;
   }
 
@@ -378,6 +381,7 @@ export function createMap(root, opts = {}) {
   function onMemories(msg) {
     const next = parseMemories(msg);
     if (!next) return;
+    memClockSkew = clockSkew(next);
     // Keyed on map+fingerprint: a same-name re-map wipes the store and
     // restarts ids at 1 — without the fingerprint those reborn ids would all
     // be "known" and never pulse (and dead-map cards would linger).
@@ -391,6 +395,10 @@ export function createMap(root, opts = {}) {
       memSearch = null;
       hideMemSearchCard();
     } else {
+      // "Forget all" wipes the store without changing the fingerprint and
+      // restarts ids at 1 — an empty payload resets what counts as known, so
+      // the reborn ids pulse like the new memories they are.
+      if (next.memories.length === 0) memKnown.clear();
       for (const m of next.memories) {
         if (memKnown.has(m.id)) continue;
         memKnown.add(m.id);
@@ -410,9 +418,9 @@ export function createMap(root, opts = {}) {
   }
 
   // The first memsearch message after subscribing is the latched replay:
-  // history, shown only while fresh. Later arrivals are live news — never
-  // gated on the stamp, because the robot's wall clock can disagree with the
-  // browser's (no RTC before NTP settles) by more than the freshness window.
+  // history, shown only while fresh (aged on the robot's clock via the skew —
+  // the browser's can sit hours off before NTP settles). Later arrivals are
+  // live news, never stamp-gated.
   let memSearchSeen = false;
   /** @param {any} msg std_msgs/String — /brain/memory_search (latched) */
   function onMemorySearch(msg) {
@@ -420,7 +428,7 @@ export function createMap(root, opts = {}) {
     if (!verdict) return;
     const replay = !memSearchSeen;
     memSearchSeen = true;
-    if (replay && Date.now() / 1000 - verdict.stamp > SEARCH_REPLAY_FRESH_S) return; // stale latched replay
+    if (replay && robotNowS() - verdict.stamp > SEARCH_REPLAY_FRESH_S) return; // stale latched replay
     memSearch = verdict;
     memSearchUntil = performance.now() + (verdict.found ? MEM_SEARCH_GLOW_MS : 0);
     showMemSearchCard(verdict);
@@ -430,7 +438,12 @@ export function createMap(root, opts = {}) {
 
   // rAF ticker for the layer's animations (pulse-ins, the recalled-spot glow).
   // Runs only while something is animating; every other redraw stays event-driven.
+  // Capped at ~30 fps: each tick repaints the whole scene (grid, overlays, a
+  // gradient per memory), and the glow runs for many seconds — full-rate
+  // redraws double that cost for no visible gain.
+  const MEM_ANIM_FRAME_MS = 30;
   let memAnimFrame = 0;
+  let memAnimLast = 0;
   function memAnimActive() {
     const now = performance.now();
     for (const born of memPulses.values()) if (now - born < MEM_PULSE_MS) return true;
@@ -438,9 +451,13 @@ export function createMap(root, opts = {}) {
   }
   function kickMemAnim() {
     if (memAnimFrame) return;
-    const step = () => {
+    /** @param {number} ts */
+    const step = (ts) => {
       memAnimFrame = 0;
-      draw();
+      if (ts - memAnimLast >= MEM_ANIM_FRAME_MS) {
+        memAnimLast = ts;
+        draw();
+      }
       if (memAnimActive()) memAnimFrame = requestAnimationFrame(step);
     };
     memAnimFrame = requestAnimationFrame(step);
@@ -494,7 +511,7 @@ export function createMap(root, opts = {}) {
     img.src = memoryImageUrl(memState.map, m);
     const meta = document.createElement("div");
     meta.className = "mem-card-meta mono";
-    meta.textContent = `seen ${ageText(m.stamp)} · click for options`;
+    meta.textContent = `seen ${ageText(m.stamp, robotNowS())} · click for options`;
     memHoverCard.append(img, meta);
     memHoverCard.hidden = false;
     placeMemCard(memHoverCard, m);
@@ -515,7 +532,7 @@ export function createMap(root, opts = {}) {
     img.addEventListener("click", () => openMemLightbox(m));
     const meta = document.createElement("div");
     meta.className = "mem-card-meta mono";
-    meta.textContent = `seen ${ageText(m.stamp)} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
+    meta.textContent = `seen ${ageText(m.stamp, robotNowS())} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
     const actions = document.createElement("div");
     actions.className = "mem-card-actions";
     const goHere = document.createElement("button");
@@ -1263,14 +1280,17 @@ export function createMap(root, opts = {}) {
   /** The remembered viewpoints: one wall-clipped view cone + dot each, fading
    * with age; a white ring blooms once when a memory is first recorded. */
   function drawMemories() {
-    if (!ctx || !grid || !view || !layers.memories || !memState?.memories.length) return;
-    const nowS = Date.now() / 1000;
+    if (!ctx || !grid || !view || !memState?.memories.length) return;
+    const nowS = robotNowS();
     const nowMs = performance.now();
     const d = dpr();
     const g = /** @type {NonNullable<typeof grid>} */ (grid);
     const v = /** @type {NonNullable<typeof view>} */ (view);
     const searchHit = memSearch?.found && nowMs < memSearchUntil ? memSearch.id : null;
     for (const m of memState.memories) {
+      // Layer off: draw nothing except a memory the sidebar reel is inspecting
+      // (highlight/popup) — its card must not float over blank map.
+      if (!layers.memories && memHighlight !== m.id && memPopupFor !== m.id) continue;
       const { px, py } = worldToCanvas(m.x, m.y);
       const active = memHover?.id === m.id || memHighlight === m.id || memPopupFor === m.id || searchHit === m.id;
       const alpha = active ? 1 : ageAlpha(m.stamp, nowS);
@@ -1711,7 +1731,11 @@ export function createMap(root, opts = {}) {
         amclPose = null;
         odomAtAmcl = null;
         // Memory marks are frames of the *finished* map — meaningless against
-        // the one being built.
+        // the one being built. Forced off here, in the widget, so every host
+        // (teleop PiP included) honors it, not just the Nav page's chips.
+        memoriesBeforeMapping = layers.memories;
+        layers.memories = false;
+        syncLayerSubs();
         setMemHover(null);
         closeMemPopup();
         hideMemSearchCard();
@@ -1732,6 +1756,10 @@ export function createMap(root, opts = {}) {
         unsubMappingPose?.();
         unsubMappingPose = null;
         mappingPose = null;
+        if (memoriesBeforeMapping) {
+          layers.memories = true;
+          syncLayerSubs();
+        }
       }
       pose = composedPose();
       render();

--- a/webapp/js/map/memories.js
+++ b/webapp/js/map/memories.js
@@ -9,8 +9,14 @@
  * mark (robot pink, goal green, route blue, scan salmon, costmap amber/red). */
 export const MEMORY_COLOR = "#b48cff";
 
+/** A latched search verdict older than this is history, not news. Only the
+ * first (replay) message after subscribing is stamp-gated — the robot's wall
+ * clock can disagree with the browser's (no RTC before NTP settles), so live
+ * arrivals always show. */
+export const SEARCH_REPLAY_FRESH_S = 20;
+
 /** @typedef {{ id: number, x: number, y: number, theta: number, stamp: number }} Memory */
-/** @typedef {{ map: string, cache: string, memories: Memory[] }} MemoryState */
+/** @typedef {{ map: string, fingerprint: string, cache: string, memories: Memory[] }} MemoryState */
 
 /**
  * Parse a /brain/memory_positions message. Null when malformed — the layer
@@ -29,6 +35,9 @@ export function parseMemories(msg) {
     }
     return {
       map: typeof data.map === "string" ? data.map : "",
+      // Identity of the map's content: a same-name re-map wipes the memories
+      // and restarts ids, and this is the only field that changes with it.
+      fingerprint: typeof data.fingerprint === "string" ? data.fingerprint : "",
       cache: typeof data.cache === "string" ? data.cache : "off",
       memories,
     };

--- a/webapp/js/map/memories.js
+++ b/webapp/js/map/memories.js
@@ -16,7 +16,7 @@ export const MEMORY_COLOR = "#b48cff";
 export const SEARCH_REPLAY_FRESH_S = 20;
 
 /** @typedef {{ id: number, x: number, y: number, theta: number, stamp: number }} Memory */
-/** @typedef {{ map: string, fingerprint: string, cache: string, now: number, memories: Memory[] }} MemoryState */
+/** @typedef {{ map: string, fingerprint: string, cache: string, memories: Memory[] }} MemoryState */
 
 /**
  * Parse a /brain/memory_positions message. Null when malformed — the layer
@@ -39,10 +39,6 @@ export function parseMemories(msg) {
       // and restarts ids, and this is the only field that changes with it.
       fingerprint: typeof data.fingerprint === "string" ? data.fingerprint : "",
       cache: typeof data.cache === "string" ? data.cache : "off",
-      // The robot's clock at publish. Stamps are robot time, so ages must be
-      // computed against this (via clockSkew), never the browser's clock — a
-      // robot without NTP can sit hours off.
-      now: typeof data.now === "number" ? data.now : 0,
       memories,
     };
   } catch {
@@ -66,12 +62,17 @@ export function parseSearch(msg) {
 }
 
 /**
- * Seconds to add to the browser's clock to get the robot's, learned from a
- * positions payload's `now`. 0 when the payload predates the field.
- * @param {MemoryState} state
+ * Seconds to add to the browser's clock to get the robot's — stamps are robot
+ * time, and a robot without NTP can sit hours off. Learned from any *streaming*
+ * stamped message (odom): a latched topic can't teach the clock, because its
+ * replay arrives arbitrarily long after publish. Null when there's no stamp.
+ * @param {any} msg any ROS message with a header.stamp
+ * @returns {number | null}
  */
-export function clockSkew(state) {
-  return state.now ? state.now - Date.now() / 1000 : 0;
+export function headerSkew(msg) {
+  const stamp = msg?.header?.stamp;
+  if (typeof stamp?.sec !== "number") return null;
+  return stamp.sec + (stamp.nanosec ?? 0) / 1e9 - Date.now() / 1000;
 }
 
 /**

--- a/webapp/js/map/memories.js
+++ b/webapp/js/map/memories.js
@@ -1,0 +1,123 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Pure helpers shared by the spatial-memory map layer and sidebar panel:
+// payload parsing, /memory/image URLs, age formatting, and the layer's color
+// math. No DOM, no ROS — node-testable (tests/memories.test.js).
+
+/** The memory layer's hue — violet, deliberately distinct from every other map
+ * mark (robot pink, goal green, route blue, scan salmon, costmap amber/red). */
+export const MEMORY_COLOR = "#b48cff";
+
+/** @typedef {{ id: number, x: number, y: number, theta: number, stamp: number }} Memory */
+/** @typedef {{ map: string, cache: string, memories: Memory[] }} MemoryState */
+
+/**
+ * Parse a /brain/memory_positions message. Null when malformed — the layer
+ * just keeps its last good state.
+ * @param {any} msg std_msgs/String @returns {MemoryState | null}
+ */
+export function parseMemories(msg) {
+  try {
+    const data = JSON.parse(msg?.data ?? "");
+    if (!Array.isArray(data?.positions)) return null;
+    /** @type {Memory[]} */
+    const memories = [];
+    for (const p of data.positions) {
+      if (typeof p?.id !== "number" || typeof p?.x !== "number" || typeof p?.y !== "number") continue;
+      memories.push({ id: p.id, x: p.x, y: p.y, theta: typeof p.theta === "number" ? p.theta : 0, stamp: typeof p.stamp === "number" ? p.stamp : 0 });
+    }
+    return {
+      map: typeof data.map === "string" ? data.map : "",
+      cache: typeof data.cache === "string" ? data.cache : "off",
+      memories,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a /brain/memory_search verdict. Null when malformed.
+ * @param {any} msg std_msgs/String
+ * @returns {{ query: string, found: boolean, stamp: number, id?: number, x?: number, y?: number, theta?: number, seen_stamp?: number, explanation?: string, error?: string, latency_sec?: number, cached?: boolean } | null}
+ */
+export function parseSearch(msg) {
+  try {
+    const data = JSON.parse(msg?.data ?? "");
+    if (typeof data?.query !== "string" || typeof data?.stamp !== "number") return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Same-origin URL of a memory's JPEG. The stamp rides along as a cache-buster:
+ * a refreshed viewpoint overwrites its file in place, so the URL changes
+ * exactly when the pixels do and the browser may cache hard.
+ * @param {string} map the payload's map name ("Home.yaml") @param {Memory} memory
+ */
+export function memoryImageUrl(map, memory) {
+  return `/memory/image?map=${encodeURIComponent(map)}&id=${memory.id}&v=${Math.round(memory.stamp)}`;
+}
+
+/**
+ * "just now" → "5 min ago" → "3 h ago" → "2 d ago".
+ * @param {number} stamp epoch seconds @param {number} [now] epoch seconds (tests)
+ */
+export function ageText(stamp, now = Date.now() / 1000) {
+  const s = Math.max(0, now - stamp);
+  if (s < 90) return "just now";
+  if (s < 90 * 60) return `${Math.round(s / 60)} min ago`;
+  if (s < 36 * 3600) return `${Math.round(s / 3600)} h ago`;
+  return `${Math.round(s / 86400)} d ago`;
+}
+
+/**
+ * Draw opacity for a memory's marks: fresh memories glow, old ones recede but
+ * never vanish. Full for the first 10 minutes, easing to a 0.35 floor by 24 h
+ * (fast early fade, long tail — the difference between "this drive" and
+ * "yesterday" matters more than 3 d vs 4 d).
+ * @param {number} stamp epoch seconds @param {number} [now] epoch seconds (tests)
+ */
+export function ageAlpha(stamp, now = Date.now() / 1000) {
+  const s = Math.max(0, now - stamp);
+  const FULL_S = 600;
+  const FLOOR_S = 86400;
+  const FLOOR = 0.35;
+  if (s <= FULL_S) return 1;
+  if (s >= FLOOR_S) return FLOOR;
+  return 1 - (1 - FLOOR) * Math.sqrt((s - FULL_S) / (FLOOR_S - FULL_S));
+}
+
+/**
+ * A hex color at an alpha, as a canvas/CSS color string.
+ * @param {string} hex "#rrggbb" @param {number} alpha 0–1 (clamped)
+ */
+export function withAlpha(hex, alpha) {
+  const n = parseInt(hex.slice(1), 16);
+  const a = Math.max(0, Math.min(1, alpha));
+  return `rgb(${(n >> 16) & 255} ${(n >> 8) & 255} ${n & 255} / ${a})`;
+}
+
+/**
+ * Chip copy for the payload's cache state — how the next recall will feel.
+ * "cold" self-heals (the robot re-warms ~30 s after recording settles), so it
+ * reads as in-progress, not as an error.
+ * @param {string} state @returns {{ text: string, kind: "ok" | "warn" | "muted" }}
+ */
+export function cacheLabel(state) {
+  switch (state) {
+    case "warm":
+      return { text: "instant recall ready", kind: "ok" };
+    case "inline":
+      return { text: "recall ready", kind: "ok" };
+    case "cold":
+      return { text: "recall warming…", kind: "warn" };
+    case "unsupported":
+      return { text: "recall uncached", kind: "warn" };
+    default:
+      return { text: "recall offline", kind: "muted" };
+  }
+}

--- a/webapp/js/map/memories.js
+++ b/webapp/js/map/memories.js
@@ -16,7 +16,7 @@ export const MEMORY_COLOR = "#b48cff";
 export const SEARCH_REPLAY_FRESH_S = 20;
 
 /** @typedef {{ id: number, x: number, y: number, theta: number, stamp: number }} Memory */
-/** @typedef {{ map: string, fingerprint: string, cache: string, memories: Memory[] }} MemoryState */
+/** @typedef {{ map: string, fingerprint: string, cache: string, now: number, memories: Memory[] }} MemoryState */
 
 /**
  * Parse a /brain/memory_positions message. Null when malformed — the layer
@@ -39,6 +39,10 @@ export function parseMemories(msg) {
       // and restarts ids, and this is the only field that changes with it.
       fingerprint: typeof data.fingerprint === "string" ? data.fingerprint : "",
       cache: typeof data.cache === "string" ? data.cache : "off",
+      // The robot's clock at publish. Stamps are robot time, so ages must be
+      // computed against this (via clockSkew), never the browser's clock — a
+      // robot without NTP can sit hours off.
+      now: typeof data.now === "number" ? data.now : 0,
       memories,
     };
   } catch {
@@ -59,6 +63,15 @@ export function parseSearch(msg) {
   } catch {
     return null;
   }
+}
+
+/**
+ * Seconds to add to the browser's clock to get the robot's, learned from a
+ * positions payload's `now`. 0 when the payload predates the field.
+ * @param {MemoryState} state
+ */
+export function clockSkew(state) {
+  return state.now ? state.now - Date.now() / 1000 : 0;
 }
 
 /**

--- a/webapp/js/nav/main.js
+++ b/webapp/js/nav/main.js
@@ -24,6 +24,7 @@ import {
   LOCAL_COSTMAP_TOPIC,
   MEMORY_POSITIONS_TOPIC,
   MEMORY_SEARCH_TOPIC,
+  NAV_CURRENT_MAP_TOPIC,
   ODOM_TOPIC,
   PLAN_TOPICS,
   SCAN_TOPIC,
@@ -43,10 +44,16 @@ import { dismissAllConfirms } from "./confirm.js";
 const ZOOM_KEY = "innate.navZoom";
 const DEFAULT_ZOOM_M = 14;
 
+// The mobile app's navigation glyph (DistanceIcon, a pin over its landing
+// spot) — the page title and the current-map pill wear the same mark the
+// phone uses for its map.
+const PIN_ICON =
+  '<svg viewBox="0 0 24 25" fill="currentColor" aria-hidden="true"><path d="M12 22C10.3103 22 8.92958 21.7577 7.85775 21.273C6.78592 20.7885 6.25 20.1623 6.25 19.3943C6.25 19.0904 6.35292 18.8052 6.55875 18.5385C6.76442 18.2718 7.057 18.0314 7.4365 17.8173C7.61217 17.7019 7.80383 17.6625 8.0115 17.699C8.21917 17.7355 8.38075 17.8416 8.49625 18.0173C8.61158 18.1929 8.64683 18.383 8.602 18.5875C8.55717 18.792 8.44692 18.9519 8.27125 19.0673C8.16225 19.1058 8.05808 19.1538 7.95875 19.2115C7.85925 19.2692 7.79992 19.3268 7.78075 19.3845C7.94608 19.6833 8.43808 19.9439 9.25675 20.1663C10.0752 20.3888 10.9897 20.5 12 20.5C13.0103 20.5 13.9247 20.3888 14.7432 20.1663C15.5619 19.9439 16.0539 19.6833 16.2193 19.3845C16.2001 19.3268 16.1408 19.2692 16.0413 19.2115C15.9419 19.1538 15.8378 19.1058 15.7288 19.0673C15.5531 18.9519 15.4428 18.792 15.398 18.5875C15.3532 18.383 15.3884 18.1929 15.5038 18.0173C15.6193 17.8416 15.7808 17.7355 15.9885 17.699C16.1962 17.6625 16.3878 17.7019 16.5635 17.8173C16.943 18.0314 17.2356 18.2718 17.4413 18.5385C17.6471 18.8052 17.75 19.0904 17.75 19.3943C17.75 20.1623 17.2141 20.7885 16.1423 21.273C15.0704 21.7577 13.6897 22 12 22ZM12.025 17.125C13.6813 15.8698 14.9246 14.6266 15.7548 13.3953C16.5849 12.1638 17 10.941 17 9.727C17 8.00133 16.4599 6.69875 15.3798 5.81925C14.2996 4.93975 13.173 4.5 12 4.5C10.8333 4.5 9.70833 4.93975 8.625 5.81925C7.54167 6.69875 7 8.00133 7 9.727C7 10.8628 7.40992 12.0398 8.22975 13.2578C9.04958 14.4758 10.3147 15.7648 12.025 17.125ZM12 18.5635C11.8192 18.5635 11.6384 18.5317 11.4577 18.4682C11.2769 18.4047 11.1096 18.3127 10.9558 18.1923C9.12375 16.7154 7.7565 15.2744 6.854 13.8693C5.95133 12.4641 5.5 11.0833 5.5 9.727C5.5 8.61417 5.6965 7.63917 6.0895 6.802C6.4825 5.96483 6.98983 5.26383 7.6115 4.699C8.23333 4.13433 8.9305 3.71 9.703 3.426C10.4753 3.142 11.241 3 12 3C12.759 3 13.5247 3.142 14.297 3.426C15.0695 3.71 15.7667 4.13433 16.3885 4.699C17.0102 5.26383 17.5175 5.96483 17.9105 6.802C18.3035 7.63917 18.5 8.61417 18.5 9.727C18.5 11.0833 18.0487 12.4641 17.146 13.8693C16.2435 15.2744 14.8763 16.7154 13.0443 18.1923C12.8904 18.3127 12.7231 18.4047 12.5423 18.4682C12.3616 18.5317 12.1808 18.5635 12 18.5635ZM12 11.3943C12.4987 11.3943 12.9246 11.2193 13.2777 10.8693C13.6311 10.5193 13.8077 10.0917 13.8077 9.5865C13.8077 9.08783 13.6311 8.66192 13.2777 8.30875C12.9246 7.95542 12.4987 7.77875 12 7.77875C11.5077 7.77875 11.0833 7.95542 10.727 8.30875C10.3705 8.66192 10.1923 9.08783 10.1923 9.5865C10.1923 10.0917 10.3705 10.5193 10.727 10.8693C11.0833 11.2193 11.5077 11.3943 12 11.3943Z"/></svg>';
+
 /** @type {Array<{ key: import("../map/mapWidget.js").LayerName, label: string, on: boolean, topic: string }>} */
 const LAYERS = [
   { key: "scan", label: "LIDAR", on: true, topic: SCAN_TOPIC },
-  { key: "costmap", label: "Global costmap", on: true, topic: GLOBAL_COSTMAP_TOPIC },
+  { key: "costmap", label: "Global costmap", on: false, topic: GLOBAL_COSTMAP_TOPIC },
   { key: "local", label: "Local costmap", on: false, topic: LOCAL_COSTMAP_TOPIC },
   { key: "trail", label: "Path traveled", on: true, topic: ODOM_TOPIC },
   { key: "memories", label: "Memories", on: true, topic: MEMORY_POSITIONS_TOPIC },
@@ -66,8 +73,8 @@ function buildView(root) {
   const head = document.createElement("div");
   head.className = "page-head";
   const heading = document.createElement("h1");
-  heading.className = "page-title";
-  heading.textContent = "Nav";
+  heading.className = "page-title page-title-iconed";
+  heading.innerHTML = `${PIN_ICON}Nav`;
   const chips = document.createElement("div");
   chips.className = "layer-chips";
   head.append(heading, chips);
@@ -99,6 +106,16 @@ function buildView(root) {
   mapfreeNote.textContent = "map-free mode — no map is loaded; the scene may show the last map, which is not in use";
   mapfreeNote.hidden = true;
   scene.appendChild(mapfreeNote);
+
+  // Current-map pill (bottom-left) — the map-name pill the mobile app pins to
+  // its expanded map, same glyph.
+  const mapPill = document.createElement("div");
+  mapPill.className = "map-name-pill mono";
+  mapPill.title = NAV_CURRENT_MAP_TOPIC;
+  mapPill.innerHTML = PIN_ICON;
+  const mapPillName = document.createElement("span");
+  mapPill.appendChild(mapPillName);
+  scene.appendChild(mapPill);
 
   // ---- store + scene ---------------------------------------------------------
   const store = createNavStore();
@@ -163,6 +180,7 @@ function buildView(root) {
   function onMappingChange(mapping) {
     map.setMappingMode(mapping);
     legend.setHidden(mapping); // the drive kit's overlays own the scene corners
+    mapPill.hidden = mapping;
     const gen = ++kitGen;
     clearTrailBtn.disabled = mapping;
     if (mapping) {
@@ -196,6 +214,9 @@ function buildView(root) {
     veil.hidden = !s.busy;
     if (s.busy) veilText.textContent = `${s.busy}…`;
     mapfreeNote.hidden = s.mode !== "mapfree";
+    const noMap = !s.currentMap || s.mode === "mapfree";
+    mapPill.classList.toggle("is-empty", noMap);
+    mapPillName.textContent = noMap ? "no map" : s.currentMap;
     const mapping = s.mode === "mapping";
     if (mapping !== wasMapping) {
       wasMapping = mapping;

--- a/webapp/js/nav/main.js
+++ b/webapp/js/nav/main.js
@@ -22,6 +22,8 @@ import {
   COMMANDED_GOAL_TOPIC,
   GLOBAL_COSTMAP_TOPIC,
   LOCAL_COSTMAP_TOPIC,
+  MEMORY_POSITIONS_TOPIC,
+  MEMORY_SEARCH_TOPIC,
   ODOM_TOPIC,
   PLAN_TOPICS,
   SCAN_TOPIC,
@@ -30,6 +32,7 @@ import { createMap, MAP_COLORS } from "../map/mapWidget.js";
 import { createNavStore } from "./navStore.js";
 import { createMapsPanel } from "./mapsPanel.js";
 import { createMappingSession } from "./mappingSession.js";
+import { createMemoriesPanel } from "./memoriesPanel.js";
 import { createNavPanels } from "./panels.js";
 import { createNavPlots } from "./plots.js";
 import { createDriveKit } from "./driveKit.js";
@@ -46,6 +49,7 @@ const LAYERS = [
   { key: "costmap", label: "Global costmap", on: true, topic: GLOBAL_COSTMAP_TOPIC },
   { key: "local", label: "Local costmap", on: false, topic: LOCAL_COSTMAP_TOPIC },
   { key: "trail", label: "Path traveled", on: true, topic: ODOM_TOPIC },
+  { key: "memories", label: "Memories", on: true, topic: MEMORY_POSITIONS_TOPIC },
 ];
 
 /** @param {HTMLElement} stage */
@@ -170,6 +174,7 @@ function buildView(root) {
       forceLayer("scan", true);
       forceLayer("costmap", false);
       forceLayer("trail", false);
+      forceLayer("memories", false); // memory marks are frames of the finished map
       createDriveKit(scene).then((kit) => {
         if (gen !== kitGen) kit.destroy(); // mapping ended while mounting
         else driveKit = kit;
@@ -209,12 +214,14 @@ function buildView(root) {
   // rolling plots. Each in its own host so no module's teardown can clear
   // another's DOM.
   const mapsHost = document.createElement("div");
+  const memoriesHost = document.createElement("div");
   const readoutHost = document.createElement("div");
   const plotHost = document.createElement("div");
-  side.append(mapsHost, readoutHost, plotHost);
+  side.append(mapsHost, memoriesHost, readoutHost, plotHost);
 
   const parts = [
     createMapsPanel(mapsHost, store),
+    createMemoriesPanel(memoriesHost, map),
     createMappingSession(scene, store),
     createNavPanels(readoutHost, store),
     createNavPlots(plotHost),
@@ -270,6 +277,7 @@ function createLegend(scene, chipEls) {
   row(null, line(MAP_COLORS.route), "planned path", PLAN_TOPICS.join(" · "));
   row(["scan"], dot(MAP_COLORS.scan), "lidar", SCAN_TOPIC);
   row(["trail"], line(MAP_COLORS.trail), "path traveled", ODOM_TOPIC);
+  row(["memories"], dot(MAP_COLORS.memory), "remembered view", `${MEMORY_POSITIONS_TOPIC} · ${MEMORY_SEARCH_TOPIC}`);
   row(["costmap", "local"], '<span class="legend-swatch legend-cost"></span>', "cost low → lethal", `${GLOBAL_COSTMAP_TOPIC} · ${LOCAL_COSTMAP_TOPIC}`);
 
   function sync() {

--- a/webapp/js/nav/mappingSession.js
+++ b/webapp/js/nav/mappingSession.js
@@ -52,6 +52,7 @@ export function createMappingSession(scene, store) {
   nameInput.type = "text";
   nameInput.className = "mapping-name mono";
   nameInput.placeholder = "map name";
+  nameInput.title = "Letters, digits, _ and - only";
   const hint = document.createElement("span");
   hint.className = "mapping-hint mono";
   const primaryBtn = document.createElement("button");
@@ -97,7 +98,9 @@ export function createMappingSession(scene, store) {
     nameInput.hidden = !naming;
     hint.hidden = !naming;
     primaryBtn.textContent = naming ? "Save" : "Finish";
+    primaryBtn.title = naming ? "Save the map and make it the active one" : "Stop recording and name the map";
     secondaryBtn.textContent = naming ? "Back" : "Discard";
+    secondaryBtn.title = naming ? "Return to recording" : "Throw away the recording and leave mapping mode";
     secondaryBtn.classList.toggle("danger", !naming);
     primaryBtn.disabled = !!s.busy || (naming && validName() === null);
     secondaryBtn.disabled = !!s.busy;

--- a/webapp/js/nav/memoriesPanel.js
+++ b/webapp/js/nav/memoriesPanel.js
@@ -30,6 +30,7 @@ export function createMemoriesPanel(root, map) {
   const label = document.createElement("p");
   label.className = "microlabel";
   label.textContent = "Memories";
+  label.title = MEMORY_POSITIONS_TOPIC;
   const count = document.createElement("span");
   count.className = "mem-panel-count mono";
   count.textContent = "—";
@@ -72,6 +73,7 @@ export function createMemoriesPanel(root, map) {
 
   const lastSearch = document.createElement("p");
   lastSearch.className = "mem-panel-search mono";
+  lastSearch.title = `the most recent recall verdict — ${MEMORY_SEARCH_TOPIC}`;
   lastSearch.hidden = true;
   section.appendChild(lastSearch);
 

--- a/webapp/js/nav/memoriesPanel.js
+++ b/webapp/js/nav/memoriesPanel.js
@@ -9,7 +9,7 @@
 // the reel costs no rosbridge bandwidth.
 
 import { ros } from "../rosClient.js";
-import { MEMORY_POSITIONS_TOPIC, MEMORY_SEARCH_TOPIC } from "../constants.js";
+import { CLEAR_MEMORIES_SERVICE, MEMORY_POSITIONS_TOPIC, MEMORY_SEARCH_TOPIC } from "../constants.js";
 import { SEARCH_REPLAY_FRESH_S, ageText, cacheLabel, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
 
 // Age labels ("5 min ago") drift while nothing else changes — refresh slowly.
@@ -37,7 +37,26 @@ export function createMemoriesPanel(root, map) {
   chip.className = "mem-panel-chip mono";
   chip.hidden = true;
   chip.title = "Whether the remembered views are pre-cached with the vision model (searches answer in ~a second)";
-  head.append(label, count, chip);
+  const clearBtn = document.createElement("button");
+  clearBtn.type = "button";
+  clearBtn.className = "mem-panel-clear mono";
+  clearBtn.hidden = true;
+  clearBtn.textContent = "forget all";
+  clearBtn.title = "Forget every remembered view on this map";
+  clearBtn.addEventListener("click", () => {
+    const n = count.textContent;
+    if (!window.confirm(`Forget all ${n} remembered views on this map? The robot rebuilds them as it drives around.`)) {
+      return;
+    }
+    clearBtn.disabled = true;
+    ros
+      .callService(CLEAR_MEMORIES_SERVICE)
+      .catch(() => {}) // the reel simply not emptying is the failure signal
+      .finally(() => {
+        clearBtn.disabled = false;
+      });
+  });
+  head.append(label, count, chip, clearBtn);
   section.appendChild(head);
 
   const empty = document.createElement("p");
@@ -105,6 +124,7 @@ export function createMemoriesPanel(root, map) {
       chip.hidden = state.memories.length === 0;
       chip.textContent = cache.text;
       chip.dataset.kind = cache.kind;
+      clearBtn.hidden = state.memories.length === 0;
       empty.hidden = state.memories.length > 0;
       reel.hidden = state.memories.length === 0;
       const sig = `${state.map}|${state.memories.map((m) => `${m.id}:${m.stamp}`).join(",")}`;

--- a/webapp/js/nav/memoriesPanel.js
+++ b/webapp/js/nav/memoriesPanel.js
@@ -10,7 +10,7 @@
 
 import { ros } from "../rosClient.js";
 import { MEMORY_POSITIONS_TOPIC, MEMORY_SEARCH_TOPIC } from "../constants.js";
-import { ageText, cacheLabel, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
+import { SEARCH_REPLAY_FRESH_S, ageText, cacheLabel, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
 
 // Age labels ("5 min ago") drift while nothing else changes — refresh slowly.
 const AGE_REFRESH_MS = 30_000;
@@ -117,11 +117,18 @@ export function createMemoriesPanel(root, map) {
     "std_msgs/msg/String",
   );
 
+  // Same replay policy as the map layer: the first message after subscribing
+  // is the latched history — shown only while fresh, so a page opened hours
+  // later doesn't advertise an old recall as news.
+  let searchSeen = false;
   const unsubSearch = ros.subscribe(
     MEMORY_SEARCH_TOPIC,
     (msg) => {
       const verdict = parseSearch(msg);
       if (!verdict) return;
+      const replay = !searchSeen;
+      searchSeen = true;
+      if (replay && Date.now() / 1000 - verdict.stamp > SEARCH_REPLAY_FRESH_S) return;
       lastSearch.hidden = false;
       const outcome = verdict.found ? "found" : verdict.error ? "failed" : "no match";
       lastSearch.textContent = `last recall · “${verdict.query}” → ${outcome}`;

--- a/webapp/js/nav/memoriesPanel.js
+++ b/webapp/js/nav/memoriesPanel.js
@@ -10,14 +10,14 @@
 
 import { ros } from "../rosClient.js";
 import { CLEAR_MEMORIES_SERVICE, MEMORY_POSITIONS_TOPIC, MEMORY_SEARCH_TOPIC } from "../constants.js";
-import { SEARCH_REPLAY_FRESH_S, ageText, cacheLabel, clockSkew, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
+import { SEARCH_REPLAY_FRESH_S, ageText, cacheLabel, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
 
 // Age labels ("5 min ago") drift while nothing else changes — refresh slowly.
 const AGE_REFRESH_MS = 30_000;
 
 /**
  * @param {HTMLElement} root sidebar host.
- * @param {{ highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void }} map
+ * @param {{ highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void, robotNowS: () => number }} map
  *   the scene widget — the reel drives its memory highlight/focus.
  * @returns {{ destroy: () => void }}
  */
@@ -80,8 +80,7 @@ export function createMemoriesPanel(root, map) {
   root.appendChild(section);
 
   let signature = ""; // map + ids + stamps of the rendered reel; rebuild only on change
-  let skew = 0; // robot clock − browser clock; stamps are robot time
-  const robotNowS = () => Date.now() / 1000 + skew;
+  const robotNowS = () => map.robotNowS(); // stamps are robot time; the widget owns the clock
 
   /** @param {import("../map/memories.js").MemoryState} state */
   function renderReel(state) {
@@ -123,7 +122,6 @@ export function createMemoriesPanel(root, map) {
     (msg) => {
       const state = parseMemories(msg);
       if (!state) return;
-      skew = clockSkew(state);
       count.textContent = String(state.memories.length);
       const cache = cacheLabel(state.cache);
       chip.hidden = state.memories.length === 0;

--- a/webapp/js/nav/memoriesPanel.js
+++ b/webapp/js/nav/memoriesPanel.js
@@ -1,0 +1,142 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// "Memories" sidebar panel — the robot's visual memory of the current map made
+// tangible: a count, a recall-cache health chip, and a reel of remembered
+// views (newest first). Hovering a thumbnail lights its viewpoint on the map;
+// clicking centres the map there and opens the Go-here popup. Data comes from
+// the two memory topics; the images ride same-origin HTTP (/memory/image), so
+// the reel costs no rosbridge bandwidth.
+
+import { ros } from "../rosClient.js";
+import { MEMORY_POSITIONS_TOPIC, MEMORY_SEARCH_TOPIC } from "../constants.js";
+import { ageText, cacheLabel, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
+
+// Age labels ("5 min ago") drift while nothing else changes — refresh slowly.
+const AGE_REFRESH_MS = 30_000;
+
+/**
+ * @param {HTMLElement} root sidebar host.
+ * @param {{ highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void }} map
+ *   the scene widget — the reel drives its memory highlight/focus.
+ * @returns {{ destroy: () => void }}
+ */
+export function createMemoriesPanel(root, map) {
+  const section = document.createElement("section");
+  section.className = "nav-panel mem-panel";
+
+  const head = document.createElement("div");
+  head.className = "mem-panel-head";
+  const label = document.createElement("p");
+  label.className = "microlabel";
+  label.textContent = "Memories";
+  const count = document.createElement("span");
+  count.className = "mem-panel-count mono";
+  count.textContent = "—";
+  const chip = document.createElement("span");
+  chip.className = "mem-panel-chip mono";
+  chip.hidden = true;
+  chip.title = "Whether the remembered views are pre-cached with the vision model (searches answer in ~a second)";
+  head.append(label, count, chip);
+  section.appendChild(head);
+
+  const empty = document.createElement("p");
+  empty.className = "mem-panel-empty";
+  empty.textContent =
+    "Nothing remembered on this map yet — drive around while localized and the robot will remember what it sees.";
+  section.appendChild(empty);
+
+  const reel = document.createElement("div");
+  reel.className = "mem-reel";
+  reel.hidden = true;
+  section.appendChild(reel);
+
+  const lastSearch = document.createElement("p");
+  lastSearch.className = "mem-panel-search mono";
+  lastSearch.hidden = true;
+  section.appendChild(lastSearch);
+
+  root.appendChild(section);
+
+  let signature = ""; // map + ids + stamps of the rendered reel; rebuild only on change
+
+  /** @param {import("../map/memories.js").MemoryState} state */
+  function renderReel(state) {
+    map.highlightMemory(null); // a hovered thumb may be about to disappear
+    reel.innerHTML = "";
+    const newestFirst = [...state.memories].sort((a, b) => b.stamp - a.stamp);
+    for (const m of newestFirst) {
+      const thumb = document.createElement("button");
+      thumb.type = "button";
+      thumb.className = "mem-thumb";
+      thumb.title = `x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m — click to show on the map`;
+      const img = new Image();
+      img.className = "mem-thumb-img";
+      img.loading = "lazy";
+      img.alt = "remembered view";
+      img.src = memoryImageUrl(state.map, m);
+      const age = document.createElement("span");
+      age.className = "mem-thumb-age mono";
+      age.dataset.stamp = String(m.stamp);
+      age.textContent = ageText(m.stamp);
+      thumb.append(img, age);
+      thumb.addEventListener("mouseenter", () => map.highlightMemory(m.id));
+      thumb.addEventListener("mouseleave", () => map.highlightMemory(null));
+      thumb.addEventListener("click", () => map.focusMemory(m.id));
+      reel.appendChild(thumb);
+    }
+  }
+
+  function refreshAges() {
+    for (const el of section.querySelectorAll(".mem-thumb-age")) {
+      const stamp = Number(/** @type {HTMLElement} */ (el).dataset.stamp);
+      if (stamp) el.textContent = ageText(stamp);
+    }
+  }
+  const ageTimer = setInterval(refreshAges, AGE_REFRESH_MS);
+
+  const unsubPositions = ros.subscribe(
+    MEMORY_POSITIONS_TOPIC,
+    (msg) => {
+      const state = parseMemories(msg);
+      if (!state) return;
+      count.textContent = String(state.memories.length);
+      const cache = cacheLabel(state.cache);
+      chip.hidden = state.memories.length === 0;
+      chip.textContent = cache.text;
+      chip.dataset.kind = cache.kind;
+      empty.hidden = state.memories.length > 0;
+      reel.hidden = state.memories.length === 0;
+      const sig = `${state.map}|${state.memories.map((m) => `${m.id}:${m.stamp}`).join(",")}`;
+      if (sig !== signature) {
+        signature = sig;
+        renderReel(state);
+      }
+    },
+    0,
+    "std_msgs/msg/String",
+  );
+
+  const unsubSearch = ros.subscribe(
+    MEMORY_SEARCH_TOPIC,
+    (msg) => {
+      const verdict = parseSearch(msg);
+      if (!verdict) return;
+      lastSearch.hidden = false;
+      const outcome = verdict.found ? "found" : verdict.error ? "failed" : "no match";
+      lastSearch.textContent = `last recall · “${verdict.query}” → ${outcome}`;
+    },
+    0,
+    "std_msgs/msg/String",
+  );
+
+  return {
+    destroy() {
+      clearInterval(ageTimer);
+      unsubPositions();
+      unsubSearch();
+      map.highlightMemory(null);
+      section.remove();
+    },
+  };
+}

--- a/webapp/js/nav/memoriesPanel.js
+++ b/webapp/js/nav/memoriesPanel.js
@@ -10,7 +10,7 @@
 
 import { ros } from "../rosClient.js";
 import { CLEAR_MEMORIES_SERVICE, MEMORY_POSITIONS_TOPIC, MEMORY_SEARCH_TOPIC } from "../constants.js";
-import { SEARCH_REPLAY_FRESH_S, ageText, cacheLabel, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
+import { SEARCH_REPLAY_FRESH_S, ageText, cacheLabel, clockSkew, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
 
 // Age labels ("5 min ago") drift while nothing else changes — refresh slowly.
 const AGE_REFRESH_MS = 30_000;
@@ -80,6 +80,8 @@ export function createMemoriesPanel(root, map) {
   root.appendChild(section);
 
   let signature = ""; // map + ids + stamps of the rendered reel; rebuild only on change
+  let skew = 0; // robot clock − browser clock; stamps are robot time
+  const robotNowS = () => Date.now() / 1000 + skew;
 
   /** @param {import("../map/memories.js").MemoryState} state */
   function renderReel(state) {
@@ -99,7 +101,7 @@ export function createMemoriesPanel(root, map) {
       const age = document.createElement("span");
       age.className = "mem-thumb-age mono";
       age.dataset.stamp = String(m.stamp);
-      age.textContent = ageText(m.stamp);
+      age.textContent = ageText(m.stamp, robotNowS());
       thumb.append(img, age);
       thumb.addEventListener("mouseenter", () => map.highlightMemory(m.id));
       thumb.addEventListener("mouseleave", () => map.highlightMemory(null));
@@ -111,7 +113,7 @@ export function createMemoriesPanel(root, map) {
   function refreshAges() {
     for (const el of section.querySelectorAll(".mem-thumb-age")) {
       const stamp = Number(/** @type {HTMLElement} */ (el).dataset.stamp);
-      if (stamp) el.textContent = ageText(stamp);
+      if (stamp) el.textContent = ageText(stamp, robotNowS());
     }
   }
   const ageTimer = setInterval(refreshAges, AGE_REFRESH_MS);
@@ -121,6 +123,7 @@ export function createMemoriesPanel(root, map) {
     (msg) => {
       const state = parseMemories(msg);
       if (!state) return;
+      skew = clockSkew(state);
       count.textContent = String(state.memories.length);
       const cache = cacheLabel(state.cache);
       chip.hidden = state.memories.length === 0;
@@ -150,7 +153,7 @@ export function createMemoriesPanel(root, map) {
       if (!verdict) return;
       const replay = !searchSeen;
       searchSeen = true;
-      if (replay && Date.now() / 1000 - verdict.stamp > SEARCH_REPLAY_FRESH_S) return;
+      if (replay && robotNowS() - verdict.stamp > SEARCH_REPLAY_FRESH_S) return;
       lastSearch.hidden = false;
       const outcome = verdict.found ? "found" : verdict.error ? "failed" : "no match";
       lastSearch.textContent = `last recall · “${verdict.query}” → ${outcome}`;

--- a/webapp/js/nav/panels.js
+++ b/webapp/js/nav/panels.js
@@ -68,13 +68,14 @@ function makeRate() {
  * @returns {{ destroy: () => void }}
  */
 export function createNavPanels(root, store) {
-  /** @param {string} title @returns {{ row: (label: string) => HTMLElement }} */
-  function panel(title) {
+  /** @param {string} title @param {string} [hint] tooltip on the panel label @returns {{ row: (label: string, topic?: string) => HTMLElement }} */
+  function panel(title, hint = "") {
     const section = document.createElement("section");
     section.className = "nav-panel";
     const label = document.createElement("p");
     label.className = "microlabel";
     label.textContent = title;
+    if (hint) label.title = hint;
     section.appendChild(label);
     root.appendChild(section);
     return {
@@ -144,7 +145,7 @@ export function createNavPanels(root, store) {
     navLoc.title = hint;
   }
 
-  const rates = panel("Received rates");
+  const rates = panel("Received rates", "Message arrival rate per topic, averaged over a 5 s sliding window");
 
   // ---- subscriptions -------------------------------------------------------
   /** @type {Array<() => void>} */

--- a/webapp/js/nav/plots.js
+++ b/webapp/js/nav/plots.js
@@ -117,6 +117,7 @@ function createChart(parent, spec) {
 
   const plot = document.createElement("div");
   plot.className = "telemetry-plot nav-plot";
+  plot.title = "rolling 30 s window";
   const canvas = document.createElement("canvas");
   canvas.className = "nav-plot-canvas";
   plot.appendChild(canvas);

--- a/webapp/js/profiling/main.js
+++ b/webapp/js/profiling/main.js
@@ -80,6 +80,7 @@ function buildView(root) {
 
   const live = document.createElement("span");
   live.className = "prof-live";
+  live.title = INFERENCE_PROFILE_TOPIC;
   live.innerHTML = '<span class="prof-live-dot"></span><span class="prof-live-text">no signal</span>';
 
   const spacer = document.createElement("div");
@@ -88,9 +89,11 @@ function buildView(root) {
   const exportBtn = document.createElement("button");
   exportBtn.className = "prof-btn";
   exportBtn.textContent = "Export JSON";
+  exportBtn.title = "Copy the recorded profile as JSON (downloads a file if the clipboard is blocked)";
   const clearBtn = document.createElement("button");
   clearBtn.className = "prof-btn";
   clearBtn.textContent = "Clear";
+  clearBtn.title = "Discard the samples buffered in this page — nothing on the robot changes";
 
   // The whole rollout lifecycle (skill run + this chart window + robot-side
   // episode capture) hangs off one control; the page just lends it the buffer.

--- a/webapp/js/profiling/rebootArm.js
+++ b/webapp/js/profiling/rebootArm.js
@@ -16,6 +16,7 @@ export function buildRebootArm() {
   const btn = document.createElement("button");
   btn.className = "prof-btn prof-btn-reboot";
   btn.type = "button";
+  btn.title = "Reboot the arm's servos, then torque back on";
 
   let rebooting = false;
 

--- a/webapp/js/profiling/rolloutControl.js
+++ b/webapp/js/profiling/rolloutControl.js
@@ -40,21 +40,25 @@ export function buildRolloutControl(chartWindow, session) {
 
   const select = document.createElement("select");
   select.className = "prof-select";
+  select.title = `learned skills only — ${AVAILABLE_SKILLS_TOPIC}`;
   const placeholder = new Option("Select a learned skill…", "");
   select.add(placeholder);
   select.addEventListener("change", () => sync());
 
   const runBtn = document.createElement("button");
   runBtn.className = "prof-btn prof-btn-rec";
+  runBtn.title = `run the skill and record an evaluation episode — ${EXECUTE_SKILL_ACTION}`;
   const profileBtn = document.createElement("button");
   profileBtn.className = "prof-btn prof-btn-quiet";
   profileBtn.textContent = "Profile only";
+  profileBtn.title = "Run the skill and chart it without recording an episode";
 
   const autoLabel = document.createElement("label");
   autoLabel.className = "prof-auto microlabel";
   const autoBox = document.createElement("input");
   autoBox.type = "checkbox";
   autoLabel.append(autoBox, document.createTextNode("auto-continue"));
+  autoLabel.title = `After each judged rollout, start the next one automatically in ${AUTO_CONTINUE_DELAY_S}s`;
 
   el.append(select, runBtn, profileBtn, autoLabel);
 
@@ -85,12 +89,15 @@ export function buildRolloutControl(chartWindow, session) {
   const okBtn = document.createElement("button");
   okBtn.className = "prof-btn prof-btn-ok";
   okBtn.textContent = "✓ Success";
+  okBtn.title = "Save the episode and judge it a success";
   const failBtn = document.createElement("button");
   failBtn.className = "prof-btn prof-btn-fail";
   failBtn.textContent = "✗ Failure";
+  failBtn.title = "Save the episode and judge it a failure (pick failure tags above)";
   const discardBtn = document.createElement("button");
   discardBtn.className = "prof-btn";
   discardBtn.textContent = "Discard";
+  discardBtn.title = "Throw the recording away — nothing is saved";
 
   reviewEl.append(reviewText, tagRow, okBtn, failBtn, discardBtn);
 

--- a/webapp/js/settings/main.js
+++ b/webapp/js/settings/main.js
@@ -314,6 +314,7 @@ function buildVolumeSection() {
   const slider = document.createElement("input");
   slider.type = "range";
   slider.className = "set-slider";
+  slider.title = `${SET_VOLUME_SERVICE} — live value from ${ROBOT_INFO_TOPIC}`;
   slider.min = "0";
   slider.max = "100";
   slider.step = "1";
@@ -476,6 +477,7 @@ function build() {
     const count = document.createElement("span");
     count.className = "set-group-count";
     count.textContent = String(group.knobs.length);
+    count.title = "Settings in this section";
     h.append(chev, labelEl, dot, count);
     h.addEventListener("click", () => g.classList.toggle("open"));
     g.appendChild(h);
@@ -507,6 +509,7 @@ function build() {
   saveBtn = document.createElement("button");
   saveBtn.className = "set-save";
   saveBtn.textContent = "Save";
+  saveBtn.title = "Write these overrides to the robot's settings file";
   saveBtn.disabled = true;
   saveBtn.addEventListener("click", onSave);
   dirtyEl = document.createElement("span");
@@ -514,6 +517,7 @@ function build() {
   resetAllBtn = document.createElement("button");
   resetAllBtn.className = "set-reset-all";
   resetAllBtn.textContent = "Reset all to defaults";
+  resetAllBtn.title = "Clear every override in the form — click Save to commit";
   resetAllBtn.disabled = true;
   resetAllBtn.addEventListener("click", resetAll);
   restartBtn = document.createElement("button");
@@ -732,6 +736,7 @@ function buildScalarControl(/** @type {HTMLElement} */ ctl, /** @type {Entry} */
   const reset = document.createElement("button");
   reset.className = "set-reset";
   reset.textContent = "reset";
+  reset.title = `Reset to ${defaultLabel(knob)}`;
   reset.addEventListener("click", () => {
     entry.overridden = false;
     entry.value = cloneDefault(knob);
@@ -760,9 +765,11 @@ function buildListControl(/** @type {HTMLElement} */ ctl, /** @type {Entry} */ e
   const def = document.createElement("span");
   def.className = "set-default";
   def.textContent = defaultLabel(knob);
+  def.title = def.textContent;
   const reset = document.createElement("button");
   reset.className = "set-reset";
   reset.textContent = "reset";
+  reset.title = `Reset to ${defaultLabel(knob)}`;
   meta.append(def, reset);
   ctl.appendChild(meta);
 

--- a/webapp/js/teleop/armPanel.js
+++ b/webapp/js/teleop/armPanel.js
@@ -48,6 +48,7 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   const header = document.createElement("button");
   header.type = "button";
   header.className = "arm-header";
+  header.title = "Show/hide the leader-arm controls";
   header.innerHTML =
     '<span class="microlabel">arm</span>' +
     '<svg class="arm-caret" viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>';
@@ -90,6 +91,7 @@ export function createArmPanel(parent, rosClient, opts = {}) {
       switchBtn.className = "arm-button";
       switchBtn.type = "button";
       switchBtn.textContent = "Switch to HTTPS";
+      switchBtn.title = "Reload over HTTPS — WebSerial needs a secure origin";
       switchBtn.addEventListener("click", () => {
         const url = new URL(location.href);
         url.protocol = "https:";
@@ -115,9 +117,11 @@ export function createArmPanel(parent, rosClient, opts = {}) {
 
   const status = document.createElement("p");
   status.className = "arm-status mono";
+  status.title = "Leader-arm read rate over USB";
 
   const joints = document.createElement("div");
   joints.className = "arm-joints";
+  joints.title = "Live leader-arm joint positions (Dynamixel ticks, ±half turn)";
   /** @type {HTMLElement[]} */
   const dots = [];
   for (let i = 0; i < 6; i++) {
@@ -134,10 +138,12 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   connectBtn.className = "arm-button";
   connectBtn.type = "button";
   connectBtn.textContent = "Connect arm";
+  connectBtn.title = "Pick the leader arm's USB serial port (WebSerial)";
 
   const engageBtn = document.createElement("button");
   engageBtn.className = "arm-button arm-engage";
   engageBtn.type = "button";
+  engageBtn.title = `the follower mirrors the leader live — ${LEADER_POSITIONS_TOPIC}`;
 
   // Copy the live joint ticks — handy for pasting a pose into a skill.
   const copyBtn = document.createElement("button");
@@ -335,10 +341,12 @@ function buildArmServices(rosClient) {
   const rebootBtn = document.createElement("button");
   rebootBtn.className = "arm-button";
   rebootBtn.type = "button";
+  rebootBtn.title = "Reboot the follower arm's servos, then torque back on";
 
   const torqueBtn = document.createElement("button");
   torqueBtn.className = "arm-button arm-torque";
   torqueBtn.type = "button";
+  torqueBtn.title = `${ARM_TORQUE_ON_SERVICE} / ${ARM_TORQUE_OFF_SERVICE} — state from ${ARM_STATUS_TOPIC}`;
   torqueBtn.innerHTML =
     '<span class="arm-torque-cap">Torque</span><span class="arm-torque-state"></span>';
   const torqueState = /** @type {HTMLElement} */ (torqueBtn.querySelector(".arm-torque-state"));

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -220,7 +220,7 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   }
 
   function buildMapTile() {
-    const tile = liveTile(MAP_ID, "Map", "Make the map the main view");
+    const tile = liveTile(MAP_ID, "Map", "Make the map the main view · scroll to zoom");
     tile.classList.add("cam-tile-map");
     if (mapHost) tile.prepend(mapHost); // reparent the persistent host into the thumbnail
     return tile;

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -148,6 +148,9 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
           mapZoom[mapMode] = m;
           saveMapZoom();
         },
+        // Memories pulse in live while you drive — the tour builds the
+        // robot's spatial memory, and this is where you watch it happen.
+        layers: { memories: true },
       });
     } else if (!mapOn && mapWidget) {
       mapWidget.destroy();

--- a/webapp/js/teleop/connectPanel.js
+++ b/webapp/js/teleop/connectPanel.js
@@ -4,6 +4,8 @@
 // Connect panel — the one quiet card shown while disconnected. Mono IP input
 // prefilled from the last successful connection, inline error on failure.
 
+import { ROSBRIDGE_PORT } from "../constants.js";
+
 /**
  * @param {HTMLElement} parent
  * @param {import("../rosClient.js").RosClient} rosClient
@@ -35,6 +37,7 @@ export function createConnectPanel(parent, rosClient) {
   button.className = "connect-button";
   button.type = "submit";
   button.textContent = "Connect";
+  button.title = `Open the rosbridge websocket to this robot (port ${ROSBRIDGE_PORT})`;
 
   const error = document.createElement("p");
   error.className = "connect-error";

--- a/webapp/js/teleop/headTilt.js
+++ b/webapp/js/teleop/headTilt.js
@@ -35,6 +35,7 @@ export function createHeadTilt(parent, rosClient) {
 
   const track = document.createElement("div");
   track.className = "ht-track";
+  track.title = `drag to tilt the head — ${HEAD_SET_POSITION_TOPIC}`;
 
   const rail = document.createElement("div");
   rail.className = "ht-rail";
@@ -45,6 +46,7 @@ export function createHeadTilt(parent, rosClient) {
 
   const actual = document.createElement("div");
   actual.className = "ht-actual";
+  actual.title = `where the head actually is — ${HEAD_CURRENT_POSITION_TOPIC}`;
   actual.hidden = true;
 
   const thumb = document.createElement("div");

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -46,6 +46,10 @@ export function createJoystick(parent, driveController) {
     })
   );
 
+  // SVG tooltips come from a <title> child, not the title attribute.
+  const tooltip = svgEl("title", {});
+  tooltip.textContent = "drag to drive — /joystick · press j to hide";
+  svg.appendChild(tooltip);
   svg.appendChild(svgEl("circle", { class: "joy-rim", cx: String(CENTER), cy: String(CENTER), r: String(OUTER_R) }));
 
   // Four faint cardinal ticks just inside the rim.

--- a/webapp/js/teleop/profilingPanel.js
+++ b/webapp/js/teleop/profilingPanel.js
@@ -61,22 +61,22 @@ export function createProfilingPanel(parent, session) {
   const grid = document.createElement("div");
   grid.className = "profiling-grid";
 
-  const jitterBuffer = metric("jitter buf", "ms", true);
-  const rtt = metric("rtt", "ms");
-  const jitter = metric("jitter", "ms");
-  const fps = metric("fps", "");
-  const resolution = metric("res", "");
-  const bitrate = metric("bitrate", "kb/s");
-  const loss = metric("loss", "%");
-  const dropped = metric("dropped", "");
-  const freezes = metric("freezes", "");
+  const jitterBuffer = metric("jitter buf", "ms", true, "Average de-jitter buffer delay of frames played out since the last poll");
+  const rtt = metric("rtt", "ms", false, "Round-trip time on the selected ICE candidate pair");
+  const jitter = metric("jitter", "ms", false, "Inter-arrival jitter, inbound video RTP");
+  const fps = metric("fps", "", false, "Decoded frames per second");
+  const resolution = metric("res", "", false, "Received video resolution");
+  const bitrate = metric("bitrate", "kb/s", false, "Inbound video bitrate since the last poll");
+  const loss = metric("loss", "%", false, "Packet loss since the last poll");
+  const dropped = metric("dropped", "", false, "Frames dropped (cumulative)");
+  const freezes = metric("freezes", "", false, "Freeze events (cumulative)");
   const all = [jitterBuffer, rtt, jitter, fps, resolution, bitrate, loss, dropped, freezes];
   for (const m of all) grid.append(m.el);
 
   // Connection state — driven by session changes (not the getStats poll), so it stays meaningful even
   // when no media is flowing (the very case a failed link needs to surface). Kept out of `all` so the
   // poll's clearValues() never wipes it.
-  const conn = metric("conn", "");
+  const conn = metric("conn", "", false, "ICE connection state; ·stun = relayed through the STUN fallback");
   grid.append(conn.el);
 
   wrap.append(head, grid);
@@ -91,10 +91,12 @@ export function createProfilingPanel(parent, session) {
    * @param {string} labelText
    * @param {string} unit
    * @param {boolean} [headline]
+   * @param {string} [title]
    */
-  function metric(labelText, unit, headline = false) {
+  function metric(labelText, unit, headline = false, title = "") {
     const el = document.createElement("div");
     el.className = headline ? "profiling-item headline" : "profiling-item";
+    if (title) el.title = title;
     const label = document.createElement("span");
     label.className = "microlabel";
     label.textContent = labelText;

--- a/webapp/js/teleop/skillsMenu.js
+++ b/webapp/js/teleop/skillsMenu.js
@@ -27,8 +27,10 @@ export function createSkillsMenu(parent, rosClient) {
   const btn = document.createElement("button");
   btn.type = "button";
   btn.className = "skills-menu-btn";
+  btn.title = `run a skill — roster from ${AVAILABLE_SKILLS_TOPIC}`;
   const btnDot = document.createElement("span");
   btnDot.className = "skills-menu-dot";
+  btnDot.title = "green while a skill is running";
   const btnLabel = document.createElement("span");
   btnLabel.className = "skills-menu-label";
   btnLabel.textContent = "Skills";
@@ -364,6 +366,7 @@ export function createSkillsMenu(parent, rosClient) {
     const head = document.createElement("button");
     head.type = "button";
     head.className = "skills-pop-group";
+    head.title = "Collapse/expand this skill folder";
     const name = document.createElement("span");
     name.className = "skills-pop-group-name";
     name.textContent = prettify(group);
@@ -391,6 +394,7 @@ export function createSkillsMenu(parent, rosClient) {
     stop.type = "button";
     stop.className = "skill-confirm stop";
     stop.textContent = externCanceling ? "Stopping" : "Stop";
+    stop.title = `this run was started elsewhere (agent or another client) — ${CANCEL_SKILL_SERVICE}`;
     stop.disabled = externCanceling || rosClient.state !== "connected";
     stop.addEventListener("click", stopExternRun);
     status.append(txt, stop);
@@ -448,7 +452,7 @@ export function createSkillsMenu(parent, rosClient) {
     name.className = "skills-pop-name";
     name.textContent = formatName(skill);
     const guidelines = skill.guidelines || skill.guidelines_when_running;
-    if (guidelines) head.title = guidelines;
+    head.title = guidelines || `run ${skill.id} — ${EXECUTE_SKILL_ACTION}`;
 
     const tail = document.createElement("span");
     tail.className = "skills-pop-tail mono";
@@ -526,6 +530,7 @@ export function createSkillsMenu(parent, rosClient) {
     } else {
       action.className = "skill-confirm";
       action.textContent = "Run";
+      action.title = EXECUTE_SKILL_ACTION;
       const otherRunning = run && !run.done && run.skillId !== skill.id;
       action.disabled = !!otherRunning || rosClient.state !== "connected";
       action.addEventListener("click", () => startRun(skill));
@@ -549,6 +554,7 @@ export function createSkillsMenu(parent, rosClient) {
     labelRow.className = "skill-param-label";
     const pn = document.createElement("span");
     pn.textContent = paramName + (isRequired(spec) ? " *" : "");
+    if (isRequired(spec)) pn.title = "Required";
     const pt = document.createElement("span");
     pt.className = "skill-param-type mono";
     pt.textContent = typeof spec === "string" ? spec : spec?.type ?? "any";
@@ -735,13 +741,14 @@ function skillTypeMeta(skill) {
 function buildTypeLegend() {
   const legend = document.createElement("div");
   legend.className = "skills-pop-legend";
-  for (const { cls, label } of [
-    { cls: "learned", label: "Learned" },
-    { cls: "replay", label: "Replay" },
-    { cls: "digital", label: "Digital" },
+  for (const { cls, label, hint } of [
+    { cls: "learned", label: "Learned", hint: "Trained from demonstrations (ACT policy)" },
+    { cls: "replay", label: "Replay", hint: "Recorded motion played back" },
+    { cls: "digital", label: "Digital", hint: "Python skill" },
   ]) {
     const item = document.createElement("span");
     item.className = "skills-pop-legend-item";
+    item.title = hint;
     const dot = document.createElement("span");
     dot.className = `skills-pop-type-dot ${cls}`;
     const text = document.createElement("span");

--- a/webapp/js/teleop/speedModes.js
+++ b/webapp/js/teleop/speedModes.js
@@ -72,6 +72,7 @@ export function createSpeedModes(parent, rosClient) {
   const title = document.createElement("span");
   title.className = "sm-label";
   title.textContent = "SPEED";
+  title.title = `robot-wide drive speed scale (${SPEED_SCALE_PARAM}) — shared with the mobile app`;
   wrap.appendChild(title);
 
   const group = document.createElement("div");
@@ -107,6 +108,7 @@ export function createSpeedModes(parent, rosClient) {
     button.type = "button";
     button.className = "sm-btn";
     button.textContent = mode.label;
+    button.title = `${SET_PARAMETERS_SERVICE} · ${SPEED_SCALE_PARAM}=${mode.scale}`;
     button.setAttribute("role", "radio");
     button.setAttribute("aria-checked", "false");
     button.addEventListener("click", async () => {

--- a/webapp/js/teleop/telemetry.js
+++ b/webapp/js/teleop/telemetry.js
@@ -19,22 +19,24 @@ export function createTelemetry(parent, rosClient, opts = {}) {
   const wrap = document.createElement("div");
   wrap.className = "telemetry";
 
-  const name = item("robot", "—");
-  const battery = showBattery ? item("batt", "—") : null;
-  const link = item("link", "—");
+  const name = item("robot", "—", ROBOT_INFO_TOPIC);
+  const battery = showBattery ? item("batt", "—", BATTERY_STATE_TOPIC) : null;
+  const link = item("link", "—", "rosbridge websocket to the robot");
   // Cloud/local agent backend connection (the brain's websocket to its agent
   // backend) — distinct from the rosbridge LINK above.
-  const agent = item("agent", "—");
+  const agent = item("agent", "—", `the brain's connection to its agent backend — ${WEBSOCKET_STATUS_TOPIC}`);
   wrap.append(name.el, ...(battery ? [battery.el] : []), link.el, agent.el);
   parent.appendChild(wrap);
 
   /**
    * @param {string} labelText
    * @param {string} initial
+   * @param {string} [title]
    */
-  function item(labelText, initial) {
+  function item(labelText, initial, title = "") {
     const el = document.createElement("div");
     el.className = "telemetry-item";
+    if (title) el.title = title;
     const label = document.createElement("span");
     label.className = "microlabel";
     label.textContent = labelText;

--- a/webapp/js/teleop/ttsBar.js
+++ b/webapp/js/teleop/ttsBar.js
@@ -31,6 +31,7 @@ export function createTtsBar(parent, rosClient) {
   sendBtn.type = "button";
   sendBtn.className = "tts-hint mono";
   sendBtn.textContent = "↵";
+  sendBtn.title = TTS_TOPIC;
   sendBtn.setAttribute("aria-label", "Send");
 
   wrap.append(input, sendBtn);
@@ -76,7 +77,7 @@ export function createTtsBar(parent, rosClient) {
     input.disabled = !available;
     sendBtn.disabled = !available;
     input.placeholder = available ? "Make the robot speak…" : TTS_UNAVAILABLE_PLACEHOLDER;
-    input.title = available ? "" : "The speak bar needs the hosted Innate brain (INNATE_SERVICE_KEY).";
+    input.title = available ? TTS_TOPIC : "The speak bar needs the hosted Innate brain (INNATE_SERVICE_KEY).";
   }, undefined, "std_msgs/msg/String");
 
   return {

--- a/webapp/js/teleop/videoStage.js
+++ b/webapp/js/teleop/videoStage.js
@@ -31,6 +31,7 @@ export function createVideoStage(parent, session) {
   retry.className = "video-retry";
   retry.type = "button";
   retry.textContent = "Retry video";
+  retry.title = "Tear down and rebuild the WebRTC video link";
   retry.hidden = true;
   status.append(statusText, retry);
 

--- a/webapp/js/training/configurePanel.js
+++ b/webapp/js/training/configurePanel.js
@@ -6,7 +6,7 @@
 // the sync→create_run orchestration, then closes. So the run still gets created
 // even if this modal is dismissed mid-upload.
 
-import { GET_TASK_METADATA_SERVICE } from "../constants.js";
+import { GET_TASK_METADATA_SERVICE, START_TRAINING_SERVICE } from "../constants.js";
 
 const MIN_EPISODES = 5;
 
@@ -48,6 +48,7 @@ export function createConfigurePanel(parent, ros, store, opts) {
   close.type = "button";
   close.className = "modal-close";
   close.textContent = "✕";
+  close.title = "Close";
   close.addEventListener("click", () => opts.onClose());
   head.append(title, close);
 
@@ -58,6 +59,7 @@ export function createConfigurePanel(parent, ros, store, opts) {
   const skillRow = field("Skill");
   const skillSel = document.createElement("select");
   skillSel.className = "modal-select";
+  skillSel.title = "Only learned skills can be trained";
   for (const s of store.skills) {
     if (s.type !== "learned") continue;
     const o = document.createElement("option");
@@ -85,6 +87,7 @@ export function createConfigurePanel(parent, ros, store, opts) {
     const inp = document.createElement("input");
     inp.type = "text";
     inp.className = "modal-input";
+    inp.title = f.env;
     inp.value = f.def;
     inp.addEventListener("input", validate);
     inputs[f.key] = inp;
@@ -97,6 +100,7 @@ export function createConfigurePanel(parent, ros, store, opts) {
   successRow.className = "modal-check";
   const successChk = document.createElement("input");
   successChk.type = "checkbox";
+  successChk.title = "Sets TRAIN_ON_SUCCESS_ONLY — episodes labeled Unsuccessful are excluded";
   const successTxt = document.createElement("span");
   successTxt.textContent = "Train on successful episodes only";
   successRow.append(successChk, successTxt);
@@ -116,6 +120,7 @@ export function createConfigurePanel(parent, ros, store, opts) {
   startBtn.type = "button";
   startBtn.className = "modal-start";
   startBtn.textContent = "Start training run";
+  startBtn.title = START_TRAINING_SERVICE;
   startBtn.addEventListener("click", start);
 
   formEl.append(skillRow, epLine, hyperWrap, successRow, warn, note, startBtn);

--- a/webapp/js/training/logsModal.js
+++ b/webapp/js/training/logsModal.js
@@ -46,14 +46,17 @@ export function createLogsModal(parent, skillDir, runId, opts) {
   title.textContent = live ? `Run #${runId} · live logs` : `Run #${runId} logs`;
   const fileSel = document.createElement("select");
   fileSel.className = "modal-select logs-filesel";
+  fileSel.title = "Result file to view";
   fileSel.addEventListener("change", () => showFile(fileSel.value));
   const liveBadge = document.createElement("span");
   liveBadge.className = "logs-live-badge";
   liveBadge.textContent = "● live";
+  liveBadge.title = "Tailing the orchestrator's log buffer";
   const close = document.createElement("button");
   close.type = "button";
   close.className = "modal-close";
   close.textContent = "✕";
+  close.title = "Close";
   close.addEventListener("click", () => opts.onClose());
   const copyBtn = document.createElement("button");
   copyBtn.type = "button";

--- a/webapp/js/training/runDashboard.js
+++ b/webapp/js/training/runDashboard.js
@@ -92,6 +92,7 @@ export function createRunDashboard(parent, ros, store, opts) {
   trainBtn.type = "button";
   trainBtn.className = "training-train-btn";
   trainBtn.textContent = "+ Train a skill";
+  trainBtn.title = "Configure and start a cloud training run";
   trainBtn.addEventListener("click", () => opts.onTrain());
   tools.append(search, filter, trainBtn);
   head.append(titleBox, tools);
@@ -351,6 +352,7 @@ export function createRunDashboard(parent, ros, store, opts) {
       const ds = document.createElement("span");
       ds.className = "run-daemon";
       ds.textContent = run.daemon_state;
+      ds.title = "Raw orchestrator state — /training/job_statuses";
       label.append(ds);
     }
     left.append(id, dot, label);
@@ -365,6 +367,7 @@ export function createRunDashboard(parent, ros, store, opts) {
       const err = document.createElement("span");
       err.className = "run-error";
       err.textContent = run.error_message;
+      err.title = run.error_message;
       mid.appendChild(err);
     } else if (info && !info.has_checkpoint && info.error_excerpt) {
       // No orchestrator message — show the exception line dug out of the
@@ -426,6 +429,7 @@ export function createRunDashboard(parent, ros, store, opts) {
       cancel.type = "button";
       cancel.className = "run-btn run-cancel";
       cancel.textContent = "Cancel";
+      cancel.title = "Stop training and free the GPU instance";
       cancel.addEventListener("click", () => {
         if (!window.confirm(`Cancel run #${run.run_id}? This stops training and frees the GPU.`)) return;
         cancel.disabled = true;
@@ -453,6 +457,7 @@ export function createRunDashboard(parent, ros, store, opts) {
         : run.status === STATUS.DOWNLOADED
           ? "Re-download"
           : "Download";
+      dl.title = "Fetch the trained checkpoint + logs onto the robot";
       dl.addEventListener("click", () => {
         dl.disabled = true;
         ros.callService(DOWNLOAD_RESULTS_SERVICE, { skill_dir: sk.skill_dir, run_id: run.run_id }).catch((err) => {
@@ -468,6 +473,7 @@ export function createRunDashboard(parent, ros, store, opts) {
       live.type = "button";
       live.className = "run-btn";
       live.textContent = "Live logs";
+      live.title = "Tail the orchestrator's log buffer while the run trains";
       live.addEventListener("click", () => opts.onOpenLogs(sk.skill_dir, run.run_id, true));
       els.push(live);
     }
@@ -477,6 +483,7 @@ export function createRunDashboard(parent, ros, store, opts) {
       logs.type = "button";
       logs.className = "run-btn";
       logs.textContent = "Logs";
+      logs.title = "Browse this run's downloaded result files";
       logs.addEventListener("click", () => opts.onOpenLogs(sk.skill_dir, run.run_id));
       els.push(logs);
     }
@@ -488,6 +495,7 @@ export function createRunDashboard(parent, ros, store, opts) {
       wb.target = "_blank";
       wb.rel = "noopener";
       wb.textContent = "W&B";
+      wb.title = `Open in Weights & Biases — ${run.wandb_url}`;
       els.push(wb);
     }
     return els;

--- a/webapp/js/training/runDetail.js
+++ b/webapp/js/training/runDetail.js
@@ -137,6 +137,7 @@ export function createRunDetail(parent, ros, store, opts) {
     close.type = "button";
     close.className = "rd-close";
     close.textContent = "✕";
+    close.title = "Close details";
     close.setAttribute("aria-label", "Close details");
     close.addEventListener("click", opts.onClose);
     head.append(titleBox, close);
@@ -152,6 +153,7 @@ export function createRunDetail(parent, ros, store, opts) {
     statusRow.className = "rd-statusrow";
     const dot = document.createElement("span");
     dot.className = failed ? "run-dot s-failed" : `run-dot s-${run.status}`;
+    dot.title = statusText;
     const statusLbl = document.createElement("span");
     statusLbl.textContent = statusText;
     statusRow.append(dot, statusLbl);
@@ -159,6 +161,7 @@ export function createRunDetail(parent, ros, store, opts) {
       const ds = document.createElement("span");
       ds.className = "run-daemon";
       ds.textContent = run.daemon_state;
+      ds.title = "Raw orchestrator state — /training/job_statuses";
       statusRow.append(ds);
     }
     frag.appendChild(statusRow);
@@ -207,10 +210,14 @@ export function createRunDetail(parent, ros, store, opts) {
     const hyperRows = [];
     if (p.preset) hyperRows.push(["Preset", String(p.preset)]);
     if (p.gpu_type) hyperRows.push(["GPU", `${p.gpu_type}${p.min_gpus ? ` ×${p.min_gpus}` : ""}`]);
-    for (const [k, v] of Object.entries(env)) hyperRows.push([humanize(k), String(v)]);
+    for (const [k, v] of Object.entries(env)) hyperRows.push([humanize(k), String(v), k]);
     if (hyperRows.length) {
       frag.appendChild(section("Hyperparameters"));
-      for (const [k, v] of hyperRows) frag.appendChild(row(k, v));
+      for (const [k, v, raw] of hyperRows) {
+        const r = row(k, v);
+        if (raw) r.title = raw; // the wire-format env var the pretty label hides
+        frag.appendChild(r);
+      }
     }
 
     // ── actions ─────────────────────────────────────────────────────

--- a/webapp/js/training/runningHero.js
+++ b/webapp/js/training/runningHero.js
@@ -35,6 +35,7 @@ export function renderRunningHero({ sk, run, eta, actions, onOpen }) {
   const titleRow = document.createElement("button");
   titleRow.type = "button";
   titleRow.className = "hero-title";
+  titleRow.title = "Open this run in the detail pane";
   const name = document.createElement("span");
   name.textContent = `${sk.skill_name} / run #${run.run_id}`;
   const badge = document.createElement("span");

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -47,6 +47,7 @@ from media_routes import (
     episode_response,
     joints_response,
     map_preview_response,
+    memory_image_response,
     profile_response,
     run_info_response,
     run_log_response,
@@ -375,6 +376,7 @@ def build_app() -> web.Application:
     app.router.add_get("/episode/profile", profile_response)
     app.router.add_get("/episode/thumb", thumb_response)
     app.router.add_get("/map/preview", map_preview_response)
+    app.router.add_get("/memory/image", memory_image_response)
     app.router.add_get("/run/info", run_info_response)
     app.router.add_get("/run/log", run_log_response)
     app.router.add_get("/settings.json", settings_get)

--- a/webapp/proxy/media_routes.py
+++ b/webapp/proxy/media_routes.py
@@ -208,6 +208,33 @@ def map_preview_response(request: web.Request) -> web.Response:
     return web.Response(status=200, body=data, headers={"Content-Type": "image/png", "Cache-Control": "no-cache"})
 
 
+# The robot's per-map spatial memory (brain_client/memory): one JPEG per
+# remembered viewpoint, written by the brain node.
+MEMORY_DIR = (Path(_INNATE_OS_ROOT) / "data" / "spatial_memory").resolve()
+
+
+@threaded
+def memory_image_response(request: web.Request) -> web.Response:
+    """GET /memory/image?map=<base or file.yaml>&id=<n> → the remembered JPEG of
+    one spatial-memory viewpoint. A refresh overwrites the file in place, so
+    clients append the memory's stamp as ?v= and this can be cached hard."""
+    qs = parse_qs(request.query_string)
+    name = (qs.get("map") or [""])[0]
+    if name.endswith(".yaml"):
+        name = name[:-5]
+    memory_id = (qs.get("id") or [""])[0]
+    # The map-name charset and a numeric id make the joined path traversal-proof.
+    if not _MAP_NAME_RE.match(name) or not memory_id.isdigit():
+        return _plain(404, "Not Found", "no such memory")
+    try:
+        data = (MEMORY_DIR / name / f"{int(memory_id)}.jpg").read_bytes()
+    except OSError:
+        return _plain(404, "Not Found", "no such memory")
+    return web.Response(
+        status=200, body=data, headers={"Content-Type": "image/jpeg", "Cache-Control": "max-age=86400, immutable"}
+    )
+
+
 @threaded
 def joints_response(request: web.Request) -> web.Response:
     """GET /episode/joints?dir=<skill_dir>&id=<n> → qpos/qvel/timestamps JSON,

--- a/webapp/proxy/test/test_media_routes.py
+++ b/webapp/proxy/test/test_media_routes.py
@@ -156,6 +156,25 @@ async def test_map_preview(tmp_path, monkeypatch):
 
 
 @sync
+async def test_memory_image_serves_and_fences(tmp_path, monkeypatch):
+    memories = tmp_path / "spatial_memory"
+    (memories / "Home").mkdir(parents=True)
+    (memories / "Home" / "3.jpg").write_bytes(b"\xff\xd8\xff\xe0jpegbytes")
+    monkeypatch.setattr(media_routes, "MEMORY_DIR", memories.resolve())
+    root = make_app_root(tmp_path)
+    async with serve(ROOT=root) as (s, base):
+        r = await s.get(base + "/memory/image", params={"map": "Home", "id": "3"})
+        assert r.status == 200 and r.headers["Content-Type"] == "image/jpeg"
+        assert await r.read() == b"\xff\xd8\xff\xe0jpegbytes"
+        # the map name may arrive as the yaml filename the topic publishes
+        assert (await s.get(base + "/memory/image", params={"map": "Home.yaml", "id": "3"})).status == 200
+        # traversal-shaped names and non-numeric ids -> 404
+        assert (await s.get(base + "/memory/image", params={"map": "../etc", "id": "3"})).status == 404
+        assert (await s.get(base + "/memory/image", params={"map": "Home", "id": "../3"})).status == 404
+        assert (await s.get(base + "/memory/image", params={"map": "Home", "id": "9"})).status == 404
+
+
+@sync
 async def test_thumb(tmp_path, monkeypatch):
     cv2 = pytest.importorskip("cv2")
     import numpy as np

--- a/webapp/public/robot-drawing.svg
+++ b/webapp/public/robot-drawing.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="11.695in"
+   height="10.469544in"
+   viewBox="0 0 297.05299 265.92643"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="robot-drawnig.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.40105859"
+     inkscape:cx="-340.34927"
+     inkscape:cy="1008.5808"
+     inkscape:window-width="2256"
+     inkscape:window-height="1440"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     units="in"
+     width="11in"
+     height="10.6in"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-2.4215565,-2.8072839)">
+    <rect
+       style="fill:#54575a;fill-opacity:1;stroke:#31353b;stroke-width:5.31905;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:5;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect858"
+       width="52.305626"
+       height="137.5004"
+       x="5.0810814"
+       y="26.715858" />
+    <rect
+       style="fill:#54575a;fill-opacity:1;stroke:#31353b;stroke-width:14.311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:5;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect858-3"
+       width="173.013"
+       height="171.00655"
+       x="65.720993"
+       y="9.9627838" />
+    <circle
+       style="fill:#54575a;fill-opacity:1;stroke:#31353b;stroke-width:7.43338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:5;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path7846-6"
+       cx="105.2597"
+       cy="95.466057"
+       r="33.880524" />
+    <path
+       id="rect4668"
+       style="fill:#54575a;stroke:#31353b;stroke-width:14.311;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:5;paint-order:stroke fill markers"
+       d="m 133.72707,34.331956 84.13983,-0.03771 V 156.31656 l -83.99939,0.28693 z m 32.73086,59.87406 c 0,30.458044 -12.88302,62.431854 -32.58847,62.431854 -19.70549,0 -38.815877,-32.05198 -38.815877,-62.510024 0,-29.51179 13.254887,-57.613331 36.326577,-59.663135 15.4219,-2.243495 34.78887,44.831265 35.07777,59.741305 z"
+       sodipodi:nodetypes="ccccccsscc" />
+    <rect
+       style="fill:#25292e;fill-opacity:1;stroke:#25292e;stroke-width:5.15231;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:5;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect7979"
+       width="18.942125"
+       height="28.741573"
+       x="246.24249"
+       y="133.82196" />
+    <rect
+       style="fill:#eaa052;fill-opacity:1;stroke:none;stroke-width:3.42932;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:5;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect12067"
+       width="32.055077"
+       height="181.95"
+       x="271.11151"
+       y="61.492687"
+       transform="matrix(0.99645308,0.08415023,-0.04255349,0.99909419,0,0)" />
+  </g>
+</svg>

--- a/webapp/tests/memories.test.js
+++ b/webapp/tests/memories.test.js
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Pure-helper tests for js/map/memories.js — zero dependencies, plain node:
+//   node tests/memories.test.js
+// Parsing tolerance matters most: these payloads cross rosbridge as JSON in a
+// String and a malformed one must degrade to "keep the last good state", never
+// to a layer crash.
+
+import assert from "node:assert/strict";
+import {
+  ageAlpha,
+  ageText,
+  cacheLabel,
+  memoryImageUrl,
+  parseMemories,
+  parseSearch,
+  withAlpha,
+} from "../js/map/memories.js";
+
+let passed = 0;
+/** @param {string} name @param {() => void} fn */
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+const NOW = 1_754_500_000;
+
+test("parseMemories reads a full payload", () => {
+  const msg = {
+    data: JSON.stringify({
+      map: "Home.yaml",
+      cache: "warm",
+      positions: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
+    }),
+  };
+  assert.deepEqual(parseMemories(msg), {
+    map: "Home.yaml",
+    cache: "warm",
+    memories: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
+  });
+});
+
+test("parseMemories skips malformed entries and defaults missing fields", () => {
+  const msg = {
+    data: JSON.stringify({ positions: [{ id: 1, x: 0, y: 0 }, { x: 2, y: 2 }, "junk", null] }),
+  };
+  const state = parseMemories(msg);
+  assert.equal(state?.map, "");
+  assert.equal(state?.cache, "off");
+  assert.deepEqual(state?.memories, [{ id: 1, x: 0, y: 0, theta: 0, stamp: 0 }]);
+});
+
+test("parseMemories rejects garbage rather than throwing", () => {
+  assert.equal(parseMemories({ data: "{not json" }), null);
+  assert.equal(parseMemories({ data: JSON.stringify({ positions: "nope" }) }), null);
+  assert.equal(parseMemories({}), null);
+});
+
+test("parseSearch keeps a verdict and rejects garbage", () => {
+  const verdict = { query: "the kitchen", found: true, id: 2, x: 1, y: 2, stamp: NOW };
+  assert.deepEqual(parseSearch({ data: JSON.stringify(verdict) }), verdict);
+  assert.equal(parseSearch({ data: JSON.stringify({ found: true }) }), null); // no query/stamp
+  assert.equal(parseSearch({ data: "]" }), null);
+});
+
+test("memoryImageUrl carries the map, id, and stamp cache-buster", () => {
+  const url = memoryImageUrl("My Home.yaml", { id: 7, x: 0, y: 0, theta: 0, stamp: 1234.6 });
+  assert.equal(url, "/memory/image?map=My%20Home.yaml&id=7&v=1235");
+});
+
+test("ageText buckets read naturally", () => {
+  assert.equal(ageText(NOW - 30, NOW), "just now");
+  assert.equal(ageText(NOW - 5 * 60, NOW), "5 min ago");
+  assert.equal(ageText(NOW - 3 * 3600, NOW), "3 h ago");
+  assert.equal(ageText(NOW - 2 * 86400, NOW), "2 d ago");
+  assert.equal(ageText(NOW + 999, NOW), "just now"); // clock skew must not go negative
+});
+
+test("ageAlpha glows fresh, floors old, and eases between", () => {
+  assert.equal(ageAlpha(NOW, NOW), 1);
+  assert.equal(ageAlpha(NOW - 599, NOW), 1);
+  assert.equal(ageAlpha(NOW - 100 * 86400, NOW), 0.35);
+  const mid = ageAlpha(NOW - 4 * 3600, NOW);
+  assert.ok(mid > 0.35 && mid < 1, `mid-age alpha in the open interval, got ${mid}`);
+});
+
+test("withAlpha formats and clamps", () => {
+  assert.equal(withAlpha("#b48cff", 0.5), "rgb(180 140 255 / 0.5)");
+  assert.equal(withAlpha("#000000", 2), "rgb(0 0 0 / 1)");
+  assert.equal(withAlpha("#ffffff", -1), "rgb(255 255 255 / 0)");
+});
+
+test("cacheLabel covers every state the robot publishes", () => {
+  for (const state of ["warm", "cold", "inline", "unsupported", "off"]) {
+    const { text, kind } = cacheLabel(state);
+    assert.ok(text.length > 0 && ["ok", "warn", "muted"].includes(kind), state);
+  }
+  assert.equal(cacheLabel("warm").kind, "ok");
+  assert.equal(cacheLabel("cold").kind, "warn");
+  assert.equal(cacheLabel("banana").kind, "muted");
+});
+
+console.log(`\n${passed} passed`);

--- a/webapp/tests/memories.test.js
+++ b/webapp/tests/memories.test.js
@@ -11,6 +11,7 @@ import {
   ageAlpha,
   ageText,
   cacheLabel,
+  clockSkew,
   memoryImageUrl,
   parseMemories,
   parseSearch,
@@ -33,6 +34,7 @@ test("parseMemories reads a full payload", () => {
       map: "Home.yaml",
       fingerprint: "abc123def456",
       cache: "warm",
+      now: NOW + 5,
       positions: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
     }),
   };
@@ -40,6 +42,7 @@ test("parseMemories reads a full payload", () => {
     map: "Home.yaml",
     fingerprint: "abc123def456",
     cache: "warm",
+    now: NOW + 5,
     memories: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
   });
 });
@@ -52,7 +55,15 @@ test("parseMemories skips malformed entries and defaults missing fields", () => 
   assert.equal(state?.map, "");
   assert.equal(state?.fingerprint, "");
   assert.equal(state?.cache, "off");
+  assert.equal(state?.now, 0);
   assert.deepEqual(state?.memories, [{ id: 1, x: 0, y: 0, theta: 0, stamp: 0 }]);
+});
+
+test("clockSkew reads the robot-browser offset, 0 without the field", () => {
+  const state = { map: "", fingerprint: "", cache: "off", now: Date.now() / 1000 + 3600, memories: [] };
+  const skew = clockSkew(state);
+  assert.ok(Math.abs(skew - 3600) < 5, `an hour-ahead robot reads as ~+3600, got ${skew}`);
+  assert.equal(clockSkew({ ...state, now: 0 }), 0);
 });
 
 test("parseMemories rejects garbage rather than throwing", () => {

--- a/webapp/tests/memories.test.js
+++ b/webapp/tests/memories.test.js
@@ -11,7 +11,7 @@ import {
   ageAlpha,
   ageText,
   cacheLabel,
-  clockSkew,
+  headerSkew,
   memoryImageUrl,
   parseMemories,
   parseSearch,
@@ -34,7 +34,6 @@ test("parseMemories reads a full payload", () => {
       map: "Home.yaml",
       fingerprint: "abc123def456",
       cache: "warm",
-      now: NOW + 5,
       positions: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
     }),
   };
@@ -42,7 +41,6 @@ test("parseMemories reads a full payload", () => {
     map: "Home.yaml",
     fingerprint: "abc123def456",
     cache: "warm",
-    now: NOW + 5,
     memories: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
   });
 });
@@ -55,15 +53,15 @@ test("parseMemories skips malformed entries and defaults missing fields", () => 
   assert.equal(state?.map, "");
   assert.equal(state?.fingerprint, "");
   assert.equal(state?.cache, "off");
-  assert.equal(state?.now, 0);
   assert.deepEqual(state?.memories, [{ id: 1, x: 0, y: 0, theta: 0, stamp: 0 }]);
 });
 
-test("clockSkew reads the robot-browser offset, 0 without the field", () => {
-  const state = { map: "", fingerprint: "", cache: "off", now: Date.now() / 1000 + 3600, memories: [] };
-  const skew = clockSkew(state);
-  assert.ok(Math.abs(skew - 3600) < 5, `an hour-ahead robot reads as ~+3600, got ${skew}`);
-  assert.equal(clockSkew({ ...state, now: 0 }), 0);
+test("headerSkew reads the robot-browser offset from a stamped message", () => {
+  const sec = Math.floor(Date.now() / 1000) + 3600;
+  const skew = headerSkew({ header: { stamp: { sec, nanosec: 500_000_000 } } });
+  assert.ok(skew !== null && Math.abs(skew - 3600.5) < 5, `an hour-ahead robot reads as ~+3600, got ${skew}`);
+  assert.equal(headerSkew({ header: { stamp: {} } }), null);
+  assert.equal(headerSkew({}), null);
 });
 
 test("parseMemories rejects garbage rather than throwing", () => {

--- a/webapp/tests/memories.test.js
+++ b/webapp/tests/memories.test.js
@@ -31,12 +31,14 @@ test("parseMemories reads a full payload", () => {
   const msg = {
     data: JSON.stringify({
       map: "Home.yaml",
+      fingerprint: "abc123def456",
       cache: "warm",
       positions: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
     }),
   };
   assert.deepEqual(parseMemories(msg), {
     map: "Home.yaml",
+    fingerprint: "abc123def456",
     cache: "warm",
     memories: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
   });
@@ -48,6 +50,7 @@ test("parseMemories skips malformed entries and defaults missing fields", () => 
   };
   const state = parseMemories(msg);
   assert.equal(state?.map, "");
+  assert.equal(state?.fingerprint, "");
   assert.equal(state?.cache, "off");
   assert.deepEqual(state?.memories, [{ id: 1, x: 0, y: 0, theta: 0, stamp: 0 }]);
 });

--- a/workspace/innate_agents/basic_agent.py
+++ b/workspace/innate_agents/basic_agent.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 Innate Inc
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.navigate_with_vision import NavigateWithVision
+from innate_skills.search_memory import SearchMemory
 from inputs.micro_input import MicroInput
 
 from brain_client.agents.types import Agent, InputRef, SkillRef
@@ -24,7 +25,7 @@ class BasicAgent(Agent):
     def get_skills(self) -> list[SkillRef]:
         """The skills this directive can use — classes for code skills;
         physical skills (no class) stay id strings like "local/pick_socks"."""
-        return [NavigateToPosition, NavigateWithVision]
+        return [NavigateToPosition, NavigateWithVision, SearchMemory]
 
     def get_inputs(self) -> list[InputRef]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -4,6 +4,7 @@ from innate_skills.close_gripper import CloseGripper
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.open_gripper import OpenGripper
 from innate_skills.pick_any_object import PickAnyObject
+from innate_skills.search_memory import SearchMemory
 from innate_skills.wave import Wave
 from inputs.micro_input import MicroInput
 
@@ -26,7 +27,7 @@ class DemoAgent(Agent):
     def get_skills(self) -> list[SkillRef]:
         """Navigation code skills plus the recorded wave — Wave is the typed
         ref generated inside the recording folder (see skills/physical_refs.py)."""
-        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper]
+        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper, SearchMemory]
 
     def get_inputs(self) -> list[InputRef]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -35,7 +35,7 @@ class DemoAgent(Agent):
 
     def get_prompt(self) -> str:
         """Return the prompt that defines the robot's personality and behavior"""
-        return """You are Mars, a friendly and curious robot assistant. Keep responses concise and conversational. You can see through a camera and use tools to wave, move, and interact. Greet people warmly when you see them! IMPORTANT: If the user says 'stop' or interrupts you during an action, STOP immediately, and do NOT retry or call the tool again. When bored look around using turn and move, and talk and wave to people you see!"""
+        return """You are Mars, a friendly and curious robot assistant. Keep responses concise and conversational. You can see through a camera and use tools to wave, move, and interact. You have a long-term memory of what you've seen on this map — consult it via your skills before saying no. Greet people warmly when you see them! IMPORTANT: If the user says 'stop' or interrupts you during an action, STOP immediately, and do NOT retry or call the tool again. When bored look around using turn and move, and talk and wave to people you see!"""
 
     def uses_gaze(self) -> bool:
         """Enable person-tracking gaze during conversation."""

--- a/workspace/innate_skills/search_memory.py
+++ b/workspace/innate_skills/search_memory.py
@@ -8,9 +8,10 @@ class SearchMemory(Skill):
     or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my airpods');
     a vision model reviews every remembered view and returns the best match — its image, map
     coordinates, and when it was seen. When asked to find or go to something not in the current
-    camera view, search first and drive to the match with navigate_to_position
-    (local_frame=false) — don't wander. If the search finds nothing, say so and only then
-    explore."""
+    camera view, or whether you've seen something, search first and drive to the match with
+    navigate_to_position (local_frame=false) — don't wander. Never claim you haven't seen or
+    don't remember something without searching first. If the search finds nothing, say so and
+    only then explore."""
 
     memory: SpatialMemory
 

--- a/workspace/innate_skills/search_memory.py
+++ b/workspace/innate_skills/search_memory.py
@@ -7,8 +7,10 @@ class SearchMemory(Skill):
     """Search the robot's long-term memory of places it has seen on this map. Describe the place
     or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my airpods');
     a vision model reviews every remembered view and returns the best match — its image, map
-    coordinates, and when it was seen. Use it to find anything not in the current camera view,
-    then drive there with navigate_to_position (local_frame=false)."""
+    coordinates, and when it was seen. When asked to find or go to something not in the current
+    camera view, search first and drive to the match with navigate_to_position
+    (local_frame=false) — don't wander. If the search finds nothing, say so and only then
+    explore."""
 
     memory: SpatialMemory
 

--- a/workspace/innate_skills/search_memory.py
+++ b/workspace/innate_skills/search_memory.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+from innate import Skill, SkillOutput, SpatialMemory
+
+
+class SearchMemory(Skill):
+    """Search the robot's long-term memory of places it has seen on this map. Describe the place
+    or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my airpods');
+    a vision model reviews every remembered view and returns the best match — its image, map
+    coordinates, and when it was seen. Use it to find anything not in the current camera view,
+    then drive there with navigate_to_position (local_frame=false)."""
+
+    memory: SpatialMemory
+
+    def execute(self, query: str):
+        recall = self.memory.begin(query)
+        verdict = self.wait_for(recall, timeout=90.0)
+        if verdict is None:
+            self.fail("memory search timed out")
+        if verdict.error:
+            self.fail(verdict.message)
+        # A clean no-match is still a successful search — the answer is "nowhere".
+        return SkillOutput(verdict.message, image=verdict.image)

--- a/workspace/innate_skills/search_memory.py
+++ b/workspace/innate_skills/search_memory.py
@@ -17,7 +17,9 @@ class SearchMemory(Skill):
 
     def execute(self, query: str):
         recall = self.memory.begin(query)
-        verdict = self.wait_for(recall, timeout=90.0)
+        # Must outlive the transport's 120 s HTTP ceiling: the server rejects
+        # cancels, so a wait that gives up first strands the goal mid-search.
+        verdict = self.wait_for(recall, timeout=150.0)
         if verdict is None:
             self.fail("memory search timed out")
         if verdict.error:


### PR DESCRIPTION
## Summary

The complete local spatial memory for MARS, in the spirit of [Mobility VLA](https://arxiv.org/abs/2407.07775): while driving well-localized the robot **remembers what it sees**; a VLM then **recalls** the remembered frame that answers a request ("go to the kitchen", "find my airpods", "I am hungry" → the counter with the bananas) and the agent navigates to its pose. Stacked on #565 (`feat/local-gemini-brain`) — this is the "memory system … to be rebuilt locally later" from that PR's summary. Built in themed layers (a merge duplicated some early commits; the sections below are the review map).

### 1 · The memory core (`feat(brain): local spatial memory…` + the 12 h TTL bump)

- **Recording** (`brain_client/memory/`, new): an always-on `MemoryRecorder` (webapp teleop tours build memory too, not just brain-driven runs) ticks at 1 Hz and records only what a *well-localized* robot saw: AMCL covariance must hold below the webapp's "confident" thresholds (`max(var_x, var_y) ≤ 0.10 m²`, `var_yaw ≤ 0.18 rad²`) for **3 s straight**, in `navigation` mode, with a fresh frame and the head not pitched at the floor.
- **Storage**: a plain JSON index + one JPEG per memory under `data/spatial_memory/<map>/` — thread-safe, atomically written, persistent across restarts. (The cloud era's networkx pose graph is gone: it built edges retrieval never used.) Memories key off `/nav/current_map`, and the index stores a SHA-256 of the map's `.pgm` — **re-mapping under the same name wipes memories whose coordinate frame died**.
- **Admission** is a small pure policy (`memory/selection.py`): a viewpoint earns a slot only if no kept frame is both near (<1 m) *and* similarly oriented (<100°); revisiting a known viewpoint after 30 min refreshes its image in place (memories age — the banana moves); at the 50-frame cap the older half of the closest pair is evicted.
- **Retrieval** (`brain/memory_search.py`, new): every remembered frame goes to Gemini labeled with id, capture time, and map pose; a structured verdict (`{found, frame, explanation}`) picks the best match. Frames ride in an explicit **Gemini context cache** (12 h TTL — ~$0.02/h storage for a ~20 k-token blob), pre-warmed in the background once recording has been quiet 30 s, so recall re-uploads nothing and restarts re-cache on their own.

### 2 · Made visible (`feat(webapp): the spatial memory made visible…`)

- `/brain/memory_positions` carries `id` + `stamp` per memory and a `cache` health field; every finished search mirrors its verdict onto a latched `/brain/memory_search`; each memory's JPEG is served same-origin at `GET /memory/image` (`webapp/proxy`, same fenced-route pattern as `/map/preview`, `?v=` stamp as cache-buster) — images never cross rosbridge.
- **"Memories" map layer** (Nav page + teleop PiP): one violet view cone + dot per viewpoint, opacity fading with age; a white ring blooms the instant a memory is recorded — you drive the tour and watch the robot learn. Hover → the remembered image; click → a pinned card with a **Go here** button (existing NavigateToPose path).
- **The recall moment**: on a fresh verdict the matched memory breathes with pulse rings, a dashed thread drifts robot→memory, and a card floats in with the query, the model's explanation, the frame, and `1.2 s · cached ⚡`. Stale latched verdicts (page reloads) deliberately show nothing.
- **"Memories" sidebar panel**: count, recall-cache chip (*instant recall ready / warming… / uncached*), and a reel of remembered views newest-first (hover lights the cone; click centres the map). All canvas animation runs on a rAF ticker that only spins while something animates.

### 3 · Made callable (`feat(skills): recall as a capability…`)

The capability-server pattern the codebase already uses twice (Nav2 behind `navigate_to_position`, `arm_sdk_server`): state and secrets live in a server; skills are thin, cancel-aware orchestrators.

- **`SearchMemory` action** (`brain_messages`) served by `brain/search_server.py` *inside the brain process beside `MemorySearch`* — cache, transport, credentials never leave it; own node + spin thread so a multi-second search can't stall a turn; cancels rejected by design (a caller that stops waiting abandons the goal; the verdict is dropped).
- **Result images, typed**: `SkillOutput` grows `image=jpeg_bytes`, `ExecuteSkill.Result` grows `image_b64`, the runner decodes it into the completion event — any skill can now *show* the agent its evidence (mirrors the feedback lane's `image_b64` precedent; additive msg change).
- **SDK accessor**: `memory: SpatialMemory` injects like `mobility: Mobility`; `begin(query)` returns a reader for `self.wait_for` (cancel-aware, no polling), concluding in a typed `RecallVerdict`.
- **The skill** (`workspace/innate_skills/search_memory.py`, ~15 lines) is in the basic + demo directives. The brain's built-in tool is removed — the declaration comes from the skill's docstring. `verdict_text()` is the single source of the model-facing sentence for every door the search comes through.

### 4 · Made cheap (`feat(brain): files tier…`)

The cache blob used to carry the frame *bytes*, so any memory change meant re-uploading all ~50 frames (~3 MB). Three invariants now hold, each degrading without changing answers:

- **Bytes cross once, at record time** (`brain/frame_files.py`): a background chore on the recorder's tick uploads each JPEG to the Gemini Files API; requests reference it as `fileData`. The registry is a `files.json` sidecar — restarts re-upload nothing — and entries are trusted only while their stamp matches the live memory. Server expiry 48 h; re-upload past 40 h, references stop at 47 h.
- **A search is one round trip and never waits for maintenance**: cache builds live only in `warm()`'s thread (which no longer holds the search lock). Fresh cache → question only; **stale cache → the stale `cachedContent` + a delta** (new/re-captured frames with supersede notes, retire notes for evicted ids); no cache → all frames as references; a not-yet-uploaded frame rides `inlineData`.
- **Clean degradation**: no upload endpoint → permanent latch, frames inline; no cache endpoint → reference-only requests; both → byte-identical to the plain inline behavior. Frames are labeled by **stable store id** (not position), so delta notes and verdicts survive additions/refreshes/evictions; the cache itself builds from `fileData`, making rebuilds reference-only POSTs.

### 5 · Made agnostic (`refactor(brain): the agent forgets memory exists`)

An earlier revision dispatched recall in-process and slot-free so the model could search while driving. That kept memory-specific machinery in the agent (a hardcoded skill id in tool building *and* dispatch), which taxes exactly the thing this system should invite: swapping the retrieval mechanism. The refactor (17 insertions, 161 deletions) makes `search_memory` an **ordinary blocking skill** — it occupies the slot for the seconds a cached search takes, and its verdict returns as a normal completion event carrying the matched frame.

- `agent.py` now has **zero memory references**: no skill-id special cases, no MEMORY event kind, no memory collaborator. The system-prompt paragraph moved into the skill's docstring — the same text the model reads as the tool description, now traveling with the skill.
- The brain *process* still hosts the capability (recorder, store, `/brain/search_memory` server) the way it hosts the camera; the reasoning loop doesn't know it exists.
- **Experimenting with a different retriever = editing one workspace file.** A new skill can call a different server, a different model, or no cache at all — the brain needs no changes.
- Traded away: recall isn't offered while another skill runs (stop it or wait, like any skill). The natural flow — search first, then navigate to the match — is unaffected.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - **180 brain tests pass** (`test_spatial_memory.py` reads as the spec: admission policy, store round-trip/fingerprint-wipe/eviction, the sustained-confidence gate, the full cache lifecycle — a search never builds the cache, a stale cache serves with a delta, warm rebuilds+deletes — and the files tier: upload-once, registry survives restart, aging-upload refresh, expired-reference inline fallback, the 404 latch vs transient retry, cache-from-references, mixed reference+inline requests, delta shape, **search-never-waits** while an upload hangs, id-stable labels/verdicts. `test_memory_skill.py`: action mapping, the accessor's unblock-on-every-failure-path contract, result-image plumbing. `test_local_brain.py`: skill completion events carry result images; the agent itself has no memory tests left to write — it has no memory code.)
  - **Proxy: 21 tests pass** (`/memory/image` serve + traversal fences). **Webapp**: `node tests/memories.test.js` + existing node tests pass; `tsc` reports zero errors in touched files (the repo's 47 pre-existing elsewhere unchanged).
  - `ruff` clean; `basedpyright brain_client/` at 13 errors vs the pre-stack base's 14 (a stale-install import got fixed by the `brain_messages` rebuild; nothing new, and every new module checks clean).
  - `brain_messages` rebuilt locally (new `SearchMemory` action + `Result.image_b64`), so suites run against real generated types. Nodes need the usual full rebuild to agree on the new type hash.
  - **Not yet driven live** — see the drive-test list below.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — *No sim-specific changes: same topics; the layer stays empty until memories exist; the brain constructs the search server only when it has Gemini access.*
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — *No asset changes.*

## What only a live drive test can answer

Tour SmallRoom on the Nav page (chip green, rings bloom), then ask the brain to find something, watching the node log:

1. **Proxy passthroughs**: does the service proxy forward `cachedContents` and `/upload/v1beta/files`? The proxy client also cannot attach the raw-upload header yet, so proxied robots likely log `backend has no file-upload endpoint` and latch to inline (direct `GEMINI_API_KEY` setups should work as-is) — a server-side proxy change would enable both tiers.
2. Whether `cachedContents` ingests `fileData` content at creation (cache outlives file expiry) — the 4xx fallback covers if not.
3. Retrieval quality on the four use-case shapes: "go to the kitchen", "find my airpods", "I'm hungry", "exit the room" — first-search vs cached-search latency shows in the recall card.

## Notes for reviewers

- **What's consciously traded** by recall-as-a-skill: the tool declaration is directive-gated (basic + demo include it), an empty memory rejects with an outcome message rather than a hidden tool, and recall isn't offered while another skill runs (section 5 — the price of a retrieval-agnostic brain).
- A search's empty-store answer comes from the search itself now (an honest "no memories yet" verdict), not an agent-side gate.
- Memory hue `#b48cff` (violet) is new to the map palette on purpose; mapping mode forces the layer off (marks are frames of the *finished* map) and restores it after, like the costmap chip.
- Cache cost: ~50 frames ≈ 15–50 k cached tokens; 12 h of storage ≈ $0.24 — cheap insurance against cold starts (TTL bump commit).

