### PR TITLE
feat(voice): swap speech-to-text to ElevenLabs Scribe, behind a backend switch

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -214,8 +214,16 @@
 # input_manager_node runs the realtime voice / transcription loop; its model settings
 # live here. The TTS voice is shared globally — set it once under /** above (it
 # reaches both nodes; .env CARTESIA_VOICE_ID is the default).
+# stt_backend picks the transcription service: "elevenlabs" (Scribe realtime) or
+# "openai" (Realtime transcription sessions). The vad knobs apply to both; the
+# model knob of the *other* backend is simply unused.
 # input_manager_node:
 #   ros__parameters:
+#     stt_backend: "elevenlabs"
+#     stt_language: "en"
+#     stt_vad_threshold: 0.3        # lower = more sensitive to speech
+#     stt_vad_silence_secs: 0.7     # silence that closes an utterance
+#     elevenlabs_stt_model: "scribe_v2_realtime"
 #     openai_realtime_model: "gpt-4o-realtime-preview"
 #     openai_transcribe_model: "gpt-4o-mini-transcribe"
 

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
@@ -44,11 +44,21 @@ class InputManagerNode(Node):
 
     def _init_proxy(self):
         # Credentials come from env (INNATE_PROXY_URL, INNATE_SERVICE_KEY); config from params.
