### PR TITLE
feat(brain): expose navigation map images to local agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,17 @@ class NavigateAgent(Agent):
 
     def get_prompt(self):
         return "You are a helpful robot. When asked, navigate to the requested location using the navigate_to_position skill."
+
+    def uses_map(self):
+        return True
 ```
+
+Override `uses_map()` to include the latest navigation occupancy map in every
+local-brain turn. The brain reads the latched `nav_msgs/OccupancyGrid` on
+`/map`, renders it as a labeled JPEG, and keeps only the current map in model
+history. If no valid map is available (including map-free mode's placeholder),
+the turn continues without a map image. Agents that do not override
+`uses_map()` keep the default `False` behavior.
 
 ### Testing agents in sim
 

--- a/ros2_ws/src/brain/brain_client/brain_client/README.md
+++ b/ros2_ws/src/brain/brain_client/brain_client/README.md
@@ -8,7 +8,7 @@ code, start from what it *does*:
 | `nodes/` | The runnable ROS entry points (the only files with `main()`). Thin composition roots — they build collaborators, wire them, and spin. No behaviour. |
 | `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached) + `search_server` (the `/brain/search_memory` action skills call), and the system `prompt`. |
 | `core/` | The activate/deactivate/reset state machine and directive switching (`lifecycle`), typed `config`, and the shared `state`. |
-| `perception/` | Turning sensors into what the agent sees: `camera`, `pose`/`pose_tracking`, `scan_health`, `gaze`. |
+| `perception/` | Turning sensors into what the agent sees: `camera`, `map_image`/`map_capture`, `pose`/`pose_tracking`, `scan_health`, `gaze`. |
 | `memory/` | Persistent per-map spatial memory: `store` (JSON index + JPEGs on disk), pure `selection` (which viewpoints earn a slot), `recorder` (the always-on ROS adapter that captures them). |
 | `skills/` | The skill system: `registry`, `roster` (available + directive-active sets), `runner` (action lifecycle), `loader`, `hot_reload`, and the public `types` SDK base classes. |
 | `agents/` | Directives/behaviours: `loader`, `initializer`, and the public `types` SDK base class. |

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
@@ -73,7 +73,7 @@ def build_agent_instances(
     """Instantiate discovered agent classes; returns ``(agents by id, broken)``.
 
     Construction probes every surface the brain reads later (id, display
-    name, prompt, skill and input refs, gaze flag, icon) so a bad agent fails here — as
+    name, prompt, skill and input refs, perception flags, icon) so a bad agent fails here — as
     a broken roster entry with its error — rather than inside the directives
     service or at activation, where one bad agent would take the whole
     response down.
@@ -90,6 +90,7 @@ def build_agent_instances(
             agent.get_prompt()
             agent.input_names()
             agent.uses_gaze()
+            agent.uses_map()
             skill_ids = agent.skill_ids()
         except Exception as e:  # noqa: BLE001 — one bad agent must not stop the roster
             name = class_name_to_snake_case(cls.__name__)

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
@@ -190,3 +190,8 @@ class Agent(ABC):
         Default: False.
         """
         return False
+
+    def uses_map(self) -> bool:
+        """Whether each local-brain turn includes the latest navigation map
+        as an image. Subclasses can opt in; the default is False."""
+        return False

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from brain_client.core.state import BrainState, RunningSkill
     from brain_client.perception.camera import CameraCapture
     from brain_client.perception.gaze_control import GazeController
+    from brain_client.perception.map_capture import MapCapture
     from brain_client.perception.pose import Pose
     from brain_client.perception.pose_tracking import PoseTracker
     from brain_client.perception.scan_health import ScanHealthMonitor
@@ -82,6 +83,7 @@ class BrainAgent:
         config: BrainConfig,
         *,
         camera: CameraCapture,
+        map_capture: MapCapture,
         pose_tracker: PoseTracker,
         runner: PrimitiveRunner,
         roster: SkillRoster,
@@ -95,6 +97,7 @@ class BrainAgent:
         self._state = state
         self._config = config
         self._camera = camera
+        self._map = map_capture
         self._pose = pose_tracker
         self._runner = runner
         self._roster = roster
@@ -273,6 +276,7 @@ class BrainAgent:
         if self._frame_at_capture is None:
             return  # the feed died between the loop's freshness check and the look
         wrist_frames = [i for i, (label, _) in enumerate(frames) if label == FrameLabel.WRIST]
+        map_frames = [i for i, (label, _) in enumerate(frames) if label == FrameLabel.MAP]
         message = GeminiContext.user_message(text, [jpeg for _, jpeg in frames])
         tools = self._build_tools(events)
         directive = self._state.current_directive
@@ -281,7 +285,7 @@ class BrainAgent:
             self._logger.info(f"[Brain] Turn input:\n{text}")
         self._trace_turn_start(text, frames, tools, system, context)
 
-        response = await self._generate(context, message, tools, system, speaker, wrist_frames)
+        response = await self._generate(context, message, tools, system, speaker, wrist_frames, map_frames)
         latency = self._elapsed()
         self._report_recovered()
         if not self._state.is_brain_active:
@@ -289,7 +293,12 @@ class BrainAgent:
             self._trace(TraceEvent.TURN_DROPPED, turn=self._turn_count, latency=latency)
             return
 
-        decision = context.absorb(message, response, latest_only_images=wrist_frames)
+        decision = context.absorb(
+            message,
+            response,
+            latest_only_images=wrist_frames,
+            current_map_images=map_frames,
+        )
         del self._events[: len(events)]
         events.clear()  # committed: a failure below backs off against an empty peek
         outcomes = self._act(decision, speaker, context)
@@ -312,13 +321,20 @@ class BrainAgent:
         system: str,
         speaker: SpeechStreamer,
         wrist_frames: list[int],
+        map_frames: list[int],
     ) -> dict:
         """The only blocking call, on a worker thread. Cancellation unwinds HERE —
         the orphaned HTTP call finishes and its result is dropped."""
         self._turn_in_flight = True
         try:
             return await asyncio.to_thread(
-                context.generate, message, tools, system, speaker.feed, latest_only_images=wrist_frames
+                context.generate,
+                message,
+                tools,
+                system,
+                speaker.feed,
+                latest_only_images=wrist_frames,
+                current_map_images=map_frames,
             )
         finally:
             self._turn_in_flight = False
