### PR TITLE
refactor(sim): drop the cloud-agent clone and its launcher plumbing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,7 +5,7 @@
 # simulator settings in sim/config.toml.
 
 # --- Secrets ---
-# INNATE_SERVICE_KEY (hosted brain mode) is written to your local .env by
+# INNATE_SERVICE_KEY (Innate proxy access) is written to your local .env by
 # `./innate setup` / `./innate-sim setup` and seeded to /etc/innate.env on update —
 # it is never kept as a line in this template.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,6 @@ log/
 scripts/build/
 ros2_ws/src/brain/manipulation/ckpts/*
 
-# Cloud-agent source lives OUTSIDE this repo (cloned next to it by `innate-sim setup`).
-# Ignore any stray in-repo copy so it never gets committed.
-sim/innate-cloud-agent/
-
 # Python artifacts
 __pycache__/
 *.py[cod]

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
@@ -65,7 +65,12 @@ class Backend(StrEnum):
 
 
 def pick_transport(proxy: ProxyClient | None) -> tuple[Transport | None, Backend]:
-    """The way to reach Gemini: the Innate proxy (managed) or GEMINI_API_KEY (dev)."""
+    """The way to reach Gemini: the Innate proxy (managed) or GEMINI_API_KEY (dev).
+
+    sim/launcher/config.py:resolve_brain_backend predicts this choice from the
+    host (it cannot import this module) to label the dashboard; change the
+    precedence here and change it there.
+    """
     if proxy is not None and proxy.is_available():
         return proxy_transport(proxy), Backend.PROXY
     api_key = os.environ.get("GEMINI_API_KEY", "").strip()

--- a/sim/README.md
+++ b/sim/README.md
@@ -92,16 +92,15 @@ Then, from the repository root:
 ./innate-sim up        # starts everything; leave the live dashboard open
 ```
 
-`setup` asks which brain — the robot's AI agent — to run. The agent is the
-open-source [innate-cloud-agent](https://github.com/innate-inc/innate-cloud-agent);
-the choice is only about *where* it runs:
+`setup` asks how the robot's AI agent reaches a cloud LLM. The agent loop
+itself always runs on the robot (`brain_client`); the choice is only about
+which key it thinks with:
 
-- **Local brain (Gemini)** — the default. Clones `innate-cloud-agent` and
-  runs it on your machine against a
+- **Your own Gemini key** — the agent calls Google directly with a
   [Gemini API key](https://aistudio.google.com/api-keys). Everything works
   except voice: the web app's speak bar is disabled without a service key.
-- **Hosted Innate brain** — the same agent, run on Innate's servers with
-  your Innate service key (it ships with a MARS robot). The full experience,
+- **Innate service key** — the agent calls Gemini through Innate's proxy with
+  your service key (it ships with a MARS robot). The full experience,
   including voice — the robot speaks.
 - **None** — no agent; you can still drive, navigate, and trigger skills
   manually.
@@ -122,7 +121,7 @@ If something stops you anyway, we want to hear about it —
 
 ```bash
 ./innate-sim status      # startup checks + health snapshot
-./innate-sim logs startup   # startup logs; `logs brain` / `logs cloud-agent` for the running stack
+./innate-sim logs startup   # startup logs; `logs brain` for the running stack
 ./innate-sim sh          # shell into the container; `innate build` rebuilds ros2_ws
 ./innate-sim down        # stop the container + world server (keeps data)
 ./innate-sim clean       # remove containers/volumes (keeps .env + config)
@@ -259,10 +258,9 @@ To connect:
 3. Enter `ws://localhost:8765` and connect.
 4. Add panels (e.g. Image, 3D, Raw Messages) and pick the topics you want to see.
 
-> **Which port?** If you're running the local brain, the address is
-> `ws://localhost:8766` instead (the cloud agent uses 8765). The sim's startup
-> log always prints the exact address to use. To force a specific port or network
-> interface, set `SIM_FOXGLOVE_PORT` / `SIM_FOXGLOVE_BIND` before starting the sim.
+> **Which port?** The sim's startup log always prints the exact address to use.
+> To force a specific port or network interface, set `SIM_FOXGLOVE_PORT` /
+> `SIM_FOXGLOVE_BIND` before starting the sim.
 
 Because the sim runs on your own machine, every topic is fast — feel free to view
 the full-resolution cameras and point clouds. This is different from a **physical
@@ -315,12 +313,8 @@ Prefer your own ROS tooling? A rosbridge server is also available at
   `./innate-sim setup` walks through them.
 - `config/settings.yaml` — optional non-secret ROS parameter tunables and
   extra agent/skill dirs.
-- `sim/config.toml` — optional overrides (OS image, cloud-agent mode),
+- `sim/config.toml` — optional overrides (OS image, build behavior),
   created from `config.toml.template` by setup.
-- `sim/cloud-agent.lock` — the innate-cloud-agent revision this checkout is
-  tested against: setup clones/aligns to it (and asks before touching an
-  existing checkout); `up` only warns on mismatch, so forks and pinned
-  experiments are never modified.
 - `INNATE_SIM_RENDER_SCALE=N` — render the robot cameras at 1/N resolution
   (the wire format stays 640×480). On machines stuck with software rendering
   (`software-speed` in the dashboard's World field), `2` makes each frame

--- a/sim/cloud-agent.lock
+++ b/sim/cloud-agent.lock
@@ -1,4 +1,0 @@
-{
-  "url": "https://github.com/innate-inc/innate-cloud-agent.git",
-  "commit": "7dba0b86335fee74df12428476c29917f9ee9225"
-}

--- a/sim/config.toml.template
+++ b/sim/config.toml.template
@@ -16,8 +16,3 @@
 # Run `colcon build` on every startup. Leave false for incremental startup:
 # the launcher rebuilds only when ros2_ws/src is newer than install/setup.zsh.
 # always_build = false
-
-[cloud_agent]
-# mode = "hosted"
-# image = "ghcr.io/your-org/innate-cloud-agent:latest"
-# source_dir = "../innate-cloud-agent"

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -59,14 +59,6 @@ services:
       # (innate foxglove status) can print the address that actually works
       # from the host. Must match the ports entry below.
       - SIM_FOXGLOVE_PORT=${SIM_FOXGLOVE_PORT:-8765}
-      # Brain ("agent") websocket the robot connects to. With
-      # COMPOSE_PROFILES=local-brain the in-compose cloud-agent service starts and
-      # the brain client is pointed at it over the shared x11 network. With no
-      # profile this resolves empty and the brain client just idles (no brain);
-      # set BRAIN_WEBSOCKET_URI explicitly to pin a hosted/remote agent. The
-      # launcher (`./innate-sim up`) overlays its own value via the mounted .env,
-      # which wins — so this default only affects raw `docker compose` runs.
-      - BRAIN_WEBSOCKET_URI=${BRAIN_WEBSOCKET_URI:-${COMPOSE_PROFILES:+ws://cloud-agent:8765}}
     ports:
       # rosbridge (rws). Loopback by default: publishing on 0.0.0.0 invites
       # internet probes that open, send nothing, and disconnect, spamming the
@@ -81,9 +73,7 @@ services:
       - "${SIM_HTTP_PORT:-80}:80"
       # Foxglove bridge websocket (auto-started by launch_sim_in_tmux.zsh).
       # Loopback by default, like rosbridge; SIM_FOXGLOVE_BIND=0.0.0.0 opens it
-      # to the LAN. The launcher publishes 8766 instead when the local brain is
-      # active (cloud-agent owns host 8765) — set SIM_FOXGLOVE_PORT yourself for
-      # raw `docker compose --profile local-brain` runs.
+      # to the LAN.
       - "${SIM_FOXGLOVE_BIND:-127.0.0.1}:${SIM_FOXGLOVE_PORT:-8765}:8765"
 
     volumes:
@@ -155,45 +145,6 @@ services:
       - x11
     extra_hosts:
       - "host.docker.internal:host-gateway"
-
-  # Local "brain" for the robot. Only started when the local-brain profile is
-  # active, e.g.:
-  #   COMPOSE_PROFILES=local-brain docker compose -f sim/docker-compose.dev.yml up
-  # The innate container's BRAIN_WEBSOCKET_URI then points here (ws://cloud-agent:8765)
-  # over the shared x11 network. Reads GEMINI_API_KEY from the same .env the innate
-  # container uses. The source repo lives OUTSIDE this repo (cloned by `./innate-sim
-  # setup`); INNATE_CLOUD_AGENT_DIR overrides the location (the launcher sets it).
-  cloud-agent:
-    profiles: ["local-brain"]
-    image: ${INNATE_CLOUD_AGENT_IMAGE:-innate-os-cloud-agent:latest}
-    build:
-      context: ${INNATE_CLOUD_AGENT_DIR:-../../innate-cloud-agent}
-      dockerfile: Dockerfile
-      # Build on the host network namespace for DNS during `pip install`, matching
-      # the innate service (systemd-resolved hosts can't resolve over bridge DNS).
-      network: host
-    container_name: innate-cloud-agent
-    working_dir: /app
-    env_file:
-      # Same secrets file as the innate container — supplies GEMINI_API_KEY.
-      - ${INNATE_OS_ENV_FILE:-../.env}
-    environment:
-      - PORT=8765
-      # Robot model the brain configures itself for (camera FOV, thresholds, ...).
-      - ROBOT_TYPE=${ROBOT_TYPE:-sim}
-      # Local dev: bypass the hosted auth handshake. SKIP_AUTH needs these three set.
-      - SKIP_AUTH=true
-      - DEFAULT_ROBOT_TOKEN=local-dev-robot-token
-      - DEFAULT_USER_ID=local-dev-user
-      - DEFAULT_SERVICE_KEY=local-dev-service-key
-    volumes:
-      # Live source for dev, mirroring the launcher's local-source mode.
-      - ${INNATE_CLOUD_AGENT_DIR:-../../innate-cloud-agent}:/app
-    command: python -u run_server.py
-    ports:
-      - "${SIM_CLOUD_AGENT_PORT:-8765}:8765"
-    networks:
-      - x11
 
 volumes:
   ros2_ws_build:

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -25,7 +25,6 @@ SCRIPT_PATH = Path(__file__).resolve()
 LAUNCHER_DIR = SCRIPT_PATH.parent
 SIM_DIR = LAUNCHER_DIR.parent
 REPO_ROOT = SIM_DIR.parent
-WORKSPACE_ROOT = REPO_ROOT.parent
 ENV_PATH = REPO_ROOT / ".env"
 ENV_TEMPLATE_PATH = REPO_ROOT / ".env.template"
 SETTINGS_PATH = REPO_ROOT / "config" / "settings.yaml"
@@ -35,7 +34,6 @@ SIM_CONFIG_TEMPLATE_PATH = REPO_ROOT / "sim" / "config.toml.template"
 STATE_DIR = LAUNCHER_DIR / ".state"
 LOG_DIR = STATE_DIR / "logs"
 BOOTSTRAP_LOG_PATH = LOG_DIR / "bootstrap.log"
-CLOUD_AGENT_LOG_PATH = LOG_DIR / "cloud-agent.log"
 COMPOSE_LOG_PATH = LOG_DIR / "compose.log"
 OS_BUILD_LOG_PATH = LOG_DIR / "os-build.log"
 VIEWER_BUILD_LOG_PATH = LOG_DIR / "viewer-build.log"
@@ -50,24 +48,13 @@ DOWN_LOG_PATH = LOG_DIR / "down.log"
 ROS_INSTALL_STATE_PATH = STATE_DIR / "ros-install.inputs.sha256"
 OS_SESSION_READY_POLL_SECONDS = 0.25
 GENERATED_OS_ENV_PATH = STATE_DIR / "innate-os.env"
-GENERATED_CLOUD_ENV_PATH = STATE_DIR / "cloud-agent.env"
-HOSTED_MODE = "hosted"
-LOCAL_IMAGE_MODE = "local-image"
-LOCAL_SOURCE_MODE = "local-source"
-AUTO_MODE = "auto"
-NONE_MODE = "none"
-LOCAL_MODES = {LOCAL_IMAGE_MODE, LOCAL_SOURCE_MODE}
-VALID_CLOUD_AGENT_MODES = {AUTO_MODE, HOSTED_MODE, LOCAL_IMAGE_MODE, LOCAL_SOURCE_MODE, NONE_MODE}
-DEFAULT_HOSTED_BRAIN_WEBSOCKET_URI = "wss://agent-v1.svc.innate.bot"
-# The local cloud-agent runs as the `local-brain` service inside the same compose
-# project as the OS container, reachable by service name on the shared network.
-DEFAULT_LOCAL_BRAIN_WEBSOCKET_URI = "ws://cloud-agent:8765"
-LOCAL_BRAIN_COMPOSE_PROFILE = "local-brain"
-# Cloud-agent source lives OUTSIDE this repo (next to it), cloned on demand by setup.
-# HTTPS so a public clone needs no SSH key / org access.
-CLOUD_AGENT_GIT_URL = "https://github.com/innate-inc/innate-cloud-agent.git"
-CLOUD_AGENT_DIR_NAME = "innate-cloud-agent"
+# How brain_client reaches Gemini: through the Innate proxy with a service key,
+# straight at Google with a Gemini key, or not at all.
+INNATE_BACKEND = "innate"
+GEMINI_BACKEND = "gemini"
+NO_BACKEND = "none"
 GEMINI_API_KEY = "GEMINI_API_KEY"
+INNATE_SERVICE_KEY = "INNATE_SERVICE_KEY"
 AUTO_OS_IMAGE = "auto"
 LOCAL_OS_IMAGE = "local"
 DEFAULT_SIM_OS_IMAGE = "ghcr.io/innate-inc/innate-os-sim-ros"
@@ -165,10 +152,9 @@ SIM_ASSET_UNITS = SIM_ASSET_UNITS_DERIVED + SIM_ASSET_UNITS_AUTHORED
 # EQUAL to this set; weaken it to a subset check and that stops being true.
 OS_CONTAINER_SERVICE = "innate"
 OS_CONTAINER_TMUX_CMD = "./scripts/launch_sim_in_tmux.zsh --detach"
-SECRET_ENV_KEYS = ("INNATE_SERVICE_KEY", "GEMINI_API_KEY")
+SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY)
 LOG_TARGETS = {
     "bootstrap": BOOTSTRAP_LOG_PATH,
-    "cloud-agent": CLOUD_AGENT_LOG_PATH,
     "compose": COMPOSE_LOG_PATH,
     "os-build": OS_BUILD_LOG_PATH,
     "viewer-build": VIEWER_BUILD_LOG_PATH,
@@ -360,37 +346,16 @@ def get_nested_bool(data: dict[str, object], *keys: str) -> bool | None:
     return None
 
 
-def resolve_brain_websocket_uri(
-    mode: str,
-    env: dict[str, str],
-) -> str:
-    if mode == NONE_MODE:
-        return ""
-    if mode in LOCAL_MODES:
-        return DEFAULT_LOCAL_BRAIN_WEBSOCKET_URI
-    return (env.get("BRAIN_WEBSOCKET_URI") or "").strip() or DEFAULT_HOSTED_BRAIN_WEBSOCKET_URI
+def resolve_brain_backend(env: dict[str, str]) -> str:
+    """Which key the in-process brain (brain_client) will use to reach Gemini.
 
-
-def resolve_cloud_agent_mode(sim_config: dict[str, object], env: dict[str, str]) -> str:
-    """Decide which brain backend to run.
-
-    An explicit ``cloud_agent.mode`` in sim/config.toml always wins. Otherwise
-    (mode unset or ``auto``) derive it from available keys: a Gemini key selects
-    the local brain, else an Innate service key selects the hosted brain, else
-    there is no agent.
+    The service key wins: it also buys voice, which a Gemini key does not.
     """
-    explicit = (get_nested_str(sim_config, "cloud_agent", "mode") or "").strip()
-    if explicit and explicit != AUTO_MODE:
-        if explicit not in VALID_CLOUD_AGENT_MODES:
-            raise StackError(
-                "sim/config.toml cloud_agent.mode must be one of: " + ", ".join(sorted(VALID_CLOUD_AGENT_MODES))
-            )
-        return explicit
+    if is_configured_secret_value(INNATE_SERVICE_KEY, env.get(INNATE_SERVICE_KEY, "")):
+        return INNATE_BACKEND
     if is_configured_secret_value(GEMINI_API_KEY, env.get(GEMINI_API_KEY, "")):
-        return LOCAL_SOURCE_MODE
-    if is_configured_secret_value("INNATE_SERVICE_KEY", env.get("INNATE_SERVICE_KEY", "")):
-        return HOSTED_MODE
-    return NONE_MODE
+        return GEMINI_BACKEND
+    return NO_BACKEND
 
 
 def resolve_brain_client_version(repo_root: Path) -> str:
@@ -420,15 +385,6 @@ def resolve_brain_client_version(repo_root: Path) -> str:
         return f"{tags.splitlines()[0].strip()}-dev"
 
     return "0.3.0-dev"
-
-
-def resolve_repo_path(value: str | None, default_name: str) -> Path:
-    if value:
-        path = Path(value).expanduser()
-        if not path.is_absolute():
-            path = (REPO_ROOT / path).resolve()
-        return path
-    return (REPO_ROOT / default_name).resolve()
 
 
 def require_path(path: Path, label: str) -> Path:
@@ -637,30 +593,14 @@ def get_config() -> dict[str, object]:
         if is_configured_secret_value(key, value):
             raw_env[key] = value
     sim_config = parse_toml_file(SIM_CONFIG_PATH)
-    cloud_port = "8765"
 
     merged_env = dict(raw_env)
     merged_env.setdefault("ROSBRIDGE_URI", "ws://localhost:9090")
 
-    mode = resolve_cloud_agent_mode(sim_config, merged_env)
-
-    # Foxglove bridge lives on 8765 (Foxglove Studio's default), but a local
-    # brain's cloud-agent owns that host port, so it shifts to 8766 unless the
-    # user pinned SIM_FOXGLOVE_PORT. Mirror runtime.py's start-up logic here so
-    # the dashboard advertises the address it actually listens on.
-    foxglove_port = os.environ.get("SIM_FOXGLOVE_PORT", "").strip() or ("8766" if mode in LOCAL_MODES else "8765")
+    foxglove_port = os.environ.get("SIM_FOXGLOVE_PORT", "").strip() or "8765"
 
     os_repo = require_path(REPO_ROOT, "innate-os repository")
     sim_repo = require_path(REPO_ROOT / "sim", "sim repository")
-
-    # Cloud-agent source lives next to the repo (WORKSPACE_ROOT/innate-cloud-agent),
-    # cloned by `sim setup`. An explicit source_dir override still wins.
-    cloud_dir_value = get_nested_str(sim_config, "cloud_agent", "source_dir")
-    cloud_repo = None
-    if cloud_dir_value:
-        cloud_repo = resolve_repo_path(cloud_dir_value, CLOUD_AGENT_DIR_NAME)
-    elif (WORKSPACE_ROOT / CLOUD_AGENT_DIR_NAME).exists():
-        cloud_repo = (WORKSPACE_ROOT / CLOUD_AGENT_DIR_NAME).resolve()
 
     os_always_build = get_nested_bool(sim_config, "os", "always_build")
     os_pull_image = get_nested_bool(sim_config, "os", "pull_image")
@@ -674,15 +614,11 @@ def get_config() -> dict[str, object]:
     return {
         "raw_env": merged_env,
         "user_env": user_env,
-        "mode": mode,
+        "brain_backend": resolve_brain_backend(merged_env),
         "os_repo": os_repo,
         "sim_repo": sim_repo,
-        "cloud_repo": cloud_repo,
-        "cloud_port": cloud_port,
         "foxglove_port": foxglove_port,
-        "brain_websocket_uri": resolve_brain_websocket_uri(mode, merged_env),
         "brain_client_version": resolve_brain_client_version(os_repo),
-        "cloud_image": get_nested_str(sim_config, "cloud_agent", "image") or "",
         "os_image": os_image,
         "os_image_auto": os_image_auto,
         "os_pull_image": os_pull_image if os_pull_image is not None else True,
@@ -702,21 +638,6 @@ def build_os_env(config: dict[str, object]) -> Path:
     ensure_state_dir()
     write_env_file(GENERATED_OS_ENV_PATH, os_env)
     return GENERATED_OS_ENV_PATH
-
-
-def build_cloud_env(config: dict[str, object]) -> Path:
-    raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
-    cloud_env: dict[str, str] = dict(raw_env)
-    cloud_env.setdefault("SKIP_AUTH", "true")
-    cloud_env.setdefault("ROBOT_TYPE", "sim")
-    cloud_env.setdefault("PORT", str(config["cloud_port"]))
-    cloud_env.setdefault("DEFAULT_ROBOT_TOKEN", "local-dev-robot-token")
-    cloud_env.setdefault("DEFAULT_USER_ID", "local-dev-user")
-    cloud_env.setdefault("DEFAULT_SERVICE_KEY", "local-dev-service-key")
-
-    ensure_state_dir()
-    write_env_file(GENERATED_CLOUD_ENV_PATH, cloud_env)
-    return GENERATED_CLOUD_ENV_PATH
 
 
 if __name__ == "__main__":

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -151,6 +151,10 @@ SIM_ASSET_UNITS = SIM_ASSET_UNITS_DERIVED + SIM_ASSET_UNITS_AUTHORED
 # tests/test_assets_image_inputs.py holds the dockerignore (which IS hashed)
 # EQUAL to this set; weaken it to a subset check and that stops being true.
 OS_CONTAINER_SERVICE = "innate"
+# Must match `container_name:` / `name:` in sim/docker-compose.dev.yml.
+OS_CONTAINER_NAME = "innate-dev"
+COMPOSE_PROJECT_NAME = "innate-os"
+LEGACY_CLOUD_AGENT_CONTAINER = "innate-cloud-agent"
 OS_CONTAINER_TMUX_CMD = "./scripts/launch_sim_in_tmux.zsh --detach"
 SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY)
 LOG_TARGETS = {
@@ -350,41 +354,15 @@ def resolve_brain_backend(env: dict[str, str]) -> str:
     """Which key the in-process brain (brain_client) will use to reach Gemini.
 
     The service key wins: it also buys voice, which a Gemini key does not.
+    brain_client's `Backend` (brain/transport.py) makes the real choice and owns
+    this precedence; the launcher runs on the host and cannot import it, so this
+    restates the rule. Change one and change the other.
     """
     if is_configured_secret_value(INNATE_SERVICE_KEY, env.get(INNATE_SERVICE_KEY, "")):
         return INNATE_BACKEND
     if is_configured_secret_value(GEMINI_API_KEY, env.get(GEMINI_API_KEY, "")):
         return GEMINI_BACKEND
     return NO_BACKEND
-
-
-def resolve_brain_client_version(repo_root: Path) -> str:
-    def git_output(*args: str) -> str:
-        try:
-            result = subprocess.run(
-                ["git", *args],
-                cwd=repo_root,
-                text=True,
-                stdin=subprocess.DEVNULL,
-                capture_output=True,
-                check=False,
-                timeout=10.0,
-            )
-        except subprocess.TimeoutExpired:
-            return ""
-        if result.returncode != 0:
-            return ""
-        return result.stdout.strip()
-
-    exact_tag = git_output("describe", "--exact-match", "--tags", "HEAD")
-    if exact_tag:
-        return exact_tag.splitlines()[0].strip()
-
-    tags = git_output("tag", "--list", "--sort=-version:refname")
-    if tags:
-        return f"{tags.splitlines()[0].strip()}-dev"
-
-    return "0.3.0-dev"
 
 
 def require_path(path: Path, label: str) -> Path:
@@ -593,6 +571,13 @@ def get_config() -> dict[str, object]:
         if is_configured_secret_value(key, value):
             raw_env[key] = value
     sim_config = parse_toml_file(SIM_CONFIG_PATH)
+    if "cloud_agent" in sim_config:
+        # An existing config.toml is never rewritten (and `clean` preserves it),
+        # so the dead section outlives the code that validated it.
+        warn(
+            f"{SIM_CONFIG_PATH} still has a [cloud_agent] section. It is ignored -- the brain now runs "
+            "inside brain_client. Delete the section to silence this."
+        )
 
     merged_env = dict(raw_env)
     merged_env.setdefault("ROSBRIDGE_URI", "ws://localhost:9090")
@@ -618,7 +603,6 @@ def get_config() -> dict[str, object]:
         "os_repo": os_repo,
         "sim_repo": sim_repo,
         "foxglove_port": foxglove_port,
-        "brain_client_version": resolve_brain_client_version(os_repo),
         "os_image": os_image,
         "os_image_auto": os_image_auto,
         "os_pull_image": os_pull_image if os_pull_image is not None else True,

--- a/sim/launcher/dashboard.py
+++ b/sim/launcher/dashboard.py
@@ -73,7 +73,6 @@ THEME = {
     "panel_frame": (128, 82, 82),
     "panel_fill": (30, 31, 36),
     "log_sim": (119, 202, 155),
-    "log_agent": (120, 198, 255),
     "log_brain": (220, 112, 112),
     "health_start": (119, 202, 155),
     "health_mid": (203, 192, 108),
@@ -100,14 +99,11 @@ THEME = {
 class DashboardCallbacks:
     collect_status_snapshot: Callable[[dict[str, object]], dict[str, object]]
     capture_os_brain_logs: Callable[..., list[str]]
-    capture_agent_logs: Callable[..., list[str]]
     success: Callable[[str], None]
 
 
 @dataclass(frozen=True)
 class DashboardOptions:
-    hosted_mode: str
-    local_modes: set[str]
     cli_sim: str
     state_dir: Path
 
@@ -128,13 +124,11 @@ class DashboardRuntime:
         self,
         config: dict[str, object],
         callbacks: DashboardCallbacks,
-        options: DashboardOptions,
         *,
         log_cache_lines: int = 160,
     ):
         self.config = config
         self.callbacks = callbacks
-        self.options = options
         self.log_cache_lines = log_cache_lines
         self.lock = threading.Lock()
         self.stop_event = threading.Event()
@@ -144,12 +138,7 @@ class DashboardRuntime:
         self.log_rev = 1
 
     def _collect_logs(self, snapshot: dict[str, object]) -> dict[str, list[str]]:
-        logs = {
-            "brain": self.callbacks.capture_os_brain_logs(self.config, lines=self.log_cache_lines),
-        }
-        if self.config["mode"] != self.options.hosted_mode:
-            logs["agent"] = self.callbacks.capture_agent_logs(self.config, lines=self.log_cache_lines)
-        return logs
+        return {"brain": self.callbacks.capture_os_brain_logs(self.config, lines=self.log_cache_lines)}
 
     def read(self) -> tuple[dict[str, object], dict[str, list[str]], int, int]:
         with self.lock:
@@ -192,7 +181,7 @@ def print_banner() -> None:
     # buffer, so it never needs a destructive clear either.
     divider()
     print_ascii_banner()
-    print(f"{DIM}one env // one cli // os + sim + optional cloud agent{NC}")
+    print(f"{DIM}one env // one cli // os + sim{NC}")
     divider()
 
 
@@ -316,29 +305,16 @@ def dashboard_brain_log_worker(runtime: DashboardRuntime, interval_seconds: floa
         runtime.stop_event.wait(interval_seconds)
 
 
-def dashboard_agent_log_worker(runtime: DashboardRuntime, interval_seconds: float = 1.5) -> None:
-    while not runtime.stop_event.is_set():
-        runtime.set_log(
-            "agent",
-            runtime.callbacks.capture_agent_logs(runtime.config, lines=runtime.log_cache_lines),
-        )
-        runtime.stop_event.wait(interval_seconds)
-
-
 @contextlib.contextmanager
 def dashboard_runtime(
     config: dict[str, object],
     callbacks: DashboardCallbacks,
-    options: DashboardOptions,
 ):
-    runtime = DashboardRuntime(config, callbacks, options)
+    runtime = DashboardRuntime(config, callbacks)
     threads = [
         threading.Thread(target=dashboard_snapshot_worker, args=(runtime,), daemon=True),
         threading.Thread(target=dashboard_brain_log_worker, args=(runtime,), daemon=True),
     ]
-    if config["mode"] != options.hosted_mode:
-        threads.append(threading.Thread(target=dashboard_agent_log_worker, args=(runtime,), daemon=True))
-
     for thread in threads:
         thread.start()
 
@@ -756,13 +732,8 @@ def print_log_columns(columns: list[tuple[str, list[str], tuple[int, int, int]]]
         print("  ".join(column[row_index] for column in rendered_columns))
 
 
-def runtime_is_down(
-    config: dict[str, object],
-    options: DashboardOptions,
-    snapshot: dict[str, object],
-) -> bool:
-    local_agent_running = config["mode"] != options.hosted_mode and bool(snapshot["agent_running"])
-    return not bool(snapshot["os_running"]) and not bool(snapshot["sim_running"]) and not local_agent_running
+def runtime_is_down(snapshot: dict[str, object]) -> bool:
+    return not bool(snapshot["os_running"]) and not bool(snapshot["sim_running"])
 
 
 def print_down_status(options: DashboardOptions) -> None:
@@ -816,21 +787,13 @@ def render_status(
                 f"{BOLD}Sim driver:{NC} {format_level(str(snapshot['sim_level']), str(snapshot['sim_label']))}",
                 f"{BOLD}Transport:{NC} {format_level(str(snapshot['transport_level']), str(snapshot['transport_label']))}",
                 f"{BOLD}Brain:{NC} {format_level(str(snapshot['brain_level']), str(snapshot['brain_label']))}",
-                f"{BOLD}Agent:{NC} {format_level(str(snapshot['agent_level']), str(snapshot['agent_label']))}",
+                f"{BOLD}LLM:{NC} {format_level(str(snapshot['llm_level']), str(snapshot['llm_label']))}",
             ]
         ),
         term_width,
     )
     used_lines += 1
-    print_dashboard_line(
-        "  ".join(
-            [
-                f"{BOLD}Cloud mode:{NC} {config['mode']}",
-                f"{BOLD}System:{NC} {snapshot['system_summary']}",
-            ]
-        ),
-        term_width,
-    )
+    print_dashboard_line(f"{BOLD}System:{NC} {snapshot['system_summary']}", term_width)
     used_lines += 1
     print()
     used_lines += 1
@@ -849,12 +812,6 @@ def render_status(
         term_width,
     )
     used_lines += 1
-    if config["mode"] in options.local_modes:
-        print_dashboard_line(
-            f"{BOLD}Local agent:{NC} ws://localhost:{config['cloud_port']}",
-            term_width,
-        )
-        used_lines += 1
     print_dashboard_line(
         "  ".join(
             [
@@ -871,7 +828,7 @@ def render_status(
     )
     used_lines += 1
 
-    if runtime_is_down(config, options, snapshot):
+    if runtime_is_down(snapshot):
         print()
         used_lines += 1
         print_dashboard_line(
@@ -890,11 +847,6 @@ def render_status(
             print(divider_line(term_width))
             print_dashboard_line(f"{BOLD}Innate OS repo:{NC} {config['os_repo']}", term_width)
             print_dashboard_line(f"{BOLD}Innate sim repo:{NC} {config['sim_repo']}", term_width)
-            if config["cloud_repo"] is not None:
-                print_dashboard_line(
-                    f"{BOLD}Local cloud-agent repo:{NC} {config['cloud_repo']}",
-                    term_width,
-                )
             print_dashboard_line(f"{BOLD}State dir:{NC} {options.state_dir}", term_width)
         return
 
@@ -920,31 +872,12 @@ def render_status(
             THEME["log_brain"],
         ),
     ]
-    if config["mode"] != options.hosted_mode:
-        agent_lines = (
-            cached_logs["agent"]
-            if cached_logs is not None and "agent" in cached_logs
-            else callbacks.capture_agent_logs(config, lines=visible_log_rows)
-        )
-        log_columns.insert(
-            0,
-            (
-                "AGENT LOGS",
-                agent_lines,
-                THEME["log_agent"],
-            ),
-        )
     print_log_columns(log_columns, available_height=available_height)
     if verbose:
         print()
         print(divider_line(term_width))
         print_dashboard_line(f"{BOLD}Innate OS repo:{NC} {config['os_repo']}", term_width)
         print_dashboard_line(f"{BOLD}Innate sim repo:{NC} {config['sim_repo']}", term_width)
-        if config["cloud_repo"] is not None:
-            print_dashboard_line(
-                f"{BOLD}Local cloud-agent repo:{NC} {config['cloud_repo']}",
-                term_width,
-            )
         print_dashboard_line(f"{BOLD}State dir:{NC} {options.state_dir}", term_width)
 
 
@@ -983,13 +916,11 @@ def print_status(
     verbose: bool = False,
 ) -> None:
     snapshot = callbacks.collect_status_snapshot(config)
-    if runtime_is_down(config, options, snapshot):
+    if runtime_is_down(snapshot):
         print_down_status(options)
         if verbose:
             print(f"Innate OS repo: {config['os_repo']}")
             print(f"Innate sim repo: {config['sim_repo']}")
-            if config["cloud_repo"] is not None:
-                print(f"Local cloud-agent repo: {config['cloud_repo']}")
             print(f"State dir: {options.state_dir}")
         return
     render_status(config, callbacks, options, verbose=verbose, snapshot=snapshot)
@@ -1053,7 +984,7 @@ def watch_dashboard(
     top_padding_rows = 1
     try:
         with (
-            dashboard_runtime(config, callbacks, options) as runtime,
+            dashboard_runtime(config, callbacks) as runtime,
             live_dashboard_terminal(),
             dashboard_input_mode() as input_mode_enabled,
         ):

--- a/sim/launcher/dashboard.py
+++ b/sim/launcher/dashboard.py
@@ -680,56 +680,26 @@ def render_log_box(
     return [top, *body, bottom]
 
 
-def print_log_columns(columns: list[tuple[str, list[str], tuple[int, int, int]]], *, available_height: int) -> None:
-    width = shutil.get_terminal_size((150, 40)).columns
+def print_log_pane(
+    title: str,
+    lines: list[str],
+    border_rgb: tuple[int, int, int],
+    *,
+    available_height: int,
+) -> None:
     if available_height < 3:
         print(
             colorize(
-                "Terminal too short for live log panes. Enlarge the window to show them.",
+                "Terminal too short for the live log pane. Enlarge the window to show it.",
                 fg=THEME["dim"],
                 dim=True,
             )
         )
         return
 
-    if len(columns) == 1 or width < 120:
-        gap_lines = 1 if available_height >= len(columns) * 5 else 0
-        total_gap_lines = gap_lines * max(len(columns) - 1, 0)
-        remaining_for_boxes = max(available_height - total_gap_lines, len(columns))
-        box_height = remaining_for_boxes // len(columns)
-        if box_height < 3:
-            print(
-                colorize(
-                    "Terminal too short for stacked log panes. Enlarge the window to show them.",
-                    fg=THEME["dim"],
-                    dim=True,
-                )
-            )
-            return
-
-        for index, (title, lines, border_rgb) in enumerate(columns):
-            if index > 0 and gap_lines:
-                print()
-            for row in render_log_box(title, lines, width=width, height=box_height, border_rgb=border_rgb):
-                print(row)
-        return
-
-    gap = 2
-    box_height = max(available_height, 3)
-    inner_width = max((width - gap * (len(columns) - 1)) // len(columns), 24)
-    rendered_columns = [
-        render_log_box(
-            title,
-            lines,
-            width=inner_width,
-            height=box_height,
-            border_rgb=border_rgb,
-        )
-        for title, lines, border_rgb in columns
-    ]
-
-    for row_index in range(box_height):
-        print("  ".join(column[row_index] for column in rendered_columns))
+    width = shutil.get_terminal_size((150, 40)).columns
+    for row in render_log_box(title, lines, width=width, height=available_height, border_rgb=border_rgb):
+        print(row)
 
 
 def runtime_is_down(snapshot: dict[str, object]) -> bool:
@@ -865,14 +835,7 @@ def render_status(
         if cached_logs is not None and "brain" in cached_logs
         else callbacks.capture_os_brain_logs(config, lines=visible_log_rows)
     )
-    log_columns = [
-        (
-            "OS BRAIN LOGS",
-            brain_lines,
-            THEME["log_brain"],
-        ),
-    ]
-    print_log_columns(log_columns, available_height=available_height)
+    print_log_pane("OS BRAIN LOGS", brain_lines, THEME["log_brain"], available_height=available_height)
     if verbose:
         print()
         print(divider_line(term_width))

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -111,6 +111,9 @@ def cmd_up(
         # workspace dirs for the invoking user (root-owned bind-mount dirs on
         # Linux otherwise), and warns if an earlier run already claimed them.
         ensure_workspace_dirs(config)
+        # Before the fast path, not after it: the container it removes is
+        # exactly what an upgrade from a still-running older stack leaves behind.
+        remove_legacy_cloud_agent()
         if runtime_already_running(config):
             # A code update can leave a stale world server running (frozen
             # 3D view); ensure_world_server restarts it.
@@ -137,7 +140,6 @@ def cmd_up(
 
         started = True
         try:
-            remove_legacy_cloud_agent()
             ensure_os_container(config, os_env_file, offline=offline)
         except StackError as exc:
             if offline:

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -14,17 +14,14 @@ if sys.version_info < (3, 10):  # noqa: UP036
 from config import (
     CLI_SIM,
     ENV_PATH,
-    HOSTED_MODE,
-    LOCAL_MODES,
     LOG_TARGETS,
-    NONE_MODE,
+    NO_BACKEND,
     OS_SESSION_LOG_PATH,
     SETTINGS_PATH,
     SHOW_LIVE_DASHBOARD_DEFAULT,
     SIM_CONFIG_PATH,
     STATE_DIR,
     StackError,
-    build_cloud_env,
     build_os_env,
     get_config,
     log,
@@ -41,11 +38,9 @@ from dashboard import (
     watch_dashboard,
 )
 from runtime import (
-    capture_agent_logs,
     capture_os_brain_logs,
     clean_runtime,
     collect_status_snapshot,
-    down_cloud_agent,
     down_os,
     ensure_docker_available,
     ensure_os_container,
@@ -57,8 +52,8 @@ from runtime import (
     ensure_world_server,
     open_os_container_shell,
     print_startup_checks,
+    remove_legacy_cloud_agent,
     runtime_already_running,
-    start_cloud_agent,
     stop_world_server,
     tail_file,
     wait_for_os_runtime_ready,
@@ -74,8 +69,6 @@ from setup_wizard import (
 )
 
 DASHBOARD_OPTIONS = DashboardOptions(
-    hosted_mode=HOSTED_MODE,
-    local_modes=LOCAL_MODES,
     cli_sim=CLI_SIM,
     state_dir=STATE_DIR,
 )
@@ -85,7 +78,6 @@ def dashboard_callbacks() -> DashboardCallbacks:
     return DashboardCallbacks(
         collect_status_snapshot=collect_status_snapshot,
         capture_os_brain_logs=capture_os_brain_logs,
-        capture_agent_logs=capture_agent_logs,
         success=success,
     )
 
@@ -128,7 +120,6 @@ def cmd_up(
             return
 
         os_env_file = build_os_env(config)
-        cloud_env_file = build_cloud_env(config)
         if offline:
             log("Offline: skipping sim/skill asset downloads.")
         else:
@@ -146,7 +137,7 @@ def cmd_up(
 
         started = True
         try:
-            start_cloud_agent(config, cloud_env_file)
+            remove_legacy_cloud_agent()
             ensure_os_container(config, os_env_file, offline=offline)
         except StackError as exc:
             if offline:
@@ -187,10 +178,10 @@ def cmd_up(
                 f"Stop everything with `{CLI_SIM} down`."
             )
             return
-        if config["mode"] == NONE_MODE:
-            warn("No brain backend configured — the sim is running WITHOUT an agent.")
+        if config["brain_backend"] == NO_BACKEND:
+            warn("No cloud LLM key configured — the sim is running WITHOUT an agent.")
             warn(
-                "Add GEMINI_API_KEY (local brain) or INNATE_SERVICE_KEY (hosted) to "
+                "Add GEMINI_API_KEY (your own Gemini key) or INNATE_SERVICE_KEY (Innate proxy) to "
                 f"{ENV_PATH}, or run `{CLI_SIM} setup`, then restart."
             )
         success("Innate sim runtime is up.")
@@ -214,7 +205,7 @@ def cmd_up(
 
 
 def cmd_down(config: dict[str, object]) -> None:
-    down_cloud_agent()
+    remove_legacy_cloud_agent()
     down_os(config)
     stop_world_server()
     log("Innate sim runtime is down.")
@@ -251,7 +242,7 @@ def cmd_clean(config: dict[str, object], *, assume_yes: bool = False) -> None:
 def cmd_logs(target: str, lines: int | None = None) -> None:
     if target == "startup":
         found_logs = False
-        for name in ("bootstrap", "world-server", "compose", "cloud-agent", "os-build", "viewer-build", "os-session"):
+        for name in ("bootstrap", "world-server", "compose", "os-build", "viewer-build", "os-session"):
             path = LOG_TARGETS[name]
             if path.exists():
                 found_logs = True
@@ -265,13 +256,6 @@ def cmd_logs(target: str, lines: int | None = None) -> None:
     if target == "brain":
         config = get_config()
         print("\n".join(capture_os_brain_logs(config, lines=lines or 60)))
-        return
-
-    if target == "cloud-agent":
-        # Live container logs, matching the dashboard's agent pane. The build/startup
-        # output is still available via `logs startup`.
-        config = get_config()
-        print("\n".join(capture_agent_logs(config, lines=lines or 60)))
         return
 
     path = LOG_TARGETS[target]

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -24,11 +24,14 @@ from config import (
     ASSETS_IMAGE_LAYERS,
     CLI_SIM,
     COMPOSE_LOG_PATH,
+    COMPOSE_PROJECT_NAME,
     DOWN_LOG_PATH,
     GENERATED_OS_ENV_PATH,
     INNATE_BACKEND,
+    LEGACY_CLOUD_AGENT_CONTAINER,
     NO_BACKEND,
     OS_BUILD_LOG_PATH,
+    OS_CONTAINER_NAME,
     OS_CONTAINER_SERVICE,
     OS_CONTAINER_TMUX_CMD,
     OS_SESSION_LOG_PATH,
@@ -493,13 +496,45 @@ def ensure_home_mount_sources() -> None:
             ssh_dir.mkdir(mode=0o700)
 
 
+def os_container_foxglove_port_current(config: dict[str, object]) -> bool:
+    """False when a running OS container publishes the Foxglove bridge on a host
+    port other than the one the launcher now advertises.
+
+    Checkouts that ran the brain in a cloud-agent container shifted the publish
+    to 8766 (the agent owned 8765); a running container's published ports cannot
+    be changed in place, so such a container has to be recreated. An unanswered
+    probe reports "current" -- a flaky answer must not cost a recreate.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "port", OS_CONTAINER_NAME, "8765"],
+            text=True,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+            timeout=DOCKER_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return True
+    if result.returncode != 0:
+        return True
+    published = str(config["foxglove_port"])
+    return any(line.strip().endswith(f":{published}") for line in result.stdout.splitlines())
+
+
 def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline: bool = False) -> None:
     os_repo: Path = config["os_repo"]  # type: ignore[assignment]
     os_image = str(config["os_image"]).strip()
     os_image_auto = bool(config["os_image_auto"])
-    container_was_running = container_running("innate-dev")
+    reuse_running_container = container_running(OS_CONTAINER_NAME)
+    if reuse_running_container and not os_container_foxglove_port_current(config):
+        log(
+            "The running OS container publishes Foxglove on an older host port; "
+            f"recreating it to serve ws://localhost:{config['foxglove_port']}."
+        )
+        reuse_running_container = False
 
-    if container_was_running:
+    if reuse_running_container:
         log("Innate OS dev container already running.")
     else:
         up_cmd = docker_compose_cmd("up", "-d")
@@ -616,7 +651,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
     )
     ros_install_already_validated = False
     if ros_install_marker_matches and not bool(config["os_always_build"]):
-        ros_install_already_validated = container_was_running or command_succeeds(
+        ros_install_already_validated = reuse_running_container or command_succeeds(
             os_compose_zsh_cmd("test -f ~/innate-os/ros2_ws/install/setup.zsh"),
             cwd=os_repo,
             env=compose_env,
@@ -637,14 +672,10 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         ROS_INSTALL_STATE_PATH.write_text(f"{ros_inputs_hash}\n", encoding="utf-8")
 
     log("Launching ROS simulation nodes inside the OS container...")
-    brain_client_version = str(config.get("brain_client_version", "")).strip()
-    brain_client_version_arg = ""
-    if brain_client_version:
-        brain_client_version_arg = f" --brain-client-version {shlex.quote(brain_client_version)}"
     launch_script = (
         "INNATE_SIM_TMUX_SETTLE_SECONDS=${INNATE_SIM_TMUX_SETTLE_SECONDS:-0} "
         "INNATE_SIM_TMUX_CLEANUP_SETTLE_SECONDS=${INNATE_SIM_TMUX_CLEANUP_SETTLE_SECONDS:-0} "
-        f"{OS_CONTAINER_TMUX_CMD}{brain_client_version_arg}"
+        f"{OS_CONTAINER_TMUX_CMD}"
     )
     launch_wrapper = (
         "rm -f /tmp/innate-os-session.log; "
@@ -714,13 +745,45 @@ def clean_runtime(config: dict[str, object]) -> None:
     down_os(config, remove_volumes=True)
     # Belt-and-suspenders: force-remove named containers that may linger outside
     # the compose project (e.g. after a partial or failed startup).
-    subprocess.run(
-        ["docker", "rm", "-f", "innate-dev"],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
+    force_remove_container(OS_CONTAINER_NAME)
+
+
+def force_remove_container(name: str) -> bool:
+    """Best-effort `docker rm -f`; True when a container was actually removed.
+
+    Never raises: this runs first in the teardown paths, where a wedged daemon
+    must not swallow the shutdown (or the startup error that triggered it).
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "rm", "-f", name],
+            text=True,
+            stdin=subprocess.DEVNULL,
+            check=False,
+            capture_output=True,
+            timeout=DOCKER_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        warn(f"Docker did not answer `docker rm -f {name}` within {DOCKER_PROBE_TIMEOUT_S:.0f}s; check `docker ps`.")
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def container_in_compose_project(name: str) -> bool:
+    """True when `name` is a container this launcher's compose project created,
+    rather than a hand-started one that happens to share the name."""
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "-f", '{{index .Config.Labels "com.docker.compose.project"}}', name],
+            text=True,
+            stdin=subprocess.DEVNULL,
+            check=False,
+            capture_output=True,
+            timeout=DOCKER_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0 and result.stdout.strip() == COMPOSE_PROJECT_NAME
 
 
 def remove_legacy_cloud_agent() -> None:
@@ -728,15 +791,12 @@ def remove_legacy_cloud_agent() -> None:
 
     It is no longer a service of this compose project, so `down` cannot see it,
     and it holds host port 8765 -- which the Foxglove bridge now publishes on.
+    Only a container this launcher started is removed: the same name run by hand
+    (an own fork, or one serving a physical MARS) is left alone.
     """
-    result = subprocess.run(
-        ["docker", "rm", "-f", "innate-cloud-agent"],
-        text=True,
-        stdin=subprocess.DEVNULL,
-        check=False,
-        capture_output=True,
-    )
-    if result.returncode == 0 and result.stdout.strip():
+    if not container_in_compose_project(LEGACY_CLOUD_AGENT_CONTAINER):
+        return
+    if force_remove_container(LEGACY_CLOUD_AGENT_CONTAINER):
         log("Removed the leftover cloud-agent container; the brain now runs inside brain_client.")
 
 
@@ -792,9 +852,9 @@ def open_os_container_shell() -> int:
     Uses an interactive (TTY) shell so ~/.zshrc runs and sources ROS — a
     non-interactive `zsh -lc` would leave `ros2` and the workspace unsourced.
     """
-    if not container_running("innate-dev"):
+    if not container_running(OS_CONTAINER_NAME):
         raise StackError(f"Innate OS dev container is not running.\nStart it with `{CLI_SIM} up` first.")
-    return subprocess.run(["docker", "exec", "-it", "innate-dev", "zsh"]).returncode
+    return subprocess.run(["docker", "exec", "-it", OS_CONTAINER_NAME, "zsh"]).returncode
 
 
 def capture_command_output(
@@ -876,7 +936,7 @@ def websocket_port_open(port: int) -> bool:
 
 
 def collect_os_process_status(config: dict[str, object]) -> dict[str, bool]:
-    os_running = container_running("innate-dev")
+    os_running = container_running(OS_CONTAINER_NAME)
     status = {
         "os_running": os_running,
         "os_session_running": False,
@@ -947,7 +1007,7 @@ _virtual_mars_confirmed = False
 
 def virtual_mars_ready(config: dict[str, object]) -> bool:
     """True if the virtual MARS driver is publishing /odom in the container."""
-    if not container_running("innate-dev"):
+    if not container_running(OS_CONTAINER_NAME):
         return False
     os_repo: Path = config["os_repo"]  # type: ignore[assignment]
     output = capture_command_output(
@@ -1026,7 +1086,10 @@ def wait_for_virtual_mars(config: dict[str, object], *, timeout_seconds: float =
 
 
 def runtime_already_running(config: dict[str, object]) -> bool:
-    return os_runtime_ready(config)
+    """The running stack is both complete and current. A container from an older
+    checkout serves the Foxglove bridge on a host port the dashboard no longer
+    prints, and only a recreate can move it -- so that stack is not reusable."""
+    return os_runtime_ready(config) and os_container_foxglove_port_current(config)
 
 
 def format_startup_check(ok: bool, label: str, detail: str) -> str:
@@ -1107,7 +1170,7 @@ def print_startup_checks(
 
 
 def capture_os_brain_logs(config: dict[str, object], lines: int = 18) -> list[str]:
-    if not container_running("innate-dev"):
+    if not container_running(OS_CONTAINER_NAME):
         return ["OS container offline."]
     os_repo: Path = config["os_repo"]  # type: ignore[assignment]
     compose_env = os_compose_env()

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -23,16 +23,11 @@ import oci
 from config import (
     ASSETS_IMAGE_LAYERS,
     CLI_SIM,
-    CLOUD_AGENT_DIR_NAME,
-    CLOUD_AGENT_LOG_PATH,
     COMPOSE_LOG_PATH,
     DOWN_LOG_PATH,
     GENERATED_OS_ENV_PATH,
-    HOSTED_MODE,
-    LOCAL_BRAIN_COMPOSE_PROFILE,
-    LOCAL_IMAGE_MODE,
-    LOCAL_MODES,
-    NONE_MODE,
+    INNATE_BACKEND,
+    NO_BACKEND,
     OS_BUILD_LOG_PATH,
     OS_CONTAINER_SERVICE,
     OS_CONTAINER_TMUX_CMD,
@@ -46,7 +41,6 @@ from config import (
     TMUX_SESSION_NAME,
     VIEWER_BUILD_LOG_PATH,
     VIEWER_TREE_PATH,
-    WORKSPACE_ROOT,
     WORLD_SERVER_LOG_PATH,
     WORLD_SERVER_MODEL_DIGEST_PATH,
     WORLD_SERVER_PID_PATH,
@@ -56,7 +50,6 @@ from config import (
     compute_ros_install_validation_hash,
     ensure_state_dir,
     log,
-    require_path,
     resolve_assets_image,
     resolve_local_os_image,
     resolve_local_viewer_image,
@@ -590,17 +583,6 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         # whichever it is exists.
         compose_values["INNATE_SIM_VIEWER_BUNDLE_IMAGE"] = viewer_image_ref(config)
         compose_values["VIRTUAL_MARS_REMOTE"] = str(config.get("world_endpoint", "") or "")
-        # Bake the brain wiring into the CONTAINER env, not just the tmux
-        # launch args: an in-container `innate restart` relaunches the session
-        # argless and must inherit the same backend (compose's own default
-        # only fires when COMPOSE_PROFILES is set, which it isn't here).
-        compose_values["BRAIN_WEBSOCKET_URI"] = str(config.get("brain_websocket_uri", "") or "")
-        # Foxglove bridge publishes on host 8765 (Foxglove Studio's default) —
-        # but a local brain's cloud-agent owns that host port, so shift the
-        # bridge to 8766 unless the user pinned a port themselves.
-        if not os.environ.get("SIM_FOXGLOVE_PORT", "").strip() and config["mode"] not in (HOSTED_MODE, NONE_MODE):
-            compose_values["SIM_FOXGLOVE_PORT"] = "8766"
-            log("Local brain owns port 8765; Foxglove bridge published on ws://localhost:8766.")
         compose_env = os_compose_env(compose_values, env_file=os_env_file)
         log("Starting Innate OS dev container...")
         run_logged_with_heartbeat(
@@ -655,10 +637,6 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         ROS_INSTALL_STATE_PATH.write_text(f"{ros_inputs_hash}\n", encoding="utf-8")
 
     log("Launching ROS simulation nodes inside the OS container...")
-    brain_websocket_uri = str(config.get("brain_websocket_uri", "")).strip()
-    brain_websocket_arg = ""
-    if brain_websocket_uri:
-        brain_websocket_arg = f" --brain-websocket-uri {shlex.quote(brain_websocket_uri)}"
     brain_client_version = str(config.get("brain_client_version", "")).strip()
     brain_client_version_arg = ""
     if brain_client_version:
@@ -666,7 +644,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
     launch_script = (
         "INNATE_SIM_TMUX_SETTLE_SECONDS=${INNATE_SIM_TMUX_SETTLE_SECONDS:-0} "
         "INNATE_SIM_TMUX_CLEANUP_SETTLE_SECONDS=${INNATE_SIM_TMUX_CLEANUP_SETTLE_SECONDS:-0} "
-        f"{OS_CONTAINER_TMUX_CMD}{brain_websocket_arg}{brain_client_version_arg}"
+        f"{OS_CONTAINER_TMUX_CMD}{brain_client_version_arg}"
     )
     launch_wrapper = (
         "rm -f /tmp/innate-os-session.log; "
@@ -731,191 +709,35 @@ def down_os(config: dict[str, object], *, remove_volumes: bool = False) -> None:
 
 def clean_runtime(config: dict[str, object]) -> None:
     """Stop the runtime and delete all related Docker resources."""
-    down_cloud_agent()
+    remove_legacy_cloud_agent()
     log("Removing Innate OS containers, networks, and named volumes...")
     down_os(config, remove_volumes=True)
     # Belt-and-suspenders: force-remove named containers that may linger outside
     # the compose project (e.g. after a partial or failed startup).
-    for container in ("innate-dev", "innate-cloud-agent"):
-        subprocess.run(
-            ["docker", "rm", "-f", container],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
-
-
-def cloud_agent_lock(config: dict[str, object]) -> dict | None:
-    """The pinned cloud-agent revision this innate-os is tested against
-    (sim/cloud-agent.lock), or None when unpinned/unreadable."""
-    os_repo: Path = config["os_repo"]  # type: ignore[assignment]
-    try:
-        lock = json.loads((os_repo / "sim" / "cloud-agent.lock").read_text())
-        return lock if isinstance(lock.get("commit"), str) else None
-    except (OSError, ValueError):
-        return None
-
-
-def cloud_agent_git_status(repo: Path) -> dict | None:
-    """Local-only git state of a cloud-agent checkout (no network): full/short
-    HEAD sha, dirty, and whether origin is the official innate repo."""
-
-    def git(*args: str) -> str | None:
-        result = subprocess.run(
-            ["git", "-C", str(repo), *args],
-            capture_output=True,
-            text=True,
-            timeout=10.0,
-            stdin=subprocess.DEVNULL,
-            check=False,
-        )
-        return result.stdout.strip() if result.returncode == 0 else None
-
-    try:
-        sha = git("rev-parse", "HEAD")
-        if sha is None:
-            return None
-        origin = git("remote", "get-url", "origin") or ""
-        return {
-            "sha": sha,
-            "short": sha[:9],
-            "dirty": bool(git("status", "--porcelain")),
-            "official": origin.rstrip("/").removesuffix(".git").endswith("innate-inc/innate-cloud-agent"),
-        }
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-
-
-def cloud_agent_checkout_pinned(repo: Path, commit: str) -> bool:
-    """Fetch + detach onto the pinned revision. Callers must ensure the
-    worktree is clean first."""
-    for args in (["fetch", "--quiet", "origin"], ["checkout", "--quiet", "--detach", commit]):
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(repo), *args],
-                stdin=subprocess.DEVNULL,
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=120.0,
-            )
-        except subprocess.TimeoutExpired:
-            return False
-        if result.returncode != 0:
-            return False
-    return True
-
-
-def _os_container_holds_host_8765() -> bool:
-    """True when a running innate-dev publishes its Foxglove port on host 8765
-    (a container created under hosted/no-brain mode, before a local-brain up
-    would have shifted the publish to 8766)."""
-    try:
-        result = subprocess.run(
-            ["docker", "port", "innate-dev", "8765"],
-            text=True,
-            stdin=subprocess.DEVNULL,
-            capture_output=True,
-            check=False,
-            timeout=DOCKER_PROBE_TIMEOUT_S,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return result.returncode == 0 and any(line.strip().endswith(":8765") for line in result.stdout.splitlines())
-
-
-def start_cloud_agent(config: dict[str, object], cloud_env_file: Path) -> None:
-    """Bring up the local brain as the `cloud-agent` service in the OS compose
-    project (gated by the local-brain profile). Hosted/none modes run no local
-    agent."""
-    mode = config["mode"]
-    if mode == HOSTED_MODE:
-        log("Brain backend is hosted. Skipping local cloud-agent startup.")
-        return
-    if mode == NONE_MODE:
-        log("No brain backend configured (no GEMINI_API_KEY or INNATE_SERVICE_KEY). Skipping cloud-agent.")
-        return
-
-    ensure_docker_available(command_hint=f"{CLI_SIM} up")
-    os_repo: Path = config["os_repo"]  # type: ignore[assignment]
-
-    # The cloud-agent reads GEMINI_API_KEY from the same env file as the OS
-    # container, and the local-brain profile must be active to start the service.
-    base_env = {
-        "COMPOSE_PROFILES": LOCAL_BRAIN_COMPOSE_PROFILE,
-        "INNATE_OS_ENV_FILE": str(cloud_env_file),
-    }
-    # An OS container that predates this local-brain up may still publish the
-    # Foxglove bridge on host 8765 (this runs before ensure_os_container, and a
-    # running container is not recreated anyway). The cloud-agent host publish
-    # is debug-only — the brain reaches it over the compose network — so shift
-    # it clear rather than failing the bind (8767: 8766 is Foxglove's own
-    # local-brain port, live again as soon as the OS container is recreated).
-    if not os.environ.get("SIM_CLOUD_AGENT_PORT", "").strip() and _os_container_holds_host_8765():
-        base_env["SIM_CLOUD_AGENT_PORT"] = "8767"
-        log("Host port 8765 is held by the running OS container (Foxglove); publishing cloud-agent on 8767.")
-    up_cmd = docker_compose_cmd("up", "-d")
-
-    if mode == LOCAL_IMAGE_MODE:
-        image = str(config["cloud_image"]).strip()
-        if not image:
-            raise StackError("sim/config.toml must set cloud_agent.image when cloud_agent.mode = 'local-image'.")
-        log(f"Starting local cloud-agent image {image}...")
-        compose_env = docker_compose_env({**base_env, "INNATE_CLOUD_AGENT_IMAGE": image})
-        run_logged(
-            [*up_cmd, "--no-build", "cloud-agent"],
-            cwd=os_repo,
-            env=compose_env,
-            log_path=CLOUD_AGENT_LOG_PATH,
-            failure_message="Local cloud-agent image startup failed.",
-        )
-        return
-
-    cloud_repo: Path | None = config["cloud_repo"]  # type: ignore[assignment]
-    if cloud_repo is None:
-        raise StackError(
-            "The innate-cloud-agent repository was not found next to innate-os "
-            f"(expected at {WORKSPACE_ROOT / CLOUD_AGENT_DIR_NAME}).\n"
-            f"Run `{CLI_SIM} setup` to clone it, or set sim/config.toml cloud_agent.source_dir."
-        )
-    require_path(cloud_repo, "innate-cloud-agent repository")
-    # Surface what will actually run: a checkout off the pinned (tested)
-    # revision is the #1 source of "agent crashes for me" reports. Local-only
-    # check; aligning is setup's interactive job.
-    status = cloud_agent_git_status(cloud_repo)
-    lock = cloud_agent_lock(config)
-    if status is not None and lock is not None and status["official"] and status["sha"] != lock["commit"]:
-        warn(
-            f"cloud-agent source is at {status['short']}, but this innate-os is tested against "
-            f"{lock['commit'][:9]} -- run `{CLI_SIM} setup` to align (or ignore if intentional)."
-        )
-    elif status is not None and not status["official"]:
-        log(
-            f"Using custom cloud-agent source at {cloud_repo} ({status['short']}{', dirty' if status['dirty'] else ''})."
-        )
-    log(f"Starting local cloud-agent from source at {cloud_repo}...")
-    compose_env = docker_compose_env({**base_env, "INNATE_CLOUD_AGENT_DIR": str(cloud_repo)})
-    run_logged(
-        [*up_cmd, "--build", "cloud-agent"],
-        cwd=os_repo,
-        env=compose_env,
-        log_path=CLOUD_AGENT_LOG_PATH,
-        failure_message="Local cloud-agent source startup failed.",
+    subprocess.run(
+        ["docker", "rm", "-f", "innate-dev"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
     )
 
 
-def down_cloud_agent() -> None:
-    # The cloud-agent now lives in the OS compose project, so `down_os` removes it.
-    # This is a defensive cleanup in case it was started on its own.
-    subprocess.run(
+def remove_legacy_cloud_agent() -> None:
+    """Drop the cloud-agent container older checkouts ran the brain in.
+
+    It is no longer a service of this compose project, so `down` cannot see it,
+    and it holds host port 8765 -- which the Foxglove bridge now publishes on.
+    """
+    result = subprocess.run(
         ["docker", "rm", "-f", "innate-cloud-agent"],
         text=True,
         stdin=subprocess.DEVNULL,
         check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
     )
+    if result.returncode == 0 and result.stdout.strip():
+        log("Removed the leftover cloud-agent container; the brain now runs inside brain_client.")
 
 
 def tail_file(path: Path, limit: int = 40) -> str:
@@ -1160,12 +982,10 @@ def collect_runtime_probe(
     os_status = collect_os_process_status(config)
     sim_running = bool(sim_driver_ready) if sim_driver_ready is not None else _sim_driver_live(config, os_status)
     rosbridge_live = _rosbridge_live(os_status)
-    agent_running = container_running("innate-cloud-agent") if config["mode"] in LOCAL_MODES else True
     return {
         "os_status": os_status,
         "sim_running": sim_running,
         "rosbridge_live": rosbridge_live,
-        "agent_running": agent_running,
     }
 
 
@@ -1206,11 +1026,7 @@ def wait_for_virtual_mars(config: dict[str, object], *, timeout_seconds: float =
 
 
 def runtime_already_running(config: dict[str, object]) -> bool:
-    if not os_runtime_ready(config):
-        return False
-    if config["mode"] in LOCAL_MODES and not container_running("innate-cloud-agent"):
-        return False
-    return True
+    return os_runtime_ready(config)
 
 
 def format_startup_check(ok: bool, label: str, detail: str) -> str:
@@ -1256,11 +1072,6 @@ def print_startup_checks(
         time.sleep(2.0)  # a saturated box can miss one ping; don't cry wolf
         world_ok, world_detail = world_server_health()
     checks = [
-        (
-            bool(probe["agent_running"]),
-            "Cloud agent",
-            "hosted mode" if config["mode"] == HOSTED_MODE else "local container",
-        ),
         (world_ok, "World server", world_detail),
         (
             os_status["os_running"],
@@ -1326,19 +1137,6 @@ def capture_os_brain_logs(config: dict[str, object], lines: int = 18) -> list[st
         ][:lines]
     if not output:
         return ["No OS brain output yet."]
-    return output.splitlines()[-lines:]
-
-
-def capture_agent_logs(config: dict[str, object], lines: int = 18) -> list[str]:
-    if config["mode"] == HOSTED_MODE:
-        return ["Hosted mode enabled.", "No local agent container is running."]
-    if config["mode"] == NONE_MODE:
-        return ["No brain backend configured.", "The sim is running without an agent."]
-    if not container_running("innate-cloud-agent"):
-        return ["Local cloud-agent is not running."]
-    output = capture_command_output(["docker", "logs", "--tail", str(lines), "innate-cloud-agent"])
-    if not output:
-        return ["No local cloud-agent output yet."]
     return output.splitlines()[-lines:]
 
 
@@ -2092,7 +1890,6 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
     os_session_running = os_status["os_session_running"]
     rosbridge_process_live = os_status["rosbridge_process_live"]
     brain_process_live = os_status["brain_process_live"]
-    agent_running = bool(probe["agent_running"])
     sim_running = bool(probe["sim_running"])
     rosbridge_live = bool(probe["rosbridge_live"])
 
@@ -2126,15 +1923,14 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
     else:
         brain_level = "warn"
         brain_label = "booting"
-    if config["mode"] == NONE_MODE:
-        agent_level, agent_label = "warn", "none"
-    elif config["mode"] == HOSTED_MODE:
-        agent_level, agent_label = "healthy", "hosted"
+    if config["brain_backend"] == NO_BACKEND:
+        llm_level, llm_label = "warn", "no key"
+    elif config["brain_backend"] == INNATE_BACKEND:
+        llm_level, llm_label = "healthy", "innate proxy"
     else:
-        agent_level = "healthy" if agent_running else "warn"
-        agent_label = "online" if agent_running else "offline"
+        llm_level, llm_label = "healthy", "gemini key"
 
-    if all(level == "healthy" for level in (world_level, sim_level, transport_level, brain_level, agent_level)):
+    if all(level == "healthy" for level in (world_level, sim_level, transport_level, brain_level, llm_level)):
         stack_mood = ("healthy", "LIVE")
     elif any(level == "error" for level in (world_level, sim_level, transport_level, brain_level)):
         stack_mood = ("error", "DEGRADED")
@@ -2151,7 +1947,6 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
     return {
         "os_running": os_running,
         "os_session_running": os_session_running,
-        "agent_running": agent_running,
         "sim_running": sim_running,
         "rosbridge_live": rosbridge_live,
         "rosbridge_process_live": rosbridge_process_live,
@@ -2164,8 +1959,8 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
         "transport_label": transport_label,
         "brain_level": brain_level,
         "brain_label": brain_label,
-        "agent_level": agent_level,
-        "agent_label": agent_label,
+        "llm_level": llm_level,
+        "llm_label": llm_label,
         "stack_level": stack_mood[0],
         "stack_label": stack_mood[1],
         "health_score": health_score(stack_mood[0]),

--- a/sim/launcher/setup_wizard.py
+++ b/sim/launcher/setup_wizard.py
@@ -10,27 +10,16 @@ from pathlib import Path
 
 from config import (
     CLI_SIM,
-    CLOUD_AGENT_DIR_NAME,
-    CLOUD_AGENT_GIT_URL,
     ENV_PATH,
     GEMINI_API_KEY,
+    INNATE_SERVICE_KEY,
     SECRET_ENV_KEYS,
-    WORKSPACE_ROOT,
     is_configured_secret_value,
-    log,
     success,
     warn,
 )
 from dashboard import BOLD, CYAN, DIM, GREEN, NC, YELLOW
-from runtime import (
-    UV_INSTALL_COMMAND,
-    cloud_agent_checkout_pinned,
-    cloud_agent_git_status,
-    cloud_agent_lock,
-    find_uv,
-)
-
-INNATE_SERVICE_KEY = "INNATE_SERVICE_KEY"
+from runtime import UV_INSTALL_COMMAND, find_uv
 
 
 def is_interactive_terminal() -> bool:
@@ -317,7 +306,7 @@ def _configure_service_key(config: dict[str, object]) -> None:
         service_key = _prompt_secret(f"Paste {INNATE_SERVICE_KEY}")
         if is_configured_secret(service_key):
             _save_service_key(config, service_key)
-            print(f"{GREEN}Hosted brain credentials are ready.{NC}")
+            print(f"{GREEN}Innate proxy credentials are ready.{NC}")
             return
         warn("Service key cannot be empty. Press Ctrl+C to cancel.")
 
@@ -345,70 +334,6 @@ def ensure_uv_prerequisite() -> None:
         warn(f"uv installation did not complete. Install it manually: {UV_INSTALL_COMMAND}")
 
 
-def ensure_cloud_agent_repo(config: dict[str, object]) -> None:
-    """Make the local cloud-agent source match sim/cloud-agent.lock -- the
-    revision this innate-os is tested against. A fresh clone lands on the
-    pin; an existing checkout on any other commit gets a warning and an
-    offer to align (never forced: forks and deliberate experiments answer
-    "no" and are left alone)."""
-    lock = cloud_agent_lock(config)
-
-    path: Path | None = None
-    existing = config.get("cloud_repo")
-    if existing and Path(str(existing)).exists():
-        path = Path(str(existing))
-    elif (WORKSPACE_ROOT / CLOUD_AGENT_DIR_NAME).exists():
-        path = WORKSPACE_ROOT / CLOUD_AGENT_DIR_NAME
-
-    if path is not None:
-        status = cloud_agent_git_status(path)
-        if status is None or lock is None:
-            success(f"Cloud-agent source present at {path}.")
-            return
-        if not status["official"]:
-            log(f"Using custom cloud-agent source at {path} ({status['short']}).")
-            return
-        if status["sha"] == lock["commit"]:
-            success(f"Cloud-agent source present at {path} (tested revision {status['short']}).")
-            return
-        warn(
-            f"Cloud-agent at {path} is at {status['short']}; this innate-os is tested "
-            f"against {lock['commit'][:9]}. Other revisions may crash the agent."
-        )
-        if status["dirty"]:
-            warn(
-                f"Checkout has local changes -- align manually: git -C {path} stash && git -C {path} checkout {lock['commit'][:9]}"
-            )
-            return
-        if is_interactive_terminal() and _prompt_yes_no("Check out the tested revision now?", default=True):
-            if cloud_agent_checkout_pinned(path, lock["commit"]):
-                success(f"Cloud-agent aligned to {lock['commit'][:9]}.")
-            else:
-                warn(
-                    f"Could not check out {lock['commit'][:9]} -- align manually with git -C {path} fetch && git -C {path} checkout {lock['commit'][:9]}."
-                )
-        else:
-            warn("Keeping the current revision.")
-        return
-
-    target = WORKSPACE_ROOT / CLOUD_AGENT_DIR_NAME
-    log(f"Cloning innate-cloud-agent into {target}...")
-    result = subprocess.run(
-        ["git", "clone", CLOUD_AGENT_GIT_URL, str(target)],
-        stdin=subprocess.DEVNULL,
-        check=False,
-    )
-    if result.returncode != 0:
-        warn(
-            f"Could not clone {CLOUD_AGENT_GIT_URL}. Clone it manually to {target} "
-            "(needs GitHub SSH access to innate-inc)."
-        )
-        return
-    if lock is not None and not cloud_agent_checkout_pinned(target, lock["commit"]):
-        warn(f"Cloned, but could not check out the tested revision {lock['commit'][:9]}; using the default branch.")
-    success(f"Cloned innate-cloud-agent to {target}" + (f" (tested revision {lock['commit'][:9]})." if lock else "."))
-
-
 def _disable_keys(config: dict[str, object], keys: list[str]) -> None:
     """Comment out the given keys in .env (only if currently configured) so the
     selected backend isn't overridden by a leftover key, and forget them for this
@@ -433,28 +358,27 @@ def report_configured_keys(config: dict[str, object]) -> None:
 
 
 def configure_brain_backend(config: dict[str, object]) -> None:
-    """Pick the brain backend and collect the matching key.
+    """Pick how the robot's brain reaches Gemini, and collect the matching key.
 
-    Local needs a Gemini key (and the cloud-agent source); hosted needs an Innate
-    service key; none runs the sim without an agent. Switching backends just
-    uncomments the relevant key and comments out the others, so you can toggle
-    back and forth without re-pasting. Non-interactively, just report what
-    auto-detection will pick.
+    The agent loop itself always runs on the robot (brain_client); the key only
+    decides which way out it takes -- straight to Google with a Gemini key, or
+    through the Innate proxy with a service key. Switching just uncomments the
+    relevant key and comments out the others, so you can toggle back and forth
+    without re-pasting. Non-interactively, just report what the robot will pick.
     """
     user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
     has_gemini = is_configured_secret_value(GEMINI_API_KEY, user_env.get(GEMINI_API_KEY))
     has_service_key = is_configured_secret(user_env.get(INNATE_SERVICE_KEY))
 
     if not is_interactive_terminal():
-        if has_gemini:
-            ensure_cloud_agent_repo(config)
-            success("Local brain selected (GEMINI_API_KEY detected).")
-        elif has_service_key:
-            success("Hosted brain selected (INNATE_SERVICE_KEY detected).")
+        if has_service_key:
+            success("Innate proxy selected (INNATE_SERVICE_KEY detected).")
+        elif has_gemini:
+            success("Direct Gemini access selected (GEMINI_API_KEY detected).")
         else:
             warn(
-                "No brain backend configured. Add GEMINI_API_KEY (local brain) or "
-                f"INNATE_SERVICE_KEY (hosted) to {ENV_PATH}."
+                f"No brain key configured. Add GEMINI_API_KEY (your own Gemini key) or "
+                f"INNATE_SERVICE_KEY (Innate proxy) to {ENV_PATH}."
             )
         report_configured_keys(config)
         return
@@ -462,16 +386,16 @@ def configure_brain_backend(config: dict[str, object]) -> None:
     print()
     print(f"{CYAN}{BOLD}Cloud LLM Access{NC}")
     print(
-        f"{DIM}The robot's agent uses a cloud LLM to think. Choose how to reach it:\n"
-        f"  - Your own Gemini key: clones the open-source agent\n"
-        f"    (https://github.com/innate-inc/innate-cloud-agent) and runs it on this\n"
-        f"    machine. Everything works except voice.\n"
-        f"  - Innate service key (ships with a MARS robot): the same agent, run by\n"
-        f"    Innate. Full experience, including the robot's voice.\n"
+        f"{DIM}The robot's agent runs on the robot, but thinks with a cloud LLM.\n"
+        f"Choose how it reaches one:\n"
+        f"  - Your own Gemini key: the agent calls Google directly. Everything\n"
+        f"    works except voice.\n"
+        f"  - Innate service key (ships with a MARS robot): the agent calls Gemini\n"
+        f"    through Innate's proxy. Full experience, including the robot's voice.\n"
         f"  - None: drive, navigate, and trigger skills manually, with no agent.{NC}"
     )
     print()
-    default_choice = "1" if has_gemini else ("2" if has_service_key else "1")
+    default_choice = "2" if has_service_key else "1"
     choice = _prompt_choice(
         "How would you like to access the cloud LLM?",
         {
@@ -483,7 +407,6 @@ def configure_brain_backend(config: dict[str, object]) -> None:
     )
     if choice == "1":
         _configure_gemini_key(config)
-        ensure_cloud_agent_repo(config)
         _disable_keys(config, [INNATE_SERVICE_KEY])
     elif choice == "2":
         _configure_service_key(config)


### PR DESCRIPTION
The brain runs in-process inside `brain_client` now — `scripts/launch_sim_in_tmux.zsh` already ignores `--brain-websocket-uri` as obsolete — so the sim launcher was the last thing still cloning, building, and pointing the robot at an external agent nobody connects to.

## What `./innate-sim setup` does now

The key prompts stay (innate-os itself needs them), reworded to say what is actually true: the agent loop always runs on the robot, and the choice is only *how it reaches Gemini* — your own Gemini key straight to Google, an Innate service key through the proxy (adds voice), or none. No clone, no lock alignment, no `[cloud_agent]` config.

## Removed

- **`setup_wizard.py`** — `ensure_cloud_agent_repo`: the clone, the pinned checkout, the drift prompts.
- **`config.py`** — the `hosted`/`local-image`/`local-source`/`auto`/`none` mode machinery, `BRAIN_WEBSOCKET_URI` resolution, `build_cloud_env`, the cloud-agent log target, `cloud_repo`/`cloud_port`/`cloud_image`. In their place `resolve_brain_backend` just reports which key is set — service key wins, matching `brain/transport.py:pick_transport`, so the dashboard cannot lie about the backend.
- **`runtime.py`** — `start_cloud_agent`, the git lock/status/checkout helpers, the 8766/8767 Foxglove port shuffle (the bridge is back on 8765 unconditionally), the `BRAIN_WEBSOCKET_URI` compose value and launch flag, `capture_agent_logs`, the "Cloud agent" startup check.
- **`dashboard.py`** — the AGENT LOGS pane and its worker thread, the "Cloud mode" / "Local agent" / cloud-repo lines. The `Agent:` field becomes `LLM: innate proxy | gemini key | no key`.
- **elsewhere** — the `cloud-agent` compose service and `local-brain` profile, `sim/cloud-agent.lock`, the `[cloud_agent]` template section, the `.gitignore` entry, `./innate-sim logs cloud-agent`.

## One thing kept deliberately

`remove_legacy_cloud_agent()` runs on `up`, `down`, and `clean`. The old container is no longer a service of this compose project, so `down` cannot see it, and it holds host port 8765 — which the Foxglove bridge now publishes on. It logs a line only when it actually removes something.

## Verification

- `ruff check` + `ruff format --check` clean on `sim/launcher/`
- 38 repo tests pass (`tests/`, including `test_launcher_imports` over every launcher module)
- `docker compose -f sim/docker-compose.dev.yml config -q` validates
- exercised by hand: `./innate-sim setup </dev/null`, `status`, `logs --help`, plus the dashboard render and `dashboard_runtime` paths

Robot-side `BRAIN_WEBSOCKET_URI` mentions (`scripts/update/post_update.sh`, `docs/PARAMETERS.md`) are left alone — this change is scoped to the sim.