### PR TITLE
fix(skills): restore _send_feedback alias for pre-#542 workspace skills

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -1103,6 +1103,10 @@ class Skill(ABC):
             except Exception as e:
                 self.logger.error(f"Error sending feedback for skill {self.name}: {e}")
 
+    def _send_feedback(self, message: str, image_b64: str | None = None) -> None:
+        """Deprecated pre-#542 name for feedback(), kept for existing workspace skills."""
+        self.feedback(message, image_b64)
+
     def set_feedback_callback(self, callback: Callable[[str, str | None], None]) -> None:
         self._feedback_callback = callback
         self.logger.debug(f"Feedback callback set for skill {self.name}.")


### PR DESCRIPTION
## Problem

#542 renamed `Skill._send_feedback(message, image_b64)` to `feedback(message, image_b64)`. Workspace skills are user code living outside the repo, so any skill written before #542 still calls the old name and now crashes with `AttributeError` the first time it sends feedback.

## Fix

A thin deprecated alias on the `Skill` base class: `_send_feedback()` delegates to `feedback()`. Signatures are identical, so old skills work unchanged; new skills keep using `self.feedback()`.

## Verification

- `ruff check` and `ruff format --check` clean on `brain_client/`
- 222/222 brain_client tests pass
- basedpyright reports no errors in the touched file (13 pre-existing errors elsewhere from basedpyright 1.39.9 being newer than the last-pinned run — none related to this change)