### PR TITLE
feat(skills): recall as a capability — SearchMemory action, memory SDK accessor, skill result images

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/README.md
+++ b/ros2_ws/src/brain/brain_client/brain_client/README.md
@@ -6,7 +6,7 @@ code, start from what it *does*:
 | Folder | What lives here |
 |---|---|
 | `nodes/` | The runnable ROS entry points (the only files with `main()`). Thin composition roots — they build collaborators, wire them, and spin. No behaviour. |
-| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached), and the system `prompt`. |
+| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached) + `search_server` (the `/brain/search_memory` action skills call), and the system `prompt`. |
 | `core/` | The activate/deactivate/reset state machine and directive switching (`lifecycle`), typed `config`, and the shared `state`. |
 | `perception/` | Turning sensors into what the agent sees: `camera`, `pose`/`pose_tracking`, `scan_health`, `gaze`. |
 | `memory/` | Persistent per-map spatial memory: `store` (JSON index + JPEGs on disk), pure `selection` (which viewpoints earn a slot), `recorder` (the always-on ROS adapter that captures them). |

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -31,15 +31,9 @@ from typing import TYPE_CHECKING
 from brain_client.brain import grounding
 from brain_client.brain.context import Decision, GeminiContext, ToolCall
 from brain_client.brain.loop import LoopThread
+from brain_client.brain.memory_search import verdict_text
 from brain_client.brain.prompt import build_system_prompt
-from brain_client.brain.tools import (
-    GO_TO_POINT_IN_VIEW,
-    SEARCH_MEMORY,
-    STOP_SKILL,
-    WAIT,
-    assign_tool_names,
-    build_tools,
-)
+from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
 from brain_client.brain.transport import pick_transport
 from brain_client.brain.utils import (
     Event,
@@ -60,7 +54,7 @@ if TYPE_CHECKING:
 
     from rclpy.node import Node
 
-    from brain_client.brain.memory_search import MemorySearch
+    from brain_client.brain.memory_search import MemorySearch, SearchVerdict
     from brain_client.core.config import BrainConfig
     from brain_client.core.state import BrainState, RunningSkill
     from brain_client.perception.camera import CameraCapture
@@ -74,6 +68,7 @@ if TYPE_CHECKING:
     from innate_proxy import ProxyClient
 
 _NAV_TO_POSITION = "innate-os/navigate_to_position"
+_SEARCH_MEMORY = "innate-os/search_memory"
 _FRESH_FRAME_SEC = 3.0  # an older camera frame means the feed is broken; don't think blind
 _MAX_EVENTS_QUEUED = 30  # the oldest beyond this are dropped as stale stimuli
 _MAX_EVENT_IMAGES = 4  # newest event images sent per turn; older ones arrive as text only
@@ -448,12 +443,7 @@ class BrainAgent:
         # the name the model calls always resolves to the skill it was declared for.
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
-        return build_tools(
-            named,
-            None,
-            can_go_to_point_in_view=_NAV_TO_POSITION in active_ids,
-            can_search_memory=self._memory is not None and self._memory.frame_count > 0,
-        )
+        return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
 
     # ================= act =================
     def _act(self, decision: Decision, speaker: SpeechStreamer, context: GeminiContext) -> list[tuple[ToolCall, str]]:
@@ -510,17 +500,19 @@ class BrainAgent:
             # (a goal that slips through anyway is cancelled by the runner's
             # generation bump, but this keeps the robot from twitching first).
             return "rejected — the brain is deactivating"
-        if call.name == SEARCH_MEMORY:
-            return self._search_memory(call.args)
-        if self._state.primitive_running is not None:
-            return "rejected — another skill is already running; stop it first"
-        if call.name == GO_TO_POINT_IN_VIEW:
-            return self._go_to_point_in_view(call.args)
         # Only names declared this turn resolve: falling back to the full
         # registry would let a hallucinated call bypass the active-skill allowlist.
         # The map can outlive a roster change (it isn't rebuilt while a skill
         # runs), so the resolved id is re-checked against the live active set.
         skill_id = self._tool_map.get(call.name)
+        if skill_id == _SEARCH_MEMORY and skill_id in self._roster.active_skill_ids():
+            # Recall is a query, not an act: it occupies no skill slot, so it
+            # resolves before the one-skill-at-a-time gate.
+            return self._search_memory(call.args)
+        if self._state.primitive_running is not None:
+            return "rejected — another skill is already running; stop it first"
+        if call.name == GO_TO_POINT_IN_VIEW:
+            return self._go_to_point_in_view(call.args)
         if skill_id is None:
             return f"unknown skill '{call.name}'"
         if skill_id not in self._roster.active_skill_ids():
@@ -578,18 +570,25 @@ class BrainAgent:
         )
 
     def _search_memory(self, args: dict) -> str:
-        """Fire a spatial-memory search; the loop must not block, so the result is an event."""
-        if self._memory is None or self._memory.frame_count == 0:
-            return "rejected — no places remembered on this map yet"
+        """Fire a spatial-memory search; the loop must not block, so the verdict is an event.
+
+        The brain hosts MemorySearch itself, so its own calls skip the
+        /brain/search_memory action the skill rides — same search, same cache,
+        one less hop.
+        """
+        if self._memory is None:
+            return "rejected — memory search is unavailable (no Gemini access)"
         query = str(args.get("query") or "").strip()
         if not query:
             return "rejected — give a query describing what to find"
-        self._memory.begin_search(query, self._on_memory_result)
+        if self._memory.frame_count == 0:
+            return "rejected — no places remembered on this map yet"
+        self._memory.begin_search(query, self._on_memory_verdict)
         return "searching memory — the result arrives as an event"
 
-    def _on_memory_result(self, text: str, image: bytes | None) -> None:
-        """Search thread: the result (and the matched frame) becomes the next turn's event."""
-        self.add_event(text, image=image, kind=EventKind.MEMORY)
+    def _on_memory_verdict(self, verdict: SearchVerdict) -> None:
+        """Search thread: the verdict (and its matched frame) becomes the next turn's event."""
+        self.add_event(verdict_text(verdict), image=verdict.image, kind=EventKind.MEMORY)
 
     def _start_skill(self, skill_id: str, inputs: dict) -> None:
         self._gaze.pause()
@@ -630,11 +629,13 @@ class BrainAgent:
         device = data.get("input_device", "unknown")
         self.add_event(f"Input from {device}: {json.dumps(data)}")
 
-    def on_skill_event(self, status: str, skill_name: str, detail: str | None = None) -> None:
+    def on_skill_event(
+        self, status: str, skill_name: str, detail: str | None = None, image: bytes | None = None
+    ) -> None:
         line = f"Skill {skill_name} {status}"
         if detail:
             line += f": {detail}"
-        self.add_event(line)
+        self.add_event(line, image=image)
 
     def on_skill_feedback(self, skill_name: str, feedback: str, image: bytes | None = None) -> None:
         self.add_event(f"Update from running skill {skill_name}: {feedback}", image=image)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -11,9 +11,11 @@ changes, expires, or the process restarts, and :meth:`warm` refreshes it in
 the background so the first search stays fast. A backend without the
 cachedContents endpoint falls back to inline frames — slower, same answers.
 
