### PR TITLE
refactor(voice): batch STT drops its local API key for the proxy [2/3]

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/batch_stt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/batch_stt.py
@@ -24,8 +24,6 @@ import wave
 from collections import deque
 from typing import TYPE_CHECKING, Any
 
-import httpx
-
 from brain_client.brain.transport import GENERATE_PATH
 
 if TYPE_CHECKING:
@@ -151,34 +149,13 @@ class Endpointer:
 
 # ---------- ElevenLabs Scribe batch ----------
 
-ELEVENLABS_DIRECT_URL = "https://api.elevenlabs.io/v1/speech-to-text"
 ELEVENLABS_PROXY_ENDPOINT = "v1/speech-to-text"
-
-
-def _elevenlabs_form(wav: bytes, model: str, language: str) -> tuple[dict, dict]:
-    files = {"file": ("utterance.wav", wav, "audio/wav")}
-    form = {"model_id": model, "language_code": language}
-    return files, form
-
-
-def elevenlabs_direct_transcriber(
-    api_key: str, model: str, language: str, transport: httpx.BaseTransport | None = None
-) -> Transcriber:
-    client = httpx.Client(headers={"xi-api-key": api_key}, timeout=30.0, transport=transport)
-
-    def transcribe(wav: bytes) -> str:
-        files, form = _elevenlabs_form(wav, model, language)
-        resp = client.post(ELEVENLABS_DIRECT_URL, files=files, data=form)
-        if resp.status_code != 200:
-            raise RuntimeError(f"elevenlabs direct: HTTP {resp.status_code}: {resp.text[:200]}")
-        return str(resp.json().get("text", "")).strip()
-
-    return transcribe
 
 
 def elevenlabs_proxy_transcriber(proxy: ProxyClient, model: str, language: str) -> Transcriber:
     def transcribe(wav: bytes) -> str:
-        files, form = _elevenlabs_form(wav, model, language)
+        files = {"file": ("utterance.wav", wav, "audio/wav")}
+        form = {"model_id": model, "language_code": language}
         with proxy.request_stream("elevenlabs", ELEVENLABS_PROXY_ENDPOINT, files=files, form=form) as resp:
             payload = resp.read()
             if resp.status_code != 200:

--- a/ros2_ws/src/brain/brain_client/test/test_batch_stt.py
+++ b/ros2_ws/src/brain/brain_client/test/test_batch_stt.py
@@ -13,8 +13,6 @@ import json
 import threading
 import wave
 
