### PR TITLE
ui(webapp): unify Agent+Brain into one page, regroup the rail

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -65,6 +65,7 @@ js/
   webrtcSession.js      camera + mic over WebRTC, signaled through rosbridge
   dynamixel.js          leader-arm WebSerial reader (Protocol 2.0)
   shell.js              icon rail + connection badge on every page
+  railLayout.js         the rail's grouped roster (pure — tests/railLayout.test.js)
   teleop/               teleop modules (joystick, keyboard, head tilt, TTS, arm)
   nav/ collect/ datasets/ training/ logging/      per-page modules
 ```

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -64,7 +64,7 @@ js/
   driveController.js    /joystick heartbeat + joystick/keyboard arbitration
   webrtcSession.js      camera + mic over WebRTC, signaled through rosbridge
   dynamixel.js          leader-arm WebSerial reader (Protocol 2.0)
-  shell.js              icon rail + connection badge on every page
+  shell.js              icon rail on every page
   railLayout.js         the rail's grouped roster (pure — tests/railLayout.test.js)
   teleop/               teleop modules (joystick, keyboard, head tilt, TTS, arm)
   nav/ collect/ datasets/ training/ logging/      per-page modules

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -299,64 +299,10 @@ select.skill-input {
   opacity: 0.85;
 }
 
-/* Bottom-pinned utility links (Settings), above the connection badge. */
+/* Bottom-pinned utility links (Settings), at the rail's very bottom. */
 .rail-foot {
   margin-top: auto;
   padding-top: 12px;
-}
-
-/* connection badge pinned at rail bottom */
-
-.badge {
-  margin-top: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 6px;
-  border-radius: 9px;
-  cursor: default;
-}
-
-.badge:not(:disabled) {
-  cursor: pointer;
-}
-
-.badge:not(:disabled):hover .badge-label {
-  color: var(--text);
-}
-
-.badge-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #5a5a63;
-}
-
-.badge[data-state="connecting"] .badge-dot,
-.badge[data-state="reconnecting"] .badge-dot {
-  background: var(--accent);
-  animation: pulse 1.4s ease-in-out infinite;
-}
-
-.badge[data-state="connected"] .badge-dot {
-  background: var(--ok);
-}
-
-.badge-label {
-  font-family: var(--font-mono);
-  font-size: 9.5px;
-  color: var(--muted);
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
-  max-height: 110px;
-  overflow: hidden;
-  letter-spacing: 0.06em;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.25; }
 }
 
 /* ---- boot splash -------------------------------------------------------- */

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -243,6 +243,68 @@ select.skill-input {
   background: var(--accent);
 }
 
+/* Group boundaries in the rail. Collapsed, a hairline tick under the icon
+   column marks the break; on hover-expand, labeled dividers trade the tick
+   for the group's header — label plus a hairline running to the right edge
+   (unlabeled ones keep the tick). */
+.rail-div {
+  position: relative;
+  flex: none;
+  height: 17px;
+  margin: 4px 0 1px;
+}
+
+.rail-div::before {
+  content: "";
+  position: absolute;
+  left: 22px;             /* 20px tick centered under the icon column (x = 32) */
+  top: 50%;
+  width: 20px;
+  height: 1px;
+  background: var(--hairline);
+  transition: opacity 120ms ease;
+}
+
+.rail:hover .rail-div.has-label::before {
+  opacity: 0;
+}
+
+.rail-div-label {
+  position: absolute;
+  left: 13px;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-size: 10.5px;
+  font-weight: 650;
+  color: var(--text);
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.rail-div-label::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--hairline);
+}
+
+.rail:hover .rail-div-label {
+  opacity: 0.85;
+}
+
+/* Bottom-pinned utility links (Settings), above the connection badge. */
+.rail-foot {
+  margin-top: auto;
+  padding-top: 12px;
+}
+
 /* connection badge pinned at rail bottom */
 
 .badge {
@@ -5915,11 +5977,109 @@ select.skill-input {
   transition: background 200ms ease, opacity 200ms ease;
 }
 
+/* Live/Brain stage switch in the panel header: the panel is the agent, these
+   pick which stage shows behind it. */
+.agent-views {
+  display: inline-flex;
+  padding: 2px;
+  border-radius: 8px;
+  background: var(--ctl-field);
+  border: 1px solid var(--hairline-strong);
+  box-shadow: var(--ctl-sheen);
+}
+
+.agent-view-btn {
+  position: relative;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 6px;
+  background: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ctl-text-off);
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.agent-view-btn:hover {
+  color: var(--ctl-text);
+}
+
+.agent-view-btn.active {
+  color: var(--text);
+  background: var(--ctl-glass);
+}
+
+/* While the loop runs, the Brain segment carries a small live dot — an
+   invitation to look inside. */
+.agent-view-btn.pulse::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: breathe 2.2s ease-in-out infinite;
+}
+
 .agent-state-dot.on {
   background: var(--accent);
   opacity: 1;
   box-shadow: 0 0 9px var(--accent);
   animation: breathe 2.2s ease-in-out infinite;
+}
+
+/* The Brain monitor layer: an opaque stage that flips in over the camera view
+   (video keeps streaming beneath — closing it is instant). Sits above the
+   stage overlays but below the panel, which stays docked in both views; the
+   monitor's own layout (incl. clearing the panel) lives in brain.css. */
+.agent-brain {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background: var(--bg);
+  animation: brain-in 220ms ease-out;
+}
+
+/* The turn inspector is a fixed full-viewport modal, but this layer's z-index
+   traps it in a stacking context below the docked panel (z 12). While it's
+   open, lift the whole layer to the inspector's own level so the modal truly
+   covers the page — panel and rail included. */
+.agent-brain:has(.br-inspect:not([hidden])) {
+  z-index: 60;
+}
+
+.agent-cockpit .agent-panel {
+  z-index: 12; /* above the brain layer; overlays sit at ≤8 */
+}
+
+@keyframes brain-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-brain {
+    animation: none;
+  }
+}
+
+/* The monitor owns the stage: the camera overlays stand down while it's open
+   (the panel carries the running state; the monitor shows pose and frames). */
+.agent-cockpit.brain-open .overlay-stack-top-left,
+.agent-cockpit.brain-open .cam-strip,
+.agent-cockpit.brain-open .agent-active-chip {
+  display: none;
 }
 
 .agent-controls {
@@ -6168,12 +6328,29 @@ select.skill-input {
   align-items: center;
   gap: 11px;
   padding: 10px 14px;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
   background: var(--ctl-glass);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border: 1px solid var(--ctl-edge-accent);
   border-radius: 12px;
   box-shadow: var(--ctl-sheen);
+  transition: border-color 120ms ease;
+}
+
+.agent-active-chip:hover {
+  border-color: var(--ctl-edge-accent-hover);
+}
+
+.agent-active-arrow {
+  display: inline-block;
+  transition: transform 120ms ease;
+}
+
+.agent-active-chip:hover .agent-active-arrow {
+  transform: translateX(3px);
 }
 
 .agent-active-dot {

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -6020,12 +6020,17 @@ select.skill-input {
   }
 }
 
-/* The monitor owns the stage: the camera overlays stand down while it's open
-   (the panel carries the running state; the monitor shows pose and frames). */
+/* The monitor owns the stage: the camera overlays and the sim debug chips
+   stand down while it's open (the panel carries the running state; the
+   monitor shows pose and frames). */
 .agent-cockpit.brain-open .overlay-stack-top-left,
 .agent-cockpit.brain-open .cam-strip,
 .agent-cockpit.brain-open .agent-active-chip {
   display: none;
+}
+
+.agent-cockpit.brain-open .sim-debug-stack {
+  display: none !important; /* the sim stage sets its display inline */
 }
 
 .agent-controls {

--- a/webapp/css/brain.css
+++ b/webapp/css/brain.css
@@ -110,9 +110,6 @@
   grid-template-rows: minmax(0, 1.35fr) minmax(0, 1fr) auto;
   grid-template-areas: "loop vision" "actions queue" "vitals vitals";
 }
-.br-panel-mind {
-  display: none;
-}
 @media (max-width: 1100px) {
   .brain-page {
     overflow-y: auto;
@@ -165,17 +162,21 @@
 }
 .br-panel-loop { grid-area: loop; align-items: center; }
 .br-panel-vision { grid-area: vision; }
-.br-panel-mind { grid-area: mind; }
+/* Hidden here, after .br-panel — an earlier display:none loses that rule's
+   display:flex on source order and the panel lands in an implicit grid track. */
+.br-panel-mind { display: none; }
 .br-panel-actions { grid-area: actions; }
 .br-panel-queue { grid-area: queue; }
 
 /* Vitals as a bottom status strip: label, tiles, sparkline, history gauge in
-   one row (back to a stacked card when the grid goes single-column). */
+   one row, wrapping rather than clipping when the row runs out of width
+   (back to a stacked card when the grid goes single-column). */
 .br-panel-vitals {
   grid-area: vitals;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 18px;
+  gap: 12px 18px;
 }
 .br-panel-vitals h2 {
   margin: 0;
@@ -187,8 +188,8 @@
   grid-template-columns: repeat(4, minmax(84px, 108px));
 }
 .br-panel-vitals .br-spark-wrap {
-  flex: 1 1 auto;
-  min-width: 120px;
+  flex: 1 1 240px;
+  min-width: 160px;
 }
 .br-panel-vitals .br-spark {
   height: 52px;

--- a/webapp/css/brain.css
+++ b/webapp/css/brain.css
@@ -42,12 +42,24 @@
   flex: none;
 }
 .br-esc-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   font-size: 10px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--muted);
   opacity: 0.65;
   white-space: nowrap;
+}
+.br-esc-hint kbd {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1;
+  padding: 3px 5px 4px;
+  border: 1px solid var(--hairline-strong);
+  border-bottom-width: 2px;
+  border-radius: 4px;
 }
 
 .br-chips {
@@ -477,7 +489,8 @@
 }
 .br-vision-cap {
   display: flex;
-  gap: 10px;
+  flex-wrap: wrap; /* the pose strip drops whole to the next line, never squashes */
+  gap: 6px 10px;
   margin-top: 8px;
   align-items: center;
   color: var(--muted);
@@ -509,6 +522,7 @@
   gap: 10px;
   align-items: center;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 .br-heading {
   width: 16px;

--- a/webapp/css/brain.css
+++ b/webapp/css/brain.css
@@ -1,11 +1,13 @@
 /* SPDX-License-Identifier: Apache-2.0
    Copyright (c) 2026 Innate Inc
 
-   Brain page — the agent-loop monitor. Structural chrome rides the app tokens
-   (--panel, --hairline, --text, --muted); the functional colors below are the
-   page's own: phase identities for the loop (look/think/act), a series blue
-   for data marks, and a fixed status set — all steps validated for the dark
-   surface. */
+   Brain monitor — the agent-loop deep view, embedded in the Agent page (the
+   .agent-brain layer carries positioning; this file owns the monitor's own
+   layout, including clearing the docked agent panel). Structural chrome rides
+   the app tokens (--panel, --hairline, --text, --muted); the functional colors
+   below are the monitor's own: phase identities for the loop (look/think/act),
+   a series blue for data marks, and a fixed status set — all steps validated
+   for the dark surface. */
 
 /* ?demo hides the connect card — there is deliberately no robot behind it. */
 .connect-layer.br-hidden {
@@ -27,7 +29,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  padding: 14px 18px 16px;
+  padding: 14px 402px 16px 18px; /* right clears the docked 360px agent panel + insets */
   gap: 12px;
   overflow: hidden;
 }
@@ -39,6 +41,15 @@
   gap: 14px;
   flex: none;
 }
+.br-esc-hint {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  opacity: 0.65;
+  white-space: nowrap;
+}
+
 .br-chips {
   display: flex;
   gap: 8px;
@@ -87,32 +98,42 @@
 }
 
 /* ---------- grid ---------- */
+/* Five panels: the mind stream is deliberately absent — the agent panel docked
+   beside the monitor is the canonical thoughts/chat stream, so showing it here
+   too would be the same words twice. Vitals ride as a bottom status strip. */
 .br-grid {
   flex: 1;
   min-height: 0;
   display: grid;
   gap: 12px;
-  grid-template-columns: 360px 1fr 360px;
-  grid-template-rows: minmax(0, 1.35fr) minmax(0, 1fr);
-  grid-template-areas: "loop vision mind" "actions queue vitals";
+  grid-template-columns: minmax(320px, 380px) 1fr;
+  grid-template-rows: minmax(0, 1.35fr) minmax(0, 1fr) auto;
+  grid-template-areas: "loop vision" "actions queue" "vitals vitals";
 }
-@media (max-width: 1280px) {
+.br-panel-mind {
+  display: none;
+}
+@media (max-width: 1100px) {
   .brain-page {
     overflow-y: auto;
   }
   .br-grid {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     grid-template-rows: none;
-    grid-template-areas: "loop vision" "mind actions" "queue vitals";
+    grid-template-areas: "loop" "vision" "actions" "queue" "vitals";
   }
   .br-panel {
     height: 420px;
   }
 }
-@media (max-width: 820px) {
-  .br-grid {
-    grid-template-columns: 1fr;
-    grid-template-areas: "loop" "vision" "mind" "actions" "queue" "vitals";
+@media (max-width: 640px) {
+  /* The agent panel docks as a bottom sheet here — full width, scroll above
+     it; no hardware Esc to hint at. */
+  .brain-page {
+    padding: 14px 18px 48vh;
+  }
+  .br-esc-hint {
+    display: none;
   }
 }
 .br-panel {
@@ -147,7 +168,57 @@
 .br-panel-mind { grid-area: mind; }
 .br-panel-actions { grid-area: actions; }
 .br-panel-queue { grid-area: queue; }
-.br-panel-vitals { grid-area: vitals; }
+
+/* Vitals as a bottom status strip: label, tiles, sparkline, history gauge in
+   one row (back to a stacked card when the grid goes single-column). */
+.br-panel-vitals {
+  grid-area: vitals;
+  flex-direction: row;
+  align-items: center;
+  gap: 18px;
+}
+.br-panel-vitals h2 {
+  margin: 0;
+  white-space: nowrap;
+}
+.br-panel-vitals .br-tiles {
+  flex: none;
+  margin-bottom: 0;
+  grid-template-columns: repeat(4, minmax(84px, 108px));
+}
+.br-panel-vitals .br-spark-wrap {
+  flex: 1 1 auto;
+  min-width: 120px;
+}
+.br-panel-vitals .br-spark {
+  height: 52px;
+}
+.br-panel-vitals .br-gauge {
+  flex: none;
+  width: 220px;
+  margin-top: 0;
+}
+@media (max-width: 1100px) {
+  .br-panel-vitals {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+  }
+  .br-panel-vitals h2 {
+    margin: 0 0 10px;
+  }
+  .br-panel-vitals .br-tiles {
+    margin-bottom: 12px;
+    grid-template-columns: repeat(4, 1fr);
+  }
+  .br-panel-vitals .br-spark {
+    height: 88px;
+  }
+  .br-panel-vitals .br-gauge {
+    width: auto;
+    margin-top: 12px;
+  }
+}
 .br-feed {
   overflow-y: auto;
   flex: 1;

--- a/webapp/css/brain.css
+++ b/webapp/css/brain.css
@@ -122,7 +122,10 @@
   grid-template-rows: minmax(0, 1.35fr) minmax(0, 1fr) auto;
   grid-template-areas: "loop vision" "actions queue" "vitals vitals";
 }
-@media (max-width: 1100px) {
+/* Breakpoints are viewport-keyed but the monitor only gets the viewport minus
+   the 64px rail and its own 420px of padding (the docked panel) — so the
+   single-column flip lands ~484px above where the grid actually runs out. */
+@media (max-width: 1280px) {
   .brain-page {
     overflow-y: auto;
   }
@@ -174,9 +177,6 @@
 }
 .br-panel-loop { grid-area: loop; align-items: center; }
 .br-panel-vision { grid-area: vision; }
-/* Hidden here, after .br-panel — an earlier display:none loses that rule's
-   display:flex on source order and the panel lands in an implicit grid track. */
-.br-panel-mind { display: none; }
 .br-panel-actions { grid-area: actions; }
 .br-panel-queue { grid-area: queue; }
 
@@ -211,7 +211,7 @@
   width: 220px;
   margin-top: 0;
 }
-@media (max-width: 1100px) {
+@media (max-width: 1280px) {
   .br-panel-vitals {
     flex-direction: column;
     align-items: stretch;
@@ -534,48 +534,13 @@
   transform-origin: 8px 8px;
 }
 
-/* ---------- mind stream ---------- */
-.br-msg {
-  border-left: 3px solid var(--br-grid);
-  padding: 7px 10px;
-  margin-bottom: 8px;
-  border-radius: 0 8px 8px 0;
-  background: rgb(255 255 255 / 3%);
-  animation: br-slidein 0.35s ease-out;
-  overflow-wrap: break-word;
-}
+/* ---------- turns & actions ---------- */
 @keyframes br-slidein {
   from {
     opacity: 0;
     transform: translateY(-8px);
   }
 }
-.br-msg .who {
-  font: 600 10px var(--font-mono);
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  margin-bottom: 3px;
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-.br-msg .when {
-  margin-left: auto;
-  color: var(--muted);
-  font-weight: 400;
-  letter-spacing: 0;
-}
-.br-msg.thought { border-color: var(--br-violet); }
-.br-msg.thought .who { color: var(--br-violet); }
-.br-msg.thought .txt { color: var(--muted); font-style: italic; }
-.br-msg.speech { border-color: var(--br-blue); }
-.br-msg.speech .who { color: var(--br-blue); }
-.br-msg.user { border-color: var(--br-aqua); }
-.br-msg.user .who { color: var(--br-aqua); }
-.br-msg.system .who { color: var(--muted); }
-.br-msg.system .txt { color: var(--muted); font-size: 13px; }
-
-/* ---------- turns & actions ---------- */
 .br-turn-row {
   padding: 8px 10px;
   border: 1px solid var(--br-grid);

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -29,9 +29,11 @@ import {
  * @param {HTMLElement} root cockpit root — the panel mounts as a right-edge overlay.
  * @param {import("../rosClient.js").RosClient} rosClient
  * @param {ReturnType<typeof import("../teleop/agentState.js").createAgentState>} agentState
- * @returns {{ destroy: () => void }}
+ * @param {{ onView: (view: "live" | "brain") => void }} opts stage-view switch,
+ *   owned by the page; setView reflects a flip the page made itself (chip, Esc).
+ * @returns {{ destroy: () => void, setView: (view: "live" | "brain") => void }}
  */
-export function createAgentPanel(root, rosClient, agentState) {
+export function createAgentPanel(root, rosClient, agentState, opts) {
   const selfOrigin = crypto.randomUUID?.() ?? `web-${Date.now()}-${Math.random()}`;
 
   const panel = document.createElement("section");
@@ -46,6 +48,21 @@ export function createAgentPanel(root, rosClient, agentState) {
   const stateDot = document.createElement("span");
   stateDot.className = "agent-state-dot";
   stateDot.title = `green while the brain is active — ${AGENT_STATUS_TOPIC}`;
+  // Live/Brain switch: the panel is the agent; these pick which stage shows
+  // behind it — the robot's eyes, or its loop instrumented turn by turn.
+  const viewSwitch = document.createElement("div");
+  viewSwitch.className = "agent-views";
+  const liveBtn = viewButton("Live", "The robot's live camera view");
+  const brainBtn = viewButton("Brain", "Brain monitor — the agent loop, turn by turn (Esc returns)");
+  liveBtn.classList.add("active");
+  viewSwitch.append(liveBtn, brainBtn);
+  liveBtn.addEventListener("click", () => opts.onView("live"));
+  brainBtn.addEventListener("click", () => opts.onView("brain"));
+  /** @param {"live" | "brain"} view */
+  function setView(view) {
+    liveBtn.classList.toggle("active", view === "live");
+    brainBtn.classList.toggle("active", view === "brain");
+  }
   // Phones dock the panel as a bottom sheet (CSS); this expands it upward.
   const expandBtn = document.createElement("button");
   expandBtn.type = "button";
@@ -57,7 +74,7 @@ export function createAgentPanel(root, rosClient, agentState) {
     expandBtn.textContent = expanded ? "\u25be" : "\u25b4";
     expandBtn.setAttribute("aria-label", expanded ? "Collapse panel" : "Expand panel");
   };
-  head.append(titleEl, stateDot, expandBtn);
+  head.append(titleEl, stateDot, viewSwitch, expandBtn);
 
   // ---- directive + start/stop --------------------------------------------
   const controls = document.createElement("div");
@@ -158,6 +175,8 @@ export function createAgentPanel(root, rosClient, agentState) {
 
     panel.classList.toggle("active", brainActive);
     stateDot.classList.toggle("on", brainActive);
+    // A running loop makes the Brain segment glow — an invitation to look inside.
+    brainBtn.classList.toggle("pulse", brainActive);
 
     toggleBtn.textContent = applying ? "…" : brainActive ? "Stop" : "Start";
     toggleBtn.classList.toggle("stop", brainActive);
@@ -554,6 +573,7 @@ export function createAgentPanel(root, rosClient, agentState) {
   }, undefined, "std_msgs/msg/String");
 
   return {
+    setView,
     destroy() {
       if (flashTimer) clearTimeout(flashTimer);
       unsubAgents();
@@ -564,6 +584,20 @@ export function createAgentPanel(root, rosClient, agentState) {
       panel.remove();
     },
   };
+}
+
+/**
+ * A segment of the panel's Live/Brain stage switch.
+ * @param {string} label
+ * @param {string} title
+ */
+function viewButton(label, title) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "agent-view-btn";
+  btn.textContent = label;
+  btn.title = title;
+  return btn;
 }
 
 /**

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -52,9 +52,10 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   // behind it — the robot's eyes, or its loop instrumented turn by turn.
   const viewSwitch = document.createElement("div");
   viewSwitch.className = "agent-views";
+  viewSwitch.setAttribute("role", "group");
+  viewSwitch.setAttribute("aria-label", "Stage view");
   const liveBtn = viewButton("Live", "The robot's live camera view");
   const brainBtn = viewButton("Brain", "Brain monitor — the agent loop, turn by turn (Esc returns)");
-  liveBtn.classList.add("active");
   viewSwitch.append(liveBtn, brainBtn);
   liveBtn.addEventListener("click", () => opts.onView("live"));
   brainBtn.addEventListener("click", () => opts.onView("brain"));
@@ -62,7 +63,10 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   function setView(view) {
     liveBtn.classList.toggle("active", view === "live");
     brainBtn.classList.toggle("active", view === "brain");
+    liveBtn.setAttribute("aria-pressed", String(view === "live"));
+    brainBtn.setAttribute("aria-pressed", String(view === "brain"));
   }
+  setView("live");
   // Phones dock the panel as a bottom sheet (CSS); this expands it upward.
   const expandBtn = document.createElement("button");
   expandBtn.type = "button";

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -4,6 +4,13 @@
 // one liquid-glass Agent panel: directive selection, a Start/Stop toggle, the
 // agent's live thinking traces + active skill + chat, and a message composer.
 //
+// The page has two stages behind that one panel: the live camera view, and the
+// Brain monitor (the agent loop instrumented turn by turn) which flips in over
+// it via the panel's Live/Brain switch — controls and chat stay docked in both.
+// The monitor is built on first open and kept until the page unmounts, so its
+// turn history survives flipping back and forth. /brain deep-links here with
+// the monitor open.
+//
 // Connect/disconnect lifecycle and optimistic mount mirror teleop (see
 // pageMount.js): the view builds immediately and panels fill in once the socket
 // is up. No mic toggle here — robot speech already plays in-browser via the
@@ -19,6 +26,7 @@ import { createCameraSwitch } from "../teleop/cameraSwitch.js";
 import { createAgentState } from "../teleop/agentState.js";
 import { createAgentPanel } from "./agentPanel.js";
 import { createChallengePanel } from "./challengePanel.js";
+import { createBrainMonitor } from "../brain/main.js";
 
 // Runtime feature flags (config.json, served static), same as teleop. simControls
 // marks a sim deployment — used here to drop the (absent) battery readout. Fetched
@@ -61,18 +69,53 @@ function buildAgentView(root) {
   cornerStack.append(telemetryOverlay);
   const agentState = createAgentState(ros);
 
+  const cameraSwitch = createCameraSwitch(root, session, ros, { storeKey: "innate.cameras.agent" });
+
+  // The Brain monitor's layer sits between the camera overlays and the panel
+  // (DOM order + z-index): opening it covers the stage but never the controls.
+  const brainLayer = document.createElement("div");
+  brainLayer.className = "agent-brain brain-page";
+  brainLayer.hidden = true;
+  root.append(brainLayer);
+
+  /** @type {{ destroy: () => void } | null} */
+  let monitor = null;
+  /** @type {"live" | "brain"} */
+  let view = "live";
+  /** @param {"live" | "brain"} next */
+  function setView(next) {
+    if (next === view) return;
+    view = next;
+    if (next === "brain" && !monitor) {
+      monitor = createBrainMonitor(brainLayer, { onRequestClose: () => setView("live") });
+    }
+    brainLayer.hidden = next !== "brain";
+    root.classList.toggle("brain-open", next === "brain");
+    panel.setView(next);
+  }
+
+  const panel = createAgentPanel(root, ros, agentState, { onView: setView });
+
   const parts = [
     videoStage,
     ...(challengePanel ? [challengePanel] : []),
     createTelemetry(telemetryOverlay, ros, { showBattery: !config.simControls }),
     // Square, always-live camera tiles (own prefs key so teleop's defaults stay put).
-    createCameraSwitch(root, session, ros, { storeKey: "innate.cameras.agent" }),
-    createAgentPanel(root, ros, agentState),
-    createActiveChip(root, agentState),
+    cameraSwitch,
+    panel,
+    createActiveChip(root, agentState, () => setView("brain")),
     { destroy: () => agentState.destroy() },
+    { destroy: () => monitor?.destroy() },
   ];
 
   session.start();
+
+  // /brain is this page with the monitor open; land there, then settle the URL
+  // on /agent so the address bar matches the one-page model.
+  if (location.pathname.replace(/\/+$/, "") === "/brain") {
+    setView("brain");
+    history.replaceState({}, "", "/agent" + location.search);
+  }
 
   return {
     destroy() {
@@ -85,14 +128,19 @@ function buildAgentView(root) {
 
 /**
  * Bottom-left "AGENT ACTIVE" chip — shown only while the brain is running.
+ * Clicking it opens the Brain monitor: the moment the robot is acting on its
+ * own is exactly when you want to see inside.
  * @param {HTMLElement} root
  * @param {ReturnType<typeof import("../teleop/agentState.js").createAgentState>} agentState
+ * @param {() => void} onWatch
  * @returns {{ destroy: () => void }}
  */
-function createActiveChip(root, agentState) {
-  const chip = document.createElement("div");
+function createActiveChip(root, agentState, onWatch) {
+  const chip = document.createElement("button");
+  chip.type = "button";
   chip.className = "agent-active-chip";
   chip.hidden = true;
+  chip.title = "Open the Brain monitor";
 
   const dot = document.createElement("span");
   dot.className = "agent-active-dot";
@@ -103,11 +151,12 @@ function createActiveChip(root, agentState) {
   title.textContent = "Agent active";
   const sub = document.createElement("span");
   sub.className = "agent-active-sub";
-  sub.textContent = "Autonomous execution in progress.";
+  sub.innerHTML = 'Watch its brain <span class="agent-active-arrow">→</span>';
   label.append(title, sub);
   chip.append(dot, label);
   root.append(chip);
 
+  chip.addEventListener("click", onWatch);
   const unsub = agentState.subscribe((s) => {
     chip.hidden = !s.brainActive;
   });

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -26,7 +26,6 @@ import { createCameraSwitch } from "../teleop/cameraSwitch.js";
 import { createAgentState } from "../teleop/agentState.js";
 import { createAgentPanel } from "./agentPanel.js";
 import { createChallengePanel } from "./challengePanel.js";
-import { createBrainMonitor } from "../brain/main.js";
 
 // Runtime feature flags (config.json, served static), same as teleop. simControls
 // marks a sim deployment — used here to drop the (absent) battery readout. Fetched
@@ -78,17 +77,33 @@ function buildAgentView(root) {
   brainLayer.hidden = true;
   root.append(brainLayer);
 
-  /** @type {{ destroy: () => void } | null} */
+  /** @type {{ destroy: () => void, setVisible: (visible: boolean) => void } | null} */
   let monitor = null;
+  let monitorLoading = false;
+  let unmounted = false;
   /** @type {"live" | "brain"} */
   let view = "live";
   /** @param {"live" | "brain"} next */
   function setView(next) {
     if (next === view) return;
     view = next;
-    if (next === "brain" && !monitor) {
-      monitor = createBrainMonitor(brainLayer, { onRequestClose: () => setView("live") });
+    if (next === "brain" && !monitor && !monitorLoading) {
+      // The monitor is its own sizeable module, fetched on first open so Agent
+      // mounts that never look inside don't pay for it. Kept once built (its
+      // turn history survives flips); hidden, it pauses its animation loop and
+      // camera fallback via setVisible.
+      monitorLoading = true;
+      void import("../brain/main.js")
+        .then((m) => {
+          if (unmounted) return;
+          monitor = m.createBrainMonitor(brainLayer, { onRequestClose: () => setView("live") });
+          monitor.setVisible(view === "brain");
+        })
+        .catch(() => {
+          monitorLoading = false; // a failed fetch can retry on the next flip
+        });
     }
+    monitor?.setVisible(next === "brain");
     brainLayer.hidden = next !== "brain";
     root.classList.toggle("brain-open", next === "brain");
     panel.setView(next);
@@ -105,7 +120,12 @@ function buildAgentView(root) {
     panel,
     createActiveChip(root, agentState, () => setView("brain")),
     { destroy: () => agentState.destroy() },
-    { destroy: () => monitor?.destroy() },
+    {
+      destroy: () => {
+        unmounted = true; // a monitor import still in flight must not build into the dead layer
+        monitor?.destroy();
+      },
+    },
   ];
 
   session.start();
@@ -114,7 +134,7 @@ function buildAgentView(root) {
   // on /agent so the address bar matches the one-page model.
   if (location.pathname.replace(/\/+$/, "") === "/brain") {
     setView("brain");
-    history.replaceState({}, "", "/agent" + location.search);
+    history.replaceState({}, "", "/agent" + location.search + location.hash);
   }
 
   return {

--- a/webapp/js/brain/demo.js
+++ b/webapp/js/brain/demo.js
@@ -19,7 +19,7 @@ Your directive:
 explore`;
 
 /**
- * @param {{ onTrace: (d: any) => void, onChat: (d: any) => void, onSkill: (d: any) => void,
+ * @param {{ onTrace: (d: any) => void, onSkill: (d: any) => void,
  *   onAgentStatus: (d: any) => void, onBrainStatus: (d: any) => void,
  *   setPose: (x: number, y: number, yaw: number) => void, setSpeaking: (on: boolean) => void }} h
  * @returns {() => void} stop
@@ -124,9 +124,7 @@ export function startDemo(h) {
       ev: "turn_end", turn: D.turn, latency: think / 1000, thoughts, speech,
       calls: theCalls, history: D.history, next_in: D.nextIn,
     });
-    if (thoughts) h.onChat({ sender: "robot_thoughts", text: thoughts, timestamp: Date.now() / 1000 });
     if (speech) {
-      h.onChat({ sender: "robot", text: speech, timestamp: Date.now() / 1000 });
       h.setSpeaking(true);
       timers.push(window.setTimeout(() => h.setSpeaking(false), 2200));
     }
@@ -187,10 +185,8 @@ export function startDemo(h) {
       D.inFlight = false;
       D.streak = 1;
       h.onTrace({ ev: "turn_error", turn: D.turn, error: "gemini via proxy: HTTP 503: overloaded", streak: 1, backoff: 5 });
-      h.onChat({ sender: "system", text: "⚠️ Brain inference failed: HTTP 503 — retrying.", timestamp: Date.now() / 1000 });
       await sleep(5100); if (!on) return;
       D.streak = 0;
-      h.onChat({ sender: "system", text: "✅ Brain inference recovered.", timestamp: Date.now() / 1000 });
       await turn({ withSock: true, think: 1500, thoughts: "Back online. Scene unchanged." });
       await sleep(3000);
     }

--- a/webapp/js/brain/main.js
+++ b/webapp/js/brain/main.js
@@ -800,7 +800,7 @@ function template() {
   return `
   <div class="br-head">
     <h1 class="page-title">Brain</h1>
-    <span class="br-esc-hint">esc closes</span>
+    <span class="br-esc-hint"><kbd>esc</kbd> closes</span>
     <div class="br-chips">
       <div class="br-chip br-chip-active" title="/brain/agent_status"><span class="led"></span><span>brain <b>—</b></span></div>
       <div class="br-chip br-chip-directive" title="current directive — /brain/agent_status"><span>directive</span><b>—</b></div>

--- a/webapp/js/brain/main.js
+++ b/webapp/js/brain/main.js
@@ -20,6 +20,7 @@
 // useful for UI work with no robot.
 
 import { ros } from "../rosClient.js";
+import { isTypingContext } from "../shell.js";
 
 const CAM_TOPIC = "/mars/main_camera/left/image_raw/compressed";
 const HIST_MAX = 60; // brain_client default history_max_entries
@@ -43,10 +44,12 @@ const RING_C = 2 * Math.PI * RING_R;
 /**
  * Build the monitor into `root` (the Agent page's brain layer) and start its
  * feeds. `onRequestClose` is the monitor asking to flip back to the live view
- * (Escape with no inspector open).
+ * (Escape with no inspector open). While hidden (`setVisible(false)`) the trace
+ * feeds stay live so turn history keeps accumulating, but the animation loop
+ * and the wire-heavy live-camera fallback pause.
  * @param {HTMLElement} root
  * @param {{ onRequestClose?: () => void }} [opts]
- * @returns {{ destroy: () => void }}
+ * @returns {{ destroy: () => void, setVisible: (visible: boolean) => void }}
  */
 export function createBrainMonitor(root, opts = {}) {
   root.innerHTML = template();
@@ -79,6 +82,7 @@ export function createBrainMonitor(root, opts = {}) {
   const TURNS_MAX = 24;
   let shownTurn = 0; // turn on the vision stage
   let inspecting = 0; // turn open in the inspector; 0 = closed
+  let visible = true; // built on first open, so the monitor starts on screen
 
   // One-shot UI timers (phase eases, queue drain), all cleared on destroy so
   // none fires against the wiped DOM after the page unmounts.
@@ -186,7 +190,6 @@ export function createBrainMonitor(root, opts = {}) {
     }
     if (d.ev === "event") {
       addQueueCard(d.kind, d.text);
-      if (d.kind === "user") addMsg("user", "USER", d.text.replace(/^The user says: "(.*)"$/s, "$1"));
       if (d.kind === "motion") motionCue();
     }
     if (d.ev === "snapshot") onSnapshot(d);
@@ -231,14 +234,6 @@ export function createBrainMonitor(root, opts = {}) {
     if (!S.haveTrace) $(".br-chip-backend b").textContent = d.backend || "—";
   }
 
-  /** @param {any} d */
-  function onChat(d) {
-    if (d.sender === "robot_thoughts") addMsg("thought", "THINKS", d.text, d.timestamp);
-    else if (d.sender === "robot") addMsg("speech", "SAYS", d.text, d.timestamp);
-    else if (d.sender === "system") addMsg("system", "SYSTEM", d.text, d.timestamp);
-    else if (d.sender === "skill_output") addMsg("system", "SKILL OUTPUT", d.text, d.timestamp);
-  }
-
   /** @param {number} x @param {number} y @param {number} yaw */
   function setPose(x, y, yaw) {
     $(".br-pose-txt").textContent = `x ${x.toFixed(2)}  y ${y.toFixed(2)}  θ ${((yaw * 180) / Math.PI).toFixed(0)}°`;
@@ -263,8 +258,6 @@ export function createBrainMonitor(root, opts = {}) {
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&#39;");
-  /** @param {number} [ts] */
-  const hhmmss = (ts) => new Date((ts ?? Date.now() / 1000) * 1000).toLocaleTimeString([], { hour12: false });
 
   /** @param {string} panelSel @param {HTMLElement} el @param {number} [cap] */
   function prepend(panelSel, el, cap = 60) {
@@ -272,15 +265,6 @@ export function createBrainMonitor(root, opts = {}) {
     feed.querySelector(".br-empty")?.remove();
     feed.prepend(el);
     while (feed.children.length > cap) /** @type {Element} */ (feed.lastChild).remove();
-  }
-
-  /** @param {string} cls @param {string} who @param {string} text @param {number} [ts] */
-  function addMsg(cls, who, text, ts) {
-    const div = document.createElement("div");
-    div.className = "br-msg " + cls;
-    div.innerHTML = `<div class="who">${who}<span class="when">${hhmmss(ts)}</span></div><div class="txt"></div>`;
-    /** @type {HTMLElement} */ (div.querySelector(".txt")).textContent = text;
-    prepend(".br-mind", div);
   }
 
   /** @param {any} d */
@@ -614,7 +598,9 @@ export function createBrainMonitor(root, opts = {}) {
   $(".br-inspect-back").addEventListener("click", closeInspector);
   /** @param {KeyboardEvent} e */
   const onKey = (e) => {
-    if (e.key !== "Escape") return;
+    // isTypingContext: Esc in the docked composer (IME/autocomplete dismiss)
+    // must not flip the stage under the user.
+    if (e.key !== "Escape" || !visible || isTypingContext()) return;
     if (inspecting) closeInspector();
     else opts.onRequestClose?.();
   };
@@ -737,17 +723,33 @@ export function createBrainMonitor(root, opts = {}) {
     if (d) fn(d);
   };
 
-  const handlers = { onTrace, onChat, onSkill, onAgentStatus, onBrainStatus, setPose, setSpeaking };
+  const handlers = { onTrace, onSkill, onAgentStatus, onBrainStatus, setPose, setSpeaking };
 
   /** @type {(() => void)[]} */
   let unsubs = [];
   /** @type {(() => void) | null} */
+  let camUnsub = null;
+  /** @type {(() => void) | null} */
   let demoStop = null;
   let destroyed = false;
+  const demoMode = new URLSearchParams(location.search).has("demo");
 
-  if (new URLSearchParams(location.search).has("demo")) {
+  // The live-camera fallback pulls base64 JPEGs over rosbridge, on a page that
+  // already streams WebRTC video — so it runs only while the monitor is on
+  // screen (see setVisible), unlike the cheap trace/status feeds.
+  const subscribeCam = () =>
+    ros.subscribe(
+      CAM_TOPIC,
+      (msg) => {
+        if (!S.haveTrace) showFrame("data:image/jpeg;base64," + msg.data, "live camera");
+      },
+      500,
+      "sensor_msgs/msg/CompressedImage",
+    );
+
+  if (demoMode) {
     // No robot in the picture: the socket's connect card would just sit over
-    // the synthetic show.
+    // the synthetic show. Restored while the monitor is hidden (setVisible).
     document.querySelector(".connect-layer")?.classList.add("br-hidden");
     void import("./demo.js").then((m) => {
       if (destroyed) return; // the page unmounted before the chunk loaded
@@ -758,7 +760,6 @@ export function createBrainMonitor(root, opts = {}) {
       ros.subscribe("/brain/trace", jsonHandler(onTrace), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/agent_status", jsonHandler(onAgentStatus), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/websocket_status", jsonHandler(onBrainStatus), 0, "std_msgs/msg/String"),
-      ros.subscribe("/brain/chat_out", jsonHandler(onChat), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/skill_status_update", jsonHandler(onSkill), 0, "std_msgs/msg/String"),
       ros.subscribe("/tts/is_playing", (msg) => setSpeaking(msg.data === "true"), 0, "std_msgs/msg/String"),
       ros.subscribe(
@@ -770,18 +771,27 @@ export function createBrainMonitor(root, opts = {}) {
         200,
         "nav_msgs/msg/Odometry",
       ),
-      ros.subscribe(
-        CAM_TOPIC,
-        (msg) => {
-          if (!S.haveTrace) showFrame("data:image/jpeg;base64," + msg.data, "live camera");
-        },
-        500,
-        "sensor_msgs/msg/CompressedImage",
-      ),
     ];
+    camUnsub = subscribeCam();
+  }
+
+  /** @param {boolean} v */
+  function setVisible(v) {
+    if (v === visible) return;
+    visible = v;
+    if (demoMode) document.querySelector(".connect-layer")?.classList.toggle("br-hidden", v);
+    if (!v) {
+      cancelAnimationFrame(raf);
+      camUnsub?.();
+      camUnsub = null;
+      return;
+    }
+    raf = requestAnimationFrame(tickUI);
+    if (!demoMode) camUnsub = subscribeCam();
   }
 
   return {
+    setVisible,
     destroy() {
       destroyed = true;
       cancelAnimationFrame(raf);
@@ -790,7 +800,9 @@ export function createBrainMonitor(root, opts = {}) {
       for (const id of uiTimers) window.clearTimeout(id);
       window.removeEventListener("keydown", onKey);
       unsubs.forEach((u) => u());
+      camUnsub?.();
       demoStop?.();
+      document.querySelector(".connect-layer")?.classList.remove("br-hidden");
       root.innerHTML = "";
     },
   };
@@ -849,11 +861,6 @@ function template() {
           <span class="br-pose-txt">pose —</span>
         </span>
       </div>
-    </section>
-
-    <section class="br-panel br-panel-mind">
-      <h2>Mind stream <span class="sub">thoughts · speech · system</span></h2>
-      <div class="br-feed br-mind"></div>
     </section>
 
     <section class="br-panel br-panel-actions">

--- a/webapp/js/brain/main.js
+++ b/webapp/js/brain/main.js
@@ -1,7 +1,9 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// Brain page — a live window into the local Gemini agent loop.
+// Brain monitor — a live window into the local Gemini agent loop. Not a page:
+// the Agent page embeds it as its deep view (createBrainMonitor), flipped in
+// over the camera stage while the agent panel stays docked alongside.
 //
 // Deep telemetry rides /brain/trace (JSON on std_msgs/String, published by
 // brain_client's BrainAgent): turn lifecycle with every image the model was
@@ -9,16 +11,15 @@
 // system instruction, tool calls with args + outcomes, think latencies, the
 // event queue, and a 1 Hz snapshot heartbeat. Recent turns are kept so any
 // turn row can be opened in the inspector overlay — the complete model input
-// and output for that turn. Everything else (mind stream, skill runs, pose,
-// live camera fallback) comes from the public topics, so the page degrades
-// gracefully on robots without the trace publisher — the deep panels just
-// stay quiet.
+// and output for that turn. Everything else (skill runs, pose, live camera
+// fallback) comes from the public topics, so the monitor degrades gracefully
+// on robots without the trace publisher — the deep panels just stay quiet.
+// The mind stream lives in the agent panel next door, not here.
 //
-// ?demo drives the whole page from a scripted synthetic brain (demo.js) —
+// ?demo drives the whole monitor from a scripted synthetic brain (demo.js) —
 // useful for UI work with no robot.
 
 import { ros } from "../rosClient.js";
-import { mountPage } from "../pageMount.js";
 
 const CAM_TOPIC = "/mars/main_camera/left/image_raw/compressed";
 const HIST_MAX = 60; // brain_client default history_max_entries
@@ -39,16 +40,15 @@ const NODE_ANGLE = { look: -90, think: 30, act: 150 };
 const RING_R = 112;
 const RING_C = 2 * Math.PI * RING_R;
 
-/** @param {HTMLElement} stage */
-export function mount(stage) {
-  return mountPage(stage, "brain-page", buildView);
-}
-
 /**
+ * Build the monitor into `root` (the Agent page's brain layer) and start its
+ * feeds. `onRequestClose` is the monitor asking to flip back to the live view
+ * (Escape with no inspector open).
  * @param {HTMLElement} root
+ * @param {{ onRequestClose?: () => void }} [opts]
  * @returns {{ destroy: () => void }}
  */
-function buildView(root) {
+export function createBrainMonitor(root, opts = {}) {
   root.innerHTML = template();
   /** @param {string} sel */
   const $ = (sel) => /** @type {HTMLElement} */ (root.querySelector(sel));
@@ -614,7 +614,9 @@ function buildView(root) {
   $(".br-inspect-back").addEventListener("click", closeInspector);
   /** @param {KeyboardEvent} e */
   const onKey = (e) => {
-    if (e.key === "Escape" && inspecting) closeInspector();
+    if (e.key !== "Escape") return;
+    if (inspecting) closeInspector();
+    else opts.onRequestClose?.();
   };
   window.addEventListener("keydown", onKey);
 
@@ -746,7 +748,7 @@ function buildView(root) {
   if (new URLSearchParams(location.search).has("demo")) {
     // No robot in the picture: the socket's connect card would just sit over
     // the synthetic show.
-    root.parentElement?.querySelector(".connect-layer")?.classList.add("br-hidden");
+    document.querySelector(".connect-layer")?.classList.add("br-hidden");
     void import("./demo.js").then((m) => {
       if (destroyed) return; // the page unmounted before the chunk loaded
       demoStop = m.startDemo(handlers);
@@ -798,6 +800,7 @@ function template() {
   return `
   <div class="br-head">
     <h1 class="page-title">Brain</h1>
+    <span class="br-esc-hint">esc closes</span>
     <div class="br-chips">
       <div class="br-chip br-chip-active" title="/brain/agent_status"><span class="led"></span><span>brain <b>—</b></span></div>
       <div class="br-chip br-chip-directive" title="current directive — /brain/agent_status"><span>directive</span><b>—</b></div>

--- a/webapp/js/pageMount.js
+++ b/webapp/js/pageMount.js
@@ -48,9 +48,10 @@ export function mountPage(stage, viewClass, buildView) {
     ros.connect(target);
   }
 
-  // Keep the view up through connecting / connected / reconnecting — the header
-  // badge carries the link status. Only a fail-fast "disconnected" (a first
-  // connect that never opened, or the idle laptop-dev state) shows the card.
+  // Keep the view up through connecting / connected / reconnecting — transient
+  // drops self-heal via rosClient while each panel shows its own loading state.
+  // Only a fail-fast "disconnected" (a first connect that never opened, or the
+  // idle laptop-dev state) shows the card.
   const unsubState = ros.onStateChange((state) => {
     const failed = state === "disconnected";
     connectLayer.hidden = !failed;

--- a/webapp/js/railLayout.js
+++ b/webapp/js/railLayout.js
@@ -113,7 +113,7 @@ export const GROUPS = [
   },
 ];
 
-// Pinned at the rail's bottom, above the connection badge.
+// Pinned at the rail's very bottom.
 /** @type {Section[]} */
 export const FOOTER_SECTIONS = [
   {

--- a/webapp/js/railLayout.js
+++ b/webapp/js/railLayout.js
@@ -1,0 +1,156 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// The rail's roster and grouping — pure data and layout, no DOM, so plain-node
+// tests can cover the boundary rules (tests/railLayout.test.js). shell.js
+// renders what railRows() returns.
+
+/** @typedef {{ key: string, label: string, icon: string }} Section */
+/** @typedef {{ label: string | null, sections: Section[] }} Group */
+/** @typedef {{ kind: "divider", label: string | null } | { kind: "section", section: Section }} RailRow */
+
+// In sim mode (config.simControls) only these sections make sense — the rest
+// (Datasets/Collect/Training/Profiling/Calibration) are robot-data workflows
+// with no sim backing — the sim has no real stereo camera or ChArUco board to
+// calibrate against — so they're hidden from the rail. Arm SDK stays: the sim
+// runs the same IK node and answers the goto services, so the page exercises
+// the real Manipulation SDK against the simulated arm. The router gates its
+// routes on this set too (route keys are section keys).
+export const SIM_SECTIONS = new Set(["teleop", "agent", "nav", "logging", "armsdk", "settings"]);
+
+// The rail is grouped: standalone pages ride alone; multi-page workflows carry
+// an eyebrow label (visible while the rail is hover-expanded; collapsed, a
+// hairline tick marks the boundary). Collect → Datasets → Training → Profiling
+// is the policy pipeline, grouped as AI Lab.
+/** @type {Group[]} */
+export const GROUPS = [
+  {
+    label: null,
+    sections: [
+      {
+        key: "teleop",
+        label: "Teleop",
+        // The joystick motif: rim, cardinal ticks, knob.
+        icon: '<circle cx="12" cy="12" r="8.5"/><line x1="12" y1="3.5" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="20.5"/><line x1="3.5" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="20.5" y2="12"/><circle cx="12" cy="12" r="2.4" fill="currentColor" stroke="none"/>',
+      },
+    ],
+  },
+  {
+    label: null,
+    sections: [
+      {
+        key: "agent",
+        label: "Agent",
+        // Sparkle motif: a four-point star for the autonomous brain.
+        icon: '<path d="M12 3.5l1.7 6.8 6.8 1.7-6.8 1.7L12 20.5l-1.7-6.8L3.5 12l6.8-1.7z"/>',
+      },
+    ],
+  },
+  {
+    label: null,
+    sections: [
+      {
+        key: "nav",
+        label: "Navigation",
+        // Radar motif: sweep arcs and a contact dot, for the live sensor view.
+        icon: '<path d="M12 12L18.4 5.6"/><path d="M15.2 8.8a4.5 4.5 0 1 0 1.3 3.2"/><path d="M18.4 5.6A9 9 0 1 0 21 12"/><circle cx="12" cy="12" r="1.4" fill="currentColor" stroke="none"/>',
+      },
+    ],
+  },
+  {
+    label: null,
+    sections: [
+      {
+        key: "logging",
+        label: "Logging",
+        icon: '<polyline points="4.5,7 10,12 4.5,17"/><line x1="12.5" y1="17" x2="19.5" y2="17"/>',
+      },
+    ],
+  },
+  {
+    label: "AI Lab",
+    sections: [
+      {
+        key: "collect",
+        label: "Collect",
+        icon: '<circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="3.2" fill="currentColor" stroke="none"/>',
+      },
+      {
+        key: "datasets",
+        label: "Datasets",
+        icon: '<ellipse cx="12" cy="6" rx="7.5" ry="3"/><path d="M4.5 6v12c0 1.66 3.36 3 7.5 3s7.5-1.34 7.5-3V6"/><path d="M4.5 12c0 1.66 3.36 3 7.5 3s7.5-1.34 7.5-3"/>',
+      },
+      {
+        key: "training",
+        label: "Training",
+        icon: '<polyline points="4,17.5 9.5,11.5 13.5,15 20,7"/><polyline points="15.5,7 20,7 20,11.5"/>',
+      },
+      {
+        key: "profiling",
+        label: "Profiling",
+        // Stopwatch motif: dial, crown, and a sweeping hand.
+        icon: '<circle cx="12" cy="13" r="7.5"/><line x1="12" y1="13" x2="15" y2="10"/><line x1="12" y1="2.5" x2="12" y2="5" /><line x1="9.5" y1="2.5" x2="14.5" y2="2.5"/>',
+      },
+    ],
+  },
+  {
+    label: "Maintenance",
+    sections: [
+      {
+        key: "armsdk",
+        label: "Arm SDK",
+        // Articulated-arm motif: base, two links with a joint, and a claw.
+        icon: '<circle cx="6" cy="19" r="2"/><path d="M7.5 17.5L10.5 10"/><circle cx="11" cy="8.8" r="1.4"/><path d="M12.3 8L17 5.5"/><path d="M17 5.5l2.5 1M17 5.5l.5 2.7"/>',
+      },
+      {
+        key: "calibration",
+        label: "Calibration",
+        // Camera motif: body with a viewfinder bump, and a lens. The body spans
+        // x 4–19, y 6–19, so its centre lands on the half unit.
+        icon: '<path d="M4 8a2 2 0 0 1 2-2h2l1.2-1.8a1 1 0 0 1 .8-.4h3a1 1 0 0 1 .8.4L15 6h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8z"/><circle cx="11.5" cy="12.5" r="3.4"/>',
+      },
+    ],
+  },
+];
+
+// Pinned at the rail's bottom, above the connection badge.
+/** @type {Section[]} */
+export const FOOTER_SECTIONS = [
+  {
+    key: "settings",
+    label: "Settings",
+    // Sliders motif: two tracks, each with a knob.
+    icon: '<line x1="4" y1="8.5" x2="20" y2="8.5"/><circle cx="10" cy="8.5" r="2.3" fill="currentColor" stroke="none"/><line x1="4" y1="15.5" x2="20" y2="15.5"/><circle cx="15" cy="15.5" r="2.3" fill="currentColor" stroke="none"/>',
+  },
+];
+
+// Flattened in rail order (footer last) — the source of number-key shortcuts
+// (1..N) and the tab-title lookup. Indices stay stable when the sim filter
+// hides sections.
+/** @type {Section[]} */
+export const SECTIONS = [...GROUPS.flatMap((group) => group.sections), ...FOOTER_SECTIONS];
+
+/**
+ * Flatten `groups` into rail rows. `visible` limits sections (the sim filter);
+ * a group left empty vanishes with its label. A divider separates two groups
+ * only when at least one of them is labeled — adjacent standalone pages read
+ * as one cluster.
+ * @param {Group[]} groups
+ * @param {Set<string> | null} visible
+ * @returns {RailRow[]}
+ */
+export function railRows(groups, visible) {
+  const kept = groups
+    .map((group) => ({
+      label: group.label,
+      sections: group.sections.filter((s) => !visible || visible.has(s.key)),
+    }))
+    .filter((group) => group.sections.length > 0);
+  /** @type {RailRow[]} */
+  const rows = [];
+  kept.forEach((group, i) => {
+    if (i > 0 && (group.label || kept[i - 1].label)) rows.push({ kind: "divider", label: group.label });
+    for (const section of group.sections) rows.push({ kind: "section", section });
+  });
+  return rows;
+}

--- a/webapp/js/router.js
+++ b/webapp/js/router.js
@@ -131,7 +131,9 @@ function dismissBootSplash() {
 function navigate(href) {
   const url = new URL(href, location.origin);
   const route = routeFor(url.pathname);
-  if (route.key === currentKey && url.search === location.search) return;
+  // Dedupe on the path, not the route key: /brain shares Agent's key, but a
+  // /brain link clicked from /agent must still render so the monitor opens.
+  if (normalize(url.pathname) === normalize(location.pathname) && url.search === location.search) return;
   history.pushState({}, "", url.pathname + url.search);
   void render(route);
 }
@@ -171,8 +173,8 @@ if (connectTarget) {
   // pages with no connect card (settings, profiling) on a refresh or deep link
   // while the robot is momentarily unreachable. So retry the initial-connect-failed
   // case here, debounced so a refused connection can't spin, and only until we've
-  // connected once: after that, drops self-heal via rosClient, and an explicit
-  // disconnect (header badge) or a manual connect from teleop's panel is respected.
+  // connected once: after that, drops self-heal via rosClient, and a manual
+  // connect from teleop's panel is respected.
   let everConnected = false;
   /** @type {number | null} */
   let connectRetry = null;

--- a/webapp/js/router.js
+++ b/webapp/js/router.js
@@ -18,6 +18,7 @@
 import { ros } from "./rosClient.js";
 import { initShell } from "./shell.js";
 import { getConfig } from "./config.js";
+import { SIM_SECTIONS } from "./railLayout.js";
 
 /**
  * @typedef {{ destroy: () => void }} PageView
@@ -26,11 +27,14 @@ import { getConfig } from "./config.js";
 
 // Teleop is the site root; every other section lives at /<key>. `key` matches
 // the shell's section keys so setActive can highlight the right rail link.
+// /brain is an alias into the Agent page (which opens its Brain monitor when
+// mounted at that path, then settles the URL on /agent) — old bookmarks keep
+// working and the rail highlights Agent.
 /** @type {Route[]} */
 const ROUTES = [
   { path: "/", key: "teleop", load: () => import("./teleop/main.js") },
   { path: "/agent", key: "agent", load: () => import("./agent/main.js") },
-  { path: "/brain", key: "brain", load: () => import("./brain/main.js") },
+  { path: "/brain", key: "agent", load: () => import("./agent/main.js") },
   { path: "/nav", key: "nav", load: () => import("./nav/main.js") },
   { path: "/logging", key: "logging", load: () => import("./logging/main.js") },
   { path: "/datasets", key: "datasets", load: () => import("./datasets/main.js") },
@@ -65,10 +69,9 @@ function routeFor(pathname) {
 
 const shell = initShell(navigate);
 
-// Sim deployments hide robot-data workflows from the rail (shell.js's
-// SIM_SECTIONS); gate the routes too, so a deep link or refresh can't mount
-// a page whose services have no sim backing.
-const SIM_ROUTE_KEYS = new Set(["teleop", "agent", "brain", "nav", "logging", "armsdk", "settings"]);
+// Sim deployments hide robot-data workflows from the rail (SIM_SECTIONS);
+// gate the routes too, so a deep link or refresh can't mount a page whose
+// services have no sim backing.
 /** @type {Promise<{simControls?: boolean}>} */
 const configPromise = getConfig();
 
@@ -80,7 +83,7 @@ const configPromise = getConfig();
  */
 async function render(route) {
   const seq = ++navSeq;
-  if ((await configPromise)?.simControls && !SIM_ROUTE_KEYS.has(route.key)) route = ROUTES[0];
+  if ((await configPromise)?.simControls && !SIM_SECTIONS.has(route.key)) route = ROUTES[0];
   if (seq !== navSeq) return; // superseded while awaiting config
   // Destroy BEFORE building the next page: the outgoing destroy() stops running
   // skills/drive and frees socket-bound panels, and clears the stage.

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -1,8 +1,8 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// Shell — the 64px icon rail + connection badge rendered into every page,
-// and the placeholder renderer for not-yet-built sections.
+// Shell — the 64px icon rail rendered into every page, and the placeholder
+// renderer for not-yet-built sections.
 
 import { ros } from "./rosClient.js";
 import { initTtsAudio } from "./ttsAudio.js";
@@ -67,8 +67,7 @@ export function initShell(navigate) {
   const nav = document.createElement("nav");
   nav.className = "rail-nav";
   nav.setAttribute("aria-label", "Sections");
-  // Settings (and any future utility page) pins to the rail's bottom, above
-  // the connection badge.
+  // Settings (and any future utility page) pins to the rail's very bottom.
   const footNav = document.createElement("nav");
   footNav.className = "rail-nav rail-foot";
   footNav.setAttribute("aria-label", "Utility");
@@ -94,18 +93,21 @@ export function initShell(navigate) {
 
   /** @param {Section} section */
   function buildLink(section) {
-    const shortcut = SECTIONS.indexOf(section) + 1; // 1..N, the number-key shortcut for this section
+    // Only single digits exist as key shortcuts, so sections past the ninth
+    // advertise none — a keycap that can't be pressed is a small lie.
+    const index = SECTIONS.indexOf(section);
+    const shortcut = index < 9 ? index + 1 : null;
     const a = document.createElement("a");
     a.className = "rail-link";
     a.dataset.section = section.key;
     a.href = pathForKey(section.key);
-    a.title = `${section.label} (${shortcut})`;
+    a.title = shortcut ? `${section.label} (${shortcut})` : section.label;
     a.setAttribute("aria-label", section.label);
-    a.setAttribute("aria-keyshortcuts", String(shortcut));
+    if (shortcut) a.setAttribute("aria-keyshortcuts", String(shortcut));
     a.innerHTML =
       `<span class="rail-ico"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${section.icon}</svg></span>` +
       `<span class="rail-label">${section.label}</span>` +
-      `<span class="rail-key" aria-hidden="true">${shortcut}</span>`;
+      (shortcut ? `<span class="rail-key" aria-hidden="true">${shortcut}</span>` : "");
     return a;
   }
 
@@ -147,7 +149,6 @@ export function initShell(navigate) {
     if (link) navigate(pathForKey(section.key));
   });
 
-  rail.appendChild(createBadge());
   document.body.prepend(rail);
 
   // Sim deployments hide robot-data workflows (SIM_SECTIONS) — rebuild the
@@ -191,38 +192,3 @@ export function initShell(navigate) {
   return { setActive };
 }
 
-/**
- * Connection badge pinned at the rail bottom: pulsing state dot + mono IP.
- * Click disconnects when connected.
- * @returns {HTMLElement}
- */
-function createBadge() {
-  const badge = document.createElement("button");
-  badge.className = "badge";
-  badge.type = "button";
-
-  const dot = document.createElement("span");
-  dot.className = "badge-dot";
-  const label = document.createElement("span");
-  label.className = "badge-label";
-  badge.append(dot, label);
-
-  ros.onStateChange((state, ip) => {
-    badge.dataset.state = state;
-    /** @type {Record<ConnState, string>} */
-    const text = {
-      disconnected: "offline",
-      connecting: "linking",
-      connected: ip ?? "linked",
-      reconnecting: "relink",
-    };
-    label.textContent = text[state];
-    badge.title = state === "connected" ? `Connected to ${ip} — click to disconnect` : state;
-    badge.disabled = state !== "connected";
-  });
-
-  badge.addEventListener("click", () => {
-    if (ros.state === "connected") ros.disconnect();
-  });
-  return badge;
-}

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -22,7 +22,7 @@ function pathForKey(key) {
 }
 
 /** True when focus is in a text field, so global key shortcuts must stand down. */
-function isTypingContext() {
+export function isTypingContext() {
   const el = document.activeElement;
   return (
     el instanceof HTMLElement &&
@@ -31,8 +31,8 @@ function isTypingContext() {
 }
 
 /**
- * Build the persistent app chrome once — the icon rail + connection badge, robot
- * speech playback, and the "agent running" indicator — and return a controller
+ * Build the persistent app chrome once — the icon rail, robot speech playback,
+ * and the "agent running" indicator — and return a controller
  * the router uses to reflect the active section on each navigation. Called once
  * by the router, not per page (navigation is client-side now).
  * @param {(path: string) => void} navigate Router navigation, for key shortcuts.
@@ -155,7 +155,7 @@ export function initShell(navigate) {
   // rail without them once the (env-driven) config says we're in sim mode.
   void getConfig().then((config) => {
     // {} on any failure → assume real robot, keep every section.
-    if (/** @type {any} */ (config)?.simControls) renderNav(SIM_SECTIONS);
+    if (config?.simControls) renderNav(SIM_SECTIONS);
   });
 
   // Play robot speech (/tts/audio) regardless of which page is open; idempotent.

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -12,89 +12,9 @@ import { createAgentIndicator } from "./agentIndicator.js";
 import { createArmAlert } from "./armAlert.js";
 import { maybeShowAppPromo } from "./appPromo.js";
 import { installPressActivate } from "./pressActivate.js";
+import { FOOTER_SECTIONS, GROUPS, SECTIONS, SIM_SECTIONS, railRows } from "./railLayout.js";
 
-/** @typedef {{ key: string, label: string, icon: string }} Section */
-
-// In sim mode (config.simControls) only these sections make sense — the rest
-// (Datasets/Collect/Training/Profiling/Calibration) are robot-data workflows
-// with no sim backing — the sim has no real stereo camera or ChArUco board to
-// calibrate against — so they're hidden from the rail. Arm SDK stays: the sim
-// runs the same IK node and answers the goto services, so the page exercises
-// the real Manipulation SDK against the simulated arm.
-const SIM_SECTIONS = new Set(["teleop", "agent", "brain", "nav", "logging", "armsdk", "settings"]);
-
-/** @type {Section[]} */
-const SECTIONS = [
-  {
-    key: "teleop",
-    label: "Teleop",
-    // The joystick motif: rim, cardinal ticks, knob.
-    icon: '<circle cx="12" cy="12" r="8.5"/><line x1="12" y1="3.5" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="20.5"/><line x1="3.5" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="20.5" y2="12"/><circle cx="12" cy="12" r="2.4" fill="currentColor" stroke="none"/>',
-  },
-  {
-    key: "agent",
-    label: "Agent",
-    // Sparkle motif: a four-point star for the autonomous brain.
-    icon: '<path d="M12 3.5l1.7 6.8 6.8 1.7-6.8 1.7L12 20.5l-1.7-6.8L3.5 12l6.8-1.7z"/>',
-  },
-  {
-    key: "brain",
-    label: "Brain",
-    // Monitor motif: an EKG pulse line, for the live agent-loop monitor.
-    icon: '<polyline points="3.5,12 7.5,12 10,6.5 13,17.5 15.5,12 20.5,12"/>',
-  },
-  {
-    key: "nav",
-    label: "Nav",
-    // Radar motif: sweep arcs and a contact dot, for the live sensor view.
-    icon: '<path d="M12 12L18.4 5.6"/><path d="M15.2 8.8a4.5 4.5 0 1 0 1.3 3.2"/><path d="M18.4 5.6A9 9 0 1 0 21 12"/><circle cx="12" cy="12" r="1.4" fill="currentColor" stroke="none"/>',
-  },
-  {
-    key: "logging",
-    label: "Logging",
-    icon: '<polyline points="4.5,7 10,12 4.5,17"/><line x1="12.5" y1="17" x2="19.5" y2="17"/>',
-  },
-  {
-    key: "datasets",
-    label: "Datasets",
-    icon: '<ellipse cx="12" cy="6" rx="7.5" ry="3"/><path d="M4.5 6v12c0 1.66 3.36 3 7.5 3s7.5-1.34 7.5-3V6"/><path d="M4.5 12c0 1.66 3.36 3 7.5 3s7.5-1.34 7.5-3"/>',
-  },
-  {
-    key: "collect",
-    label: "Collect",
-    icon: '<circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="3.2" fill="currentColor" stroke="none"/>',
-  },
-  {
-    key: "training",
-    label: "Training",
-    icon: '<polyline points="4,17.5 9.5,11.5 13.5,15 20,7"/><polyline points="15.5,7 20,7 20,11.5"/>',
-  },
-  {
-    key: "profiling",
-    label: "Profiling",
-    // Stopwatch motif: dial, crown, and a sweeping hand.
-    icon: '<circle cx="12" cy="13" r="7.5"/><line x1="12" y1="13" x2="15" y2="10"/><line x1="12" y1="2.5" x2="12" y2="5" /><line x1="9.5" y1="2.5" x2="14.5" y2="2.5"/>',
-  },
-  {
-    key: "calibration",
-    label: "Calibration",
-    // Camera motif: body with a viewfinder bump, and a lens. The body spans
-    // x 4–19, y 6–19, so its centre lands on the half unit.
-    icon: '<path d="M4 8a2 2 0 0 1 2-2h2l1.2-1.8a1 1 0 0 1 .8-.4h3a1 1 0 0 1 .8.4L15 6h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8z"/><circle cx="11.5" cy="12.5" r="3.4"/>',
-  },
-  {
-    key: "armsdk",
-    label: "Arm SDK",
-    // Articulated-arm motif: base, two links with a joint, and a claw.
-    icon: '<circle cx="6" cy="19" r="2"/><path d="M7.5 17.5L10.5 10"/><circle cx="11" cy="8.8" r="1.4"/><path d="M12.3 8L17 5.5"/><path d="M17 5.5l2.5 1M17 5.5l.5 2.7"/>',
-  },
-  {
-    key: "settings",
-    label: "Settings",
-    // Sliders motif: two tracks, each with a knob.
-    icon: '<line x1="4" y1="8.5" x2="20" y2="8.5"/><circle cx="10" cy="8.5" r="2.3" fill="currentColor" stroke="none"/><line x1="4" y1="15.5" x2="20" y2="15.5"/><circle cx="15" cy="15.5" r="2.3" fill="currentColor" stroke="none"/>',
-  },
-];
+/** @typedef {import("./railLayout.js").Section} Section */
 
 /** Path for a section key: teleop is the site root, the rest are /<key>. @param {string} key */
 function pathForKey(key) {
@@ -147,8 +67,34 @@ export function initShell(navigate) {
   const nav = document.createElement("nav");
   nav.className = "rail-nav";
   nav.setAttribute("aria-label", "Sections");
-  SECTIONS.forEach((section, i) => {
-    const shortcut = i + 1; // 1..N, the number-key shortcut for this section
+  // Settings (and any future utility page) pins to the rail's bottom, above
+  // the connection badge.
+  const footNav = document.createElement("nav");
+  footNav.className = "rail-nav rail-foot";
+  footNav.setAttribute("aria-label", "Utility");
+  let activeKey = "";
+
+  /**
+   * (Re)build the rail from railRows — links in group order, a divider at each
+   * labeled-group boundary, footer sections pinned at the bottom. `visible`
+   * filters sections (the sim rebuild).
+   * @param {Set<string> | null} visible
+   */
+  function renderNav(visible) {
+    nav.innerHTML = "";
+    for (const row of railRows(GROUPS, visible)) {
+      nav.appendChild(row.kind === "divider" ? buildDivider(row.label) : buildLink(row.section));
+    }
+    footNav.innerHTML = "";
+    for (const section of FOOTER_SECTIONS) {
+      if (!visible || visible.has(section.key)) footNav.appendChild(buildLink(section));
+    }
+    applyActive();
+  }
+
+  /** @param {Section} section */
+  function buildLink(section) {
+    const shortcut = SECTIONS.indexOf(section) + 1; // 1..N, the number-key shortcut for this section
     const a = document.createElement("a");
     a.className = "rail-link";
     a.dataset.section = section.key;
@@ -160,9 +106,34 @@ export function initShell(navigate) {
       `<span class="rail-ico"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${section.icon}</svg></span>` +
       `<span class="rail-label">${section.label}</span>` +
       `<span class="rail-key" aria-hidden="true">${shortcut}</span>`;
-    nav.appendChild(a);
-  });
-  rail.appendChild(nav);
+    return a;
+  }
+
+  /** @param {string | null} label */
+  function buildDivider(label) {
+    const div = document.createElement("div");
+    div.className = "rail-div";
+    if (!label) return div;
+    div.classList.add("has-label");
+    const span = document.createElement("span");
+    span.className = "rail-div-label";
+    span.textContent = label;
+    div.appendChild(span);
+    return div;
+  }
+
+  function applyActive() {
+    for (const link of rail.querySelectorAll(".rail-link")) {
+      const el = /** @type {HTMLElement} */ (link);
+      const active = el.dataset.section === activeKey;
+      el.classList.toggle("active", active);
+      if (active) el.setAttribute("aria-current", "page");
+      else el.removeAttribute("aria-current");
+    }
+  }
+
+  renderNav(null);
+  rail.append(nav, footNav);
 
   // Number keys 1..N jump between sections (the number shows in each tooltip).
   // Guarded so it never fires while typing in a field or as part of a
@@ -172,17 +143,19 @@ export function initShell(navigate) {
     if (e.altKey || e.ctrlKey || e.metaKey || e.repeat || isTypingContext()) return;
     const section = SECTIONS[Number(e.key) - 1];
     if (!section) return;
-    // A removed link (sim-mode filter) has no match, so its number stays inert.
-    const link = nav.querySelector(`.rail-link[data-section="${section.key}"]`);
+    const link = rail.querySelector(`.rail-link[data-section="${section.key}"]`);
     if (link) navigate(pathForKey(section.key));
   });
 
   rail.appendChild(createBadge());
   document.body.prepend(rail);
 
-  // Sim deployments only expose Teleop/Agent/Logging/Settings — drop the rest
-  // from the rail once the (env-driven) config says we're in sim mode.
-  void applySimSectionFilter(nav);
+  // Sim deployments hide robot-data workflows (SIM_SECTIONS) — rebuild the
+  // rail without them once the (env-driven) config says we're in sim mode.
+  void getConfig().then((config) => {
+    // {} on any failure → assume real robot, keep every section.
+    if (/** @type {any} */ (config)?.simControls) renderNav(SIM_SECTIONS);
+  });
 
   // Play robot speech (/tts/audio) regardless of which page is open; idempotent.
   initTtsAudio();
@@ -208,34 +181,14 @@ export function initShell(navigate) {
    * @param {string} key
    */
   function setActive(key) {
-    for (const link of nav.querySelectorAll(".rail-link")) {
-      const el = /** @type {HTMLElement} */ (link);
-      const active = el.dataset.section === key;
-      el.classList.toggle("active", active);
-      if (active) el.setAttribute("aria-current", "page");
-      else el.removeAttribute("aria-current");
-    }
+    activeKey = key;
+    applyActive();
     agentIndicator.el.style.display = key === "agent" ? "none" : "";
     const section = SECTIONS.find((s) => s.key === key);
     document.title = section ? `Innate · ${section.label}` : "Innate";
   }
 
   return { setActive };
-}
-
-/**
- * Hide robot-only sections from the rail when running in sim mode.
- * @param {HTMLElement} nav
- */
-async function applySimSectionFilter(nav) {
-  /** @type {any} */
-  let config;
-  config = await getConfig(); // {} on any failure → assume real robot, keep every section
-  if (!config?.simControls) return;
-  for (const link of nav.querySelectorAll(".rail-link")) {
-    const key = /** @type {HTMLElement} */ (link).dataset.section ?? "";
-    if (!SIM_SECTIONS.has(key)) link.remove();
-  }
 }
 
 /**

--- a/webapp/tests/railLayout.test.js
+++ b/webapp/tests/railLayout.test.js
@@ -48,4 +48,21 @@ test("settings is footer-only and survives the sim filter", () => {
   assert.ok(SIM_SECTIONS.has("settings"));
 });
 
+// Synthetic roster: today's GROUPS ends with its labeled groups, so only this
+// fixture reaches the labeled→unlabeled boundary (a plain divider) and the
+// unlabeled→unlabeled one (none).
+test("divider rules hold on boundaries the real roster never hits", () => {
+  /** @param {string} key */
+  const sec = (key) => ({ key, label: key, icon: "" });
+  const groups = [
+    { label: "A", sections: [sec("a")] },
+    { label: null, sections: [sec("b")] },
+    { label: null, sections: [sec("c")] },
+    { label: "D", sections: [] },
+    { label: "E", sections: [sec("e")] },
+  ];
+  assert.equal(fingerprint(railRows(groups, null)), "a | b c |E e");
+  assert.equal(fingerprint(railRows(groups, new Set(["b", "c"]))), "b c");
+});
+
 console.log(`\n${passed} passed`);

--- a/webapp/tests/railLayout.test.js
+++ b/webapp/tests/railLayout.test.js
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Rail-order tests for js/railLayout.js — zero dependencies, plain node:
+//   node tests/railLayout.test.js
+// Covers the boundary rules the shell renders from: dividers only around
+// labeled groups, empty groups vanishing with their label, and the sim roster.
+
+import assert from "node:assert/strict";
+import { FOOTER_SECTIONS, GROUPS, SECTIONS, SIM_SECTIONS, railRows } from "../js/railLayout.js";
+
+let passed = 0;
+/** @param {string} name @param {() => void} fn */
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+/** Compact fingerprint of a row list: section keys, "|" for a plain divider, "|LABEL" for a labeled one. */
+function fingerprint(rows) {
+  return rows.map((r) => (r.kind === "divider" ? `|${r.label ?? ""}` : r.section.key)).join(" ");
+}
+
+test("full roster: labeled groups bracketed, standalone pages cluster", () => {
+  assert.equal(
+    fingerprint(railRows(GROUPS, null)),
+    "teleop agent nav logging |AI Lab collect datasets training profiling |Maintenance armsdk calibration",
+  );
+});
+
+test("sim roster: AI Lab vanishes with its label, Maintenance keeps Arm SDK", () => {
+  assert.equal(
+    fingerprint(railRows(GROUPS, SIM_SECTIONS)),
+    "teleop agent nav logging |Maintenance armsdk",
+  );
+});
+
+test("SECTIONS flattens GROUPS then footer, with unique keys", () => {
+  assert.deepEqual(
+    SECTIONS.map((s) => s.key),
+    [...GROUPS.flatMap((g) => g.sections.map((s) => s.key)), ...FOOTER_SECTIONS.map((s) => s.key)],
+  );
+  assert.equal(new Set(SECTIONS.map((s) => s.key)).size, SECTIONS.length);
+});
+
+test("settings is footer-only and survives the sim filter", () => {
+  assert.deepEqual(FOOTER_SECTIONS.map((s) => s.key), ["settings"]);
+  assert.ok(SIM_SECTIONS.has("settings"));
+});
+
+console.log(`\n${passed} passed`);


### PR DESCRIPTION
## What

Three iterations on the webapp's navigation and the Agent experience, driven on-robot:

### Agent + Brain are one page now

The Brain monitor is no longer a separate destination — it's the Agent page's deep view:

- A **Live | Brain** segmented switch in the agent panel header flips the stage between the camera cockpit and the loop monitor. The panel (directive picker, Start/Stop, Reset, active skill, thought stream, chat composer) stays docked in both views, so you can stop the robot or message it while watching its brain.
- While the loop runs, the Brain segment carries a small breathing dot, and the bottom-left **"Agent active"** chip reads *"Watch its brain →"* and opens the monitor on click.
- **Esc** closes the monitor (the turn inspector gets Esc first). The monitor mounts on first open and lives until the page unmounts, so the turn filmstrip/history survive flipping. Video keeps streaming beneath — switching back is instant, no WebRTC renegotiation.
- The monitor's mind-stream panel is hidden (the agent panel's stream beside it is the canonical same words); its grid reflows to two columns with vitals as a bottom status strip, sized to clear the docked panel.
- `/brain` stays as a **deep-link alias**: it mounts the Agent page with the monitor open, then settles the URL on `/agent`. `?demo` still drives the monitor with the synthetic brain.
- Fix found on-robot: the turn inspector is a fixed modal inside the brain layer's stacking context, which capped it below the docked panel — the layer now lifts to the inspector's z-level while it's open (`:has()`-driven, no JS).

### The rail is grouped

New pure module `railLayout.js` (roster + boundary rules, no DOM) renders as:

- **Teleop, Agent, Navigation, Logging** — standalone
- **AI LAB** — Collect, Datasets, Training, Profiling
- **MAINTENANCE** — Arm SDK, Calibration
- **Settings** — pinned at the rail's bottom, above the connection badge

Collapsed, group boundaries are hairline ticks under the icon column; hover-expanded, labeled groups get a readable header (10.5px semibold + trailing rule). "Nav" is renamed "Navigation". Sim mode drops AI Lab entirely (label included) and keeps Arm SDK under Maintenance. Number-key shortcuts follow the new order (1 Teleop … 9 Arm SDK).

## Verification

- `node webapp/tests/railLayout.test.js` — 4 tests pin the exact rail sequences (full + sim) and the footer contract
- `npx tsc -p webapp` — same 33 pre-existing errors before and after (none in touched files)
- Exercised on mars-the-2nd in demo mode: turn history, inspector, panel stream, Live/Brain flip


<img width="1493" height="1041" alt="image" src="https://github.com/user-attachments/assets/82b599f5-8e9c-4828-9b87-9ce2a4a78ba8" />

<img width="1498" height="1036" alt="image" src="https://github.com/user-attachments/assets/cb11c5c2-4f15-4f7d-a2cb-f3c0e094a3eb" />

