### PR TITLE
feat(brain): record spatial memories during the mapping tour

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -27,6 +27,7 @@ class BrainConfig:
     current_map_topic: str
     amcl_pose_topic: str
     map_saved_topic: str
+    mapping_session_topic: str
     scan_topic: str
 
     # --- Feature flags ---
@@ -88,6 +89,7 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "current_map_topic": "/nav/current_map",
     "amcl_pose_topic": "/amcl_pose",
     "map_saved_topic": "/nav/map_saved",
+    "mapping_session_topic": "/nav/mapping_session",
     "scan_topic": "/scan",
     # --- Feature flags ---
     "send_arm_camera_image": True,

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -26,6 +26,7 @@ class BrainConfig:
     current_nav_mode_topic: str
     current_map_topic: str
     amcl_pose_topic: str
+    map_saved_topic: str
     scan_topic: str
 
     # --- Feature flags ---
@@ -86,6 +87,7 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "current_nav_mode_topic": "/nav/current_mode",
     "current_map_topic": "/nav/current_map",
     "amcl_pose_topic": "/amcl_pose",
+    "map_saved_topic": "/nav/map_saved",
     "scan_topic": "/scan",
     # --- Feature flags ---
     "send_arm_camera_image": True,

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/coverage.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/coverage.py
@@ -114,9 +114,12 @@ class Coverage:
         return union
 
     def _mask(self, memory: Memory, grid: Map) -> np.ndarray | None:
-        if grid is not self._grid:  # a new map message repaints the world
-            self._grid = grid
+        # Geometry, not identity (Map.__eq__ excludes the cells): mapping
+        # republishes the same geometry at 2 Hz, and rebuilding every mask per
+        # message costs more than paint one refinement stale is worth.
+        if self._grid is None or grid != self._grid:
             self._masks.clear()
+        self._grid = grid
         key = (memory.id, memory.stamp)
         mask = self._masks.get(key)
         if mask is None:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -171,7 +171,11 @@ class MemoryRecorder:
         self._map_name = msg.data
 
     def _on_map_saved(self, msg: String) -> None:
-        promoted = self._store.promote_mapping_session(msg.data)
+        try:
+            promoted = self._store.promote_mapping_session(msg.data)
+        except Exception as error:  # noqa: BLE001 — a full disk must not take the brain node down
+            self._logger.error(f"[Memory] promoting the mapping session to {msg.data} failed: {error!r}")
+            return
         if promoted:
             self._logger.info(f"[Memory] promoted {promoted} mapping-session memories to {msg.data}")
 

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -5,9 +5,13 @@
 Always on, independent of brain activation: a webapp teleop tour must build
 memories too, so the recorder owns its own lightweight subscriptions instead
 of borrowing the brain's activation-gated sensors. One rule governs capture —
-record only what a well-localized robot saw: AMCL's covariance must hold below
-the webapp's "confident" thresholds for a few seconds straight, then the
-admission policy (memory/selection.py) decides novelty, refresh, and eviction.
+record only what a well-localized robot saw. In navigation that means AMCL's
+covariance holding below the webapp's "confident" thresholds for a few seconds
+straight; in mapping there is no AMCL, so the SLAM estimate is taken at its
+word while a fresh grid proves slam_toolbox is alive, and the memories stage
+under the store's mapping session until ``/nav/map_saved`` hands them to the
+saved map. Then the admission policy (memory/selection.py) decides novelty,
+refresh, and eviction.
 Novelty is visibility paint: each memory paints the floor its camera saw, and
 a new picture is taken while the wedge ahead is mostly unpainted. A kept
 viewpoint's picture refreshes only from a frame aimed the same way with
@@ -65,6 +69,10 @@ _FRESH_FRAME_SEC = 2.5  # the compressed feed runs ~7.5 Hz; older means it died
 # alive. Older means AMCL died — TF keeps composing odom motion while the last
 # good covariance stays latched, and those poses are vouched for by nothing.
 _COVARIANCE_FRESH_SEC = 5.0
+# Mapping's analogue: slam_toolbox republishes /map every 0.5 s
+# (map_update_interval). An older grid means SLAM died, and TF's map frame is
+# coasting on odom alone.
+_GRID_FRESH_SEC = 5.0
 _MIN_HEAD_PITCH_DEG = -25.0  # looking further down films the floor, not the room
 
 
@@ -109,6 +117,7 @@ class MemoryRecorder:
         self._head_pitch = 0.0
         self._confident_since: float | None = None
         self._grid: Map | None = None  # sight-line + paint truth for admissions and refreshes
