### PR TITLE
fix(deps): name zenoh-cpp-vendor so the rmw can't outrun its own library

### DIFF
--- a/ros2_ws/apt-dependencies.common.txt
+++ b/ros2_ws/apt-dependencies.common.txt
@@ -51,6 +51,8 @@ ros-humble-rclcpp
 ros-humble-rclpy
 ros-humble-rclcpp-components
 ros-humble-rmw-zenoh-cpp
+# unversioned Depends of the rmw — unnamed, apt leaves libzenohc.so behind and every node dies at load
+ros-humble-zenoh-cpp-vendor
 ros-humble-launch-xml
 ros-humble-ament-cmake
 ros-humble-ament-cmake-python


### PR DESCRIPTION
## What broke

`innate update` on **mars-the-2nd** (2026-08-07 20:44) left the robot unable to start any ROS node. Every process died at dynamic-link time:

```
/opt/ros/humble/lib/librmw_zenoh_cpp.so: undefined symbol: z_reply_keyexpr_default
[ERROR] process has died [exit code 127]
```

`robot_state_publisher`, `bringup.py`, `rplidar_node`, `throttle` — i.e. everything, since they all load the rmw. The robot stayed down until `zenoh-cpp-vendor` was upgraded by hand.

## Root cause

`ros2_ws/apt-dependencies.common.txt:53` named `ros-humble-rmw-zenoh-cpp` but not `ros-humble-zenoh-cpp-vendor` — the package that ships `libzenohc.so`. `zenoh-cpp-vendor` appeared nowhere in the repo.

`post_update.sh` runs `apt-get install -y <that list>`. apt upgrades the packages you name and leaves unnamed transitive deps alone:

| Package | Before | After |
|---|---|---|
| `ros-humble-rmw-zenoh-cpp` | 0.1.8 | **0.1.9** (20260725) |
| `ros-humble-zenoh-cpp-vendor` | 0.1.8 | 0.1.8 (20260307, untouched) |

apt was within its rights — the dependency carries no version bound:

```
Depends: ..., ros-humble-zenoh-cpp-vendor      # no (>= 0.1.9)
```

so the installed 0.1.8 satisfied it. But rmw 0.1.9 resolves 8 symbols the 0.1.8 library doesn't export (`nm -D --defined-only libzenohc.so` → 0 matches), starting with `z_reply_keyexpr_default`.

## The fix

Name `ros-humble-zenoh-cpp-vendor` alongside the rmw in `common`. Once it's on the install line, apt moves both to candidate on every update and the pair can't skew again.

`common` is the right and only place: it covers the robot (`common + hardware`), the sim image (`common + sim`), and CI (`common` alone). No pin — nothing in these lists is pinned, and naming the package is what buys the lockstep.

## Notes for review

- The failure class is general: **any** explicitly-named ROS package whose deps are unversioned can skew this way on an update. This PR fixes the pair that took the robot down; it does not add a post-install ABI smoke check, which would be the systemic answer.
- Changing `common.txt` trips `ci/Dockerfile.test`'s `cmp` → reinstall path. Expected.

## Test plan

- [ ] CI test image rebuilds and integration tests pass (exercises `common` on a clean install).
- [ ] `innate update` on a robot already at rmw 0.1.9 / vendor 0.1.8 pulls vendor forward and nodes come up.