### PR TITLE
feat(webapp+skills+brain): spatial memory made visible, callable, and cheap

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/README.md
+++ b/ros2_ws/src/brain/brain_client/brain_client/README.md
@@ -6,7 +6,7 @@ code, start from what it *does*:
 | Folder | What lives here |
 |---|---|
 | `nodes/` | The runnable ROS entry points (the only files with `main()`). Thin composition roots — they build collaborators, wire them, and spin. No behaviour. |
-| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached), and the system `prompt`. |
+| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached) + `search_server` (the `/brain/search_memory` action skills call), and the system `prompt`. |
 | `core/` | The activate/deactivate/reset state machine and directive switching (`lifecycle`), typed `config`, and the shared `state`. |
 | `perception/` | Turning sensors into what the agent sees: `camera`, `pose`/`pose_tracking`, `scan_health`, `gaze`. |
 | `memory/` | Persistent per-map spatial memory: `store` (JSON index + JPEGs on disk), pure `selection` (which viewpoints earn a slot), `recorder` (the always-on ROS adapter that captures them). |

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -31,15 +31,9 @@ from typing import TYPE_CHECKING
 from brain_client.brain import grounding
 from brain_client.brain.context import Decision, GeminiContext, ToolCall
 from brain_client.brain.loop import LoopThread
+from brain_client.brain.memory_search import verdict_text
 from brain_client.brain.prompt import build_system_prompt
-from brain_client.brain.tools import (
-    GO_TO_POINT_IN_VIEW,
-    SEARCH_MEMORY,
-    STOP_SKILL,
-    WAIT,
-    assign_tool_names,
-    build_tools,
-)
+from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
 from brain_client.brain.transport import pick_transport
 from brain_client.brain.utils import (
     Event,
@@ -60,7 +54,7 @@ if TYPE_CHECKING:
 
     from rclpy.node import Node
 
-    from brain_client.brain.memory_search import MemorySearch
+    from brain_client.brain.memory_search import MemorySearch, SearchVerdict
     from brain_client.core.config import BrainConfig
     from brain_client.core.state import BrainState, RunningSkill
     from brain_client.perception.camera import CameraCapture
@@ -74,6 +68,7 @@ if TYPE_CHECKING:
     from innate_proxy import ProxyClient
 
 _NAV_TO_POSITION = "innate-os/navigate_to_position"
+_SEARCH_MEMORY = "innate-os/search_memory"
 _FRESH_FRAME_SEC = 3.0  # an older camera frame means the feed is broken; don't think blind
 _MAX_EVENTS_QUEUED = 30  # the oldest beyond this are dropped as stale stimuli
 _MAX_EVENT_IMAGES = 4  # newest event images sent per turn; older ones arrive as text only
@@ -448,12 +443,7 @@ class BrainAgent:
         # the name the model calls always resolves to the skill it was declared for.
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
-        return build_tools(
-            named,
-            None,
-            can_go_to_point_in_view=_NAV_TO_POSITION in active_ids,
-            can_search_memory=self._memory is not None and self._memory.frame_count > 0,
-        )
+        return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
 
     # ================= act =================
     def _act(self, decision: Decision, speaker: SpeechStreamer, context: GeminiContext) -> list[tuple[ToolCall, str]]:
@@ -510,17 +500,19 @@ class BrainAgent:
             # (a goal that slips through anyway is cancelled by the runner's
             # generation bump, but this keeps the robot from twitching first).
             return "rejected — the brain is deactivating"
-        if call.name == SEARCH_MEMORY:
-            return self._search_memory(call.args)
-        if self._state.primitive_running is not None:
-            return "rejected — another skill is already running; stop it first"
-        if call.name == GO_TO_POINT_IN_VIEW:
-            return self._go_to_point_in_view(call.args)
         # Only names declared this turn resolve: falling back to the full
         # registry would let a hallucinated call bypass the active-skill allowlist.
         # The map can outlive a roster change (it isn't rebuilt while a skill
         # runs), so the resolved id is re-checked against the live active set.
         skill_id = self._tool_map.get(call.name)
+        if skill_id == _SEARCH_MEMORY and skill_id in self._roster.active_skill_ids():
+            # Recall is a query, not an act: it occupies no skill slot, so it
+            # resolves before the one-skill-at-a-time gate.
+            return self._search_memory(call.args)
+        if self._state.primitive_running is not None:
+            return "rejected — another skill is already running; stop it first"
+        if call.name == GO_TO_POINT_IN_VIEW:
+            return self._go_to_point_in_view(call.args)
         if skill_id is None:
             return f"unknown skill '{call.name}'"
         if skill_id not in self._roster.active_skill_ids():
@@ -578,18 +570,25 @@ class BrainAgent:
         )
 
     def _search_memory(self, args: dict) -> str:
-        """Fire a spatial-memory search; the loop must not block, so the result is an event."""
-        if self._memory is None or self._memory.frame_count == 0:
-            return "rejected — no places remembered on this map yet"
+        """Fire a spatial-memory search; the loop must not block, so the verdict is an event.
+
+        The brain hosts MemorySearch itself, so its own calls skip the
+        /brain/search_memory action the skill rides — same search, same cache,
+        one less hop.
+        """
+        if self._memory is None:
+            return "rejected — memory search is unavailable (no Gemini access)"
         query = str(args.get("query") or "").strip()
         if not query:
             return "rejected — give a query describing what to find"
-        self._memory.begin_search(query, self._on_memory_result)
+        if self._memory.frame_count == 0:
+            return "rejected — no places remembered on this map yet"
+        self._memory.begin_search(query, self._on_memory_verdict)
         return "searching memory — the result arrives as an event"
 
-    def _on_memory_result(self, text: str, image: bytes | None) -> None:
-        """Search thread: the result (and the matched frame) becomes the next turn's event."""
-        self.add_event(text, image=image, kind=EventKind.MEMORY)
+    def _on_memory_verdict(self, verdict: SearchVerdict) -> None:
+        """Search thread: the verdict (and its matched frame) becomes the next turn's event."""
+        self.add_event(verdict_text(verdict), image=verdict.image, kind=EventKind.MEMORY)
 
     def _start_skill(self, skill_id: str, inputs: dict) -> None:
         self._gaze.pause()
@@ -630,11 +629,13 @@ class BrainAgent:
         device = data.get("input_device", "unknown")
         self.add_event(f"Input from {device}: {json.dumps(data)}")
 
-    def on_skill_event(self, status: str, skill_name: str, detail: str | None = None) -> None:
+    def on_skill_event(
+        self, status: str, skill_name: str, detail: str | None = None, image: bytes | None = None
+    ) -> None:
         line = f"Skill {skill_name} {status}"
         if detail:
             line += f": {detail}"
-        self.add_event(line)
+        self.add_event(line, image=image)
 
     def on_skill_feedback(self, skill_name: str, feedback: str, image: bytes | None = None) -> None:
         self.add_event(f"Update from running skill {skill_name}: {feedback}", image=image)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Server-side copies of the remembered frames — the Gemini Files API tier.
+
+Each recorded JPEG is uploaded once, in the background, and referenced in
+requests as ``fileData``: a frame's bytes cross the network at record time and
+never again. The registry is a sidecar beside the store's images, so a restart
+re-uploads nothing; an entry is trusted only while its stamp matches the live
+memory, so a wiped-and-recreated id can never resolve to an old upload. Files
+expire server-side after 48 h — :meth:`maintain` (driven by the recorder's
+1 Hz tick via ``MemorySearch.warm``) re-uploads well before that.
+
+The whole tier is a pure optimization: a missing, expired, or failed upload
+just means that frame rides ``inlineData`` in the next request, and a backend
+without the upload endpoint latches the tier off for the process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from brain_client.brain.transport import FILES_UPLOAD_PATH, UNSUPPORTED_ENDPOINT_STATUSES, GeminiHttpError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from brain_client.brain.transport import GeminiRest
+    from brain_client.memory.store import Memory, MemoryStore
+
+_FILE_LIFETIME_SEC = 48 * 3600  # Gemini deletes uploads after this
+_USABLE_FOR_SEC = 47 * 3600  # stop referencing this long after upload (margin under the deletion)
+_REUPLOAD_AFTER_SEC = 40 * 3600  # the background chore refreshes an upload past this age
+
+
+@dataclass(frozen=True)
+class _FileRecord:
+    uri: str
+    uploaded_at: float  # epoch seconds
+    image_stamp: float  # the memory's stamp at upload — a mismatch means the frame changed
+
+
+class FrameFiles:
+    def __init__(self, store: MemoryStore, rest: GeminiRest, logger):
+        self._store = store
+        self._rest = rest
+        self._logger = logger
+        self.unsupported = False  # latched: the backend has no upload passthrough
+        self._lock = threading.Lock()  # registry map + sidecar IO
+        self._busy = threading.Lock()  # at most one maintenance thread
+        self._dir: Path | None = None  # which map's registry is loaded
+        self._records: dict[int, _FileRecord] = {}
+
+    def uri_for(self, memory: Memory) -> str | None:
+        """A live server-side URI for exactly this frame, or None (ride inline)."""
+        with self._lock:
+            self._sync_map_locked()
+            record = self._records.get(memory.id)
+        if record is None or record.image_stamp != memory.stamp:
+            return None
+        if time.time() - record.uploaded_at > _USABLE_FOR_SEC:
+            return None
+        return record.uri
+
+    def maintain(self) -> None:
+        """Upload new/refreshed/aging frames in the background; returns immediately."""
+        if self.unsupported:
+            return
+        pending = self._pending()
+        if not pending:
+            return
+        if not self._busy.acquire(blocking=False):
+            return  # a maintenance round is already running
+
+        def run() -> None:
+            try:
+                self._upload(pending)
+            finally:
+                self._busy.release()
+
+        threading.Thread(target=run, name="memory-file-upload", daemon=True).start()
+
+    def _pending(self) -> list[Memory]:
+        snapshot = self._store.snapshot()
+        now = time.time()
+        with self._lock:
+            self._sync_map_locked()
+            if self._dir is None:
+                return []
+            records = dict(self._records)
+        pending = []
+        for memory in snapshot.memories:
+            record = records.get(memory.id)
+            if record is None or record.image_stamp != memory.stamp or now - record.uploaded_at > _REUPLOAD_AFTER_SEC:
+                pending.append(memory)
+        return pending
+
+    def _upload(self, pending: list[Memory]) -> None:
+        """One maintenance round. A transient failure ends the round (the next
+        tick retries); an unsupported-endpoint answer latches the tier off."""
+        uploaded_into = self._dir  # a map switch mid-round orphans these uploads
+        for memory in pending:
+            path = self._store.image_path(memory.id)
+            if path is None:
+                return
+            try:
+                data = path.read_bytes()
+            except OSError:
+                continue  # evicted between the scan and now
+            try:
+                response = self._rest.upload(FILES_UPLOAD_PATH, data, "image/jpeg")
+            except GeminiHttpError as error:
+                if error.status in UNSUPPORTED_ENDPOINT_STATUSES:
+                    self.unsupported = True
+                    self._logger.warn(
+                        f"[Memory] backend has no file-upload endpoint (HTTP {error.status}); frames ride inline"
+                    )
+                else:
+                    self._logger.warn(f"[Memory] frame upload failed ({error}); retrying next tick")
+                return
+            except Exception as error:  # noqa: BLE001 — network trouble ends the round, never the process
+                self._logger.warn(f"[Memory] frame upload failed ({error!r}); retrying next tick")
+                return
+            uri = str((response.get("file") or {}).get("uri") or "")
+            if not uri:
+                self._logger.warn("[Memory] frame upload returned no file uri; retrying next tick")
+                return
+            with self._lock:
+                self._sync_map_locked()
+                if self._dir != uploaded_into:
+                    return  # the map switched mid-round; these frames are gone
+                self._records[memory.id] = _FileRecord(uri=uri, uploaded_at=time.time(), image_stamp=memory.stamp)
+                self._save_locked()
+
+    # --- registry persistence (under self._lock) ---
+    def _sync_map_locked(self) -> None:
+        path = self._store.files_index_path()
+        target = path.parent if path is not None else None
+        if target == self._dir:
+            return
+        self._dir = target
+        self._records = self._load(path) if path is not None else {}
+
+    def _load(self, path: Path) -> dict[int, _FileRecord]:
+        try:
+            data = json.loads(path.read_text())
+            return {
+                int(memory_id): _FileRecord(
+                    uri=str(entry["uri"]),
+                    uploaded_at=float(entry["uploaded_at"]),
+                    image_stamp=float(entry["image_stamp"]),
+                )
+                for memory_id, entry in data.get("files", {}).items()
+            }
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return {}  # unreadable registry = nothing uploaded; the chore rebuilds it
+
+    def _save_locked(self) -> None:
+        path = self._store.files_index_path()
+        if path is None:
+            return
+        live_ids = {memory.id for memory in self._store.snapshot().memories}
+        self._records = {memory_id: record for memory_id, record in self._records.items() if memory_id in live_ids}
+        index = {
+            "version": 1,
+            "files": {
+                str(memory_id): {
+                    "uri": record.uri,
+                    "uploaded_at": record.uploaded_at,
+                    "image_stamp": record.image_stamp,
+                }
+                for memory_id, record in self._records.items()
+            },
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(index))
+        os.replace(tmp, path)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -91,10 +91,22 @@ class MemorySearch:
         self._cache_unsupported = False
         self._failed_revision: int | None = None  # cache creation failed for exactly this content; don't hammer
         self._flight = threading.Lock()  # one network operation at a time (a search or a warm)
+        # UI mirror, set by the composition root: every finished search's verdict
+        # as a JSON-able dict (query, found, pose, explanation, latency, cached).
+        self.on_result: Callable[[dict], None] | None = None
 
     @property
     def frame_count(self) -> int:
         return len(self._store.snapshot().memories)
+
+    def cache_state(self) -> str:
+        """How the next search will run: warm | cold | inline | unsupported."""
+        if self._cache_unsupported:
+            return "unsupported"
+        snapshot = self._store.snapshot()
+        if len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
+            return "inline"  # under the cache floor — always answered inline, still quick
+        return "warm" if self._cache_matches(snapshot) else "cold"
 
     def begin_search(self, query: str, on_done: Callable[[str, bytes | None], None]) -> None:
         """Run a search on a daemon thread; the outcome (text, matched jpeg) hits ``on_done``."""
@@ -104,6 +116,7 @@ class MemorySearch:
                 text, image = self.search(query)
             except Exception as error:  # noqa: BLE001 — a failed search must report back, not vanish
                 self._logger.error(f"[Memory] search failed: {error!r}")
+                self._report({"query": query, "found": False, "error": str(error)})
                 text, image = f'Memory search for "{query}" failed: {error}', None
             on_done(text, image)
 
@@ -112,6 +125,7 @@ class MemorySearch:
     def search(self, query: str) -> tuple[str, bytes | None]:
         """Blocking: ask Gemini which remembered frame serves the query."""
         with self._flight:
+            started = time.monotonic()
             snapshot = self._store.snapshot()
             if not snapshot.memories:
                 return (
@@ -127,7 +141,7 @@ class MemorySearch:
                 }
                 try:
                     response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-                    return self._conclude(query, response, cache.memories)
+                    return self._conclude(query, response, cache.memories, started, cached=True)
                 except GeminiHttpError as error:
                     if error.status >= 500:
                         raise
@@ -142,7 +156,7 @@ class MemorySearch:
                 "generationConfig": _GENERATION_CONFIG,
             }
             response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-            return self._conclude(query, response, tuple(memory for memory, _ in frames))
+            return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
 
     def warm(self) -> None:
         """Refresh the context cache in the background once the memory has settled.
@@ -238,15 +252,36 @@ class MemorySearch:
         return self._cache
 
     # --- request assembly / response handling ---
-    def _conclude(self, query: str, response: dict, memories: tuple[Memory, ...]) -> tuple[str, bytes | None]:
+    def _conclude(
+        self, query: str, response: dict, memories: tuple[Memory, ...], started: float, *, cached: bool
+    ) -> tuple[str, bytes | None]:
+        latency = round(time.monotonic() - started, 2)
         verdict = _parse_verdict(response)
         if verdict is None:
+            self._report({"query": query, "found": False, "error": "unreadable answer"})
             return f'Memory search for "{query}" returned an unreadable answer — try again.', None
         found, frame, explanation = verdict
         if not found or not 1 <= frame <= len(memories):
+            self._report(
+                {"query": query, "found": False, "explanation": explanation, "latency_sec": latency, "cached": cached}
+            )
             return f'Memory search for "{query}": nothing in the remembered views matches. {explanation}', None
         memory = memories[frame - 1]
         jpeg = self._read_image(memory)
+        self._report(
+            {
+                "query": query,
+                "found": True,
+                "id": memory.id,
+                "x": round(memory.x, 3),
+                "y": round(memory.y, 3),
+                "theta": round(memory.theta, 4),
+                "seen_stamp": memory.stamp,
+                "explanation": explanation,
+                "latency_sec": latency,
+                "cached": cached,
+            }
+        )
         return (
             f'Memory search for "{query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago at '
             f"map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
@@ -256,6 +291,15 @@ class MemorySearch:
             f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false).",
             jpeg,
         )
+
+    def _report(self, payload: dict) -> None:
+        """Mirror a search verdict to the UI; best-effort — it must never break a search."""
+        if self.on_result is None:
+            return
+        try:
+            self.on_result({**payload, "stamp": time.time()})
+        except Exception as error:  # noqa: BLE001 — the UI mirror must not break the search
+            self._logger.warn(f"[Memory] search result mirror failed: {error!r}")
 
     def _load_frames(self, memories: tuple[Memory, ...]) -> list[tuple[Memory, bytes]]:
         frames = []

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -11,9 +11,11 @@ changes, expires, or the process restarts, and :meth:`warm` refreshes it in
 the background so the first search stays fast. A backend without the
 cachedContents endpoint falls back to inline frames — slower, same answers.
 
-Searches run on a daemon thread and report through a callback: the agent loop
-must never block on the network, so a search is dispatched fire-and-forget and
-its result arrives as a new event.
+Every search concludes in a :class:`SearchVerdict` — one structured outcome
+for every consumer: the agent's fire-and-forget event path (the loop must
+never block on the network), the ``/brain/search_memory`` action server that
+skills call, and the webapp mirror. :func:`verdict_text` renders the one
+model-facing sentence for all of them.
 """
 
 from __future__ import annotations
@@ -81,6 +83,22 @@ class _CacheHandle:
     expires_monotonic: float
 
 
+@dataclass(frozen=True)
+class SearchVerdict:
+    """One search's structured outcome. ``error`` non-empty means the search
+    itself failed (transport, unreadable answer) — distinct from a clean
+    no-match, which is ``found=False`` with an explanation."""
+
+    query: str
+    found: bool
+    explanation: str = ""
+    error: str = ""
+    memory: Memory | None = None
+    image: bytes | None = None
+    latency_sec: float = 0.0
+    cached: bool = False
+
+
 class MemorySearch:
     def __init__(self, store: MemoryStore, rest: GeminiRest, *, model: str, logger):
         self._store = store
@@ -108,55 +126,66 @@ class MemorySearch:
             return "inline"  # under the cache floor — always answered inline, still quick
         return "warm" if self._cache_matches(snapshot) else "cold"
 
-    def begin_search(self, query: str, on_done: Callable[[str, bytes | None], None]) -> None:
-        """Run a search on a daemon thread; the outcome (text, matched jpeg) hits ``on_done``."""
+    def begin_search(self, query: str, on_done: Callable[[SearchVerdict], None]) -> None:
+        """Run a search on a daemon thread; the verdict hits ``on_done`` when it lands."""
 
         def run() -> None:
             try:
-                text, image = self.search(query)
-            except Exception as error:  # noqa: BLE001 — a failed search must report back, not vanish
-                self._logger.error(f"[Memory] search failed: {error!r}")
-                self._report({"query": query, "found": False, "error": str(error)})
-                text, image = f'Memory search for "{query}" failed: {error}', None
-            on_done(text, image)
+                on_done(self.search(query))
+            except Exception as error:  # noqa: BLE001 — a broken consumer must not kill the thread silently
+                self._logger.error(f"[Memory] search callback failed: {error!r}")
 
         threading.Thread(target=run, name="memory-search", daemon=True).start()
 
-    def search(self, query: str) -> tuple[str, bytes | None]:
-        """Blocking: ask Gemini which remembered frame serves the query."""
+    def search(self, query: str) -> SearchVerdict:
+        """Blocking: ask Gemini which remembered frame serves the query.
+
+        Never raises — failures come back as an ``error`` verdict every
+        consumer (agent event, action result, webapp card) can render.
+        """
         with self._flight:
             started = time.monotonic()
-            snapshot = self._store.snapshot()
-            if not snapshot.memories:
-                return (
-                    "The robot has no memories of this map yet — drive around in navigation mode to build them.",
-                    None,
-                )
-            cache = self._ensure_cache(snapshot)
-            if cache is not None:
-                body = {
-                    "cachedContent": cache.name,
-                    "contents": [_user([{"text": _question(query)}])],
-                    "generationConfig": _GENERATION_CONFIG,
-                }
-                try:
-                    response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-                    return self._conclude(query, response, cache.memories, started, cached=True)
-                except GeminiHttpError as error:
-                    if error.status >= 500:
-                        raise
-                    # The cache died server-side (expired early, deleted, rejected):
-                    # forget it and answer inline; the next warm rebuilds it.
-                    self._cache = None
-                    self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
-            frames = self._load_frames(snapshot.memories)
+            try:
+                verdict = self._search_locked(query, started)
+            except Exception as error:  # noqa: BLE001 — transport failures become a typed error verdict
+                self._logger.error(f"[Memory] search failed: {error!r}")
+                verdict = SearchVerdict(query=query, found=False, error=str(error))
+        self._report(verdict)
+        return verdict
+
+    def _search_locked(self, query: str, started: float) -> SearchVerdict:
+        snapshot = self._store.snapshot()
+        if not snapshot.memories:
+            return SearchVerdict(
+                query=query,
+                found=False,
+                explanation="The robot has no memories of this map yet — drive around in navigation mode to build them.",
+            )
+        cache = self._ensure_cache(snapshot)
+        if cache is not None:
             body = {
-                "systemInstruction": {"parts": [{"text": _SYSTEM}]},
-                "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+                "cachedContent": cache.name,
+                "contents": [_user([{"text": _question(query)}])],
                 "generationConfig": _GENERATION_CONFIG,
             }
