### PR TITLE
fix(sim): recover silent ROS stream stalls

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
@@ -72,6 +72,12 @@ SCAN_HZ = 6.0  # lidar.launch.py throttle
 JOINT_STATE_HZ = 30.0
 ARM_STATE_HZ = 20.0
 HEAD_POSITION_HZ = 10.0
+# rmw_zenoh can leave an executor asleep after dynamic graph/action churn even
+# though its timers are ready. A non-executor guard-condition wake is cheap and
+# specifically repairs that stale wait set; only intervene after a full second
+# of missed 30 Hz odometry callbacks.
+EXECUTOR_STALL_S = 1.0
+EXECUTOR_WATCHDOG_PERIOD_S = 0.5
 
 LIDAR_N_RAYS = 360
 LIDAR_RANGE_MIN = 0.15  # rplidar A-series
@@ -182,7 +188,7 @@ class VirtualMarsNode(Node):
             self.create_service(Trigger, f"/mars/arm/{name}", self._on_trigger_noop, callback_group=services)
         self.create_service(Trigger, "/mars/head/set_ai_position", self._on_head_ai_position, callback_group=services)
 
-        self.create_timer(1.0 / ODOM_HZ, self._publish_odom)
+        self._odom_timer = self.create_timer(1.0 / ODOM_HZ, self._publish_odom)
         self.create_timer(1.0 / SCAN_HZ, self._publish_scan)
         self.create_timer(1.0 / DEPTH_FPS, self._publish_camera_info)
         self.create_timer(1.0 / JOINT_STATE_HZ, self._publish_joint_states)
@@ -205,6 +211,35 @@ class VirtualMarsNode(Node):
             fn()
         except (OSError, RuntimeError) as exc:
             self.get_logger().warning(f"{what} dropped: world server unavailable ({exc})", throttle_duration_sec=5.0)
+
+    def executor_watchdog_loop(self, executor: MultiThreadedExecutor) -> None:
+        """Wake a stale ROS wait set from outside the executor.
+
+        Rendering and this watchdog have their own threads, so they remain
+        observable when every ROS timer/subscription callback stops. `wake()`
+        triggers rclpy's executor guard condition; it does not recreate the
+        node, alter commands, or touch simulation state.
+        """
+        last_warning = 0.0
+        while rclpy.ok():
+            time.sleep(EXECUTOR_WATCHDOG_PERIOD_S)
+            try:
+                until_ns = self._odom_timer.time_until_next_call()
+                overdue_s = 0.0 if until_ns is None or until_ns >= 0 else -until_ns / 1_000_000_000
+                if overdue_s < EXECUTOR_STALL_S:
+                    continue
+                now = time.monotonic()
+                if now - last_warning >= 5.0:
+                    last_warning = now
+                    print(
+                        f"[virtual_mars] ROS executor timer overdue by {overdue_s:.1f}s; waking wait set",
+                        flush=True,
+                    )
+                executor.wake()
+            except Exception as exc:  # noqa: BLE001 -- watchdog must never take down the driver
+                if time.monotonic() - last_warning >= 5.0:
+                    last_warning = time.monotonic()
+                    print(f"[virtual_mars] executor watchdog error: {exc!r}", flush=True)
 
     def _on_cmd_vel(self, msg: Twist) -> None:
         with self._lock:
@@ -641,6 +676,7 @@ def main() -> None:
     node = VirtualMarsNode()
     executor = MultiThreadedExecutor(num_threads=4)
     executor.add_node(node)
+    threading.Thread(target=node.executor_watchdog_loop, args=(executor,), daemon=True).start()
     try:
         executor.spin()
     except KeyboardInterrupt:

--- a/webapp/js/rosClient.js
+++ b/webapp/js/rosClient.js
@@ -19,6 +19,10 @@ const RECONNECT_BASE_MS = 1_000;
 const MAX_ORPHANED_GOALS = 8;
 const RECONNECT_CAP_MS = 10_000;
 const SUB_RETRY_CAP_MS = 30_000;
+// WebSocket ping/pong cannot detect an rws client whose socket is alive while
+// its ROS executor subscriptions have stopped delivering. Once a connection
+// has demonstrably flowed, 15 seconds with zero frames is a silent stall.
+const SILENT_STALL_MS = 15_000;
 
 /**
  * True when a value carries no actual data: null/undefined, or an object/array
@@ -89,6 +93,9 @@ export class RosClient {
   /** True once the current target IP has had a successful open; gates the
    * reconnect-forever loop so a typo'd address fails fast instead. */
   #everConnected = false;