@@ -410,6 +426,11 @@ class BrainAgent:
             frames.append((FrameLabel.WRIST, arm_jpeg))
         frames += [(FrameLabel.EVENT, event.image) for event in events if event.image][-_MAX_EVENT_IMAGES:]
 
+        directive = self._state.current_directive
+        map_image = self._map.latest_image() if directive is not None and directive.uses_map() else None
+        if map_image is not None:
+            frames.append((FrameLabel.MAP, map_image.jpeg))
+
         running = self._state.primitive_running
         text = observation_text(
             uptime_s=int(time.monotonic() - self._activated_at),
@@ -418,6 +439,7 @@ class BrainAgent:
             guidance=self._running_guidance(running),
             events=events,
             has_wrist_frame=arm_jpeg is not None,
+            map_note=map_image.observation_note(len(frames)) if map_image is not None else None,
         )
         return text, frames
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/context.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/context.py
@@ -27,6 +27,7 @@ from brain_client.brain.transport import Transport
 
 _FRAME_REMOVED = {"text": "[older camera frame removed]"}
 _WRIST_FRAME_REMOVED = {"text": "[older wrist camera frame removed]"}
+_MAP_FRAME_REMOVED = {"text": "[older navigation map removed]"}
 
 
 @dataclass
@@ -60,6 +61,9 @@ class GeminiContext:
         # The one history turn still carrying latest-only frames (wrist camera),
         # as (content, part indexes) — absorbing a newer set prunes these.
         self._latest_only_turn: tuple[dict, list[int]] | None = None
+        # Unlike the wrist camera, a navigation map is only meaningful for the
+        # current turn. An empty current-map set also retires the previous one.
+        self._current_map_turn: tuple[dict, list[int]] | None = None
         # Observability tap: called with the exact request body just before it
         # goes on the wire (from generate's thread). The body must be treated
         # as read-only — it shares structure with the live history.
@@ -68,6 +72,7 @@ class GeminiContext:
     def clear(self) -> None:
         self._history = []
         self._latest_only_turn = None
+        self._current_map_turn = None
 
     @property
     def history_len(self) -> int:
@@ -95,6 +100,7 @@ class GeminiContext:
         on_speech: Callable[[str], None] | None = None,
         *,
         latest_only_images: list[int] | None = None,
+        current_map_images: list[int] | None = None,
     ) -> dict:
         """Blocking network call — safe on a worker thread (history is only read).
 
@@ -108,18 +114,27 @@ class GeminiContext:
         without this every request would ship two wrist frames. History is
         masked via shallow copies, never mutated (an abandoned turn's orphaned
         request may still be reading it).
+
+        ``current_map_images`` differs intentionally: passing an empty list
+        also masks the prior map, because a map is only valid for the current
+        turn and must disappear when an agent opts out or no map is available.
         """
         contents = [*self._history, user_message]
+        masks: list[tuple[dict, list[int], dict[str, str]]] = []
         if latest_only_images and self._latest_only_turn is not None:
             stale, indexes = self._latest_only_turn
-            masked = {
-                **stale,
-                "parts": [
-                    dict(_WRIST_FRAME_REMOVED) if i in indexes and "inlineData" in p else p
-                    for i, p in enumerate(stale["parts"])
-                ],
-            }
-            contents = [masked if content is stale else content for content in contents]
+            masks.append((stale, indexes, _WRIST_FRAME_REMOVED))
+        if current_map_images is not None and self._current_map_turn is not None:
+            stale, indexes = self._current_map_turn
+            masks.append((stale, indexes, _MAP_FRAME_REMOVED))
+        for content_index, content in enumerate(contents):
+            content_masks = [(indexes, replacement) for stale, indexes, replacement in masks if content is stale]
+            if not content_masks:
+                continue
+            parts = list(content["parts"])
+            for indexes, replacement in content_masks:
+                parts = [dict(replacement) if i in indexes and "inlineData" in p else p for i, p in enumerate(parts)]
+            contents[content_index] = {**content, "parts": parts}
         thinking: dict = {"includeThoughts": True}
         if self._thinking_level:
             thinking["thinkingLevel"] = self._thinking_level