-import httpx
-
 from brain_client.brain.transport import GeminiRest
 from brain_client.inputs.batch_stt import (
     ELEVENLABS_PROXY_ENDPOINT,
@@ -23,7 +21,6 @@ from brain_client.inputs.batch_stt import (
     BatchSttSession,
     Endpointer,
     EnergyDetector,
-    elevenlabs_direct_transcriber,
     elevenlabs_proxy_transcriber,
     gemini_transcriber,
     pcm_to_wav,
@@ -132,45 +129,16 @@ def test_pcm_to_wav_round_trip():
         assert wav.readframes(wav.getnframes()) == pcm
 
 
-# ---------- elevenlabs transcribers ----------
-
-
-def test_elevenlabs_direct_request_shape_and_reply():
-    requests = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        return httpx.Response(200, json={"text": " hello robot "})
-
-    transcribe = elevenlabs_direct_transcriber("test-key", "scribe_v2", "en", transport=httpx.MockTransport(handler))
-    assert transcribe(WAV) == "hello robot"
-
-    request = requests[0]
-    assert request.url == "https://api.elevenlabs.io/v1/speech-to-text"
-    assert request.headers["xi-api-key"] == "test-key"
-    assert request.headers["content-type"].startswith("multipart/form-data")
-    body = request.read()
-    assert WAV in body
-    assert b'name="model_id"' in body and b"scribe_v2" in body
-    assert b'name="language_code"' in body
-
-
-def test_elevenlabs_direct_http_error_raises():
-    transcribe = elevenlabs_direct_transcriber(
-        "test-key", "scribe_v2", "en", transport=httpx.MockTransport(lambda r: httpx.Response(401, text="denied"))
-    )
-    try:
-        transcribe(WAV)
-        raise AssertionError("expected RuntimeError")
-    except RuntimeError as e:
-        assert "401" in str(e)
+# ---------- elevenlabs transcriber ----------
 
 
 class FakeProxyResponse:
-    status_code = 200
+    def __init__(self, status_code: int, payload: bytes):
+        self.status_code = status_code
+        self._payload = payload
 
     def read(self):
-        return json.dumps({"text": "via proxy"}).encode()
+        return self._payload
 
     def __enter__(self):
         return self
@@ -180,16 +148,17 @@ class FakeProxyResponse:
 
 
 class FakeProxy:
-    def __init__(self):
+    def __init__(self, status_code: int = 200, payload: bytes = b""):
         self.calls = []
+        self._response = FakeProxyResponse(status_code, payload)
 
     def request_stream(self, service, endpoint, **kwargs):
         self.calls.append((service, endpoint, kwargs))
-        return FakeProxyResponse()
+        return self._response
 
 
 def test_elevenlabs_proxy_request_shape_and_reply():
-    proxy = FakeProxy()
+    proxy = FakeProxy(payload=json.dumps({"text": " via proxy "}).encode())
     transcribe = elevenlabs_proxy_transcriber(proxy, "scribe_v2", "en")
 
     assert transcribe(WAV) == "via proxy"
@@ -198,6 +167,15 @@ def test_elevenlabs_proxy_request_shape_and_reply():
     assert endpoint == ELEVENLABS_PROXY_ENDPOINT
     assert kwargs["files"]["file"] == ("utterance.wav", WAV, "audio/wav")
     assert kwargs["form"] == {"model_id": "scribe_v2", "language_code": "en"}
+
+
+def test_elevenlabs_proxy_http_error_raises():
+    transcribe = elevenlabs_proxy_transcriber(FakeProxy(status_code=401, payload=b"denied"), "scribe_v2", "en")
+    try:
+        transcribe(WAV)
+        raise AssertionError("expected RuntimeError")
+    except RuntimeError as e:
+        assert "401" in str(e)
 
 
 # ---------- gemini transcriber ----------

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -25,7 +25,6 @@ Uses proxy services via self.proxy (injected by InputManager).
 
 import base64
 import json
-import os
 import queue
 import re
 import subprocess
@@ -37,7 +36,6 @@ from brain_client.common.logging import UniversalLogger
 from brain_client.inputs.batch_stt import (
     BatchSttSession,
     EnergyDetector,
-    elevenlabs_direct_transcriber,
     elevenlabs_proxy_transcriber,
     gemini_transcriber,
 )
@@ -311,15 +309,7 @@ class MicroInput(InputDevice):
     def _connect_elevenlabs_batch(self) -> str:
         """Start a batch-transcription session on ElevenLabs Scribe. Returns the model id."""
         model = self.proxy.config.get("elevenlabs_batch_stt_model", "scribe_v2")
-
-        # The robot's own key is the verified path; the proxy passthrough for
-        # this endpoint needs server-side support, so it's the fallback.
-        api_key = os.environ.get("ELEVENLABS_API_KEY", "").strip()
-        if api_key:
-            transcriber = elevenlabs_direct_transcriber(api_key, model, self._stt_language())
-        else:
-            transcriber = elevenlabs_proxy_transcriber(self.proxy, model, self._stt_language())
-
+        transcriber = elevenlabs_proxy_transcriber(self.proxy, model, self._stt_language())
         self._start_batch_session(transcriber, model)
         return model
 


### PR DESCRIPTION
> **Part 2 of 3** — batch speech-to-text end to end.
> 1. innate-os #639 — the batch STT engine, on-robot VAD, and backend switch
> **2. innate-os #643 (this PR)** — drops the robot-local API key so batch STT only ever calls the proxy
> 3. innate-inc/innate-cloud#83 — lets the proxy forward the audio upload untouched

**Stacked on #639** — base branch is `theo/elevenlabs-batch-stt`, so the diff below is only the credential change. Review #639 first.

## What this does

#639 shipped batch STT with two ways to reach ElevenLabs: a robot-local `ELEVENLABS_API_KEY` first, the proxy passthrough as fallback. That was scaffolding from before the proxy could serve `/v1/speech-to-text`. It can now — innate-inc/innate-cloud#82 merged, verified end-to-end against real speech (proxy → Scribe → verbatim transcript) — so this PR deletes the direct path and leaves one way in.

The direct path could never have been the fleet path anyway: `on_open` refuses to start the microphone without proxy credentials, so a robot with only an ElevenLabs key had no working mic regardless. Batch STT now works like every other backend in `micro_input` — Scribe realtime, OpenAI realtime, Gemini — with the robot's Innate service key as its single credential.

## What changed

- **`micro_input.py`** — `_connect_elevenlabs_batch` builds the proxy transcriber unconditionally; the `ELEVENLABS_API_KEY` branch and the `os` import are gone.
- **`batch_stt.py`** — `elevenlabs_direct_transcriber` and `ELEVENLABS_DIRECT_URL` deleted; the form-building helper folded into the one remaining transcriber; the `httpx` import is gone.
- **`test_batch_stt.py`** — the two direct-path tests removed; the fake proxy grew a configurable status/payload, and a new `test_elevenlabs_proxy_http_error_raises` keeps the error path covered on the only path left.

## Verified

- `ruff check` + `ruff format --check`: clean
- pytest in the innate-os-test image: 246 passed, 3 skipped (the onnxruntime-gated Silero tests — the image lacks onnxruntime; untouched by this diff)
- basedpyright: 31 errors, byte-for-byte the pre-existing baseline; `batch_stt.py` contributes zero

## ⚠️ Deploy order

Robots on this branch stop reading `ELEVENLABS_API_KEY` entirely, and there is no fallback if the proxy can't serve the endpoint — a robot that gets this before the proxy is ready has a mic that connects and never transcribes.

**The deployed proxy (`proxy-v1.svc.innate.bot`) must be running innate-cloud ≥ #82 before this reaches robots.** #83 should go out with it.