-Searches run on a daemon thread and report through a callback: the agent loop
-must never block on the network, so a search is dispatched fire-and-forget and
-its result arrives as a new event.
+Every search concludes in a :class:`SearchVerdict` — one structured outcome
+for every consumer: the agent's fire-and-forget event path (the loop must
+never block on the network), the ``/brain/search_memory`` action server that
+skills call, and the webapp mirror. :func:`verdict_text` renders the one
+model-facing sentence for all of them.
 """
 
 from __future__ import annotations
@@ -81,6 +83,22 @@ class _CacheHandle:
     expires_monotonic: float
 
 
+@dataclass(frozen=True)
+class SearchVerdict:
+    """One search's structured outcome. ``error`` non-empty means the search
+    itself failed (transport, unreadable answer) — distinct from a clean
+    no-match, which is ``found=False`` with an explanation."""
+
+    query: str
+    found: bool
+    explanation: str = ""
+    error: str = ""
+    memory: Memory | None = None
+    image: bytes | None = None
+    latency_sec: float = 0.0
+    cached: bool = False
+
+
 class MemorySearch:
     def __init__(self, store: MemoryStore, rest: GeminiRest, *, model: str, logger):
         self._store = store
@@ -108,55 +126,66 @@ class MemorySearch:
             return "inline"  # under the cache floor — always answered inline, still quick
         return "warm" if self._cache_matches(snapshot) else "cold"
 
-    def begin_search(self, query: str, on_done: Callable[[str, bytes | None], None]) -> None:
-        """Run a search on a daemon thread; the outcome (text, matched jpeg) hits ``on_done``."""
+    def begin_search(self, query: str, on_done: Callable[[SearchVerdict], None]) -> None:
+        """Run a search on a daemon thread; the verdict hits ``on_done`` when it lands."""
 
         def run() -> None:
             try:
-                text, image = self.search(query)
-            except Exception as error:  # noqa: BLE001 — a failed search must report back, not vanish
-                self._logger.error(f"[Memory] search failed: {error!r}")
-                self._report({"query": query, "found": False, "error": str(error)})
-                text, image = f'Memory search for "{query}" failed: {error}', None
-            on_done(text, image)
+                on_done(self.search(query))
+            except Exception as error:  # noqa: BLE001 — a broken consumer must not kill the thread silently
+                self._logger.error(f"[Memory] search callback failed: {error!r}")
 
         threading.Thread(target=run, name="memory-search", daemon=True).start()
 
-    def search(self, query: str) -> tuple[str, bytes | None]:
-        """Blocking: ask Gemini which remembered frame serves the query."""
+    def search(self, query: str) -> SearchVerdict:
+        """Blocking: ask Gemini which remembered frame serves the query.
+
+        Never raises — failures come back as an ``error`` verdict every
+        consumer (agent event, action result, webapp card) can render.
+        """
         with self._flight:
             started = time.monotonic()
-            snapshot = self._store.snapshot()
-            if not snapshot.memories:
-                return (
-                    "The robot has no memories of this map yet — drive around in navigation mode to build them.",
-                    None,
-                )
-            cache = self._ensure_cache(snapshot)
-            if cache is not None:
-                body = {
-                    "cachedContent": cache.name,
-                    "contents": [_user([{"text": _question(query)}])],
-                    "generationConfig": _GENERATION_CONFIG,
-                }
-                try:
-                    response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-                    return self._conclude(query, response, cache.memories, started, cached=True)
-                except GeminiHttpError as error:
-                    if error.status >= 500:
-                        raise
-                    # The cache died server-side (expired early, deleted, rejected):
-                    # forget it and answer inline; the next warm rebuilds it.
-                    self._cache = None
-                    self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
-            frames = self._load_frames(snapshot.memories)
+            try:
+                verdict = self._search_locked(query, started)
+            except Exception as error:  # noqa: BLE001 — transport failures become a typed error verdict
+                self._logger.error(f"[Memory] search failed: {error!r}")
+                verdict = SearchVerdict(query=query, found=False, error=str(error))
+        self._report(verdict)
+        return verdict
+
+    def _search_locked(self, query: str, started: float) -> SearchVerdict:
+        snapshot = self._store.snapshot()
+        if not snapshot.memories:
+            return SearchVerdict(
+                query=query,
+                found=False,
+                explanation="The robot has no memories of this map yet — drive around in navigation mode to build them.",
+            )
+        cache = self._ensure_cache(snapshot)
+        if cache is not None:
             body = {
-                "systemInstruction": {"parts": [{"text": _SYSTEM}]},
-                "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+                "cachedContent": cache.name,
+                "contents": [_user([{"text": _question(query)}])],
                 "generationConfig": _GENERATION_CONFIG,
             }
-            response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
-            return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
+            try:
+                response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
+                return self._conclude(query, response, cache.memories, started, cached=True)
+            except GeminiHttpError as error:
+                if error.status >= 500:
+                    raise
+                # The cache died server-side (expired early, deleted, rejected):
+                # forget it and answer inline; the next warm rebuilds it.
+                self._cache = None
+                self._logger.warn(f"[Memory] cached search failed ({error}); retrying inline")
+        frames = self._load_frames(snapshot.memories)
+        body = {
+            "systemInstruction": {"parts": [{"text": _SYSTEM}]},
+            "contents": [_user([*_frame_parts(frames), {"text": _question(query)}])],
+            "generationConfig": _GENERATION_CONFIG,
+        }
+        response = self._rest.post(GENERATE_PATH.format(model=self._model), body)
+        return self._conclude(query, response, tuple(memory for memory, _ in frames), started, cached=False)
 
     def warm(self) -> None:
         """Refresh the context cache in the background once the memory has settled.
@@ -254,50 +283,51 @@ class MemorySearch:
     # --- request assembly / response handling ---
     def _conclude(
         self, query: str, response: dict, memories: tuple[Memory, ...], started: float, *, cached: bool
-    ) -> tuple[str, bytes | None]:
+    ) -> SearchVerdict:
         latency = round(time.monotonic() - started, 2)