@@ -149,7 +164,14 @@ class GeminiContext:
             raise RuntimeError(f"gemini returned no content: {_empty_stream_reason(last_chunk)}")
         return {"candidates": [{"content": {"role": "model", "parts": _merged(parts)}}]}
 
-    def absorb(self, user_message: dict, response: dict, *, latest_only_images: list[int] | None = None) -> Decision:
+    def absorb(
+        self,
+        user_message: dict,
+        response: dict,
+        *,
+        latest_only_images: list[int] | None = None,
+        current_map_images: list[int] | None = None,
+    ) -> Decision:
         """Commit the exchange to history and distill the model's Decision.
 
         Thought-summary parts are dropped from the stored model turn (they are
@@ -161,6 +183,9 @@ class GeminiContext:
         newest turn — the wrist camera: a stale gripper close-up reads as
         current grasp state and misleads the model, so absorbing a new one
         prunes the previous turn's copy on the spot.
+
+        ``current_map_images`` names the current navigation map positions. A
+        supplied empty list permanently retires the previous map.
         """
         decision = _decision_from(response)
         self._history.append(user_message)
@@ -175,6 +200,19 @@ class GeminiContext:
             self._latest_only_turn = (
                 user_message,
                 [image_parts[i] for i in latest_only_images if i < len(image_parts)],
+            )
+        if current_map_images is not None:
+            if self._current_map_turn is not None:
+                content, indexes = self._current_map_turn
+                content["parts"] = [
+                    dict(_MAP_FRAME_REMOVED) if i in indexes and "inlineData" in p else p
+                    for i, p in enumerate(content["parts"])
+                ]
+            image_parts = [i for i, p in enumerate(user_message["parts"]) if "inlineData" in p]
+            self._current_map_turn = (
+                (user_message, [image_parts[i] for i in current_map_images if i < len(image_parts)])
+                if current_map_images
+                else None
             )
         model_content = _model_content(response)
         if model_content is not None:
@@ -210,6 +248,8 @@ class GeminiContext:
         # keep its base64 wrist frame alive for as long as the arm feed is stale.
         if self._latest_only_turn is not None and not any(c is self._latest_only_turn[0] for c in history):
             self._latest_only_turn = None
+        if self._current_map_turn is not None and not any(c is self._current_map_turn[0] for c in history):
+            self._current_map_turn = None
         # Keep camera frames only in the newest few user turns (none at all if
         # the configured keep-count is zero or nonsensical).
         keep = max(self._max_image_turns, 0)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
