### PR TITLE
feat(brain+webapp): forget one remembered view, not just all of them

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
@@ -97,6 +97,24 @@ class FrameFiles:
 
         threading.Thread(target=run, name="memory-file-purge", daemon=True).start()
 
+    def forget(self, memory_id: int) -> None:
+        """One memory was forgotten: best-effort delete its server-side copy now.
+        The registry prune (:meth:`_save_locked`) would otherwise drop the URI
+        while the upload lives on until Gemini's 48 h expiry."""
+        with self._lock:
+            self._sync_map_locked()
+            record = self._records.pop(memory_id, None)
+            if record is not None:
+                self._save_locked()
+        if record is None:
+            return
+
+        def run() -> None:
+            with contextlib.suppress(Exception):  # best effort; expiry is the backstop
+                self._rest.delete("/v1beta/files/" + record.uri.rsplit("/", 1)[-1])
+
+        threading.Thread(target=run, name="memory-file-forget", daemon=True).start()
+
     def maintain(self) -> None:
         """Upload new/refreshed/aging frames in the background; returns immediately."""
         if self.unsupported or time.monotonic() < self._retry_at:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -256,6 +256,24 @@ class MemorySearch:
 
         threading.Thread(target=run, name="memory-cache-forget", daemon=True).start()
 
+    def forget_frame(self, memory: Memory) -> None:
+        """The user forgot one memory: delete its server-side upload and drop
+        the context cache embedding the frame — a retire note only shadows it,
+        and the handle would otherwise serve the view until its 12 h TTL. The
+        other uploads stay, so the next warm() rebuild references them cheaply."""
+        self._files.forget(memory.id)
+        cache = self._cache
+        if cache is None or all(m.id != memory.id for m in cache.memories):
+            return
+        if self._cache is cache:
+            self._cache = None
+
+        def run() -> None:
+            with contextlib.suppress(Exception):
+                self._rest.delete(f"/v1beta/{cache.name}")
+
+        threading.Thread(target=run, name="memory-cache-forget", daemon=True).start()
+
     # --- cache management (under _flight, except the read-only probes) ---
     def _cache_matches(self, snapshot: MemorySnapshot) -> bool:
         cache = self._cache

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -161,12 +161,22 @@ class MemoryStore:
             return cleared
 
     def evict(self, memory: Memory) -> None:
+        self.forget(memory.id)
+
+    def forget(self, memory_id: int, fingerprint: str = "") -> Memory | None:
+        """Evict one memory by id, returning it — None when the id is unknown
+        or the caller's fingerprint is stale (a re-map restarts ids, so a stale
+        client must not delete the new map's memories; empty skips the check)."""
         with self._lock:
-            if self._dir is None or all(m.id != memory.id for m in self._memories):
-                return
-            self._memories = [m for m in self._memories if m.id != memory.id]
-            (self._dir / f"{memory.id}.jpg").unlink(missing_ok=True)
+            if self._dir is None or (fingerprint and fingerprint != self._fingerprint):
+                return None
+            memory = next((m for m in self._memories if m.id == memory_id), None)
+            if memory is None:
+                return None
+            self._memories = [m for m in self._memories if m.id != memory_id]
+            (self._dir / f"{memory_id}.jpg").unlink(missing_ok=True)
             self._commit_locked()