-            response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-            return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
+            try:
+                response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
+                return self._conclude(query, response, cache.memories, started, cached=True)
+            except GeminiHttpError as error:
+                if error.status >= 500:
+                    raise
+                # The cache died server-side (expired early, deleted, rejected):
+                # forget it and answer inline; the next warm rebuilds it.
+                self._cache = None
+                self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
+        frames = self._load_frames(snapshot.memories)
+        body = {
+            "systemInstruction": {"parts": [{"text": _SYSTEM}]},
+            "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+            "generationConfig": _GENERATION_CONFIG,
+        }
+        response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
+        return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
 
     def warm(self) -> None:
         """Refresh the context cache in the background once the memory has settled.
@@ -254,50 +283,51 @@ class MemorySearch:
     # --- request assembly / response handling ---
     def _conclude(
         self, query: str, response: dict, memories: tuple[Memory, ...], started: float, *, cached: bool
-    ) -> tuple[str, bytes | None]:
+    ) -> SearchVerdict:
         latency = round(time.monotonic() - started, 2)
-        verdict = _parse_verdict(response)
-        if verdict is None:
-            self._report({"query": query, "found": False, "error": "unreadable answer"})
-            return f'Memory search for "{query}" returned an unreadable answer — try again.', None
-        found, frame, explanation = verdict
-        if not found or not 1 <= frame <= len(memories):
-            self._report(
-                {"query": query, "found": False, "explanation": explanation, "latency_sec": latency, "cached": cached}
+        parsed = _parse_verdict(response)
+        if parsed is None:
+            return SearchVerdict(
+                query=query, found=False, error="unreadable answer", latency_sec=latency, cached=cached
             )
-            return f'Memory search for "{query}": nothing in the remembered views matches. {explanation}', None
+        found, frame, explanation = parsed
+        if not found or not 1 <= frame <= len(memories):
+            return SearchVerdict(query=query, found=False, explanation=explanation, latency_sec=latency, cached=cached)
         memory = memories[frame - 1]
-        jpeg = self._read_image(memory)
-        self._report(
-            {
-                "query": query,
-                "found": True,
+        return SearchVerdict(
+            query=query,
+            found=True,
+            explanation=explanation,
+            memory=memory,
+            image=self._read_image(memory),
+            latency_sec=latency,
+            cached=cached,
+        )
+
+    def _report(self, verdict: SearchVerdict) -> None:
+        """Mirror a verdict to the UI topic; best-effort — it must never break a search."""
+        if self.on_result is None:
+            return
+        payload: dict = {"query": verdict.query, "found": verdict.found, "stamp": time.time()}
+        if verdict.error:
+            payload["error"] = verdict.error
+        else:
+            payload |= {
+                "explanation": verdict.explanation,
+                "latency_sec": verdict.latency_sec,
+                "cached": verdict.cached,
+            }
+        if verdict.memory is not None:
+            memory = verdict.memory
+            payload |= {
                 "id": memory.id,
                 "x": round(memory.x, 3),
                 "y": round(memory.y, 3),
                 "theta": round(memory.theta, 4),
                 "seen_stamp": memory.stamp,
-                "explanation": explanation,
-                "latency_sec": latency,
-                "cached": cached,
             }
-        )
-        return (
-            f'Memory search for "{query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago at '
-            f"map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
-            f"{explanation} "
-            + ("The attached image is that memory. " if jpeg else "")
-            + f"To go there: navigate_to_position(x={memory.x:.2f}, y={memory.y:.2f}, "
-            f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false).",
-            jpeg,
-        )
-
-    def _report(self, payload: dict) -> None:
-        """Mirror a search verdict to the UI; best-effort — it must never break a search."""
-        if self.on_result is None:
-            return
         try:
-            self.on_result({**payload, "stamp": time.time()})
+            self.on_result(payload)
         except Exception as error:  # noqa: BLE001 — the UI mirror must not break the search
             self._logger.warn(f"[Memory] search result mirror failed: {error!r}")
 
@@ -315,6 +345,25 @@ class MemorySearch:
             return path.read_bytes() if path is not None else None
         except OSError:
             return None
+
+
+def verdict_text(verdict: SearchVerdict) -> str:
+    """The one model-facing sentence for a verdict — shared by the agent's
+    event path and the search skill, so the model reads the same thing
+    whichever door the search came through."""
+    if verdict.error:
+        return f'Memory search for "{verdict.query}" failed: {verdict.error}'
+    if verdict.memory is None:
+        return f'Memory search for "{verdict.query}": nothing in the remembered views matches. {verdict.explanation}'
+    memory = verdict.memory
+    return (
+        f'Memory search for "{verdict.query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago '
+        f"at map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
+        f"{verdict.explanation} "
+        + ("The attached image is that memory. " if verdict.image else "")
+        + f"To go there: navigate_to_position(x={memory.x:.2f}, y={memory.y:.2f}, "
+        f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false)."
+    )
 
 
 def _user(parts: list[dict]) -> dict:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -3,13 +3,21 @@
 """Recall over the spatial memory: which remembered view answers a request.
 
 Mobility-VLA-style retrieval: every remembered frame goes to Gemini, labeled