@@ -6,8 +6,8 @@ _SYSTEM_PROMPT = """\
 You are the brain of an Innate home robot: a small wheeled base with a camera, a robotic arm, \
 and a speaker. You run on the robot itself.
 
-Each update you receive contains the latest camera frame, the robot's state, and any new events \
-(user speech, skill results, sensor input). You act by calling tools — the robot's skills. \
+Each update you receive contains the latest camera frame, the robot's state, any navigation map \
+the active agent requested, and any new events (user speech, skill results, sensor input). You act by calling tools — the robot's skills. \
 Anything you write as plain text is spoken aloud through the robot's speaker and shown in the \
 app chat.
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
@@ -36,6 +36,7 @@ class FrameLabel(StrEnum):
     HEAD = "head camera"
     WRIST = "wrist camera"
     EVENT = "event image"
+    MAP = "navigation map"
 
 
 Frame = tuple[FrameLabel, bytes]
@@ -64,6 +65,7 @@ def observation_text(
     guidance: str,
     events: list[Event],
     has_wrist_frame: bool,
+    map_note: str | None,
 ) -> str:
     """The text half of a turn input: robot status, guidance, and new events."""
     status = f"[t+{uptime_s}s]"
@@ -77,6 +79,8 @@ def observation_text(
     lines += [f"- {event.text}" for event in events]
     if has_wrist_frame:
         lines.append("(second image is the arm wrist camera)")
+    if map_note:
+        lines.append(map_note)
     return "\n".join(lines)
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -25,6 +25,7 @@ class BrainConfig:
     odom_topic: str
     current_nav_mode_topic: str
     current_map_topic: str
+    agent_map_topic: str
     amcl_pose_topic: str
     scan_topic: str
 
@@ -85,6 +86,7 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "odom_topic": "/odom",
     "current_nav_mode_topic": "/nav/current_mode",
     "current_map_topic": "/nav/current_map",
+    "agent_map_topic": "/map",
     "amcl_pose_topic": "/amcl_pose",
     "scan_topic": "/scan",
     # --- Feature flags ---

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -37,6 +37,7 @@ from brain_client.memory.recorder import MemoryRecorder
 from brain_client.memory.store import MemoryStore
 from brain_client.perception.camera import CameraCapture
 from brain_client.perception.gaze_control import GazeController
+from brain_client.perception.map_capture import MapCapture
 from brain_client.perception.pose_tracking import PoseTracker
 from brain_client.perception.scan_health import ScanHealthMonitor
 from brain_client.robot.arm_recovery import ArmRecovery
@@ -138,6 +139,7 @@ class BrainClientNode(Node):
         cfg, state = self.config, self.state
         self.chat = ChatManager(self.get_logger(), self.chat_out_pub, self.task_status_pub, self._tts_handler)
         self.camera = CameraCapture(self, cfg)
+        self.map_capture = MapCapture(self, cfg.agent_map_topic)
         self.pose_tracker = PoseTracker(self, odom_topic=cfg.odom_topic, nav_mode_topic=cfg.current_nav_mode_topic)
         self.scan_health = ScanHealthMonitor(self, scan_topic=cfg.scan_topic, stale_after_sec=cfg.scan_stale_after_sec)
         # Spatial memory: the recorder builds it whenever the robot drives well-
@@ -184,6 +186,7 @@ class BrainClientNode(Node):
             state,
             cfg,
             camera=self.camera,
+            map_capture=self.map_capture,
             pose_tracker=self.pose_tracker,
             runner=self.runner,
             roster=self.roster,

--- a/ros2_ws/src/brain/brain_client/brain_client/perception/map_capture.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/perception/map_capture.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Latched occupancy-map source for the local agent."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from nav_msgs.msg import OccupancyGrid
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+
+from brain_client.perception.map_image import NavigationMapImage, render_navigation_map
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
+    from rclpy.subscription import Subscription
+
+_MAP_QOS = QoSProfile(
+    reliability=QoSReliabilityPolicy.RELIABLE,
+    history=QoSHistoryPolicy.KEEP_LAST,
+    depth=1,
+    durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+)
+
+
+class MapCapture:
+    def __init__(self, node: Node, map_topic: str):
+        self._map: OccupancyGrid | None = None
+        self._cache: tuple[OccupancyGrid, NavigationMapImage | None] | None = None
+        self._subscription: Subscription = node.create_subscription(OccupancyGrid, map_topic, self._on_map, _MAP_QOS)
+
+    def _on_map(self, msg: OccupancyGrid) -> None:
+        self._map = msg
+        self._cache = None
+
+    def latest_image(self) -> NavigationMapImage | None:
+        msg = self._map
+        if msg is None:
+            return None
+        cached = self._cache
+        if cached is not None and cached[0] is msg:
+            return cached[1]
+        info = msg.info
+        orientation = info.origin.orientation
+        origin_yaw = math.atan2(
+            2.0 * (orientation.w * orientation.z + orientation.x * orientation.y),
+            1.0 - 2.0 * (orientation.y * orientation.y + orientation.z * orientation.z),
+        )
+        image = render_navigation_map(
+            msg.data,
+            width=info.width,
+            height=info.height,
+            resolution=info.resolution,
+            origin_x=info.origin.position.x,
+            origin_y=info.origin.position.y,
+            origin_yaw=origin_yaw,
+            frame_id=msg.header.frame_id,
+        )
+        self._cache = (msg, image)
+        return image

--- a/ros2_ws/src/brain/brain_client/brain_client/perception/map_image.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/perception/map_image.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Pure occupancy-grid rasterization for local-agent map images."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+
+_UNKNOWN_GRAY = 205
+_FREE_GRAY = 254
+_MAX_EDGE_PX = 480
+
+
+@dataclass(frozen=True)
+class NavigationMapImage:
+    jpeg: bytes
+    resolution: float
+    width: int
+    height: int
+    origin_x: float
+    origin_y: float
+    origin_yaw: float
+    frame_id: str
+
+    def observation_note(self, image_number: int) -> str:
+        width_m = self.width * self.resolution
+        height_m = self.height * self.resolution
+        cos_yaw = math.cos(self.origin_yaw)
+        sin_yaw = math.sin(self.origin_yaw)
+        right = (self.origin_x + width_m * cos_yaw, self.origin_y + width_m * sin_yaw)
+        upper = (self.origin_x - height_m * sin_yaw, self.origin_y + height_m * cos_yaw)
+        opposite = (right[0] - height_m * sin_yaw, right[1] + height_m * cos_yaw)
+        return (
+            f"(image {image_number} is the navigation occupancy map: image right is map-local +x "
+            f"and image top is map-local +y; white is free, darker means more occupied, and unknown "
+            f"is fixed light gray; {self.resolution:g} m/cell; corners in {self.frame_id or 'map'} "
+            f"are lower-left=({self.origin_x:.2f},{self.origin_y:.2f}), "
+            f"lower-right=({right[0]:.2f},{right[1]:.2f}), upper-left=({upper[0]:.2f},{upper[1]:.2f}), "
+            f"upper-right=({opposite[0]:.2f},{opposite[1]:.2f})m; map-local yaw="
+            f"{math.degrees(self.origin_yaw):.1f}deg)"
+        )
+
+
+def occupancy_grid_raster(data: Sequence[int], width: int, height: int) -> np.ndarray | None:
+    """Render row-major occupancy cells with image-top at highest map y."""
+    cell_count = width * height
+    if width <= 0 or height <= 0 or cell_count <= 1 or len(data) != cell_count:
+        return None
+    grid = np.asarray(data, dtype=np.int16).reshape((height, width))
+    raster = np.full(grid.shape, _UNKNOWN_GRAY, dtype=np.uint8)
+    known = grid >= 0
+    occupancy = np.clip(grid[known], 0, 100)
+    raster[known] = np.rint(_FREE_GRAY * (100 - occupancy) / 100).astype(np.uint8)
+    return np.flipud(raster)
+
+
+def _downsample_conservatively(raster: np.ndarray, width: int, height: int) -> np.ndarray:
+    """Keep the darkest source cell in each output bin so thin walls survive."""
+    y_starts = np.floor(np.arange(height) * raster.shape[0] / height).astype(np.intp)
+    x_starts = np.floor(np.arange(width) * raster.shape[1] / width).astype(np.intp)
+    return np.minimum.reduceat(np.minimum.reduceat(raster, y_starts, axis=0), x_starts, axis=1)
+
+
+def render_navigation_map(
+    data: Sequence[int],
+    *,
+    width: int,
+    height: int,
+    resolution: float,
+    origin_x: float,
+    origin_y: float,
+    origin_yaw: float,
+    frame_id: str,
+) -> NavigationMapImage | None:
+    raster = occupancy_grid_raster(data, width, height)
+    if raster is None:
+        return None
+    longest_edge = max(raster.shape)
+    if longest_edge > _MAX_EDGE_PX:
+        scale = _MAX_EDGE_PX / longest_edge
+        size = (max(1, round(raster.shape[1] * scale)), max(1, round(raster.shape[0] * scale)))
+        raster = _downsample_conservatively(raster, *size)
+    encoded, jpeg = cv2.imencode(".jpg", raster, [cv2.IMWRITE_JPEG_QUALITY, 90])
+    if not encoded:
+        return None
+    return NavigationMapImage(
+        jpeg=jpeg.tobytes(),
+        resolution=resolution,
+        width=width,
+        height=height,
+        origin_x=origin_x,
+        origin_y=origin_y,
+        origin_yaw=origin_yaw,
+        frame_id=frame_id,
+    )

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
@@ -30,6 +30,11 @@ def generate_launch_description():
     map_topic_arg = DeclareLaunchArgument(
         "map_topic", default_value="/navigation/global_costmap/costmap", description="Map topic (skills server)"
     )
+    agent_map_topic_arg = DeclareLaunchArgument(
+        "agent_map_topic",
+        default_value="/map",
+        description="Navigation occupancy map shown to opted-in local agents",
+    )
     arm_camera_image_topic_arg = DeclareLaunchArgument(
         "arm_camera_image_topic",
         default_value="/mars/arm/image_raw/compressed",
@@ -80,6 +85,7 @@ def generate_launch_description():
                 "send_arm_camera_image": LaunchConfiguration("send_arm_camera_image"),
                 "simulator_mode": LaunchConfiguration("simulator_mode"),
                 "current_nav_mode_topic": LaunchConfiguration("current_nav_mode_topic"),
+                "agent_map_topic": LaunchConfiguration("agent_map_topic"),
                 "log_everything": LaunchConfiguration("log_everything"),
                 "gemini_model": LaunchConfiguration("gemini_model"),
                 # Proxy service config
@@ -99,6 +105,7 @@ def generate_launch_description():
             image_topic_arg,
             cmd_vel_topic_arg,
             map_topic_arg,
+            agent_map_topic_arg,
             arm_camera_image_topic_arg,
             send_arm_camera_image_arg,
             simulator_mode_arg,

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
@@ -26,6 +26,11 @@ def generate_launch_description():
         "cmd_vel_topic", default_value="/cmd_vel", description="Command velocity topic"
     )
     map_topic_arg = DeclareLaunchArgument("map_topic", default_value="/map", description="Map topic (skills server)")
+    agent_map_topic_arg = DeclareLaunchArgument(
+        "agent_map_topic",
+        default_value="/map",
+        description="Navigation occupancy map shown to opted-in local agents",
+    )
     send_arm_camera_image_arg = DeclareLaunchArgument(
         "send_arm_camera_image",
         default_value="False",
@@ -63,6 +68,7 @@ def generate_launch_description():
                 "send_arm_camera_image": LaunchConfiguration("send_arm_camera_image"),
                 "simulator_mode": LaunchConfiguration("simulator_mode"),
                 "current_nav_mode_topic": LaunchConfiguration("current_nav_mode_topic"),
+                "agent_map_topic": LaunchConfiguration("agent_map_topic"),
                 "log_everything": LaunchConfiguration("log_everything"),
                 "gemini_model": LaunchConfiguration("gemini_model"),
                 # Sim camera mount (the config.py defaults are the hardware's).
@@ -80,6 +86,7 @@ def generate_launch_description():
             image_topic_arg,
             cmd_vel_topic_arg,
             map_topic_arg,
+            agent_map_topic_arg,
             send_arm_camera_image_arg,
             simulator_mode_arg,
             current_nav_mode_topic_arg,

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -101,6 +101,21 @@ def test_agents_load_with_source_stamping(workspace):
     assert default_agent is agents["alpha"]  # no empty_directive -> first loaded
 
 
+def test_agents_opt_in_to_map_images(workspace):
+    write(workspace, "innate_agents/alpha.py", agent_src("Alpha"))
+    write(
+        workspace,
+        "innate_agents/mapper.py",
+        agent_src("Mapper", body="def uses_map(self):\n    return True"),
+    )
+
+    agents, _default_agent, broken = initialize_agents(LOGGER)
+
+    assert broken == {}
+    assert agents["alpha"].uses_map() is False
+    assert agents["mapper"].uses_map() is True
+
+
 def test_empty_directive_is_default(workspace):
     write(workspace, "innate_agents/alpha.py", agent_src("Alpha"))
     write(workspace, "innate_agents/empty_directive.py", agent_src("EmptyDirective", "empty_directive"))
@@ -216,6 +231,20 @@ def test_probe_failure_rosters_broken(workspace):
     assert set(agents) == {"alpha"}
     assert list(broken) == ["lazy"]
     assert "ValueError: no input device" in broken["lazy"]
+
+
+def test_uses_map_probe_failure_rosters_broken(workspace):
+    write(
+        workspace,
+        "innate_agents/lazy_map.py",
+        agent_src("LazyMap", body='def uses_map(self):\n    raise ValueError("no map")'),
+    )
+
+    agents, _default, broken = initialize_agents(LOGGER)
+
+    assert agents == {}
+    assert list(broken) == ["lazy_map"]
+    assert "ValueError: no map" in broken["lazy_map"]
 
 
 def test_function_local_agent_rosters_broken(workspace):

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -9,6 +9,7 @@ touches the network in generate(), so everything else is exercised directly
 with a None or capturing transport.
 """
 