+        self._grid_at = 0.0  # monotonic arrival of the last /map message
         self._coverage = Coverage()
 
         image_qos = QoSProfile(
@@ -127,6 +136,7 @@ class MemoryRecorder:
         node.create_subscription(String, config.current_nav_mode_topic, self._on_nav_mode, 10)
         node.create_subscription(String, config.current_map_topic, self._on_current_map, 10)
         node.create_subscription(PoseWithCovarianceStamped, config.amcl_pose_topic, self._on_amcl_pose, latched_qos)
+        node.create_subscription(String, config.map_saved_topic, self._on_map_saved, 10)
         node.create_subscription(OccupancyGrid, "/map", self._on_map, latched_qos)
         node.create_subscription(String, "/mars/head/current_position", self._on_head, 10)
         node.create_timer(_TICK_SEC, self.tick)
@@ -150,6 +160,8 @@ class MemoryRecorder:
             self._candidate = _Candidate(time.monotonic(), *pose, sharpness, jpeg)
 
     def _recordable_moment(self) -> bool:
+        if self._nav_mode == "mapping":
+            return self._slam_alive()
         return self._nav_mode == "navigation" and bool(self._map_name) and self._confident()
 
     def _on_nav_mode(self, msg: String) -> None:
@@ -158,12 +170,18 @@ class MemoryRecorder:
     def _on_current_map(self, msg: String) -> None:
         self._map_name = msg.data
 
+    def _on_map_saved(self, msg: String) -> None:
+        promoted = self._store.promote_mapping_session(msg.data)
+        if promoted:
+            self._logger.info(f"[Memory] promoted {promoted} mapping-session memories to {msg.data}")
+
     def _on_amcl_pose(self, msg: PoseWithCovarianceStamped) -> None:
         covariance = msg.pose.covariance
         self._covariance = (covariance[0], covariance[7], covariance[35])
         self._covariance_at = time.monotonic()
 
     def _on_map(self, msg: OccupancyGrid) -> None:
+        self._grid_at = time.monotonic()
         self._grid = Map(
             resolution=msg.info.resolution,
             width=msg.info.width,
@@ -183,7 +201,10 @@ class MemoryRecorder:
     # --- the 1 Hz tick ---
     def tick(self) -> None:
         try:
-            self._store.switch_map(self._map_name or None)
+            if self._nav_mode == "mapping":
+                self._store.use_mapping_session()
+            else:
+                self._store.switch_map(self._map_name or None)
             self._maybe_record()
             self._publish_positions()
             if self._warm_search is not None:
@@ -200,7 +221,7 @@ class MemoryRecorder:
         self._record(candidate.x, candidate.y, candidate.theta, candidate.jpeg)
 
     def _localized_long_enough(self) -> bool:
-        if self._nav_mode != "navigation" or not self._map_name or not self._confident():
+        if not self._recordable_moment():
             self._confident_since = None
             return False
         now = time.monotonic()
@@ -213,6 +234,9 @@ class MemoryRecorder:
             return False
         var_x, var_y, var_yaw = self._covariance
         return max(var_x, var_y) <= _POSITION_VAR_MAX and var_yaw <= _YAW_VAR_MAX
+
+    def _slam_alive(self) -> bool:
+        return self._grid is not None and time.monotonic() - self._grid_at <= _GRID_FRESH_SEC
 
     def _record(self, x: float, y: float, theta: float, jpeg: bytes) -> None:
         plan = plan_admission(self._store.snapshot().memories, x, y, theta, time.time(), self._grid, self._coverage)
@@ -230,12 +254,16 @@ class MemoryRecorder:
             self._logger.info(f"[Memory] recorded viewpoint {memory.id} at ({x:.2f}, {y:.2f}){evicted}")
 
     def _publish_positions(self) -> None:
+        snapshot = self._store.snapshot()
         payload = {
-            "map": self._map_name,
+            # The store's identity, not /nav/current_map: during mapping the
+            # positions live in the SLAM frame under the session name, and mid
+            # map-verification the store still holds the previous map.
+            "map": snapshot.map_name or "",
             # The webapp keys its per-map state on map+fingerprint: a same-name
             # re-map wipes the store and restarts ids, and only the fingerprint
             # betrays that to a client watching the name.
-            "fingerprint": self._store.fingerprint[:12],
+            "fingerprint": snapshot.fingerprint[:12],
             "cache": self._cache_state() if self._cache_state is not None else "off",
             "positions": self._store.positions(),
         }

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -199,8 +199,11 @@ class MemoryRecorder:
         except (json.JSONDecodeError, TypeError, KeyError, ValueError):
             self._logger.error(f"[Memory] unreadable map-save announcement: {msg.data!r}")
             return
-        if time.time() - stamp > _SAVE_ANNOUNCEMENT_FRESH_SEC:
-            return  # the latch replaying an old save — see _SAVE_ANNOUNCEMENT_FRESH_SEC
+        age = time.time() - stamp
+        if age > _SAVE_ANNOUNCEMENT_FRESH_SEC:
+            # The latch replaying an old save — see _SAVE_ANNOUNCEMENT_FRESH_SEC.
+            self._logger.info(f"[Memory] ignoring a stale save announcement for {map_name} ({age:.0f}s old)")
+            return
         try:
             promoted = self._store.promote_mapping_session(map_name, mapping_started)
         except StaleStageError as error:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -246,6 +246,11 @@ class MemoryRecorder:
                 # could wipe a half-tour this very session staged.
                 if self._mapping_started is not None:
                     self._store.use_mapping_session(self._mapping_started)
+                else:
+                    # Detach meanwhile: the previous map's marks must not keep
+                    # publishing over the growing grid (nor ever, against a
+                    # mars_nav too old to announce sessions).
+                    self._store.switch_map(None)
             else:
                 self._store.switch_map(self._map_name or None)
             self._maybe_record()

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -174,8 +174,12 @@ class MemoryRecorder:
     def _on_nav_mode(self, msg: String) -> None:
         if msg.data != self._nav_mode:
             # A mode change swaps the coordinate frame; confidence held in the
-            # old frame says nothing about the new one — the hold restarts.
+            # old frame says nothing about the new one — the hold restarts,
+            # and the latched /map replay is the old frame's too: only grids
+            # received in this mode may vouch for SLAM (_slam_alive).
             self._confident_since = None
+            self._grid = None
+            self._grid_at = 0.0
         self._nav_mode = msg.data
 
     def _on_current_map(self, msg: String) -> None:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -48,6 +48,7 @@ from brain_client.common.geometry import quaternion_to_yaw
 from brain_client.memory.coverage import Coverage
 from brain_client.memory.quality import MIN_SHARPNESS, frame_sharpness
 from brain_client.memory.selection import plan_admission
+from brain_client.memory.store import StaleStageError
 from brain_client.state.map import Map
 
 if TYPE_CHECKING:
@@ -116,6 +117,7 @@ class MemoryRecorder:
         self._last_published: dict | None = None
         self._nav_mode: str | None = None
         self._map_name = ""
+        self._mapping_started: float | None = None  # the live SLAM session's identity (/nav/mapping_session)
         self._covariance: tuple[float, float, float] | None = None  # (var x, var y, var yaw)
         self._covariance_at = 0.0  # monotonic arrival of the last AMCL message
         self._head_pitch = 0.0
@@ -141,6 +143,7 @@ class MemoryRecorder:
         node.create_subscription(String, config.current_map_topic, self._on_current_map, 10)
         node.create_subscription(PoseWithCovarianceStamped, config.amcl_pose_topic, self._on_amcl_pose, latched_qos)
         node.create_subscription(String, config.map_saved_topic, self._on_map_saved, latched_qos)
+        node.create_subscription(String, config.mapping_session_topic, self._on_mapping_session, latched_qos)
         node.create_subscription(OccupancyGrid, "/map", self._on_map, latched_qos)
         node.create_subscription(String, "/mars/head/current_position", self._on_head, 10)
         node.create_timer(_TICK_SEC, self.tick)
@@ -165,7 +168,7 @@ class MemoryRecorder:
 
     def _recordable_moment(self) -> bool:
         if self._nav_mode == "mapping":
-            return self._slam_alive()
+            return self._mapping_started is not None and self._slam_alive()
         return self._nav_mode == "navigation" and bool(self._map_name) and self._confident()
 
     def _on_nav_mode(self, msg: String) -> None:
@@ -178,17 +181,27 @@ class MemoryRecorder:
     def _on_current_map(self, msg: String) -> None:
         self._map_name = msg.data
 
+    def _on_mapping_session(self, msg: String) -> None:
+        try:
+            self._mapping_started = float(json.loads(msg.data)["started"])
+        except (json.JSONDecodeError, TypeError, KeyError, ValueError):
+            self._logger.error(f"[Memory] unreadable mapping-session announcement: {msg.data!r}")
+
     def _on_map_saved(self, msg: String) -> None:
         try:
             payload = json.loads(msg.data)
             map_name, stamp = str(payload["map"]), float(payload["stamp"])
+            mapping_started = float(payload["mapping_started"]) if "mapping_started" in payload else None
         except (json.JSONDecodeError, TypeError, KeyError, ValueError):
             self._logger.error(f"[Memory] unreadable map-save announcement: {msg.data!r}")
             return
         if time.time() - stamp > _SAVE_ANNOUNCEMENT_FRESH_SEC:
             return  # the latch replaying an old save — see _SAVE_ANNOUNCEMENT_FRESH_SEC
         try:
-            promoted = self._store.promote_mapping_session(map_name)
+            promoted = self._store.promote_mapping_session(map_name, mapping_started)
+        except StaleStageError as error:
+            self._logger.error(f"[Memory] stage not promoted to {map_name} — another session built it: {error}")
+            return
         except Exception as error:  # noqa: BLE001 — a full disk must not take the brain node down
             self._logger.error(f"[Memory] promoting the mapping session to {map_name} failed: {error!r}")
             return
@@ -224,7 +237,11 @@ class MemoryRecorder:
     def tick(self) -> None:
         try:
             if self._nav_mode == "mapping":
-                self._store.use_mapping_session()
+                # Entering the stage needs the session's identity: before the
+                # latched /nav/mapping_session replay arrives, touching it
+                # could wipe a half-tour this very session staged.
+                if self._mapping_started is not None:
+                    self._store.use_mapping_session(self._mapping_started)
             else:
                 self._store.switch_map(self._map_name or None)
             self._maybe_record()

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -73,6 +73,10 @@ _COVARIANCE_FRESH_SEC = 5.0
 # (map_update_interval). An older grid means SLAM died, and TF's map frame is
 # coasting on odom alone.
 _GRID_FRESH_SEC = 5.0
+# /nav/map_saved is latched so a recorder respawning across the save still
+# promotes the tour; the same latch replays that save to every later restart,
+# and an old one must not adopt a newer stage into its foreign frame.
+_SAVE_ANNOUNCEMENT_FRESH_SEC = 30.0
 _MIN_HEAD_PITCH_DEG = -25.0  # looking further down films the floor, not the room
 
 
@@ -136,7 +140,7 @@ class MemoryRecorder:
         node.create_subscription(String, config.current_nav_mode_topic, self._on_nav_mode, 10)
         node.create_subscription(String, config.current_map_topic, self._on_current_map, 10)
         node.create_subscription(PoseWithCovarianceStamped, config.amcl_pose_topic, self._on_amcl_pose, latched_qos)
-        node.create_subscription(String, config.map_saved_topic, self._on_map_saved, 10)
+        node.create_subscription(String, config.map_saved_topic, self._on_map_saved, latched_qos)
         node.create_subscription(OccupancyGrid, "/map", self._on_map, latched_qos)
         node.create_subscription(String, "/mars/head/current_position", self._on_head, 10)
         node.create_timer(_TICK_SEC, self.tick)
@@ -165,6 +169,10 @@ class MemoryRecorder:
         return self._nav_mode == "navigation" and bool(self._map_name) and self._confident()
 
     def _on_nav_mode(self, msg: String) -> None:
+        if msg.data != self._nav_mode:
+            # A mode change swaps the coordinate frame; confidence held in the
+            # old frame says nothing about the new one — the hold restarts.
+            self._confident_since = None
         self._nav_mode = msg.data
 
     def _on_current_map(self, msg: String) -> None:
@@ -172,12 +180,22 @@ class MemoryRecorder:
 
     def _on_map_saved(self, msg: String) -> None:
         try:
-            promoted = self._store.promote_mapping_session(msg.data)
-        except Exception as error:  # noqa: BLE001 — a full disk must not take the brain node down
-            self._logger.error(f"[Memory] promoting the mapping session to {msg.data} failed: {error!r}")
+            payload = json.loads(msg.data)
+            map_name, stamp = str(payload["map"]), float(payload["stamp"])
+        except (json.JSONDecodeError, TypeError, KeyError, ValueError):
+            self._logger.error(f"[Memory] unreadable map-save announcement: {msg.data!r}")
             return
-        if promoted:
-            self._logger.info(f"[Memory] promoted {promoted} mapping-session memories to {msg.data}")
+        if time.time() - stamp > _SAVE_ANNOUNCEMENT_FRESH_SEC:
+            return  # the latch replaying an old save — see _SAVE_ANNOUNCEMENT_FRESH_SEC
+        try:
+            promoted = self._store.promote_mapping_session(map_name)
+        except Exception as error:  # noqa: BLE001 — a full disk must not take the brain node down
+            self._logger.error(f"[Memory] promoting the mapping session to {map_name} failed: {error!r}")
+            return
+        if promoted is None:
+            self._logger.error(f"[Memory] mapping-session memories not promoted: {map_name} has no readable map file")
+        elif promoted:
+            self._logger.info(f"[Memory] promoted {promoted} mapping-session memories to {map_name}")
 
     def _on_amcl_pose(self, msg: PoseWithCovarianceStamped) -> None:
         covariance = msg.pose.covariance
@@ -269,7 +287,7 @@ class MemoryRecorder:
             # betrays that to a client watching the name.
             "fingerprint": snapshot.fingerprint[:12],
             "cache": self._cache_state() if self._cache_state is not None else "off",
-            "positions": self._store.positions(),
+            "positions": snapshot.positions(),
         }
         # Gate on the whole payload, not store.revision: `cache` flips by wall
         # clock (a warm() completing, a handle expiring) without a store change.

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -211,9 +211,7 @@ class MemoryStore:
                 # A failed landing must not leave the map memoryless while the
                 # process lives on: put the displaced memories back. The stage
                 # still holds the tour, so a re-save retries the promotion.
-                # Best effort — a restore that fails too leaves both sets in
-                # scratch for recovery, and raising here would bury the cause.
-                _land(displaced, target)
+                self._restore_displaced(target)
                 raise
             self._drop_scratch(displaced)  # this map's old set is spent; another map's is not
             if self._map_name == map_name:
@@ -236,11 +234,22 @@ class MemoryStore:
         entry's sweep destroys what it could have landed.
         """
         tmp = self._root / _PROMOTE_TMP
-        displaced = self._root / _DISPLACED_TMP
         target = _scratch_map_dir(self._root, tmp)
         if target is not None and not target.is_dir() and not _land(tmp, target):
+            self._restore_displaced(target)
+        self._drop_scratch(self._root / _DISPLACED_TMP)
+
+    def _restore_displaced(self, target: Path) -> None:
+        """Give a map back the set displaced from it. Best effort, and only
+        when the scratch dir is that map's: an earlier failed promotion can
+        have stranded another map's memories there, and those are a foreign
+        coordinate frame here — landing them would plant lies in this map and
+        strip the map they belong to. A restore that cannot run leaves both
+        sets in scratch for recovery; raising would bury the original error.
+        """
+        displaced = self._root / _DISPLACED_TMP
+        if _scratch_map_dir(self._root, displaced) == target:
             _land(displaced, target)
-        self._drop_scratch(displaced)
 
     def _drop_scratch(self, *scratch: Path) -> None:
         """Remove promotion scratch no map is waiting on. One still owed to a

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -11,9 +11,10 @@ a new frame, and the stale memories are wiped rather than trusted.
 Memories recorded *during* mapping have no saved map yet: they stage under
 ``spatial_memory/.mapping/`` (a name save_map's validation can never produce)
 and are copied into the saved map's directory when the save lands. The stage
-outlives the promotion — a re-saved map re-promotes the whole tour — and is
-wiped when the next session begins: its coordinates only meant anything in
-the SLAM frame that made them.
+outlives the promotion — a re-saved map re-promotes the whole tour — and its
+index remembers which SLAM session built it (mode_manager's start stamp): the
+same session re-adopts it across a brain restart, any other session wipes it,
+because its coordinates only meant anything in the frame that made them.
 
 Thread contract: mutations come from the recorder's timer (executor thread);
 :meth:`snapshot` serves readers on the agent loop and search threads. Every
@@ -38,6 +39,12 @@ MAPPING_SESSION = ".mapping"
 # can collide; leftovers from a crash are cleaned on the next session's entry.
 _PROMOTE_TMP = f"{MAPPING_SESSION}.promote"
 _DISPLACED_TMP = f"{MAPPING_SESSION}.displaced"
+
+
+class StaleStageError(Exception):
+    """The stage on disk was built by a different mapping session than the one
+    the save came from; promoting it would plant a dead frame's memories in
+    the new map."""
 
 
 @dataclass(frozen=True)
@@ -88,6 +95,7 @@ class MemoryStore:
         self._memories: list[Memory] = []
         self._next_id = 1
         self._fingerprint = ""
+        self._session: float | None = None
         self._stat_sig: tuple[int, int] | None = None
         self._revision = 0
         self.last_change_monotonic = 0.0
@@ -117,31 +125,37 @@ class MemoryStore:
             self._memories = []
             self._next_id = 1
             self._fingerprint = fingerprint
+            self._session = None
             self._revision += 1
             self.last_change_monotonic = time.monotonic()
             if self._dir is not None:
                 self._load_locked()
 
-    def use_mapping_session(self) -> None:
+    def use_mapping_session(self, session_started: float | None = None) -> None:
         """Point the store at the mapping-session stage. Idempotent per tick;
         actually entering wipes what a previous session left behind and mints a
         fresh fingerprint — every consumer tells coordinate frames apart by
         map+fingerprint, and two SLAM sessions are two frames despite sharing
-        the ``.mapping`` name."""
+        the ``.mapping`` name. ``session_started`` (mode_manager's stamp for
+        the live slam_toolbox activation) names the frame: a stage this same
+        session already built is adopted instead of wiped, so a brain restart
+        mid-tour keeps the half-tour."""
         with self._lock:
-            if self._map_name == MAPPING_SESSION:
+            if self._map_name == MAPPING_SESSION and self._session == session_started:
                 return
             self._map_name = MAPPING_SESSION
             self._dir = self._root / MAPPING_SESSION
             self._stat_sig = None
-            self._fingerprint = os.urandom(16).hex()
-            self._wipe_locked()
+            self._session = session_started
+            if session_started is None or not self._adopt_stage_locked(session_started):
+                self._fingerprint = os.urandom(16).hex()
+                self._wipe_locked()
             for scratch in (_PROMOTE_TMP, _DISPLACED_TMP):
                 shutil.rmtree(self._root / scratch, ignore_errors=True)  # crash leftovers from a promotion
             self._revision += 1
             self.last_change_monotonic = time.monotonic()
 
-    def promote_mapping_session(self, map_name: str) -> int | None:
+    def promote_mapping_session(self, map_name: str, mapping_started: float | None = None) -> int | None:
         """Hand the staged mapping-session memories to the just-saved map:
         copy the stage into the map's directory with its fingerprint stamped,
         replacing whatever the name held before (the room was just re-mapped,
@@ -151,13 +165,18 @@ class MemoryStore:
         The stage itself stays behind: a re-save — the webapp retrying after
         a failed mode switch — promotes the whole tour again. Returns how
         many were promoted (0 when nothing is staged); None when the saved
-        map can't be fingerprinted, with the stage kept.
+        map can't be fingerprinted, with the stage kept. ``mapping_started``
+        is the save's session identity: a stage another session built raises
+        :class:`StaleStageError` — it must never land in a foreign map.
         """
         with self._lock:
             stage = self._root / MAPPING_SESSION
-            count = _staged_count(stage)
-            if count == 0:
+            index = _staged_index(stage)
+            count = len(index.get("memories") or []) if index is not None else 0
+            if index is None or count == 0:
                 return 0
+            if mapping_started is not None and index.get("session") != mapping_started:
+                raise StaleStageError(f"stage session {index.get('session')!r} != save's {mapping_started!r}")
             fingerprint = _map_fingerprint(self._maps_dir, map_name)
             if not fingerprint:
                 return None
@@ -167,10 +186,10 @@ class MemoryStore:
             if tmp.is_dir():
                 shutil.rmtree(tmp)
             shutil.copytree(stage, tmp)
-            index = json.loads((tmp / "index.json").read_text())
-            index["map"] = map_name
-            index["fingerprint"] = fingerprint
-            (tmp / "index.json").write_text(json.dumps(index))
+            stamped = json.loads((tmp / "index.json").read_text())
+            stamped["map"] = map_name
+            stamped["fingerprint"] = fingerprint
+            (tmp / "index.json").write_text(json.dumps(stamped))
             # Displace-then-swap, never delete-then-swap: destroying the
             # target before its replacement is in place would leave the map
             # memoryless if a crash lands between the two.
@@ -290,12 +309,33 @@ class MemoryStore:
                 and index.get("fingerprint") == self._fingerprint
             )
             if fresh:
-                self._memories = [Memory(**entry) for entry in index.get("memories", [])]
-                self._next_id = int(index.get("next_id", 1))
+                self._restore_locked(index)
                 return
         except (OSError, json.JSONDecodeError, TypeError, ValueError):
             pass  # a wrong-shaped index is as stale as a wrong fingerprint
         self._wipe_locked()
+
+    def _adopt_stage_locked(self, session_started: float) -> bool:
+        """Re-attach to a stage this same SLAM session built (a brain restart
+        mid-tour): the frame is still live, so the half-tour — memories,
+        fingerprint, ids — survives. False means the stage is another
+        session's (or unreadable) and the caller wipes it."""
+        assert self._dir is not None
+        try:
+            index = json.loads((self._dir / "index.json").read_text())
+            if not isinstance(index, dict) or index.get("version") != _INDEX_VERSION:
+                return False
+            if index.get("session") != session_started or not index.get("fingerprint"):
+                return False
+            self._restore_locked(index)
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            return False
+        self._fingerprint = str(index["fingerprint"])
+        return True
+
+    def _restore_locked(self, index: dict) -> None:
+        self._memories = [Memory(**entry) for entry in index.get("memories", [])]
+        self._next_id = int(index.get("next_id", 1))
 
     def _wipe_locked(self) -> None:
         """The map was re-made (or the index is unreadable): the coordinates lie."""
@@ -323,6 +363,7 @@ class MemoryStore:
             "version": _INDEX_VERSION,
             "map": self._map_name,
             "fingerprint": self._fingerprint,
+            "session": self._session,
             "next_id": self._next_id,
             "memories": [asdict(m) for m in self._memories],
         }
@@ -334,17 +375,17 @@ class MemoryStore:
         self.last_change_monotonic = time.monotonic()
 
 
-def _staged_count(stage: Path) -> int:
-    """How many memories the on-disk stage holds; 0 when absent or unreadable.
-    Every mutation commits inside the store lock, so the disk index is never
+def _staged_index(stage: Path) -> dict | None:
+    """The on-disk stage's index; None when absent or unreadable. Every
+    mutation commits inside the store lock, so the disk index is never
     behind the live session."""
     try:
         index = json.loads((stage / "index.json").read_text())
     except (OSError, json.JSONDecodeError, ValueError):
-        return 0
+        return None
     if not isinstance(index, dict) or index.get("version") != _INDEX_VERSION or index.get("map") != MAPPING_SESSION:
-        return 0
-    return len(index.get("memories") or [])
+        return None
+    return index
 
 
 def _map_source(maps_dir: Path, map_name: str) -> Path:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -91,6 +91,7 @@ class MemoryStore:
         self._stat_sig: tuple[int, int] | None = None
         self._revision = 0
         self.last_change_monotonic = 0.0
+        self._finish_interrupted_promotion()
 
     def switch_map(self, map_name: str | None) -> None:
         """Point the store at a map's memories, loading them from disk.
@@ -189,6 +190,23 @@ class MemoryStore:
                 self._revision += 1
                 self.last_change_monotonic = time.monotonic()
             return count
+
+    def _finish_interrupted_promotion(self) -> None:
+        """Land a promotion a crash cut short. Between promote's two
+        os.replace calls the map's directory is gone — a crash there would
+        wake the map memoryless, with both sets in scratch dirs the next
+        session wipes. The stamped copy names its map, so finish the swap.
+        An unstamped copy names ``.mapping``, whose dir exists: a no-op.
+        """
+        tmp = self._root / _PROMOTE_TMP
+        try:
+            map_name = str(json.loads((tmp / "index.json").read_text())["map"])
+            target = self._root / Path(map_name).stem
+            if not target.is_dir():
+                os.replace(tmp, target)
+        except (OSError, json.JSONDecodeError, TypeError, KeyError):
+            pass  # nothing stamped to land; session entry sweeps the scratch
+        shutil.rmtree(self._root / _DISPLACED_TMP, ignore_errors=True)
 
     def snapshot(self) -> MemorySnapshot:
         with self._lock:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -10,10 +10,10 @@ a new frame, and the stale memories are wiped rather than trusted.
 
 Memories recorded *during* mapping have no saved map yet: they stage under
 ``spatial_memory/.mapping/`` (a name save_map's validation can never produce)
-and are promoted into the saved map's directory when the save lands. A stage
-never promoted — mapping abandoned, or the robot restarted mid-tour — is wiped
-when the next session begins: its coordinates only meant anything in the SLAM
-frame that made them.
+and are copied into the saved map's directory when the save lands. The stage
+outlives the promotion — a re-saved map re-promotes the whole tour — and is
+wiped when the next session begins: its coordinates only meant anything in
+the SLAM frame that made them.
 
 Thread contract: mutations come from the recorder's timer (executor thread);
 :meth:`snapshot` serves readers on the agent loop and search threads. Every
@@ -118,35 +118,46 @@ class MemoryStore:
 
     def promote_mapping_session(self, map_name: str) -> int | None:
         """Hand the staged mapping-session memories to the just-saved map:
-        stamp its fingerprint into the index and move the directory into
-        place, replacing whatever the name held before (the room was just
-        re-mapped, so its old memories lie). Returns how many were promoted;
-        None when nothing is staged or the saved map can't be fingerprinted.
+        copy the stage into the map's directory with its fingerprint stamped,
+        replacing whatever the name held before (the room was just re-mapped,
+        so its old memories lie). Works from the stage on disk, not the live
+        attachment — the save announcement races the mode-driven switch_map
+        through independent topics, and a lost race must not lose the tour.
+        The stage itself stays behind: a re-save — the webapp retrying after
+        a failed mode switch — promotes the whole tour again. Returns how
+        many were promoted; None when nothing is staged or the saved map
+        can't be fingerprinted.
         """
         with self._lock:
-            if self._map_name != MAPPING_SESSION or self._dir is None or not self._memories:
+            stage = self._root / MAPPING_SESSION
+            count = _staged_count(stage)
+            if count == 0:
                 return None
             fingerprint = _map_fingerprint(self._maps_dir, map_name)
             if not fingerprint:
                 return None
-            count = len(self._memories)
-            self._map_name = map_name
-            self._fingerprint = fingerprint
-            self._commit_locked()
+            # Build the copy aside and swap it in whole: the proxy reads these
+            # files without the lock and must never see a half-copied frame.
+            # Dot-prefixed like the stage, so no saved map name can collide.
+            tmp = self._root / f"{MAPPING_SESSION}.promote"
+            if tmp.is_dir():
+                shutil.rmtree(tmp)
+            shutil.copytree(stage, tmp)
+            index = json.loads((tmp / "index.json").read_text())
+            index["map"] = map_name
+            index["fingerprint"] = fingerprint
+            (tmp / "index.json").write_text(json.dumps(index))
             target = self._root / Path(map_name).stem
             if target.is_dir():
                 shutil.rmtree(target)
-            os.replace(self._dir, target)
-            # Detach: the next switch_map (the recorder tick) reloads the
-            # promoted index from its new home.
-            self._map_name = None
-            self._dir = None
-            self._memories = []
-            self._next_id = 1
-            self._fingerprint = ""
-            self._stat_sig = None
-            self._revision += 1
-            self.last_change_monotonic = time.monotonic()
+            os.replace(tmp, target)
+            if self._map_name == map_name:
+                # The switch won the race and loaded an empty store; adopt the
+                # promoted memories now — no later tick would reload them.
+                self._fingerprint = fingerprint
+                self._load_locked()
+                self._revision += 1
+                self.last_change_monotonic = time.monotonic()
             return count
 
     def snapshot(self) -> MemorySnapshot:
@@ -288,6 +299,19 @@ class MemoryStore:
         os.replace(tmp, self._dir / "index.json")
         self._revision += 1
         self.last_change_monotonic = time.monotonic()
+
+
+def _staged_count(stage: Path) -> int:
+    """How many memories the on-disk stage holds; 0 when absent or unreadable.
+    Every mutation commits inside the store lock, so the disk index is never
+    behind the live session."""
+    try:
+        index = json.loads((stage / "index.json").read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(index, dict) or index.get("version") != _INDEX_VERSION or index.get("map") != MAPPING_SESSION:
+        return 0
+    return len(index.get("memories") or [])
 
 
 def _map_source(maps_dir: Path, map_name: str) -> Path:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -281,12 +281,6 @@ class MemoryStore:
         with self._lock:
             return MemorySnapshot(self._map_name, self._revision, tuple(self._memories), self._fingerprint)
 
-    @property
-    def fingerprint(self) -> str:
-        """Identity of the loaded map's content — changes exactly when the memories wipe."""
-        with self._lock:
-            return self._fingerprint
-
     def image_path(self, memory_id: int) -> Path | None:
         with self._lock:
             return self._dir / f"{memory_id}.jpg" if self._dir is not None else None

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -34,6 +34,10 @@ from threading import Lock
 
 _INDEX_VERSION = 1
 MAPPING_SESSION = ".mapping"
+# Promotion scratch dirs — dot-prefixed like the stage, so no saved map name
+# can collide; leftovers from a crash are cleaned on the next session's entry.
+_PROMOTE_TMP = f"{MAPPING_SESSION}.promote"
+_DISPLACED_TMP = f"{MAPPING_SESSION}.displaced"
 
 
 @dataclass(frozen=True)
@@ -57,6 +61,21 @@ class MemorySnapshot:
     # Same-name remaps reset memory ids, so name equality alone cannot prove
     # two snapshots share a coordinate frame — the fingerprint can.
     fingerprint: str = ""
+
+    def positions(self) -> list[dict]:
+        """The webapp mirror payload: one ``{id, x, y, theta, stamp}`` per
+        memory, rounded to display precision — full floats bloat the JSON by
+        half."""
+        return [
+            {
+                "id": m.id,
+                "x": round(m.x, 3),
+                "y": round(m.y, 3),
+                "theta": round(m.theta, 4),
+                "stamp": round(m.stamp, 1),
+            }
+            for m in self.memories
+        ]
 
 
 class MemoryStore:
@@ -104,15 +123,20 @@ class MemoryStore:
 
     def use_mapping_session(self) -> None:
         """Point the store at the mapping-session stage. Idempotent per tick;
-        actually entering wipes whatever a previous session left behind."""
+        actually entering wipes what a previous session left behind and mints a
+        fresh fingerprint — every consumer tells coordinate frames apart by
+        map+fingerprint, and two SLAM sessions are two frames despite sharing
+        the ``.mapping`` name."""
         with self._lock:
             if self._map_name == MAPPING_SESSION:
                 return
             self._map_name = MAPPING_SESSION
             self._dir = self._root / MAPPING_SESSION
             self._stat_sig = None
-            self._fingerprint = ""
+            self._fingerprint = os.urandom(16).hex()
             self._wipe_locked()
+            for scratch in (_PROMOTE_TMP, _DISPLACED_TMP):
+                shutil.rmtree(self._root / scratch, ignore_errors=True)  # crash leftovers from a promotion
             self._revision += 1
             self.last_change_monotonic = time.monotonic()
 
@@ -125,21 +149,20 @@ class MemoryStore:
         through independent topics, and a lost race must not lose the tour.
         The stage itself stays behind: a re-save — the webapp retrying after
         a failed mode switch — promotes the whole tour again. Returns how
-        many were promoted; None when nothing is staged or the saved map
-        can't be fingerprinted.
+        many were promoted (0 when nothing is staged); None when the saved
+        map can't be fingerprinted, with the stage kept.
         """
         with self._lock:
             stage = self._root / MAPPING_SESSION
             count = _staged_count(stage)
             if count == 0:
-                return None
+                return 0
             fingerprint = _map_fingerprint(self._maps_dir, map_name)
             if not fingerprint:
                 return None
             # Build the copy aside and swap it in whole: the proxy reads these
             # files without the lock and must never see a half-copied frame.
-            # Dot-prefixed like the stage, so no saved map name can collide.
-            tmp = self._root / f"{MAPPING_SESSION}.promote"
+            tmp = self._root / _PROMOTE_TMP
             if tmp.is_dir():
                 shutil.rmtree(tmp)
             shutil.copytree(stage, tmp)
@@ -147,10 +170,17 @@ class MemoryStore:
             index["map"] = map_name
             index["fingerprint"] = fingerprint
             (tmp / "index.json").write_text(json.dumps(index))
+            # Displace-then-swap, never delete-then-swap: destroying the
+            # target before its replacement is in place would leave the map
+            # memoryless if a crash lands between the two.
             target = self._root / Path(map_name).stem
+            displaced = self._root / _DISPLACED_TMP
+            if displaced.is_dir():
+                shutil.rmtree(displaced)
             if target.is_dir():
-                shutil.rmtree(target)
+                os.replace(target, displaced)
             os.replace(tmp, target)
+            shutil.rmtree(displaced, ignore_errors=True)
             if self._map_name == map_name:
                 # The switch won the race and loaded an empty store; adopt the
                 # promoted memories now — no later tick would reload them.
@@ -169,21 +199,6 @@ class MemoryStore:
         """Identity of the loaded map's content — changes exactly when the memories wipe."""
         with self._lock:
             return self._fingerprint
-
-    def positions(self) -> list[dict]:
-        """The webapp mirror payload: one ``{id, x, y, theta, stamp}`` per memory,
-        rounded to display precision — full floats bloat the JSON by half."""
-        with self._lock:
-            return [
-                {
-                    "id": m.id,
-                    "x": round(m.x, 3),
-                    "y": round(m.y, 3),
-                    "theta": round(m.theta, 4),
-                    "stamp": round(m.stamp, 1),
-                }
-                for m in self._memories
-            ]
 
     def image_path(self, memory_id: int) -> Path | None:
         with self._lock:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -169,27 +169,30 @@ class MemoryStore:
         is the save's session identity: a stage another session built raises
         :class:`StaleStageError` — it must never land in a foreign map.
         """
+        stage = self._root / MAPPING_SESSION
+        index = _staged_index(stage)
+        count = len(index.get("memories") or []) if index is not None else 0
+        if index is None or count == 0:
+            return 0
+        if mapping_started is not None and index.get("session") != mapping_started:
+            raise StaleStageError(f"stage session {index.get('session')!r} != save's {mapping_started!r}")
+        fingerprint = _map_fingerprint(self._maps_dir, map_name)
+        if not fingerprint:
+            return None
+        # The map hash and the stage copy run without the lock (switch_map
+        # hashes outside it too): every stage mutation runs on this same
+        # executor thread, so the stage cannot change under the copy.
+        # Build the copy aside and swap it in whole: the proxy reads these
+        # files without the lock and must never see a half-copied frame.
+        tmp = self._root / _PROMOTE_TMP
+        if tmp.is_dir():
+            shutil.rmtree(tmp)
+        shutil.copytree(stage, tmp)
+        stamped = json.loads((tmp / "index.json").read_text())
+        stamped["map"] = map_name
+        stamped["fingerprint"] = fingerprint
+        (tmp / "index.json").write_text(json.dumps(stamped))
         with self._lock:
-            stage = self._root / MAPPING_SESSION
-            index = _staged_index(stage)
-            count = len(index.get("memories") or []) if index is not None else 0
-            if index is None or count == 0:
-                return 0
-            if mapping_started is not None and index.get("session") != mapping_started:
-                raise StaleStageError(f"stage session {index.get('session')!r} != save's {mapping_started!r}")
-            fingerprint = _map_fingerprint(self._maps_dir, map_name)
-            if not fingerprint:
-                return None
-            # Build the copy aside and swap it in whole: the proxy reads these
-            # files without the lock and must never see a half-copied frame.
-            tmp = self._root / _PROMOTE_TMP
-            if tmp.is_dir():
-                shutil.rmtree(tmp)
-            shutil.copytree(stage, tmp)
-            stamped = json.loads((tmp / "index.json").read_text())
-            stamped["map"] = map_name
-            stamped["fingerprint"] = fingerprint
-            (tmp / "index.json").write_text(json.dumps(stamped))
             # Displace-then-swap, never delete-then-swap: destroying the
             # target before its replacement is in place would leave the map
             # memoryless if a crash lands between the two.

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -183,16 +183,22 @@ class MemoryStore:
         # The map hash and the stage copy run without the lock (switch_map
         # hashes outside it too): every stage mutation runs on this same
         # executor thread, so the stage cannot change under the copy.
-        # Build the copy aside and swap it in whole: the proxy reads these
-        # files without the lock and must never see a half-copied frame.
         tmp = self._root / _PROMOTE_TMP
         if tmp.is_dir():
             shutil.rmtree(tmp)
-        shutil.copytree(stage, tmp)
+        # Built aside and swapped in whole (the proxy reads without the lock),
+        # via hardlinks: a byte copy of a long tour would stall the node's
+        # only spin thread for seconds.
+        shutil.copytree(stage, tmp, copy_function=os.link)
         stamped = json.loads((tmp / "index.json").read_text())
         stamped["map"] = map_name
         stamped["fingerprint"] = fingerprint
-        (tmp / "index.json").write_text(json.dumps(stamped))
+        # Not write_text: stage files are only ever replaced, never edited in
+        # place -- that is what keeps every hardlinked file frozen, this one
+        # included.
+        stamped_tmp = tmp / "index.json.tmp"
+        stamped_tmp.write_text(json.dumps(stamped))
+        os.replace(stamped_tmp, tmp / "index.json")
         with self._lock:
             # Displace-then-swap, never delete-then-swap: destroying the
             # target before its replacement is in place would leave the map

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -36,7 +36,8 @@ from threading import Lock
 _INDEX_VERSION = 1
 MAPPING_SESSION = ".mapping"
 # Promotion scratch dirs — dot-prefixed like the stage, so no saved map name
-# can collide; leftovers from a crash are cleaned on the next session's entry.
+# can collide; leftovers from an interrupted promotion are landed or swept at
+# startup and again on the next session's entry.
 _PROMOTE_TMP = f"{MAPPING_SESSION}.promote"
 _DISPLACED_TMP = f"{MAPPING_SESSION}.displaced"
 
@@ -150,8 +151,9 @@ class MemoryStore:
             if session_started is None or not self._adopt_stage_locked(session_started):
                 self._fingerprint = os.urandom(16).hex()
                 self._wipe_locked()
+            self._finish_interrupted_promotion()  # a stamped leftover is a map's only memories — land it
             for scratch in (_PROMOTE_TMP, _DISPLACED_TMP):
-                shutil.rmtree(self._root / scratch, ignore_errors=True)  # crash leftovers from a promotion
+                shutil.rmtree(self._root / scratch, ignore_errors=True)
             self._revision += 1
             self.last_change_monotonic = time.monotonic()
 
@@ -202,7 +204,15 @@ class MemoryStore:
                 shutil.rmtree(displaced)
             if target.is_dir():
                 os.replace(target, displaced)
-            os.replace(tmp, target)
+            try:
+                os.replace(tmp, target)
+            except OSError:
+                # A failed landing must not leave the map memoryless while the
+                # process lives on: put the displaced memories back. The stage
+                # still holds the tour, so a re-save retries the promotion.
+                if displaced.is_dir() and not target.is_dir():
+                    os.replace(displaced, target)
+                raise
             shutil.rmtree(displaced, ignore_errors=True)
             if self._map_name == map_name:
                 # The switch won the race and loaded an empty store; adopt the
@@ -214,11 +224,13 @@ class MemoryStore:
             return count
 
     def _finish_interrupted_promotion(self) -> None:
-        """Land a promotion a crash cut short. Between promote's two
-        os.replace calls the map's directory is gone — a crash there would
-        wake the map memoryless, with both sets in scratch dirs the next
-        session wipes. The stamped copy names its map, so finish the swap.
-        An unstamped copy names ``.mapping``, whose dir exists: a no-op.
+        """Land a promotion an interruption cut short. Between promote's two
+        os.replace calls the map's directory is gone — a crash there (or a
+        failed swap whose in-line restore also failed) leaves the map
+        memoryless, with both sets in scratch dirs. The stamped copy names
+        its map, so finish the swap. An unstamped copy names ``.mapping``,
+        whose dir exists: a no-op. Runs at startup and on session entry,
+        before the entry's sweep destroys what it could have landed.
         """
         tmp = self._root / _PROMOTE_TMP
         try:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -199,10 +199,7 @@ class MemoryStore:
             # memoryless if a crash lands between the two.
             target = self._root / Path(map_name).stem
             displaced = self._root / _DISPLACED_TMP
-            # Not a bare rmtree: a set still owed to an absent map survives, and
-            # the displace below then fails on the non-empty dir — a promotion
-            # that refuses to run beats one that eats another map's memories.
-            self._drop_scratch(displaced)
+            self._clear_displaced_slot()
             if target.is_dir():
                 os.replace(target, displaced)
             try:
@@ -237,7 +234,7 @@ class MemoryStore:
         target = _scratch_map_dir(self._root, tmp)
         if target is not None and not target.is_dir() and not _land(tmp, target):
             self._restore_displaced(target)
-        self._drop_scratch(self._root / _DISPLACED_TMP)
+        self._clear_displaced_slot()
 
     def _restore_displaced(self, target: Path) -> None:
         """Give a map back the set displaced from it. Best effort, and only
@@ -250,6 +247,18 @@ class MemoryStore:
         displaced = self._root / _DISPLACED_TMP
         if _scratch_map_dir(self._root, displaced) == target:
             _land(displaced, target)
+
+    def _clear_displaced_slot(self) -> None:
+        """Empty the displaced scratch slot. A set owed to a map whose
+        directory is absent is that map's only memories: land it back home --
+        left in the slot it would fail every later displace with ENOTEMPTY --
+        and sweep whatever remains as spent. A set that will not land (the
+        fault persists) stays put for the next recovery."""
+        displaced = self._root / _DISPLACED_TMP
+        owed = _scratch_map_dir(self._root, displaced)
+        if owed is not None and not owed.is_dir():
+            _land(displaced, owed)
+        self._drop_scratch(displaced)
 
     def _drop_scratch(self, *scratch: Path) -> None:
         """Remove promotion scratch no map is waiting on. One still owed to a

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -215,7 +215,7 @@ class MemoryStore:
                 # scratch for recovery, and raising here would bury the cause.
                 _land(displaced, target)
                 raise
-            shutil.rmtree(displaced, ignore_errors=True)
+            self._drop_scratch(displaced)  # this map's old set is spent; another map's is not
             if self._map_name == map_name:
                 # The switch won the race and loaded an empty store; adopt the
                 # promoted memories now — no later tick would reload them.

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -152,8 +152,7 @@ class MemoryStore:
                 self._fingerprint = os.urandom(16).hex()
                 self._wipe_locked()
             self._finish_interrupted_promotion()  # a stamped leftover is a map's only memories — land it
-            for scratch in (_PROMOTE_TMP, _DISPLACED_TMP):
-                shutil.rmtree(self._root / scratch, ignore_errors=True)
+            self._drop_scratch(self._root / _PROMOTE_TMP, self._root / _DISPLACED_TMP)
             self._revision += 1
             self.last_change_monotonic = time.monotonic()
 
@@ -200,8 +199,10 @@ class MemoryStore:
             # memoryless if a crash lands between the two.
             target = self._root / Path(map_name).stem
             displaced = self._root / _DISPLACED_TMP
-            if displaced.is_dir():
-                shutil.rmtree(displaced)
+            # Not a bare rmtree: a set still owed to an absent map survives, and
+            # the displace below then fails on the non-empty dir — a promotion
+            # that refuses to run beats one that eats another map's memories.
+            self._drop_scratch(displaced)
             if target.is_dir():
                 os.replace(target, displaced)
             try:
@@ -210,8 +211,9 @@ class MemoryStore:
                 # A failed landing must not leave the map memoryless while the
                 # process lives on: put the displaced memories back. The stage
                 # still holds the tour, so a re-save retries the promotion.
-                if displaced.is_dir() and not target.is_dir():
-                    os.replace(displaced, target)
+                # Best effort — a restore that fails too leaves both sets in
+                # scratch for recovery, and raising here would bury the cause.
+                _land(displaced, target)
                 raise
             shutil.rmtree(displaced, ignore_errors=True)
             if self._map_name == map_name:
@@ -227,20 +229,29 @@ class MemoryStore:
         """Land a promotion an interruption cut short. Between promote's two
         os.replace calls the map's directory is gone — a crash there (or a
         failed swap whose in-line restore also failed) leaves the map
-        memoryless, with both sets in scratch dirs. The stamped copy names
-        its map, so finish the swap. An unstamped copy names ``.mapping``,
-        whose dir exists: a no-op. Runs at startup and on session entry,
-        before the entry's sweep destroys what it could have landed.
+        memoryless, with both sets in scratch dirs. The stamped copy names its
+        map, so finish the swap; when it will not land, give the map back the
+        set it had instead. An unstamped copy names ``.mapping``, whose dir
+        exists: a no-op. Runs at startup and on session entry, before the
+        entry's sweep destroys what it could have landed.
         """
         tmp = self._root / _PROMOTE_TMP
-        try:
-            map_name = str(json.loads((tmp / "index.json").read_text())["map"])
-            target = self._root / Path(map_name).stem
-            if not target.is_dir():
-                os.replace(tmp, target)
-        except (OSError, json.JSONDecodeError, TypeError, KeyError):
-            pass  # nothing stamped to land; session entry sweeps the scratch
-        shutil.rmtree(self._root / _DISPLACED_TMP, ignore_errors=True)
+        displaced = self._root / _DISPLACED_TMP
+        target = _scratch_map_dir(self._root, tmp)
+        if target is not None and not target.is_dir() and not _land(tmp, target):
+            _land(displaced, target)
+        self._drop_scratch(displaced)
+
+    def _drop_scratch(self, *scratch: Path) -> None:
+        """Remove promotion scratch no map is waiting on. One still owed to a
+        map whose directory is absent stays put: it holds that map's only
+        memories, and the next recovery gets another chance to land it —
+        deleting it there is the one way to lose the map's memories for good.
+        """
+        for path in scratch:
+            owed = _scratch_map_dir(self._root, path)
+            if owed is None or owed.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
 
     def snapshot(self) -> MemorySnapshot:
         with self._lock:
@@ -388,6 +399,30 @@ class MemoryStore:
         os.replace(tmp, self._dir / "index.json")
         self._revision += 1
         self.last_change_monotonic = time.monotonic()
+
+
+def _scratch_map_dir(root: Path, scratch: Path) -> Path | None:
+    """The saved-map directory whose memories a promotion scratch dir is
+    holding, or None when it holds none a map could be waiting on — an
+    unreadable index, or a copy of the stage, which the stage itself still has."""
+    try:
+        map_name = str(json.loads((scratch / "index.json").read_text())["map"])
+    except (OSError, json.JSONDecodeError, ValueError, TypeError, KeyError):
+        return None
+    return None if map_name == MAPPING_SESSION else root / Path(map_name).stem
+
+
+def _land(scratch: Path, target: Path) -> bool:
+    """Move a scratch copy into place, reporting whether it got there. False
+    leaves it where it stands for the next recovery to retry — never for a
+    caller to treat as spent."""
+    if not scratch.is_dir():
+        return False
+    try:
+        os.replace(scratch, target)
+    except OSError:
+        return False
+    return True
 
 
 def _staged_index(stage: Path) -> dict | None:

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/store.py
@@ -8,6 +8,13 @@ map they were recorded on, so each map gets its own directory, and the index
 carries a fingerprint of the map file — re-mapping under the same name yields
 a new frame, and the stale memories are wiped rather than trusted.
 
+Memories recorded *during* mapping have no saved map yet: they stage under
+``spatial_memory/.mapping/`` (a name save_map's validation can never produce)
+and are promoted into the saved map's directory when the save lands. A stage
+never promoted — mapping abandoned, or the robot restarted mid-tour — is wiped
+when the next session begins: its coordinates only meant anything in the SLAM
+frame that made them.
+
 Thread contract: mutations come from the recorder's timer (executor thread);
 :meth:`snapshot` serves readers on the agent loop and search threads. Every
 index access takes the store lock; image files are read without it, so a
@@ -19,12 +26,14 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from threading import Lock
 
 _INDEX_VERSION = 1
+MAPPING_SESSION = ".mapping"
 
 
 @dataclass(frozen=True)
@@ -92,6 +101,53 @@ class MemoryStore:
             self.last_change_monotonic = time.monotonic()
             if self._dir is not None:
                 self._load_locked()
+
+    def use_mapping_session(self) -> None:
+        """Point the store at the mapping-session stage. Idempotent per tick;
+        actually entering wipes whatever a previous session left behind."""
+        with self._lock:
+            if self._map_name == MAPPING_SESSION:
+                return
+            self._map_name = MAPPING_SESSION
+            self._dir = self._root / MAPPING_SESSION
+            self._stat_sig = None
+            self._fingerprint = ""
+            self._wipe_locked()
+            self._revision += 1
+            self.last_change_monotonic = time.monotonic()
+
+    def promote_mapping_session(self, map_name: str) -> int | None:
+        """Hand the staged mapping-session memories to the just-saved map:
+        stamp its fingerprint into the index and move the directory into
+        place, replacing whatever the name held before (the room was just
+        re-mapped, so its old memories lie). Returns how many were promoted;
+        None when nothing is staged or the saved map can't be fingerprinted.
+        """
+        with self._lock:
+            if self._map_name != MAPPING_SESSION or self._dir is None or not self._memories:
+                return None
+            fingerprint = _map_fingerprint(self._maps_dir, map_name)
+            if not fingerprint:
+                return None
+            count = len(self._memories)
+            self._map_name = map_name
+            self._fingerprint = fingerprint
+            self._commit_locked()
+            target = self._root / Path(map_name).stem
+            if target.is_dir():
+                shutil.rmtree(target)
+            os.replace(self._dir, target)
+            # Detach: the next switch_map (the recorder tick) reloads the
+            # promoted index from its new home.
+            self._map_name = None
+            self._dir = None
+            self._memories = []
+            self._next_id = 1
+            self._fingerprint = ""
+            self._stat_sig = None
+            self._revision += 1
+            self.last_change_monotonic = time.monotonic()
+            return count
 
     def snapshot(self) -> MemorySnapshot:
         with self._lock:

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -470,7 +470,7 @@ def test_promote_with_nothing_staged_is_a_noop(data_dir):
     store = MemoryStore(data_dir)
     store.switch_map("A.yaml")
     store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
-    assert store.promote_mapping_session("A.yaml") is None
+    assert store.promote_mapping_session("A.yaml") == 0
     assert len(store.snapshot().memories) == 1
 
 
@@ -505,9 +505,33 @@ def test_promote_reaches_a_stage_the_store_left(data_dir):
 def test_the_session_survives_its_every_tick_call(data_dir):
     store = MemoryStore(data_dir)
     store.use_mapping_session()
+    fingerprint = store.snapshot().fingerprint
     store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
     store.use_mapping_session()  # the recorder's every-tick call must not wipe
-    assert len(store.snapshot().memories) == 1
+    snapshot = store.snapshot()
+    assert len(snapshot.memories) == 1 and snapshot.fingerprint == fingerprint
+
+
+def test_each_session_is_its_own_coordinate_frame(data_dir):
+    # Clients (the search cache, forget's staleness check, the webapp) tell
+    # frames apart by map+fingerprint, and every session is named ".mapping" —
+    # only a fresh per-session fingerprint keeps one tour's ids from resolving
+    # against another's pictures.
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    first = store.snapshot().fingerprint
+    store.switch_map("A.yaml")
+    store.use_mapping_session()
+    assert first and store.snapshot().fingerprint and store.snapshot().fingerprint != first
+
+
+def test_session_entry_sweeps_crashed_promotion_scratch(data_dir):
+    store = MemoryStore(data_dir)
+    (data_dir / "spatial_memory" / ".mapping.promote").mkdir(parents=True)
+    (data_dir / "spatial_memory" / ".mapping.displaced").mkdir()
+    store.use_mapping_session()
+    assert not (data_dir / "spatial_memory" / ".mapping.promote").exists()
+    assert not (data_dir / "spatial_memory" / ".mapping.displaced").exists()
 
 
 def test_entering_a_session_wipes_the_previous_ones_leftovers(data_dir):
@@ -889,6 +913,11 @@ def mapping_observe(recorder, clock, jpeg: bytes, advance: float = 1.0):
     recorder.tick()
 
 
+def announce_save(recorder, clock, name: str, age: float = 0.0):
+    """mode_manager's /nav/map_saved payload, stamped ``age`` seconds ago."""
+    recorder._on_map_saved(SimpleNamespace(data=json.dumps({"map": name, "stamp": clock.now - age})))
+
+
 def test_mapping_records_into_the_session_stage(data_dir, clock):
     recorder, store = make_recorder(data_dir)
     see_mapping_world(recorder)
@@ -923,7 +952,7 @@ def test_a_saved_map_adopts_the_mapping_memories(data_dir, clock):
 
     # The webapp's save sequence: save_map, then navigation on the new map.
     (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
-    recorder._on_map_saved(SimpleNamespace(data="tour.yaml"))
+    announce_save(recorder, clock, "tour.yaml")
     recorder._on_nav_mode(SimpleNamespace(data="navigation"))
     recorder._on_current_map(SimpleNamespace(data="tour.yaml"))
     recorder.tick()
@@ -947,7 +976,7 @@ def test_a_promotion_landing_after_the_mode_switch_still_adopts(data_dir, clock)
     recorder._on_current_map(SimpleNamespace(data="tour.yaml"))
     recorder.tick()  # the switch wins the race: empty store on the new map
     assert store.snapshot().memories == ()
-    recorder._on_map_saved(SimpleNamespace(data="tour.yaml"))  # save lands late
+    announce_save(recorder, clock, "tour.yaml")  # save lands late
     snapshot = store.snapshot()
     assert snapshot.map_name == "tour.yaml" and len(snapshot.memories) == 1
     assert stored_image(store, snapshot.memories[0].id) == GOOD_JPEG
@@ -962,7 +991,34 @@ def test_a_failing_promotion_never_escapes_the_callback(data_dir, clock):
         raise OSError("disk full")
 
     store.promote_mapping_session = full_disk
-    recorder._on_map_saved(SimpleNamespace(data="tour.yaml"))
+    announce_save(recorder, clock, "tour.yaml")
+
+
+def test_an_unreadable_save_announcement_never_escapes_the_callback(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    recorder._on_map_saved(SimpleNamespace(data="tour.yaml"))  # pre-stamp wire format
+    assert not (data_dir / "spatial_memory" / "tour").exists()  # nothing was promoted
+
+
+def test_a_stale_save_replay_never_promotes(data_dir, clock):
+    # /nav/map_saved is latched so a recorder respawning across the save still
+    # hears it — but the same latch replays *old* saves to every restart, and
+    # adopting the current stage into a map saved from an earlier SLAM session
+    # would stamp this tour's coordinates onto a foreign frame.
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+
+    (data_dir / "maps" / "old.pgm").write_bytes(b"old-map-content")
+    announce_save(recorder, clock, "old.yaml", age=300.0)
+    assert (data_dir / "spatial_memory" / MAPPING_SESSION / "1.jpg").exists()  # the stage is untouched
+    store.switch_map("old.yaml")
+    assert store.snapshot().memories == ()
 
 
 def test_an_abandoned_session_is_wiped_when_the_next_begins(data_dir, clock):
@@ -989,8 +1045,22 @@ def test_mapping_positions_mirror_carries_the_session_identity(data_dir, clock):
     recorder.tick()
     mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
     payload = json.loads(published[-1].data)
-    assert payload["map"] == MAPPING_SESSION and payload["fingerprint"] == ""
+    assert payload["map"] == MAPPING_SESSION and len(payload["fingerprint"]) == 12
     assert len(payload["positions"]) == 1
+
+
+def test_a_mode_change_restarts_the_confidence_hold(data_dir, clock):
+    # A hold accrued in navigation is evidence about the OLD frame; carrying it
+    # across the switch would let the first mapping tick record instantly.
+    recorder, store = make_recorder(data_dir)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    clock.now += 5.0  # the navigation hold is long since satisfied
+    see_mapping_world(recorder)
+    recorder.tick()  # first mapping tick: the hold restarts
+    assert store.snapshot().memories == ()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
 
 
 # ================= memory search =================

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1949,3 +1949,38 @@ def test_a_later_promotion_spares_another_maps_stranded_memories(data_dir):
     recovered = MemoryStore(data_dir)
     recovered.switch_map("A.yaml")
     assert [m.x for m in recovered.snapshot().memories] == [9.0]
+
+
+def test_a_failed_promotion_never_restores_another_maps_set(data_dir, monkeypatch):
+    # Greptile P1 (store.py:216): B's memories are stranded in
+    # .mapping.displaced. A promotion for A then fails to land, and the restore
+    # must not hand B's set to A -- a foreign coordinate frame in A, and B
+    # stripped of its only copy.
+    store = MemoryStore(data_dir)
+    store.switch_map("B.yaml")
+    store.add(9.0, 9.0, 0.0, 900.0, b"jpg-b")
+
+    root = data_dir / "spatial_memory"
+    (root / "B").rename(root / ".mapping.displaced")  # B stranded by an earlier failure
+
+    store.use_mapping_session(session_started=222.0)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-tour-a")
+
+    real_replace = os.replace
+
+    def landing_into_a_fails(src, dst):
+        # Only the tour's landing fails; a restore into A would be free to run,
+        # which is exactly what must not happen with B's set sitting there.
+        if Path(src).name == ".mapping.promote" and Path(dst).name == "A":
+            raise OSError("disk went away")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", landing_into_a_fails)
+    with pytest.raises(OSError):
+        store.promote_mapping_session("A.yaml", mapping_started=222.0)
+    monkeypatch.undo()
+
+    assert not (root / "A").is_dir(), "A was given another map's memories"
+    stranded = json.loads((root / ".mapping.displaced" / "index.json").read_text())
+    assert stranded["map"] == "B.yaml", "B's set was moved out from under it"
+    assert [m["x"] for m in stranded["memories"]] == [9.0]

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -351,7 +351,7 @@ def test_forget_removes_the_memory_and_its_image(data_dir):
     added = store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
     assert added is not None
     # The truncated digest from /brain/memory_positions — what a client sends.
-    assert store.forget(added.id, store.fingerprint[:12]) == added
+    assert store.forget(added.id, store.snapshot().fingerprint[:12]) == added
     path = store.image_path(added.id)
     assert path is not None and not path.exists()
     assert store.snapshot().memories == ()

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1886,3 +1886,39 @@ def test_a_same_name_remap_disqualifies_the_cache(data_dir):
     remap_in_place(data_dir, store)
     search.search("the kitchen")
     assert "cachedContent" not in fake.generates[-1]  # old-map frames must not vouch for reused ids
+
+
+def test_a_fault_outliving_the_promotion_keeps_both_sets_recoverable(data_dir, monkeypatch):
+    # The landing fails, the in-line restore fails, and the fault persists into
+    # recovery. Neither scratch dir may be deleted while the map is absent --
+    # they hold the map's only memories -- and once the fault clears, recovery
+    # must put the map back.
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(9.0, 9.0, 0.0, 900.0, b"jpg-old")
+    store.use_mapping_session(session_started=111.0)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-new")
+
+    root = data_dir / "spatial_memory"
+    real_replace = os.replace
+
+    def landing_always_fails(src, dst):
+        if Path(dst).name == "A":
+            raise OSError("disk went away")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", landing_always_fails)
+    with pytest.raises(OSError):
+        store.promote_mapping_session("A.yaml", mapping_started=111.0)
+
+    assert not (root / "A").is_dir()  # the window: map gone, both sets in scratch
+
+    # A new mapping session runs while the fault persists: its sweep must spare
+    # what the map is still owed.
+    store.use_mapping_session(session_started=222.0)
+    assert (root / ".mapping.displaced").is_dir(), "deleted the map's only surviving memories"
+
+    monkeypatch.undo()  # the disk comes back
+    recovered = MemoryStore(data_dir)
+    recovered.switch_map("A.yaml")
+    assert recovered.snapshot().memories, "recovery never gave the map its memories back"

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1924,11 +1924,11 @@ def test_a_fault_outliving_the_promotion_keeps_both_sets_recoverable(data_dir, m
     assert recovered.snapshot().memories, "recovery never gave the map its memories back"
 
 
-def test_a_later_promotion_spares_another_maps_stranded_memories(data_dir):
-    # Greptile P1 (store.py:218): a failed promotion for A leaves A's only
-    # memories stranded in .mapping.displaced with A's directory gone. A later
-    # promotion for B -- whose own directory does not exist, so nothing of B's
-    # is displaced -- must not sweep A's set away on its successful way out.
+def test_session_entry_lands_a_stranded_displaced_set_home(data_dir):
+    # A failed promotion for A left A's only memories stranded in
+    # .mapping.displaced with A's directory gone. The next recovery point
+    # gives A its set back -- left in the slot, the stranded set would fail
+    # every later displace into it with ENOTEMPTY.
     store = MemoryStore(data_dir)
     store.switch_map("A.yaml")
     store.add(9.0, 9.0, 0.0, 900.0, b"jpg-a")
@@ -1937,25 +1937,45 @@ def test_a_later_promotion_spares_another_maps_stranded_memories(data_dir):
     (root / "A").rename(root / ".mapping.displaced")  # the state a failed swap leaves
 
     store.use_mapping_session(session_started=222.0)
-    assert (root / ".mapping.displaced").is_dir(), "session entry swept A's stranded memories"
+    assert not (root / ".mapping.displaced").exists(), "the stranded set stayed to poison later saves"
     store.add(3.0, 4.0, 0.0, 2000.0, b"jpg-tour-b")
-
-    assert not (root / "B").is_dir()  # nothing of B's to displace
     assert store.promote_mapping_session("B.yaml", mapping_started=222.0) == 1
-    assert (root / ".mapping.displaced").is_dir(), "B's promotion swept A's only memories"
 
-    # And A is still recoverable from it.
-    (root / ".mapping.displaced").rename(root / "A")
     recovered = MemoryStore(data_dir)
     recovered.switch_map("A.yaml")
     assert [m.x for m in recovered.snapshot().memories] == [9.0]
+    recovered.switch_map("B.yaml")
+    assert [m.x for m in recovered.snapshot().memories] == [3.0]
+
+
+def test_a_stranded_set_never_blocks_a_save_over_an_existing_map(data_dir):
+    # Mid-session strand: a failed save-as-A left A's set in the displaced
+    # slot with A's directory gone, and the user re-saves the tour as B --
+    # whose directory exists. Promotion must land A's set home and use the
+    # cleared slot, not fail the displace with ENOTEMPTY on every save.
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(9.0, 9.0, 0.0, 900.0, b"jpg-a")
+    store.switch_map("B.yaml")
+    store.add(8.0, 8.0, 0.0, 901.0, b"jpg-b")
+    store.use_mapping_session(session_started=222.0)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-tour")
+
+    root = data_dir / "spatial_memory"
+    (root / "A").rename(root / ".mapping.displaced")  # the state a failed A-save leaves
+
+    assert store.promote_mapping_session("B.yaml", mapping_started=222.0) == 1
+    store.switch_map("B.yaml")
+    assert [m.x for m in store.snapshot().memories] == [1.0]
+    store.switch_map("A.yaml")
+    assert [m.x for m in store.snapshot().memories] == [9.0]
 
 
 def test_a_failed_promotion_never_restores_another_maps_set(data_dir, monkeypatch):
-    # Greptile P1 (store.py:216): B's memories are stranded in
-    # .mapping.displaced. A promotion for A then fails to land, and the restore
-    # must not hand B's set to A -- a foreign coordinate frame in A, and B
-    # stripped of its only copy.
+    # B's memories are stranded in .mapping.displaced and a persistent fault
+    # keeps them from landing home. A promotion for A then fails to land, and
+    # the restore must not hand B's set to A -- a foreign coordinate frame in
+    # A, and B stripped of its only copy.
     store = MemoryStore(data_dir)
     store.switch_map("B.yaml")
     store.add(9.0, 9.0, 0.0, 900.0, b"jpg-b")
@@ -1963,19 +1983,19 @@ def test_a_failed_promotion_never_restores_another_maps_set(data_dir, monkeypatc
     root = data_dir / "spatial_memory"
     (root / "B").rename(root / ".mapping.displaced")  # B stranded by an earlier failure
 
-    store.use_mapping_session(session_started=222.0)
-    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-tour-a")
-
     real_replace = os.replace
 
-    def landing_into_a_fails(src, dst):
-        # Only the tour's landing fails; a restore into A would be free to run,
-        # which is exactly what must not happen with B's set sitting there.
-        if Path(src).name == ".mapping.promote" and Path(dst).name == "A":
+    def replace_with_fault(src, dst):
+        # B's landing home and the tour's landing both fail; a restore into A
+        # would be free to run, which is exactly what must not happen with
+        # B's set sitting there.
+        if Path(dst).name in ("A", "B"):
             raise OSError("disk went away")
         return real_replace(src, dst)
 
-    monkeypatch.setattr(os, "replace", landing_into_a_fails)
+    monkeypatch.setattr(os, "replace", replace_with_fault)
+    store.use_mapping_session(session_started=222.0)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-tour-a")
     with pytest.raises(OSError):
         store.promote_mapping_session("A.yaml", mapping_started=222.0)
     monkeypatch.undo()

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -26,7 +26,7 @@ from brain_client.memory.coverage import Coverage, wedge_mask
 from brain_client.memory.quality import MIN_SHARPNESS, frame_sharpness, frame_worth_keeping
 from brain_client.memory.recorder import MemoryRecorder
 from brain_client.memory.selection import MAX_MEMORIES, plan_admission
-from brain_client.memory.store import Memory, MemoryStore
+from brain_client.memory.store import MAPPING_SESSION, Memory, MemoryStore
 from brain_client.state.map import Map
 
 
@@ -412,6 +412,72 @@ def test_without_a_map_nothing_is_recorded(data_dir):
     assert store.snapshot().memories == ()
 
 
+def test_promote_hands_the_stage_to_the_saved_map(data_dir):
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.add(4.0, 2.0, 0.5, 1001.0, b"jpg-two")
+    (data_dir / "maps" / "new.pgm").write_bytes(b"new-map-content")
+    assert store.promote_mapping_session("new.yaml") == 2
+
+    store.switch_map("new.yaml")
+    snapshot = store.snapshot()
+    assert [m.id for m in snapshot.memories] == [1, 2] and snapshot.fingerprint
+    path = store.image_path(1)
+    assert path is not None and path.read_bytes() == b"jpg-one"
+    assert not (data_dir / "spatial_memory" / MAPPING_SESSION).exists()
+
+
+def test_promote_replaces_the_names_previous_memories(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(9.0, 9.0, 0.0, 900.0, b"jpg-old")
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-new")
+    assert store.promote_mapping_session("A.yaml") == 1
+
+    store.switch_map("A.yaml")
+    (memory,) = store.snapshot().memories
+    assert memory.id == 1 and memory.x == 1.0
+    path = store.image_path(1)
+    assert path is not None and path.read_bytes() == b"jpg-new"
+
+
+def test_promote_with_nothing_staged_is_a_noop(data_dir):
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    assert store.promote_mapping_session("A.yaml") is None
+    assert len(store.snapshot().memories) == 1
+
+
+def test_promote_without_a_readable_map_keeps_the_stage(data_dir):
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    assert store.promote_mapping_session("ghost.yaml") is None
+    snapshot = store.snapshot()
+    assert snapshot.map_name == MAPPING_SESSION and len(snapshot.memories) == 1
+
+
+def test_the_session_survives_its_every_tick_call(data_dir):
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.use_mapping_session()  # the recorder's every-tick call must not wipe
+    assert len(store.snapshot().memories) == 1
+
+
+def test_entering_a_session_wipes_the_previous_ones_leftovers(data_dir):
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.switch_map("A.yaml")  # mapping abandoned without a save
+    store.use_mapping_session()
+    assert store.snapshot().memories == ()
+    assert list((data_dir / "spatial_memory" / MAPPING_SESSION).glob("*.jpg")) == []
+
+
 def test_a_transiently_unreadable_map_file_never_wipes(data_dir):
     store = MemoryStore(data_dir)
     store.switch_map("A.yaml")
@@ -464,6 +530,7 @@ def make_recorder(
         current_nav_mode_topic="/nav/current_mode",
         current_map_topic="/nav/current_map",
         amcl_pose_topic="/amcl_pose",
+        map_saved_topic="/nav/map_saved",
     )
     pose = pose if pose is not None else SimpleNamespace(xyt=(1.0, 2.0, 0.5))
     cache = cache if cache is not None else SimpleNamespace(state="warm")
@@ -554,10 +621,10 @@ def test_a_silent_amcl_stops_recording(data_dir, clock):
     assert len(store.snapshot().memories) == 1  # only the pre-death viewpoint
 
 
-def test_only_navigation_mode_records(data_dir, clock):
+def test_mapfree_never_records(data_dir, clock):
     recorder, store = make_recorder(data_dir)
     see_confident_world(recorder, clock)
-    recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    recorder._on_nav_mode(SimpleNamespace(data="mapfree"))
     for _ in range(5):
         recorder.tick()
         clock.now += 2.0
@@ -757,6 +824,98 @@ def test_bad_frames_never_overwrite_a_view(data_dir, clock):
     assert stored_image(store, 1) == frame(1)
     observe(recorder, clock, frame(2))  # the first keepable frame lands it
     assert stored_image(store, 1) == frame(2)
+
+
+# ================= recording while mapping =================
+
+
+def see_mapping_world(recorder):
+    """Feed the recorder everything a mapping-mode record needs: SLAM's live
+    grid stands in for AMCL confidence."""
+    recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    recorder._on_map(grid_msg(open_room(40)))
+    recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -10.0})))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
+
+
+def mapping_observe(recorder, clock, jpeg: bytes, advance: float = 1.0):
+    """One mapping tick seeing this frame; re-feeds the grid like the live
+    slam_toolbox does (map_update_interval 0.5 s)."""
+    clock.now += advance
+    recorder._on_map(grid_msg(open_room(40)))
+    recorder._on_image(SimpleNamespace(data=jpeg))
+    recorder.tick()
+
+
+def test_mapping_records_into_the_session_stage(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()  # starts the hold
+    assert store.snapshot().memories == ()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    snapshot = store.snapshot()
+    assert snapshot.map_name == MAPPING_SESSION and len(snapshot.memories) == 1
+
+
+def test_a_silent_slam_stops_recording(data_dir, clock):
+    # slam_toolbox republishes /map twice a second while alive. When it dies
+    # mid-tour, TF keeps composing odom motion in the map frame — those
+    # unvouched poses must not become memories.
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+    clock.now += 6.0  # the grid has gone stale
+    recorder._on_image(SimpleNamespace(data=frame(2)))
+    recorder.tick()
+    assert len(store.snapshot().memories) == 1
+
+
+def test_a_saved_map_adopts_the_mapping_memories(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+
+    # The webapp's save sequence: save_map, then navigation on the new map.
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
+    recorder._on_map_saved(SimpleNamespace(data="tour.yaml"))
+    recorder._on_nav_mode(SimpleNamespace(data="navigation"))
+    recorder._on_current_map(SimpleNamespace(data="tour.yaml"))
+    recorder.tick()
+    snapshot = store.snapshot()
+    assert snapshot.map_name == "tour.yaml" and len(snapshot.memories) == 1
+    assert stored_image(store, snapshot.memories[0].id) == GOOD_JPEG
+
+
+def test_an_abandoned_session_is_wiped_when_the_next_begins(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+
+    recorder._on_nav_mode(SimpleNamespace(data="navigation"))  # left without saving
+    recorder._on_current_map(SimpleNamespace(data="A.yaml"))
+    recorder.tick()
+    recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    recorder.tick()
+    snapshot = store.snapshot()
+    assert snapshot.map_name == MAPPING_SESSION and snapshot.memories == ()
+    assert list((data_dir / "spatial_memory" / MAPPING_SESSION).glob("*.jpg")) == []
+
+
+def test_mapping_positions_mirror_carries_the_session_identity(data_dir, clock):
+    published: list = []
+    recorder, store = make_recorder(data_dir, published)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    payload = json.loads(published[-1].data)
+    assert payload["map"] == MAPPING_SESSION and payload["fingerprint"] == ""
+    assert len(payload["positions"]) == 1
 
 
 # ================= memory search =================

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import shutil
 import threading
 import time
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 
 import cv2
@@ -557,6 +559,61 @@ def test_restart_lands_a_promotion_cut_down_mid_swap(data_dir):
     assert path is not None and path.read_bytes() == b"jpg-tour"
     assert not (root / ".mapping.promote").exists()
     assert not (root / ".mapping.displaced").exists()
+
+
+def test_a_failed_swap_puts_the_displaced_memories_back(data_dir, monkeypatch):
+    # The landing os.replace fails while the process lives on: the map must
+    # get its displaced memories back, and the stage must still hold the tour
+    # so a re-save can retry the whole promotion.
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(9.0, 9.0, 0.0, 900.0, b"jpg-old")
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-new")
+
+    real_replace = os.replace
+
+    def failing_landing(src, dst):
+        if Path(src).name == ".mapping.promote" and Path(dst).name == "A":
+            raise OSError("disk went away")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", failing_landing)
+    with pytest.raises(OSError):
+        store.promote_mapping_session("A.yaml")
+    monkeypatch.undo()
+
+    store.switch_map("A.yaml")
+    (memory,) = store.snapshot().memories
+    assert memory.x == 9.0  # the displaced memories are back
+    assert store.promote_mapping_session("A.yaml") == 1  # the retry lands the tour
+    store.switch_map("A.yaml")
+    (memory,) = store.snapshot().memories
+    assert memory.x == 1.0
+
+
+def test_session_entry_lands_a_stranded_promotion(data_dir):
+    # A failed swap whose in-line restore also failed leaves the stamped tour
+    # in scratch and the map's directory gone; the next session's entry must
+    # land it, not sweep it.
+    store = MemoryStore(data_dir)
+    store.use_mapping_session(1234.5)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-tour")
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
+    assert store.promote_mapping_session("tour.yaml") == 1
+
+    root = data_dir / "spatial_memory"
+    (root / "tour").rename(root / ".mapping.promote")
+    (root / ".mapping.displaced").mkdir()
+
+    store.use_mapping_session(5678.0)  # the next tour begins
+    assert not (root / ".mapping.promote").exists()
+    assert not (root / ".mapping.displaced").exists()
+    store.switch_map("tour.yaml")
+    (memory,) = store.snapshot().memories
+    assert memory.id == 1
+    path = store.image_path(1)
+    assert path is not None and path.read_bytes() == b"jpg-tour"
 
 
 def test_restart_leaves_an_unstamped_promotion_copy_alone(data_dir):

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1922,3 +1922,30 @@ def test_a_fault_outliving_the_promotion_keeps_both_sets_recoverable(data_dir, m
     recovered = MemoryStore(data_dir)
     recovered.switch_map("A.yaml")
     assert recovered.snapshot().memories, "recovery never gave the map its memories back"
+
+
+def test_a_later_promotion_spares_another_maps_stranded_memories(data_dir):
+    # Greptile P1 (store.py:218): a failed promotion for A leaves A's only
+    # memories stranded in .mapping.displaced with A's directory gone. A later
+    # promotion for B -- whose own directory does not exist, so nothing of B's
+    # is displaced -- must not sweep A's set away on its successful way out.
+    store = MemoryStore(data_dir)
+    store.switch_map("A.yaml")
+    store.add(9.0, 9.0, 0.0, 900.0, b"jpg-a")
+
+    root = data_dir / "spatial_memory"
+    (root / "A").rename(root / ".mapping.displaced")  # the state a failed swap leaves
+
+    store.use_mapping_session(session_started=222.0)
+    assert (root / ".mapping.displaced").is_dir(), "session entry swept A's stranded memories"
+    store.add(3.0, 4.0, 0.0, 2000.0, b"jpg-tour-b")
+
+    assert not (root / "B").is_dir()  # nothing of B's to displace
+    assert store.promote_mapping_session("B.yaml", mapping_started=222.0) == 1
+    assert (root / ".mapping.displaced").is_dir(), "B's promotion swept A's only memories"
+
+    # And A is still recoverable from it.
+    (root / ".mapping.displaced").rename(root / "A")
+    recovered = MemoryStore(data_dir)
+    recovered.switch_map("A.yaml")
+    assert [m.x for m in recovered.snapshot().memories] == [9.0]

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -27,7 +27,7 @@ from brain_client.memory.coverage import Coverage, wedge_mask
 from brain_client.memory.quality import MIN_SHARPNESS, frame_sharpness, frame_worth_keeping
 from brain_client.memory.recorder import MemoryRecorder
 from brain_client.memory.selection import MAX_MEMORIES, plan_admission
-from brain_client.memory.store import MAPPING_SESSION, Memory, MemoryStore
+from brain_client.memory.store import MAPPING_SESSION, Memory, MemoryStore, StaleStageError
 from brain_client.state.map import Map
 
 
@@ -583,6 +583,80 @@ def test_entering_a_session_wipes_the_previous_ones_leftovers(data_dir):
     assert list((data_dir / "spatial_memory" / MAPPING_SESSION).glob("*.jpg")) == []
 
 
+def test_a_restarted_store_adopts_the_same_sessions_stage(data_dir):
+    # A brain-only restart mid-tour: slam_toolbox never died, the frame is
+    # still live, so the half-tour must survive the respawn.
+    store = MemoryStore(data_dir)
+    store.use_mapping_session(1234.5)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    fingerprint = store.snapshot().fingerprint
+
+    reborn = MemoryStore(data_dir)
+    reborn.use_mapping_session(1234.5)
+    snapshot = reborn.snapshot()
+    assert [m.id for m in snapshot.memories] == [1] and snapshot.fingerprint == fingerprint
+    path = reborn.image_path(1)
+    assert path is not None and path.read_bytes() == b"jpg-one"
+    added = reborn.add(4.0, 2.0, 0.5, 1001.0, b"jpg-two")
+    assert added is not None and added.id == 2  # ids continue, not restart
+
+
+def test_another_sessions_stage_is_wiped_on_entry(data_dir):
+    store = MemoryStore(data_dir)
+    store.use_mapping_session(1234.5)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+
+    reborn = MemoryStore(data_dir)
+    reborn.use_mapping_session(9999.0)
+    assert reborn.snapshot().memories == ()
+    assert list((data_dir / "spatial_memory" / MAPPING_SESSION).glob("*.jpg")) == []
+
+
+def test_a_sessionless_entry_keeps_the_legacy_wipe(data_dir):
+    store = MemoryStore(data_dir)
+    store.use_mapping_session(1234.5)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+
+    reborn = MemoryStore(data_dir)
+    reborn.use_mapping_session()
+    assert reborn.snapshot().memories == ()
+
+
+def test_a_new_session_stamp_supersedes_the_stage_in_place(data_dir):
+    # mode_manager restarted slam under a live brain: the store is already on
+    # the stage, but the new stamp names a new frame — the tick must wipe.
+    store = MemoryStore(data_dir)
+    store.use_mapping_session(1234.5)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.use_mapping_session(1234.5)  # the every-tick call must not wipe
+    assert len(store.snapshot().memories) == 1
+    store.use_mapping_session(5678.0)
+    assert store.snapshot().memories == ()
+
+
+def test_promotion_refuses_a_stage_another_session_built(data_dir):
+    # A crashed earlier session's stage replayed against a later save must
+    # never land in that foreign map's directory.
+    store = MemoryStore(data_dir)
+    store.use_mapping_session(1234.5)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
+    with pytest.raises(StaleStageError):
+        store.promote_mapping_session("tour.yaml", mapping_started=9999.0)
+    store.switch_map("tour.yaml")
+    assert store.snapshot().memories == ()
+
+
+def test_promotion_lands_its_own_sessions_stage(data_dir):
+    store = MemoryStore(data_dir)
+    store.use_mapping_session(1234.5)
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
+    assert store.promote_mapping_session("tour.yaml", mapping_started=1234.5) == 1
+    store.switch_map("tour.yaml")
+    assert len(store.snapshot().memories) == 1
+
+
 def test_a_transiently_unreadable_map_file_never_wipes(data_dir):
     store = MemoryStore(data_dir)
     store.switch_map("A.yaml")
@@ -636,6 +710,7 @@ def make_recorder(
         current_map_topic="/nav/current_map",
         amcl_pose_topic="/amcl_pose",
         map_saved_topic="/nav/map_saved",
+        mapping_session_topic="/nav/mapping_session",
     )
     pose = pose if pose is not None else SimpleNamespace(xyt=(1.0, 2.0, 0.5))
     cache = cache if cache is not None else SimpleNamespace(state="warm")
@@ -934,10 +1009,12 @@ def test_bad_frames_never_overwrite_a_view(data_dir, clock):
 # ================= recording while mapping =================
 
 
-def see_mapping_world(recorder):
+def see_mapping_world(recorder, started: float = 1000.0):
     """Feed the recorder everything a mapping-mode record needs: SLAM's live
-    grid stands in for AMCL confidence."""
+    grid stands in for AMCL confidence, mode_manager's latched session stamp
+    names the frame."""
     recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    recorder._on_mapping_session(SimpleNamespace(data=json.dumps({"started": started})))
     recorder._on_map(grid_msg(open_room(40)))
     recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -10.0})))
     recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
@@ -952,9 +1029,14 @@ def mapping_observe(recorder, clock, jpeg: bytes, advance: float = 1.0):
     recorder.tick()
 
 
-def announce_save(recorder, clock, name: str, age: float = 0.0):
-    """mode_manager's /nav/map_saved payload, stamped ``age`` seconds ago."""
-    recorder._on_map_saved(SimpleNamespace(data=json.dumps({"map": name, "stamp": clock.now - age})))
+def announce_save(recorder, clock, name: str, age: float = 0.0, mapping_started: float | None = 1000.0):
+    """mode_manager's /nav/map_saved payload, stamped ``age`` seconds ago;
+    ``mapping_started`` defaults to see_mapping_world's session, None mimics a
+    legacy announcement."""
+    payload = {"map": name, "stamp": clock.now - age}
+    if mapping_started is not None:
+        payload["mapping_started"] = mapping_started
+    recorder._on_map_saved(SimpleNamespace(data=json.dumps(payload)))
 
 
 def test_mapping_records_into_the_session_stage(data_dir, clock):
@@ -1026,7 +1108,7 @@ def test_a_failing_promotion_never_escapes_the_callback(data_dir, clock):
     # disk mid-promotion must log, not kill the node.
     recorder, store = make_recorder(data_dir)
 
-    def full_disk(_name):
+    def full_disk(_name, _started):
         raise OSError("disk full")
 
     store.promote_mapping_session = full_disk
@@ -1070,7 +1152,7 @@ def test_an_abandoned_session_is_wiped_when_the_next_begins(data_dir, clock):
     recorder._on_nav_mode(SimpleNamespace(data="navigation"))  # left without saving
     recorder._on_current_map(SimpleNamespace(data="A.yaml"))
     recorder.tick()
-    recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    see_mapping_world(recorder, started=2000.0)  # re-entry restarts slam: a new session stamp
     recorder.tick()
     snapshot = store.snapshot()
     assert snapshot.map_name == MAPPING_SESSION and snapshot.memories == ()
@@ -1100,6 +1182,55 @@ def test_a_mode_change_restarts_the_confidence_hold(data_dir, clock):
     assert store.snapshot().memories == ()
     mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
     assert len(store.snapshot().memories) == 1
+
+
+def test_a_respawned_recorder_adopts_its_sessions_stage(data_dir, clock):
+    # A brain-only restart mid-tour: the mode arrives before the latched
+    # session replay, and the recorder must not touch the stage until it
+    # knows whose it is — then the same stamp adopts the half-tour.
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+
+    reborn, reborn_store = make_recorder(data_dir)
+    reborn._on_nav_mode(SimpleNamespace(data="mapping"))
+    reborn.tick()  # session unknown: no wipe, no record
+    assert (data_dir / "spatial_memory" / MAPPING_SESSION / "1.jpg").exists()
+    assert reborn_store.snapshot().map_name is None
+    reborn._on_mapping_session(SimpleNamespace(data=json.dumps({"started": 1000.0})))
+    reborn.tick()
+    snapshot = reborn_store.snapshot()
+    assert snapshot.map_name == MAPPING_SESSION and len(snapshot.memories) == 1
+
+
+def test_mapping_without_a_session_identity_never_records(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    recorder._on_map(grid_msg(open_room(40)))
+    recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -10.0})))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    snapshot = store.snapshot()
+    assert snapshot.map_name is None and snapshot.memories == ()
+
+
+def test_a_save_from_another_session_never_gets_the_stage(data_dir, clock):
+    # A stage left by a crashed earlier session must not ride a later
+    # session's save into that foreign map.
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
+    announce_save(recorder, clock, "tour.yaml", mapping_started=9999.0)
+    assert (data_dir / "spatial_memory" / MAPPING_SESSION / "1.jpg").exists()  # the stage is kept
+    store.switch_map("tour.yaml")
+    assert store.snapshot().memories == ()
 
 
 # ================= memory search =================

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -425,7 +425,30 @@ def test_promote_hands_the_stage_to_the_saved_map(data_dir):
     assert [m.id for m in snapshot.memories] == [1, 2] and snapshot.fingerprint
     path = store.image_path(1)
     assert path is not None and path.read_bytes() == b"jpg-one"
-    assert not (data_dir / "spatial_memory" / MAPPING_SESSION).exists()
+    # The stage outlives the promotion (a re-save must re-promote the whole
+    # tour); the next session's entry wipes it.
+    assert (data_dir / "spatial_memory" / MAPPING_SESSION / "1.jpg").exists()
+
+
+def test_a_resave_promotes_the_whole_tour_again(data_dir):
+    # A failed mode switch leaves the robot mapping and the webapp retries the
+    # save. The second promotion must carry the whole tour — not replace the
+    # first batch with just the frames staged since.
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-v1")
+    assert store.promote_mapping_session("tour.yaml") == 1
+
+    store.add(3.0, 2.0, 0.5, 1001.0, b"jpg-two")
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-v2")  # SLAM kept refining
+    assert store.promote_mapping_session("tour.yaml") == 2
+
+    store.switch_map("tour.yaml")
+    snapshot = store.snapshot()
+    assert [m.id for m in snapshot.memories] == [1, 2] and snapshot.fingerprint
+    path = store.image_path(1)
+    assert path is not None and path.read_bytes() == b"jpg-one"
 
 
 def test_promote_replaces_the_names_previous_memories(data_dir):
@@ -458,6 +481,25 @@ def test_promote_without_a_readable_map_keeps_the_stage(data_dir):
     assert store.promote_mapping_session("ghost.yaml") is None
     snapshot = store.snapshot()
     assert snapshot.map_name == MAPPING_SESSION and len(snapshot.memories) == 1
+
+
+def test_promote_reaches_a_stage_the_store_left(data_dir):
+    # Mid mode-switch the tick can land the store back on the previous map
+    # ("switching" republishes it) before the save announcement arrives; the
+    # stage is promoted from disk and picked up on the eventual switch.
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-one")
+    store.switch_map("A.yaml")
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
+    assert store.promote_mapping_session("tour.yaml") == 1
+    assert store.snapshot().map_name == "A.yaml"  # the detour is undisturbed
+
+    store.switch_map("tour.yaml")
+    snapshot = store.snapshot()
+    assert len(snapshot.memories) == 1 and snapshot.fingerprint
+    path = store.image_path(1)
+    assert path is not None and path.read_bytes() == b"jpg-one"
 
 
 def test_the_session_survives_its_every_tick_call(data_dir):
@@ -888,6 +930,39 @@ def test_a_saved_map_adopts_the_mapping_memories(data_dir, clock):
     snapshot = store.snapshot()
     assert snapshot.map_name == "tour.yaml" and len(snapshot.memories) == 1
     assert stored_image(store, snapshot.memories[0].id) == GOOD_JPEG
+
+
+def test_a_promotion_landing_after_the_mode_switch_still_adopts(data_dir, clock):
+    # /nav/map_saved and /nav/current_mode arrive on independent topics: the
+    # tick may switch the store onto the just-saved map (finding it empty)
+    # before the save announcement is handled. The tour must survive the race.
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder)
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
+    recorder._on_nav_mode(SimpleNamespace(data="navigation"))
+    recorder._on_current_map(SimpleNamespace(data="tour.yaml"))
+    recorder.tick()  # the switch wins the race: empty store on the new map
+    assert store.snapshot().memories == ()
+    recorder._on_map_saved(SimpleNamespace(data="tour.yaml"))  # save lands late
+    snapshot = store.snapshot()
+    assert snapshot.map_name == "tour.yaml" and len(snapshot.memories) == 1
+    assert stored_image(store, snapshot.memories[0].id) == GOOD_JPEG
+
+
+def test_a_failing_promotion_never_escapes_the_callback(data_dir, clock):
+    # brain_client_node's spin loop re-raises what escapes a callback: a full
+    # disk mid-promotion must log, not kill the node.
+    recorder, store = make_recorder(data_dir)
+
+    def full_disk(_name):
+        raise OSError("disk full")
+
+    store.promote_mapping_session = full_disk
+    recorder._on_map_saved(SimpleNamespace(data="tour.yaml"))
 
 
 def test_an_abandoned_session_is_wiped_when_the_next_begins(data_dir, clock):

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1184,6 +1184,28 @@ def test_a_mode_change_restarts_the_confidence_hold(data_dir, clock):
     assert len(store.snapshot().memories) == 1
 
 
+def test_a_latched_old_map_grid_never_vouches_for_slam(data_dir, clock):
+    # /map is TRANSIENT_LOCAL: entering mapping can replay the previous map's
+    # grid, which must not stand in for a slam_toolbox that hasn't spoken yet.
+    recorder, store = make_recorder(data_dir)
+    recorder._on_nav_mode(SimpleNamespace(data="navigation"))
+    recorder._on_map(grid_msg(open_room(40)))  # the old map, latched
+    recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    recorder._on_mapping_session(SimpleNamespace(data=json.dumps({"started": 1000.0})))
+    recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -10.0})))
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
+    recorder.tick()
+    clock.now += 3.1
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
+    recorder.tick()  # would record by now if the stale grid still counted
+    assert store.snapshot().memories == ()
+
+    recorder._on_map(grid_msg(open_room(40)))  # slam's first grid: the hold starts here
+    recorder.tick()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+
+
 def test_a_respawned_recorder_adopts_its_sessions_stage(data_dir, clock):
     # A brain-only restart mid-tour: the mode arrives before the latched
     # session replay, and the recorder must not touch the stage until it

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import math
+import shutil
 import threading
 import time
 from dataclasses import replace
@@ -532,6 +533,44 @@ def test_session_entry_sweeps_crashed_promotion_scratch(data_dir):
     store.use_mapping_session()
     assert not (data_dir / "spatial_memory" / ".mapping.promote").exists()
     assert not (data_dir / "spatial_memory" / ".mapping.displaced").exists()
+
+
+def test_restart_lands_a_promotion_cut_down_mid_swap(data_dir):
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-tour")
+    (data_dir / "maps" / "tour.pgm").write_bytes(b"tour-map-content")
+    assert store.promote_mapping_session("tour.yaml") == 1
+
+    # Rewind to the crash window between promote's two os.replace calls: the
+    # stamped copy back in scratch, the old memories displaced, the map's
+    # directory gone.
+    root = data_dir / "spatial_memory"
+    (root / "tour").rename(root / ".mapping.promote")
+    (root / ".mapping.displaced").mkdir()
+
+    reloaded = MemoryStore(data_dir)
+    reloaded.switch_map("tour.yaml")
+    (memory,) = reloaded.snapshot().memories
+    assert memory.id == 1
+    path = reloaded.image_path(1)
+    assert path is not None and path.read_bytes() == b"jpg-tour"
+    assert not (root / ".mapping.promote").exists()
+    assert not (root / ".mapping.displaced").exists()
+
+
+def test_restart_leaves_an_unstamped_promotion_copy_alone(data_dir):
+    # A crash before the stamp landed leaves the copy still naming ".mapping";
+    # landing it anywhere would mint a bogus map dir. Session entry sweeps it.
+    store = MemoryStore(data_dir)
+    store.use_mapping_session()
+    store.add(1.0, 2.0, 0.5, 1000.0, b"jpg-tour")
+    root = data_dir / "spatial_memory"
+    shutil.copytree(root / MAPPING_SESSION, root / ".mapping.promote")
+
+    MemoryStore(data_dir)
+    assert (root / ".mapping.promote").is_dir()
+    assert (root / MAPPING_SESSION / "1.jpg").exists()
 
 
 def test_entering_a_session_wipes_the_previous_ones_leftovers(data_dir):

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -446,6 +446,16 @@ class AppControl : public rclcpp::Node {
                 apply_speed_policy();
             });
 
+        // The mode as the robot actually entered it, not as a client asked for it:
+        // mode_manager redirects to mapping whenever there is no current map, and
+        // auto-starts there on a mapless boot, so no client can be trusted to know
+        // a mapping run began. Republished at 1 Hz; the policy ignores repeats.
+        nav_mode_sub_ = this->create_subscription<std_msgs::msg::String>(
+            "/nav/current_mode", 10, [this](const std_msgs::msg::String::SharedPtr msg) {
+                mapping_ = (msg->data == "mapping");
+                apply_speed_policy();
+            });
+
         // Heading feedback. /odom's x,y are dead-reckoned from commanded speeds and are
         // useless as feedback, but its orientation is genuine IMU heading from the MCU.
         odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
@@ -771,20 +781,32 @@ class AppControl : public rclcpp::Node {
         return bounded;
     }
 
-    // Preset the current activity wants, or 0 when none applies. Mapping is
-    // deliberately absent: mode_manager drops repeat change_mode requests, so
-    // there is no transition to key on.
-    double policy_scale() const {
+    // Preset the current activity wants (scale 0 = none applies), with the name
+    // for the log. Both at once takes the slower: mapping's care outranks
+    // recording's pace.
+    struct SpeedPolicy {
+        double scale;
+        const char* reason;
+    };
+    SpeedPolicy policy_scale() const {
+        SpeedPolicy policy{0.0, "idle"};
         if (recording_) {
-            return drive::scale_for_mode(drive::RECORDING_SCALE_ID);
+            policy = {drive::scale_for_mode(drive::RECORDING_SCALE_ID), "recording"};
         }
-        return 0.0;
+        if (mapping_) {
+            const double scale = drive::scale_for_mode(drive::MAPPING_SCALE_ID);
+            if (policy.scale == 0.0 || scale < policy.scale) {
+                policy = {scale, "mapping"};
+            }
+        }
+        return policy;
     }
 
     // Acts only on a transition, so an operator who picks another mode
     // mid-activity keeps it; restores only what it set.
     void apply_speed_policy() {
-        const double desired = policy_scale();
+        const SpeedPolicy policy = policy_scale();
+        const double desired = policy.scale;
         if (desired == policy_desired_) {
             return;  // no transition
         }
@@ -812,8 +834,7 @@ class AppControl : public rclcpp::Node {
             return;
         }
         this->set_parameter(rclcpp::Parameter("motion_control.speed_scale", next));
-        RCLCPP_INFO(this->get_logger(), "Speed policy: %s -> speed_scale %.2f", desired > 0.0 ? "recording" : "idle",
-                    next);
+        RCLCPP_INFO(this->get_logger(), "Speed policy: %s -> speed_scale %.2f", policy.reason, next);
     }
 
     // Polled: Humble has no post-set parameter hook, and the pre-set callback
@@ -1468,6 +1489,7 @@ class AppControl : public rclcpp::Node {
     rclcpp::Subscription<std_msgs::msg::Int32MultiArray>::SharedPtr leader_sub_;
     rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
     rclcpp::Subscription<brain_messages::msg::RecorderStatus>::SharedPtr recorder_sub_;
+    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr nav_mode_sub_;
     rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr arm_command_state_sub_;
     rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
@@ -1496,6 +1518,7 @@ class AppControl : public rclcpp::Node {
     // Speed policy state. policy_desired_ is the scale the current activity wants (0 = none);
     // policy_owns_scale_ tracks whether the value on the robot is still the one we set.
     bool recording_ = false;
+    bool mapping_ = false;
     double policy_desired_ = 0.0;
     double policy_restore_scale_ = 1.0;
     bool policy_owns_scale_ = false;

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/drive_smoother.hpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/drive_smoother.hpp
@@ -70,6 +70,7 @@ constexpr std::array<SpeedMode, 4> SPEED_MODES{
     {{"slow", "Slow", 0.35}, {"medium", "Med", 0.65}, {"fast", "Fast", 1.0}, {"mad", "Mad", 2.0}}};
 constexpr const char* MAD_MODE_ID = "mad";
 constexpr const char* RECORDING_SCALE_ID = "medium";
+constexpr const char* MAPPING_SCALE_ID = "slow";
 constexpr double SPEED_SCALE = 1.0;
 
 // Mad states its accelerations outright: it wants 2.0 m/s^2 where scaling gives 0.4 and

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -182,6 +182,21 @@ class ModeManager(Node):
             ),
         )
 
+        # Identity of the live SLAM session as {"started": epoch seconds},
+        # published on each entry into mapping mode. Latched so a brain_client
+        # respawning mid-tour can tell whether the memory stage it finds on
+        # disk was built by this very session (adopt) or an earlier one (wipe).
+        self._mapping_session_started = None
+        self.mapping_session_publisher = self.create_publisher(
+            String,
+            "/nav/mapping_session",
+            QoSProfile(
+                depth=1,
+                reliability=QoSReliabilityPolicy.RELIABLE,
+                durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            ),
+        )
+
         # Pre-create service clients for all nodes and service types we'll use
         self._init_service_clients()
 
@@ -1198,9 +1213,10 @@ class ModeManager(Node):
                     action_word = "overwritten" if is_overwriting else "saved"
                     response.message = f"Successfully {action_word} map as '{map_name}.yaml'"
                     self.get_logger().info(response.message)
-                    self.map_saved_publisher.publish(
-                        String(data=json.dumps({"map": map_yaml_name, "stamp": time.time()}))
-                    )
+                    save_announcement = {"map": map_yaml_name, "stamp": time.time()}
+                    if self._mapping_session_started is not None:
+                        save_announcement["mapping_started"] = self._mapping_session_started
+                    self.map_saved_publisher.publish(String(data=json.dumps(save_announcement)))
 
                     # Refresh available maps list
                     self.available_maps = self.discover_maps()
@@ -1395,6 +1411,14 @@ class ModeManager(Node):
                         self.get_logger().info("BasicNavigator initialized for navigation mode")
                     except Exception as e:
                         self.get_logger().warning(f"Could not initialize BasicNavigator: {e}")
+                elif target_mode == "mapping":
+                    # Every slam_toolbox activation is a new coordinate frame;
+                    # stamp it before the mode flips so no subscriber pairs
+                    # mode "mapping" with a previous session's stamp.
+                    self._mapping_session_started = time.time()
+                    self.mapping_session_publisher.publish(
+                        String(data=json.dumps({"started": self._mapping_session_started}))
+                    )
                 self.current_mode = target_mode
                 self.save_last_mode(target_mode)
                 self.get_logger().info(response.message)

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -168,6 +168,10 @@ class ModeManager(Node):
         # Publisher to announce current map
         self.current_map_publisher = self.create_publisher(String, "/nav/current_map", 10)
 
+        # Announces each successful map save (the saved yaml name); brain_client's
+        # memory recorder promotes its staged mapping-session memories on this.
+        self.map_saved_publisher = self.create_publisher(String, "/nav/map_saved", 10)
+
         # Pre-create service clients for all nodes and service types we'll use
         self._init_service_clients()
 
@@ -1184,6 +1188,7 @@ class ModeManager(Node):
                     action_word = "overwritten" if is_overwriting else "saved"
                     response.message = f"Successfully {action_word} map as '{map_name}.yaml'"
                     self.get_logger().info(response.message)
+                    self.map_saved_publisher.publish(String(data=map_yaml_name))
 
                     # Refresh available maps list
                     self.available_maps = self.discover_maps()

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -168,9 +168,19 @@ class ModeManager(Node):
         # Publisher to announce current map
         self.current_map_publisher = self.create_publisher(String, "/nav/current_map", 10)
 
-        # Announces each successful map save (the saved yaml name); brain_client's
-        # memory recorder promotes its staged mapping-session memories on this.
-        self.map_saved_publisher = self.create_publisher(String, "/nav/map_saved", 10)
+        # Each successful save as {"map": yaml name, "stamp": epoch seconds};
+        # brain_client promotes its staged mapping memories on it. Latched so a
+        # recorder respawning across the save still hears it — hence the stamp,
+        # which lets it tell that replay from an old save's.
+        self.map_saved_publisher = self.create_publisher(
+            String,
+            "/nav/map_saved",
+            QoSProfile(
+                depth=1,
+                reliability=QoSReliabilityPolicy.RELIABLE,
+                durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            ),
+        )
 
         # Pre-create service clients for all nodes and service types we'll use
         self._init_service_clients()
@@ -1188,7 +1198,9 @@ class ModeManager(Node):
                     action_word = "overwritten" if is_overwriting else "saved"
                     response.message = f"Successfully {action_word} map as '{map_name}.yaml'"
                     self.get_logger().info(response.message)
-                    self.map_saved_publisher.publish(String(data=map_yaml_name))
+                    self.map_saved_publisher.publish(
+                        String(data=json.dumps({"map": map_yaml_name, "stamp": time.time()}))
+                    )
 
                     # Refresh available maps list
                     self.available_maps = self.discover_maps()

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -361,10 +361,12 @@ export function createMap(root, opts = {}) {
   /** @type {ReturnType<typeof parseSearch>} latest fresh search verdict */
   let memSearch = null;
   let memSearchUntil = 0; // performance.now() deadline for the recalled-spot glow
-  // Robot-time watermark: a verdict answered before this points into a frame
-  // that has since died. Clearing memSearch alone can't hold — a later
-  // resubscribe replays the latched verdict straight back.
-  let memSearchFloorS = 0;
+  // Browser-time watermark: a verdict answered before this instant points into
+  // a frame that has since died (clearing memSearch alone can't hold — a later
+  // resubscribe replays the latched verdict straight back). Skewed at compare
+  // time, not here: the floor can be latched before odom teaches memClockSkew,
+  // and a robotNowS() floor taken then would mute live verdicts for hours.
+  let memSearchFloorBrowserS = 0;
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let memSearchCardTimer;
   let memCardsViewSig = ""; // the view framing the cards were last placed against
@@ -475,7 +477,7 @@ export function createMap(root, opts = {}) {
     if (!verdict) return;
     const replay = !memSearchSeen;
     memSearchSeen = true;
-    if (verdict.stamp <= memSearchFloorS) return; // answered on a frame that has since died
+    if (verdict.stamp <= memSearchFloorBrowserS + memClockSkew) return; // answered on a frame that has since died
     if (replay && robotNowS() - verdict.stamp > SEARCH_REPLAY_FRESH_S) return; // stale latched replay
     memSearch = verdict;
     memSearchUntil = performance.now() + (verdict.found ? MEM_SEARCH_GLOW_MS : 0);
@@ -1789,7 +1791,7 @@ export function createMap(root, opts = {}) {
     closeMemPopup();
     hideMemSearchCard();
     memSearch = null;
-    memSearchFloorS = robotNowS();
+    memSearchFloorBrowserS = Date.now() / 1000;
     pose = composedPose();
   }
 
@@ -1873,7 +1875,7 @@ export function createMap(root, opts = {}) {
         // the meantime.)
         memState = null;
         memKnown = null;
-        memSearchFloorS = robotNowS();
+        memSearchFloorBrowserS = Date.now() / 1000;
         setMemHover(null);
         closeMemPopup();
         hideMemSearchCard();

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -298,7 +298,6 @@ export function createMap(root, opts = {}) {
   // against the growing grid is mode_manager's /mapping_pose (map frame, from
   // TF): raw odom drifts against it and any AMCL fix predates the map.
   let mappingMode = false;
-  let memoriesBeforeMapping = false; // restore the memories layer when mapping ends
   /** @type {{ x: number, y: number, yaw: number } | null} */
   let mappingPose = null;
   /** @type {(() => void) | null} */
@@ -1855,12 +1854,14 @@ export function createMap(root, opts = {}) {
       if (on) {
         amclPose = null;
         odomAtAmcl = null;
-        // Memory marks are frames of the *finished* map — meaningless against
-        // the one being built. Forced off here, in the widget, so every host
-        // (teleop PiP included) honors it, not just the Nav page's chips.
-        memoriesBeforeMapping = layers.memories;
-        layers.memories = false;
-        syncLayerSubs();
+        // The tour records its own memories, in the very frame being built, so
+        // the marks stay — but everything tied to the *previous* map goes: its
+        // recall verdict and any open card point into a frame that just died.
+        // (The positions feed swaps to the mapping session within a tick, and
+        // dropping both here keeps the old frame's marks off the new grid in
+        // the meantime.)
+        memState = null;
+        memKnown = null;
         setMemHover(null);
         closeMemPopup();
         hideMemSearchCard();
@@ -1881,10 +1882,6 @@ export function createMap(root, opts = {}) {
         unsubMappingPose?.();
         unsubMappingPose = null;
         mappingPose = null;
-        if (memoriesBeforeMapping) {
-          layers.memories = true;
-          syncLayerSubs();
-        }
       }
       pose = composedPose();
       render();

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -361,6 +361,10 @@ export function createMap(root, opts = {}) {
   /** @type {ReturnType<typeof parseSearch>} latest fresh search verdict */
   let memSearch = null;
   let memSearchUntil = 0; // performance.now() deadline for the recalled-spot glow
+  // Robot-time watermark: a verdict answered before this points into a frame
+  // that has since died. Clearing memSearch alone can't hold — a later
+  // resubscribe replays the latched verdict straight back.
+  let memSearchFloorS = 0;
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let memSearchCardTimer;
   let memCardsViewSig = ""; // the view framing the cards were last placed against
@@ -471,6 +475,7 @@ export function createMap(root, opts = {}) {
     if (!verdict) return;
     const replay = !memSearchSeen;
     memSearchSeen = true;
+    if (verdict.stamp <= memSearchFloorS) return; // answered on a frame that has since died
     if (replay && robotNowS() - verdict.stamp > SEARCH_REPLAY_FRESH_S) return; // stale latched replay
     memSearch = verdict;
     memSearchUntil = performance.now() + (verdict.found ? MEM_SEARCH_GLOW_MS : 0);
@@ -1779,6 +1784,7 @@ export function createMap(root, opts = {}) {
     closeMemPopup();
     hideMemSearchCard();
     memSearch = null;
+    memSearchFloorS = robotNowS();
     pose = composedPose();
   }
 
@@ -1862,6 +1868,7 @@ export function createMap(root, opts = {}) {
         // the meantime.)
         memState = null;
         memKnown = null;
+        memSearchFloorS = robotNowS();
         setMemHover(null);
         closeMemPopup();
         hideMemSearchCard();

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -1921,7 +1921,6 @@ export function createMap(root, opts = {}) {
     },
     /** Gallery click: centre the view on a memory and open its popup. @param {number} id */
     focusMemory(id) {
-      if (mappingMode) return; // the coordinates belong to the finished map, and Go-here mid-mapping is wrong
       const m = memState?.memories.find((mem) => mem.id === id);
       if (!m) return;
       panCenter = { x: m.x, y: m.y };

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -583,15 +583,20 @@ export function createMap(root, opts = {}) {
     meta.textContent = `seen ${ageText(m.stamp, robotNowS())} · x ${m.x.toFixed(2)} m, y ${m.y.toFixed(2)} m`;
     const actions = document.createElement("div");
     actions.className = "mem-card-actions";
-    const goHere = document.createElement("button");
-    goHere.type = "button";
-    goHere.className = "mem-card-btn mem-card-btn-go";
-    goHere.textContent = "Go here";
-    goHere.title = "/navigate_to_pose (action) — drive to this remembered viewpoint";
-    goHere.addEventListener("click", () => {
-      closeMemPopup();
-      publishGoal(m.x, m.y, m.theta);
-    });
+    // Mid-mapping only slam_toolbox runs — /navigate_to_pose has no server, so
+    // the tour's popups keep the picture and Forget but never offer Go here.
+    if (!mappingMode) {
+      const goHere = document.createElement("button");
+      goHere.type = "button";
+      goHere.className = "mem-card-btn mem-card-btn-go";
+      goHere.textContent = "Go here";
+      goHere.title = "/navigate_to_pose (action) — drive to this remembered viewpoint";
+      goHere.addEventListener("click", () => {
+        closeMemPopup();
+        publishGoal(m.x, m.y, m.theta);
+      });
+      actions.append(goHere);
+    }
     const forget = document.createElement("button");
     forget.type = "button";
     forget.className = "mem-card-btn mem-card-btn-forget";
@@ -619,7 +624,7 @@ export function createMap(root, opts = {}) {
     close.className = "mem-card-btn";
     close.textContent = "Close";
     close.addEventListener("click", closeMemPopup);
-    actions.append(goHere, forget, close);
+    actions.append(forget, close);
     memPopup.append(img, meta, actions);
     memPopup.hidden = false;
     placeMemCard(memPopup, m);

--- a/webapp/js/nav/main.js
+++ b/webapp/js/nav/main.js
@@ -192,7 +192,7 @@ function buildView(root) {
       forceLayer("scan", true);
       forceLayer("costmap", false);
       forceLayer("trail", false);
-      forceLayer("memories", false); // memory marks are frames of the finished map
+      forceLayer("memories", true); // the tour records them; watching them land is the point
       createDriveKit(scene).then((kit) => {
         if (gen !== kitGen) kit.destroy(); // mapping ended while mounting
         else driveKit = kit;

--- a/webapp/js/nav/navStore.js
+++ b/webapp/js/nav/navStore.js
@@ -18,10 +18,6 @@ import {
   NAV_AVAILABLE_MAPS_TOPIC,
   NAV_CHANGE_MAP_SERVICE,
   NAV_CHANGE_MODE_SERVICE,
-  PARAMETER_DOUBLE,
-  SET_PARAMETERS_SERVICE,
-  SPEED_MODES,
-  SPEED_SCALE_PARAM,
   NAV_CURRENT_MAP_TOPIC,
   NAV_CURRENT_MODE_TOPIC,
   NAV_DELETE_MAP_SERVICE,
@@ -80,31 +76,6 @@ export function createNavStore() {
    * @param {string} service @param {object} args @param {string} doing
    * @returns {Promise<boolean>}
    */
-  /**
-   * Drop to the Slow preset when a mapping run starts. Mapping wants care, and the
-   * default speed is easy to forget about.
-   *
-   * Done here rather than on the robot because mode_manager early-returns on a
-   * change_mode request for the mode it is already in, so starting a second map emits
-   * no state change and there is nothing for the robot to key on. mars_app does apply
-   * the same policy on a genuine mode transition; this covers the case it cannot see.
-   * The robot-side event is the better fix and should replace this.
-   *
-   * Best-effort: a failure here must not fail the mapping run, and older robot software
-   * has no such parameter at all.
-   */
-  async function setSlowForMapping() {
-    const slow = SPEED_MODES.find((m) => m.id === "slow");
-    if (!slow) return;
-    try {
-      await ros.callService(SET_PARAMETERS_SERVICE, {
-        parameters: [{ name: SPEED_SCALE_PARAM, value: { type: PARAMETER_DOUBLE, double_value: slow.scale } }],
-      });
-    } catch (err) {
-      console.warn("Could not set Slow speed for mapping:", err);
-    }
-  }
-
   async function call(service, args, doing) {
     // destroyed: the page is gone, but a caller may still resolve later (a
     // confirm dialog orphaned by navigation) — never command the robot then.
@@ -160,10 +131,12 @@ export function createNavStore() {
       return () => listeners.delete(cb);
     },
 
+    // The Slow preset that mapping runs at is mars_app's business: it watches
+    // /nav/current_mode, so it covers the runs no client asked for (a mapless
+    // boot, mode_manager redirecting a navigation request) and restores the
+    // operator's preset on the way out.
     async startMapping() {
-      const ok = await call(NAV_CHANGE_MODE_SERVICE, { mode: "mapping" }, "Starting mapping");
-      if (ok) void setSlowForMapping();
-      return ok;
+      return call(NAV_CHANGE_MODE_SERVICE, { mode: "mapping" }, "Starting mapping");
     },
 
     /** @param {string} mode "navigation" | "mapfree" */

--- a/webapp/proxy/media_routes.py
+++ b/webapp/proxy/media_routes.py
@@ -36,6 +36,9 @@ def _under_skills_root(p: Path) -> bool:
 MAPS_DIR = (Path(_INNATE_OS_ROOT) / "data" / "maps").resolve()
 # mode_manager's save_map name validation, mirrored.
 _MAP_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+# brain_client's in-progress mapping session stages memories under this
+# literal — dot-prefixed exactly so no saved map name can collide with it.
+_MAPPING_SESSION = ".mapping"
 
 
 def _plain(status: int, reason: str, text: str) -> web.Response:
@@ -223,8 +226,9 @@ def memory_image_response(request: web.Request) -> web.Response:
     if name.endswith(".yaml"):
         name = name[:-5]
     memory_id = (qs.get("id") or [""])[0]
-    # The map-name charset and a numeric id make the joined path traversal-proof.
-    if not _MAP_NAME_RE.match(name) or not memory_id.isdigit():
+    # The map-name charset (or the session literal) and a numeric id make the
+    # joined path traversal-proof.
+    if (name != _MAPPING_SESSION and not _MAP_NAME_RE.match(name)) or not memory_id.isdigit():
         return _plain(404, "Not Found", "no such memory")
     try:
         data = (MEMORY_DIR / name / f"{int(memory_id)}.jpg").read_bytes()

--- a/webapp/proxy/test/test_media_routes.py
+++ b/webapp/proxy/test/test_media_routes.py
@@ -172,6 +172,14 @@ async def test_memory_image_serves_and_fences(tmp_path, monkeypatch):
         assert (await s.get(base + "/memory/image", params={"map": "../etc", "id": "3"})).status == 404
         assert (await s.get(base + "/memory/image", params={"map": "Home", "id": "../3"})).status == 404
         assert (await s.get(base + "/memory/image", params={"map": "Home", "id": "9"})).status == 404
+        # the in-progress mapping session is the one dotted name that serves
+        (memories / ".mapping").mkdir()
+        (memories / ".mapping" / "1.jpg").write_bytes(b"\xff\xd8staged")
+        assert (
+            await (await s.get(base + "/memory/image", params={"map": ".mapping", "id": "1"})).read()
+            == b"\xff\xd8staged"
+        )
+        assert (await s.get(base + "/memory/image", params={"map": ".hidden", "id": "1"})).status == 404
 
 
 @sync


### PR DESCRIPTION
The mapping run is the one time a human deliberately drives the robot past everything in the room, and until now it was the one time the memory recorder stayed silent — so the tour built a map and threw the pictures away. Memories only started accumulating on whatever incidental driving happened afterwards.

The reason was the "well-localized" gate: AMCL's covariance, and mapping mode has no AMCL.

### Recording

The gate is now mode-aware. In mapping the SLAM estimate is taken at its word, and liveness stands in for confidence: `slam_toolbox` republishes `/map` every 0.5 s (`map_update_interval`), so a grid older than 5 s means SLAM died and TF's map frame is coasting on odometry alone. That mirrors what the AMCL freshness check already does in navigation.

Everything downstream is unchanged — the 3-second hold, the sharpest-frame-of-the-window pick, the quality gates, and the coverage/novelty admission policy all run as they do today, against the live SLAM grid.

Accepted tradeoff: a memory keeps the pose SLAM believed at capture time, so a loop closure late in a tour can leave one recorded early slightly off in the final map.

### Staging and promotion

A memory means nothing outside the coordinate frame of the map it was recorded on, and during a tour that map has no name and no file yet. Memories stage under `spatial_memory/.mapping` — dot-prefixed exactly so `save_map`'s alphanumeric name validation can never mint a colliding one.

`mode_manager` gains a `/nav/map_saved` announcement, and on it the store copies the stage into the saved map's directory with the map's fingerprint stamped in, replacing whatever that name held before (the room was just re-mapped, so the old coordinates lie).

Three details that review turned up, all in the second commit:

- **Promotion copies, it doesn't move.** A re-save — the webapp retrying after a failed mode switch — would otherwise replace the just-promoted tour with the retry window's handful of frames. The stage outlives promotion, so a re-save re-promotes the whole tour.
- **It reads the stage from disk, not the live attachment.** `/nav/map_saved` and `/nav/current_mode` are independent topics: a tick can switch the store off `.mapping` before the save announcement lands, and the original attachment guard dropped the tour when it lost that race. When the switch wins, the promoted memories are adopted in place, since no later tick would reload them.
- **The callback carries an error boundary,** like `tick()` — `rmtree`/`os.replace` ran bare in a subscription, where a full disk would escape into the node's re-raising spin loop.

A stage that never gets promoted (mapping abandoned, or a restart mid-tour) is wiped when the next session begins.

### Showing them

The marks are visible on the map during the tour. Two places previously forced the memories layer off the moment mapping started, both citing a premise this PR retires — "memory marks are frames of the finished map, meaningless against the one being built." They're now recorded in that very frame, and watching them bloom in is how you tell whether a corner got captured before you save.

This was a deliberate call with a real tradeoff: each memory draws a wall-clipped view cone, so a long tour lays translucent violet over floor you're also reading to judge map coverage. The knob if it proves noisy in practice is `MEM_WEDGE_RANGE_M`, which shortens the cone without touching the layer logic.

Everything anchored to the map that just died is still dropped on entering mapping — the recall verdict, any open card, and `memState`/`memKnown` themselves, so the old frame's marks don't linger over the new grid for the tick until the positions feed swaps over.

Two supporting fixes, both visible during a tour: `/brain/memory_positions` carries the store's own identity rather than `/nav/current_map`, which is empty in mapping and stale mid-switch; and the image proxy's map-name fence admits the `.mapping` literal, without which every thumbnail 404'd until the save landed.

The sidebar reel needed nothing — it subscribes to the positions feed independently of the layer chips.

### Verification

- **237** brain_client tests pass, covering the mapping gates, the SLAM-death cutoff, the save-adoption flow, the abandoned-session wipe, the re-save and lost-race promotion paths, and the store's promotion edges.
- **11** proxy tests pass, with new fence cases for `.mapping` versus other dotted names.
- **6** webapp JS tests pass; `tsc` clean on both touched JS files.
- `ruff check` and `ruff format --check` clean on every touched package.
- `basedpyright` adds no errors. It reports 2 in `skills/runner.py`, pre-existing on `main` (verified by stashing) and unrelated.

Needs `innate build brain_client mars_nav` plus a hard webapp reload — the layer fix is JS, so a cached bundle keeps the old force-off.