-        verdict = _parse_verdict(response)
-        if verdict is None:
-            self._report({"query": query, "found": False, "error": "unreadable answer"})
-            return f'Memory search for "{query}" returned an unreadable answer — try again.', None
-        found, frame, explanation = verdict
-        if not found or not 1 <= frame <= len(memories):
-            self._report(
-                {"query": query, "found": False, "explanation": explanation, "latency_sec": latency, "cached": cached}
+        parsed = _parse_verdict(response)
+        if parsed is None:
+            return SearchVerdict(
+                query=query, found=False, error="unreadable answer", latency_sec=latency, cached=cached
             )
-            return f'Memory search for "{query}": nothing in the remembered views matches. {explanation}', None
+        found, frame, explanation = parsed
+        if not found or not 1 <= frame <= len(memories):
+            return SearchVerdict(query=query, found=False, explanation=explanation, latency_sec=latency, cached=cached)
         memory = memories[frame - 1]
-        jpeg = self._read_image(memory)
-        self._report(
-            {
-                "query": query,
-                "found": True,
+        return SearchVerdict(
+            query=query,
+            found=True,
+            explanation=explanation,
+            memory=memory,
+            image=self._read_image(memory),
+            latency_sec=latency,
+            cached=cached,
+        )
+
+    def _report(self, verdict: SearchVerdict) -> None:
+        """Mirror a verdict to the UI topic; best-effort — it must never break a search."""
+        if self.on_result is None:
+            return
+        payload: dict = {"query": verdict.query, "found": verdict.found, "stamp": time.time()}
+        if verdict.error:
+            payload["error"] = verdict.error
+        else:
+            payload |= {
+                "explanation": verdict.explanation,
+                "latency_sec": verdict.latency_sec,
+                "cached": verdict.cached,
+            }
+        if verdict.memory is not None:
+            memory = verdict.memory
+            payload |= {
                 "id": memory.id,
                 "x": round(memory.x, 3),
                 "y": round(memory.y, 3),
                 "theta": round(memory.theta, 4),
                 "seen_stamp": memory.stamp,
-                "explanation": explanation,
-                "latency_sec": latency,
-                "cached": cached,
             }
-        )
-        return (
-            f'Memory search for "{query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago at '
-            f"map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
-            f"{explanation} "
-            + ("The attached image is that memory. " if jpeg else "")
-            + f"To go there: navigate_to_position(x={memory.x:.2f}, y={memory.y:.2f}, "
-            f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false).",
-            jpeg,
-        )
-
-    def _report(self, payload: dict) -> None:
-        """Mirror a search verdict to the UI; best-effort — it must never break a search."""
-        if self.on_result is None:
-            return
         try:
-            self.on_result({**payload, "stamp": time.time()})
+            self.on_result(payload)
         except Exception as error:  # noqa: BLE001 — the UI mirror must not break the search
             self._logger.warn(f"[Memory] search result mirror failed: {error!r}")
 
@@ -315,6 +345,25 @@ class MemorySearch:
             return path.read_bytes() if path is not None else None
         except OSError:
             return None
+
+
+def verdict_text(verdict: SearchVerdict) -> str:
+    """The one model-facing sentence for a verdict — shared by the agent's
+    event path and the search skill, so the model reads the same thing
+    whichever door the search came through."""
+    if verdict.error:
+        return f'Memory search for "{verdict.query}" failed: {verdict.error}'
+    if verdict.memory is None:
+        return f'Memory search for "{verdict.query}": nothing in the remembered views matches. {verdict.explanation}'
+    memory = verdict.memory
+    return (
+        f'Memory search for "{verdict.query}": found a match, recorded {_age_text(time.time() - memory.stamp)} ago '
+        f"at map position x={memory.x:.2f}m y={memory.y:.2f}m heading={math.degrees(memory.theta):.0f}°. "
+        f"{verdict.explanation} "
+        + ("The attached image is that memory. " if verdict.image else "")
+        + f"To go there: navigate_to_position(x={memory.x:.2f}, y={memory.y:.2f}, "
+        f"theta_degrees={math.degrees(memory.theta):.0f}, local_frame=false)."
+    )
 
 
 def _user(parts: list[dict]) -> dict:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/search_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/search_server.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The ``/brain/search_memory`` action: spatial-memory recall as a capability.
+
+The capability server pattern (arm_sdk_server, the nav stack): the state that
+makes search fast and safe — the Gemini context cache, the transport, the
+credentials — stays in the brain process with :class:`MemorySearch`; skills
+and SDK users reach it through this action and never see any of it.
+
+Runs on its own node and spin thread because a search blocks for seconds and
+the brain node is spun single-threaded — recall must never stall a turn.
+Cancellation is rejected by design: the network call can't be unwound, so a
+caller that stops waiting simply abandons the goal and the verdict is dropped
+(the skill layer's Stop already works exactly that way).
+"""
+
+from __future__ import annotations
+
+import base64
+import threading
+from typing import TYPE_CHECKING
+
+import rclpy
+from brain_messages.action import SearchMemory
+from rclpy.action import ActionServer, CancelResponse
+from rclpy.executors import SingleThreadedExecutor
+
+from brain_client.brain.memory_search import verdict_text
+
+if TYPE_CHECKING:
+    from brain_client.brain.memory_search import MemorySearch, SearchVerdict
+
+
+class MemorySearchServer:
+    def __init__(self, search: MemorySearch):
+        self._search = search
+        self._node = rclpy.create_node("memory_search_server")
+        self._server = ActionServer(
+            self._node,
+            SearchMemory,
+            "/brain/search_memory",
+            execute_callback=self._execute,
+            cancel_callback=lambda _: CancelResponse.REJECT,
+        )
+        self._executor = SingleThreadedExecutor()
+        self._executor.add_node(self._node)
+        self._thread = threading.Thread(target=self._executor.spin, name="memory-search-server", daemon=True)
+        self._thread.start()
+
+    def _execute(self, goal_handle) -> SearchMemory.Result:
+        verdict = self._search.search(str(goal_handle.request.query))  # never raises: errors are verdicts
+        goal_handle.succeed()
+        return _to_result(verdict)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(timeout_sec=2.0)
+        self._node.destroy_node()
+
+
+def _to_result(verdict: SearchVerdict) -> SearchMemory.Result:
+    result = SearchMemory.Result()
+    result.found = verdict.found
+    result.message = verdict_text(verdict)
+    result.explanation = verdict.explanation
+    result.error = verdict.error
+    result.latency_sec = float(verdict.latency_sec)
+    result.cached = verdict.cached
+    if verdict.memory is not None:
+        result.x = verdict.memory.x
+        result.y = verdict.memory.y
+        result.theta = verdict.memory.theta
+        result.seen_stamp = verdict.memory.stamp
+    if verdict.image:
+        result.image_b64 = base64.b64encode(verdict.image).decode()
+    return result

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -11,7 +11,6 @@ from brain_client.skills.registry import SkillMeta
 STOP_SKILL = "stop_current_skill"
 WAIT = "wait"
 GO_TO_POINT_IN_VIEW = "go_to_point_in_view"
-SEARCH_MEMORY = "search_memory"
 
 # An explicit no-op keeps idle turns clean: without it, models tend to emit
 # placeholder text ("[]", "Empty response") rather than returning nothing.
@@ -42,24 +41,6 @@ _GO_TO_POINT_IN_VIEW_DECLARATION = {
     },
 }
 
-# Recall over the robot's persistent spatial memory (brain/memory_search.py).
-# Declared only while the memory holds at least one frame for the current map.
-_SEARCH_MEMORY_DECLARATION = {
-    "name": SEARCH_MEMORY,
-    "description": (
-        "Search the robot's long-term memory of places it has seen on this map. Describe the place "
-        "or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my "
-        "airpods'); a vision model reviews every remembered view and an event brings back the best "
-        "match — its image, map coordinates, and when it was seen. Use it to find anything not in "
-        "the current camera view, then drive there with navigate_to_position (local_frame=false)."
-    ),
-    "parameters": {
-        "type": "OBJECT",
-        "properties": {"query": {"type": "STRING", "description": "what to look for, with any helpful context"}},
-        "required": ["query"],
-    },
-}
-
 # Skill input "type" strings (python annotation names from skill introspection)
 # -> Gemini schema types. Anything else is passed as a string with the expected
 # type noted in the description.
@@ -85,7 +66,7 @@ def assign_tool_names(skills: list[SkillMeta]) -> list[tuple[str, SkillMeta]]:
     shadow a built-in tool); colliding names get a numeric suffix so a call
     never silently dispatches to the wrong skill.
     """
-    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW, SEARCH_MEMORY}
+    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW}
     named: list[tuple[str, SkillMeta]] = []
     for meta in skills:
         base = name = tool_name(meta["name"])