+import base64
 import json
 
 import pytest
@@ -252,6 +253,50 @@ def test_generate_keeps_the_old_wrist_frame_when_this_turn_has_none():
     assert images_in(captured["contents"][0]) == 2  # arm camera stale: last wrist frame still shown
 
 
+def test_navigation_map_is_current_only_and_retires_when_absent():
+    captured = {}
+
+    def transport(model, body):
+        captured.update(body)
+        return [model_response({"text": "ok"})]
+
+    context = make_context(transport, max_image_turns=3)
+    first = GeminiContext.user_message("head and map", [b"head-1", b"map-1"])
+    context.absorb(first, model_response({"text": "ok"}), current_map_images=[1])
+
+    second = GeminiContext.user_message("new head and map", [b"head-2", b"map-2"])
+    context.generate(second, [], "S", current_map_images=[1])
+    assert images_in(captured["contents"][0]) == 1
+    assert any("older navigation map removed" in p.get("text", "") for p in captured["contents"][0]["parts"])
+    context.absorb(second, model_response({"text": "ok"}), current_map_images=[1])
+
+    third = GeminiContext.user_message("head only", [b"head-3"])
+    context.generate(third, [], "S", current_map_images=[])
+    assert images_in(captured["contents"][2]) == 1
+    context.absorb(third, model_response({"text": "ok"}), current_map_images=[])
+    assert context._current_map_turn is None
+
+
+def test_generate_masks_prior_wrist_and_map_from_the_same_turn():
+    captured = {}
+
+    def transport(model, body):
+        captured.update(body)
+        return [model_response({"text": "ok"})]
+
+    context = make_context(transport, max_image_turns=3)
+    first = GeminiContext.user_message("head, wrist, and map", [b"head-1", b"wrist-1", b"map-1"])
+    context.absorb(first, model_response({"text": "ok"}), latest_only_images=[1], current_map_images=[2])
+
+    second = GeminiContext.user_message("new frames", [b"head-2", b"wrist-2", b"map-2"])
+    context.generate(second, [], "S", latest_only_images=[1], current_map_images=[2])
+
+    prior_parts = captured["contents"][0]["parts"]
+    assert images_in(captured["contents"][0]) == 1
+    assert any("older wrist camera frame removed" in p.get("text", "") for p in prior_parts)
+    assert any("older navigation map removed" in p.get("text", "") for p in prior_parts)
+
+
 def test_generate_taps_the_exact_request_body():
     # The on_request hook must see the request verbatim: system, full history
     # (images and all), and the new message — it feeds the /brain/trace monitor.
