### PR TITLE
feat(webapp): shut down the robot from settings, not just restart it

### DIFF
--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -145,6 +145,11 @@ export const ROBOT_INFO_TOPIC = "/robot/info";
 // mobile app's volume slider calls; current value rides on /robot/info.
 export const SET_VOLUME_SERVICE = "/set_volume";
 
+// Power off the Jetson (mars_msgs/srv/Shutdown): request {delay_seconds},
+// response {success, message}. mars_control runs `sudo shutdown` — the same
+// service the mobile app's power-off calls.
+export const SHUTDOWN_SERVICE = "/shutdown";
+
 // WebRTC signaling over rosbridge. START is a std_msgs/String JSON payload that
 // carries our client_id: {"source":"live","audio":bool,"client_id":"...","video":[...]}.
 // The robot routes offer/answer/ICE on the *_id topics, each enveloped as {client_id, ...}

--- a/webapp/js/settings/main.js
+++ b/webapp/js/settings/main.js
@@ -12,7 +12,7 @@
 // *unsaved* edit (differs from what's saved) shows blue. Save is enabled only
 // while there are unsaved changes.
 
-import { ROBOT_INFO_TOPIC, SET_VOLUME_SERVICE } from "../constants.js";
+import { ROBOT_INFO_TOPIC, SET_VOLUME_SERVICE, SHUTDOWN_SERVICE } from "../constants.js";
 import { ros } from "../rosClient.js";
 import { CATALOG } from "./catalog.js";
 
@@ -59,6 +59,7 @@ const sections = [];
 /** @type {HTMLButtonElement} */ let saveBtn;
 /** @type {HTMLButtonElement} */ let resetAllBtn;
 /** @type {HTMLButtonElement} */ let restartBtn;
+/** @type {HTMLButtonElement} */ let shutdownBtn;
 /** @type {HTMLElement} */ let dirtyEl;
 /** @type {HTMLElement} */ let statusEl;
 
