### PR TITLE
deps: use innate builds of rmw_zenoh

### DIFF
--- a/ros2_ws/apt-dependencies.common.txt
+++ b/ros2_ws/apt-dependencies.common.txt
@@ -50,9 +50,11 @@ python3-pytest
 ros-humble-rclcpp
 ros-humble-rclpy
 ros-humble-rclcpp-components
-ros-humble-rmw-zenoh-cpp
+# Innate build carries the rmw_wait lost-wakeup fix upstream 0.1.9 still ships
+# (innate-inc/rmw_zenoh#1)
+ros-humble-innate-rmw-zenoh-cpp
 # unversioned Depends of the rmw — unnamed, apt leaves libzenohc.so behind and every node dies at load
-ros-humble-zenoh-cpp-vendor
+ros-humble-innate-zenoh-cpp-vendor
 ros-humble-launch-xml
 ros-humble-ament-cmake
 ros-humble-ament-cmake-python


### PR DESCRIPTION
## ⚠️ Blocked — do not merge until the packages exist

`ros-humble-innate-rmw-zenoh-cpp` and `ros-humble-innate-zenoh-cpp-vendor` are **not yet published** to the innate apt repo. That repo currently carries 26 packages (the `nav2` family plus `ros-humble-innate-rws`) and no zenoh builds.

`post_update.sh` installs this file with `xargs apt-get install -y`, so a single unresolvable name aborts the **entire** dependency install on every robot. Merging this before publishing bricks updates fleet-wide. Opened as a draft for that reason.

## What this does

Switches the Zenoh RMW to innate-built packages, matching how we already consume `rws` (`ros-humble-innate-rws`) and nav2 (`ros-humble-innate-nav2-*`).

## Why

Upstream `rmw_zenoh_cpp` 0.1.9 has a lost-wakeup race in `rmw_wait` that intermittently deadlocks any long-lived multi-topic subscriber. `check_and_attach_condition()` clears `wait_set_data->triggered` without holding `condition_mutex` — a comment there still claims the caller holds it, but upstream #1005/#1015 removed that lock to fix a different deadlock (#998) and left the write behind. It races with `add_new_message()` setting the flag under the mutex, so a wakeup gets swallowed and `rmw_wait` blocks forever with messages already queued.

Fix: **innate-inc/rmw_zenoh#1**.

Symptoms this explains on the robot — `rws_server` stops delivering topics while its websocket stays alive (ping/pong fine, new connections accepted), affecting **every** client at once, with the process alive at ~0 % CPU. Restarting the webapp appeared to "fix" it because a fresh subscribe re-triggers the wait set.

Measured on mars-the-44th, same binary and workload, sole delta being the one-line fix:

| | time to wedge | messages delivered |
|---|---|---|
| upstream 0.1.9 | 13 s, 22 s, 85 s, 108 s (4 for 4) | 512 / 1 951 / 10 566 / 12 363 |
| 0.1.9 + fix | no wedge | > 100 000, 17+ min continuous at 99 msg/s |

Note this bug has been in **every humble release since 0.1.2** (2025-06-19) — it long predates the recent 0.1.8 → 0.1.9 upgrade, and is unrelated to the vendor-skew incident. Rolling back is not an option: 0.1.9 is the only humble release that has ever contained the #1015 deadlock fix, so every earlier version has strictly more deadlocks.

## Before merging

1. Build and publish both packages to `innate-inc/innate-packages` from the `humble` branch of `innate-inc/rmw_zenoh` (after #1 lands there).
2. Publish **both together** — `rmw-zenoh-cpp` depends on the vendor package unversioned, and that skew already took a robot down with `undefined symbol: z_reply_keyexpr_default` at dynamic-link time.
3. Verify a robot resolves to the innate build, then merge this.

## Notes

- The `zenoh-cpp-vendor` line and its comment came from main; this only renames it.
- `sim/apt-dependencies.txt` was removed on main in favour of `ros2_ws/apt-dependencies.sim.txt`; the sim and hardware overlays carry no zenoh entries, so `common.txt` is the only file needing the change.

Closes INN-786
