### PR TITLE
refactor(webapp): fold Brain into the Agent page as its second view

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -5788,7 +5788,8 @@ select.skill-input {
 /* ---- Agent page --------------------------------------------------------- */
 /* Full-bleed live feed (reused from teleop) with one liquid-glass control
    column pinned to the right edge. The cam PiP strip is nudged left so it
-   never tucks behind the panel. */
+   never tucks behind the panel. The panel stays put in the page's other view
+   (Brain, brain.css); everything that belongs to the live feed steps aside. */
 
 .agent-cockpit .cam-strip {
   right: calc(360px + 34px);
@@ -5814,6 +5815,47 @@ select.skill-input {
   justify-content: center;
   height: var(--pip-h);
   padding: 0;
+}
+
+.agent-cockpit.brain-mode .cam-strip,
+.agent-cockpit.brain-mode .overlay-stack-top-left,
+.agent-cockpit.brain-mode .agent-active-chip,
+.agent-cockpit.brain-mode .sim-debug-stack {
+  display: none !important; /* the sim stage sets its stack's display inline */
+}
+
+/* Live/Brain switch, seated in the Agent panel's header. */
+.agent-views {
+  display: flex;
+  margin-left: auto;
+  padding: 2px;
+  gap: 2px;
+  border-radius: 9px;
+  background: var(--ctl-field);
+  box-shadow: inset 0 0 0 1px var(--hairline);
+}
+
+.agent-view {
+  padding: 3px 10px;
+  border: none;
+  border-radius: 7px;
+  background: none;
+  color: var(--ctl-text-off);
+  font: 600 10px var(--font-ui);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.agent-view:hover {
+  color: var(--ctl-text);
+}
+
+.agent-view.on {
+  background: var(--ctl-glass);
+  color: var(--text);
+  box-shadow: var(--ctl-sheen);
 }
 
 .agent-panel {
@@ -5885,6 +5927,11 @@ select.skill-input {
     justify-content: center;
   }
 
+  /* Thumb-sized view tabs on the bottom sheet. */
+  .agent-view {
+    padding: 7px 14px;
+  }
+
   /* No right dock to clear on phones. */
   .agent-cockpit .cam-strip {
     right: 14px;
@@ -5898,7 +5945,6 @@ select.skill-input {
 }
 
 .agent-title {
-  flex: 1;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.24em;

--- a/webapp/css/brain.css
+++ b/webapp/css/brain.css
@@ -1,19 +1,18 @@
 /* SPDX-License-Identifier: Apache-2.0
    Copyright (c) 2026 Innate Inc
 
-   Brain page — the agent-loop monitor. Structural chrome rides the app tokens
-   (--panel, --hairline, --text, --muted); the functional colors below are the
-   page's own: phase identities for the loop (look/think/act), a series blue
-   for data marks, and a fixed status set — all steps validated for the dark
-   surface. */
+   Brain view — the agent-loop monitor, the Agent page's second face (the Live/
+   Brain switch lives in the Agent panel's header; see app.css). Structural
+   chrome rides the app tokens (--panel, --hairline, --text, --muted); the
+   functional colors below are the view's own: phase identities for the loop
+   (look/think/act), a series blue for data marks, and a fixed status set — all
+   steps validated for the dark surface. */
 
-/* ?demo hides the connect card — there is deliberately no robot behind it. */
-.connect-layer.br-hidden {
-  display: none;
-}
-
-.brain-page {
-  --br-blue: #3987e5;     /* series: sparkline, speech, running */
+/* The view and its turn inspector are siblings (the inspector is a page-level
+   modal), so the palette is declared for both. */
+.brain-view,
+.br-inspect {
+  --br-blue: #3987e5;     /* series: sparkline, running */
   --br-aqua: #199e70;     /* LOOK */
   --br-violet: #9085e9;   /* THINK */
   --br-orange: #d95926;   /* ACT */
@@ -22,27 +21,38 @@
   --br-serious: #ec835a;
   --br-critical: #d03b3b;
   --br-grid: rgb(255 255 255 / 10%);
+}
 
-  height: 100%;
-  min-height: 0;
+/* A layer over the cockpit, stopping short of the Agent panel's dock, that
+   fades in without disturbing anything under it — the live feed keeps running
+   behind the wash, so switching back is instant. */
+.brain-view {
+  position: absolute;
+  inset: 0 calc(360px + 14px) 0 0; /* stop where the Agent panel's dock starts */
+  z-index: 5;
   display: flex;
   flex-direction: column;
-  padding: 14px 18px 16px;
-  gap: 12px;
+  padding: 14px 12px 16px 18px;
+  gap: 11px;
   overflow: hidden;
+  background: rgb(8 8 10 / 88%);
+  backdrop-filter: blur(26px) saturate(0.9);
+  -webkit-backdrop-filter: blur(26px) saturate(0.9);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 180ms ease, visibility 180ms;
 }
 
-/* ---------- head ---------- */
-.br-head {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  flex: none;
+.agent-cockpit.brain-mode .brain-view {
+  opacity: 1;
+  visibility: visible;
 }
+
+/* ---------- status strip ---------- */
 .br-chips {
   display: flex;
   gap: 8px;
-  margin-left: auto;
+  flex: none;
   flex-wrap: wrap;
 }
 .br-chip {
@@ -86,35 +96,42 @@
   }
 }
 
-/* ---------- grid ---------- */
+/* ---------- grid ----------
+   Vision is the hero across the top; the loop dial anchors the left; the three
+   feeds sit as a band underneath. Proportional columns, because the rail and
+   the Agent panel take ~440px off the viewport before this grid gets any. */
 .br-grid {
   flex: 1;
   min-height: 0;
   display: grid;
-  gap: 12px;
-  grid-template-columns: 360px 1fr 360px;
-  grid-template-rows: minmax(0, 1.35fr) minmax(0, 1fr);
-  grid-template-areas: "loop vision mind" "actions queue vitals";
+  gap: 11px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: minmax(0, 1.2fr) minmax(0, 1fr);
+  grid-template-areas: "loop vision vision" "queue actions vitals";
 }
-@media (max-width: 1280px) {
-  .brain-page {
+/* Too narrow to keep three columns readable: stack and scroll instead. */
+@media (max-width: 1140px) {
+  .brain-view {
     overflow-y: auto;
   }
   .br-grid {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     grid-template-rows: none;
-    grid-template-areas: "loop vision" "mind actions" "queue vitals";
+    grid-template-areas: "loop" "vision" "actions" "queue" "vitals";
   }
   .br-panel {
-    height: 420px;
+    height: 360px;
   }
 }
-@media (max-width: 820px) {
-  .br-grid {
-    grid-template-columns: 1fr;
-    grid-template-areas: "loop" "vision" "mind" "actions" "queue" "vitals";
+/* Phones dock the Agent panel as a bottom sheet, so the view takes the top of
+   the screen instead of the left of it. */
+@media (max-width: 640px) {
+  .brain-view {
+    inset: 0 0 calc(44vh + 22px) 0;
+    padding: 12px 12px 14px;
   }
 }
+
 .br-panel {
   background: var(--panel);
   border: 1px solid var(--hairline);
@@ -135,16 +152,20 @@
   display: flex;
   gap: 8px;
   align-items: baseline;
+  white-space: nowrap;
 }
+/* The narrow columns can't hold a title and its note; the note gives way. */
 .br-panel h2 .sub {
   letter-spacing: 0;
   text-transform: none;
   font-weight: 400;
   margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .br-panel-loop { grid-area: loop; align-items: center; }
 .br-panel-vision { grid-area: vision; }
-.br-panel-mind { grid-area: mind; }
 .br-panel-actions { grid-area: actions; }
 .br-panel-queue { grid-area: queue; }
 .br-panel-vitals { grid-area: vitals; }
@@ -157,11 +178,12 @@
 }
 
 /* ---------- the loop ---------- */
+/* The viewBox keeps the dial round, so the box is free to take the whole panel. */
 .br-loop-svg {
+  flex: 1;
   width: 100%;
   max-width: 330px;
-  aspect-ratio: 1;
-  margin: auto 0;
+  margin: auto;
   min-height: 0;
 }
 .br-ring-base {
@@ -251,11 +273,13 @@
 }
 
 /* ---------- vision ---------- */
+/* A well, not a screen: camera frames rarely match the panel's proportions, so
+   what surrounds a contain-fitted frame should read as surface, not as bars. */
 .br-stage {
   position: relative;
   border-radius: 10px;
   overflow: hidden;
-  background: #000;
+  background: rgb(0 0 0 / 45%);
   border: 1px solid var(--br-grid);
   flex: 1;
   min-height: 0;
@@ -413,6 +437,7 @@
   font-family: var(--font-mono);
 }
 .br-inspect-btn {
+  white-space: nowrap;
   border: 1px solid var(--hairline);
   border-radius: 999px;
   background: none;
@@ -447,47 +472,6 @@
   transition: transform 0.3s;
   transform-origin: 8px 8px;
 }
-
-/* ---------- mind stream ---------- */
-.br-msg {
-  border-left: 3px solid var(--br-grid);
-  padding: 7px 10px;
-  margin-bottom: 8px;
-  border-radius: 0 8px 8px 0;
-  background: rgb(255 255 255 / 3%);
-  animation: br-slidein 0.35s ease-out;
-  overflow-wrap: break-word;
-}
-@keyframes br-slidein {
-  from {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-}
-.br-msg .who {
-  font: 600 10px var(--font-mono);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  margin-bottom: 3px;
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-.br-msg .when {
-  margin-left: auto;
-  color: var(--muted);
-  font-weight: 400;
-  letter-spacing: 0;
-}
-.br-msg.thought { border-color: var(--br-violet); }
-.br-msg.thought .who { color: var(--br-violet); }
-.br-msg.thought .txt { color: var(--muted); font-style: italic; }
-.br-msg.speech { border-color: var(--br-blue); }
-.br-msg.speech .who { color: var(--br-blue); }
-.br-msg.user { border-color: var(--br-aqua); }
-.br-msg.user .who { color: var(--br-aqua); }
-.br-msg.system .who { color: var(--muted); }
-.br-msg.system .txt { color: var(--muted); font-size: 13px; }
 
 /* ---------- turns & actions ---------- */
 .br-turn-row {
@@ -527,12 +511,18 @@
   gap: 6px;
   margin-top: 6px;
 }
+/* A call and its args are one unbreakable token; in a narrow column it clips
+   rather than bursting the row (the outcome tooltip carries the full text). */
 .br-call {
   font: 500 12px var(--font-mono);
   border: 1px solid var(--hairline);
   border-radius: 7px;
   padding: 3px 8px;
   color: var(--muted);
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .br-call.go {
   border-color: var(--br-blue);
@@ -546,6 +536,7 @@
 }
 .br-skill-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 9px;
   padding: 8px 10px;
@@ -556,6 +547,14 @@
   font-family: var(--font-mono);
   font-size: 12.5px;
   animation: br-slidein 0.35s;
+}
+/* Same rule for the skill rows: a long failure reason truncates instead of
+   folding the row into a vertical strip. */
+.br-skill-row > span {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .br-skill-row .st {
   width: 9px;
@@ -587,7 +586,13 @@
   20%, 60% { transform: translateX(-4px); }
   40%, 80% { transform: translateX(4px); }
 }
-.br-skill-row .reason { color: var(--br-serious); }
+/* A failure reason takes the line under the run rather than the sliver left
+   over beside it. */
+.br-skill-row .reason {
+  color: var(--br-serious);
+  flex: 1 0 100%;
+  margin-top: 4px;
+}
 
 /* ---------- queue ---------- */
 .br-qcard {
@@ -627,9 +632,10 @@
 }
 
 /* ---------- vitals ---------- */
+/* One row of four where there's room, 2x2 in a narrow column. */
 .br-tiles {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
   gap: 8px;
   margin-bottom: 12px;
 }
@@ -650,10 +656,16 @@
   text-transform: uppercase;
   margin-top: 1px;
 }
-.br-spark-wrap { position: relative; }
+/* Grows into the panel, but a sparkline that becomes a wall stops being one. */
+.br-spark-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 72px;
+  max-height: 150px;
+}
 .br-spark {
   width: 100%;
-  height: 88px;
+  height: 100%;
   display: block;
 }
 .br-spark .line {
@@ -684,7 +696,7 @@
   white-space: nowrap;
   transform: translate(-50%, -130%);
 }
-.br-gauge { margin-top: 12px; }
+.br-gauge { margin-top: auto; padding-top: 12px; }
 .br-gauge .bar {
   height: 8px;
   border-radius: 4px;

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -29,9 +29,11 @@ import {
  * @param {HTMLElement} root cockpit root — the panel mounts as a right-edge overlay.
  * @param {import("../rosClient.js").RosClient} rosClient
  * @param {ReturnType<typeof import("../teleop/agentState.js").createAgentState>} agentState
+ * @param {{ headerExtra?: HTMLElement }} [opts] element to seat in the header row
+ *   (the page's Live/Brain switch), kept here so it holds still across views.
  * @returns {{ destroy: () => void }}
  */
-export function createAgentPanel(root, rosClient, agentState) {
+export function createAgentPanel(root, rosClient, agentState, opts = {}) {
   const selfOrigin = crypto.randomUUID?.() ?? `web-${Date.now()}-${Math.random()}`;
 
   const panel = document.createElement("section");
@@ -57,7 +59,7 @@ export function createAgentPanel(root, rosClient, agentState) {
     expandBtn.textContent = expanded ? "\u25be" : "\u25b4";
     expandBtn.setAttribute("aria-label", expanded ? "Collapse panel" : "Expand panel");
   };
-  head.append(titleEl, stateDot, expandBtn);
+  head.append(titleEl, stateDot, ...(opts.headerExtra ? [opts.headerExtra] : []), expandBtn);
 
   // ---- directive + start/stop --------------------------------------------
   const controls = document.createElement("div");

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -1,8 +1,18 @@
 // @ts-check
-// Agent page entry — the autonomous-control room. Same full-bleed live feed as
-// teleop (WebRTC video + camera/map PiP + telemetry), but the right edge hosts
-// one liquid-glass Agent panel: directive selection, a Start/Stop toggle, the
-// agent's live thinking traces + active skill + chat, and a message composer.
+// Agent page entry — the autonomous-control room. The Agent panel is pinned to
+// the right edge in both of the page's views: directive selection, a Start/Stop
+// toggle, the agent's live thinking traces + active skill + chat, and a message
+// composer. Its header switches what fills the rest of the page:
+//
+//   Live  — the full-bleed feed reused from teleop (WebRTC video + camera/map
+//           PiP + telemetry). The default.
+//   Brain — the agent-loop monitor (brain/view.js, its own rail section until
+//           it moved here): what the model saw, thought and called, turn by
+//           turn. Deep-linked as /agent?view=brain.
+//
+// Keeping one panel across both is the point: you can start, stop and message
+// the agent without leaving its internals, and the brain view drops the chat
+// feed it used to carry because the panel next to it already is one.
 //
 // Connect/disconnect lifecycle and optimistic mount mirror teleop (see
 // pageMount.js): the view builds immediately and panels fill in once the socket
@@ -13,12 +23,15 @@ import { ros } from "../rosClient.js";
 import { mountPage } from "../pageMount.js";
 import { getConfig } from "../config.js";
 import { robotSessionFactory } from "../robotSession.js";
+import { createBrainView } from "../brain/view.js";
 import { createVideoStage } from "../teleop/videoStage.js";
 import { createTelemetry } from "../teleop/telemetry.js";
 import { createCameraSwitch } from "../teleop/cameraSwitch.js";
 import { createAgentState } from "../teleop/agentState.js";
 import { createAgentPanel } from "./agentPanel.js";
 import { createChallengePanel } from "./challengePanel.js";
+
+/** @typedef {"live" | "brain"} AgentView */
 
 // Runtime feature flags (config.json, served static), same as teleop. simControls
 // marks a sim deployment — used here to drop the (absent) battery readout. Fetched
@@ -34,14 +47,20 @@ const { createSession, createStage } = await robotSessionFactory();
 
 /** @param {HTMLElement} stage */
 export function mount(stage) {
-  return mountPage(stage, "cockpit agent-cockpit", buildAgentView);
+  const params = new URLSearchParams(location.search);
+  // ?demo runs the brain view off a scripted synthetic brain — there is no
+  // robot behind it, so the socket (and its connect card) stands down.
+  const demo = params.has("demo");
+  const view = /** @type {AgentView} */ (demo || params.get("view") === "brain" ? "brain" : "live");
+  return mountPage(stage, "cockpit agent-cockpit", (root) => buildAgentView(root, { demo, view }), { offline: demo });
 }
 
 /**
  * @param {HTMLElement} root
+ * @param {{ demo: boolean, view: AgentView }} opts
  * @returns {{ destroy: () => void }}
  */
-function buildAgentView(root) {
+function buildAgentView(root, opts) {
   const session = createSession();
 
   const videoStage = createStage ? createStage(root, session) : createVideoStage(root, session);
@@ -61,26 +80,105 @@ function buildAgentView(root) {
   cornerStack.append(telemetryOverlay);
   const agentState = createAgentState(ros);
 
+  // The brain view is built on first open — it's the heavier half, and a
+  // cockpit that never opens it should not pay for /brain/trace. Once built it
+  // stays: toggling back to Live only suspends its feeds, so the turns and
+  // latencies it collected are still there on the way back in.
+  /** @type {ReturnType<typeof createBrainView> | null} */
+  let brain = null;
+  /** @type {AgentView} */
+  let view = "live";
+
+  const tabs = createViewTabs(opts.view, setView);
+
   const parts = [
     videoStage,
     ...(challengePanel ? [challengePanel] : []),
     createTelemetry(telemetryOverlay, ros, { showBattery: !config.simControls }),
     // Square, always-live camera tiles (own prefs key so teleop's defaults stay put).
     createCameraSwitch(root, session, ros, { storeKey: "innate.cameras.agent" }),
-    createAgentPanel(root, ros, agentState),
+    createAgentPanel(root, ros, agentState, { headerExtra: tabs.el }),
     createActiveChip(root, agentState),
     { destroy: () => agentState.destroy() },
   ];
 
+  /** @param {AgentView} next */
+  function setView(next) {
+    if (next === view) return;
+    view = next;
+    root.classList.toggle("brain-mode", next === "brain");
+    if (next === "brain") {
+      brain ??= createBrainView(root, { demo: opts.demo });
+      brain.resume();
+    } else {
+      brain?.suspend();
+    }
+    tabs.select(next);
+    // Shareable address, no navigation: the router owns history, and re-rendering
+    // the route here would tear the video session down mid-switch.
+    const url = new URL(location.href);
+    if (next === "brain") url.searchParams.set("view", "brain");
+    else url.searchParams.delete("view");
+    history.replaceState({}, "", url);
+    document.title = next === "brain" ? "Innate · Agent · Brain" : "Innate · Agent";
+  }
+
+  setView(opts.view);
   session.start();
 
   return {
     destroy() {
       for (const part of parts) part.destroy();
+      brain?.destroy();
       session.destroy();
       root.innerHTML = "";
     },
   };
+}
+
+/**
+ * The Live/Brain switch that lives in the Agent panel's header — the one piece
+ * of chrome that stays put across both views.
+ * @param {AgentView} initial
+ * @param {(view: AgentView) => void} onSelect
+ * @returns {{ el: HTMLElement, select: (view: AgentView) => void }}
+ */
+function createViewTabs(initial, onSelect) {
+  /** @type {{ key: AgentView, label: string, title: string }[]} */
+  const VIEWS = [
+    { key: "live", label: "Live", title: "The live feed, cameras and telemetry" },
+    { key: "brain", label: "Brain", title: "The agent loop: what the model saw, thought and called" },
+  ];
+  const el = document.createElement("div");
+  el.className = "agent-views";
+  el.setAttribute("role", "tablist");
+  el.setAttribute("aria-label", "Agent view");
+
+  /** @type {Map<AgentView, HTMLButtonElement>} */
+  const buttons = new Map();
+  for (const v of VIEWS) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "agent-view";
+    btn.setAttribute("role", "tab");
+    btn.title = v.title;
+    btn.textContent = v.label;
+    btn.addEventListener("click", () => onSelect(v.key));
+    buttons.set(v.key, btn);
+    el.append(btn);
+  }
+
+  /** @param {AgentView} view */
+  function select(view) {
+    for (const [key, btn] of buttons) {
+      const on = key === view;
+      btn.classList.toggle("on", on);
+      btn.setAttribute("aria-selected", String(on));
+    }
+  }
+  select(initial);
+
+  return { el, select };
 }
 
 /**

--- a/webapp/js/brain/demo.js
+++ b/webapp/js/brain/demo.js
@@ -1,7 +1,7 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// Scripted synthetic brain for the Brain page (?demo) — drives the page's
+// Scripted synthetic brain for the Agent page's brain view (?demo) — drives its
 // handlers through an idle→command→navigate→error→recover story so the UI can
 // be exercised with no robot. Loaded lazily; never imported on the real path.
 
@@ -19,7 +19,7 @@ Your directive:
 explore`;
 
 /**
- * @param {{ onTrace: (d: any) => void, onChat: (d: any) => void, onSkill: (d: any) => void,
+ * @param {{ onTrace: (d: any) => void, onSkill: (d: any) => void,
  *   onAgentStatus: (d: any) => void, onBrainStatus: (d: any) => void,
  *   setPose: (x: number, y: number, yaw: number) => void, setSpeaking: (on: boolean) => void }} h
  * @returns {() => void} stop
@@ -124,9 +124,7 @@ export function startDemo(h) {
       ev: "turn_end", turn: D.turn, latency: think / 1000, thoughts, speech,
       calls: theCalls, history: D.history, next_in: D.nextIn,
     });
-    if (thoughts) h.onChat({ sender: "robot_thoughts", text: thoughts, timestamp: Date.now() / 1000 });
     if (speech) {
-      h.onChat({ sender: "robot", text: speech, timestamp: Date.now() / 1000 });
       h.setSpeaking(true);
       timers.push(window.setTimeout(() => h.setSpeaking(false), 2200));
     }
@@ -187,10 +185,8 @@ export function startDemo(h) {
       D.inFlight = false;
       D.streak = 1;
       h.onTrace({ ev: "turn_error", turn: D.turn, error: "gemini via proxy: HTTP 503: overloaded", streak: 1, backoff: 5 });
-      h.onChat({ sender: "system", text: "⚠️ Brain inference failed: HTTP 503 — retrying.", timestamp: Date.now() / 1000 });
       await sleep(5100); if (!on) return;
       D.streak = 0;
-      h.onChat({ sender: "system", text: "✅ Brain inference recovered.", timestamp: Date.now() / 1000 });
       await turn({ withSock: true, think: 1500, thoughts: "Back online. Scene unchanged." });
       await sleep(3000);
     }

--- a/webapp/js/brain/view.js
+++ b/webapp/js/brain/view.js
@@ -1,7 +1,9 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// Brain page — a live window into the local Gemini agent loop.
+// Brain view — the Agent page's second face: a live window into the local
+// Gemini agent loop, shown behind the same Agent panel that starts, stops and
+// talks to the brain (see agent/main.js).
 //
 // Deep telemetry rides /brain/trace (JSON on std_msgs/String, published by
 // brain_client's BrainAgent): turn lifecycle with every image the model was
@@ -9,16 +11,17 @@
 // system instruction, tool calls with args + outcomes, think latencies, the
 // event queue, and a 1 Hz snapshot heartbeat. Recent turns are kept so any
 // turn row can be opened in the inspector overlay — the complete model input
-// and output for that turn. Everything else (mind stream, skill runs, pose,
-// live camera fallback) comes from the public topics, so the page degrades
-// gracefully on robots without the trace publisher — the deep panels just
-// stay quiet.
+// and output for that turn. Everything else (skill runs, pose, live camera
+// fallback) comes from the public topics, so the view degrades gracefully on
+// robots without the trace publisher — the deep panels just stay quiet.
 //
-// ?demo drives the whole page from a scripted synthetic brain (demo.js) —
-// useful for UI work with no robot.
+// Thoughts, speech and chat are deliberately absent here: the Agent panel next
+// to it is the canonical stream, and two chat feeds on one screen is noise.
+//
+// ?demo drives it from a scripted synthetic brain (demo.js) — useful for UI
+// work with no robot.
 
 import { ros } from "../rosClient.js";
-import { mountPage } from "../pageMount.js";
 
 const CAM_TOPIC = "/mars/main_camera/left/image_raw/compressed";
 const HIST_MAX = 60; // brain_client default history_max_entries
@@ -39,19 +42,31 @@ const NODE_ANGLE = { look: -90, think: 30, act: 150 };
 const RING_R = 112;
 const RING_C = 2 * Math.PI * RING_R;
 
-/** @param {HTMLElement} stage */
-export function mount(stage) {
-  return mountPage(stage, "brain-page", buildView);
-}
-
 /**
- * @param {HTMLElement} root
- * @returns {{ destroy: () => void }}
+ * Build the brain view into its own layer inside the Agent cockpit. It starts
+ * suspended: nothing is subscribed and no frame loop runs until resume(), so a
+ * cockpit that never opens it pays nothing — /brain/trace carries full JPEGs
+ * every turn.
+ * @param {HTMLElement} parent cockpit root — the view mounts as a full-bleed layer.
+ * @param {{ demo?: boolean }} [opts]
+ * @returns {{ resume: () => void, suspend: () => void, destroy: () => void }}
  */
-function buildView(root) {
+export function createBrainView(parent, opts = {}) {
+  const root = document.createElement("div");
+  root.className = "brain-view";
   root.innerHTML = template();
+  // The inspector is a page-level modal, so it hangs off the cockpit rather than
+  // the view: the view's backdrop-filter would otherwise become the containing
+  // block for its fixed positioning and pin the card inside this layer.
+  const inspector = document.createElement("div");
+  inspector.className = "br-inspect";
+  inspector.hidden = true;
+  inspector.innerHTML = inspectorTemplate();
+  parent.append(root, inspector);
   /** @param {string} sel */
   const $ = (sel) => /** @type {HTMLElement} */ (root.querySelector(sel));
+  /** @param {string} sel */
+  const $i = (sel) => /** @type {HTMLElement} */ (inspector.querySelector(sel));
 
   // ---- live state ----------------------------------------------------------
   const S = {
@@ -186,7 +201,6 @@ function buildView(root) {
     }
     if (d.ev === "event") {
       addQueueCard(d.kind, d.text);
-      if (d.kind === "user") addMsg("user", "USER", d.text.replace(/^The user says: "(.*)"$/s, "$1"));
       if (d.kind === "motion") motionCue();
     }
     if (d.ev === "snapshot") onSnapshot(d);
@@ -194,6 +208,7 @@ function buildView(root) {
 
   /** @param {any} d */
   function onSnapshot(d) {
+    S.turn = d.turn ?? S.turn; // the view is usually opened mid-run, not at turn 0
     S.history = d.history;
     S.streak = d.streak;
     S.uptime = d.uptime;
@@ -219,9 +234,6 @@ function buildView(root) {
 
   /** @param {any} d */
   function onAgentStatus(d) {
-    $(".br-chip-active b").textContent = d.brain_active ? "active" : "stopped";
-    $(".br-chip-active").className = "br-chip br-chip-active " + (d.brain_active ? "live" : "off");
-    $(".br-chip-directive b").textContent = d.current_directive || "—";
     if (!d.brain_active) setPhase("off");
     else if (S.phase === "off") setPhase("idle");
   }
@@ -229,14 +241,6 @@ function buildView(root) {
   /** @param {any} d */
   function onBrainStatus(d) {
     if (!S.haveTrace) $(".br-chip-backend b").textContent = d.backend || "—";
-  }
-
-  /** @param {any} d */
-  function onChat(d) {
-    if (d.sender === "robot_thoughts") addMsg("thought", "THINKS", d.text, d.timestamp);
-    else if (d.sender === "robot") addMsg("speech", "SAYS", d.text, d.timestamp);
-    else if (d.sender === "system") addMsg("system", "SYSTEM", d.text, d.timestamp);
-    else if (d.sender === "skill_output") addMsg("system", "SKILL OUTPUT", d.text, d.timestamp);
   }
 
   /** @param {number} x @param {number} y @param {number} yaw */
@@ -263,8 +267,6 @@ function buildView(root) {
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;");
-  /** @param {number} [ts] */
-  const hhmmss = (ts) => new Date((ts ?? Date.now() / 1000) * 1000).toLocaleTimeString([], { hour12: false });
 
   /** @param {string} panelSel @param {HTMLElement} el @param {number} [cap] */
   function prepend(panelSel, el, cap = 60) {
@@ -272,15 +274,6 @@ function buildView(root) {
     feed.querySelector(".br-empty")?.remove();
     feed.prepend(el);
     while (feed.children.length > cap) /** @type {Element} */ (feed.lastChild).remove();
-  }
-
-  /** @param {string} cls @param {string} who @param {string} text @param {number} [ts] */
-  function addMsg(cls, who, text, ts) {
-    const div = document.createElement("div");
-    div.className = "br-msg " + cls;
-    div.innerHTML = `<div class="who">${who}<span class="when">${hhmmss(ts)}</span></div><div class="txt"></div>`;
-    /** @type {HTMLElement} */ (div.querySelector(".txt")).textContent = text;
-    prepend(".br-mind", div);
   }
 
   /** @param {any} d */
@@ -333,11 +326,11 @@ function buildView(root) {
       if (skillRows.size > 40) skillRows.delete(/** @type {string} */ (skillRows.keys().next().value));
     }
     row.className = "br-skill-row " + d.status;
-    row.title = "/brain/skill_status_update";
+    row.title = d.reason || "/brain/skill_status_update";
     row.innerHTML =
       `<span class="st"></span><span>${esc(d.skill_name || d.primitive_name)}</span>` +
-      (d.reason ? `<span class="reason">${esc(trunc(d.reason, 60))}</span>` : "") +
-      `<span class="status">${esc(d.status)}</span>`;
+      `<span class="status">${esc(d.status)}</span>` +
+      (d.reason ? `<span class="reason">${esc(trunc(d.reason, 60))}</span>` : "");
   }
 
   /** @param {string} kind @param {string} text */
@@ -436,7 +429,7 @@ function buildView(root) {
     const f = rec?.start.frames[idx];
     if (!f) return;
     shownTurn = turn;
-    showFrame("data:image/jpeg;base64," + f.jpeg, `what the brain saw · turn ${turn} · ${f.label}`);
+    showFrame("data:image/jpeg;base64," + f.jpeg, `turn ${turn} · ${f.label}`);
     if (idx !== 0) hidePing(); // the go-to-point ping is grounded in the head frame
     const film = $(".br-film");
     film.innerHTML = "";
@@ -459,11 +452,11 @@ function buildView(root) {
     if (!turns.has(turn)) return;
     inspecting = turn;
     renderInspector();
-    $(".br-inspect").hidden = false;
+    inspector.hidden = false;
   }
   function closeInspector() {
     inspecting = 0;
-    $(".br-inspect").hidden = true;
+    inspector.hidden = true;
   }
 
   /** A labeled block for the inspector's output section.
@@ -536,19 +529,20 @@ function buildView(root) {
     // Count history images straight from the request body when we have it.
     const reqImgs = req
       ? (req.contents || []).reduce(
-          (a, /** @type {any} */ c) => a + (c.parts || []).filter((/** @type {any} */ p) => p.inlineData).length,
+          (/** @type {number} */ a, /** @type {any} */ c) =>
+            a + (c.parts || []).filter((/** @type {any} */ p) => p.inlineData).length,
           0,
         )
       : 0;
     const nHist = req ? reqImgs - n : (start.history_images ?? 0) * n;
-    $(".br-i-title").textContent = `turn ${start.turn}`;
-    $(".br-i-meta").textContent =
+    $i(".br-i-title").textContent = `turn ${start.turn}`;
+    $i(".br-i-meta").textContent =
       `${n} new image${n === 1 ? "" : "s"}` +
       (nHist > 0 ? ` + ${nHist} in history` : "") +
       ` · history ${start.history} entries · ` +
       (end ? `${end.latency.toFixed(1)}s think` : "thinking…");
 
-    const fr = $(".br-i-frames");
+    const fr = $i(".br-i-frames");
     fr.innerHTML = "";
     for (const f of start.frames || []) {
       const fig = document.createElement("figure");
@@ -559,9 +553,9 @@ function buildView(root) {
     }
 
     // The request itself: every history entry and the new message, verbatim.
-    const conv = $(".br-i-conv");
+    const conv = $i(".br-i-conv");
     conv.innerHTML = "";
-    $(".br-i-conv-h").hidden = /** @type {HTMLElement} */ (conv).hidden = !req;
+    $i(".br-i-conv-h").hidden = /** @type {HTMLElement} */ (conv).hidden = !req;
     if (req) {
       const cfg = document.createElement("div");
       cfg.className = "br-i-cfg";
@@ -578,9 +572,9 @@ function buildView(root) {
       conv.append(decl);
     }
 
-    $(".br-i-input").textContent = start.input || "—";
+    $i(".br-i-input").textContent = start.input || "—";
 
-    const tools = $(".br-i-tools");
+    const tools = $i(".br-i-tools");
     tools.innerHTML = "";
     for (const t of start.tools || []) {
       const chip = document.createElement("span");
@@ -589,7 +583,7 @@ function buildView(root) {
       tools.append(chip);
     }
 
-    const out = $(".br-i-out");
+    const out = $i(".br-i-out");
     out.innerHTML = "";
     if (!end) {
       out.innerHTML = `<div class="br-empty">still thinking…</div>`;
@@ -603,15 +597,15 @@ function buildView(root) {
       if (!out.children.length) out.innerHTML = `<div class="br-empty">no output — observed only</div>`;
     }
 
-    $(".br-i-sys pre").textContent =
+    $i(".br-i-sys pre").textContent =
       req?.systemInstruction?.parts?.[0]?.text ||
       start.system ||
       "(system prompt not reported by this robot's trace)";
   }
 
   $(".br-inspect-btn").addEventListener("click", () => openInspector(shownTurn));
-  $(".br-i-close").addEventListener("click", closeInspector);
-  $(".br-inspect-back").addEventListener("click", closeInspector);
+  $i(".br-i-close").addEventListener("click", closeInspector);
+  $i(".br-inspect-back").addEventListener("click", closeInspector);
   /** @param {KeyboardEvent} e */
   const onKey = (e) => {
     if (e.key === "Escape" && inspecting) closeInspector();
@@ -623,7 +617,7 @@ function buildView(root) {
     /** @type {HTMLImageElement} */ ($(".br-frame")).src = src;
     $(".br-stage-idle").style.display = "none";
     $(".br-frame-cap").innerHTML = `<b>${caption}</b>`;
-    $(".br-vision-src").textContent = S.haveTrace ? "turn-exact frames · /brain/trace" : "live · " + CAM_TOPIC;
+    $(".br-vision-src").textContent = shownTurn ? "turn-exact frames · /brain/trace" : "live · " + CAM_TOPIC;
   }
 
   function sweep() {
@@ -704,7 +698,7 @@ function buildView(root) {
     if (S.running) {
       sub.textContent = "▶ " + S.running;
       sub.classList.remove("err");
-    } else if (S.phase !== "error" && sub.textContent.startsWith("▶")) sub.textContent = "";
+    } else if (S.phase !== "error" && sub.textContent?.startsWith("▶")) sub.textContent = "";
 
     $(".br-turn").textContent = "TURN " + S.turn;
     if (S.uptimeAt) {
@@ -718,7 +712,6 @@ function buildView(root) {
     }
     raf = requestAnimationFrame(tickUI);
   }
-  raf = requestAnimationFrame(tickUI);
 
   // ---- data in -------------------------------------------------------------
   /** @param {any} msg */
@@ -735,28 +728,30 @@ function buildView(root) {
     if (d) fn(d);
   };
 
-  const handlers = { onTrace, onChat, onSkill, onAgentStatus, onBrainStatus, setPose, setSpeaking };
-
   /** @type {(() => void)[]} */
   let unsubs = [];
   /** @type {(() => void) | null} */
   let demoStop = null;
   let destroyed = false;
+  let demoStarted = false;
+  let live = false;
 
-  if (new URLSearchParams(location.search).has("demo")) {
-    // No robot in the picture: the socket's connect card would just sit over
-    // the synthetic show.
-    root.parentElement?.querySelector(".connect-layer")?.classList.add("br-hidden");
+  // Dev-only synthetic brain: started once, then left running for the life of
+  // the view — there is no robot behind it to spare.
+  function startDemo() {
+    if (demoStarted) return;
+    demoStarted = true;
     void import("./demo.js").then((m) => {
-      if (destroyed) return; // the page unmounted before the chunk loaded
-      demoStop = m.startDemo(handlers);
+      if (destroyed) return;
+      demoStop = m.startDemo({ onTrace, onSkill, onAgentStatus, onBrainStatus, setPose, setSpeaking });
     });
-  } else {
+  }
+
+  function subscribe() {
     unsubs = [
       ros.subscribe("/brain/trace", jsonHandler(onTrace), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/agent_status", jsonHandler(onAgentStatus), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/websocket_status", jsonHandler(onBrainStatus), 0, "std_msgs/msg/String"),
-      ros.subscribe("/brain/chat_out", jsonHandler(onChat), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/skill_status_update", jsonHandler(onSkill), 0, "std_msgs/msg/String"),
       ros.subscribe("/tts/is_playing", (msg) => setSpeaking(msg.data === "true"), 0, "std_msgs/msg/String"),
       ros.subscribe(
@@ -771,7 +766,9 @@ function buildView(root) {
       ros.subscribe(
         CAM_TOPIC,
         (msg) => {
-          if (!S.haveTrace) showFrame("data:image/jpeg;base64," + msg.data, "live camera");
+          // Until the first traced turn lands, the live camera stands in — on a
+          // view opened mid-run that's the difference between a picture and NO SIGNAL.
+          if (!shownTurn) showFrame("data:image/jpeg;base64," + msg.data, "live camera");
         },
         500,
         "sensor_msgs/msg/CompressedImage",
@@ -780,31 +777,44 @@ function buildView(root) {
   }
 
   return {
+    // Switching back to the live cockpit keeps the built view and everything it
+    // has collected (turns, latencies, the inspector) — only the feeds stop.
+    resume() {
+      if (live || destroyed) return;
+      live = true;
+      raf = requestAnimationFrame(tickUI);
+      if (opts.demo) startDemo();
+      else subscribe();
+    },
+    suspend() {
+      if (!live) return;
+      live = false;
+      cancelAnimationFrame(raf);
+      for (const u of unsubs) u();
+      unsubs = [];
+    },
     destroy() {
       destroyed = true;
+      live = false;
       cancelAnimationFrame(raf);
       window.clearTimeout(pingTimer);
       window.clearTimeout(motionTimer);
       for (const id of uiTimers) window.clearTimeout(id);
       window.removeEventListener("keydown", onKey);
-      unsubs.forEach((u) => u());
+      for (const u of unsubs) u();
       demoStop?.();
-      root.innerHTML = "";
+      root.remove();
+      inspector.remove();
     },
   };
 }
 
 function template() {
   return `
-  <div class="br-head">
-    <h1 class="page-title">Brain</h1>
-    <div class="br-chips">
-      <div class="br-chip br-chip-active" title="/brain/agent_status"><span class="led"></span><span>brain <b>—</b></span></div>
-      <div class="br-chip br-chip-directive" title="current directive — /brain/agent_status"><span>directive</span><b>—</b></div>
-      <div class="br-chip br-chip-backend" title="inference backend — /brain/trace, falling back to /brain/websocket_status"><span>backend</span><b>—</b></div>
-      <div class="br-chip br-chip-model" title="model in use — /brain/trace"><span>model</span><b>—</b></div>
-      <div class="br-chip br-chip-voice" title="pulses while the robot speaks — /tts/is_playing"><span class="led"></span><span>voice</span></div>
-    </div>
+  <div class="br-chips">
+    <div class="br-chip br-chip-backend" title="inference backend — /brain/trace, falling back to /brain/websocket_status"><span>backend</span><b>—</b></div>
+    <div class="br-chip br-chip-model" title="model in use — /brain/trace"><span>model</span><b>—</b></div>
+    <div class="br-chip br-chip-voice" title="pulses while the robot speaks — /tts/is_playing"><span class="led"></span><span>voice</span></div>
   </div>
   <div class="br-grid">
     <section class="br-panel br-panel-loop">
@@ -848,14 +858,9 @@ function template() {
       </div>
     </section>
 
-    <section class="br-panel br-panel-mind">
-      <h2>Mind stream <span class="sub">thoughts · speech · system</span></h2>
-      <div class="br-feed br-mind"></div>
-    </section>
-
     <section class="br-panel br-panel-actions">
       <h2>Turns &amp; actions <span class="sub">tool calls and skill runs</span></h2>
-      <div class="br-feed br-actions"></div>
+      <div class="br-feed br-actions"><div class="br-empty">waiting for the first turn</div></div>
     </section>
 
     <section class="br-panel br-panel-queue">
@@ -880,8 +885,11 @@ function template() {
         <div class="lab" title="Entries in the rolling conversation history the model sees"><span>conversation history</span><span class="br-hist-txt">0 / ${HIST_MAX}</span></div>
       </div>
     </section>
-  </div>
-  <div class="br-inspect" hidden>
+  </div>`;
+}
+
+function inspectorTemplate() {
+  return `
     <div class="br-inspect-back"></div>
     <div class="br-inspect-card">
       <div class="br-i-head">
@@ -901,6 +909,5 @@ function template() {
         <div class="br-i-out"></div>
         <details class="br-i-sys"><summary>system instruction</summary><pre></pre></details>
       </div>
-    </div>
-  </div>`;
+    </div>`;
 }

--- a/webapp/js/pageMount.js
+++ b/webapp/js/pageMount.js
@@ -20,9 +20,11 @@ import { createConnectPanel } from "./teleop/connectPanel.js";
  * @param {string} viewClass CSS class for the view layer (e.g. "cockpit").
  * @param {(root: HTMLElement) => { destroy: () => void }} buildView
  *   Builds the page's content; called once, immediately, before the socket is up.
+ * @param {{ offline?: boolean }} [opts] `offline` means no robot is expected
+ *   (a ?demo run): don't dial, and never trade the view for the connect card.
  * @returns {{ destroy: () => void }} the built view
  */
-export function mountPage(stage, viewClass, buildView) {
+export function mountPage(stage, viewClass, buildView, opts = {}) {
   const connectLayer = document.createElement("div");
   connectLayer.className = "connect-layer";
   const viewLayer = document.createElement("div");
@@ -44,7 +46,7 @@ export function mountPage(stage, viewClass, buildView) {
   const servedHost = location.hostname;
   const robotServed = servedHost && servedHost !== "localhost" && servedHost !== "127.0.0.1";
   const target = robotServed ? servedHost : (ros.lastIp ?? servedHost);
-  if (target) {
+  if (target && !opts.offline) {
     ros.connect(target);
   }
 
@@ -52,7 +54,7 @@ export function mountPage(stage, viewClass, buildView) {
   // badge carries the link status. Only a fail-fast "disconnected" (a first
   // connect that never opened, or the idle laptop-dev state) shows the card.
   const unsubState = ros.onStateChange((state) => {
-    const failed = state === "disconnected";
+    const failed = state === "disconnected" && !opts.offline;
     connectLayer.hidden = !failed;
     viewLayer.hidden = failed;
   });

--- a/webapp/js/router.js
+++ b/webapp/js/router.js
@@ -30,7 +30,6 @@ import { getConfig } from "./config.js";
 const ROUTES = [
   { path: "/", key: "teleop", load: () => import("./teleop/main.js") },
   { path: "/agent", key: "agent", load: () => import("./agent/main.js") },
-  { path: "/brain", key: "brain", load: () => import("./brain/main.js") },
   { path: "/nav", key: "nav", load: () => import("./nav/main.js") },
   { path: "/logging", key: "logging", load: () => import("./logging/main.js") },
   { path: "/datasets", key: "datasets", load: () => import("./datasets/main.js") },
@@ -41,6 +40,20 @@ const ROUTES = [
   { path: "/armsdk", key: "armsdk", load: () => import("./armsdk/main.js") },
   { path: "/settings", key: "settings", load: () => import("./settings/main.js") },
 ];
+
+// Sections that folded into another page. Brain is a view of Agent now, so old
+// links (/brain, /brain?demo) land on it instead of falling back to teleop.
+/** @type {Record<string, string>} */
+const MOVED = { "/brain": "/agent?view=brain" };
+
+/** The current URL for a possibly-moved path, keeping the caller's query. @param {URL} url */
+function relocate(url) {
+  const moved = MOVED[normalize(url.pathname)];
+  if (!moved) return url;
+  const next = new URL(moved, location.origin);
+  for (const [k, v] of url.searchParams) next.searchParams.set(k, v);
+  return next;
+}
 
 const stage = /** @type {HTMLElement} */ (document.getElementById("stage"));
 
@@ -63,12 +76,25 @@ function routeFor(pathname) {
   return ROUTES.find((r) => r.path === p) || ROUTES[0];
 }
 
+/** True for anything this router handles, including the moved paths. @param {string} pathname */
+function isAppPath(pathname) {
+  const p = normalize(pathname);
+  return p in MOVED || ROUTES.some((r) => r.path === p);
+}
+
+/** Where we should be: rewrites a moved path in place, then reports it. */
+function landing() {
+  const url = relocate(new URL(location.href));
+  if (url.href !== location.href) history.replaceState({}, "", url.pathname + url.search);
+  return url;
+}
+
 const shell = initShell(navigate);
 
 // Sim deployments hide robot-data workflows from the rail (shell.js's
 // SIM_SECTIONS); gate the routes too, so a deep link or refresh can't mount
 // a page whose services have no sim backing.
-const SIM_ROUTE_KEYS = new Set(["teleop", "agent", "brain", "nav", "logging", "armsdk", "settings"]);
+const SIM_ROUTE_KEYS = new Set(["teleop", "agent", "nav", "logging", "armsdk", "settings"]);
 /** @type {Promise<{simControls?: boolean}>} */
 const configPromise = getConfig();
 
@@ -126,7 +152,7 @@ function dismissBootSplash() {
  * @param {string} href pathname (+ optional search), e.g. "/collect?dir=x".
  */
 function navigate(href) {
-  const url = new URL(href, location.origin);
+  const url = relocate(new URL(href, location.origin));
   const route = routeFor(url.pathname);
   if (route.key === currentKey && url.search === location.search) return;
   history.pushState({}, "", url.pathname + url.search);
@@ -143,14 +169,14 @@ document.addEventListener("click", (e) => {
   const a = target instanceof Element ? target.closest("a") : null;
   if (!(a instanceof HTMLAnchorElement)) return;
   if (a.target === "_blank" || a.hasAttribute("download") || a.origin !== location.origin) return;
-  if (!ROUTES.some((r) => r.path === normalize(a.pathname))) return; // not an app route
+  if (!isAppPath(a.pathname)) return; // not an app route
   e.preventDefault();
   navigate(a.pathname + a.search);
 });
 
 // Back/forward: re-render for the target location (history is already updated).
 window.addEventListener("popstate", () => {
-  const route = routeFor(location.pathname);
+  const route = routeFor(landing().pathname);
   if (route.key === currentKey) return;
   void render(route);
 });
@@ -191,7 +217,7 @@ if (connectTarget) {
 
 // Render the page for the URL we loaded at (deep link or refresh), then prefetch
 // the other route modules while idle so later switches are instant.
-void render(routeFor(location.pathname));
+void render(routeFor(landing().pathname));
 prefetchRoutes();
 
 function prefetchRoutes() {

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -21,7 +21,7 @@ import { installPressActivate } from "./pressActivate.js";
 // calibrate against — so they're hidden from the rail. Arm SDK stays: the sim
 // runs the same IK node and answers the goto services, so the page exercises
 // the real Manipulation SDK against the simulated arm.
-const SIM_SECTIONS = new Set(["teleop", "agent", "brain", "nav", "logging", "armsdk", "settings"]);
+const SIM_SECTIONS = new Set(["teleop", "agent", "nav", "logging", "armsdk", "settings"]);
 
 /** @type {Section[]} */
 const SECTIONS = [
@@ -36,12 +36,6 @@ const SECTIONS = [
     label: "Agent",
     // Sparkle motif: a four-point star for the autonomous brain.
     icon: '<path d="M12 3.5l1.7 6.8 6.8 1.7-6.8 1.7L12 20.5l-1.7-6.8L3.5 12l6.8-1.7z"/>',
-  },
-  {
-    key: "brain",
-    label: "Brain",
-    // Monitor motif: an EKG pulse line, for the live agent-loop monitor.
-    icon: '<polyline points="3.5,12 7.5,12 10,6.5 13,17.5 15.5,12 20.5,12"/>',
   },
   {
     key: "nav",


### PR DESCRIPTION
Brain was its own rail section showing the agent loop, while Agent showed the same
brain's chat and Start/Stop — two pages for one thing, and you had to leave the
controls to watch the internals.

Now the Agent page has two views behind one panel. Its header carries a **Live /
Brain** switch: Live is the cockpit as before, Brain is the loop monitor filling
the stage left of the panel. The panel itself never moves, so a directive can be
started, stopped or messaged from inside the trace view.

### What's in it

- **Brain sheds its duplicates.** The Mind stream panel and the brain/directive
  chips are gone: the Agent panel beside it is the canonical chat (thought
  grouping, skill runs, composer), and two feeds on one screen is noise. What
  stays is what only the trace can tell you — the loop dial, turn-exact frames +
  inspector, tool calls, event queue, vitals.
- **Optional in the way that matters.** The layer is built on first open and only
  *suspends* on the way out, so a cockpit that never opens it never subscribes to
  `/brain/trace` (full JPEGs every turn), and the turns it collected survive a
  round trip to Live and back.
- **The turn inspector hangs off the cockpit, not the layer** — the layer's
  `backdrop-filter` would otherwise become the containing block for its fixed
  positioning and pin the modal inside the layer's box.
- **Old links keep working.** The router relocates `/brain` to `/agent?view=brain`
  with the query intact; the view is deep-linkable and syncs the URL with
  `replaceState`, so switching never re-renders the route (which would tear down
  the WebRTC session mid-switch).
- **`?demo` renders again.** It was being hidden by `mountPage`'s disconnect
  handler on a laptop with no robot; `mountPage` learned `offline`, which keeps
  the view up instead of trading it for the connect card.
- **Cold start reads the turn number from the trace snapshot** and falls back to
  the live camera until the first traced turn lands — opening mid-run is now the
  common case, not turn 0.

Layout reflows for the narrower stage: vision spans the top, the three feeds band
underneath, stacking and scrolling below ~1140px and riding above the bottom sheet
on phones.

### Verification

Driven against a throwaway fake-rosbridge server with synthetic brain traces, at
1920 / 1440 / 1280 / 1100 / 375px, plus over a simulated blown-out white feed to
check the wash. Subscribe/unsubscribe verified on the wire (entering Brain
subscribes `/brain/trace`, leaving drops it; ref-counted topics shared with the
panel are untouched). `tsc --noEmit` shows no new errors — and the two pre-existing
ones in the brain module are fixed. `webapp/tests` pass.