-with its number, capture time, and map pose, and the model picks the one that
+with its id, capture time, and map pose, and the model picks the one that
 best serves the query — directly ("the kitchen") or by reasoning ("I am
-hungry"). The frames ride in an explicit Gemini context cache, so a search
-uploads only the question; the cache is rebuilt lazily whenever the memory
-changes, expires, or the process restarts, and :meth:`warm` refreshes it in
-the background so the first search stays fast. A backend without the
-cachedContents endpoint falls back to inline frames — slower, same answers.
+hungry").
+
+Bandwidth is tiered, and every tier is a pure optimization that degrades
+without changing answers. Each frame's bytes cross the network once, at
+record time — a background chore (:mod:`frame_files`) uploads them to the
+Gemini Files API and requests reference them as ``fileData``. On top rides an
+explicit context cache: fresh → the search sends only the question; stale →
+the search *still* uses it and appends the delta (added/refreshed frames plus
+short supersede/retire notes) — a search is always exactly one round trip and
+never waits for maintenance (cache builds happen only in :meth:`warm`'s
+background thread). A frame not yet uploaded rides ``inlineData``; a backend
+without an endpoint latches that tier off, bottoming out at today's
+all-inline behavior.
 
 Every search concludes in a :class:`SearchVerdict` — one structured outcome
 for every consumer: the agent's fire-and-forget event path (the loop must
@@ -30,7 +38,13 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from brain_client.brain.transport import CACHED_CONTENTS_PATH, GENERATE_PATH, GeminiHttpError
+from brain_client.brain.frame_files import FrameFiles
+from brain_client.brain.transport import (
+    CACHED_CONTENTS_PATH,
+    GENERATE_PATH,
+    UNSUPPORTED_ENDPOINT_STATUSES,
+    GeminiHttpError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -41,24 +55,24 @@ if TYPE_CHECKING:
 _TTL_SEC = 12 * 3600  # ~20k-token cache: 12h of storage costs ~$0.24, cheap insurance against cold starts
 _TTL_SAFETY_SEC = 120  # treat the cache as gone this long before Gemini actually expires it
 _MIN_FRAMES_TO_CACHE = 6  # fewer frames sit under the API's minimum cache size (and upload fast anyway)
-_WARM_AFTER_QUIET_SEC = 30.0  # let a recording burst settle before re-uploading every frame
-_UNSUPPORTED_STATUSES = (404, 405, 501)  # the backend has no cachedContents passthrough
+_WARM_AFTER_QUIET_SEC = 30.0  # let a recording burst settle before rebuilding the cache
 
 _SYSTEM = (
     "You are the spatial memory of a small home robot. You hold snapshots the robot remembered "
-    "while driving around its current map; each frame is labeled with its number, when it was "
-    "recorded, and the map pose it was taken from. Given what the robot needs, pick the single "
-    "frame whose view best serves it — the place itself, or where the needed thing was last "
-    'seen. Needs may be indirect: "I am hungry" points at food or the kitchen, "exit the '
-    'room" at a doorway. Prefer the most recent frame among equals. If no remembered view '
-    "plausibly helps, be honest and report no match."
+    "while driving around its current map; each frame is labeled with its id number, when it was "
+    "recorded, and the map pose it was taken from. Later messages may add frames, supersede one "
+    "with a newer view, or retire one — always honor the latest state. Given what the robot "
+    "needs, pick the single frame whose view best serves it — the place itself, or where the "
+    'needed thing was last seen. Needs may be indirect: "I am hungry" points at food or the '
+    'kitchen, "exit the room" at a doorway. Prefer the most recent frame among equals. If no '
+    "remembered view plausibly helps, be honest and report no match."
 )
 
 _RESPONSE_SCHEMA = {
     "type": "OBJECT",
     "properties": {
         "found": {"type": "BOOLEAN"},
-        "frame": {"type": "INTEGER", "description": "number of the best frame, 0 when found is false"},
+        "frame": {"type": "INTEGER", "description": "id number of the best frame, 0 when found is false"},
         "explanation": {
             "type": "STRING",
             "description": "one sentence: what the frame shows and why it serves the need",
@@ -105,10 +119,14 @@ class MemorySearch:
         self._rest = rest
         self._model = model
         self._logger = logger
+        self._files = FrameFiles(store, rest, logger)
         self._cache: _CacheHandle | None = None
         self._cache_unsupported = False
         self._failed_revision: int | None = None  # cache creation failed for exactly this content; don't hammer
-        self._flight = threading.Lock()  # one network operation at a time (a search or a warm)
+        self._flight = threading.Lock()  # searches run one at a time
+        # Maintenance never holds _flight: a search must proceed mid-rebuild
+        # (it rides the old handle — the swap is a single reference write).
+        self._warming = threading.Lock()  # at most one cache rebuild
         # UI mirror, set by the composition root: every finished search's verdict
         # as a JSON-able dict (query, found, pose, explanation, latency, cached).
         self.on_result: Callable[[dict], None] | None = None
@@ -118,13 +136,17 @@ class MemorySearch:
         return len(self._store.snapshot().memories)
 
     def cache_state(self) -> str:
-        """How the next search will run: warm | cold | inline | unsupported."""
+        """How the next search will run: warm | cold | inline | unsupported.
+
+        A stale-but-usable cache reports warm — the search rides it with a
+        delta, so recall is still instant (rebuilds are warm()'s business).
+        """
         if self._cache_unsupported:
             return "unsupported"
         snapshot = self._store.snapshot()
         if len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
-            return "inline"  # under the cache floor — always answered inline, still quick
-        return "warm" if self._cache_matches(snapshot) else "cold"
+            return "inline"  # under the cache floor — always answered from frames, still quick
+        return "warm" if self._usable_cache(snapshot) is not None else "cold"
 
     def begin_search(self, query: str, on_done: Callable[[SearchVerdict], None]) -> None:
         """Run a search on a daemon thread; the verdict hits ``on_done`` when it lands."""
@@ -154,6 +176,8 @@ class MemorySearch:
         return verdict
 
     def _search_locked(self, query: str, started: float) -> SearchVerdict:
+        """One round trip from the best context available NOW — a search never
+        builds a cache and never waits for an upload (that's warm()'s job)."""
         snapshot = self._store.snapshot()
         if not snapshot.memories:
             return SearchVerdict(
@@ -161,53 +185,55 @@ class MemorySearch:
                 found=False,
                 explanation="The robot has no memories of this map yet — drive around in navigation mode to build them.",
             )
-        cache = self._ensure_cache(snapshot)
+        cache = self._usable_cache(snapshot)
         if cache is not None:
+            # A stale cache still serves: the delta (new/refreshed frames plus
+            # supersede/retire notes) rides alongside the question.
             body = {
                 "cachedContent": cache.name,
-                "contents": [_user([{"text": _question(query)}])],
+                "contents": [_user([*self._delta_parts(cache, snapshot), {"text": _question(query)}])],
                 "generationConfig": _GENERATION_CONFIG,
             }
             try:
                 response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-                return self._conclude(query, response, cache.memories, started, cached=True)
+                return self._conclude(query, response, snapshot.memories, started, cached=True)
             except GeminiHttpError as error:
                 if error.status >= 500:
                     raise
                 # The cache died server-side (expired early, deleted, rejected):
-                # forget it and answer inline; the next warm rebuilds it.
+                # forget it and answer from frames; the next warm rebuilds it.
                 self._cache = None
-                self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
-        frames = self._load_frames(snapshot.memories)
+                self._logger.warn(f"[Memory] cached search failed ({error}); retrying without it")
+        parts, _included = self._frame_parts(snapshot.memories)
         body = {
             "systemInstruction": {"parts": [{"text": _SYSTEM}]},
-            "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+            "contents": [_user([*parts, {"text": _question(query)}])],
             "generationConfig": _GENERATION_CONFIG,
         }
         response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-        return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
+        return self._conclude(query, response, snapshot.memories, started, cached=False)
 
     def warm(self) -> None:
-        """Refresh the context cache in the background once the memory has settled.
-
-        Called from the recorder's tick; returns immediately. Keeps the first
-        search after a boot or a recording burst from paying the frame upload.
+        """All background maintenance, driven by the recorder's 1 Hz tick:
+        upload new/aging frames server-side, and rebuild the context cache once
+        the memory has settled. Returns immediately; searches never wait on it.
         """
+        self._files.maintain()
         snapshot = self._store.snapshot()
         if not self._should_warm(snapshot):
             return
         if time.monotonic() - self._store.last_change_monotonic < _WARM_AFTER_QUIET_SEC:
             return
-        if not self._flight.acquire(blocking=False):
-            return  # a search or another warm is already on the wire
+        if not self._warming.acquire(blocking=False):
+            return  # a rebuild is already on the wire
 
         def run() -> None:
             try:
                 self._ensure_cache(self._store.snapshot())
-            except Exception as error:  # noqa: BLE001 — warming is opportunistic; the search path retries
+            except Exception as error:  # noqa: BLE001 — warming is opportunistic; the search path degrades
                 self._logger.warn(f"[Memory] cache warm failed: {error!r}")
             finally:
-                self._flight.release()
+                self._warming.release()
 
         threading.Thread(target=run, name="memory-warm", daemon=True).start()
 
@@ -220,6 +246,14 @@ class MemorySearch:
             and cache.map_name == snapshot.map_name
             and time.monotonic() < cache.expires_monotonic
         )
+
+    def _usable_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
+        """The handle a search may ride right now — fresh OR stale (the delta
+        covers staleness); only the wrong map or expiry disqualifies it."""
+        cache = self._cache
+        if cache is None or cache.map_name != snapshot.map_name:
+            return None
+        return cache if time.monotonic() < cache.expires_monotonic else None
 
     def _should_warm(self, snapshot: MemorySnapshot) -> bool:
         if self._cache_unsupported or len(snapshot.memories) < _MIN_FRAMES_TO_CACHE:
@@ -238,13 +272,13 @@ class MemorySearch:
         return self._create_cache(snapshot)
 
     def _create_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
-        frames = self._load_frames(snapshot.memories)
-        if len(frames) < _MIN_FRAMES_TO_CACHE:
+        parts, included = self._frame_parts(snapshot.memories)
+        if len(included) < _MIN_FRAMES_TO_CACHE:
             return None
         body = {
             "model": f"models/{self._model}",
             "systemInstruction": {"parts": [{"text": _SYSTEM}]},
-            "contents": [_user(_frame_parts(frames))],
+            "contents": [_user(parts)],
             "ttl": f"{_TTL_SEC}s",
             "displayName": f"mars-spatial-memory-{snapshot.map_name or 'unknown'}",
         }
@@ -252,7 +286,7 @@ class MemorySearch:
         try:
             name = str(self._rest.post(CACHED_CONTENTS_PATH, body).get("name") or "")
         except GeminiHttpError as error:
-            if error.status in _UNSUPPORTED_STATUSES:
+            if error.status in UNSUPPORTED_ENDPOINT_STATUSES:
                 self._cache_unsupported = True
                 self._logger.warn(
                     f"[Memory] backend has no context-cache endpoint (HTTP {error.status}); searches run uncached"
@@ -270,14 +304,14 @@ class MemorySearch:
                 name=name,
                 revision=snapshot.revision,
                 map_name=snapshot.map_name,
-                memories=tuple(memory for memory, _ in frames),
+                memories=included,
                 expires_monotonic=started + _TTL_SEC - _TTL_SAFETY_SEC,
             ),
         )
         if old is not None:
             with contextlib.suppress(Exception):
                 self._rest.delete(f"/v1beta/{old.name}")
-        self._logger.info(f"[Memory] cached {len(frames)} frames for search in {time.monotonic() - started:.1f}s")
+        self._logger.info(f"[Memory] cached {len(included)} frames for search in {time.monotonic() - started:.1f}s")
         return self._cache
 
     # --- request assembly / response handling ---
@@ -290,10 +324,12 @@ class MemorySearch:
             return SearchVerdict(
                 query=query, found=False, error="unreadable answer", latency_sec=latency, cached=cached
             )
-        found, frame, explanation = parsed
-        if not found or not 1 <= frame <= len(memories):
+        found, frame_id, explanation = parsed
+        # Frames are labeled by stable store id, so the answer resolves against
+        # the CURRENT snapshot — a cached-but-since-evicted id cleanly misses.
+        memory = next((m for m in memories if m.id == frame_id), None)
+        if not found or memory is None:
             return SearchVerdict(query=query, found=False, explanation=explanation, latency_sec=latency, cached=cached)
-        memory = memories[frame - 1]
         return SearchVerdict(
             query=query,
             found=True,
@@ -331,13 +367,52 @@ class MemorySearch:
         except Exception as error:  # noqa: BLE001 — the UI mirror must not break the search
             self._logger.warn(f"[Memory] search result mirror failed: {error!r}")
 
-    def _load_frames(self, memories: tuple[Memory, ...]) -> list[tuple[Memory, bytes]]:
-        frames = []
+    def _frame_parts(self, memories: tuple[Memory, ...]) -> tuple[list[dict], tuple[Memory, ...]]:
+        """Request parts for these frames, and which memories made it in
+        (an evicted-mid-read frame just drops out)."""
+        parts: list[dict] = []
+        included: list[Memory] = []
         for memory in memories:
+            frame = self._frame_part(memory)
+            if frame is None:
+                continue
+            parts.extend(frame)
+            included.append(memory)
+        return parts, tuple(included)
+
+    def _frame_part(self, memory: Memory) -> list[dict] | None:
+        """One frame as [image part, label part] — a server-side fileData
+        reference when the upload tier has one, inline bytes otherwise."""
+        uri = self._files.uri_for(memory)
+        if uri is not None:
+            image: dict = {"fileData": {"mimeType": "image/jpeg", "fileUri": uri}}
+        else:
             jpeg = self._read_image(memory)
-            if jpeg:  # evicted between snapshot and read: the frame just drops out
-                frames.append((memory, jpeg))
-        return frames
+            if not jpeg:
+                return None
+            image = {"inlineData": {"mimeType": "image/jpeg", "data": base64.b64encode(jpeg).decode()}}
+        return [image, {"text": _frame_label(memory)}]
+
+    def _delta_parts(self, cache: _CacheHandle, snapshot: MemorySnapshot) -> list[dict]:
+        """What changed since the cache was built: new frames, re-captured
+        frames with a supersede note, and retire notes for evicted ids.
+        Empty exactly when the cache is fresh."""
+        cached = {memory.id: memory for memory in cache.memories}
+        parts: list[dict] = []
+        for memory in snapshot.memories:
+            old = cached.get(memory.id)
+            if old is not None and old.stamp == memory.stamp:
+                continue
+            frame = self._frame_part(memory)
+            if frame is None:
+                continue
+            if old is not None:
+                parts.append({"text": f"Frame {memory.id} was re-captured — this newer view supersedes it:"})
+            parts.extend(frame)
+        current_ids = {memory.id for memory in snapshot.memories}
+        for gone in sorted(cached.keys() - current_ids):
+            parts.append({"text": f"Frame {gone} no longer exists — ignore it."})
+        return parts
 
     def _read_image(self, memory: Memory) -> bytes | None:
         path = self._store.image_path(memory.id)
@@ -370,18 +445,12 @@ def _user(parts: list[dict]) -> dict:
     return {"role": "user", "parts": parts}
 
 
-def _frame_parts(frames: list[tuple[Memory, bytes]]) -> list[dict]:
-    parts: list[dict] = []
-    for number, (memory, jpeg) in enumerate(frames, start=1):
-        parts.append({"inlineData": {"mimeType": "image/jpeg", "data": base64.b64encode(jpeg).decode()}})
-        parts.append({"text": _frame_label(number, memory)})
-    return parts
-
-
-def _frame_label(number: int, memory: Memory) -> str:
+def _frame_label(memory: Memory) -> str:
+    # Labeled by the stable store id (not enumeration position), so delta
+    # notes and verdicts stay valid across additions, refreshes, and evictions.
     when = datetime.fromtimestamp(memory.stamp).strftime("%Y-%m-%d %H:%M")
     return (
-        f"Frame {number} — recorded {when}, from map position x={memory.x:.2f}m y={memory.y:.2f}m "
+        f"Frame {memory.id} — recorded {when}, from map position x={memory.x:.2f}m y={memory.y:.2f}m "
         f"heading={math.degrees(memory.theta):.0f}°"
     )
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/search_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/search_server.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The ``/brain/search_memory`` action: spatial-memory recall as a capability.
+
+The capability server pattern (arm_sdk_server, the nav stack): the state that
+makes search fast and safe — the Gemini context cache, the transport, the
+credentials — stays in the brain process with :class:`MemorySearch`; skills
+and SDK users reach it through this action and never see any of it.
+
+Runs on its own node and spin thread because a search blocks for seconds and
+the brain node is spun single-threaded — recall must never stall a turn.
+Cancellation is rejected by design: the network call can't be unwound, so a
+caller that stops waiting simply abandons the goal and the verdict is dropped
+(the skill layer's Stop already works exactly that way).
+"""
+
+from __future__ import annotations
+
+import base64
+import threading
+from typing import TYPE_CHECKING
+
+import rclpy
+from brain_messages.action import SearchMemory
+from rclpy.action import ActionServer, CancelResponse
+from rclpy.executors import SingleThreadedExecutor
+
+from brain_client.brain.memory_search import verdict_text
+
+if TYPE_CHECKING:
+    from brain_client.brain.memory_search import MemorySearch, SearchVerdict
+
+
+class MemorySearchServer:
+    def __init__(self, search: MemorySearch):
+        self._search = search
+        self._node = rclpy.create_node("memory_search_server")
+        self._server = ActionServer(
+            self._node,
+            SearchMemory,
+            "/brain/search_memory",
+            execute_callback=self._execute,
+            cancel_callback=lambda _: CancelResponse.REJECT,
+        )
+        self._executor = SingleThreadedExecutor()
+        self._executor.add_node(self._node)
+        self._thread = threading.Thread(target=self._executor.spin, name="memory-search-server", daemon=True)
+        self._thread.start()
+
+    def _execute(self, goal_handle) -> SearchMemory.Result:
+        verdict = self._search.search(str(goal_handle.request.query))  # never raises: errors are verdicts
+        goal_handle.succeed()
+        return _to_result(verdict)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(timeout_sec=2.0)
+        self._node.destroy_node()
+
+
+def _to_result(verdict: SearchVerdict) -> SearchMemory.Result:
+    result = SearchMemory.Result()
+    result.found = verdict.found
+    result.message = verdict_text(verdict)
+    result.explanation = verdict.explanation
+    result.error = verdict.error
+    result.latency_sec = float(verdict.latency_sec)
+    result.cached = verdict.cached
+    if verdict.memory is not None:
+        result.x = verdict.memory.x
+        result.y = verdict.memory.y
+        result.theta = verdict.memory.theta
+        result.seen_stamp = verdict.memory.stamp
+    if verdict.image:
+        result.image_b64 = base64.b64encode(verdict.image).decode()
+    return result

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -11,7 +11,6 @@ from brain_client.skills.registry import SkillMeta
 STOP_SKILL = "stop_current_skill"
 WAIT = "wait"
 GO_TO_POINT_IN_VIEW = "go_to_point_in_view"
-SEARCH_MEMORY = "search_memory"
 
 # An explicit no-op keeps idle turns clean: without it, models tend to emit
 # placeholder text ("[]", "Empty response") rather than returning nothing.
@@ -42,24 +41,6 @@ _GO_TO_POINT_IN_VIEW_DECLARATION = {
     },
 }
 
-# Recall over the robot's persistent spatial memory (brain/memory_search.py).
-# Declared only while the memory holds at least one frame for the current map.
-_SEARCH_MEMORY_DECLARATION = {
-    "name": SEARCH_MEMORY,
-    "description": (
-        "Search the robot's long-term memory of places it has seen on this map. Describe the place "
-        "or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my "
-        "airpods'); a vision model reviews every remembered view and an event brings back the best "
-        "match — its image, map coordinates, and when it was seen. Use it to find anything not in "
-        "the current camera view, then drive there with navigate_to_position (local_frame=false)."
-    ),
-    "parameters": {
-        "type": "OBJECT",
-        "properties": {"query": {"type": "STRING", "description": "what to look for, with any helpful context"}},
-        "required": ["query"],
-    },
-}
-
 # Skill input "type" strings (python annotation names from skill introspection)
 # -> Gemini schema types. Anything else is passed as a string with the expected
 # type noted in the description.
@@ -85,7 +66,7 @@ def assign_tool_names(skills: list[SkillMeta]) -> list[tuple[str, SkillMeta]]:
     shadow a built-in tool); colliding names get a numeric suffix so a call
     never silently dispatches to the wrong skill.
     """
-    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW, SEARCH_MEMORY}
+    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW}
     named: list[tuple[str, SkillMeta]] = []
     for meta in skills:
         base = name = tool_name(meta["name"])
@@ -104,7 +85,6 @@ def build_tools(
     running_skill_name: str | None,
     *,
     can_go_to_point_in_view: bool = False,
-    can_search_memory: bool = False,
     user_spoke: bool = False,
 ) -> list[dict]:
     """One function declaration per available skill, in a native tools block.
@@ -135,8 +115,6 @@ def build_tools(
     declarations = [_declaration(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)
-    if can_search_memory:
-        declarations.append(_SEARCH_MEMORY_DECLARATION)
     declarations.append(_WAIT_DECLARATION)
     return [{"functionDeclarations": declarations}]
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
@@ -29,6 +29,11 @@ DIRECT_BASE_URL = "https://generativelanguage.googleapis.com"
 STREAM_PATH = "/v1beta/models/{model}:streamGenerateContent?alt=sse"
 GENERATE_PATH = "/v1beta/models/{model}:generateContent"
 CACHED_CONTENTS_PATH = "/v1beta/cachedContents"
+FILES_UPLOAD_PATH = "/upload/v1beta/files"
+
+# The backend has no passthrough for this endpoint at all — callers latch the
+# feature off permanently rather than retry (shared by the cache and files tiers).
+UNSUPPORTED_ENDPOINT_STATUSES = (404, 405, 501)
 
 Transport = Callable[[str, dict], Iterator[dict]]
 """(model, request body) -> streamed response chunks."""
@@ -44,10 +49,11 @@ class GeminiHttpError(RuntimeError):
 
 @dataclass(frozen=True)
 class GeminiRest:
-    """Blocking JSON calls against the same backend the stream uses."""
+    """Blocking JSON + media calls against the same backend the stream uses."""
 
     post: Callable[[str, dict], dict]  # (api path, body) -> parsed response; raises GeminiHttpError on non-200
     delete: Callable[[str], dict]  # api path -> parsed response (usually empty)
+    upload: Callable[[str, bytes, str], dict]  # (api path, raw bytes, mime type) -> parsed response
 
 
 class Backend(StrEnum):
@@ -112,16 +118,20 @@ def pick_rest(proxy: ProxyClient | None) -> GeminiRest | None:
 def proxy_rest(proxy: ProxyClient) -> GeminiRest:
     """Non-streaming Gemini calls through the proxy (same service passthrough as the stream)."""
 
-    def request(method: str, path: str, body: dict | None = None) -> dict:
-        with proxy.request_stream(PROXY_SERVICE, path, method=method, json=body) as resp:
-            data = resp.read()
+    def request(method: str, path: str, body: dict | None = None, data: bytes | None = None) -> dict:
+        with proxy.request_stream(PROXY_SERVICE, path, method=method, json=body, data=data) as resp:
+            payload = resp.read()
             if resp.status_code != 200:
-                raise GeminiHttpError(resp.status_code, data[:200].decode(errors="replace"))
-            return json.loads(data) if data else {}
+                raise GeminiHttpError(resp.status_code, payload[:200].decode(errors="replace"))
+            return json.loads(payload) if payload else {}
 
+    # The proxy client cannot attach the raw-upload protocol headers; a
+    # passthrough that requires them answers non-200 and the caller latches
+    # the files tier off (frames ride inline — today's behavior).
     return GeminiRest(
         post=lambda path, body: request("POST", path, body),
         delete=lambda path: request("DELETE", path),
+        upload=lambda path, data, mime: request("POST", path, data=data),
     )
 
 
@@ -137,9 +147,20 @@ def direct_rest(api_key: str) -> GeminiRest:
             raise GeminiHttpError(resp.status_code, resp.text[:200])
         return resp.json() if resp.content else {}
 
+    def upload(path: str, data: bytes, mime: str) -> dict:
+        resp = client.post(
+            DIRECT_BASE_URL + path,
+            content=data,
+            headers={"X-Goog-Upload-Protocol": "raw", "Content-Type": mime},
+        )
+        if resp.status_code != 200:
+            raise GeminiHttpError(resp.status_code, resp.text[:200])
+        return resp.json() if resp.content else {}
+
     return GeminiRest(
         post=lambda path, body: request("POST", path, body),
         delete=lambda path: request("DELETE", path),
+        upload=upload,
     )
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -54,12 +54,14 @@ class MemoryRecorder:
         store: MemoryStore,
         pose_tracker: PoseTracker,
         warm_search: Callable[[], None] | None,
+        cache_state: Callable[[], str] | None,
         positions_pub: Publisher,
     ):
         self._logger = node.get_logger()
         self._store = store
         self._pose = pose_tracker
         self._warm_search = warm_search
+        self._cache_state = cache_state
         self._positions_pub = positions_pub
 
         self._frame: tuple[float, bytes] | None = None  # (monotonic arrival, jpeg)
@@ -162,5 +164,9 @@ class MemoryRecorder:
             self._logger.info(f"[Memory] recorded viewpoint {memory.id} at ({x:.2f}, {y:.2f}){evicted}")
 
     def _publish_positions(self) -> None:
-        payload = {"map": self._map_name, "positions": self._store.positions()}
+        payload = {
+            "map": self._map_name,
+            "cache": self._cache_state() if self._cache_state is not None else "off",
+            "positions": self._store.positions(),
+        }
         self._positions_pub.publish(String(data=json.dumps(payload)))

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -85,9 +85,9 @@ class MemoryStore:
             return MemorySnapshot(self._map_name, self._revision, tuple(self._memories))
 
     def positions(self) -> list[dict]:
-        """The webapp mirror payload: one ``{x, y, theta}`` per memory."""
+        """The webapp mirror payload: one ``{id, x, y, theta, stamp}`` per memory."""
         with self._lock:
-            return [{"x": m.x, "y": m.y, "theta": m.theta} for m in self._memories]
+            return [{"id": m.id, "x": m.x, "y": m.y, "theta": m.theta, "stamp": m.stamp} for m in self._memories]
 
     def image_path(self, memory_id: int) -> Path | None:
         with self._lock:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -93,6 +93,11 @@ class MemoryStore:
         with self._lock:
             return self._dir / f"{memory_id}.jpg" if self._dir is not None else None
 
+    def files_index_path(self) -> Path | None:
+        """Where the current map's server-side-upload registry lives (brain/frame_files.py)."""
+        with self._lock:
+            return self._dir / "files.json" if self._dir is not None else None
+
     def add(self, x: float, y: float, theta: float, stamp: float, jpeg: bytes) -> Memory | None:
         """Record a new memory; None when no map is loaded."""
         with self._lock:
@@ -144,6 +149,7 @@ class MemoryStore:
             for stale in self._dir.glob("*.jpg"):
                 stale.unlink(missing_ok=True)
             (self._dir / "index.json").unlink(missing_ok=True)
+            (self._dir / "files.json").unlink(missing_ok=True)
         self._memories = []
         self._next_id = 1
 

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -154,8 +154,16 @@ class BrainClientNode(Node):
             store=self.memory_store,
             pose_tracker=self.pose_tracker,
             warm_search=self.memory_search.warm if self.memory_search is not None else None,
+            cache_state=self.memory_search.cache_state if self.memory_search is not None else None,
             positions_pub=self.create_publisher(String, "/brain/memory_positions", 10),
         )
+        # Search verdicts for the webapp's map (latched: a page opened after the
+        # search still sees the last one; clients gate on the payload's stamp).
+        self.memory_search_pub = self.create_publisher(String, "/brain/memory_search", LATCHED_QOS)
+        if self.memory_search is not None:
+            self.memory_search.on_result = lambda payload: self.memory_search_pub.publish(
+                String(data=json.dumps(payload))
+            )
         self.gaze = GazeController(self, state)
         self.runner = PrimitiveRunner(
             self,

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -26,6 +26,7 @@ from std_srvs.srv import SetBool, Trigger
 from brain_client.agents.initializer import initialize_agents
 from brain_client.brain.agent import BrainAgent
 from brain_client.brain.memory_search import MemorySearch
+from brain_client.brain.search_server import MemorySearchServer
 from brain_client.brain.transport import pick_rest
 from brain_client.brain.utils import EventKind
 from brain_client.common.script_paths import get_innate_os_root
@@ -160,10 +161,14 @@ class BrainClientNode(Node):
         # Search verdicts for the webapp's map (latched: a page opened after the
         # search still sees the last one; clients gate on the payload's stamp).
         self.memory_search_pub = self.create_publisher(String, "/brain/memory_search", LATCHED_QOS)
+        self.memory_search_server = None
         if self.memory_search is not None:
             self.memory_search.on_result = lambda payload: self.memory_search_pub.publish(
                 String(data=json.dumps(payload))
             )
+            # Recall as a capability: skills reach the same cache-backed search
+            # through /brain/search_memory (see brain/search_server.py).
+            self.memory_search_server = MemorySearchServer(self.memory_search)
         self.gaze = GazeController(self, state)
         self.runner = PrimitiveRunner(
             self,
@@ -552,6 +557,8 @@ class BrainClientNode(Node):
     def destroy_node(self):
         self.exit_event.set()
         self.brain.shutdown()
+        if self.memory_search_server is not None:
+            self.memory_search_server.shutdown()
         if self._agent_status_heartbeat is not None and not self._agent_status_heartbeat.is_canceled():
             self._agent_status_heartbeat.cancel()
         self.reload.stop_watcher()

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -9,6 +9,7 @@ skills.robot_state. This node wires those together and owns the action server.
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import threading
@@ -30,6 +31,7 @@ from brain_client.perception.camera_provider import CameraProvider
 from brain_client.robot.head import Head
 from brain_client.robot.manipulation import Manipulation
 from brain_client.robot.mobility import Mobility
+from brain_client.robot.spatial_memory import SpatialMemory
 from brain_client.skills.catalog import SkillRepository
 from brain_client.skills.cli_bridge import SkillCliBridge, SkillCliGoalHandle
 from brain_client.skills.invoker import SkillInvoker
@@ -83,6 +85,7 @@ class SkillsActionServer(Node):
         self.manipulation = Manipulation(self, self.get_logger(), lazy=True)
         self.mobility = Mobility(self, self.get_logger(), self.cmd_vel_topic)
         self.head = Head(self, self.get_logger(), self.head_position_topic)
+        self.spatial_memory = SpatialMemory(self, self.get_logger())
 
         self.robot_state = RobotStateProvider(
             self,
@@ -90,6 +93,7 @@ class SkillsActionServer(Node):
             manipulation=self.manipulation,
             mobility=self.mobility,
             head=self.head,
+            memory=self.spatial_memory,
             head_current_position_topic=self.head_current_position_topic,
         )
 
@@ -408,7 +412,11 @@ class SkillsActionServer(Node):
             finalize, success = _FINALIZE[output.status]
             getattr(goal_handle, finalize)()
             return ExecuteSkill.Result(
-                success=success, message=output.message, skill_type=skill_type, success_type=output.status.value
+                success=success,
+                message=output.message,
+                skill_type=skill_type,
+                success_type=output.status.value,
+                image_b64=base64.b64encode(output.image).decode() if output.image else "",
             )
         except Exception as e:
             self.get_logger().error(f"Error executing skill: {str(e)}")

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Skill-facing recall over the robot's spatial memory.
+
+A thin client of the brain's ``/brain/search_memory`` action — the Gemini
+context cache, transport, and credentials all live server-side; a skill only
+ever sees a typed :class:`RecallVerdict`. Declared like any interface::
+
+    memory: SpatialMemory
+
+    def execute(self, query: str):
+        recall = self.memory.begin(query)
+        verdict = self.wait_for(recall, timeout=60.0)
+
+``begin`` returns a zero-arg reader that stays None until the verdict lands,
+so the wait runs through ``self.wait_for`` — cancel-aware like every blocking
+framework call. A skill that stops waiting simply abandons the goal; the
+search concludes server-side and its verdict is dropped.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from brain_messages.action import SearchMemory
+from rclpy.action import ActionClient
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class RecallVerdict:
+    """One memory search's outcome. ``error`` non-empty means the search
+    itself failed — distinct from a clean no-match (``found=False`` with an
+    explanation). ``message`` is the model-ready sentence; the pose fields
+    chain directly into navigation."""
+
+    found: bool
+    message: str
+    explanation: str = ""
+    error: str = ""
+    x: float = 0.0
+    y: float = 0.0
+    theta: float = 0.0
+    seen_stamp: float = 0.0
+    image: bytes | None = None
+    latency_sec: float = 0.0
+    cached: bool = False
+
+
+class SpatialMemory:
+    def __init__(self, node, logger):
+        self._logger = logger
+        self._client = ActionClient(node, SearchMemory, "/brain/search_memory")
+
+    def begin(self, query: str) -> Callable[[], RecallVerdict | None]:
+        """Start a search; hand the returned reader to ``self.wait_for``."""
+        holder: list[RecallVerdict | None] = [None]
+
+        def conclude(verdict: RecallVerdict) -> None:
+            holder[0] = verdict
+
+        if not self._client.wait_for_server(timeout_sec=2.0):
+            conclude(_error_verdict("memory search unavailable — is the brain node running?"))
+            return lambda: holder[0]
+
+        def on_result(future) -> None:
+            try:
+                conclude(_from_result(future.result().result))
+            except Exception as error:  # noqa: BLE001 — a lost result must still unblock the waiter
+                conclude(_error_verdict(f"memory search result lost: {error}"))
+
+        def on_goal(future) -> None:
+            try:
+                handle = future.result()
+            except Exception as error:  # noqa: BLE001 — same: the waiter needs an answer, not a hang
+                conclude(_error_verdict(f"memory search goal failed: {error}"))
+                return
+            if handle is None or not handle.accepted:
+                conclude(_error_verdict("memory search goal rejected"))
+                return
+            handle.get_result_async().add_done_callback(on_result)
+
+        goal = SearchMemory.Goal()
+        goal.query = str(query)
+        self._client.send_goal_async(goal).add_done_callback(on_goal)
+        return lambda: holder[0]
+
+
+def _error_verdict(error: str) -> RecallVerdict:
+    return RecallVerdict(found=False, message=f"Memory search failed: {error}", error=error)
+
+
+def _from_result(result) -> RecallVerdict:
+    return RecallVerdict(
+        found=result.found,
+        message=result.message,
+        explanation=result.explanation,
+        error=result.error,
+        x=result.x,
+        y=result.y,
+        theta=result.theta,
+        seen_stamp=result.seen_stamp,
+        image=base64.b64decode(result.image_b64) if result.image_b64 else None,
+        latency_sec=result.latency_sec,
+        cached=result.cached,
+    )

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
@@ -32,13 +32,14 @@ from brain_client.state.pose import Pose
 
 
 class RobotStateProvider:
-    def __init__(self, node, camera_node, *, manipulation, mobility, head, head_current_position_topic: str):
+    def __init__(self, node, camera_node, *, manipulation, mobility, head, memory, head_current_position_topic: str):
         self._node = node
         self._logger = node.get_logger()
         self._camera = camera_node
         self._manipulation = manipulation
         self._mobility = mobility
         self._head = head
+        self._memory = memory
         self._head_current_position_topic = head_current_position_topic
 
         self.last_odom = None
@@ -107,6 +108,8 @@ class RobotStateProvider:
                 skill.inject_interface(interface_type, self._mobility)
             elif interface_type == InterfaceType.HEAD:
                 skill.inject_interface(interface_type, self._head)
+            elif interface_type == InterfaceType.MEMORY:
+                skill.inject_interface(interface_type, self._memory)
 
     # --- subscriptions ---
     def start_subscriptions(self) -> None:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -34,7 +34,7 @@ class PrimitiveRunner:
         self._on_task_finished = on_task_finished
 
         # Bound late by the node (mutual cycle: the brain needs the runner too).
-        self.on_event = lambda status, skill_name, detail=None: None
+        self.on_event = lambda status, skill_name, detail=None, image=None: None
         self.on_feedback = lambda skill_name, feedback, image=None: None
 
         self.action_client = ActionClient(node, ExecuteSkill, "execute_skill")
@@ -353,7 +353,8 @@ class PrimitiveRunner:
         # client's job.
         status, detail = self._classify_result(result, is_code)
         if status is not None:
-            self.on_event(status, primitive_name, detail)
+            image = base64.b64decode(result.image_b64) if result.image_b64 else None
+            self.on_event(status, primitive_name, detail, image=image)
         self._emit_skill_output(result, is_code)
 
     def _is_code_skill(self, skill_id: str) -> bool:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -82,19 +82,25 @@ def cancellable_sleep(seconds: float) -> None:
 
 class SkillOutput:
     """The result of a skill run: the message, the status (a SkillResult, not
-    a string), and an optional structured payload for chaining callers.
+    a string), an optional structured payload for chaining callers, and an
+    optional evidence image (JPEG bytes) that travels with the result — the
+    agent sees it in the completion event, so a skill can show what it found,
+    not just say it (``return SkillOutput("found it", image=jpeg)``).
 
     ``str(output)`` and f-strings give the message; ``output.ok`` is the
     success check. Unpacking as the legacy ``(message, status)`` tuple still
     works but is deprecated.
     """
 
-    __slots__ = ("message", "data", "status")
+    __slots__ = ("message", "data", "status", "image")
 
-    def __init__(self, message: str, data: Any = None, status: "SkillResult" = SkillResult.SUCCESS):
+    def __init__(
+        self, message: str, data: Any = None, status: "SkillResult" = SkillResult.SUCCESS, image: bytes | None = None
+    ):
         self.message = str(message)
         self.data = data
         self.status = status
+        self.image = image
 
     @property
     def ok(self) -> bool:
@@ -180,6 +186,7 @@ class InterfaceType(Enum):
     MANIPULATION = "manipulation"
     MOBILITY = "mobility"
     HEAD = "head"
+    MEMORY = "memory"
 
 
 class SkillStorage:
@@ -501,6 +508,7 @@ def _feed_specs() -> "tuple[_FeedSpec, ...]":
     from brain_client.robot.head import Head
     from brain_client.robot.manipulation import Manipulation
     from brain_client.robot.mobility import Mobility
+    from brain_client.robot.spatial_memory import SpatialMemory
     from brain_client.state.arm import Arm
     from brain_client.state.battery import Battery
     from brain_client.state.head import HeadState
@@ -517,6 +525,7 @@ def _feed_specs() -> "tuple[_FeedSpec, ...]":
         _FeedSpec(Manipulation, Interface, InterfaceType.MANIPULATION, "Manipulation", ("manipulation",)),
         _FeedSpec(Mobility, Interface, InterfaceType.MOBILITY, "Mobility", ("mobility",)),
         _FeedSpec(Head, Interface, InterfaceType.HEAD, "Head", ("head",)),
+        _FeedSpec(SpatialMemory, Interface, InterfaceType.MEMORY, "SpatialMemory", ("memory",)),
         # cameras start per run (and sim renders on demand) — longer grace
         _FeedSpec(MainImage, Camera, main, "MainImage", ("image", "main_image"), "main camera", grace_s=3.0),
         _FeedSpec(WristImage, Camera, wrist, "WristImage", ("wrist_image",), "wrist camera", grace_s=3.0),

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -27,7 +27,8 @@ One rule covers interfaces, cameras and robot state: annotate what you read.
 ``battery: Battery``, ``odom: Odometry``, ``pose: Pose``, ``lidar: Lidar``,
 ``arm: Arm``, ``map: Map``, ``joint_states: JointStates``,
 ``head_position: HeadState``, ``image: MainImage`` / ``WristImage`` /
-``DepthMap``, ``mobility: Mobility``, ``head: Head``. A plain annotation is
+``DepthMap``, ``mobility: Mobility``, ``head: Head``,
+``memory: SpatialMemory`` (recall over the robot's spatial memory). A plain annotation is
 guaranteed inside execute() — the server waits for the first value and fails
 the run up front if none arrives — so no None guards are needed; ``| None``
 (``head: Head | None``) makes it best effort instead, injected when available
@@ -36,7 +37,9 @@ it before you ship.
 
 execute() returns the run's result: the message str, or
 ``SkillOutput(message, data)`` to attach a structured payload for chaining
-callers, or None. Call ``self.fail(message)`` to end the run as a failure.
+callers (``image=jpeg_bytes`` attaches an evidence image the agent sees in
+the completion event), or None. Call ``self.fail(message)`` to end the run
+as a failure.
 Callers of other skills get that SkillOutput back — ``out = self.turn(...)``
 then ``out.message`` / ``out.data`` / ``out.ok``, with ``out.status`` a
 SkillResult enum, never a bare string. (Legacy ``(message, SkillResult)``
@@ -99,12 +102,14 @@ __all__ = [
     "Mobility",
     "Odometry",
     "Pose",
+    "RecallVerdict",
     "Skill",
     "SkillCancelled",
     "SkillFailed",
     "SkillOutput",
     "SkillResult",
     "SkillReturn",
+    "SpatialMemory",
     "TrainedSkill",
     "Waypoint",
     "WristImage",
@@ -118,12 +123,15 @@ if TYPE_CHECKING:
     from brain_client.robot.head import Head
     from brain_client.robot.manipulation import Manipulation, Waypoint
     from brain_client.robot.mobility import Mobility
+    from brain_client.robot.spatial_memory import RecallVerdict, SpatialMemory
 
 _LAZY_INTERFACES = {
     "Mobility": ("brain_client.robot.mobility", "Mobility"),
     "Manipulation": ("brain_client.robot.manipulation", "Manipulation"),
     "Head": ("brain_client.robot.head", "Head"),
     "Waypoint": ("brain_client.robot.manipulation", "Waypoint"),
+    "SpatialMemory": ("brain_client.robot.spatial_memory", "SpatialMemory"),
+    "RecallVerdict": ("brain_client.robot.spatial_memory", "RecallVerdict"),
 }
 
 

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -1077,51 +1077,91 @@ def test_trace_reports_the_turn_lifecycle(agent_factory, monkeypatch):
     assert snapshot["active"] is False and snapshot["backend"] == "gemini-direct" and snapshot["history"] == 3
 
 
-# ---------- spatial memory tool ----------
+# ---------- spatial memory (the search_memory skill's non-occupying dispatch) ----------
 
 from brain_client.brain.context import ToolCall  # noqa: E402
+from brain_client.brain.memory_search import SearchVerdict  # noqa: E402
+from brain_client.memory.store import Memory  # noqa: E402
+from brain_client.skills.registry import SkillRegistry  # noqa: E402
+
+SEARCH_SKILL = {
+    "id": "innate-os/search_memory",
+    "name": "search_memory",
+    "type": "code",
+    "guidelines": "Search the robot's memory of this map.",
+    "inputs": {"query": {"type": "str", "required": True}},
+}
+
+FOUND_VERDICT = SearchVerdict(
+    query="banana",
+    found=True,
+    explanation="a banana on the counter",
+    memory=Memory(id=2, x=1.5, y=0.5, theta=0.0, stamp=1000.0),
+    image=JPEG,
+    latency_sec=1.2,
+    cached=True,
+)
 
 
-def declared_tool_names(agent) -> list[str]:
-    return [d["name"] for d in agent._build_tools([])[0]["functionDeclarations"]]
+def arm_search_skill(agent) -> None:
+    """Put the search skill in the registry + active roster, like a directive would."""
+    agent._state.registry = SkillRegistry.from_metadata([SEARCH_SKILL])
+    agent._roster = SimpleNamespace(active_skill_ids=lambda: ["innate-os/search_memory"])
 
 
-def test_search_memory_is_declared_only_while_frames_exist(agent_factory):
-    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
-    assert "search_memory" not in declared_tool_names(agent)
-    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=3))
-    assert "search_memory" in declared_tool_names(agent)
-    agent, _ = agent_factory()  # no memory subsystem (no Gemini access at all)
-    assert "search_memory" not in declared_tool_names(agent)
-
-
-def test_search_memory_result_returns_as_an_event_with_the_matched_frame(agent_factory):
+def test_search_memory_skill_dispatches_without_occupying_the_slot(agent_factory):
     searches = []
     memory = SimpleNamespace(
         frame_count=3,
-        begin_search=lambda query, on_done: (searches.append(query), on_done("Memory search: found it", JPEG)),
+        begin_search=lambda query, on_done: (searches.append(query), on_done(FOUND_VERDICT)),
     )
-    agent, _ = agent_factory(memory=memory)
+    agent, state = agent_factory(memory=memory)
+    arm_search_skill(agent)
     agent._context._transport = lambda model, body: [model_response(call_part("search_memory", {"query": "banana"}))]
     run_turn(agent)
 
     assert searches == ["banana"]
+    assert state.primitive_running is None  # a query, not an act: the slot stays free
     # The call was answered immediately (started, not blocked on)...
     outcome = agent._context._history[-1]["parts"][0]["functionResponse"]["response"]["outcome"]
     assert outcome == "searching memory — the result arrives as an event"
-    # ...and the result waits in the queue as a MEMORY event carrying the frame.
+    # ...and the verdict waits in the queue as a MEMORY event carrying the frame.
     (event,) = agent._events
-    assert event.kind == EventKind.MEMORY and event.image == JPEG and "found it" in event.text
+    assert event.kind == EventKind.MEMORY and event.image == JPEG
+    assert "banana on the counter" in event.text and "x=1.50m" in event.text
+
+
+def test_search_memory_runs_even_while_another_skill_occupies_the_slot(agent_factory):
+    # Recall is a query: unlike every actuator skill, it must not be blocked by
+    # one-skill-at-a-time (search while driving is a deliberate property).
+    memory = SimpleNamespace(frame_count=3, begin_search=lambda query, on_done: on_done(FOUND_VERDICT))
+    agent, state = agent_factory(memory=memory)
+    arm_search_skill(agent)
+    state.primitive_running = RunningSkill(primitive_name="navigate", skill_id="innate-os/navigate_to_position")
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
+    outcome = agent._execute(ToolCall("search_memory", {"query": "keys"}))
+    assert outcome == "searching memory — the result arrives as an event"
 
 
 def test_search_memory_rejects_an_empty_memory_and_a_missing_query(agent_factory):
     agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
+    arm_search_skill(agent)
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
     assert (
         agent._execute(ToolCall("search_memory", {"query": "keys"}))
         == "rejected — no places remembered on this map yet"
     )
     agent, _ = agent_factory(memory=SimpleNamespace(frame_count=2))
+    arm_search_skill(agent)
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
     assert agent._execute(ToolCall("search_memory", {})) == "rejected — give a query describing what to find"
+
+
+def test_skill_completion_event_carries_the_result_image(agent_factory):
+    agent, _ = agent_factory()
+    agent.on_skill_event("completed", "inspect_shelf", "found the mug", image=JPEG)
+    (event,) = agent._events
+    assert event.image == JPEG and "found the mug" in event.text
 
 
 # ---------- prompt ----------

--- a/ros2_ws/src/brain/brain_client/test/test_memory_skill.py
+++ b/ros2_ws/src/brain/brain_client/test/test_memory_skill.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Memory recall as a capability: the SearchMemory action mapping, the SDK
+accessor's begin/wait contract, and the result-image channel that carries a
+skill's evidence frame back into the agent's events."""
+
+from __future__ import annotations
+
+import base64
+import threading
+from types import SimpleNamespace
+
+from brain_client.brain.memory_search import SearchVerdict, verdict_text
+from brain_client.brain.search_server import _to_result
+from brain_client.core.state import BrainState, RunningSkill
+from brain_client.memory.store import Memory
+from brain_client.robot.spatial_memory import SpatialMemory
+from brain_client.skills.registry import SkillRegistry
+from brain_client.skills.runner import PrimitiveRunner
+from brain_client.skills.types import SkillOutput, SkillResult
+
+JPEG = b"\xff\xd8\xff\xe0fakejpegbytes"
+
+FOUND = SearchVerdict(
+    query="the kitchen",
+    found=True,
+    explanation="counter with a kettle",
+    memory=Memory(id=3, x=1.5, y=-0.5, theta=1.57, stamp=1000.0),
+    image=JPEG,
+    latency_sec=1.2,
+    cached=True,
+)
+
+
+# ---------- action result mapping ----------
+
+
+def test_to_result_maps_a_found_verdict_completely():
+    result = _to_result(FOUND)
+    assert result.found and result.cached and result.error == ""
+    assert (result.x, result.y, result.theta, result.seen_stamp) == (1.5, -0.5, 1.57, 1000.0)
+    assert base64.b64decode(result.image_b64) == JPEG
+    assert result.message == verdict_text(FOUND)
+    assert "navigate_to_position" in result.message
+
+
+def test_to_result_maps_errors_and_no_match():
+    error = _to_result(SearchVerdict(query="x", found=False, error="network down"))
+    assert not error.found and error.error == "network down" and error.image_b64 == ""
+    assert "failed" in error.message
+    no_match = _to_result(SearchVerdict(query="x", found=False, explanation="nothing like that"))
+    assert not no_match.found and no_match.error == "" and no_match.seen_stamp == 0.0
+    assert "nothing in the remembered views matches" in no_match.message
+
+
+# ---------- the SDK accessor ----------
+
+
+class FakeFuture:
+    """A future whose callback fires immediately — the whole chain runs inline."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def result(self):
+        return self._value
+
+    def add_done_callback(self, callback):
+        callback(self)
+
+
+def make_accessor(result_msg=None, *, accepted=True, server_up=True):
+    accessor = SpatialMemory.__new__(SpatialMemory)
+    accessor._logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
+    handle = SimpleNamespace(accepted=accepted, get_result_async=lambda: FakeFuture(SimpleNamespace(result=result_msg)))
+    accessor._client = SimpleNamespace(
+        wait_for_server=lambda timeout_sec: server_up,
+        send_goal_async=lambda goal: FakeFuture(handle),
+    )
+    return accessor
+
+
+def test_begin_delivers_a_typed_verdict_through_the_reader():
+    result_msg = SimpleNamespace(
+        found=True,
+        message="Found it.",
+        explanation="the counter",
+        error="",
+        x=1.5,
+        y=-0.5,
+        theta=1.57,
+        seen_stamp=1000.0,
+        image_b64=base64.b64encode(JPEG).decode(),
+        latency_sec=1.2,
+        cached=True,
+    )
+    reader = make_accessor(result_msg).begin("the kitchen")
+    verdict = reader()
+    assert verdict is not None and verdict.found and verdict.image == JPEG
+    assert verdict.x == 1.5 and verdict.cached and verdict.message == "Found it."
+
+
+def test_begin_unblocks_the_waiter_on_every_failure_path():
+    rejected = make_accessor(accepted=False).begin("x")()
+    assert rejected is not None and rejected.error == "memory search goal rejected"
+    down = make_accessor(server_up=False).begin("x")()
+    assert down is not None and "is the brain node running" in down.error
+    # A reader with no verdict yet reads None — wait_for's contract.
+    pending = SpatialMemory.__new__(SpatialMemory)
+    pending._logger = SimpleNamespace(error=lambda *a: None)
+    pending._client = SimpleNamespace(
+        wait_for_server=lambda timeout_sec: True,
+        send_goal_async=lambda goal: SimpleNamespace(add_done_callback=lambda cb: None),  # never resolves
+    )
+    assert pending.begin("x")() is None
+
+
+# ---------- the result-image channel ----------
+
+
+def test_skill_output_carries_an_optional_image():
+    assert SkillOutput("done").image is None
+    assert SkillOutput("found it", image=JPEG).image == JPEG
+
+
+def make_runner(events: list):
+    runner = PrimitiveRunner.__new__(PrimitiveRunner)
+    state = BrainState()
+    state.registry = SkillRegistry.from_metadata(
+        [{"id": "innate-os/search_memory", "name": "search_memory", "type": "code"}]
+    )
+    state.primitive_running = RunningSkill(primitive_name="search_memory", skill_id="innate-os/search_memory")
+    runner._state = state
+    runner._goal_handle = SimpleNamespace()
+    runner._generation = 0
+    runner._slot_lock = threading.Lock()
+    runner._logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
+    runner._stop_robot = lambda: None
+    runner._on_task_finished = lambda: None
+    runner._chat = SimpleNamespace(publish_task_status=lambda **kwargs: None, emit=lambda *a, **k: None)
+    runner.on_event = lambda status, name, detail=None, image=None: events.append((status, name, detail, image))
+    return runner
+
+
+def test_runner_decodes_the_result_image_into_the_brain_event():
+    events: list = []
+    runner = make_runner(events)
+    result = SimpleNamespace(
+        success=True,
+        success_type=SkillResult.SUCCESS.value,
+        skill_type="innate-os/search_memory",
+        message="Found it.",
+        image_b64=base64.b64encode(JPEG).decode(),
+    )
+    runner._on_result(SimpleNamespace(result=lambda: SimpleNamespace(result=result)), generation=0)
+    ((status, name, detail, image),) = events
+    assert status == "completed" and image == JPEG and detail == "Found it."
+
+
+def test_runner_passes_no_image_when_the_result_has_none():
+    events: list = []
+    runner = make_runner(events)
+    result = SimpleNamespace(
+        success=True,
+        success_type=SkillResult.SUCCESS.value,
+        skill_type="innate-os/search_memory",
+        message="nothing matched",
+        image_b64="",
+    )
+    runner._on_result(SimpleNamespace(result=lambda: SimpleNamespace(result=result)), generation=0)
+    ((status, _, _, image),) = events
+    assert status == "completed" and image is None

--- a/ros2_ws/src/brain/brain_client/test/test_runner_deactivation.py
+++ b/ros2_ws/src/brain/brain_client/test/test_runner_deactivation.py
@@ -25,7 +25,7 @@ def make_runner(running: RunningSkill | None, goal_handle=None):
     runner._stop_robot = lambda: None
     runner._on_task_finished = lambda: None
     runner._chat = SimpleNamespace(publish_task_status=lambda **kwargs: None)
-    runner.on_event = lambda status, name, detail=None: None
+    runner.on_event = lambda status, name, detail=None, image=None: None
     return runner, state
 
 

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -184,6 +184,7 @@ def make_recorder(data_dir, published: list | None = None):
         store=store,
         pose_tracker=SimpleNamespace(map_pose_xyt=lambda: (1.0, 2.0, 0.5)),
         warm_search=None,
+        cache_state=lambda: "warm",
         positions_pub=SimpleNamespace(publish=(published if published is not None else []).append),
     )
     return recorder, store
@@ -265,7 +266,7 @@ def test_a_stale_frame_blocks_capture(data_dir, clock):
     assert store.snapshot().memories == ()
 
 
-def test_positions_mirror_publishes_map_and_poses(data_dir, clock):
+def test_positions_mirror_publishes_map_poses_and_cache_state(data_dir, clock):
     published: list = []
     recorder, store = make_recorder(data_dir, published)
     see_confident_world(recorder, clock)
@@ -274,8 +275,10 @@ def test_positions_mirror_publishes_map_and_poses(data_dir, clock):
     recorder._on_image(SimpleNamespace(data=b"live-frame"))
     recorder.tick()
     payload = json.loads(published[-1].data)
-    assert payload["map"] == "A.yaml"
-    assert payload["positions"] == [{"x": 1.0, "y": 2.0, "theta": 0.5}]
+    assert payload["map"] == "A.yaml" and payload["cache"] == "warm"
+    (position,) = payload["positions"]
+    assert position["id"] == 1 and position["x"] == 1.0 and position["y"] == 2.0 and position["theta"] == 0.5
+    assert position["stamp"] > 0
 
 
 # ================= memory search =================
@@ -423,3 +426,53 @@ def test_warm_waits_for_recording_to_settle(data_dir):
     search.warm()
     time.sleep(0.05)
     assert fake.creates == []
+
+
+def test_search_mirrors_verdicts_to_the_ui(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "kitchen"})
+    reports: list[dict] = []
+    search.on_result = reports.append
+    search.search("the kitchen")
+    (report,) = reports
+    assert report["found"] and report["id"] == 2 and report["x"] == 3.0 and report["cached"]
+    assert report["query"] == "the kitchen" and report["explanation"] == "kitchen"
+    assert report["latency_sec"] >= 0 and report["stamp"] > 0 and report["seen_stamp"] == 1001.0
+
+    fake.verdict = {"found": False, "frame": 0, "explanation": "no such view"}
+    search.search("a unicorn")
+    assert reports[-1] == {
+        "query": "a unicorn",
+        "found": False,
+        "explanation": "no such view",
+        "latency_sec": reports[-1]["latency_sec"],
+        "cached": True,
+        "stamp": reports[-1]["stamp"],
+    }
+
+
+def test_a_broken_ui_mirror_does_not_break_the_search(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+
+    def explode(payload: dict) -> None:
+        raise RuntimeError("publisher gone")
+
+    search.on_result = explode
+    text, image = search.search("anything")
+    assert image == b"jpg-1"  # the search itself still succeeded
+
+
+def test_cache_state_reflects_the_lifecycle(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    assert search.cache_state() == "cold"
+    search.search("first")
+    assert search.cache_state() == "warm"
+    store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
+    assert search.cache_state() == "cold"
+
+    small, _, _ = make_search(data_dir / "small", frames=0)
+    assert small.cache_state() == "inline"
+
+    unsupported, fake2, _ = make_search(data_dir / "unsup", frames=6)
+    fake2.create_error = GeminiHttpError(404, "no endpoint")
+    unsupported.search("first")
+    assert unsupported.cache_state() == "unsupported"

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import json
 import math
+import threading
 import time
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -295,10 +297,13 @@ class FakeGemini:
         self.creates: list[dict] = []
         self.generates: list[dict] = []
         self.deletes: list[str] = []
+        self.uploads: list[bytes] = []
         self.create_error: GeminiHttpError | None = None
         self.cached_generate_error: GeminiHttpError | None = None
+        self.upload_error: GeminiHttpError | None = None
+        self.upload_gate: threading.Event | None = None  # when set, uploads block on it
         self.verdict = verdict if verdict is not None else {"found": True, "frame": 1, "explanation": "matches"}
-        self.rest = GeminiRest(post=self._post, delete=self._delete)
+        self.rest = GeminiRest(post=self._post, delete=self._delete, upload=self._upload)
 
     def _post(self, path: str, body: dict) -> dict:
         if path == CACHED_CONTENTS_PATH:
@@ -315,6 +320,14 @@ class FakeGemini:
         self.deletes.append(path)
         return {}
 
+    def _upload(self, path: str, data: bytes, mime: str) -> dict:
+        if self.upload_gate is not None:
+            self.upload_gate.wait(timeout=5)
+        if self.upload_error is not None:
+            raise self.upload_error
+        self.uploads.append(data)
+        return {"file": {"name": f"files/f{len(self.uploads)}", "uri": f"https://files/f{len(self.uploads)}"}}
+
 
 def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[MemorySearch, FakeGemini, MemoryStore]:
     store = MemoryStore(data_dir)
@@ -326,28 +339,81 @@ def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[Mem
     return MemorySearch(store, fake.rest, model="test-model", logger=logger), fake, store
 
 
-def test_cache_is_created_once_and_reused(data_dir):
+def build_cache(search: MemorySearch) -> None:
+    """Synchronous stand-in for warm()'s background cache rebuild."""
+    search._ensure_cache(search._store.snapshot())
+
+
+def upload_frames(search: MemorySearch) -> None:
+    """Synchronous stand-in for maintain()'s background upload round."""
+    search._files._upload(search._files._pending())
+
+
+def part_kinds(body: dict) -> list[str]:
+    return [next(iter(part)) for part in body["contents"][0]["parts"]]
+
+
+def memory_with_id(store: MemoryStore, memory_id: int):
+    (memory,) = [m for m in store.snapshot().memories if m.id == memory_id]
+    return memory
+
+
+def test_search_rides_a_fresh_cache_with_only_the_question(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "the kitchen"})
+    build_cache(search)
     verdict = search.search("the kitchen")
     search.search("the kitchen again")
     assert len(fake.creates) == 1
     assert [body.get("cachedContent") for body in fake.generates] == ["cachedContents/c1", "cachedContents/c1"]
+    assert part_kinds(fake.generates[0]) == ["text"]  # fresh cache: no frame bytes at all
     assert verdict.found and verdict.cached and verdict.image == b"jpg-2"
     assert verdict.memory is not None and verdict.memory.x == 3.0
-    assert "x=3.00m" in verdict_text(verdict) and "the kitchen" in verdict_text(verdict)
-    assert "navigate_to_position" in verdict_text(verdict)
+    assert "x=3.00m" in verdict_text(verdict) and "navigate_to_position" in verdict_text(verdict)
 
 
-def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
+def test_a_search_never_builds_the_cache(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    search.search("anything")
+    assert fake.creates == []  # a cold search answers from frames; rebuilds belong to warm()
+
+
+def test_a_stale_cache_serves_with_a_delta_of_new_frames(data_dir):
+    search, fake, store = make_search(data_dir, frames=6, verdict={"found": True, "frame": 7, "explanation": "new"})
+    build_cache(search)
+    store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")  # id 7
+    verdict = search.search("the new spot")
+    assert len(fake.creates) == 1  # the search path never rebuilds
+    body = fake.generates[-1]
+    assert body["cachedContent"] == "cachedContents/c1"
+    assert part_kinds(body) == ["inlineData", "text", "text"]  # the new frame, its label, the question
+    assert "Frame 7" in body["contents"][0]["parts"][1]["text"]
+    assert verdict.found and verdict.cached
+    assert verdict.memory is not None and verdict.memory.id == 7 and verdict.image == b"jpg-late"
+
+
+def test_delta_notes_supersede_and_retire_frames(data_dir):
     search, fake, store = make_search(data_dir, frames=6)
-    search.search("first")
+    build_cache(search)
+    store.replace(memory_with_id(store, 2), 3.0, 0.0, 0.0, 5000.0, b"jpg-2-new")
+    store.evict(memory_with_id(store, 3))
+    search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    texts = [part["text"] for part in parts if "text" in part]
+    assert any("Frame 2 was re-captured" in text for text in texts)
+    assert any("Frame 3 no longer exists" in text for text in texts)
+    assert sum("inlineData" in part for part in parts) == 1  # only the re-captured frame's bytes travel
+
+
+def test_warm_rebuilds_a_stale_cache_and_deletes_the_old(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    build_cache(search)
     store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
-    search.search("second")
+    build_cache(search)
     assert len(fake.creates) == 2
     assert fake.deletes == ["/v1beta/cachedContents/c1"]
 
 
-def test_few_frames_answer_inline_without_caching(data_dir):
+def test_few_frames_answer_from_frames_without_caching(data_dir):
     search, fake, _ = make_search(data_dir, frames=3)
     verdict = search.search("anything")
     assert fake.creates == []
@@ -360,35 +426,36 @@ def test_few_frames_answer_inline_without_caching(data_dir):
 def test_unsupported_backend_disables_caching_permanently(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     fake.create_error = GeminiHttpError(404, "no such endpoint")
+    build_cache(search)
+    build_cache(search)
+    assert len(fake.creates) == 1  # latched after the first answer
     verdict = search.search("first")
-    search.search("second")
-    assert len(fake.creates) == 1  # never attempted again
-    assert all("cachedContent" not in body for body in fake.generates)
+    assert "cachedContent" not in fake.generates[-1]
     assert verdict.image == b"jpg-1"
 
 
 def test_failed_cache_creation_retries_only_after_the_memory_changes(data_dir):
     search, fake, store = make_search(data_dir, frames=6)
     fake.create_error = GeminiHttpError(400, "cache too small")
-    search.search("first")
-    search.search("second")
+    build_cache(search)
+    build_cache(search)
     assert len(fake.creates) == 1
     fake.create_error = None
     store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
-    search.search("third")
+    build_cache(search)
     assert len(fake.creates) == 2
 
 
-def test_a_dead_cache_falls_back_inline_and_is_forgotten(data_dir):
+def test_a_dead_cache_falls_back_and_is_forgotten(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
-    search.search("first")
+    build_cache(search)
     fake.cached_generate_error = GeminiHttpError(403, "cache expired")
     verdict = search.search("second")
     assert verdict.image == b"jpg-1" and not verdict.cached
-    assert "cachedContent" not in fake.generates[-1]  # answered inline
+    assert "cachedContent" not in fake.generates[-1]  # answered from frames within the same search
     fake.cached_generate_error = None
-    search.search("third")
-    assert len(fake.creates) == 2  # the dead handle was dropped, a fresh cache built
+    build_cache(search)
+    assert len(fake.creates) == 2  # the dead handle was dropped; warm rebuilt
 
 
 def test_no_match_is_a_clean_verdict_not_an_error(data_dir):
@@ -412,7 +479,7 @@ def test_a_transport_crash_becomes_an_error_verdict_not_an_exception(data_dir):
     def explode(path: str, body: dict) -> dict:
         raise RuntimeError("network down")
 
-    search._rest = GeminiRest(post=explode, delete=lambda path: {})
+    search._rest = GeminiRest(post=explode, delete=lambda path: {}, upload=lambda path, data, mime: {})
     verdict = search.search("anything")
     assert not verdict.found and "network down" in verdict.error
 
@@ -445,6 +512,7 @@ def test_warm_waits_for_recording_to_settle(data_dir):
 
 def test_search_mirrors_verdicts_to_the_ui(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "kitchen"})
+    build_cache(search)
     reports: list[dict] = []
     search.on_result = reports.append
     search.search("the kitchen")
@@ -479,15 +547,132 @@ def test_a_broken_ui_mirror_does_not_break_the_search(data_dir):
 def test_cache_state_reflects_the_lifecycle(data_dir):
     search, fake, store = make_search(data_dir, frames=6)
     assert search.cache_state() == "cold"
-    search.search("first")
+    build_cache(search)
     assert search.cache_state() == "warm"
     store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
-    assert search.cache_state() == "cold"
+    assert search.cache_state() == "warm"  # stale-but-usable: the delta keeps recall instant
 
     small, _, _ = make_search(data_dir / "small", frames=0)
     assert small.cache_state() == "inline"
 
     unsupported, fake2, _ = make_search(data_dir / "unsup", frames=6)
     fake2.create_error = GeminiHttpError(404, "no endpoint")
-    unsupported.search("first")
+    build_cache(unsupported)
     assert unsupported.cache_state() == "unsupported"
+
+
+# ================= files tier =================
+
+
+def test_frames_upload_once_and_ride_as_file_references(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    assert len(fake.uploads) == 6
+    upload_frames(search)
+    assert len(fake.uploads) == 6  # nothing left to do
+    search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    file_parts = [part for part in parts if "fileData" in part]
+    assert len(file_parts) == 6 and not any("inlineData" in part for part in parts)
+    assert file_parts[0]["fileData"]["fileUri"].startswith("https://files/")
+
+
+def test_the_upload_registry_survives_a_restart(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    reborn, fake2, _ = make_search(data_dir, frames=0)  # same map dir, fresh process
+    upload_frames(reborn)
+    assert fake2.uploads == []  # every frame is already server-side
+
+
+def test_an_aging_upload_is_refreshed_before_server_expiry(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    files = search._files
+    with files._lock:
+        files._records = {i: replace(r, uploaded_at=r.uploaded_at - 41 * 3600) for i, r in files._records.items()}
+    upload_frames(search)
+    assert len(fake.uploads) == 12
+
+
+def test_an_expired_reference_rides_inline_instead(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+    upload_frames(search)
+    files = search._files
+    with files._lock:
+        files._records = {i: replace(r, uploaded_at=r.uploaded_at - 47.5 * 3600) for i, r in files._records.items()}
+    search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    assert not any("fileData" in part for part in parts)  # too old to trust server-side
+    assert sum("inlineData" in part for part in parts) == 3
+
+
+def test_a_refreshed_frame_invalidates_its_upload(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    upload_frames(search)
+    store.replace(memory_with_id(store, 2), 3.0, 0.0, 0.0, 5000.0, b"jpg-2-new")
+    upload_frames(search)
+    assert len(fake.uploads) == 7 and fake.uploads[-1] == b"jpg-2-new"
+
+
+def test_upload_latch_on_unsupported_backend(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    fake.upload_error = GeminiHttpError(404, "no upload passthrough")
+    upload_frames(search)
+    assert search._files.unsupported and fake.uploads == []
+    search._files.maintain()  # latched: no thread is even spawned
+    search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    assert sum("inlineData" in part for part in parts) == 6  # exactly the pre-files behavior
+
+
+def test_a_transient_upload_failure_retries_next_round(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+    fake.upload_error = GeminiHttpError(500, "hiccup")
+    upload_frames(search)
+    assert not search._files.unsupported and fake.uploads == []
+    fake.upload_error = None
+    upload_frames(search)
+    assert len(fake.uploads) == 3
+
+
+def test_the_cache_builds_from_file_references(data_dir):
+    search, fake, _ = make_search(data_dir, frames=6)
+    upload_frames(search)
+    build_cache(search)
+    (create,) = fake.creates
+    parts = create["contents"][0]["parts"]
+    assert sum("fileData" in part for part in parts) == 6 and not any("inlineData" in part for part in parts)
+
+
+def test_a_not_yet_uploaded_frame_rides_inline_beside_references(data_dir):
+    search, fake, store = make_search(data_dir, frames=3)
+    upload_frames(search)
+    store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")
+    search.search("anything")  # before any maintenance round reaches the new frame
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    assert sum("fileData" in part for part in parts) == 3
+    assert sum("inlineData" in part for part in parts) == 1
+
+
+def test_search_never_waits_for_maintenance(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    fake.upload_gate = threading.Event()
+    search._files.maintain()  # the background round is now stuck on the gate
+    try:
+        verdict = search.search("anything")  # must conclude while the upload hangs
+        assert verdict.found
+    finally:
+        fake.upload_gate.set()
+    assert search._files._busy.acquire(timeout=2)  # the round finishes once released
+    search._files._busy.release()
+
+
+def test_labels_and_verdicts_use_stable_store_ids(data_dir):
+    search, fake, store = make_search(data_dir, frames=6, verdict={"found": True, "frame": 5, "explanation": "there"})
+    store.evict(memory_with_id(store, 1))
+    verdict = search.search("anything")
+    parts = fake.generates[-1]["contents"][0]["parts"]
+    labels = [part["text"] for part in parts if "text" in part][:-1]  # the last text part is the question
+    assert labels[0].startswith("Frame 2 ")  # ids, not positions, after the eviction
+    assert verdict.found and verdict.memory is not None and verdict.memory.id == 5

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from brain_client.brain.memory_search import MemorySearch
+from brain_client.brain.memory_search import MemorySearch, verdict_text
 from brain_client.brain.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
 from brain_client.memory import recorder as recorder_module
 from brain_client.memory.recorder import MemoryRecorder
@@ -328,12 +328,14 @@ def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[Mem
 
 def test_cache_is_created_once_and_reused(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "the kitchen"})
-    text, image = search.search("the kitchen")
+    verdict = search.search("the kitchen")
     search.search("the kitchen again")
     assert len(fake.creates) == 1
     assert [body.get("cachedContent") for body in fake.generates] == ["cachedContents/c1", "cachedContents/c1"]
-    assert "x=3.00m" in text and "the kitchen" in text
-    assert image == b"jpg-2"
+    assert verdict.found and verdict.cached and verdict.image == b"jpg-2"
+    assert verdict.memory is not None and verdict.memory.x == 3.0
+    assert "x=3.00m" in verdict_text(verdict) and "the kitchen" in verdict_text(verdict)
+    assert "navigate_to_position" in verdict_text(verdict)
 
 
 def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
@@ -347,22 +349,22 @@ def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
 
 def test_few_frames_answer_inline_without_caching(data_dir):
     search, fake, _ = make_search(data_dir, frames=3)
-    text, image = search.search("anything")
+    verdict = search.search("anything")
     assert fake.creates == []
     (body,) = fake.generates
     assert "systemInstruction" in body and "cachedContent" not in body
     assert sum("inlineData" in part for part in body["contents"][0]["parts"]) == 3
-    assert image == b"jpg-1"
+    assert verdict.image == b"jpg-1" and not verdict.cached
 
 
 def test_unsupported_backend_disables_caching_permanently(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     fake.create_error = GeminiHttpError(404, "no such endpoint")
-    _, image = search.search("first")
+    verdict = search.search("first")
     search.search("second")
     assert len(fake.creates) == 1  # never attempted again
     assert all("cachedContent" not in body for body in fake.generates)
-    assert image == b"jpg-1"
+    assert verdict.image == b"jpg-1"
 
 
 def test_failed_cache_creation_retries_only_after_the_memory_changes(data_dir):
@@ -381,32 +383,45 @@ def test_a_dead_cache_falls_back_inline_and_is_forgotten(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     search.search("first")
     fake.cached_generate_error = GeminiHttpError(403, "cache expired")
-    text, image = search.search("second")
-    assert image == b"jpg-1"
+    verdict = search.search("second")
+    assert verdict.image == b"jpg-1" and not verdict.cached
     assert "cachedContent" not in fake.generates[-1]  # answered inline
     fake.cached_generate_error = None
     search.search("third")
     assert len(fake.creates) == 2  # the dead handle was dropped, a fresh cache built
 
 
-def test_no_match_returns_text_only(data_dir):
+def test_no_match_is_a_clean_verdict_not_an_error(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": False, "frame": 0, "explanation": "no kitchen"})
-    text, image = search.search("the kitchen")
-    assert image is None and "nothing in the remembered views matches" in text
+    verdict = search.search("the kitchen")
+    assert not verdict.found and verdict.image is None and verdict.error == ""
+    assert "nothing in the remembered views matches" in verdict_text(verdict)
 
 
-def test_unreadable_answer_reports_gracefully(data_dir):
+def test_unreadable_answer_becomes_an_error_verdict(data_dir):
     search, fake, _ = make_search(data_dir, frames=3)
     fake.verdict = None  # type: ignore[assignment] — json.dumps(None) is valid JSON but not a verdict
-    text, image = search.search("anything")
-    assert image is None and "unreadable" in text
+    verdict = search.search("anything")
+    assert verdict.error == "unreadable answer" and verdict.image is None
+    assert "failed" in verdict_text(verdict)
+
+
+def test_a_transport_crash_becomes_an_error_verdict_not_an_exception(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+
+    def explode(path: str, body: dict) -> dict:
+        raise RuntimeError("network down")
+
+    search._rest = GeminiRest(post=explode, delete=lambda path: {})
+    verdict = search.search("anything")
+    assert not verdict.found and "network down" in verdict.error
 
 
 def test_empty_memory_answers_without_the_network(data_dir):
     search, fake, _ = make_search(data_dir, frames=0)
-    text, image = search.search("anything")
-    assert fake.generates == [] and image is None
-    assert "no memories" in text
+    verdict = search.search("anything")
+    assert fake.generates == [] and verdict.image is None and not verdict.found
+    assert "no memories" in verdict_text(verdict)
 
 
 def test_warm_builds_the_cache_in_the_background(data_dir):
@@ -457,8 +472,8 @@ def test_a_broken_ui_mirror_does_not_break_the_search(data_dir):
         raise RuntimeError("publisher gone")
 
     search.on_result = explode
-    text, image = search.search("anything")
-    assert image == b"jpg-1"  # the search itself still succeeded
+    verdict = search.search("anything")
+    assert verdict.image == b"jpg-1"  # the search itself still succeeded
 
 
 def test_cache_state_reflects_the_lifecycle(data_dir):

--- a/ros2_ws/src/brain/brain_messages/CMakeLists.txt
+++ b/ros2_ws/src/brain/brain_messages/CMakeLists.txt
@@ -50,6 +50,7 @@ set(action_files
   "action/ExecutePolicy.action"
   "action/ExecuteBehavior.action"
   "action/ExecuteArmCommand.action"
+  "action/SearchMemory.action"
 )
 
 if(BUILD_TESTING)

--- a/ros2_ws/src/brain/brain_messages/action/ExecuteSkill.action
+++ b/ros2_ws/src/brain/brain_messages/action/ExecuteSkill.action
@@ -7,6 +7,7 @@ bool success
 string message
 string skill_type
 string success_type  # One of: "success", "cancelled", "failure"
+string image_b64     # optional evidence image the skill attached to its result
 ---
 # Feedback definition
 string skill_type

--- a/ros2_ws/src/brain/brain_messages/action/SearchMemory.action
+++ b/ros2_ws/src/brain/brain_messages/action/SearchMemory.action
@@ -1,0 +1,17 @@
+# Goal definition
+string query
+---
+# Result definition
+bool found
+string message      # model-ready verdict text (coordinates, age, explanation, navigation hint)
+string explanation  # the vision model's one-line reasoning
+string error        # non-empty when the search itself failed (transport, unreadable answer)
+float64 x           # map-frame pose of the matched viewpoint (0 when not found)
+float64 y
+float64 theta
+float64 seen_stamp  # epoch seconds when the matched view was recorded (0 when none)
+string image_b64    # the matched remembered frame ("" when none)
+float64 latency_sec
+bool cached         # answered from the Gemini context cache
+---
+# Feedback definition

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -6963,6 +6963,267 @@ select.skill-input {
   opacity: 0.45;
 }
 
+/* ---- Spatial memory (map layer cards + sidebar reel) ----------------------
+   The layer's violet (#b48cff) is deliberately distinct from every other map
+   mark; the cards share the scene's glass language (legend, status). */
+
+.mem-card {
+  position: absolute;
+  z-index: 5;
+  padding: 6px;
+  background: rgb(10 10 12 / 88%);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgb(0 0 0 / 45%);
+}
+
+/* The hover thumbnail is read-only — it must never steal the canvas's cursor. */
+.mem-card-hover {
+  pointer-events: none;
+}
+
+.mem-card-img {
+  display: block;
+  width: 180px;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 6px;
+  background: rgb(255 255 255 / 4%);
+}
+
+.mem-card-img-lg {
+  width: 248px;
+}
+
+.mem-card-meta {
+  padding-top: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.mem-card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.mem-card-btn {
+  flex: 1;
+  padding: 6px 12px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ctl-text);
+  background: var(--ctl-glass);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 7px;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.mem-card-btn:hover {
+  color: var(--text);
+  border-color: rgb(255 255 255 / 30%);
+}
+
+.mem-card-btn-go {
+  color: #cbaefc;
+  border-color: rgb(180 140 255 / 45%);
+}
+
+.mem-card-btn-go:hover {
+  color: #e2d2ff;
+  border-color: rgb(180 140 255 / 80%);
+}
+
+/* The recall verdict — floats in from the top of the scene, dismisses itself. */
+.mem-search-card {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  z-index: 6;
+  width: min(430px, calc(100% - 24px));
+  padding: 10px 12px;
+  background: rgb(10 10 12 / 90%);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgb(0 0 0 / 50%);
+  opacity: 0;
+  transform: translate(-50%, -10px);
+  transition: opacity 260ms ease, transform 260ms ease;
+}
+
+.mem-search-card.is-in {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.mem-search-card.is-found {
+  border-color: rgb(180 140 255 / 45%);
+  box-shadow: 0 8px 30px rgb(0 0 0 / 50%), 0 0 26px rgb(180 140 255 / 14%);
+}
+
+.mem-search-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.mem-search-head .microlabel {
+  margin: 0;
+  flex: none;
+  color: #cbaefc;
+}
+
+.mem-search-query {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 13px;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mem-search-chip {
+  flex: none;
+  padding: 2px 8px;
+  font-size: 10px;
+  color: #cbaefc;
+  background: rgb(180 140 255 / 12%);
+  border: 1px solid rgb(180 140 255 / 35%);
+  border-radius: 999px;
+}
+
+.mem-search-close {
+  flex: none;
+  margin-left: auto;
+  padding: 0 4px;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--muted);
+  background: none;
+  border: none;
+}
+
+.mem-search-close:hover {
+  color: var(--text);
+}
+
+.mem-search-body {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin-top: 8px;
+}
+
+.mem-search-img {
+  flex: none;
+  width: 132px;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 6px;
+  background: rgb(255 255 255 / 4%);
+}
+
+.mem-search-text {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+/* Sidebar panel: count + cache chip + the reel of remembered views. */
+.mem-panel-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.mem-panel-head .microlabel {
+  margin-bottom: 8px;
+}
+
+.mem-panel-count {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.mem-panel-chip {
+  margin-left: auto;
+  padding: 2px 8px;
+  font-size: 10px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 999px;
+  color: var(--muted);
+}
+
+.mem-panel-chip[data-kind="ok"] {
+  color: var(--ok);
+  border-color: rgb(86 194 140 / 40%);
+}
+
+.mem-panel-chip[data-kind="warn"] {
+  color: var(--ctl-accent);
+  border-color: rgb(232 163 61 / 40%);
+}
+
+.mem-panel-empty {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.mem-reel {
+  display: flex;
+  gap: 8px;
+  padding-bottom: 4px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.mem-thumb {
+  position: relative;
+  flex: none;
+  padding: 0;
+  overflow: hidden;
+  background: none;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 8px;
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.mem-thumb:hover {
+  border-color: rgb(180 140 255 / 70%);
+  transform: translateY(-1px);
+}
+
+.mem-thumb-img {
+  display: block;
+  width: 96px;
+  height: 72px;
+  object-fit: cover;
+}
+
+.mem-thumb-age {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 2px 5px;
+  font-size: 9px;
+  color: #ddd;
+  text-align: left;
+  background: linear-gradient(transparent, rgb(0 0 0 / 78%));
+}
+
+.mem-panel-search {
+  margin-top: 8px;
+  overflow: hidden;
+  font-size: 10px;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Phones: scene on top, telemetry scrolling beneath it. */
 @media (max-width: 700px) {
   .nav-grid {

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -126,6 +126,19 @@ export const NAV_DELETE_MAP_SERVICE = "/nav/delete_map";
 // stale from navigation mode.
 export const MAPPING_POSE_TOPIC = "/mapping_pose";
 
+// ---- Spatial memory ---------------------------------------------------------
+// The robot's per-map visual memory (brain_client/memory): places it remembered
+// while driving well-localized. Positions mirror at 1 Hz (std_msgs/String JSON
+// {map, cache: warm|cold|inline|unsupported|off, positions:[{id,x,y,theta,stamp}]});
+// the JPEG behind each entry is served same-origin by the front door at
+// /memory/image?map=…&id=… (webapp/proxy/media_routes.py).
+export const MEMORY_POSITIONS_TOPIC = "/brain/memory_positions";
+// One latched message per finished memory search (std_msgs/String JSON:
+// {query, found, id?, x?, y?, theta?, seen_stamp?, explanation?, error?,
+// latency_sec?, cached?, stamp}). Latched so a page opened just after the
+// search still sees it; clients gate the animation on the payload's stamp.
+export const MEMORY_SEARCH_TOPIC = "/brain/memory_search";
+
 // Skill-execution status (std_msgs/String JSON: {primitive_name|skill_name,
 // status: running|completed|failed|interrupted, primitive_id, ...}), published
 // as the agent runs primitives. Separate from chat_out — the chat surfaces it so

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -2,11 +2,11 @@
 // Reusable nav-map widget — a plain 2D <canvas> rendering the occupancy grid
 // (/map), robot pose (/odom), planner route (/plan), and click-to-navigate
 // (sends a NavigateToPose goal via the router), plus opt-in overlay layers
-// (lidar scan / global costmap / local costmap / odometry trail) for the Nav page.
-// Sizes itself to its container via a ResizeObserver, so
-// it can be the standalone Map page OR a teleop PiP tile that reparents between
-// a small thumbnail and the full stage. No three.js — a canvas + putImageData
-// is all a 2D map needs.
+// (lidar scan / global costmap / local costmap / odometry trail / spatial
+// memories) for the Nav page. Sizes itself to its container via a
+// ResizeObserver, so it can be the standalone Map page OR a teleop PiP tile
+// that reparents between a small thumbnail and the full stage. No three.js —
+// a canvas + putImageData is all a 2D map needs.
 
 import { ros } from "../rosClient.js";
 import {
@@ -23,7 +23,10 @@ import {
   LOCAL_COSTMAP_TOPIC,
   TF_STATIC_TOPIC,
   MAPPING_POSE_TOPIC,
+  MEMORY_POSITIONS_TOPIC,
+  MEMORY_SEARCH_TOPIC,
 } from "../constants.js";
+import { MEMORY_COLOR, ageAlpha, ageText, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
 
 // Overlay palette — exported so the Nav page legend shows the same colors.
 // The robot is deliberately far from the costmap ramp (blue → amber → red):
@@ -34,6 +37,7 @@ export const MAP_COLORS = {
   goal: "#00ff88",
   route: "#00b7ff",
   scan: "#d96a5a",
+  memory: MEMORY_COLOR,
   costLethal: "rgb(217 106 90 / 82%)",
   costInscribed: "rgb(232 163 61 / 75%)",
   costInflation: "rgb(77 124 254 / 45%)",
@@ -60,8 +64,21 @@ const TRAIL_MAX_POINTS = 600;
 const TRAIL_JUMP_M = 1;
 
 /**
- * @typedef {"scan" | "costmap" | "local" | "trail"} LayerName
+ * @typedef {"scan" | "costmap" | "local" | "trail" | "memories"} LayerName
  */
+
+// ---- spatial-memory layer tuning -------------------------------------------
+// A stylized view cone per remembered frame: wide enough to read as "the robot
+// looked this way", far narrower than the camera's real 128° FOV (which would
+// wash the map in overlapping wedges).
+const MEM_WEDGE_HALF_RAD = (28 * Math.PI) / 180;
+const MEM_WEDGE_RANGE_M = 1.15;
+const MEM_HIT_PX = 16; // hover/click hit radius around a memory dot (css px)
+const MEM_PULSE_MS = 1200; // ring animation when a new memory is recorded
+// A latched search verdict older than this is history, not news — show nothing.
+const MEM_SEARCH_FRESH_S = 20;
+const MEM_SEARCH_GLOW_MS = 18_000; // how long the recalled spot keeps breathing
+const MEM_SEARCH_CARD_MS = 14_000; // the verdict card auto-dismisses
 
 /**
  * Rasterize a nav_msgs/OccupancyGrid into `canvas` at 1px per cell, flipped
@@ -108,7 +125,7 @@ function rasterizeGrid(msg, canvas, ctx, paint) {
  *   small); enables scroll-to-zoom. Omit to fit the whole grid (the standalone page). onZoomChange
  *   fires after each wheel-zoom. layers turns on optional overlays (Nav page): live lidar scan,
  *   global/local costmaps, odometry trail — each adds its subscription only while enabled.
- * @returns {{ destroy: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void }}
+ * @returns {{ destroy: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void, highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void }}
  */
 export function createMap(root, opts = {}) {
   let zoomMeters = opts.zoom;
@@ -237,7 +254,7 @@ export function createMap(root, opts = {}) {
 
   // ---- optional overlay layers (Nav page) ---------------------------------
   /** @type {Record<LayerName, boolean>} */
-  const layers = { scan: false, costmap: false, local: false, trail: false, ...opts.layers };
+  const layers = { scan: false, costmap: false, local: false, trail: false, memories: false, ...opts.layers };
   /** @type {any} latest sensor_msgs/LaserScan */
   let scanMsg = null;
   // base_link -> base_laser from /tf_static (URDF); zero until it arrives.
@@ -254,8 +271,255 @@ export function createMap(root, opts = {}) {
   let localGrid = null;
   /** @type {Array<{ x: number, y: number }>} map-frame breadcrumb trail */
   const trail = [];
-  /** @type {Partial<Record<"scan" | "costmap" | "local" | "tf", () => void>>} live layer subscriptions */
+  /** @type {Partial<Record<"scan" | "costmap" | "local" | "tf" | "memories" | "memsearch", () => void>>} live layer subscriptions */
   const layerUnsubs = {};
+
+  // ---- spatial-memory layer state -----------------------------------------
+  /** @type {import("./memories.js").MemoryState | null} */
+  let memState = null;
+  /** @type {Set<number> | null} ids seen so far; null until the first payload
+   * (which adopts everything silently — a page load must not pulse the world) */
+  let memKnown = null;
+  /** @type {Map<number, number>} memory id -> performance.now() of its pulse-in */
+  const memPulses = new Map();
+  /** @type {import("./memories.js").Memory | null} memory under the cursor */
+  let memHover = null;
+  /** @type {number | null} memory highlighted from outside (gallery hover) */
+  let memHighlight = null;
+  /** @type {number | null} memory whose popup card is open */
+  let memPopupFor = null;
+  /** @type {ReturnType<typeof parseSearch>} latest fresh search verdict */
+  let memSearch = null;
+  let memSearchUntil = 0; // performance.now() deadline for the recalled-spot glow
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let memSearchCardTimer;
+
+  // The three DOM overlays: a hover thumbnail, a pinned popup (Go here), and
+  // the search-verdict card. All positioned within `root` over the canvas.
+  const memHoverCard = document.createElement("div");
+  memHoverCard.className = "mem-card mem-card-hover";
+  memHoverCard.hidden = true;
+  root.appendChild(memHoverCard);
+  const memPopup = document.createElement("div");
+  memPopup.className = "mem-card mem-card-popup";
+  memPopup.hidden = true;
+  root.appendChild(memPopup);
+  const memSearchCard = document.createElement("div");
+  memSearchCard.className = "mem-search-card";
+  memSearchCard.hidden = true;
+  root.appendChild(memSearchCard);
+
+  /** @param {any} msg std_msgs/String — /brain/memory_positions */
+  function onMemories(msg) {
+    const next = parseMemories(msg);
+    if (!next) return;
+    if (memKnown === null || (memState && memState.map !== next.map)) {
+      memKnown = new Set(next.memories.map((m) => m.id));
+      memPulses.clear();
+      closeMemPopup();
+    } else {
+      for (const m of next.memories) {
+        if (memKnown.has(m.id)) continue;
+        memKnown.add(m.id);
+        memPulses.set(m.id, performance.now());
+      }
+    }
+    memState = next;
+    if (memHover && !next.memories.some((m) => m.id === memHover?.id)) setMemHover(null);
+    if (memPopupFor !== null && !next.memories.some((m) => m.id === memPopupFor)) closeMemPopup();
+    kickMemAnim();
+    draw();
+  }
+
+  /** @param {any} msg std_msgs/String — /brain/memory_search (latched) */
+  function onMemorySearch(msg) {
+    const verdict = parseSearch(msg);
+    if (!verdict) return;
+    if (Date.now() / 1000 - verdict.stamp > MEM_SEARCH_FRESH_S) return; // stale latched replay
+    memSearch = verdict;
+    memSearchUntil = performance.now() + (verdict.found ? MEM_SEARCH_GLOW_MS : 0);
+    showMemSearchCard(verdict);
+    kickMemAnim();
+    draw();
+  }
+
+  // rAF ticker for the layer's animations (pulse-ins, the recalled-spot glow).
+  // Runs only while something is animating; every other redraw stays event-driven.
+  let memAnimFrame = 0;
+  function memAnimActive() {
+    const now = performance.now();
+    for (const born of memPulses.values()) if (now - born < MEM_PULSE_MS) return true;
+    return Boolean(memSearch?.found) && now < memSearchUntil;
+  }
+  function kickMemAnim() {
+    if (memAnimFrame) return;
+    const step = () => {
+      memAnimFrame = 0;
+      draw();
+      if (memAnimActive()) memAnimFrame = requestAnimationFrame(step);
+    };
+    memAnimFrame = requestAnimationFrame(step);
+  }
+
+  /** Nearest memory within the hit radius of a canvas point, or null.
+   * @param {number} px @param {number} py */
+  function hitMemory(px, py) {
+    if (!layers.memories || !memState || !grid || !view) return null;
+    let best = null;
+    let bestD = MEM_HIT_PX * dpr();
+    for (const m of memState.memories) {
+      const c = worldToCanvas(m.x, m.y);
+      const dist = Math.hypot(c.px - px, c.py - py);
+      if (dist < bestD) {
+        bestD = dist;
+        best = m;
+      }
+    }
+    return best;
+  }
+
+  /** Anchor a card next to a memory's dot, clamped inside the scene.
+   * @param {HTMLElement} el @param {import("./memories.js").Memory} m */
+  function placeMemCard(el, m) {
+    if (!grid || !view) return;
+    const d = dpr();
+    const { px, py } = worldToCanvas(m.x, m.y);
+    const x = px / d;
+    const y = py / d;
+    const left = Math.min(Math.max(8, x + 16), Math.max(8, root.clientWidth - el.offsetWidth - 8));
+    const above = y - el.offsetHeight - 16;
+    el.style.left = `${left}px`;
+    el.style.top = `${above > 8 ? above : Math.min(y + 16, Math.max(8, root.clientHeight - el.offsetHeight - 8))}px`;
+  }
+
+  /** @param {import("./memories.js").Memory | null} m */
+  function setMemHover(m) {
+    if (memHover?.id === m?.id) return;
+    memHover = m;
+    render();
+    if (!m || !memState || memPopupFor !== null) {
+      memHoverCard.hidden = true;
+      draw();
+      return;
+    }
+    memHoverCard.innerHTML = "";
+    const img = new Image();
+    img.className = "mem-card-img";
+    img.alt = "remembered view";
+    img.src = memoryImageUrl(memState.map, m);
+    const meta = document.createElement("div");
+    meta.className = "mem-card-meta mono";
+    meta.textContent = `seen ${ageText(m.stamp)} · click for options`;
+    memHoverCard.append(img, meta);
+    memHoverCard.hidden = false;
+    placeMemCard(memHoverCard, m);
+    draw();
+  }
+
+  /** @param {import("./memories.js").Memory} m */
+  function openMemPopup(m) {
+    if (!memState) return;
+    memPopupFor = m.id;
+    memHoverCard.hidden = true;
+    memPopup.innerHTML = "";
+    const img = new Image();
+    img.className = "mem-card-img mem-card-img-lg";
+    img.alt = "remembered view";
+    img.src = memoryImageUrl(memState.map, m);
+    const meta = document.createElement("div");
+    meta.className = "mem-card-meta mono";
+    meta.textContent = `seen ${ageText(m.stamp)} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
+    const actions = document.createElement("div");
+    actions.className = "mem-card-actions";
+    const goHere = document.createElement("button");
+    goHere.type = "button";
+    goHere.className = "mem-card-btn mem-card-btn-go";
+    goHere.textContent = "Go here";
+    goHere.title = "/navigate_to_pose (action) — drive to this remembered viewpoint";
+    goHere.addEventListener("click", () => {
+      closeMemPopup();
+      publishGoal(m.x, m.y, m.theta);
+    });
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "mem-card-btn";
+    close.textContent = "Close";
+    close.addEventListener("click", closeMemPopup);
+    actions.append(goHere, close);
+    memPopup.append(img, meta, actions);
+    memPopup.hidden = false;
+    placeMemCard(memPopup, m);
+    draw();
+  }
+
+  function closeMemPopup() {
+    if (memPopupFor === null) return;
+    memPopupFor = null;
+    memPopup.hidden = true;
+    draw();
+  }
+
+  /** @param {NonNullable<ReturnType<typeof parseSearch>>} verdict */
+  function showMemSearchCard(verdict) {
+    clearTimeout(memSearchCardTimer);
+    memSearchCard.innerHTML = "";
+    memSearchCard.classList.toggle("is-found", Boolean(verdict.found));
+    const head = document.createElement("div");
+    head.className = "mem-search-head";
+    const label = document.createElement("span");
+    label.className = "microlabel";
+    label.textContent = "memory recall";
+    const query = document.createElement("span");
+    query.className = "mem-search-query";
+    query.textContent = `“${verdict.query}”`;
+    head.append(label, query);
+    if (typeof verdict.latency_sec === "number") {
+      const chip = document.createElement("span");
+      chip.className = "mem-search-chip mono";
+      chip.textContent = `${verdict.latency_sec.toFixed(1)} s${verdict.cached ? " · cached ⚡" : ""}`;
+      head.appendChild(chip);
+    }
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "mem-search-close";
+    closeBtn.textContent = "×";
+    closeBtn.setAttribute("aria-label", "dismiss");
+    closeBtn.addEventListener("click", hideMemSearchCard);
+    head.appendChild(closeBtn);
+    memSearchCard.appendChild(head);
+    const body = document.createElement("div");
+    body.className = "mem-search-body";
+    if (verdict.found && memState) {
+      const match = memState.memories.find((m) => m.id === verdict.id);
+      if (match) {
+        const img = new Image();
+        img.className = "mem-search-img";
+        img.alt = "recalled view";
+        img.src = memoryImageUrl(memState.map, match);
+        body.appendChild(img);
+      }
+    }
+    const text = document.createElement("div");
+    text.className = "mem-search-text";
+    text.textContent = verdict.found
+      ? verdict.explanation || "Found a matching remembered view."
+      : verdict.error
+        ? `Recall failed — ${verdict.error}`
+        : verdict.explanation || "Nothing in the remembered views matches.";
+    body.appendChild(text);
+    memSearchCard.appendChild(body);
+    memSearchCard.hidden = false;
+    // Two frames so the transition runs from the hidden state.
+    memSearchCard.classList.remove("is-in");
+    requestAnimationFrame(() => requestAnimationFrame(() => memSearchCard.classList.add("is-in")));
+    memSearchCardTimer = setTimeout(hideMemSearchCard, MEM_SEARCH_CARD_MS);
+  }
+
+  function hideMemSearchCard() {
+    clearTimeout(memSearchCardTimer);
+    memSearchCard.classList.remove("is-in");
+    memSearchCard.hidden = true;
+  }
 
   /** @param {any} msg sensor_msgs/LaserScan */
   function onScan(msg) {
@@ -346,6 +610,22 @@ export function createMap(root, opts = {}) {
       layerUnsubs.local();
       delete layerUnsubs.local;
       localGrid = null;
+    }
+    if (layers.memories && !layerUnsubs.memories) {
+      layerUnsubs.memories = ros.subscribe(MEMORY_POSITIONS_TOPIC, onMemories, 0, "std_msgs/msg/String");
+      layerUnsubs.memsearch = ros.subscribe(MEMORY_SEARCH_TOPIC, onMemorySearch, 0, "std_msgs/msg/String");
+    } else if (!layers.memories && layerUnsubs.memories) {
+      layerUnsubs.memories();
+      layerUnsubs.memsearch?.();
+      delete layerUnsubs.memories;
+      delete layerUnsubs.memsearch;
+      memState = null;
+      memKnown = null;
+      memPulses.clear();
+      memSearch = null;
+      setMemHover(null);
+      closeMemPopup();
+      hideMemSearchCard();
     }
   }
 
@@ -615,6 +895,8 @@ export function createMap(root, opts = {}) {
       ctx.restore();
     }
 
+    drawMemories();
+
     if (layers.trail && trail.length >= 2) {
       ctx.strokeStyle = MAP_COLORS.trail;
       ctx.lineWidth = 1.5 * dpr();
@@ -660,6 +942,8 @@ export function createMap(root, opts = {}) {
         ctx.fillRect(px - size / 2, py - size / 2, size, size);
       }
     }
+
+    drawMemorySearch();
 
     // Ghost dot under the cursor while manual/goto is armed, until the press
     // starts the real drag.
@@ -712,6 +996,100 @@ export function createMap(root, opts = {}) {
       ctx.lineTo(px + Math.cos(pose.yaw) * rad * 2.4, py - Math.sin(pose.yaw) * rad * 2.4);
       ctx.stroke();
     }
+
+    // Cards are world-anchored DOM: keep them glued to their memory through
+    // every pan/zoom/follow reframe.
+    if (!memHoverCard.hidden && memHover) placeMemCard(memHoverCard, memHover);
+    if (!memPopup.hidden && memPopupFor !== null) {
+      const m = memState?.memories.find((mem) => mem.id === memPopupFor);
+      if (m) placeMemCard(memPopup, m);
+      else closeMemPopup();
+    }
+  }
+
+  /** The remembered viewpoints: one soft view cone + dot each, fading with
+   * age; a white ring blooms once when a memory is first recorded. */
+  function drawMemories() {
+    if (!ctx || !grid || !view || !layers.memories || !memState?.memories.length) return;
+    const nowS = Date.now() / 1000;
+    const nowMs = performance.now();
+    const d = dpr();
+    const g = /** @type {NonNullable<typeof grid>} */ (grid);
+    const v = /** @type {NonNullable<typeof view>} */ (view);
+    const range = (MEM_WEDGE_RANGE_M / g.resolution) * v.scale;
+    const searchHit = memSearch?.found && nowMs < memSearchUntil ? memSearch.id : null;
+    for (const m of memState.memories) {
+      const { px, py } = worldToCanvas(m.x, m.y);
+      const active = memHover?.id === m.id || memHighlight === m.id || memPopupFor === m.id || searchHit === m.id;
+      const alpha = active ? 1 : ageAlpha(m.stamp, nowS);
+      // The view cone (canvas y is down, so world angles negate).
+      const grad = ctx.createRadialGradient(px, py, 0, px, py, range);
+      grad.addColorStop(0, withAlpha(MEMORY_COLOR, (active ? 0.5 : 0.3) * alpha));
+      grad.addColorStop(1, withAlpha(MEMORY_COLOR, 0));
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.moveTo(px, py);
+      ctx.arc(px, py, range, -m.theta - MEM_WEDGE_HALF_RAD, -m.theta + MEM_WEDGE_HALF_RAD);
+      ctx.closePath();
+      ctx.fill();
+      // The dot.
+      ctx.fillStyle = withAlpha(MEMORY_COLOR, active ? 1 : 0.45 + 0.55 * alpha);
+      ctx.beginPath();
+      ctx.arc(px, py, (active ? 4.5 : 3) * d, 0, Math.PI * 2);
+      ctx.fill();
+      if (active) {
+        ctx.strokeStyle = withAlpha("#ffffff", 0.9);
+        ctx.lineWidth = 1.5 * d;
+        ctx.beginPath();
+        ctx.arc(px, py, 6.5 * d, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+      // Pulse-in: a ring blooms outward as the robot commits a new memory.
+      const born = memPulses.get(m.id);
+      if (born !== undefined) {
+        const t = (nowMs - born) / MEM_PULSE_MS;
+        if (t >= 1) memPulses.delete(m.id);
+        else {
+          const ease = 1 - (1 - t) ** 3;
+          ctx.strokeStyle = withAlpha("#ffffff", 0.85 * (1 - t));
+          ctx.lineWidth = 2 * d;
+          ctx.beginPath();
+          ctx.arc(px, py, (6 + 30 * ease) * d, 0, Math.PI * 2);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+
+  /** The recall moment: breathing rings on the matched memory and a drifting
+   * dashed thread from the robot to it — "I remember it's over there". */
+  function drawMemorySearch() {
+    if (!ctx || !grid || !view || !layers.memories) return;
+    if (!memSearch?.found || typeof memSearch.x !== "number" || typeof memSearch.y !== "number") return;
+    if (performance.now() >= memSearchUntil) return;
+    const d = dpr();
+    const t = performance.now() / 1000;
+    const { px, py } = worldToCanvas(memSearch.x, memSearch.y);
+    if (pose) {
+      const from = worldToCanvas(pose.x, pose.y);
+      ctx.strokeStyle = withAlpha(MEMORY_COLOR, 0.75);
+      ctx.lineWidth = 1.5 * d;
+      ctx.setLineDash([6 * d, 6 * d]);
+      ctx.lineDashOffset = -((t * 30 * d) % (12 * d));
+      ctx.beginPath();
+      ctx.moveTo(from.px, from.py);
+      ctx.lineTo(px, py);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+    for (let k = 0; k < 2; k++) {
+      const phase = (t * 0.8 + k * 0.5) % 1;
+      ctx.strokeStyle = withAlpha(MEMORY_COLOR, 0.9 * (1 - phase));
+      ctx.lineWidth = 2 * d;
+      ctx.beginPath();
+      ctx.arc(px, py, (7 + phase * 26) * d, 0, Math.PI * 2);
+      ctx.stroke();
+    }
   }
 
   function render() {
@@ -733,12 +1111,16 @@ export function createMap(root, opts = {}) {
     setHint(goBtn, ui === "goto" ? "click & drag on the map" : "tap a point to navigate");
     stopBtn.hidden = !(ui === "idle" && navActive) || mappingMode;
     centerBtn.hidden = panCenter === null;
-    canvas.style.cursor = ui === "manual" || ui === "goto" ? "crosshair" : "grab";
+    canvas.style.cursor = ui === "manual" || ui === "goto" ? "crosshair" : memHover ? "pointer" : "grab";
   }
 
   /** @param {"idle" | "locate" | "manual" | "goto"} next */
   function setUi(next) {
     ui = next;
+    if (ui !== "idle") {
+      setMemHover(null);
+      closeMemPopup();
+    }
     if ((ui !== "manual" && ui !== "goto") && (goalDrag || hoverPt)) {
       goalDrag = null;
       hoverPt = null;
@@ -888,6 +1270,10 @@ export function createMap(root, opts = {}) {
       draw();
       return;
     }
+    if (!panDrag && ui === "idle") {
+      const { px, py } = eventToCanvas(e);
+      setMemHover(hitMemory(px, py));
+    }
     if (!panDrag || !grid || !view) return;
     const { px, py } = eventToCanvas(e);
     const dx = px - panDrag.px;
@@ -907,8 +1293,15 @@ export function createMap(root, opts = {}) {
   /** @param {PointerEvent} e */
   function onPointerUp(e) {
     if (panDrag) {
+      const clicked = !panDrag.moved;
       panDrag = null;
       render(); // restore the cursor, surface Recenter
+      // A plain click (no pan) opens the memory under the cursor — or lets an
+      // open popup go when the click landed on empty map.
+      if (clicked) {
+        if (memHover) openMemPopup(memHover);
+        else closeMemPopup();
+      }
       return;
     }
     if (!goalDrag) return;
@@ -994,11 +1387,19 @@ export function createMap(root, opts = {}) {
   canvas.addEventListener("pointermove", onPointerMove);
   canvas.addEventListener("pointerup", onPointerUp);
   canvas.addEventListener("pointerleave", () => {
+    setMemHover(null);
     if (!hoverPt) return;
     hoverPt = null;
     draw();
   });
   canvas.addEventListener("wheel", onWheel, { passive: false });
+  /** @param {KeyboardEvent} e */
+  function onKeyDown(e) {
+    if (e.key !== "Escape") return;
+    closeMemPopup();
+    hideMemSearchCard();
+  }
+  document.addEventListener("keydown", onKeyDown);
 
   // Resize with the container, not just the window — covers reparenting between
   // the small PiP tile and the full stage in teleop.
@@ -1040,6 +1441,12 @@ export function createMap(root, opts = {}) {
       if (on) {
         amclPose = null;
         odomAtAmcl = null;
+        // Memory marks are frames of the *finished* map — meaningless against
+        // the one being built.
+        setMemHover(null);
+        closeMemPopup();
+        hideMemSearchCard();
+        memSearch = null;
         unsubMappingPose = ros.subscribe(
           MAPPING_POSE_TOPIC,
           (msg) => {
@@ -1076,7 +1483,27 @@ export function createMap(root, opts = {}) {
       amclPose = null;
       odomAtAmcl = null;
       trail.length = 0;
+      // The memory layer swaps itself when the positions payload names the new
+      // map; the search verdict and popup belong to the old frame — drop now.
+      closeMemPopup();
+      hideMemSearchCard();
+      memSearch = null;
       pose = composedPose();
+      draw();
+    },
+    /** Gallery hover: hold one memory bright without opening anything. @param {number | null} id */
+    highlightMemory(id) {
+      if (memHighlight === id) return;
+      memHighlight = id;
+      draw();
+    },
+    /** Gallery click: centre the view on a memory and open its popup. @param {number} id */
+    focusMemory(id) {
+      const m = memState?.memories.find((mem) => mem.id === id);
+      if (!m) return;
+      panCenter = { x: m.x, y: m.y };
+      render(); // surfaces Recenter, like a hand pan
+      openMemPopup(m);
       draw();
     },
     /** Toggle an overlay layer (subscribes/unsubscribes its topics live).
@@ -1090,6 +1517,9 @@ export function createMap(root, opts = {}) {
     destroy() {
       clearTimeout(navStaleTimer);
       clearTimeout(statusClearTimer);
+      clearTimeout(memSearchCardTimer);
+      cancelAnimationFrame(memAnimFrame);
+      document.removeEventListener("keydown", onKeyDown);
       ro.disconnect();
       unsubMap();
       unsubOdom();
@@ -1100,6 +1530,9 @@ export function createMap(root, opts = {}) {
       for (const unsub of Object.values(layerUnsubs)) unsub();
       canvas.remove();
       controls.remove();
+      memHoverCard.remove();
+      memPopup.remove();
+      memSearchCard.remove();
     },
   };
 }

--- a/webapp/js/map/memories.js
+++ b/webapp/js/map/memories.js
@@ -1,0 +1,123 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Pure helpers shared by the spatial-memory map layer and sidebar panel:
+// payload parsing, /memory/image URLs, age formatting, and the layer's color
+// math. No DOM, no ROS — node-testable (tests/memories.test.js).
+
+/** The memory layer's hue — violet, deliberately distinct from every other map
+ * mark (robot pink, goal green, route blue, scan salmon, costmap amber/red). */
+export const MEMORY_COLOR = "#b48cff";
+
+/** @typedef {{ id: number, x: number, y: number, theta: number, stamp: number }} Memory */
+/** @typedef {{ map: string, cache: string, memories: Memory[] }} MemoryState */
+
+/**
+ * Parse a /brain/memory_positions message. Null when malformed — the layer
+ * just keeps its last good state.
+ * @param {any} msg std_msgs/String @returns {MemoryState | null}
+ */
+export function parseMemories(msg) {
+  try {
+    const data = JSON.parse(msg?.data ?? "");
+    if (!Array.isArray(data?.positions)) return null;
+    /** @type {Memory[]} */
+    const memories = [];
+    for (const p of data.positions) {
+      if (typeof p?.id !== "number" || typeof p?.x !== "number" || typeof p?.y !== "number") continue;
+      memories.push({ id: p.id, x: p.x, y: p.y, theta: typeof p.theta === "number" ? p.theta : 0, stamp: typeof p.stamp === "number" ? p.stamp : 0 });
+    }
+    return {
+      map: typeof data.map === "string" ? data.map : "",
+      cache: typeof data.cache === "string" ? data.cache : "off",
+      memories,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a /brain/memory_search verdict. Null when malformed.
+ * @param {any} msg std_msgs/String
+ * @returns {{ query: string, found: boolean, stamp: number, id?: number, x?: number, y?: number, theta?: number, seen_stamp?: number, explanation?: string, error?: string, latency_sec?: number, cached?: boolean } | null}
+ */
+export function parseSearch(msg) {
+  try {
+    const data = JSON.parse(msg?.data ?? "");
+    if (typeof data?.query !== "string" || typeof data?.stamp !== "number") return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Same-origin URL of a memory's JPEG. The stamp rides along as a cache-buster:
+ * a refreshed viewpoint overwrites its file in place, so the URL changes
+ * exactly when the pixels do and the browser may cache hard.
+ * @param {string} map the payload's map name ("Home.yaml") @param {Memory} memory
+ */
+export function memoryImageUrl(map, memory) {
+  return `/memory/image?map=${encodeURIComponent(map)}&id=${memory.id}&v=${Math.round(memory.stamp)}`;
+}
+
+/**
+ * "just now" → "5 min ago" → "3 h ago" → "2 d ago".
+ * @param {number} stamp epoch seconds @param {number} [now] epoch seconds (tests)
+ */
+export function ageText(stamp, now = Date.now() / 1000) {
+  const s = Math.max(0, now - stamp);
+  if (s < 90) return "just now";
+  if (s < 90 * 60) return `${Math.round(s / 60)} min ago`;
+  if (s < 36 * 3600) return `${Math.round(s / 3600)} h ago`;
+  return `${Math.round(s / 86400)} d ago`;
+}
+
+/**
+ * Draw opacity for a memory's marks: fresh memories glow, old ones recede but
+ * never vanish. Full for the first 10 minutes, easing to a 0.35 floor by 24 h
+ * (fast early fade, long tail — the difference between "this drive" and
+ * "yesterday" matters more than 3 d vs 4 d).
+ * @param {number} stamp epoch seconds @param {number} [now] epoch seconds (tests)
+ */
+export function ageAlpha(stamp, now = Date.now() / 1000) {
+  const s = Math.max(0, now - stamp);
+  const FULL_S = 600;
+  const FLOOR_S = 86400;
+  const FLOOR = 0.35;
+  if (s <= FULL_S) return 1;
+  if (s >= FLOOR_S) return FLOOR;
+  return 1 - (1 - FLOOR) * Math.sqrt((s - FULL_S) / (FLOOR_S - FULL_S));
+}
+
+/**
+ * A hex color at an alpha, as a canvas/CSS color string.
+ * @param {string} hex "#rrggbb" @param {number} alpha 0–1 (clamped)
+ */
+export function withAlpha(hex, alpha) {
+  const n = parseInt(hex.slice(1), 16);
+  const a = Math.max(0, Math.min(1, alpha));
+  return `rgb(${(n >> 16) & 255} ${(n >> 8) & 255} ${n & 255} / ${a})`;
+}
+
+/**
+ * Chip copy for the payload's cache state — how the next recall will feel.
+ * "cold" self-heals (the robot re-warms ~30 s after recording settles), so it
+ * reads as in-progress, not as an error.
+ * @param {string} state @returns {{ text: string, kind: "ok" | "warn" | "muted" }}
+ */
+export function cacheLabel(state) {
+  switch (state) {
+    case "warm":
+      return { text: "instant recall ready", kind: "ok" };
+    case "inline":
+      return { text: "recall ready", kind: "ok" };
+    case "cold":
+      return { text: "recall warming…", kind: "warn" };
+    case "unsupported":
+      return { text: "recall uncached", kind: "warn" };
+    default:
+      return { text: "recall offline", kind: "muted" };
+  }
+}

--- a/webapp/js/nav/main.js
+++ b/webapp/js/nav/main.js
@@ -22,6 +22,8 @@ import {
   COMMANDED_GOAL_TOPIC,
   GLOBAL_COSTMAP_TOPIC,
   LOCAL_COSTMAP_TOPIC,
+  MEMORY_POSITIONS_TOPIC,
+  MEMORY_SEARCH_TOPIC,
   ODOM_TOPIC,
   PLAN_TOPICS,
   SCAN_TOPIC,
@@ -30,6 +32,7 @@ import { createMap, MAP_COLORS } from "../map/mapWidget.js";
 import { createNavStore } from "./navStore.js";
 import { createMapsPanel } from "./mapsPanel.js";
 import { createMappingSession } from "./mappingSession.js";
+import { createMemoriesPanel } from "./memoriesPanel.js";
 import { createNavPanels } from "./panels.js";
 import { createNavPlots } from "./plots.js";
 import { createDriveKit } from "./driveKit.js";
@@ -46,6 +49,7 @@ const LAYERS = [
   { key: "costmap", label: "Global costmap", on: true, topic: GLOBAL_COSTMAP_TOPIC },
   { key: "local", label: "Local costmap", on: false, topic: LOCAL_COSTMAP_TOPIC },
   { key: "trail", label: "Path traveled", on: true, topic: ODOM_TOPIC },
+  { key: "memories", label: "Memories", on: true, topic: MEMORY_POSITIONS_TOPIC },
 ];
 
 /** @param {HTMLElement} stage */
@@ -170,6 +174,7 @@ function buildView(root) {
       forceLayer("scan", true);
       forceLayer("costmap", false);
       forceLayer("trail", false);
+      forceLayer("memories", false); // memory marks are frames of the finished map
       createDriveKit(scene).then((kit) => {
         if (gen !== kitGen) kit.destroy(); // mapping ended while mounting
         else driveKit = kit;
@@ -209,12 +214,14 @@ function buildView(root) {
   // rolling plots. Each in its own host so no module's teardown can clear
   // another's DOM.
   const mapsHost = document.createElement("div");
+  const memoriesHost = document.createElement("div");
   const readoutHost = document.createElement("div");
   const plotHost = document.createElement("div");
-  side.append(mapsHost, readoutHost, plotHost);
+  side.append(mapsHost, memoriesHost, readoutHost, plotHost);
 
   const parts = [
     createMapsPanel(mapsHost, store),
+    createMemoriesPanel(memoriesHost, map),
     createMappingSession(scene, store),
     createNavPanels(readoutHost, store),
     createNavPlots(plotHost),
@@ -270,6 +277,7 @@ function createLegend(scene, chipEls) {
   row(null, line(MAP_COLORS.route), "planned path", PLAN_TOPICS.join(" · "));
   row(["scan"], dot(MAP_COLORS.scan), "lidar", SCAN_TOPIC);
   row(["trail"], line(MAP_COLORS.trail), "path traveled", ODOM_TOPIC);
+  row(["memories"], dot(MAP_COLORS.memory), "remembered view", `${MEMORY_POSITIONS_TOPIC} · ${MEMORY_SEARCH_TOPIC}`);
   row(["costmap", "local"], '<span class="legend-swatch legend-cost"></span>', "cost low → lethal", `${GLOBAL_COSTMAP_TOPIC} · ${LOCAL_COSTMAP_TOPIC}`);
 
   function sync() {

--- a/webapp/js/nav/memoriesPanel.js
+++ b/webapp/js/nav/memoriesPanel.js
@@ -1,0 +1,142 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// "Memories" sidebar panel — the robot's visual memory of the current map made
+// tangible: a count, a recall-cache health chip, and a reel of remembered
+// views (newest first). Hovering a thumbnail lights its viewpoint on the map;
+// clicking centres the map there and opens the Go-here popup. Data comes from
+// the two memory topics; the images ride same-origin HTTP (/memory/image), so
+// the reel costs no rosbridge bandwidth.
+
+import { ros } from "../rosClient.js";
+import { MEMORY_POSITIONS_TOPIC, MEMORY_SEARCH_TOPIC } from "../constants.js";
+import { ageText, cacheLabel, memoryImageUrl, parseMemories, parseSearch } from "../map/memories.js";
+
+// Age labels ("5 min ago") drift while nothing else changes — refresh slowly.
+const AGE_REFRESH_MS = 30_000;
+
+/**
+ * @param {HTMLElement} root sidebar host.
+ * @param {{ highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void }} map
+ *   the scene widget — the reel drives its memory highlight/focus.
+ * @returns {{ destroy: () => void }}
+ */
+export function createMemoriesPanel(root, map) {
+  const section = document.createElement("section");
+  section.className = "nav-panel mem-panel";
+
+  const head = document.createElement("div");
+  head.className = "mem-panel-head";
+  const label = document.createElement("p");
+  label.className = "microlabel";
+  label.textContent = "Memories";
+  const count = document.createElement("span");
+  count.className = "mem-panel-count mono";
+  count.textContent = "—";
+  const chip = document.createElement("span");
+  chip.className = "mem-panel-chip mono";
+  chip.hidden = true;
+  chip.title = "Whether the remembered views are pre-cached with the vision model (searches answer in ~a second)";
+  head.append(label, count, chip);
+  section.appendChild(head);
+
+  const empty = document.createElement("p");
+  empty.className = "mem-panel-empty";
+  empty.textContent =
+    "Nothing remembered on this map yet — drive around while localized and the robot will remember what it sees.";
+  section.appendChild(empty);
+
+  const reel = document.createElement("div");
+  reel.className = "mem-reel";
+  reel.hidden = true;
+  section.appendChild(reel);
+
+  const lastSearch = document.createElement("p");
+  lastSearch.className = "mem-panel-search mono";
+  lastSearch.hidden = true;
+  section.appendChild(lastSearch);
+
+  root.appendChild(section);
+
+  let signature = ""; // map + ids + stamps of the rendered reel; rebuild only on change
+
+  /** @param {import("../map/memories.js").MemoryState} state */
+  function renderReel(state) {
+    map.highlightMemory(null); // a hovered thumb may be about to disappear
+    reel.innerHTML = "";
+    const newestFirst = [...state.memories].sort((a, b) => b.stamp - a.stamp);
+    for (const m of newestFirst) {
+      const thumb = document.createElement("button");
+      thumb.type = "button";
+      thumb.className = "mem-thumb";
+      thumb.title = `x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m — click to show on the map`;
+      const img = new Image();
+      img.className = "mem-thumb-img";
+      img.loading = "lazy";
+      img.alt = "remembered view";
+      img.src = memoryImageUrl(state.map, m);
+      const age = document.createElement("span");
+      age.className = "mem-thumb-age mono";
+      age.dataset.stamp = String(m.stamp);
+      age.textContent = ageText(m.stamp);
+      thumb.append(img, age);
+      thumb.addEventListener("mouseenter", () => map.highlightMemory(m.id));
+      thumb.addEventListener("mouseleave", () => map.highlightMemory(null));
+      thumb.addEventListener("click", () => map.focusMemory(m.id));
+      reel.appendChild(thumb);
+    }
+  }
+
+  function refreshAges() {
+    for (const el of section.querySelectorAll(".mem-thumb-age")) {
+      const stamp = Number(/** @type {HTMLElement} */ (el).dataset.stamp);
+      if (stamp) el.textContent = ageText(stamp);
+    }
+  }
+  const ageTimer = setInterval(refreshAges, AGE_REFRESH_MS);
+
+  const unsubPositions = ros.subscribe(
+    MEMORY_POSITIONS_TOPIC,
+    (msg) => {
+      const state = parseMemories(msg);
+      if (!state) return;
+      count.textContent = String(state.memories.length);
+      const cache = cacheLabel(state.cache);
+      chip.hidden = state.memories.length === 0;
+      chip.textContent = cache.text;
+      chip.dataset.kind = cache.kind;
+      empty.hidden = state.memories.length > 0;
+      reel.hidden = state.memories.length === 0;
+      const sig = `${state.map}|${state.memories.map((m) => `${m.id}:${m.stamp}`).join(",")}`;
+      if (sig !== signature) {
+        signature = sig;
+        renderReel(state);
+      }
+    },
+    0,
+    "std_msgs/msg/String",
+  );
+
+  const unsubSearch = ros.subscribe(
+    MEMORY_SEARCH_TOPIC,
+    (msg) => {
+      const verdict = parseSearch(msg);
+      if (!verdict) return;
+      lastSearch.hidden = false;
+      const outcome = verdict.found ? "found" : verdict.error ? "failed" : "no match";
+      lastSearch.textContent = `last recall · “${verdict.query}” → ${outcome}`;
+    },
+    0,
+    "std_msgs/msg/String",
+  );
+
+  return {
+    destroy() {
+      clearInterval(ageTimer);
+      unsubPositions();
+      unsubSearch();
+      map.highlightMemory(null);
+      section.remove();
+    },
+  };
+}

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -148,6 +148,9 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
           mapZoom[mapMode] = m;
           saveMapZoom();
         },
+        // Memories pulse in live while you drive — the tour builds the
+        // robot's spatial memory, and this is where you watch it happen.
+        layers: { memories: true },
       });
     } else if (!mapOn && mapWidget) {
       mapWidget.destroy();

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -47,6 +47,7 @@ from media_routes import (
     episode_response,
     joints_response,
     map_preview_response,
+    memory_image_response,
     profile_response,
     run_info_response,
     run_log_response,
@@ -371,6 +372,7 @@ def build_app() -> web.Application:
     app.router.add_get("/episode/profile", profile_response)
     app.router.add_get("/episode/thumb", thumb_response)
     app.router.add_get("/map/preview", map_preview_response)
+    app.router.add_get("/memory/image", memory_image_response)
     app.router.add_get("/run/info", run_info_response)
     app.router.add_get("/run/log", run_log_response)
     app.router.add_get("/settings.json", settings_get)

--- a/webapp/proxy/media_routes.py
+++ b/webapp/proxy/media_routes.py
@@ -208,6 +208,33 @@ def map_preview_response(request: web.Request) -> web.Response:
     return web.Response(status=200, body=data, headers={"Content-Type": "image/png", "Cache-Control": "no-cache"})
 
 
+# The robot's per-map spatial memory (brain_client/memory): one JPEG per
+# remembered viewpoint, written by the brain node.
+MEMORY_DIR = (Path(_INNATE_OS_ROOT) / "data" / "spatial_memory").resolve()
+
+
+@threaded
+def memory_image_response(request: web.Request) -> web.Response:
+    """GET /memory/image?map=<base or file.yaml>&id=<n> → the remembered JPEG of
+    one spatial-memory viewpoint. A refresh overwrites the file in place, so
+    clients append the memory's stamp as ?v= and this can be cached hard."""
+    qs = parse_qs(request.query_string)
+    name = (qs.get("map") or [""])[0]
+    if name.endswith(".yaml"):
+        name = name[:-5]
+    memory_id = (qs.get("id") or [""])[0]
+    # The map-name charset and a numeric id make the joined path traversal-proof.
+    if not _MAP_NAME_RE.match(name) or not memory_id.isdigit():
+        return _plain(404, "Not Found", "no such memory")
+    try:
+        data = (MEMORY_DIR / name / f"{int(memory_id)}.jpg").read_bytes()
+    except OSError:
+        return _plain(404, "Not Found", "no such memory")
+    return web.Response(
+        status=200, body=data, headers={"Content-Type": "image/jpeg", "Cache-Control": "max-age=86400, immutable"}
+    )
+
+
 @threaded
 def joints_response(request: web.Request) -> web.Response:
     """GET /episode/joints?dir=<skill_dir>&id=<n> → qpos/qvel/timestamps JSON,

--- a/webapp/proxy/test/test_media_routes.py
+++ b/webapp/proxy/test/test_media_routes.py
@@ -156,6 +156,25 @@ async def test_map_preview(tmp_path, monkeypatch):
 
 
 @sync
+async def test_memory_image_serves_and_fences(tmp_path, monkeypatch):
+    memories = tmp_path / "spatial_memory"
+    (memories / "Home").mkdir(parents=True)
+    (memories / "Home" / "3.jpg").write_bytes(b"\xff\xd8\xff\xe0jpegbytes")
+    monkeypatch.setattr(media_routes, "MEMORY_DIR", memories.resolve())
+    root = make_app_root(tmp_path)
+    async with serve(ROOT=root) as (s, base):
+        r = await s.get(base + "/memory/image", params={"map": "Home", "id": "3"})
+        assert r.status == 200 and r.headers["Content-Type"] == "image/jpeg"
+        assert await r.read() == b"\xff\xd8\xff\xe0jpegbytes"
+        # the map name may arrive as the yaml filename the topic publishes
+        assert (await s.get(base + "/memory/image", params={"map": "Home.yaml", "id": "3"})).status == 200
+        # traversal-shaped names and non-numeric ids -> 404
+        assert (await s.get(base + "/memory/image", params={"map": "../etc", "id": "3"})).status == 404
+        assert (await s.get(base + "/memory/image", params={"map": "Home", "id": "../3"})).status == 404
+        assert (await s.get(base + "/memory/image", params={"map": "Home", "id": "9"})).status == 404
+
+
+@sync
 async def test_thumb(tmp_path, monkeypatch):
     cv2 = pytest.importorskip("cv2")
     import numpy as np

--- a/webapp/tests/memories.test.js
+++ b/webapp/tests/memories.test.js
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Pure-helper tests for js/map/memories.js — zero dependencies, plain node:
+//   node tests/memories.test.js
+// Parsing tolerance matters most: these payloads cross rosbridge as JSON in a
+// String and a malformed one must degrade to "keep the last good state", never
+// to a layer crash.
+
+import assert from "node:assert/strict";
+import {
+  ageAlpha,
+  ageText,
+  cacheLabel,
+  memoryImageUrl,
+  parseMemories,
+  parseSearch,
+  withAlpha,
+} from "../js/map/memories.js";
+
+let passed = 0;
+/** @param {string} name @param {() => void} fn */
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+const NOW = 1_754_500_000;
+
+test("parseMemories reads a full payload", () => {
+  const msg = {
+    data: JSON.stringify({
+      map: "Home.yaml",
+      cache: "warm",
+      positions: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
+    }),
+  };
+  assert.deepEqual(parseMemories(msg), {
+    map: "Home.yaml",
+    cache: "warm",
+    memories: [{ id: 3, x: 1.5, y: -0.25, theta: 1.57, stamp: NOW }],
+  });
+});
+
+test("parseMemories skips malformed entries and defaults missing fields", () => {
+  const msg = {
+    data: JSON.stringify({ positions: [{ id: 1, x: 0, y: 0 }, { x: 2, y: 2 }, "junk", null] }),
+  };
+  const state = parseMemories(msg);
+  assert.equal(state?.map, "");
+  assert.equal(state?.cache, "off");
+  assert.deepEqual(state?.memories, [{ id: 1, x: 0, y: 0, theta: 0, stamp: 0 }]);
+});
+
+test("parseMemories rejects garbage rather than throwing", () => {
+  assert.equal(parseMemories({ data: "{not json" }), null);
+  assert.equal(parseMemories({ data: JSON.stringify({ positions: "nope" }) }), null);
+  assert.equal(parseMemories({}), null);
+});
+
+test("parseSearch keeps a verdict and rejects garbage", () => {
+  const verdict = { query: "the kitchen", found: true, id: 2, x: 1, y: 2, stamp: NOW };
+  assert.deepEqual(parseSearch({ data: JSON.stringify(verdict) }), verdict);
+  assert.equal(parseSearch({ data: JSON.stringify({ found: true }) }), null); // no query/stamp
+  assert.equal(parseSearch({ data: "]" }), null);
+});
+
+test("memoryImageUrl carries the map, id, and stamp cache-buster", () => {
+  const url = memoryImageUrl("My Home.yaml", { id: 7, x: 0, y: 0, theta: 0, stamp: 1234.6 });
+  assert.equal(url, "/memory/image?map=My%20Home.yaml&id=7&v=1235");
+});
+
+test("ageText buckets read naturally", () => {
+  assert.equal(ageText(NOW - 30, NOW), "just now");
+  assert.equal(ageText(NOW - 5 * 60, NOW), "5 min ago");
+  assert.equal(ageText(NOW - 3 * 3600, NOW), "3 h ago");
+  assert.equal(ageText(NOW - 2 * 86400, NOW), "2 d ago");
+  assert.equal(ageText(NOW + 999, NOW), "just now"); // clock skew must not go negative
+});
+
+test("ageAlpha glows fresh, floors old, and eases between", () => {
+  assert.equal(ageAlpha(NOW, NOW), 1);
+  assert.equal(ageAlpha(NOW - 599, NOW), 1);
+  assert.equal(ageAlpha(NOW - 100 * 86400, NOW), 0.35);
+  const mid = ageAlpha(NOW - 4 * 3600, NOW);
+  assert.ok(mid > 0.35 && mid < 1, `mid-age alpha in the open interval, got ${mid}`);
+});
+
+test("withAlpha formats and clamps", () => {
+  assert.equal(withAlpha("#b48cff", 0.5), "rgb(180 140 255 / 0.5)");
+  assert.equal(withAlpha("#000000", 2), "rgb(0 0 0 / 1)");
+  assert.equal(withAlpha("#ffffff", -1), "rgb(255 255 255 / 0)");
+});
+
+test("cacheLabel covers every state the robot publishes", () => {
+  for (const state of ["warm", "cold", "inline", "unsupported", "off"]) {
+    const { text, kind } = cacheLabel(state);
+    assert.ok(text.length > 0 && ["ok", "warn", "muted"].includes(kind), state);
+  }
+  assert.equal(cacheLabel("warm").kind, "ok");
+  assert.equal(cacheLabel("cold").kind, "warn");
+  assert.equal(cacheLabel("banana").kind, "muted");
+});
+
+console.log(`\n${passed} passed`);

--- a/workspace/innate_agents/basic_agent.py
+++ b/workspace/innate_agents/basic_agent.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 Innate Inc
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.navigate_with_vision import NavigateWithVision
+from innate_skills.search_memory import SearchMemory
 from inputs.micro_input import MicroInput
 
 from brain_client.agents.types import Agent, InputRef, SkillRef
@@ -24,7 +25,7 @@ class BasicAgent(Agent):
     def get_skills(self) -> list[SkillRef]:
         """The skills this directive can use — classes for code skills;
         physical skills (no class) stay id strings like "local/pick_socks"."""
-        return [NavigateToPosition, NavigateWithVision]
+        return [NavigateToPosition, NavigateWithVision, SearchMemory]
 
     def get_inputs(self) -> list[InputRef]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -4,6 +4,7 @@ from innate_skills.close_gripper import CloseGripper
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.open_gripper import OpenGripper
 from innate_skills.pick_any_object import PickAnyObject
+from innate_skills.search_memory import SearchMemory
 from innate_skills.wave import Wave
 from inputs.micro_input import MicroInput
 
@@ -26,7 +27,7 @@ class DemoAgent(Agent):
     def get_skills(self) -> list[SkillRef]:
         """Navigation code skills plus the recorded wave — Wave is the typed
         ref generated inside the recording folder (see skills/physical_refs.py)."""
-        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper]
+        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper, SearchMemory]
 
     def get_inputs(self) -> list[InputRef]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_skills/search_memory.py
+++ b/workspace/innate_skills/search_memory.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+from innate import Skill, SkillOutput, SpatialMemory
+
+
+class SearchMemory(Skill):
+    """Search the robot's long-term memory of places it has seen on this map. Describe the place
+    or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my airpods');
+    a vision model reviews every remembered view and returns the best match — its image, map
+    coordinates, and when it was seen. Use it to find anything not in the current camera view,
+    then drive there with navigate_to_position (local_frame=false)."""
+
+    memory: SpatialMemory
+
+    def execute(self, query: str):
+        recall = self.memory.begin(query)
+        verdict = self.wait_for(recall, timeout=90.0)
+        if verdict is None:
+            self.fail("memory search timed out")
+        if verdict.error:
+            self.fail(verdict.message)
+        # A clean no-match is still a successful search — the answer is "nowhere".
+        return SkillOutput(verdict.message, image=verdict.image)


### PR DESCRIPTION
## Summary

Everything that turns the spatial memory from #617 into something you can **see**, **call**, and run **cheaply forever**. Three commits, stacked on #617:

1. **Make it visible** — the map shows what the robot remembers, and the moment of recall is animated.
2. **Make it callable** — recall becomes a real skill backed by a capability server, so the model, the webapp, and other skills all reach the same cache-backed search.
3. **Make it cheap** — a Gemini Files API tier: every frame's bytes cross the network once, at record time, and a search is always exactly one round trip that never waits for maintenance.

---

## Part 1 — the memory made visible

### Robot side (small)

- `/brain/memory_positions` now carries `id` + `stamp` per memory and a `cache` health field (`warm | cold | inline | unsupported | off`), so the UI can key, age-fade, and report recall readiness.
- Every finished search mirrors its verdict onto a **latched `/brain/memory_search`** topic (`query, found, id, x, y, theta, seen_stamp, explanation, latency_sec, cached, stamp`). Latched so a page opened right after still sees it; clients gate animation on the payload's `stamp` — a fresh verdict is news, a stale one is history and shows nothing.
- The front door serves each memory's JPEG at **`GET /memory/image?map=…&id=…`** (`webapp/proxy/media_routes.py`, same fenced-route pattern as `/map/preview`; charset-validated name + numeric id make it traversal-proof). The memory's stamp rides as a `?v=` cache-buster, so the browser may cache hard — refreshed viewpoints change URL exactly when the pixels change. Images never cross rosbridge.

### Webapp

- **"Memories" map layer** (Nav page chip + legend row, on by default; live sub/unsub like every layer): one violet view cone + dot per remembered viewpoint, **opacity fading with age** (fresh glows, yesterday recedes to a floor); a **white ring blooms the instant a new memory is recorded**. The layer is also on in the **teleop PiP map** — you drive the tour and watch the robot learn in real time.
- **Hover a memory → the remembered image** appears beside it; **click → a pinned card** with the full view, its age and coordinates, and a **Go here** button that drives the widget's existing NavigateToPose path. Esc or clicking empty map dismisses. Cards are world-anchored DOM — they stay glued to their memory through pan/zoom/follow.
- **The recall moment**: on a fresh `/brain/memory_search` verdict the matched memory breathes with pulse rings, a dashed thread drifts from the robot to it, and a card floats in from the top with the query, the model's explanation, the remembered frame, and the answer latency (`1.2 s · cached ⚡`). Auto-dismisses; a no-match verdict gets a quiet card, no glow.
- **"Memories" sidebar panel**: count, a recall-cache chip (*instant recall ready / recall warming… / recall uncached*), and a reel of remembered views newest-first. Hovering a thumb lights its cone on the map; clicking centres the map there and opens the card. Empty state explains how memories get made.
- All map drawing stays event-driven; a rAF ticker runs **only** while a pulse or recall glow is actually animating. Pure helpers (payload parsing, image URLs, age math, color) live in `js/map/memories.js`, shared by widget and panel.

---

## Part 2 — recall as a real skill (was #620)

Memory search becomes a first-class skill — callable by the model, runnable from the webapp, composable from any skill's code — **with zero regression against the built-in tool it replaces**: same cache, same non-blocking agent loop, same verdict-with-image, and it still runs while the robot is driving.

The shape is the capability-server pattern the codebase already uses twice (Nav2 behind `navigate_to_position`, `arm_sdk_server` behind the SDK): **state and secrets live in a server; skills are thin, cancel-aware orchestrators.**

- **`SearchMemory` action** (`brain_messages`): `query` → `found, message, explanation, error, x, y, theta, seen_stamp, image_b64, latency_sec, cached`. Served by `brain/search_server.py` *inside the brain process, beside `MemorySearch`* — the Gemini context cache, transport, and credentials never leave it. The server runs on its own node + spin thread (a multi-second search must not stall the brain node); cancels are rejected by design — a caller that stops waiting abandons the goal, the search concludes server-side, and its verdict is dropped.
- **Structured verdicts**: `MemorySearch.search()` now returns a frozen `SearchVerdict` and never raises — transport failures are `error` verdicts every consumer can render. `verdict_text()` is the single source of the model-facing sentence, shared by the agent's event path and the action's `message` field, so the model reads the same thing whichever door the search came through.
- **Result images — the general typed channel**: `SkillOutput` grows `image=jpeg_bytes`, `ExecuteSkill.Result` grows `image_b64`, and the runner decodes it into the completion event. Any skill can now *show* the agent what it found — inspection, photo, verify-grasp skills get the same evidence channel recall uses. Mirrors the feedback lane's existing `image_b64` precedent.
- **SDK accessor**: `memory: SpatialMemory` injects like `mobility: Mobility`. `begin(query)` returns a zero-arg reader for `self.wait_for` — cancel-aware like every blocking framework call, no polling code in the skill — concluding in a typed `RecallVerdict`. Exported from `innate` (lazy, like the other interfaces).
- **The skill** (`workspace/innate_skills/search_memory.py`) is ~15 lines: `begin` → `wait_for` → `SkillOutput(verdict.message, image=verdict.image)`. Added to the basic and demo directives.
- **Non-occupying dispatch**: the brain's built-in `search_memory` tool is removed (the declaration now comes from the skill's metadata), but when the model calls it, the agent dispatches **in-process and slot-free**: recall is a query, not an act, so it resolves *before* the one-skill-at-a-time gate, pauses no gaze, and runs while navigation runs. Same `MemorySearch`, same MEMORY event carrying the matched frame, one less hop than the action. Manual webapp runs go through the skills server normally (and now benefit from the result image).

---

## Part 3 — the files tier (bandwidth solved for good)

The weakness this closes: the context cache carried the frame *bytes*, so any memory change invalidated the whole blob and a rebuild re-uploaded all ~50 frames (~3 MB) — on the quiet-window warm, or worse, on a search's critical path. Three invariants now hold, each a pure optimization that degrades without changing answers:

- **Bytes cross once, at record time** (`brain/frame_files.py`): a background chore on the recorder's 1 Hz tick (piggybacked in `warm()`) uploads each JPEG to the Gemini Files API; requests reference it as `fileData`. The registry is a `files.json` sidecar beside the store's images — **restarts re-upload nothing** — and an entry is trusted only while its stamp matches the live memory, so a wiped-and-recreated id can never resolve to an old upload. Files expire server-side at 48 h; the chore re-uploads past 40 h, references stop at 47 h.
- **A search is one round trip and never waits for maintenance**: cache builds moved entirely into `warm()`'s background thread, which no longer holds the search lock (a search proceeds mid-rebuild on the old handle — and mid-upload; both covered by tests). Fresh cache → question only. **Stale cache → the *stale* `cachedContent` plus a delta**: added/re-captured frames as `fileData`-or-inline with "Frame N was re-captured — this newer view supersedes it" / "Frame N no longer exists — ignore it" notes. No cache → all frames as references. A frame not yet uploaded rides `inlineData` in that request.
- **Every tier degrades cleanly**: no upload endpoint → permanent latch (same 404/405/501 pattern as the cache latch; the status tuple now lives once in `transport.py`), frames ride inline. No cache endpoint → reference-only requests (bandwidth still solved). Both → byte-identical to the previous inline behavior. Verdict semantics, MEMORY events, and the webapp mirror payloads are untouched.

Supporting changes: frames are labeled by **stable store id** instead of enumeration position (delta notes and verdict resolution survive additions/refreshes/evictions; verdicts resolve against the current snapshot, so a cached-but-evicted id cleanly misses); the context cache itself builds from `fileData` when uploads exist, making rebuilds reference-only POSTs; `GeminiRest` grows `upload()` (raw media protocol direct; via the proxy passthrough if it forwards `/upload` — the latch covers it if not); `cache_state` keeps its five-word vocabulary, with stale-but-usable honestly reporting `warm` since the delta keeps recall instant.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - **172 brain tests pass.** Visualization: verdict mirroring (found / no-match / broken-mirror guard), `cache_state` lifecycle, enriched positions payload. Skill capability: action-result mapping (found / no-match / error), the accessor's begin/wait contract incl. every unblock-on-failure path, `SkillOutput.image` + runner decode → event, the non-occupying dispatch (slot stays free; **search executes even while another skill occupies the slot**), rejection paths, and search-never-raises. Files tier: upload-once-per-frame, registry survives restart (no re-upload), aging-upload refresh, expired-reference inline fallback, refreshed-frame invalidation, the 404 latch and transient-failure retry, cache-from-references, mixed reference+inline requests, delta shape (added / superseded / retired notes), **search-never-waits** (concludes while an upload hangs on a gate), and id-stable labels/verdicts. The cache-lifecycle suite was rewritten for warm-owned creation: a search never builds the cache; a stale cache serves with a delta; warm rebuilds and deletes the old.
  - **Proxy: 21 tests pass** (new: `/memory/image` serve + `.yaml`-name tolerance + traversal/404 fences).
  - **Webapp**: `node tests/memories.test.js` (9 assertions on the pure helpers) plus the existing node tests all pass; `tsc -p tsconfig.json` reports **zero errors in the touched files** (the repo's pre-existing 47 errors elsewhere are unchanged — this PR added none, and fixed the one it introduced along the way).
  - `ruff` clean; `basedpyright brain_client/` is at **13 errors vs the base's 14** (the `brain_messages` rebuild fixed a stale-install import; this PR adds none, and the new skill/accessor/server files check clean under the strict workspace include).
  - `brain_messages` rebuilt (`colcon build --packages-select brain_messages`) so the suites run against the real generated types.
  - Not yet driven live — the full-stack drive test (tour → "find my airpods" → watch the recall card + navigation) is the next step on the robot, same as the rest of the stack.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — *No sim-specific changes; the layer simply stays empty until memories exist, and the sim brain constructs the action server only when it has Gemini access, like the robot.*
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — *No asset changes.*

## Notes for reviewers

- **Three commits, readable separately**: `feat(webapp): the spatial memory made visible…`, `feat(skills): recall as a capability…` (briefly PR #620, folded here), then `feat(brain): files tier…`.
- **The live drive test should specifically target the files tier's unverifiables**: (a) whether the proxy passthrough forwards `/upload/v1beta/files` — the proxy client *cannot attach* the `X-Goog-Upload-Protocol: raw` header, so proxied robots likely latch to inline (`[Memory] backend has no file-upload endpoint` in the log) until the proxy adds header support; direct `GEMINI_API_KEY` setups should work as-is. (b) Whether `cachedContents` ingests `fileData` content at creation, so the cache outlives file expiry — the 4xx fallback covers if not. (c) The real Files API response shape and images being ACTIVE immediately.
- **What's consciously traded** by moving recall to a skill: the tool's conditional declaration is gone — the skill is declared whenever a directive includes it, even with zero memories. The dispatch rejects that case instantly ("no places remembered on this map yet") so it costs an outcome string, not a wasted network turn. And recall is now directive-gated: a directive must list `SearchMemory` to have it (basic + demo do).
- The `image_b64`-on-Result msg change is additive; every existing consumer (webapp, CLI, sim console) tolerates the new field silently. Nodes need the usual full rebuild to agree on the new type hash.
- The memory hue `#b48cff` (violet) is new to the map palette on purpose — every other mark's color stays untouched, and the legend row rides the layer chip.
- Mapping mode forces the layer off (memory marks are frames of the *finished* map) and restores the chip state after, exactly like the costmap chip.
- The hover card is `pointer-events: none` so it can never fight the canvas's own pointer state machine; the click-to-pin path reuses the existing pan dead-zone ("a click is a pan that never moved").
- The agent's in-process dispatch is keyed on the skill id (`innate-os/search_memory`), the same precedent as `_NAV_TO_POSITION`'s special handling. If a second query-shaped skill ever appears, that's the moment to promote the special case into a `SkillMeta` flag.
