### PR TITLE
feat(ssh): land interactive SSH logins in ~/innate-os

### DIFF
--- a/scripts/ssh_welcome.zsh
+++ b/scripts/ssh_welcome.zsh
@@ -18,6 +18,7 @@ UPDATE_CMD="${INNATE_OS_ROOT}/scripts/update/innate-update"
 WEBAPP_URI_SCRIPT="${INNATE_OS_ROOT}/scripts/webapp_uri.zsh"
 ANIMATE="${INNATE_WELCOME_ANIMATE:-1}"
 ANIMATION_DELAY="${INNATE_WELCOME_DELAY:-0.04}"
+START_IN_REPO="${INNATE_SSH_CD:-1}"
 
 if [[ ! -x "$UPDATE_CMD" ]] && command -v innate-update >/dev/null 2>&1; then
     UPDATE_CMD="$(command -v innate-update)"
@@ -106,3 +107,10 @@ case "$STATUS_MODE" in
 esac
 
 echo ""
+
+# Only when the shell is still in $HOME (where a login lands), so an explicit
+# `ssh robot -t 'cd elsewhere && zsh'` keeps its directory instead of being
+# yanked into the repo.
+if [[ "$START_IN_REPO" == "1" ]] && [[ "$PWD" == "$HOME" ]] && [[ -d "$INNATE_OS_ROOT" ]]; then
+    cd "$INNATE_OS_ROOT"
+fi

--- a/scripts/ssh_welcome.zsh
+++ b/scripts/ssh_welcome.zsh
@@ -18,7 +18,14 @@ UPDATE_CMD="${INNATE_OS_ROOT}/scripts/update/innate-update"
 WEBAPP_URI_SCRIPT="${INNATE_OS_ROOT}/scripts/webapp_uri.zsh"
 ANIMATE="${INNATE_WELCOME_ANIMATE:-1}"
 ANIMATION_DELAY="${INNATE_WELCOME_DELAY:-0.04}"
+# post_update.sh rewrites ~/.zshrc from config/zsh/.zshrc on every update, and the
+# env var only reaches a shell that is already past this script, so the persistent
+# opt-out has to be a file outside both.
+SSH_CD_OPT_OUT="${XDG_CONFIG_HOME:-$HOME/.config}/innate/no-ssh-cd"
 START_IN_REPO="${INNATE_SSH_CD:-1}"
+if [[ -e "$SSH_CD_OPT_OUT" ]]; then
+    START_IN_REPO=0
+fi
 
 if [[ ! -x "$UPDATE_CMD" ]] && command -v innate-update >/dev/null 2>&1; then
     UPDATE_CMD="$(command -v innate-update)"

--- a/scripts/ssh_welcome.zsh
+++ b/scripts/ssh_welcome.zsh
@@ -18,14 +18,9 @@ UPDATE_CMD="${INNATE_OS_ROOT}/scripts/update/innate-update"
 WEBAPP_URI_SCRIPT="${INNATE_OS_ROOT}/scripts/webapp_uri.zsh"
 ANIMATE="${INNATE_WELCOME_ANIMATE:-1}"
 ANIMATION_DELAY="${INNATE_WELCOME_DELAY:-0.04}"
-# post_update.sh rewrites ~/.zshrc from config/zsh/.zshrc on every update, and the
-# env var only reaches a shell that is already past this script, so the persistent
-# opt-out has to be a file outside both.
-SSH_CD_OPT_OUT="${XDG_CONFIG_HOME:-$HOME/.config}/innate/no-ssh-cd"
+# To opt out: echo 'INNATE_SSH_CD=0' >> ~/.zshenv — not ~/.zshrc, which
+# post_update.sh overwrites from config/zsh/.zshrc on every update.
 START_IN_REPO="${INNATE_SSH_CD:-1}"
-if [[ -e "$SSH_CD_OPT_OUT" ]]; then
-    START_IN_REPO=0
-fi
 
 if [[ ! -x "$UPDATE_CMD" ]] && command -v innate-update >/dev/null 2>&1; then
     UPDATE_CMD="$(command -v innate-update)"