@@ -451,8 +496,9 @@ import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
 from brain_client.brain.agent import BrainAgent  # noqa: E402
-from brain_client.brain.utils import Event, EventKind  # noqa: E402
+from brain_client.brain.utils import Event, EventKind, FrameLabel  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
+from brain_client.perception.map_image import NavigationMapImage  # noqa: E402
 from brain_client.transport.chat import SpeechStreamer  # noqa: E402
 
 
@@ -498,6 +544,7 @@ def agent_factory(monkeypatch):
             state,
             config,
             camera=camera,
+            map_capture=SimpleNamespace(latest_image=lambda: None),
             pose_tracker=pose,
             runner=SimpleNamespace(),
             roster=SimpleNamespace(active_skill_ids=lambda: []),
@@ -1012,6 +1059,73 @@ def test_running_skill_guidance_reads_registry_metadata(agent_factory):
     state.primitive_running = RunningSkill(primitive_name="wave", skill_id="local/wave", primitive_id="p1")
     text, images = agent._look([])
     assert "(guidance while this skill runs: do not block the arm)" in text
+
+
+def test_navigation_map_is_opt_in_and_appended_after_event_images(agent_factory):
+    agent, state = agent_factory()
+    map_image = NavigationMapImage(
+        jpeg=b"map-jpeg",
+        resolution=0.05,
+        width=200,
+        height=100,
+        origin_x=-5.0,
+        origin_y=-2.5,
+        origin_yaw=0.0,
+        frame_id="map",
+    )
+    agent._map.latest_image = lambda: map_image
+    event = Event("inspection result", image=b"event-jpeg")
+
+    state.current_directive = SimpleNamespace(uses_map=lambda: False)
+    text, frames = agent._look([event])
+    assert [label for label, _jpeg in frames] == [FrameLabel.HEAD, FrameLabel.EVENT]
+    assert "navigation occupancy map" not in text
+
+    state.current_directive = SimpleNamespace(uses_map=lambda: True)
+    text, frames = agent._look([event])
+    assert [label for label, _jpeg in frames] == [FrameLabel.HEAD, FrameLabel.EVENT, FrameLabel.MAP]
+    assert frames[-1][1] == b"map-jpeg"
+    assert "image 3 is the navigation occupancy map" in text
+    assert "white is free, darker means more occupied" in text
+    assert "lower-left=(-5.00,-2.50), lower-right=(5.00,-2.50)" in text
+
+
+def test_opted_in_navigation_map_reaches_gemini_as_labeled_jpeg(agent_factory):
+    agent, state = agent_factory()
+    agent._map.latest_image = lambda: NavigationMapImage(
+        jpeg=b"map-jpeg",
+        resolution=0.05,
+        width=200,
+        height=100,
+        origin_x=-5.0,
+        origin_y=-2.5,
+        origin_yaw=0.0,
+        frame_id="map",
+    )
+    state.current_directive = SimpleNamespace(uses_map=lambda: True, get_prompt=lambda: "")
+    captured = {}
+
+    def transport(model, body):
+        captured["body"] = body
+        return [model_response(call_part("wait", {}))]
+
+    agent._context._transport = transport
+    run_turn(agent)
+
+    parts = captured["body"]["contents"][-1]["parts"]
+    assert "image 2 is the navigation occupancy map" in parts[0]["text"]
+    assert parts[-1]["inlineData"]["mimeType"] == "image/jpeg"
+    assert base64.b64decode(parts[-1]["inlineData"]["data"]) == b"map-jpeg"
+
+
+def test_opted_in_agent_gracefully_omits_an_unavailable_map(agent_factory):
+    agent, state = agent_factory()
+    state.current_directive = SimpleNamespace(uses_map=lambda: True)
+
+    text, frames = agent._look([])
+
+    assert [label for label, _jpeg in frames] == [FrameLabel.HEAD]
+    assert "navigation occupancy map" not in text
 
 
 def test_a_turn_bug_backs_off_instead_of_killing_the_loop(agent_factory, monkeypatch):

