### PR TITLE
fix(brain): match maps by fingerprint, not name — same-name remaps reuse memory ids

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -100,6 +100,7 @@ class _CacheHandle:
     name: str  # "cachedContents/…"
     revision: int
     map_name: str | None
+    fingerprint: str
     memories: tuple[Memory, ...]  # frame numbers resolve against what was cached, not the live store
     expires_monotonic: float
 
@@ -267,9 +268,11 @@ class MemorySearch:
 
     def _usable_cache(self, snapshot: MemorySnapshot) -> _CacheHandle | None:
         """The handle a search may ride right now — fresh OR stale (the delta
-        covers staleness); only the wrong map or expiry disqualifies it."""
+        covers staleness); only the wrong map or expiry disqualifies it. The
+        delta's supersede/retire notes trust stable ids, which a same-name
+        remap resets — so the map is matched by fingerprint, not just name."""
         cache = self._cache
-        if cache is None or cache.map_name != snapshot.map_name:
+        if cache is None or cache.map_name != snapshot.map_name or cache.fingerprint != snapshot.fingerprint:
             return None
         return cache if time.monotonic() < cache.expires_monotonic else None
 
@@ -347,6 +350,7 @@ class MemorySearch:
                 name=name,
                 revision=snapshot.revision,
                 map_name=snapshot.map_name,
+                fingerprint=snapshot.fingerprint,
                 memories=included,
                 expires_monotonic=expires,
             ),
@@ -369,10 +373,10 @@ class MemorySearch:
             )
         found, frame_id, explanation = parsed
         # The coordinates only mean anything on the map the frames came from —
-        # a map switched mid-flight voids the verdict rather than steering the
-        # robot toward another map's frame.
+        # a map switched (or remapped under its own name) mid-flight voids the
+        # verdict rather than steering the robot toward another map's frame.
         live = self._store.snapshot()
-        if live.map_name != snapshot.map_name:
+        if live.map_name != snapshot.map_name or live.fingerprint != snapshot.fingerprint:
             return SearchVerdict(
                 query=query,
                 found=False,

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -45,6 +45,9 @@ class MemorySnapshot:
     map_name: str | None
     revision: int
     memories: tuple[Memory, ...]
+    # Same-name remaps reset memory ids, so name equality alone cannot prove
+    # two snapshots share a coordinate frame — the fingerprint can.
+    fingerprint: str = ""
 
 
 class MemoryStore:
@@ -92,7 +95,7 @@ class MemoryStore:
 
     def snapshot(self) -> MemorySnapshot:
         with self._lock:
-            return MemorySnapshot(self._map_name, self._revision, tuple(self._memories))
+            return MemorySnapshot(self._map_name, self._revision, tuple(self._memories), self._fingerprint)
 
     @property
     def fingerprint(self) -> str:

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1255,3 +1255,26 @@ def test_an_eviction_mid_search_misses_cleanly(data_dir):
     mutate_after_generate(search, fake, lambda: store.evict(memory_with_id(store, 1)))
     verdict = search.search("the kitchen")
     assert not verdict.found and not verdict.error
+
+
+def remap_in_place(data_dir, store: MemoryStore) -> None:
+    """Overwrite the active map under its own name and record a frame that
+    reuses id 1 — the collision a name-only guard would hand to the agent."""
+    (data_dir / "maps" / "A.pgm").write_bytes(b"remapped-content")
+    store.switch_map("A.yaml")
+    store.add(9.0, 9.0, 0.0, 2000.0, b"new-map-frame")
+
+
+def test_a_same_name_remap_mid_search_voids_the_verdict(data_dir):
+    search, fake, store = make_search(data_dir, frames=2)  # the fake's verdict picks frame 1
+    mutate_after_generate(search, fake, lambda: remap_in_place(data_dir, store))
+    verdict = search.search("the kitchen")
+    assert not verdict.found and "map changed" in verdict.error
+
+
+def test_a_same_name_remap_disqualifies_the_cache(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    build_cache(search)
+    remap_in_place(data_dir, store)
+    search.search("the kitchen")
+    assert "cachedContent" not in fake.generates[-1]  # old-map frames must not vouch for reused ids


### PR DESCRIPTION
## Summary

Closes the two residual Greptile findings from #617 that survived the review-hardening pass. Both had one root cause: the search path proved "same map" by **name** alone, while a same-name remap resets memory ids (`_next_id` goes back to 1). So an id from before the remap could resolve against an unrelated new frame.

- **Mid-search guard** (`_conclude`): a remap over the active map's own name during the multi-second Gemini round trip passed `live.map_name != snapshot.map_name`, and the matched id then resolved to whatever new frame had claimed it — exposing an unrelated pose as the recalled destination.
- **Cache guard** (`_usable_cache`): the same remap left the previous map's cache "usable", so the stale-cache delta could label a new-map frame as a *recapture* of a dead one until `warm()` rebuilt.

`MemorySnapshot` and `_CacheHandle` now carry the store's map fingerprint (the SHA-256 the store already computes for exactly this purpose), and both guards compare it. `revision` can't serve here — it bumps on every commit, not just wipes.

### Why this can't fire spuriously

`_fingerprint` changes in exactly one place: the `switch_map` block that also wipes the memories and resets ids. So a mismatch means a wipe *already happened* — precisely when frame ids stopped meaning anything. A transiently unreadable map file early-returns without touching it; a touched-but-byte-identical file re-hashes the same and keeps its memories. Ordinary mid-search mutations (a frame recorded, an eviction) leave the fingerprint alone and keep their existing behavior.

After a real remap the search falls back to inline frames of the new map — correct answers, slightly slower — `cache_state()` honestly reports cold, and `warm()` rebuilds as it already did. Switching maps A→B→A without remapping still reuses the cache.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - **222 brain_client tests pass** (2 new, in the CI-parity `fullbuild` image): a same-name remap mid-search voids the verdict; a same-name remap disqualifies the cache so the next search carries no `cachedContent`. The existing map-switch, eviction-mid-search, and touched-but-identical-file tests still pass unchanged.
  - `ruff check` + `ruff format --check` clean; `basedpyright` **0 errors** on `brain_client/memory/` and `brain_client/brain/`.
  - No `.msg`/`.srv`/action changes — pure Python inside `brain_client`, no type-hash rebuild coordination. `SearchVerdict`'s shape is unchanged, and the "map changed" error verdict it returns already existed, so the webapp, proxy, and skill SDK need nothing.
  - **Not driven live** — the sequence needs a remap over the active map's name mid-search, which is what the two regression tests construct.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — *No sim changes.*
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — *No asset changes.*

## Not addressed here

The third open Greptile comment — **"Recall coordinates outlive their map"** — is a separate design call: `SearchVerdict`/`verdict_text()` emit absolute `local_frame=false` coordinates with no map identity, so a verdict sitting in the agent's context survives a *user-initiated* map switch and would be read in the new frame on a later turn. Fixing it means deciding where cross-map verdicts get discarded (the agent's whole context survives map switches, not just this one hint). Left for a follow-up.