--- a/scripts/update/README.md
+++ b/scripts/update/README.md
@@ -348,23 +348,11 @@ echo 'source ~/innate-os/scripts/ssh_welcome.zsh' >> ~/.zshrc
 ```
 
 This shows a notification on login if updates are available, and drops interactive
-SSH sessions straight into `~/innate-os` so `innate`, updates, and skills are all
-relative to the repo.
-
-Both behaviors only apply to interactive SSH logins, and only once per session, so
-`ssh robot '<command>'`, `scp`/`sftp`, and nested shells are untouched. The `cd` is
-also skipped whenever the shell did not start in `$HOME` — `ssh robot -t 'cd /var/log && zsh'`
-keeps its directory. To opt out permanently:
+SSH logins into `~/innate-os`. To opt out of the `cd`:
 
 ```bash
-mkdir -p ~/.config/innate && touch ~/.config/innate/no-ssh-cd
+echo 'INNATE_SSH_CD=0' >> ~/.zshenv
 ```
-
-The marker file is used rather than an entry in `~/.zshrc` because `post_update.sh`
-rewrites `~/.zshrc` from `config/zsh/.zshrc` on every update, which would discard it.
-`INNATE_SSH_CD=0` also works, but only where it is set before the shell starts (a
-wrapper or `AcceptEnv`) — exporting it at an existing prompt is too late to affect
-that session and does not carry to the next login.
 
 ---
 

--- a/scripts/update/README.md
+++ b/scripts/update/README.md
@@ -347,7 +347,18 @@ Add update notifications to your shell prompt:
 echo 'source ~/innate-os/scripts/ssh_welcome.zsh' >> ~/.zshrc
 ```
 
-This shows a notification on login if updates are available.
+This shows a notification on login if updates are available, and drops interactive
+SSH sessions straight into `~/innate-os` so `innate`, updates, and skills are all
+relative to the repo.
+
+Both behaviors only apply to interactive SSH logins, and only once per session, so
+`ssh robot '<command>'`, `scp`/`sftp`, and nested shells are untouched. The `cd` is
+also skipped whenever the shell did not start in `$HOME` — `ssh robot -t 'cd /var/log && zsh'`
+keeps its directory. To opt out entirely:
+
+```bash
+export INNATE_SSH_CD=0
+```
 
 ---
 

--- a/scripts/update/README.md
+++ b/scripts/update/README.md
@@ -354,11 +354,17 @@ relative to the repo.
 Both behaviors only apply to interactive SSH logins, and only once per session, so
 `ssh robot '<command>'`, `scp`/`sftp`, and nested shells are untouched. The `cd` is
 also skipped whenever the shell did not start in `$HOME` — `ssh robot -t 'cd /var/log && zsh'`
-keeps its directory. To opt out entirely:
+keeps its directory. To opt out permanently:
 
 ```bash
-export INNATE_SSH_CD=0
+mkdir -p ~/.config/innate && touch ~/.config/innate/no-ssh-cd
 ```
+
+The marker file is used rather than an entry in `~/.zshrc` because `post_update.sh`
+rewrites `~/.zshrc` from `config/zsh/.zshrc` on every update, which would discard it.
+`INNATE_SSH_CD=0` also works, but only where it is set before the shell starts (a
+wrapper or `AcceptEnv`) — exporting it at an existing prompt is too late to affect
+that session and does not carry to the next login.
 
 ---
 


### PR DESCRIPTION
## Summary

- Interactive SSH logins now land in `~/innate-os` instead of `$HOME`.
- Done in `ssh_welcome.zsh`, which already gates on interactive-SSH-once-per-session. sshd has no directive for a login working directory, and `ForceCommand` would break scp/sftp.
- Skipped unless the shell is still in `$HOME`, so `ssh robot -t 'cd elsewhere && zsh'` keeps its directory. Opt out with `echo 'INNATE_SSH_CD=0' >> ~/.zshenv`.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.

Tested on a robot over SSH. Also exercised under zsh 5.9 against a fake `$HOME`: cd happens on login from `$HOME`; skipped when started elsewhere, on a local tty, non-interactive, in a nested shell, when the repo is missing, and when opted out via `~/.zshenv`.

- [x] Simulator checks — N/A, no simulator changes.