--- a/ros2_ws/src/brain/brain_client/test/test_map_capture.py
+++ b/ros2_ws/src/brain/brain_client/test/test_map_capture.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+
+from types import SimpleNamespace
+
+from nav_msgs.msg import OccupancyGrid
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSReliabilityPolicy
+
+from brain_client.perception import map_capture
+
+
+class FakeNode:
+    def create_subscription(self, message_type, topic, callback, qos):
+        self.message_type = message_type
+        self.topic = topic
+        self.callback = callback
+        self.qos = qos
+        return SimpleNamespace()
+
+
+def occupancy_grid(data: list[int]) -> OccupancyGrid:
+    msg = OccupancyGrid()
+    msg.header.frame_id = "map"
+    msg.info.width = len(data)
+    msg.info.height = 1
+    msg.info.resolution = 0.05
+    msg.info.origin.position.x = -1.0
+    msg.info.origin.position.y = -2.0
+    msg.data = data
+    return msg
+
+
+def test_map_capture_uses_latched_map_qos_and_requested_topic():
+    node = FakeNode()
+
+    map_capture.MapCapture(node, "/semantic_map")
+
+    assert node.message_type is OccupancyGrid
+    assert node.topic == "/semantic_map"
+    assert node.qos.reliability == QoSReliabilityPolicy.RELIABLE
+    assert node.qos.history == QoSHistoryPolicy.KEEP_LAST
+    assert node.qos.depth == 1
+    assert node.qos.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL
+
+
+def test_map_capture_renders_lazily_and_invalidates_the_cached_image(monkeypatch):
+    node = FakeNode()
+    capture = map_capture.MapCapture(node, "/map")
+    render = map_capture.render_navigation_map
+    calls = []
+
+    def counting_render(*args, **kwargs):
+        calls.append((args, kwargs))
+        return render(*args, **kwargs)
+
+    monkeypatch.setattr(map_capture, "render_navigation_map", counting_render)
+    node.callback(occupancy_grid([0, 100]))
+
+    first = capture.latest_image()
+    assert first is not None
+    assert capture.latest_image() is first
+    assert len(calls) == 1
+
+    node.callback(occupancy_grid([100, 0]))
+
+    second = capture.latest_image()
+    assert second is not None
+    assert second is not first
+    assert len(calls) == 2