+            return memory
 
     # --- locked internals ---
     def _load_locked(self) -> None:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -166,9 +166,10 @@ class MemoryStore:
     def forget(self, memory_id: int, fingerprint: str = "") -> Memory | None:
         """Evict one memory by id, returning it — None when the id is unknown
         or the caller's fingerprint is stale (a re-map restarts ids, so a stale
-        client must not delete the new map's memories; empty skips the check)."""
+        client must not delete the new map's memories; empty skips the check).
+        Prefix-matched: the positions payload publishes a truncated digest."""
         with self._lock:
-            if self._dir is None or (fingerprint and fingerprint != self._fingerprint):
+            if self._dir is None or (fingerprint and not self._fingerprint.startswith(fingerprint)):
                 return None
             memory = next((m for m in self._memories if m.id == memory_id), None)
             if memory is None:

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -16,7 +16,7 @@ import threading
 import time
 
 import rclpy
-from brain_messages.srv import GetAvailableDirectives, GetChatHistory, ReloadSkillsAgents, ResetBrain
+from brain_messages.srv import ForgetMemory, GetAvailableDirectives, GetChatHistory, ReloadSkillsAgents, ResetBrain
 from geometry_msgs.msg import Twist
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
@@ -243,6 +243,7 @@ class BrainClientNode(Node):
         self.create_service(SetBool, "/brain/set_brain_active", self._svc_set_brain_active)
         self.create_service(Trigger, "/brain/reload", self._svc_reload)
         self.create_service(Trigger, "/brain/clear_memories", self._svc_clear_memories)
+        self.create_service(ForgetMemory, "/brain/forget_memory", self._svc_forget_memory)
         self.create_service(ReloadSkillsAgents, "/brain/reload_skills_agents", self._svc_reload_skills_agents)
         self.create_service(GetAvailableDirectives, "/brain/get_available_directives", self._svc_get_directives)
 
@@ -491,6 +492,21 @@ class BrainClientNode(Node):
         self.get_logger().info(f"[BrainClient] Cleared {cleared} spatial memories on user request")
         response.success = True
         response.message = f"Forgot {cleared} remembered views"
+        return response
+
+    def _svc_forget_memory(
+        self, request: ForgetMemory.Request, response: ForgetMemory.Response
+    ) -> ForgetMemory.Response:
+        # Unlike clear, no memory_search.forget(): a single eviction reaches
+        # the cached search as a retire note on its next query (_delta_parts).
+        memory = self.memory_store.forget(request.memory_id, request.fingerprint)
+        if memory is None:
+            response.success = False
+            response.message = "No such memory — the map may have been re-made; refresh and retry"
+            return response
+        self.get_logger().info(f"[BrainClient] Forgot spatial memory {memory.id} on user request")
+        response.success = True
+        response.message = f"Forgot the view at x {memory.x:.2f}, y {memory.y:.2f}"
         return response
 
     def _svc_reload(self, request, response):

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -497,13 +497,16 @@ class BrainClientNode(Node):
     def _svc_forget_memory(
         self, request: ForgetMemory.Request, response: ForgetMemory.Response
     ) -> ForgetMemory.Response:
-        # Unlike clear, no memory_search.forget(): a single eviction reaches
-        # the cached search as a retire note on its next query (_delta_parts).
         memory = self.memory_store.forget(request.memory_id, request.fingerprint)
         if memory is None:
             response.success = False
             response.message = "No such memory — the map may have been re-made; refresh and retry"
             return response
+        if self.memory_search is not None:
+            # Forgetting must reach the server-side copies too (same reason as
+            # clear): the frame's upload and the cache embedding it would
+            # otherwise keep serving the forgotten view until their own expiry.
+            self.memory_search.forget_frame(memory)
         self.get_logger().info(f"[BrainClient] Forgot spatial memory {memory.id} on user request")
         response.success = True
         response.message = f"Forgot the view at x {memory.x:.2f}, y {memory.y:.2f}"

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -342,6 +342,34 @@ def test_eviction_removes_the_image_file(data_dir):
     assert store.snapshot().memories == ()
 
 
+def test_forget_removes_the_memory_and_its_image(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    added = store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    assert added is not None
+    assert store.forget(added.id, store.fingerprint) == added
+    path = store.image_path(added.id)
+    assert path is not None and not path.exists()
+    assert store.snapshot().memories == ()
+
+
+def test_forget_with_a_stale_fingerprint_is_refused(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    added = store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    assert added is not None
+    assert store.forget(added.id, "fingerprint-of-the-old-map") is None
+    assert len(store.snapshot().memories) == 1
+
+
+def test_forget_an_unknown_id_is_a_noop(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    assert store.forget(99) is None
+    assert len(store.snapshot().memories) == 1
+
+
 def test_replace_keeps_the_slot_and_updates_everything_else(data_dir):
     store = MemoryStore(data_dir)
     store.switch_map("A.yaml")

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -347,7 +347,8 @@ def test_forget_removes_the_memory_and_its_image(data_dir):
     store.switch_map("A.yaml")
     added = store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
     assert added is not None
-    assert store.forget(added.id, store.fingerprint) == added
+    # The truncated digest from /brain/memory_positions — what a client sends.
+    assert store.forget(added.id, store.fingerprint[:12]) == added
     path = store.image_path(added.id)
     assert path is not None and not path.exists()
     assert store.snapshot().memories == ()
@@ -963,6 +964,32 @@ def test_a_busy_search_returns_a_typed_verdict_instead_of_queuing(data_dir, monk
         search._flight.release()
     assert not verdict.found and "still running" in verdict.error
     assert fake.generates == []  # never reached the network
+
+
+def test_forget_frame_purges_its_upload_and_the_cache_embedding_it(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    upload_frames(search)
+    build_cache(search)
+    memory = memory_with_id(store, 2)
+    assert store.forget(memory.id) == memory
+    search.forget_frame(memory)
+    assert search._cache is None
+    assert 2 not in search._files._records and len(search._files._records) == 5
+    deadline = time.time() + 2.0
+    while len(fake.deletes) < 2 and time.time() < deadline:
+        time.sleep(0.01)
+    assert "/v1beta/cachedContents/c1" in fake.deletes
+    assert "/v1beta/files/f2" in fake.deletes
+    assert len(fake.deletes) == 2  # the other five uploads survive for the next rebuild
+
+
+def test_forget_frame_keeps_a_cache_that_never_embedded_it(data_dir):
+    search, fake, store = make_search(data_dir, frames=6)
+    build_cache(search)
+    added = store.add(30.0, 0.0, 0.0, 2000.0, b"jpg-late")  # id 7, after the build
+    assert added is not None and store.forget(added.id) == added
+    search.forget_frame(added)
+    assert search._cache is not None and fake.deletes == []
 
 
 def test_forget_drops_the_cache_and_purges_the_uploads(data_dir):

--- a/ros2_ws/src/brain/brain_messages/CMakeLists.txt
+++ b/ros2_ws/src/brain/brain_messages/CMakeLists.txt
@@ -35,6 +35,7 @@ set(srv_files
   "srv/SetEpisodeOutcome.srv"
   "srv/DeleteEpisode.srv"
   "srv/CopyEpisode.srv"
+  "srv/ForgetMemory.srv"
 )
 
 set(msg_files

--- a/ros2_ws/src/brain/brain_messages/srv/ForgetMemory.srv
+++ b/ros2_ws/src/brain/brain_messages/srv/ForgetMemory.srv
@@ -1,0 +1,10 @@
+# Request — forget one remembered viewpoint on the current map. Ids restart
+# from 1 after a same-name re-map, so the request carries the map fingerprint
+# from /brain/memory_positions — a stale client must not delete the new map's
+# memories. Empty fingerprint skips the check (CLI callers).
+int32 memory_id
+string fingerprint
+---
+# Response
+bool success
+string message

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -7184,6 +7184,16 @@ select.skill-input {
   border-color: rgb(180 140 255 / 80%);
 }
 
+.mem-card-btn-forget:hover:not(:disabled) {
+  color: var(--danger);
+  border-color: rgb(217 106 90 / 60%);
+}
+
+.mem-card-btn-forget:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 /* The recall verdict — floats in from the top of the scene, dismisses itself. */
 .mem-search-card {
   position: absolute;

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -135,6 +135,10 @@ export const MAPPING_POSE_TOPIC = "/mapping_pose";
 // /memory/image?map=…&id=… (webapp/proxy/media_routes.py).
 export const MEMORY_POSITIONS_TOPIC = "/brain/memory_positions";
 export const CLEAR_MEMORIES_SERVICE = "/brain/clear_memories";
+// Per-memory delete (brain_messages/ForgetMemory: memory_id + the positions
+// payload's fingerprint — a stale tab must not delete from a re-made map
+// whose ids restarted).
+export const FORGET_MEMORY_SERVICE = "/brain/forget_memory";
 // One latched message per finished memory search (std_msgs/String JSON:
 // {query, found, id?, x?, y?, theta?, seen_stamp?, explanation?, error?,
 // latency_sec?, cached?, stamp}). Latched so a page opened just after the

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -25,6 +25,7 @@ import {
   MAPPING_POSE_TOPIC,
   MEMORY_POSITIONS_TOPIC,
   MEMORY_SEARCH_TOPIC,
+  FORGET_MEMORY_SERVICE,
 } from "../constants.js";
 import { MEMORY_COLOR, SEARCH_REPLAY_FRESH_S, ageAlpha, ageText, headerSkew, memoryImageUrl, parseMemories, parseSearch, withAlpha } from "./memories.js";
 
@@ -546,12 +547,34 @@ export function createMap(root, opts = {}) {
       closeMemPopup();
       publishGoal(m.x, m.y, m.theta);
     });
+    const forget = document.createElement("button");
+    forget.type = "button";
+    forget.className = "mem-card-btn mem-card-btn-forget";
+    forget.textContent = "Forget";
+    forget.title = `${FORGET_MEMORY_SERVICE} — permanently forget this remembered view`;
+    const fingerprint = memState.fingerprint;
+    forget.addEventListener("click", () => {
+      if (!window.confirm("Forget this remembered view? The robot re-learns the spot next time it looks around there.")) {
+        return;
+      }
+      forget.disabled = true;
+      ros
+        .callService(FORGET_MEMORY_SERVICE, { memory_id: m.id, fingerprint })
+        .then((res) => {
+          if (res && res.success === false) throw new Error(res.message || "forget failed");
+          closeMemPopup(); // the dot and thumbnail leave when the positions topic republishes
+        })
+        .catch((err) => {
+          forget.disabled = false;
+          window.alert(`Couldn't forget this view: ${err.message}`);
+        });
+    });
     const close = document.createElement("button");
     close.type = "button";
     close.className = "mem-card-btn";
     close.textContent = "Close";
     close.addEventListener("click", closeMemPopup);
-    actions.append(goHere, close);
+    actions.append(goHere, forget, close);
     memPopup.append(img, meta, actions);
     memPopup.hidden = false;
     placeMemCard(memPopup, m);


### PR DESCRIPTION
## Summary

Spatial memory was all-or-nothing. If the robot remembered a bad viewpoint — a blurry frame, a spot it shouldn't have kept — the only cure was **forget all** and re-driving the map to rebuild everything. This adds the per-memory delete.

The popup that already offers **Go here** now also offers **Forget**, reachable from either surface that opens it: a dot on the map, or a thumbnail in the Memories sidebar reel. It confirms, calls the service, and the dot and thumbnail leave when `/brain/memory_positions` republishes — the same "the topic is the success signal" pattern **forget all** already uses.

### The fingerprint on the request

`ForgetMemory` takes `memory_id` **and** the `fingerprint` from the positions payload. Memory ids only mean anything within a `(map, fingerprint)` pair: a same-name remap wipes the memories and restarts `_next_id` at 1 (`store.py`, the `switch_map` block). Without the guard, a tab left open across a remap would delete a *different* memory than the one pictured in its popup. Empty fingerprint skips the check, so a CLI caller doesn't have to look one up. Same reasoning as #626, same field.

### What it deliberately doesn't do

`_svc_clear_memories` calls `memory_search.forget()` to drop the Gemini context cache and its uploaded frames. A single eviction doesn't need that: `_delta_parts` already emits `"Frame N no longer exists — ignore it."` for ids missing from the snapshot, so the next search is correct against the existing cache instead of paying a full rebuild. The frame's server-side upload is left to its own expiry, and `files.json` prunes it to the live ids on the next save — matching what eviction by the recorder has always done.

`MemoryStore.forget()` holds the store lock across lookup, guard, and eviction, so a concurrent recorder tick can't evict the same slot in between. The recorder's `evict()` is now a one-line delegate to it — one code path, not two.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - **225 brain_client tests pass** (3 new against the store: forget removes the memory and its image file; a stale fingerprint is refused and the memory survives; an unknown id is a no-op). The existing eviction/replace/clear tests pass unchanged.
  - `ruff check` + `ruff format --check` clean. `basedpyright` shows the same 13 errors as clean `main` — all in files this PR doesn't touch (`runner.py`, `arm_sdk_server.py`, `manipulation.py`, `initializer.py`); verified by stashing. Nothing new.
  - `node webapp/tests/memories.test.js` — 10 passed.
  - **Driven live**: `brain_messages` and `brain_client` rebuilt, `innate restart`, and `/brain/forget_memory` answers on the live graph — a call with an unknown id returns `success=False, "No such memory — the map may have been re-made; refresh and retry"`.
  - **New `.srv`** — `brain_messages` needs a rebuild before `brain_client` starts, so this is one of the changes that wants a full `innate build` rather than a node restart.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — *No sim changes.*
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — *No asset changes.*