+        self.declare_parameter("stt_backend", "elevenlabs")
+        self.declare_parameter("stt_language", "en")
+        self.declare_parameter("stt_vad_threshold", 0.3)
+        self.declare_parameter("stt_vad_silence_secs", 0.7)
+        self.declare_parameter("elevenlabs_stt_model", "scribe_v2_realtime")
         self.declare_parameter("openai_realtime_model", "gpt-4o-realtime-preview")
         self.declare_parameter("openai_realtime_url", "wss://api.openai.com/v1/realtime")
         self.declare_parameter("openai_transcribe_model", "gpt-4o-mini-transcribe")
         self.declare_parameter("cartesia_voice_id", "9fdaae0b-f885-4813-b589-3c07cf9d5fea")
         proxy_config = {
+            "stt_backend": self.get_parameter("stt_backend").value,
+            "stt_language": self.get_parameter("stt_language").value,
+            "stt_vad_threshold": self.get_parameter("stt_vad_threshold").value,
+            "stt_vad_silence_secs": self.get_parameter("stt_vad_silence_secs").value,
+            "elevenlabs_stt_model": self.get_parameter("elevenlabs_stt_model").value,
             "openai_realtime_model": self.get_parameter("openai_realtime_model").value,
             "openai_realtime_url": self.get_parameter("openai_realtime_url").value,
             "openai_transcribe_model": self.get_parameter("openai_transcribe_model").value,

--- a/ros2_ws/src/brain/brain_client/launch/input_manager.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/input_manager.launch.py
@@ -4,6 +4,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 from mars_bringup.config_loader import get_env, load_env_file, settings_params
 
 from brain_client.common.logging import get_logging_env_vars
@@ -19,6 +20,31 @@ def generate_launch_description():
     # --- Proxy service configuration ---
     # Credentials come from env vars (INNATE_PROXY_URL, INNATE_SERVICE_KEY)
     # These are service configs that can be overridden at launch
+    stt_backend_arg = DeclareLaunchArgument(
+        "stt_backend",
+        default_value="elevenlabs",
+        description="Realtime STT backend: elevenlabs | openai",
+    )
+    stt_language_arg = DeclareLaunchArgument(
+        "stt_language",
+        default_value="en",
+        description="Transcription language code",
+    )
+    stt_vad_threshold_arg = DeclareLaunchArgument(
+        "stt_vad_threshold",
+        default_value="0.3",
+        description="VAD speech-detection threshold (lower = more sensitive)",
+    )
+    stt_vad_silence_secs_arg = DeclareLaunchArgument(
+        "stt_vad_silence_secs",
+        default_value="0.7",
+        description="Silence needed to close an utterance, in seconds",
+    )
+    elevenlabs_stt_model_arg = DeclareLaunchArgument(
+        "elevenlabs_stt_model",
+        default_value="scribe_v2_realtime",
+        description="ElevenLabs Scribe realtime model",
+    )
     openai_realtime_model_arg = DeclareLaunchArgument(
         "openai_realtime_model",
         default_value="gpt-4o-realtime-preview",
@@ -44,6 +70,11 @@ def generate_launch_description():
     return LaunchDescription(
         env_vars
         + [
+            stt_backend_arg,
+            stt_language_arg,
+            stt_vad_threshold_arg,
+            stt_vad_silence_secs_arg,
+            elevenlabs_stt_model_arg,
             openai_realtime_model_arg,
             openai_realtime_url_arg,
             openai_transcribe_model_arg,
@@ -55,6 +86,15 @@ def generate_launch_description():
                 output="screen",
                 parameters=[
                     {
+                        "stt_backend": LaunchConfiguration("stt_backend"),
+                        "stt_language": LaunchConfiguration("stt_language"),
+                        # Substitutions resolve to strings; the node declares these
+                        # as doubles, so coerce or the node rejects the parameter.
+                        "stt_vad_threshold": ParameterValue(LaunchConfiguration("stt_vad_threshold"), value_type=float),
+                        "stt_vad_silence_secs": ParameterValue(
+                            LaunchConfiguration("stt_vad_silence_secs"), value_type=float
+                        ),
+                        "elevenlabs_stt_model": LaunchConfiguration("elevenlabs_stt_model"),
                         "openai_realtime_model": LaunchConfiguration("openai_realtime_model"),
                         "openai_realtime_url": LaunchConfiguration("openai_realtime_url"),
                         "openai_transcribe_model": LaunchConfiguration("openai_transcribe_model"),

--- a/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/__init__.py
+++ b/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/__init__.py
@@ -3,8 +3,8 @@
 """Innate proxy client library.
 
 Provides :class:`ProxyClient` for authenticated HTTP requests through the
-Innate service proxy, plus drop-in adapter classes for Cartesia TTS and
-OpenAI (Realtime WebSocket).
+Innate service proxy, plus drop-in adapter classes for Cartesia TTS,
+OpenAI (Realtime WebSocket) and ElevenLabs (Scribe realtime STT).
 
 Usage::
 
@@ -12,12 +12,15 @@ Usage::
 """
 
 from innate_proxy.adapters.cartesia import ProxyCartesiaClient
-from innate_proxy.adapters.openai import ProxyOpenAIClient, SyncRealtimeConnection
+from innate_proxy.adapters.elevenlabs import ProxyElevenLabsClient
+from innate_proxy.adapters.openai import ProxyOpenAIClient
 from innate_proxy.client import ProxyClient
+from innate_proxy.ws import SyncRealtimeConnection
 
 __all__: list[str] = [
     "ProxyClient",
     "ProxyCartesiaClient",
+    "ProxyElevenLabsClient",
     "ProxyOpenAIClient",
     "SyncRealtimeConnection",
 ]

--- a/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/adapters/elevenlabs.py
+++ b/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/adapters/elevenlabs.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
-"""OpenAI adapter for the Innate proxy client.
+"""ElevenLabs adapter for the Innate proxy client.
 
-Provides :class:`ProxyOpenAIClient` with a ``realtime`` WebSocket sub-API.
+Provides :class:`ProxyElevenLabsClient` with a ``realtime`` WebSocket
+sub-API for Scribe speech-to-text.
 
 The adapter expects a *parent* object that exposes:
 
@@ -14,10 +15,10 @@ construction time for WebSocket auth.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import urlencode
 
 from auth_client import AuthProvider
 
@@ -25,18 +26,15 @@ from innate_proxy.ws import SyncRealtimeConnection
 
 logger = logging.getLogger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Main adapter
-# ---------------------------------------------------------------------------
+REALTIME_ENDPOINT = "v1/speech-to-text/realtime"
 
 
-class ProxyOpenAIClient:
-    """OpenAI client that routes through the Innate service proxy.
+class ProxyElevenLabsClient:
+    """ElevenLabs client that routes through the Innate service proxy.
 
-    Provides a realtime WebSocket sub-API (async *and* sync).
-    Auth is delegated to :mod:`auth_client` — this adapter carries no
-    token / JWT logic of its own.
+    Unlike the OpenAI Realtime API, a Scribe session is configured entirely
+    through query parameters at connect time — there is no session.update
+    frame, so changing any of these means reconnecting.
     """
 
     def __init__(self, parent: Any, auth: AuthProvider | None = None) -> None:
@@ -51,45 +49,41 @@ class ProxyOpenAIClient:
     # -- Realtime -------------------------------------------------------------
 
     class Realtime:
-        def __init__(self, openai_client: ProxyOpenAIClient) -> None:
-            self._oc = openai_client
+        def __init__(self, elevenlabs_client: ProxyElevenLabsClient) -> None:
+            self._ec = elevenlabs_client
 
-        def _build_ws_url(self, model: str) -> str:
-            proxy_url = self._oc._get_proxy_url()
+        def _build_ws_url(self, params: dict[str, Any]) -> str:
+            proxy_url = self._ec._get_proxy_url()
             ws_url = proxy_url.replace("https://", "wss://").replace("http://", "ws://")
-            return f"{ws_url}/v1/services/openai/v1/realtime?model={model}"
-
-        async def connect(
-            self,
-            model: str = "gpt-4o-realtime-preview",
-            on_message: Callable | None = None,
-        ):
-            """Open an async WebSocket to the OpenAI Realtime API via proxy."""
-            ws_url = self._build_ws_url(model)
-            ws = await self._oc._auth.ws_connect(ws_url)
-
-            if on_message:
-
-                async def _handler() -> None:
-                    async for message in ws:
-                        await on_message(ws, message)
-
-                asyncio.create_task(_handler())
-
-            return ws
+            query = urlencode({k: v for k, v in params.items() if v is not None})
+            return f"{ws_url}/v1/services/elevenlabs/{REALTIME_ENDPOINT}?{query}"
 
         def connect_sync(
             self,
-            model: str = "gpt-4o-realtime-preview",
+            model_id: str = "scribe_v2_realtime",
+            audio_format: str = "pcm_24000",
+            language_code: str | None = None,
+            commit_strategy: str = "vad",
+            vad_threshold: float | None = None,
+            vad_silence_threshold_secs: float | None = None,
             on_message: Callable | None = None,
             on_open: Callable | None = None,
             on_error: Callable | None = None,
             on_close: Callable | None = None,
         ) -> SyncRealtimeConnection:
             """Return a :class:`SyncRealtimeConnection` (call ``.start()`` to connect)."""
-            ws_url = self._build_ws_url(model)
+            ws_url = self._build_ws_url(
+                {
+                    "model_id": model_id,
+                    "audio_format": audio_format,
+                    "language_code": language_code,
+                    "commit_strategy": commit_strategy,
+                    "vad_threshold": vad_threshold,
+                    "vad_silence_threshold_secs": vad_silence_threshold_secs,
+                }
+            )
             return SyncRealtimeConnection(
-                auth=self._oc._auth,
+                auth=self._ec._auth,
                 ws_url=ws_url,
                 on_message=on_message,
                 on_open=on_open,
@@ -106,7 +100,7 @@ class ProxyOpenAIClient:
     async def close(self) -> None:
         await self._parent.close_async()
 
-    async def __aenter__(self) -> ProxyOpenAIClient:
+    async def __aenter__(self) -> ProxyElevenLabsClient:
         return self
 
     async def __aexit__(self, *exc: Any) -> None:

--- a/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/client.py
+++ b/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/client.py
@@ -72,6 +72,7 @@ class ProxyClient:
         self._async_client: httpx.AsyncClient | None = None
         self._cartesia: Any = None
         self._openai: Any = None
+        self._elevenlabs: Any = None
 
     # -- Availability ---------------------------------------------------------
 
@@ -199,6 +200,15 @@ class ProxyClient:
 
             self._openai = ProxyOpenAIClient(self, auth=self._auth)
         return self._openai
+
+    @property
+    def elevenlabs(self) -> Any:
+        """Lazy ElevenLabs adapter (Scribe realtime STT)."""
+        if self._elevenlabs is None:
+            from innate_proxy.adapters.elevenlabs import ProxyElevenLabsClient
+
+            self._elevenlabs = ProxyElevenLabsClient(self, auth=self._auth)
+        return self._elevenlabs
 
     # -- Lifecycle ------------------------------------------------------------
 

--- a/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/ws.py
+++ b/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/ws.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Sync wrapper around an async proxy WebSocket.
+
+Shared by the realtime adapters (OpenAI Realtime, ElevenLabs Scribe) — the
+transport is identical, only the URL and the frame vocabulary differ.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from auth_client import AuthProvider
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# TODO: This adds indirection.  Long-term we want to make MicroInput
+#       fully async and drop this class entirely.
+# ---------------------------------------------------------------------------
+
+
+class SyncRealtimeConnection:
+    """Sync wrapper around an async WebSocket.
+
+    Presents the callback-based API expected by existing consumers::
+
+        conn = proxy.openai.realtime.connect_sync(
+            model=model,
+            on_message=my_handler,   # (ws, message_str)
+            on_open=on_open_cb,      # ()
+            on_error=on_error_cb,    # (error)
+            on_close=on_close_cb,    # ()
+        )
+        conn.start()                 # non-blocking, spawns background thread
+        conn.wait_until_connected()  # blocks
+        conn.send_json({...})
+        conn.stop()
+    """
+
+    def __init__(
+        self,
+        auth: AuthProvider,
+        ws_url: str,
+        on_message: Callable | None = None,
+        on_open: Callable | None = None,
+        on_error: Callable | None = None,
+        on_close: Callable | None = None,
+    ) -> None:
+        self._auth = auth
+        self._ws_url = ws_url
+        self._on_message = on_message
+        self._on_open = on_open
+        self._on_error = on_error
+        self._on_close = on_close
+
+        self._ws: Any = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._task: asyncio.Task | None = None
+        self._thread: threading.Thread | None = None
+        self._connected = threading.Event()
+        self._stopped = threading.Event()
+
+    # -- public API -----------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background event-loop thread and connect."""
+        self._loop = loop = asyncio.new_event_loop()
+
+        def _run() -> None:
+            # Bound locally: stop() nulls self._loop, possibly while this
+            # thread is still unwinding.
+            asyncio.set_event_loop(loop)
+            self._task = loop.create_task(self._run_ws())
+            try:
+                loop.run_until_complete(self._task)
+            except asyncio.CancelledError:
+                pass  # normal stop() path
+            finally:
+                loop.close()
+
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Close the websocket and stop the background loop."""
+        self._stopped.set()
+        # Cancel the task and let _run_ws unwind (closing the socket on the
+        # way out); stopping the loop out from under run_until_complete would
+        # raise "Event loop stopped before Future completed" in the thread.
+        if self._task and self._loop and not self._loop.is_closed():
+            try:
+                self._loop.call_soon_threadsafe(self._task.cancel)
+            except RuntimeError:
+                pass  # loop closed between the check and the call — already done
+        if self._thread:
+            self._thread.join(timeout=2.0)
+        self._loop = None
+        self._task = None
+        self._thread = None
+
+    def send_json(self, data: dict) -> None:
+        """Send a JSON payload (thread-safe)."""
+        if self._ws and self._loop and self._loop.is_running():
+            raw = json.dumps(data)
+            asyncio.run_coroutine_threadsafe(self._ws.send(raw), self._loop)
+
+    def wait_until_connected(self, timeout: float = 10) -> bool:
+        """Block until the websocket is open. Returns *True* on success."""
+        return self._connected.wait(timeout=timeout)
+
+    # -- internals ------------------------------------------------------------
+
+    async def _run_ws(self) -> None:
+        try:
+            self._ws = await self._auth.ws_connect(self._ws_url)
+            self._connected.set()
+            if self._on_open:
+                self._on_open()
+
+            async for message in self._ws:
+                if self._stopped.is_set():
+                    break
+                if self._on_message:
+                    self._on_message(self._ws, message)
+        except Exception as exc:
+            if self._on_error and not self._stopped.is_set():
+                self._on_error(exc)
+        finally:
+            self._connected.clear()
+            if self._ws is not None:
+                try:
+                    await self._ws.close()
+                except Exception:
+                    pass
+            if self._on_close and not self._stopped.is_set():
+                self._on_close()

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/config_loader.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/config_loader.py
@@ -191,6 +191,9 @@ _SETTINGS_DOUBLE_KEYS = frozenset(
         "idle_turn_interval",
         "supervision_turn_interval",
         "scan_stale_after_sec",
+        # input_manager_node
+        "stt_vad_threshold",
+        "stt_vad_silence_secs",
         # uninavid_node
         "forward_speed",
         "turn_speed",

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -83,6 +83,11 @@ const VOICE_OPTIONS = [
   { value: "79f8b5fb-2cc8-479a-80df-29f7a7cf1a3e", label: "Nonfiction Man" },
 ];
 
+const STT_BACKEND_OPTIONS = [
+  { value: "elevenlabs", label: "ElevenLabs Scribe" },
+  { value: "openai", label: "OpenAI Realtime" },
+];
+
 /** @type {SettingsPage[]} */
 export const SETTINGS_PAGES = [
   {
@@ -282,11 +287,16 @@ export const SETTINGS_PAGES = [
       },
       {
         title: "AI models",
-        note: "The brain and the realtime-voice path use separate models. Keep the realtime-voice pair in sync.",
+        note: "The brain and the speech-to-text path use separate models. The transcribe backend picks which STT model knob applies.",
         knobs: [
           { path: ["brain_client_node", P, "gemini_model"], label: "Brain model", default: "gemini-3.6-flash", type: "string", doc: "Gemini model powering the local brain", subsection: "Brain" },
-          { path: ["input_manager_node", P, "openai_realtime_model"], label: "Realtime model", default: "gpt-4o-realtime-preview", type: "string", doc: "OpenAI realtime model", subsection: "Realtime voice" },
-          { path: ["input_manager_node", P, "openai_transcribe_model"], label: "Transcribe model", default: "gpt-4o-mini-transcribe", type: "string", doc: "OpenAI transcription model", subsection: "Realtime voice" },
+          { path: ["input_manager_node", P, "stt_backend"], label: "Transcribe backend", default: "elevenlabs", type: "string", options: STT_BACKEND_OPTIONS, doc: "Which service transcribes the microphone", subsection: "Speech to text" },
+          { path: ["input_manager_node", P, "elevenlabs_stt_model"], label: "Scribe model", default: "scribe_v2_realtime", type: "string", doc: "ElevenLabs realtime STT model", subsection: "Speech to text" },
+          { path: ["input_manager_node", P, "stt_language"], label: "Language", default: "en", type: "string", doc: "Transcription language code", subsection: "Speech to text" },
+          { path: ["input_manager_node", P, "stt_vad_threshold"], label: "VAD threshold", default: 0.3, type: "float", doc: "Lower is more sensitive to speech", subsection: "Speech to text" },
+          { path: ["input_manager_node", P, "stt_vad_silence_secs"], label: "Silence to end turn", default: 0.7, type: "float", unit: "s", doc: "Silence that closes an utterance", subsection: "Speech to text" },
+          { path: ["input_manager_node", P, "openai_realtime_model"], label: "Realtime model", default: "gpt-4o-realtime-preview", type: "string", doc: "OpenAI realtime model (openai backend only)", subsection: "Realtime voice" },
+          { path: ["input_manager_node", P, "openai_transcribe_model"], label: "Transcribe model", default: "gpt-4o-mini-transcribe", type: "string", doc: "OpenAI transcription model (openai backend only)", subsection: "Realtime voice" },
         ],
       },
       {

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -38,6 +38,8 @@ CHUNK_DURATION_SEC = 0.02
 # transcript comes out time-warped.
 ELEVENLABS_AUDIO_FORMAT = f"pcm_{DEFAULT_SAMPLE_RATE}"
 
+STT_BACKENDS = frozenset({"elevenlabs", "openai"})
+
 ELEVENLABS_ERROR_TYPES = frozenset(
     {
         "error",
@@ -256,7 +258,13 @@ class MicroInput(InputDevice):
 
     def _connect_via_proxy(self):
         """Connect to the configured STT backend via proxy."""
-        self._backend = str(self.proxy.config.get("stt_backend") or "elevenlabs").lower()
+        backend = str(self.proxy.config.get("stt_backend") or "elevenlabs").strip().lower()
+        if backend not in STT_BACKENDS:
+            self.logger.error(
+                f"❌ Unknown stt_backend {backend!r} — using 'elevenlabs' (options: {sorted(STT_BACKENDS)})"
+            )
+            backend = "elevenlabs"
+        self._backend = backend
 
         if self._backend == "openai":
             model = self._connect_openai()

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -4,8 +4,17 @@
 """
 Microphone Input Device
 
-Connects to microphone hardware and OpenAI's realtime API to get voice transcripts.
-This is a pure Python class with NO ROS dependencies.
+Connects to microphone hardware and a realtime speech-to-text backend to get
+voice transcripts. This is a pure Python class with NO ROS dependencies.
+
+Two backends, selected by the ``stt_backend`` setting:
+
+- ``elevenlabs`` — ElevenLabs Scribe realtime (default)
+- ``openai``     — OpenAI Realtime transcription sessions
+
+They differ in how a session is configured (query string vs. a session.update
+frame), in the audio frame shape, and in the transcript event names; the
+microphone, ducking, and reconnect machinery is shared.
 
 Uses proxy services via self.proxy (injected by InputManager).
 """
@@ -25,12 +34,33 @@ DEFAULT_SAMPLE_RATE = 24_000
 DEFAULT_CHANNELS = 1
 CHUNK_DURATION_SEC = 0.02
 
+# ElevenLabs names the wire format after the rate; the two must agree or the
+# transcript comes out time-warped.
+ELEVENLABS_AUDIO_FORMAT = f"pcm_{DEFAULT_SAMPLE_RATE}"
+
+ELEVENLABS_ERROR_TYPES = frozenset(
+    {
+        "error",
+        "auth_error",
+        "quota_exceeded",
+        "commit_throttled",
+        "unaccepted_terms",
+        "rate_limited",
+        "queue_overflow",
+        "resource_exhausted",
+        "session_time_limit_exceeded",
+        "input_error",
+        "chunk_size_exceeded",
+        "transcriber_error",
+    }
+)
+
 
 class MicroInput(InputDevice):
     """
     Microphone input device.
 
-    Connects to OpenAI Realtime API via proxy (self.proxy.openai.realtime).
+    Connects to a realtime STT backend via proxy (self.proxy.<backend>.realtime).
     Config comes from self.proxy.config (set by InputManagerNode).
 
     Supports "ducking" - suppresses audio while robot is speaking.
@@ -41,6 +71,7 @@ class MicroInput(InputDevice):
         super().__init__()
         self.mic = None
         self.client = None
+        self._backend = "elevenlabs"
         self._stop_evt = threading.Event()
         self._audio_thread = None
         self._is_robot_talking = False  # For ducking (mic-specific)
@@ -73,7 +104,7 @@ class MicroInput(InputDevice):
         self._is_robot_talking = is_playing
 
     def on_open(self):
-        """Start microphone and connect to OpenAI via proxy."""
+        """Start microphone and connect to the STT backend via proxy."""
         # Check proxy is available
         if not self.proxy or not self.proxy.is_available():
             self.logger.error("❌ Proxy not configured - cannot start microphone input")
@@ -105,6 +136,35 @@ class MicroInput(InputDevice):
             import traceback
 
             traceback.print_exc()
+
+    def _on_elevenlabs_message(self, ws, message: str):
+        """Handle incoming messages from the ElevenLabs Scribe realtime API."""
+        try:
+            event = json.loads(message)
+        except Exception:
+            self.logger.error(f"Failed to parse message: {message[:200]}")
+            return
+
+        etype = event.get("message_type")
+
+        if etype == "committed_transcript":
+            text = event.get("text", "")
+            if text and self.is_active():
+                self._on_transcript(text)
+        elif etype == "partial_transcript":
+            pass  # interim result — only the committed transcript reaches chat
+        elif etype == "session_started":
+            self.logger.info(f"📋 Scribe session started: {event.get('config', {})}")
+        elif etype == "insufficient_audio_activity":
+            pass  # expected whenever the room is quiet — not worth a log line
+        elif etype in ELEVENLABS_ERROR_TYPES:
+            self.logger.error(f"❌ ElevenLabs error ({etype}): {event.get('message', event)}")
+        else:
+            self.logger.info(f"📨 ElevenLabs event: {etype}")
+
+    def _on_elevenlabs_open(self):
+        """Scribe takes its whole session config in the connect URL — nothing to send."""
+        self.logger.info("📤 WebSocket opened (Scribe session configured via query params)")
 
     def _on_openai_message(self, ws, message: str):
         """Handle incoming messages from OpenAI Realtime API."""
@@ -170,11 +230,11 @@ class MicroInput(InputDevice):
         self.client.send_json(session_update)
         self.logger.info("📤 session.update sent")
 
-    def _on_openai_error(self, error):
+    def _on_ws_error(self, error):
         """Handle WebSocket error event."""
         self.logger.error(f"[ws error] {error}")
 
-    def _on_openai_close(self):
+    def _on_ws_close(self):
         """Handle WebSocket close event - trigger reconnection."""
         self.logger.warning("WebSocket closed")
         self._is_connected = False
@@ -187,20 +247,14 @@ class MicroInput(InputDevice):
         self._schedule_reconnect()
 
     def _connect_via_proxy(self):
-        """Connect to OpenAI Realtime API via proxy."""
-        self.logger.info("🔗 Connecting to OpenAI via proxy...")
+        """Connect to the configured STT backend via proxy."""
+        self._backend = str(self.proxy.config.get("stt_backend") or "elevenlabs").lower()
 
-        # Get config from proxy (injected by InputManager)
-        model = self.proxy.config.get("openai_realtime_model", "gpt-4o-realtime-preview")
+        if self._backend == "openai":
+            model = self._connect_openai()
+        else:
+            model = self._connect_elevenlabs()
 
-        # Use proxy's OpenAI adapter
-        self.client = self.proxy.openai.realtime.connect_sync(
-            model=model,
-            on_message=self._on_openai_message,
-            on_open=self._on_openai_open,
-            on_error=self._on_openai_error,
-            on_close=self._on_openai_close,
-        )
         self.client.start()
 
         # Start audio streaming thread
@@ -208,7 +262,49 @@ class MicroInput(InputDevice):
 
         self._is_connected = True
         self._reconnect_delay = 1  # Reset delay on successful connection
-        self.logger.info(f"✅ Connected to OpenAI Realtime (model: {model})")
+        self.logger.info(f"✅ Connected to {self._backend} STT (model: {model})")
+
+    def _connect_elevenlabs(self) -> str:
+        """Open a Scribe realtime session. Returns the model id."""
+        self.logger.info("🔗 Connecting to ElevenLabs Scribe via proxy...")
+
+        cfg = self.proxy.config
+        model = cfg.get("elevenlabs_stt_model", "scribe_v2_realtime")
+        vad_threshold = float(cfg.get("stt_vad_threshold", 0.3))
+        silence_secs = float(cfg.get("stt_vad_silence_secs", 0.7))
+
+        self.logger.info(
+            f"📤 Scribe config: model={model}, audio_format={ELEVENLABS_AUDIO_FORMAT}, "
+            f"vad_threshold={vad_threshold}, silence={silence_secs}s"
+        )
+        self.client = self.proxy.elevenlabs.realtime.connect_sync(
+            model_id=model,
+            audio_format=ELEVENLABS_AUDIO_FORMAT,
+            language_code=cfg.get("stt_language", "en"),
+            commit_strategy="vad",
+            vad_threshold=vad_threshold,
+            vad_silence_threshold_secs=silence_secs,
+            on_message=self._on_elevenlabs_message,
+            on_open=self._on_elevenlabs_open,
+            on_error=self._on_ws_error,
+            on_close=self._on_ws_close,
+        )
+        return model
+
+    def _connect_openai(self) -> str:
+        """Open an OpenAI Realtime transcription session. Returns the model id."""
+        self.logger.info("🔗 Connecting to OpenAI via proxy...")
+
+        model = self.proxy.config.get("openai_realtime_model", "gpt-4o-realtime-preview")
+
+        self.client = self.proxy.openai.realtime.connect_sync(
+            model=model,
+            on_message=self._on_openai_message,
+            on_open=self._on_openai_open,
+            on_error=self._on_ws_error,
+            on_close=self._on_ws_close,
+        )
+        return model
 
     def _schedule_reconnect(self):
         """Schedule a reconnection attempt in a background thread."""
@@ -253,6 +349,13 @@ class MicroInput(InputDevice):
         self._reconnect_thread = threading.Thread(target=reconnect_loop, daemon=True)
         self._reconnect_thread.start()
 
+    def _audio_frame(self, chunk: bytes) -> dict:
+        """Wrap a raw PCM chunk in the backend's audio-append frame."""
+        audio = base64.b64encode(chunk).decode("ascii")
+        if self._backend == "openai":
+            return {"type": "input_audio_buffer.append", "audio": audio}
+        return {"message_type": "input_audio_chunk", "audio_base_64": audio}
+
     def _start_audio_thread(self):
         """Start the audio streaming thread."""
         self._stop_evt.clear()
@@ -290,11 +393,7 @@ class MicroInput(InputDevice):
                         continue
                     ducking_logged = False
 
-                    payload = {
-                        "type": "input_audio_buffer.append",
-                        "audio": base64.b64encode(chunk).decode("ascii"),
-                    }
-                    self.client.send_json(payload)
+                    self.client.send_json(self._audio_frame(chunk))
                     chunks_sent += 1
 
                     # Log periodically (much less frequently)

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -158,7 +158,7 @@ class MicroInput(InputDevice):
         elif etype == "insufficient_audio_activity":
             pass  # expected whenever the room is quiet — not worth a log line
         elif etype in ELEVENLABS_ERROR_TYPES:
-            self.logger.error(f"❌ ElevenLabs error ({etype}): {event.get('message', event)}")
+            self.logger.error(f"❌ ElevenLabs error ({etype}): {event.get('error', event)}")
         else:
             self.logger.info(f"📨 ElevenLabs event: {etype}")
 
@@ -207,23 +207,26 @@ class MicroInput(InputDevice):
 
     def _on_openai_open(self):
         """Handle WebSocket open event - send session configuration."""
-        transcribe_model = self.proxy.config.get("openai_transcribe_model", "gpt-4o-mini-transcribe")
-        vad_threshold = 0.3  # Lower = more sensitive to speech
+        cfg = self.proxy.config
+        transcribe_model = cfg.get("openai_transcribe_model", "gpt-4o-mini-transcribe")
+        language = self._stt_language()
+        vad_threshold = float(cfg.get("stt_vad_threshold", 0.3))
+        silence_secs = float(cfg.get("stt_vad_silence_secs", 0.7))
 
         self.logger.info("📤 WebSocket opened, sending session.update...")
         session_update = {
             "type": "session.update",
             "session": {
                 "input_audio_format": "pcm16",
-                "input_audio_transcription": {"model": transcribe_model, "language": "en"},
+                "input_audio_transcription": {"model": transcribe_model, "language": language},
                 "turn_detection": {
                     "type": "server_vad",
-                    "threshold": float(vad_threshold),
+                    "threshold": vad_threshold,
                     "prefix_padding_ms": 300,
-                    "silence_duration_ms": 700,
+                    "silence_duration_ms": int(silence_secs * 1000),
                     "create_response": False,
                 },
-                "instructions": "Transcribe user audio only in English; do not reply.",
+                "instructions": "Transcribe user audio only; do not reply.",
             },
         }
         self.logger.info(f"📤 Session config: model={transcribe_model}, vad_threshold={vad_threshold}")
@@ -245,6 +248,11 @@ class MicroInput(InputDevice):
 
         # Start reconnection in background thread
         self._schedule_reconnect()
+
+    def _stt_language(self) -> str:
+        # `or` (not a .get default): a blank setting must fall back too, or it
+        # reaches the wire as an empty language code and the session is refused.
+        return str(self.proxy.config.get("stt_language") or "en")
 
     def _connect_via_proxy(self):
         """Connect to the configured STT backend via proxy."""
@@ -280,7 +288,7 @@ class MicroInput(InputDevice):
         self.client = self.proxy.elevenlabs.realtime.connect_sync(
             model_id=model,
             audio_format=ELEVENLABS_AUDIO_FORMAT,
-            language_code=cfg.get("stt_language", "en"),
+            language_code=self._stt_language(),
             commit_strategy="vad",
             vad_threshold=vad_threshold,
             vad_silence_threshold_secs=silence_secs,
@@ -313,7 +321,7 @@ class MicroInput(InputDevice):
 
         def reconnect_loop():
             while not self._stop_evt.is_set() and not self._is_connected:
-                self.logger.info(f"🔄 Reconnecting to OpenAI in {self._reconnect_delay}s...")
+                self.logger.info(f"🔄 Reconnecting to {self._backend} STT in {self._reconnect_delay}s...")
 
                 # Wait before reconnecting (interruptible)
                 if self._stop_evt.wait(timeout=self._reconnect_delay):


### PR DESCRIPTION
Replaces OpenAI Realtime transcription with ElevenLabs Scribe v2 Realtime as the robot's speech-to-text, keeping the OpenAI path intact behind an `stt_backend` switch.

Needs innate-inc/innate-cloud#82 (the proxy-side ElevenLabs adapter) **deployed with `ELEVENLABS_API_KEY` populated before this lands on robots** — the default here is `elevenlabs`, and without the key upstream the mic socket closes with 1011 and voice goes quiet. To stage it, set `stt_backend: "openai"` in `settings.yaml` and flip per-robot from the settings UI.

## Approach

Both backends are kept and selected at connect time rather than ripping OpenAI out, so a robot can be flipped back without a redeploy and the two can be compared on real hardware. Once Scribe wins, the OpenAI branch can go.

They differ in exactly three places — session setup (query string vs. a `session.update` frame), the audio frame shape, and the transcript event names. The microphone, ducking, reconnect and device detection are untouched and shared.

- `innate_proxy/ws.py` — `SyncRealtimeConnection` lifted out of the OpenAI adapter; the transport is identical for both. New `adapters/elevenlabs.py` + `ProxyClient.elevenlabs`.
- `workspace/inputs/micro_input.py` — the backend switch.
- Config plumbed through `input_manager.py`, `input_manager.launch.py`, `settings.yaml.template`, and a new **Speech to text** settings group with a backend dropdown.

Two things fall out nicely: the mic already produces 24 kHz PCM16 mono, which is `pcm_24000` on the wire, so nothing resamples; and the existing VAD tuning carries over directly (threshold `0.3`, and the 700 ms silence window becomes `vad_silence_threshold_secs: 0.7`).

Only `committed_transcript` reaches chat — partials are interim and would double-post.

## Verification

- `ruff check` / `ruff format --check` clean; `pre-commit -c .config/pre-commit-config.yaml` all green. Its drift guard caught a real bug: float tunables must be in `config_loader._SETTINGS_DOUBLE_KEYS` or `stt_vad_threshold: 1` would fail at node startup with an opaque `InvalidParameterTypeException`. Added.
- brain_client tests: **208 passed, 1 failed — byte-identical to the stashed baseline** on this branch. The failure and the 2 collection errors are the test image's stale `mars_msgs`/`brain_messages`, not this change.
- basedpyright: zero real errors in the file this touches (everything else reported is `reportMissingImports` from running outside the ROS env).
- Offline wire check: connect URL and query params, both backends' audio frames, one-chat-message-per-utterance across a partial/partial/commit sequence, empty and malformed frames handled.
- Relay verified end-to-end against a fake upstream in innate-inc/innate-cloud#82.

## Not yet verified — needs hardware

- Chat posts on `committed_transcript`. The API also lists `final_transcript`; the official SDK treats committed as the definitive one, so that's what I went with. If transcripts never arrive, the unknown-event log line names what actually came instead, and it's a one-line fix.
- Scribe's VAD may trip on chassis/fan noise — ducking only suppresses the mic during TTS, not the robot's own motors.
- End-to-end latency to first committed transcript vs. the current OpenAI path, and per-minute cost vs. `gpt-4o-mini-transcribe`, are both worth measuring before a fleet-wide rollout.