+  #flowFrames = 0;
+  #lastFrameAt = 0;
+  #stallClosing = false;
 
   constructor() {
     // Safety net: a hidden or closing page must never leave the robot
@@ -103,6 +110,8 @@ export class RosClient {
     document.addEventListener("visibilitychange", () => {
       if (document.visibilityState === "hidden") publishZero();
     });
+    // Some zero-DOM unit tests provide only the window methods they exercise.
+    window.setInterval?.(() => this.#checkSilentStall(), 5000);
   }
 
   /** @returns {ConnState} */
@@ -332,6 +341,9 @@ export class RosClient {
       this.#clearConnectTimer();
       this.#reconnectDelay = RECONNECT_BASE_MS;
       this.#everConnected = true;
+      this.#flowFrames = 0;
+      this.#lastFrameAt = 0;
+      this.#stallClosing = false;
       try {
         localStorage.setItem(LAST_IP_KEY, ip);
       } catch {
@@ -355,7 +367,10 @@ export class RosClient {
 
     ws.onmessage = (event) => {
       if (this.#ws !== ws) return;
-      this.#handleFrame(String(event.data));
+      const raw = String(event.data);
+      this.#flowFrames += 1;
+      this.#lastFrameAt = performance.now();
+      this.#handleFrame(raw);
     };
 
     ws.onclose = () => {
@@ -519,6 +534,22 @@ export class RosClient {
   #send(payload) {
     if (this.#ws?.readyState === WebSocket.OPEN) {
       this.#ws.send(JSON.stringify(payload));
+    }
+  }
+
+  #checkSilentStall() {
+    const now = performance.now();
+    const frameAgeMs = this.#lastFrameAt ? now - this.#lastFrameAt : null;
+    if (
+      !this.#stallClosing &&
+      this.#state === "connected" &&
+      this.#ws?.readyState === WebSocket.OPEN &&
+      this.#flowFrames >= 10 &&
+      frameAgeMs !== null &&
+      frameAgeMs >= SILENT_STALL_MS
+    ) {
+      this.#stallClosing = true;
+      this.#ws.close(4000, "ROS frame stream stalled");
     }
   }
 


### PR DESCRIPTION
## Summary

- Observed two silent stalls after action traffic: an `rws` client kept its WebSocket open but stopped forwarding subscribed ROS topics, and `virtual_mars` stopped running ROS timers/subscription callbacks while its render thread and host world stream stayed alive. `/cmd_vel` remained present on the ROS bus but was no longer applied.
- A new temporary subscription immediately revived the existing `rws` client, and the driver timers were all ready but increasingly overdue. This points to stale executor/wait-set state around `rmw_zenoh` dynamic graph/action churn; the exact lower-level defect is not established.
- Mitigate the driver stall by waking its executor guard condition when the 30 Hz odometry timer is more than one second overdue. Mitigate the browser stall by closing an already-flowing socket after 15 seconds with no frames, allowing the existing reconnect path to replay subscriptions.
- These are intentionally narrow recovery mechanisms, not a claim that this is the preferred root fix; a lower-level `rws` or `rmw_zenoh` change may be better.

## Reproduction without this fix

1. Start the simulator with `./innate-sim up`.
2. In the simulator UI, navigate the robot to a goal pose.
3. Repeat navigation to different goal poses several times.
4. Eventually, the simulator can stop receiving the ROS data stream even though the WebSocket still reports itself as connected. The UI then stops reflecting robot movement or other live state until the stream recovers or the connection is recreated.

The failure is intermittent, so the number of navigation attempts varies.

## Validation

- [x] Python compilation and Ruff pass for the driver change.
- [x] Browser syntax, existing RosClient transport tests (9), and changed-file TypeScript checks pass.
- [x] Launcher/proxy test subset passes (17 tests).
- [x] Reproduced live: the browser socket stayed open with frame delivery frozen; a fresh subscription revived the old client. Separately, `virtual_mars` showed all ROS timers overdue while rendering continued and `/cmd_vel` remained on the bus.
- [ ] I did not launch a second full simulator from the isolated PR worktree because the equivalent patch was already running in the active simulator checkout.