@@ -120,6 +121,7 @@ const STYLE = `
   background: none; color: var(--text, #e7e7ea); font: inherit; cursor: pointer; transition: border-color .15s ease, color .15s ease; }
 .set-restart:not(:disabled):hover { border-color: var(--primary, #7569FD); color: var(--primary, #7569FD); }
 .set-restart:disabled { opacity: .4; cursor: default; }
+.set-shutdown:not(:disabled):hover { border-color: #e95656; color: #e95656; }
 .set-dirty { font-size: 13px; color: var(--primary, #7569FD); }
 .set-status { font-size: 13px; }
 .set-status.ok { color: #3ecf8e; }
@@ -521,12 +523,18 @@ function build() {
   restartBtn.textContent = "Restart robot";
   restartBtn.title = "Restart the robot to apply saved settings (same as `innate restart`)";
   restartBtn.addEventListener("click", onRestart);
+  shutdownBtn = document.createElement("button");
+  shutdownBtn.className = "set-restart set-shutdown";
+  shutdownBtn.textContent = "Shut down";
+  shutdownBtn.title = "Power off the Jetson (press the power button to turn it back on)";
+  shutdownBtn.addEventListener("click", onShutdown);
   statusEl = document.createElement("span");
   bar.appendChild(saveBtn);
   bar.appendChild(dirtyEl);
   bar.appendChild(statusEl);
   bar.appendChild(resetAllBtn);
   bar.appendChild(restartBtn);
+  bar.appendChild(shutdownBtn);
   page.appendChild(bar);
 
   stage.appendChild(page);
@@ -997,6 +1005,35 @@ async function onRestart() {
     setStatus("Couldn't reach the robot to restart: " + (err instanceof Error ? err.message : String(err)), "err");
     restartBtn.disabled = false;
   }
+}
+
+async function onShutdown() {
+  if (!window.confirm("Shut down the robot now? The Jetson will power off — press its power button to turn it back on.")) {
+    return;
+  }
+  shutdownBtn.disabled = true;
+  setStatus("Shutting down the robot…");
+  const wasConnected = ros.state === "connected";
+  try {
+    const res = await ros.callService(SHUTDOWN_SERVICE, { delay_seconds: 0 });
+    if (!res.success) {
+      setStatus("Shutdown failed: " + (res.message || "unknown error"), "err");
+      shutdownBtn.disabled = false;
+      return;
+    }
+  } catch (err) {
+    // The power-off can kill rosbridge before the response frame escapes, so a
+    // link that was up at call time and dropped during it IS a success signal.
+    if (!wasConnected || ros.state === "connected") {
+      setStatus("Couldn't reach the robot to shut down: " + (err instanceof Error ? err.message : String(err)), "err");
+      shutdownBtn.disabled = false;
+      return;
+    }
+  }
+  // The box is going down, so both power buttons stay disabled until the
+  // operator powers it back on and reloads.
+  restartBtn.disabled = true;
+  setStatus("Shutting down — the robot will power off in a few seconds.", "ok");
 }
 
 /** @param {HTMLElement} stageEl */

--- a/webapp/js/settings/main.js
+++ b/webapp/js/settings/main.js
@@ -27,6 +27,10 @@ let styleEl = null;
 /** @type {(() => void)[]} */
 let cleanups = [];
 
+// Long enough for several reconnect attempts (1s base, 10s cap), far shorter
+// than a real power cycle — see the reconnect watch in onShutdown().
+const SHUTDOWN_RECONNECT_WATCH_MS = 15_000;
+
 /**
  * @typedef {Object} Entry
  * @property {import("./catalog.js").Knob} knob
@@ -1023,12 +1027,29 @@ async function onShutdown() {
     }
   } catch (err) {
     // The power-off can kill rosbridge before the response frame escapes, so a
-    // link that was up at call time and dropped during it IS a success signal.
+    // link that was up at call time and dropped during it reads as a success —
+    // but the same drop could be an unrelated blip that ate the request. Only
+    // a reconnect can tell them apart: the client retries within seconds, and
+    // a robot that really powered off can't be back inside the watch window
+    // (a full power cycle takes about a minute).
     if (!wasConnected || ros.state === "connected") {
       setStatus("Couldn't reach the robot to shut down: " + (err instanceof Error ? err.message : String(err)), "err");
       shutdownBtn.disabled = false;
       return;
     }
+    const unlisten = ros.onStateChange((state) => {
+      if (state !== "connected") return;
+      stopWatch();
+      shutdownBtn.disabled = false;
+      restartBtn.disabled = false;
+      setStatus("The connection came back — the robot is still up, so the shutdown request was lost. Try again.", "err");
+    });
+    const timer = setTimeout(unlisten, SHUTDOWN_RECONNECT_WATCH_MS);
+    const stopWatch = () => {
+      clearTimeout(timer);
+      unlisten();
+    };
+    cleanups.push(stopWatch);
   }
   // The box is going down, so both power buttons stay disabled until the
   // operator powers it back on and reloads.

--- a/webapp/js/settings/main.js
+++ b/webapp/js/settings/main.js
@@ -27,9 +27,10 @@ let styleEl = null;
 /** @type {(() => void)[]} */
 let cleanups = [];
 
-// Long enough for several reconnect attempts (1s base, 10s cap), far shorter
-// than a real power cycle — see the reconnect watch in onShutdown().
-const SHUTDOWN_RECONNECT_WATCH_MS = 15_000;
+// A reconnect faster than this after a shutdown-time drop means the request
+// was lost (a real power cycle takes about a minute); slower means the robot
+// was powered back on — see the reconnect watch in onShutdown().
+const SHUTDOWN_QUICK_RECONNECT_MS = 15_000;
 
 /**
  * @typedef {Object} Entry
@@ -1028,28 +1029,29 @@ async function onShutdown() {
   } catch (err) {
     // The power-off can kill rosbridge before the response frame escapes, so a
     // link that was up at call time and dropped during it reads as a success —
-    // but the same drop could be an unrelated blip that ate the request. Only
-    // a reconnect can tell them apart: the client retries within seconds, and
-    // a robot that really powered off can't be back inside the watch window
-    // (a full power cycle takes about a minute).
+    // but the same drop could be an unrelated blip that ate the request. A
+    // reconnect settles it: whether the request was lost or the robot was
+    // powered back on, a live link means the robot is up and the buttons must
+    // work again, so the watch never expires — elapsed time only picks the
+    // message.
     if (!wasConnected || ros.state === "connected") {
       setStatus("Couldn't reach the robot to shut down: " + (err instanceof Error ? err.message : String(err)), "err");
       shutdownBtn.disabled = false;
       return;
     }
+    const droppedAt = performance.now();
     const unlisten = ros.onStateChange((state) => {
       if (state !== "connected") return;
-      stopWatch();
+      unlisten();
       shutdownBtn.disabled = false;
       restartBtn.disabled = false;
-      setStatus("The connection came back — the robot is still up, so the shutdown request was lost. Try again.", "err");
+      if (performance.now() - droppedAt < SHUTDOWN_QUICK_RECONNECT_MS) {
+        setStatus("The connection came back — the robot is still up, so the shutdown request was lost. Try again.", "err");
+      } else {
+        setStatus("Reconnected — the robot is back online.", "ok");
+      }
     });
-    const timer = setTimeout(unlisten, SHUTDOWN_RECONNECT_WATCH_MS);
-    const stopWatch = () => {
-      clearTimeout(timer);
-      unlisten();
-    };
-    cleanups.push(stopWatch);
+    cleanups.push(unlisten);
   }
   // The box is going down, so both power buttons stay disabled until the
   // operator powers it back on and reloads.


### PR DESCRIPTION
## What

The settings bar could restart the robot but never power it off — the only clean way to shut the Jetson down was SSH or the hardware button. This adds a **Shut down** button next to **Restart robot**.

## How

- **`GET /shutdown`** in the front door ([`webapp/proxy/https_server.py`](../blob/feat/webapp-shutdown/webapp/proxy/https_server.py)), mirroring `restart_handler`: same `X-Requested-By: innate-webapp` guard, same detach-with-a-1s-delay spawn so the 200 reaches the browser before the box goes down.
- It runs `sudo -n /sbin/shutdown now` through the passwordless rule `post_update.sh` already provisions in `/etc/sudoers.d/ros-shutdown` — the same mechanism `app.cpp`'s `shutdown_callback` uses for the hardware power button, so no new privilege is introduced.
- `sudo -n` fails fast rather than hanging on a password prompt, and the handler pre-checks the rule with `sudo -n -l` so an unprovisioned host gets a clear 500 instead of a false success.
- The button shares the restart styling but hovers red, confirms before firing, and on success disables both power buttons — the robot is on its way down and neither action can succeed again.

## Testing

- `test_restart_requires_header` now also asserts `/shutdown` 403s without the header. The happy path stays unexercised for the same reason restart's does — it would power off the test machine.
- Proxy suite: 20 passed. `ruff check` + `ruff format --check` clean.
- Verified on the robot that `sudo -n -l /sbin/shutdown` (the pre-check) and passwordless `sudo /sbin/shutdown` both succeed on a provisioned Jetson.

## Note

The running proxy predates this change, so `/shutdown` 404s until the robot restarts once to pick it up.