@@ -104,7 +85,6 @@ def build_tools(
     running_skill_name: str | None,
     *,
     can_go_to_point_in_view: bool = False,
-    can_search_memory: bool = False,
     user_spoke: bool = False,
 ) -> list[dict]:
     """One function declaration per available skill, in a native tools block.
@@ -135,8 +115,6 @@ def build_tools(
     declarations = [_declaration(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)
-    if can_search_memory:
-        declarations.append(_SEARCH_MEMORY_DECLARATION)
     declarations.append(_WAIT_DECLARATION)
     return [{"functionDeclarations": declarations}]
 

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -26,6 +26,7 @@ from std_srvs.srv import SetBool, Trigger
 from brain_client.agents.initializer import initialize_agents
 from brain_client.brain.agent import BrainAgent
 from brain_client.brain.memory_search import MemorySearch
+from brain_client.brain.search_server import MemorySearchServer
 from brain_client.brain.transport import pick_rest
 from brain_client.brain.utils import EventKind
 from brain_client.common.script_paths import get_innate_os_root
@@ -160,10 +161,14 @@ class BrainClientNode(Node):
         # Search verdicts for the webapp's map (latched: a page opened after the
         # search still sees the last one; clients gate on the payload's stamp).
         self.memory_search_pub = self.create_publisher(String, "/brain/memory_search", LATCHED_QOS)
+        self.memory_search_server = None
         if self.memory_search is not None:
             self.memory_search.on_result = lambda payload: self.memory_search_pub.publish(
                 String(data=json.dumps(payload))
             )
+            # Recall as a capability: skills reach the same cache-backed search
+            # through /brain/search_memory (see brain/search_server.py).
+            self.memory_search_server = MemorySearchServer(self.memory_search)
         self.gaze = GazeController(self, state)
         self.runner = PrimitiveRunner(
             self,
@@ -552,6 +557,8 @@ class BrainClientNode(Node):
     def destroy_node(self):
         self.exit_event.set()
         self.brain.shutdown()
+        if self.memory_search_server is not None:
+            self.memory_search_server.shutdown()
         if self._agent_status_heartbeat is not None and not self._agent_status_heartbeat.is_canceled():
             self._agent_status_heartbeat.cancel()
         self.reload.stop_watcher()

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -9,6 +9,7 @@ skills.robot_state. This node wires those together and owns the action server.
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import threading
@@ -30,6 +31,7 @@ from brain_client.perception.camera_provider import CameraProvider
 from brain_client.robot.head import Head
 from brain_client.robot.manipulation import Manipulation
 from brain_client.robot.mobility import Mobility
+from brain_client.robot.spatial_memory import SpatialMemory
 from brain_client.skills.catalog import SkillRepository
 from brain_client.skills.cli_bridge import SkillCliBridge, SkillCliGoalHandle
 from brain_client.skills.invoker import SkillInvoker
@@ -83,6 +85,7 @@ class SkillsActionServer(Node):
         self.manipulation = Manipulation(self, self.get_logger(), lazy=True)
         self.mobility = Mobility(self, self.get_logger(), self.cmd_vel_topic)
         self.head = Head(self, self.get_logger(), self.head_position_topic)
+        self.spatial_memory = SpatialMemory(self, self.get_logger())
 
         self.robot_state = RobotStateProvider(
             self,
@@ -90,6 +93,7 @@ class SkillsActionServer(Node):
             manipulation=self.manipulation,
             mobility=self.mobility,
             head=self.head,
+            memory=self.spatial_memory,
             head_current_position_topic=self.head_current_position_topic,
         )
 
@@ -408,7 +412,11 @@ class SkillsActionServer(Node):
             finalize, success = _FINALIZE[output.status]
             getattr(goal_handle, finalize)()
             return ExecuteSkill.Result(
-                success=success, message=output.message, skill_type=skill_type, success_type=output.status.value
+                success=success,
+                message=output.message,
+                skill_type=skill_type,
+                success_type=output.status.value,
+                image_b64=base64.b64encode(output.image).decode() if output.image else "",
             )
         except Exception as e:
             self.get_logger().error(f"Error executing skill: {str(e)}")

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/spatial_memory.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Skill-facing recall over the robot's spatial memory.
+
+A thin client of the brain's ``/brain/search_memory`` action — the Gemini
+context cache, transport, and credentials all live server-side; a skill only
+ever sees a typed :class:`RecallVerdict`. Declared like any interface::
+
+    memory: SpatialMemory
+
+    def execute(self, query: str):
+        recall = self.memory.begin(query)
+        verdict = self.wait_for(recall, timeout=60.0)
+
+``begin`` returns a zero-arg reader that stays None until the verdict lands,
+so the wait runs through ``self.wait_for`` — cancel-aware like every blocking
+framework call. A skill that stops waiting simply abandons the goal; the
+search concludes server-side and its verdict is dropped.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from brain_messages.action import SearchMemory
+from rclpy.action import ActionClient
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class RecallVerdict:
+    """One memory search's outcome. ``error`` non-empty means the search
+    itself failed — distinct from a clean no-match (``found=False`` with an
+    explanation). ``message`` is the model-ready sentence; the pose fields
+    chain directly into navigation."""
+
+    found: bool
+    message: str
+    explanation: str = ""
+    error: str = ""
+    x: float = 0.0
+    y: float = 0.0
+    theta: float = 0.0
+    seen_stamp: float = 0.0
+    image: bytes | None = None
+    latency_sec: float = 0.0
+    cached: bool = False
+
+
+class SpatialMemory:
+    def __init__(self, node, logger):
+        self._logger = logger
+        self._client = ActionClient(node, SearchMemory, "/brain/search_memory")
+
+    def begin(self, query: str) -> Callable[[], RecallVerdict | None]:
+        """Start a search; hand the returned reader to ``self.wait_for``."""
+        holder: list[RecallVerdict | None] = [None]
+
+        def conclude(verdict: RecallVerdict) -> None:
+            holder[0] = verdict
+
+        if not self._client.wait_for_server(timeout_sec=2.0):
+            conclude(_error_verdict("memory search unavailable — is the brain node running?"))
+            return lambda: holder[0]
+
+        def on_result(future) -> None:
+            try:
+                conclude(_from_result(future.result().result))
+            except Exception as error:  # noqa: BLE001 — a lost result must still unblock the waiter
+                conclude(_error_verdict(f"memory search result lost: {error}"))
+
+        def on_goal(future) -> None:
+            try:
+                handle = future.result()
+            except Exception as error:  # noqa: BLE001 — same: the waiter needs an answer, not a hang
+                conclude(_error_verdict(f"memory search goal failed: {error}"))
+                return
+            if handle is None or not handle.accepted:
+                conclude(_error_verdict("memory search goal rejected"))
+                return
+            handle.get_result_async().add_done_callback(on_result)
+
+        goal = SearchMemory.Goal()
+        goal.query = str(query)
+        self._client.send_goal_async(goal).add_done_callback(on_goal)
+        return lambda: holder[0]
+
+
+def _error_verdict(error: str) -> RecallVerdict:
+    return RecallVerdict(found=False, message=f"Memory search failed: {error}", error=error)
+
+
+def _from_result(result) -> RecallVerdict:
+    return RecallVerdict(
+        found=result.found,
+        message=result.message,
+        explanation=result.explanation,
+        error=result.error,
+        x=result.x,
+        y=result.y,
+        theta=result.theta,
+        seen_stamp=result.seen_stamp,
+        image=base64.b64decode(result.image_b64) if result.image_b64 else None,
+        latency_sec=result.latency_sec,
+        cached=result.cached,
+    )

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
@@ -32,13 +32,14 @@ from brain_client.state.pose import Pose
 
 
 class RobotStateProvider:
-    def __init__(self, node, camera_node, *, manipulation, mobility, head, head_current_position_topic: str):
+    def __init__(self, node, camera_node, *, manipulation, mobility, head, memory, head_current_position_topic: str):
         self._node = node
         self._logger = node.get_logger()
         self._camera = camera_node
         self._manipulation = manipulation
         self._mobility = mobility
         self._head = head
+        self._memory = memory
         self._head_current_position_topic = head_current_position_topic
 
         self.last_odom = None
@@ -107,6 +108,8 @@ class RobotStateProvider:
                 skill.inject_interface(interface_type, self._mobility)
             elif interface_type == InterfaceType.HEAD:
                 skill.inject_interface(interface_type, self._head)
+            elif interface_type == InterfaceType.MEMORY:
+                skill.inject_interface(interface_type, self._memory)
 
     # --- subscriptions ---
     def start_subscriptions(self) -> None:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -34,7 +34,7 @@ class PrimitiveRunner:
         self._on_task_finished = on_task_finished
 
         # Bound late by the node (mutual cycle: the brain needs the runner too).
-        self.on_event = lambda status, skill_name, detail=None: None
+        self.on_event = lambda status, skill_name, detail=None, image=None: None
         self.on_feedback = lambda skill_name, feedback, image=None: None
 
         self.action_client = ActionClient(node, ExecuteSkill, "execute_skill")
@@ -353,7 +353,8 @@ class PrimitiveRunner:
         # client's job.
         status, detail = self._classify_result(result, is_code)
         if status is not None:
-            self.on_event(status, primitive_name, detail)
+            image = base64.b64decode(result.image_b64) if result.image_b64 else None
+            self.on_event(status, primitive_name, detail, image=image)
         self._emit_skill_output(result, is_code)
 
     def _is_code_skill(self, skill_id: str) -> bool:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -82,19 +82,25 @@ def cancellable_sleep(seconds: float) -> None:
 
 class SkillOutput:
     """The result of a skill run: the message, the status (a SkillResult, not
-    a string), and an optional structured payload for chaining callers.
+    a string), an optional structured payload for chaining callers, and an
+    optional evidence image (JPEG bytes) that travels with the result — the
+    agent sees it in the completion event, so a skill can show what it found,
+    not just say it (``return SkillOutput("found it", image=jpeg)``).
 
     ``str(output)`` and f-strings give the message; ``output.ok`` is the
     success check. Unpacking as the legacy ``(message, status)`` tuple still
     works but is deprecated.
     """
 
-    __slots__ = ("message", "data", "status")
+    __slots__ = ("message", "data", "status", "image")
 
-    def __init__(self, message: str, data: Any = None, status: "SkillResult" = SkillResult.SUCCESS):
+    def __init__(
+        self, message: str, data: Any = None, status: "SkillResult" = SkillResult.SUCCESS, image: bytes | None = None
+    ):
         self.message = str(message)
         self.data = data
         self.status = status
+        self.image = image
 
     @property
     def ok(self) -> bool:
@@ -180,6 +186,7 @@ class InterfaceType(Enum):
     MANIPULATION = "manipulation"
     MOBILITY = "mobility"
     HEAD = "head"
+    MEMORY = "memory"
 
 
 class SkillStorage:
@@ -501,6 +508,7 @@ def _feed_specs() -> "tuple[_FeedSpec, ...]":
     from brain_client.robot.head import Head
     from brain_client.robot.manipulation import Manipulation
     from brain_client.robot.mobility import Mobility
+    from brain_client.robot.spatial_memory import SpatialMemory
     from brain_client.state.arm import Arm
     from brain_client.state.battery import Battery
     from brain_client.state.head import HeadState
@@ -517,6 +525,7 @@ def _feed_specs() -> "tuple[_FeedSpec, ...]":
         _FeedSpec(Manipulation, Interface, InterfaceType.MANIPULATION, "Manipulation", ("manipulation",)),
         _FeedSpec(Mobility, Interface, InterfaceType.MOBILITY, "Mobility", ("mobility",)),
         _FeedSpec(Head, Interface, InterfaceType.HEAD, "Head", ("head",)),
+        _FeedSpec(SpatialMemory, Interface, InterfaceType.MEMORY, "SpatialMemory", ("memory",)),
         # cameras start per run (and sim renders on demand) — longer grace
         _FeedSpec(MainImage, Camera, main, "MainImage", ("image", "main_image"), "main camera", grace_s=3.0),
         _FeedSpec(WristImage, Camera, wrist, "WristImage", ("wrist_image",), "wrist camera", grace_s=3.0),

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -27,7 +27,8 @@ One rule covers interfaces, cameras and robot state: annotate what you read.
 ``battery: Battery``, ``odom: Odometry``, ``pose: Pose``, ``lidar: Lidar``,
 ``arm: Arm``, ``map: Map``, ``joint_states: JointStates``,
 ``head_position: HeadState``, ``image: MainImage`` / ``WristImage`` /
-``DepthMap``, ``mobility: Mobility``, ``head: Head``. A plain annotation is
+``DepthMap``, ``mobility: Mobility``, ``head: Head``,
+``memory: SpatialMemory`` (recall over the robot's spatial memory). A plain annotation is
 guaranteed inside execute() — the server waits for the first value and fails
 the run up front if none arrives — so no None guards are needed; ``| None``
 (``head: Head | None``) makes it best effort instead, injected when available
@@ -36,7 +37,9 @@ it before you ship.
 
 execute() returns the run's result: the message str, or
 ``SkillOutput(message, data)`` to attach a structured payload for chaining
-callers, or None. Call ``self.fail(message)`` to end the run as a failure.
+callers (``image=jpeg_bytes`` attaches an evidence image the agent sees in
+the completion event), or None. Call ``self.fail(message)`` to end the run
+as a failure.
 Callers of other skills get that SkillOutput back — ``out = self.turn(...)``
 then ``out.message`` / ``out.data`` / ``out.ok``, with ``out.status`` a
 SkillResult enum, never a bare string. (Legacy ``(message, SkillResult)``
@@ -99,12 +102,14 @@ __all__ = [
     "Mobility",
     "Odometry",
     "Pose",
+    "RecallVerdict",
     "Skill",
     "SkillCancelled",
     "SkillFailed",
     "SkillOutput",
     "SkillResult",
     "SkillReturn",
+    "SpatialMemory",
     "TrainedSkill",
     "Waypoint",
     "WristImage",
@@ -118,12 +123,15 @@ if TYPE_CHECKING:
     from brain_client.robot.head import Head
     from brain_client.robot.manipulation import Manipulation, Waypoint
     from brain_client.robot.mobility import Mobility
+    from brain_client.robot.spatial_memory import RecallVerdict, SpatialMemory
 
 _LAZY_INTERFACES = {
     "Mobility": ("brain_client.robot.mobility", "Mobility"),
     "Manipulation": ("brain_client.robot.manipulation", "Manipulation"),
     "Head": ("brain_client.robot.head", "Head"),
     "Waypoint": ("brain_client.robot.manipulation", "Waypoint"),
+    "SpatialMemory": ("brain_client.robot.spatial_memory", "SpatialMemory"),
+    "RecallVerdict": ("brain_client.robot.spatial_memory", "RecallVerdict"),
 }
 
 

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -1077,51 +1077,91 @@ def test_trace_reports_the_turn_lifecycle(agent_factory, monkeypatch):
     assert snapshot["active"] is False and snapshot["backend"] == "gemini-direct" and snapshot["history"] == 3
 
 
-# ---------- spatial memory tool ----------
+# ---------- spatial memory (the search_memory skill's non-occupying dispatch) ----------
 
 from brain_client.brain.context import ToolCall  # noqa: E402
+from brain_client.brain.memory_search import SearchVerdict  # noqa: E402
+from brain_client.memory.store import Memory  # noqa: E402
+from brain_client.skills.registry import SkillRegistry  # noqa: E402
+
+SEARCH_SKILL = {
+    "id": "innate-os/search_memory",
+    "name": "search_memory",
+    "type": "code",
+    "guidelines": "Search the robot's memory of this map.",
+    "inputs": {"query": {"type": "str", "required": True}},
+}
+
+FOUND_VERDICT = SearchVerdict(
+    query="banana",
+    found=True,
+    explanation="a banana on the counter",
+    memory=Memory(id=2, x=1.5, y=0.5, theta=0.0, stamp=1000.0),
+    image=JPEG,
+    latency_sec=1.2,
+    cached=True,
+)
 
 
-def declared_tool_names(agent) -> list[str]:
-    return [d["name"] for d in agent._build_tools([])[0]["functionDeclarations"]]
+def arm_search_skill(agent) -> None:
+    """Put the search skill in the registry + active roster, like a directive would."""
+    agent._state.registry = SkillRegistry.from_metadata([SEARCH_SKILL])
+    agent._roster = SimpleNamespace(active_skill_ids=lambda: ["innate-os/search_memory"])
 
 
-def test_search_memory_is_declared_only_while_frames_exist(agent_factory):
-    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
-    assert "search_memory" not in declared_tool_names(agent)
-    agent, _ = agent_factory(memory=SimpleNamespace(frame_count=3))
-    assert "search_memory" in declared_tool_names(agent)
-    agent, _ = agent_factory()  # no memory subsystem (no Gemini access at all)
-    assert "search_memory" not in declared_tool_names(agent)
-
-
-def test_search_memory_result_returns_as_an_event_with_the_matched_frame(agent_factory):
+def test_search_memory_skill_dispatches_without_occupying_the_slot(agent_factory):
     searches = []
     memory = SimpleNamespace(
         frame_count=3,
-        begin_search=lambda query, on_done: (searches.append(query), on_done("Memory search: found it", JPEG)),
+        begin_search=lambda query, on_done: (searches.append(query), on_done(FOUND_VERDICT)),
     )
-    agent, _ = agent_factory(memory=memory)
+    agent, state = agent_factory(memory=memory)
+    arm_search_skill(agent)
     agent._context._transport = lambda model, body: [model_response(call_part("search_memory", {"query": "banana"}))]
     run_turn(agent)
 
     assert searches == ["banana"]
+    assert state.primitive_running is None  # a query, not an act: the slot stays free
     # The call was answered immediately (started, not blocked on)...
     outcome = agent._context._history[-1]["parts"][0]["functionResponse"]["response"]["outcome"]
     assert outcome == "searching memory — the result arrives as an event"
-    # ...and the result waits in the queue as a MEMORY event carrying the frame.
+    # ...and the verdict waits in the queue as a MEMORY event carrying the frame.
     (event,) = agent._events
-    assert event.kind == EventKind.MEMORY and event.image == JPEG and "found it" in event.text
+    assert event.kind == EventKind.MEMORY and event.image == JPEG
+    assert "banana on the counter" in event.text and "x=1.50m" in event.text
+
+
+def test_search_memory_runs_even_while_another_skill_occupies_the_slot(agent_factory):
+    # Recall is a query: unlike every actuator skill, it must not be blocked by
+    # one-skill-at-a-time (search while driving is a deliberate property).
+    memory = SimpleNamespace(frame_count=3, begin_search=lambda query, on_done: on_done(FOUND_VERDICT))
+    agent, state = agent_factory(memory=memory)
+    arm_search_skill(agent)
+    state.primitive_running = RunningSkill(primitive_name="navigate", skill_id="innate-os/navigate_to_position")
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
+    outcome = agent._execute(ToolCall("search_memory", {"query": "keys"}))
+    assert outcome == "searching memory — the result arrives as an event"
 
 
 def test_search_memory_rejects_an_empty_memory_and_a_missing_query(agent_factory):
     agent, _ = agent_factory(memory=SimpleNamespace(frame_count=0))
+    arm_search_skill(agent)
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
     assert (
         agent._execute(ToolCall("search_memory", {"query": "keys"}))
         == "rejected — no places remembered on this map yet"
     )
     agent, _ = agent_factory(memory=SimpleNamespace(frame_count=2))
+    arm_search_skill(agent)
+    agent._tool_map = {"search_memory": "innate-os/search_memory"}
     assert agent._execute(ToolCall("search_memory", {})) == "rejected — give a query describing what to find"
+
+
+def test_skill_completion_event_carries_the_result_image(agent_factory):
+    agent, _ = agent_factory()
+    agent.on_skill_event("completed", "inspect_shelf", "found the mug", image=JPEG)
+    (event,) = agent._events
+    assert event.image == JPEG and "found the mug" in event.text
 
 
 # ---------- prompt ----------

--- a/ros2_ws/src/brain/brain_client/test/test_memory_skill.py
+++ b/ros2_ws/src/brain/brain_client/test/test_memory_skill.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Memory recall as a capability: the SearchMemory action mapping, the SDK
+accessor's begin/wait contract, and the result-image channel that carries a
+skill's evidence frame back into the agent's events."""
+
+from __future__ import annotations
+
+import base64
+import threading
+from types import SimpleNamespace
+
+from brain_client.brain.memory_search import SearchVerdict, verdict_text
+from brain_client.brain.search_server import _to_result
+from brain_client.core.state import BrainState, RunningSkill
+from brain_client.memory.store import Memory
+from brain_client.robot.spatial_memory import SpatialMemory
+from brain_client.skills.registry import SkillRegistry
+from brain_client.skills.runner import PrimitiveRunner
+from brain_client.skills.types import SkillOutput, SkillResult
+
+JPEG = b"\xff\xd8\xff\xe0fakejpegbytes"
+
+FOUND = SearchVerdict(
+    query="the kitchen",
+    found=True,
+    explanation="counter with a kettle",
+    memory=Memory(id=3, x=1.5, y=-0.5, theta=1.57, stamp=1000.0),
+    image=JPEG,
+    latency_sec=1.2,
+    cached=True,
+)
+
+
+# ---------- action result mapping ----------
+
+
+def test_to_result_maps_a_found_verdict_completely():
+    result = _to_result(FOUND)
+    assert result.found and result.cached and result.error == ""
+    assert (result.x, result.y, result.theta, result.seen_stamp) == (1.5, -0.5, 1.57, 1000.0)
+    assert base64.b64decode(result.image_b64) == JPEG
+    assert result.message == verdict_text(FOUND)
+    assert "navigate_to_position" in result.message
+
+
+def test_to_result_maps_errors_and_no_match():
+    error = _to_result(SearchVerdict(query="x", found=False, error="network down"))
+    assert not error.found and error.error == "network down" and error.image_b64 == ""
+    assert "failed" in error.message
+    no_match = _to_result(SearchVerdict(query="x", found=False, explanation="nothing like that"))
+    assert not no_match.found and no_match.error == "" and no_match.seen_stamp == 0.0
+    assert "nothing in the remembered views matches" in no_match.message
+
+
+# ---------- the SDK accessor ----------
+
+
+class FakeFuture:
+    """A future whose callback fires immediately — the whole chain runs inline."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def result(self):
+        return self._value
+
+    def add_done_callback(self, callback):
+        callback(self)
+
+
+def make_accessor(result_msg=None, *, accepted=True, server_up=True):
+    accessor = SpatialMemory.__new__(SpatialMemory)
+    accessor._logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
+    handle = SimpleNamespace(accepted=accepted, get_result_async=lambda: FakeFuture(SimpleNamespace(result=result_msg)))
+    accessor._client = SimpleNamespace(
+        wait_for_server=lambda timeout_sec: server_up,
+        send_goal_async=lambda goal: FakeFuture(handle),
+    )
+    return accessor
+
+
+def test_begin_delivers_a_typed_verdict_through_the_reader():
+    result_msg = SimpleNamespace(
+        found=True,
+        message="Found it.",
+        explanation="the counter",
+        error="",
+        x=1.5,
+        y=-0.5,
+        theta=1.57,
+        seen_stamp=1000.0,
+        image_b64=base64.b64encode(JPEG).decode(),
+        latency_sec=1.2,
+        cached=True,
+    )
+    reader = make_accessor(result_msg).begin("the kitchen")
+    verdict = reader()
+    assert verdict is not None and verdict.found and verdict.image == JPEG
+    assert verdict.x == 1.5 and verdict.cached and verdict.message == "Found it."
+
+
+def test_begin_unblocks_the_waiter_on_every_failure_path():
+    rejected = make_accessor(accepted=False).begin("x")()
+    assert rejected is not None and rejected.error == "memory search goal rejected"
+    down = make_accessor(server_up=False).begin("x")()
+    assert down is not None and "is the brain node running" in down.error
+    # A reader with no verdict yet reads None — wait_for's contract.
+    pending = SpatialMemory.__new__(SpatialMemory)
+    pending._logger = SimpleNamespace(error=lambda *a: None)
+    pending._client = SimpleNamespace(
+        wait_for_server=lambda timeout_sec: True,
+        send_goal_async=lambda goal: SimpleNamespace(add_done_callback=lambda cb: None),  # never resolves
+    )
+    assert pending.begin("x")() is None
+
+
+# ---------- the result-image channel ----------
+
+
+def test_skill_output_carries_an_optional_image():
+    assert SkillOutput("done").image is None
+    assert SkillOutput("found it", image=JPEG).image == JPEG
+
+
+def make_runner(events: list):
+    runner = PrimitiveRunner.__new__(PrimitiveRunner)
+    state = BrainState()
+    state.registry = SkillRegistry.from_metadata(
+        [{"id": "innate-os/search_memory", "name": "search_memory", "type": "code"}]
+    )
+    state.primitive_running = RunningSkill(primitive_name="search_memory", skill_id="innate-os/search_memory")
+    runner._state = state
+    runner._goal_handle = SimpleNamespace()
+    runner._generation = 0
+    runner._slot_lock = threading.Lock()
+    runner._logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
+    runner._stop_robot = lambda: None
+    runner._on_task_finished = lambda: None
+    runner._chat = SimpleNamespace(publish_task_status=lambda **kwargs: None, emit=lambda *a, **k: None)
+    runner.on_event = lambda status, name, detail=None, image=None: events.append((status, name, detail, image))
+    return runner
+
+
+def test_runner_decodes_the_result_image_into_the_brain_event():
+    events: list = []
+    runner = make_runner(events)
+    result = SimpleNamespace(
+        success=True,
+        success_type=SkillResult.SUCCESS.value,
+        skill_type="innate-os/search_memory",
+        message="Found it.",
+        image_b64=base64.b64encode(JPEG).decode(),
+    )
+    runner._on_result(SimpleNamespace(result=lambda: SimpleNamespace(result=result)), generation=0)
+    ((status, name, detail, image),) = events
+    assert status == "completed" and image == JPEG and detail == "Found it."
+
+
+def test_runner_passes_no_image_when_the_result_has_none():
+    events: list = []
+    runner = make_runner(events)
+    result = SimpleNamespace(
+        success=True,
+        success_type=SkillResult.SUCCESS.value,
+        skill_type="innate-os/search_memory",
+        message="nothing matched",
+        image_b64="",
+    )
+    runner._on_result(SimpleNamespace(result=lambda: SimpleNamespace(result=result)), generation=0)
+    ((status, _, _, image),) = events
+    assert status == "completed" and image is None

--- a/ros2_ws/src/brain/brain_client/test/test_runner_deactivation.py
+++ b/ros2_ws/src/brain/brain_client/test/test_runner_deactivation.py
@@ -25,7 +25,7 @@ def make_runner(running: RunningSkill | None, goal_handle=None):
     runner._stop_robot = lambda: None
     runner._on_task_finished = lambda: None
     runner._chat = SimpleNamespace(publish_task_status=lambda **kwargs: None)
-    runner.on_event = lambda status, name, detail=None: None
+    runner.on_event = lambda status, name, detail=None, image=None: None
     return runner, state
 
 

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from brain_client.brain.memory_search import MemorySearch
+from brain_client.brain.memory_search import MemorySearch, verdict_text
 from brain_client.brain.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
 from brain_client.memory import recorder as recorder_module
 from brain_client.memory.recorder import MemoryRecorder
@@ -328,12 +328,14 @@ def make_search(data_dir, frames: int, verdict: dict | None = None) -> tuple[Mem
 
 def test_cache_is_created_once_and_reused(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": True, "frame": 2, "explanation": "the kitchen"})
-    text, image = search.search("the kitchen")
+    verdict = search.search("the kitchen")
     search.search("the kitchen again")
     assert len(fake.creates) == 1
     assert [body.get("cachedContent") for body in fake.generates] == ["cachedContents/c1", "cachedContents/c1"]
-    assert "x=3.00m" in text and "the kitchen" in text
-    assert image == b"jpg-2"
+    assert verdict.found and verdict.cached and verdict.image == b"jpg-2"
+    assert verdict.memory is not None and verdict.memory.x == 3.0
+    assert "x=3.00m" in verdict_text(verdict) and "the kitchen" in verdict_text(verdict)
+    assert "navigate_to_position" in verdict_text(verdict)
 
 
 def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
@@ -347,22 +349,22 @@ def test_new_memories_rebuild_the_cache_and_delete_the_old(data_dir):
 
 def test_few_frames_answer_inline_without_caching(data_dir):
     search, fake, _ = make_search(data_dir, frames=3)
-    text, image = search.search("anything")
+    verdict = search.search("anything")
     assert fake.creates == []
     (body,) = fake.generates
     assert "systemInstruction" in body and "cachedContent" not in body
     assert sum("inlineData" in part for part in body["contents"][0]["parts"]) == 3
-    assert image == b"jpg-1"
+    assert verdict.image == b"jpg-1" and not verdict.cached
 
 
 def test_unsupported_backend_disables_caching_permanently(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     fake.create_error = GeminiHttpError(404, "no such endpoint")
-    _, image = search.search("first")
+    verdict = search.search("first")
     search.search("second")
     assert len(fake.creates) == 1  # never attempted again
     assert all("cachedContent" not in body for body in fake.generates)
-    assert image == b"jpg-1"
+    assert verdict.image == b"jpg-1"
 
 
 def test_failed_cache_creation_retries_only_after_the_memory_changes(data_dir):
@@ -381,32 +383,45 @@ def test_a_dead_cache_falls_back_inline_and_is_forgotten(data_dir):
     search, fake, _ = make_search(data_dir, frames=6)
     search.search("first")
     fake.cached_generate_error = GeminiHttpError(403, "cache expired")
-    text, image = search.search("second")
-    assert image == b"jpg-1"
+    verdict = search.search("second")
+    assert verdict.image == b"jpg-1" and not verdict.cached
     assert "cachedContent" not in fake.generates[-1]  # answered inline
     fake.cached_generate_error = None
     search.search("third")
     assert len(fake.creates) == 2  # the dead handle was dropped, a fresh cache built
 
 
-def test_no_match_returns_text_only(data_dir):
+def test_no_match_is_a_clean_verdict_not_an_error(data_dir):
     search, fake, _ = make_search(data_dir, frames=6, verdict={"found": False, "frame": 0, "explanation": "no kitchen"})
-    text, image = search.search("the kitchen")
-    assert image is None and "nothing in the remembered views matches" in text
+    verdict = search.search("the kitchen")
+    assert not verdict.found and verdict.image is None and verdict.error == ""
+    assert "nothing in the remembered views matches" in verdict_text(verdict)
 
 
-def test_unreadable_answer_reports_gracefully(data_dir):
+def test_unreadable_answer_becomes_an_error_verdict(data_dir):
     search, fake, _ = make_search(data_dir, frames=3)
     fake.verdict = None  # type: ignore[assignment] — json.dumps(None) is valid JSON but not a verdict
-    text, image = search.search("anything")
-    assert image is None and "unreadable" in text
+    verdict = search.search("anything")
+    assert verdict.error == "unreadable answer" and verdict.image is None
+    assert "failed" in verdict_text(verdict)
+
+
+def test_a_transport_crash_becomes_an_error_verdict_not_an_exception(data_dir):
+    search, fake, _ = make_search(data_dir, frames=3)
+
+    def explode(path: str, body: dict) -> dict:
+        raise RuntimeError("network down")
+
+    search._rest = GeminiRest(post=explode, delete=lambda path: {})
+    verdict = search.search("anything")
+    assert not verdict.found and "network down" in verdict.error
 
 
 def test_empty_memory_answers_without_the_network(data_dir):
     search, fake, _ = make_search(data_dir, frames=0)
-    text, image = search.search("anything")
-    assert fake.generates == [] and image is None
-    assert "no memories" in text
+    verdict = search.search("anything")
+    assert fake.generates == [] and verdict.image is None and not verdict.found
+    assert "no memories" in verdict_text(verdict)
 
 
 def test_warm_builds_the_cache_in_the_background(data_dir):
@@ -457,8 +472,8 @@ def test_a_broken_ui_mirror_does_not_break_the_search(data_dir):
         raise RuntimeError("publisher gone")
 
     search.on_result = explode
-    text, image = search.search("anything")
-    assert image == b"jpg-1"  # the search itself still succeeded
+    verdict = search.search("anything")
+    assert verdict.image == b"jpg-1"  # the search itself still succeeded
 
 
 def test_cache_state_reflects_the_lifecycle(data_dir):

--- a/ros2_ws/src/brain/brain_messages/CMakeLists.txt
+++ b/ros2_ws/src/brain/brain_messages/CMakeLists.txt
@@ -50,6 +50,7 @@ set(action_files
   "action/ExecutePolicy.action"
   "action/ExecuteBehavior.action"
   "action/ExecuteArmCommand.action"
+  "action/SearchMemory.action"
 )
 
 if(BUILD_TESTING)

--- a/ros2_ws/src/brain/brain_messages/action/ExecuteSkill.action
+++ b/ros2_ws/src/brain/brain_messages/action/ExecuteSkill.action
@@ -7,6 +7,7 @@ bool success
 string message
 string skill_type
 string success_type  # One of: "success", "cancelled", "failure"
+string image_b64     # optional evidence image the skill attached to its result
 ---
 # Feedback definition
 string skill_type

--- a/ros2_ws/src/brain/brain_messages/action/SearchMemory.action
+++ b/ros2_ws/src/brain/brain_messages/action/SearchMemory.action
@@ -1,0 +1,17 @@
+# Goal definition
+string query
+---
+# Result definition
+bool found
+string message      # model-ready verdict text (coordinates, age, explanation, navigation hint)
+string explanation  # the vision model's one-line reasoning
+string error        # non-empty when the search itself failed (transport, unreadable answer)
+float64 x           # map-frame pose of the matched viewpoint (0 when not found)
+float64 y
+float64 theta
+float64 seen_stamp  # epoch seconds when the matched view was recorded (0 when none)
+string image_b64    # the matched remembered frame ("" when none)
+float64 latency_sec
+bool cached         # answered from the Gemini context cache
+---
+# Feedback definition

--- a/workspace/innate_agents/basic_agent.py
+++ b/workspace/innate_agents/basic_agent.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 Innate Inc
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.navigate_with_vision import NavigateWithVision
+from innate_skills.search_memory import SearchMemory
 from inputs.micro_input import MicroInput
 
 from brain_client.agents.types import Agent, InputRef, SkillRef
@@ -24,7 +25,7 @@ class BasicAgent(Agent):
     def get_skills(self) -> list[SkillRef]:
         """The skills this directive can use — classes for code skills;
         physical skills (no class) stay id strings like "local/pick_socks"."""
-        return [NavigateToPosition, NavigateWithVision]
+        return [NavigateToPosition, NavigateWithVision, SearchMemory]
 
     def get_inputs(self) -> list[InputRef]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -4,6 +4,7 @@ from innate_skills.close_gripper import CloseGripper
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.open_gripper import OpenGripper
 from innate_skills.pick_any_object import PickAnyObject
+from innate_skills.search_memory import SearchMemory
 from innate_skills.wave import Wave
 from inputs.micro_input import MicroInput
 
@@ -26,7 +27,7 @@ class DemoAgent(Agent):
     def get_skills(self) -> list[SkillRef]:
         """Navigation code skills plus the recorded wave — Wave is the typed
         ref generated inside the recording folder (see skills/physical_refs.py)."""
-        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper]
+        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper, SearchMemory]
 
     def get_inputs(self) -> list[InputRef]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_skills/search_memory.py
+++ b/workspace/innate_skills/search_memory.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+from innate import Skill, SkillOutput, SpatialMemory
+
+
+class SearchMemory(Skill):
+    """Search the robot's long-term memory of places it has seen on this map. Describe the place
+    or thing ('the kitchen', 'a banana', 'the door out of this room', 'where you saw my airpods');
+    a vision model reviews every remembered view and returns the best match — its image, map
+    coordinates, and when it was seen. Use it to find anything not in the current camera view,
+    then drive there with navigate_to_position (local_frame=false)."""
+
+    memory: SpatialMemory
+
+    def execute(self, query: str):
+        recall = self.memory.begin(query)
+        verdict = self.wait_for(recall, timeout=90.0)
+        if verdict is None:
+            self.fail("memory search timed out")
+        if verdict.error:
+            self.fail(verdict.message)
+        # A clean no-match is still a successful search — the answer is "nowhere".
+        return SkillOutput(verdict.message, image=verdict.image)


### PR DESCRIPTION
## Summary

Memory recall becomes a first-class skill — callable by the model, runnable from the webapp, composable from any skill's code — **with zero regression against the built-in tool it replaces**: same cache, same non-blocking agent loop, same verdict-with-image, and it still runs while the robot is driving. Stacked on #619.

The shape is the capability-server pattern the codebase already uses twice (Nav2 behind `navigate_to_position`, `arm_sdk_server` behind the SDK): **state and secrets live in a server; skills are thin, cancel-aware orchestrators.**

- **`SearchMemory` action** (`brain_messages`): `query` → `found, message, explanation, error, x, y, theta, seen_stamp, image_b64, latency_sec, cached`. Served by `brain/search_server.py` *inside the brain process, beside `MemorySearch`* — the Gemini context cache, transport, and credentials never leave it. The server runs on its own node + spin thread (a multi-second search must not stall the brain node); cancels are rejected by design — a caller that stops waiting abandons the goal, the search concludes server-side, and its verdict is dropped.
- **Structured verdicts**: `MemorySearch.search()` now returns a frozen `SearchVerdict` and never raises — transport failures are `error` verdicts every consumer can render. `verdict_text()` is the single source of the model-facing sentence, shared by the agent's event path and the action's `message` field, so the model reads the same thing whichever door the search came through.
- **Result images — the general typed channel** (the "skills can give images back" half): `SkillOutput` grows `image=jpeg_bytes`, `ExecuteSkill.Result` grows `image_b64`, and the runner decodes it into the completion event. Any skill can now *show* the agent what it found — inspection, photo, verify-grasp skills get the same evidence channel recall uses. Mirrors the feedback lane's existing `image_b64` precedent.
- **SDK accessor**: `memory: SpatialMemory` injects like `mobility: Mobility`. `begin(query)` returns a zero-arg reader for `self.wait_for` — cancel-aware like every blocking framework call, no polling code in the skill — concluding in a typed `RecallVerdict`. Exported from `innate` (lazy, like the other interfaces).
- **The skill** ([workspace/innate_skills/search_memory.py](../blob/feat/memory-skill/workspace/innate_skills/search_memory.py)) is ~15 lines: `begin` → `wait_for` → `SkillOutput(verdict.message, image=verdict.image)`. Added to the basic and demo directives.
- **Non-occupying dispatch — the simple form of `claims: []`**: the brain's built-in `search_memory` tool is removed (the declaration now comes from the skill's metadata), but when the model calls it, the agent dispatches **in-process and slot-free**: recall is a query, not an act, so it resolves *before* the one-skill-at-a-time gate, pauses no gaze, and runs while navigation runs. Same `MemorySearch`, same MEMORY event carrying the matched frame, one less hop than the action. Manual webapp runs go through the skills server normally (and now benefit from the result image).

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - 158 tests pass. New coverage: action-result mapping (found / no-match / error), the accessor's begin/wait contract incl. every unblock-on-failure path, `SkillOutput.image` + runner decode → event, the non-occupying dispatch (slot stays free; **search executes even while another skill occupies the slot**), rejection paths, and search-never-raises. The verdict refactor is covered by the rewritten cache-lifecycle suite (create-once/reuse, rebuild+delete, 404-disable, 400-no-retry, dead-cache fallback all unchanged in behavior).
  - `ruff` clean; `basedpyright brain_client/` is at **13 errors vs the base's 14** (the `brain_messages` rebuild fixed a stale-install import; this PR adds none, and the new skill/accessor/server files check clean under the strict workspace include).
  - `brain_messages` rebuilt (`colcon build --packages-select brain_messages`) so the suites run against the real generated types.
  - Not yet driven live — the full-stack drive test (tour → "find my airpods" → watch the recall card + navigation) is the next step on the robot, same as the rest of the stack.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — *No sim-specific changes; the sim brain constructs the action server only when it has Gemini access, like the robot.*
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — *No asset changes.*

## Notes for reviewers

- **What's consciously traded**: the tool's conditional declaration is gone — the skill is declared whenever a directive includes it, even with zero memories. The dispatch rejects that case instantly ("no places remembered on this map yet") so it costs an outcome string, not a wasted network turn. And recall is now directive-gated: a directive must list `SearchMemory` to have it (basic + demo do).
- The `image_b64`-on-Result msg change is additive; every existing consumer (webapp, CLI, sim console) tolerates the new field silently. Nodes need the usual full rebuild to agree on the new type hash.
- The agent's in-process dispatch is keyed on the skill id (`innate-os/search_memory`), the same precedent as `_NAV_TO_POSITION`'s special handling. If a second query-shaped skill ever appears, that's the moment to promote the special case into a `SkillMeta` flag.
- `arm_search_skill` in the tests shows the minimal registry+roster arrangement a directive produces — useful as a template for future skill-dispatch tests.