--- a/ros2_ws/src/brain/brain_client/test/test_map_image.py
+++ b/ros2_ws/src/brain/brain_client/test/test_map_image.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+
+import math
+
+import cv2
+import numpy as np
+
+from brain_client.perception.map_image import occupancy_grid_raster, render_navigation_map
+
+
+def test_occupancy_grid_raster_flips_y_and_maps_occupancy_to_grayscale():
+    raster = occupancy_grid_raster(
+        [-1, 0, 100, 25, 50, 75],
+        width=3,
+        height=2,
+    )
+
+    assert raster is not None
+    assert raster.tolist() == [[190, 127, 64], [205, 254, 0]]
+
+
+def test_occupancy_grid_raster_rejects_invalid_and_null_maps():
+    assert occupancy_grid_raster([], width=0, height=0) is None
+    assert occupancy_grid_raster([0], width=1, height=1) is None
+    assert occupancy_grid_raster([0, 100], width=2, height=2) is None
+
+
+def test_render_navigation_map_caps_size_and_describes_world_bounds():
+    width, height = 600, 300
+    image = render_navigation_map(
+        [0] * (width * height),
+        width=width,
+        height=height,
+        resolution=0.05,
+        origin_x=-10.0,
+        origin_y=-4.0,
+        origin_yaw=0.0,
+        frame_id="map",
+    )
+
+    assert image is not None
+    decoded = cv2.imdecode(np.frombuffer(image.jpeg, np.uint8), cv2.IMREAD_GRAYSCALE)
+    assert decoded.shape == (240, 480)
+    assert image.jpeg.startswith(b"\xff\xd8")
+    note = image.observation_note(3)
+    assert "image 3 is the navigation occupancy map" in note
+    assert "0.05 m/cell" in note
+    assert "white is free, darker means more occupied" in note
+    assert "lower-left=(-10.00,-4.00), lower-right=(20.00,-4.00)" in note
+
+
+def test_render_navigation_map_describes_a_rotated_origin():
+    image = render_navigation_map(
+        [0, 100, 0, 100],
+        width=2,
+        height=2,
+        resolution=1.0,
+        origin_x=1.0,
+        origin_y=2.0,
+        origin_yaw=math.pi / 2,
+        frame_id="map",
+    )
+
+    assert image is not None
+    note = image.observation_note(2)
+    assert "lower-right=(1.00,4.00)" in note
+    assert "upper-left=(-1.00,2.00)" in note
+    assert "map-local yaw=90.0deg" in note
+
+
+def test_render_navigation_map_preserves_thin_walls_when_downsampling():
+    data = np.zeros((100, 960), dtype=np.int16)
+    data[:, 1] = 100
+    image = render_navigation_map(
+        data.ravel(),
+        width=960,
+        height=100,
+        resolution=0.05,
+        origin_x=0.0,
+        origin_y=0.0,
+        origin_yaw=0.0,
+        frame_id="map",
+    )
+
+    assert image is not None
+    decoded = cv2.imdecode(np.frombuffer(image.jpeg, np.uint8), cv2.IMREAD_GRAYSCALE)
+    assert decoded.shape == (50, 480)
+    assert decoded[:, 0].max() < 10


### PR DESCRIPTION
## Summary

- Add an opt-in Agent.uses_map() authoring hook and a configurable /map subscription for the local brain.
- Render latched OccupancyGrid messages as orientation-aware, topology-preserving JPEGs with map coordinates and an accurate occupancy legend.
- Append the map as the final labeled image, keep only the current map in Gemini history, and preserve existing wrist-camera retention semantics.
- Ignore malformed and map-free placeholder grids, cache each rendered update, and document the opt-in interface.

No shipped agent opts in, so existing agents keep their current behavior until they override uses_map().

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - Ruff check and format check pass.
  - Brain client pytest suite: 236 passed.
  - Basedpyright on every modified production module: 0 errors, 0 warnings. The full package has the same 14 pre-existing errors as main.
  - brain_client builds successfully with colcon.
  - Installed brain_client and skills-server node boot smoke passes in simulator mode.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with ./innate-sim up.
  - Full simulator startup was not run; the installed simulator-mode ROS nodes were built and boot-tested instead.
- [x] If I changed simulator asset files or asset references, I published the asset pack and committed the updated sim/assets.lock.json. Not applicable; no assets changed.