### PR TITLE
fix(sim): warn when the daemon is a Docker 29 that cannot mount images

### DIFF
--- a/.github/workflows/launcher-tests.yml
+++ b/.github/workflows/launcher-tests.yml
@@ -1,0 +1,27 @@
+name: Launcher Tests
+
+# tests/ guards host-side, no-ROS invariants (launcher preflights, image-tag
+# hashing, workflow path filters); nothing else in CI runs pytest, so without
+# this job the suite only runs when a developer remembers to.
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # 3.12 for stdlib tomllib; the launcher itself still supports 3.10+tomli.
+          python-version: "3.12"
+
+      - name: Run the host-side test suite
+        run: |
+          pip install pytest pyyaml
+          python -m pytest tests/ -q

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -292,6 +292,51 @@ def ensure_docker_available(*, command_hint: str = CLI_SIM, require_compose: boo
         command_hint,
         COMPOSE_INSTALL_URL,
     )
+    _warn_broken_image_mounts(result.stdout, command_hint)
+
+
+# Docker 29.0.0 started naming an image mount's layer directory after the hex of
+# the whole `<digest>,src=<ref>,dst=<target>` spec -- twice its length, against
+# NAME_MAX=255. Our refs are content-addressed (`inputs-` + 64 hex), so the spec
+# is 218 chars and `up` dies at container create with "file name too long".
+# moby#51687, fixed in 29.1.4. Not a warning we can act on for the user: even the
+# `:main` default is over the ~53-char budget the two viewer targets leave.
+BROKEN_IMAGE_MOUNT_VERSIONS = ((29, 0, 0), (29, 1, 4))
+
+
+def _warn_broken_image_mounts(version_output: str | None, command_hint: str) -> None:
+    """Warn when the daemon is one that cannot mount the viewer's assets.
+
+    A warning rather than a refusal: every other verb works, and a stale patch
+    release should not be the launcher's call to make. Silent on an unparseable
+    version, like _require_min_version.
+    """
+    found = re.search(r"(\d+)\.(\d+)\.(\d+)", version_output or "")
+    if not found:
+        return
+    low, fixed = BROKEN_IMAGE_MOUNT_VERSIONS
+    if not low <= (int(found.group(1)), int(found.group(2)), int(found.group(3))) < fixed:
+        return
+    first_broken = ".".join(str(part) for part in low)
+    last_broken = ".".join(str(part) for part in (*fixed[:2], fixed[2] - 1))
+    fixed_version = ".".join(str(part) for part in fixed)
+    remedy = (
+        f"Update Docker Desktop to {fixed_version} or newer."
+        if sys.platform == "darwin"
+        else (
+            f"Update Docker Engine to {fixed_version} or newer. Ubuntu's docker.io can sit on a\n"
+            "      broken patch with nothing newer to upgrade to -- if `apt` offers none, switch to\n"
+            "      Docker's own repo: `curl -fsSL https://get.docker.com | sudo sh`"
+        )
+    )
+    warn(
+        f"Docker Engine {found.group(0)} cannot mount the sim viewer's assets.\n"
+        f"      {first_broken}-{last_broken} fail every `type: image` mount with 'file name too long'\n"
+        f"      (moby#51687), so `{command_hint}` will die at container create. No launcher-side\n"
+        f"      workaround exists -- the mount spec is over budget even for the shortest ref.\n"
+        f"      {remedy}\n"
+        f"      Details: https://github.com/moby/moby/issues/51687"
+    )
 
 
 def _require_min_version(

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -292,7 +292,7 @@ def ensure_docker_available(*, command_hint: str = CLI_SIM, require_compose: boo
         command_hint,
         COMPOSE_INSTALL_URL,
     )
-    _warn_broken_image_mounts(result.stdout, command_hint)
+    _warn_broken_image_mounts(result.stdout)
 
 
 # Docker 29.0.0 started naming an image mount's layer directory after the hex of
@@ -304,12 +304,14 @@ def ensure_docker_available(*, command_hint: str = CLI_SIM, require_compose: boo
 BROKEN_IMAGE_MOUNT_VERSIONS = ((29, 0, 0), (29, 1, 4))
 
 
-def _warn_broken_image_mounts(version_output: str | None, command_hint: str) -> None:
+def _warn_broken_image_mounts(version_output: str | None) -> None:
     """Warn when the daemon is one that cannot mount the viewer's assets.
 
     A warning rather than a refusal: every other verb works, and a stale patch
-    release should not be the launcher's call to make. Silent on an unparseable
-    version, like _require_min_version.
+    release should not be the launcher's call to make. Names `up` rather than
+    the caller's command_hint -- every verb runs this preflight, but only `up`
+    creates the container the mount fails on. Silent on an unparseable version,
+    like _require_min_version.
     """
     found = re.search(r"(\d+)\.(\d+)\.(\d+)", version_output or "")
     if not found:
@@ -332,7 +334,7 @@ def _warn_broken_image_mounts(version_output: str | None, command_hint: str) -> 
     warn(
         f"Docker Engine {found.group(0)} cannot mount the sim viewer's assets.\n"
         f"      {first_broken}-{last_broken} fail every `type: image` mount with 'file name too long'\n"
-        f"      (moby#51687), so `{command_hint}` will die at container create. No launcher-side\n"
+        f"      (moby#51687), so `{CLI_SIM} up` will die at container create. No launcher-side\n"
         f"      workaround exists -- the mount spec is over budget even for the shortest ref.\n"
         f"      {remedy}\n"
         f"      Details: https://github.com/moby/moby/issues/51687"

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -236,6 +236,11 @@ def ensure_docker_available(*, command_hint: str = CLI_SIM, require_compose: boo
         )
         raise StackError(f"{message}\n{start_help}, then rerun `{command_hint}`.")
 
+    # Right after the engine probe, before any Compose check can raise over
+    # it: a broken-mount daemon plus an old Compose plugin are two problems,
+    # and fixing the second must not hide the first.
+    _warn_broken_image_mounts(result.stdout)
+
     if not require_compose:
         return
 
@@ -292,53 +297,56 @@ def ensure_docker_available(*, command_hint: str = CLI_SIM, require_compose: boo
         command_hint,
         COMPOSE_INSTALL_URL,
     )
-    _warn_broken_image_mounts(result.stdout)
 
 
-# Docker 29.0.0 started naming an image mount's layer directory after the hex of
-# the whole `<digest>,src=<ref>,dst=<target>` spec -- twice its length, against
-# NAME_MAX=255. Our refs are content-addressed (`inputs-` + 64 hex), so the spec
-# is 218 chars and `up` dies at container create with "file name too long".
-# moby#51687, fixed in 29.1.4. Not a warning we can act on for the user: even the
-# `:main` default is over the ~53-char budget the two viewer targets leave.
-BROKEN_IMAGE_MOUNT_VERSIONS = ((29, 0, 0), (29, 1, 4))
+# Docker 29.0.0 names an image mount's layer directory after the hex of the whole
+# mount spec -- past NAME_MAX=255 for even our shortest ref, so `up` dies at
+# container create with "file name too long" (moby#51687; 29.1.4 hashes it).
+BROKEN_IMAGE_MOUNTS_SINCE = (29, 0, 0)
+BROKEN_IMAGE_MOUNTS_FIXED = (29, 1, 4)
 
 
+@functools.cache  # `up` probes the daemon twice (cmd_up, then start_cloud_agent) -- warn once
 def _warn_broken_image_mounts(version_output: str | None) -> None:
-    """Warn when the daemon is one that cannot mount the viewer's assets.
-
-    A warning rather than a refusal: every other verb works, and a stale patch
-    release should not be the launcher's call to make. Names `up` rather than
-    the caller's command_hint -- every verb runs this preflight, but only `up`
-    creates the container the mount fails on. Silent on an unparseable version,
-    like _require_min_version.
-    """
-    found = re.search(r"(\d+)\.(\d+)\.(\d+)", version_output or "")
-    if not found:
+    """Warn -- not refuse, every other verb works -- when the daemon's `type: image`
+    mounts are broken, so `up` fails at preflight with a diagnosis instead of a hex
+    blob. Names `up` whichever verb ran the preflight: only `up` creates the
+    container. Silent on an unparseable version, like _require_min_version."""
+    version = _parse_version(version_output)
+    if version is None or len(version) < 3:
         return
-    low, fixed = BROKEN_IMAGE_MOUNT_VERSIONS
-    if not low <= (int(found.group(1)), int(found.group(2)), int(found.group(3))) < fixed:
+    if not BROKEN_IMAGE_MOUNTS_SINCE <= version < BROKEN_IMAGE_MOUNTS_FIXED:
         return
-    first_broken = ".".join(str(part) for part in low)
-    last_broken = ".".join(str(part) for part in (*fixed[:2], fixed[2] - 1))
-    fixed_version = ".".join(str(part) for part in fixed)
+    running = ".".join(map(str, version))
+    since = ".".join(map(str, BROKEN_IMAGE_MOUNTS_SINCE))
+    fixed = ".".join(map(str, BROKEN_IMAGE_MOUNTS_FIXED))
     remedy = (
-        f"Update Docker Desktop to {fixed_version} or newer."
+        f"Update Docker Desktop -- the app update ships a fixed engine ({fixed} or newer)."
         if sys.platform == "darwin"
         else (
-            f"Update Docker Engine to {fixed_version} or newer. Ubuntu's docker.io can sit on a\n"
-            "      broken patch with nothing newer to upgrade to -- if `apt` offers none, switch to\n"
-            "      Docker's own repo: `curl -fsSL https://get.docker.com | sudo sh`"
+            f"Update Docker Engine to {fixed} or newer (Docker Desktop: update the app).\n"
+            "      Ubuntu's docker.io can sit on a broken patch with nothing newer to upgrade\n"
+            "      to -- if `apt` offers none, switch to Docker's own repo:\n"
+            "      `curl -fsSL https://get.docker.com | sudo sh`"
         )
     )
     warn(
-        f"Docker Engine {found.group(0)} cannot mount the sim viewer's assets.\n"
-        f"      {first_broken}-{last_broken} fail every `type: image` mount with 'file name too long'\n"
-        f"      (moby#51687), so `{CLI_SIM} up` will die at container create. No launcher-side\n"
-        f"      workaround exists -- the mount spec is over budget even for the shortest ref.\n"
+        f"Docker Engine {running} cannot mount the sim viewer's assets.\n"
+        f"      Engines since {since} fail every `type: image` mount with 'file name too\n"
+        f"      long' (moby#51687, fixed in {fixed}), so `{CLI_SIM} up` will die at container\n"
+        f"      create. No launcher-side workaround exists -- the mount spec is over budget\n"
+        f"      even for the shortest ref.\n"
         f"      {remedy}\n"
         f"      Details: https://github.com/moby/moby/issues/51687"
     )
+
+
+def _parse_version(version_output: str | None) -> tuple[int, ...] | None:
+    """First `[v]major.minor[.patch]` in a version-command's output, or None."""
+    found = re.search(r"v?(\d+)\.(\d+)(?:\.(\d+))?", version_output or "")
+    if found is None:
+        return None
+    return tuple(int(part) for part in found.groups() if part is not None)
 
 
 def _require_min_version(
@@ -353,11 +361,11 @@ def _require_min_version(
     `minimum`. Silent when the version cannot be parsed: an unrecognised build
     string is not evidence of an old one, and a false refusal to start is worse
     than the raw error this pre-empts."""
-    found = re.search(r"v?(\d+)\.(\d+)", version_output or "")
-    if not found or (int(found.group(1)), int(found.group(2))) >= minimum:
+    version = _parse_version(version_output)
+    if version is None or version[:2] >= minimum:
         return
     raise StackError(
-        f"{label} {found.group(0)} is too old: the sim mounts its viewer assets straight from "
+        f"{label} {'.'.join(map(str, version))} is too old: the sim mounts its viewer assets straight from "
         f"an image (`type: image`), which needs {label} {minimum[0]}.{minimum[1]} or newer.\n"
         f"{remedy}, then rerun `{command_hint}`.\nGuide: {guide_url}"
     )

--- a/tests/test_broken_image_mount_versions.py
+++ b/tests/test_broken_image_mount_versions.py
@@ -2,14 +2,13 @@
 # Copyright (c) 2026 Innate Inc
 """Which Docker daemons the launcher warns about before `up` fails on them.
 
-The window is closed at both ends and patch-precise, which is the whole point:
-29.1.3 breaks every `type: image` mount and 29.1.4 fixes it (moby#51687), so a
-check that only reads major.minor -- like _require_min_version does -- would
-warn every 29.1.x user forever. Verified against real daemons in dind: 28.4.0
-and 29.1.4+ mount our 111-char asset ref fine, 29.0.0 and 29.1.3 do not, under
-both the overlay2 graphdriver and the containerd snapshotter.
+The window is patch-precise -- 29.1.3 breaks every `type: image` mount and
+29.1.4 fixes it (moby#51687) -- so it cannot fold into _require_min_version,
+which reads only major.minor. Boundaries verified against real daemons in dind,
+under both the overlay2 graphdriver and the containerd snapshotter.
 """
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -18,30 +17,41 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "sim" / "launcher"))
 
+import runtime  # noqa: E402
+
 
 @pytest.fixture
 def warnings(monkeypatch):
-    import runtime
-
     emitted: list[str] = []
     monkeypatch.setattr(runtime, "warn", emitted.append)
+    runtime._warn_broken_image_mounts.cache_clear()
     return emitted
 
 
 @pytest.mark.parametrize("version", ["29.0.0", "29.1.0", "29.1.3"])
 def test_a_broken_daemon_is_named_before_it_fails(warnings, version):
-    import runtime
-
     runtime._warn_broken_image_mounts(version)
     assert len(warnings) == 1
-    assert version in warnings[0]
+    # The running version, not the range literal the message also carries.
+    assert warnings[0].startswith(f"Docker Engine {version} ")
     assert "51687" in warnings[0]
+    assert f"{runtime.CLI_SIM} up" in warnings[0]
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [("darwin", "Docker Desktop"), ("linux", "get.docker.com")],
+)
+def test_the_remedy_matches_the_host_platform(warnings, monkeypatch, platform, expected):
+    monkeypatch.setattr(runtime.sys, "platform", platform)
+    runtime._warn_broken_image_mounts("29.1.3")
+    assert len(warnings) == 1
+    assert expected in warnings[0]
+    assert "29.1.4" in warnings[0]  # both remedies name the fixed engine
 
 
 @pytest.mark.parametrize("version", ["28.4.0", "29.1.4", "29.7.1", "30.0.0"])
 def test_a_working_daemon_says_nothing(warnings, version):
-    import runtime
-
     runtime._warn_broken_image_mounts(version)
     assert warnings == []
 
@@ -50,8 +60,25 @@ def test_an_unparseable_version_says_nothing(warnings):
     """`docker info` answered, but not with something we recognise. An
     unrecognised build string is not evidence of a broken one, and a false
     'your Docker is broken' sends people to reinstall for nothing."""
-    import runtime
-
     for output in ("", None, "dev", "29.1"):
         runtime._warn_broken_image_mounts(output)
     assert warnings == []
+
+
+def _fake_docker(engine_version):
+    def run(cmd, **kwargs):
+        stdout = engine_version if cmd[:2] == ["docker", "info"] else "Docker Compose version v2.39.1"
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    return run
+
+
+def test_the_preflight_wires_the_warning_in(warnings, monkeypatch):
+    """Deleting the ensure_docker_available call site must not leave the suite
+    green -- the direct tests above cannot see it."""
+    monkeypatch.setattr(runtime.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(runtime.subprocess, "run", _fake_docker("29.1.3"))
+    runtime.ensure_docker_available()
+    assert len(warnings) == 1 and "29.1.3" in warnings[0]
+    runtime.ensure_docker_available()
+    assert len(warnings) == 1  # `up` preflights twice; the user reads one warning

--- a/tests/test_broken_image_mount_versions.py
+++ b/tests/test_broken_image_mount_versions.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Which Docker daemons the launcher warns about before `up` fails on them.
+
+The window is closed at both ends and patch-precise, which is the whole point:
+29.1.3 breaks every `type: image` mount and 29.1.4 fixes it (moby#51687), so a
+check that only reads major.minor -- like _require_min_version does -- would
+warn every 29.1.x user forever. Verified against real daemons in dind: 28.4.0
+and 29.1.4+ mount our 111-char asset ref fine, 29.0.0 and 29.1.3 do not, under
+both the overlay2 graphdriver and the containerd snapshotter.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "sim" / "launcher"))
+
+
+@pytest.fixture
+def warnings(monkeypatch):
+    import runtime
+
+    emitted: list[str] = []
+    monkeypatch.setattr(runtime, "warn", emitted.append)
+    return emitted
+
+
+@pytest.mark.parametrize("version", ["29.0.0", "29.1.0", "29.1.3"])
+def test_a_broken_daemon_is_named_before_it_fails(warnings, version):
+    import runtime
+
+    runtime._warn_broken_image_mounts(version, "./innate-sim up")
+    assert len(warnings) == 1
+    assert version in warnings[0]
+    assert "51687" in warnings[0]
+
+
+@pytest.mark.parametrize("version", ["28.4.0", "29.1.4", "29.7.1", "30.0.0"])
+def test_a_working_daemon_says_nothing(warnings, version):
+    import runtime
+
+    runtime._warn_broken_image_mounts(version, "./innate-sim up")
+    assert warnings == []
+
+
+def test_an_unparseable_version_says_nothing(warnings):
+    """`docker info` answered, but not with something we recognise. An
+    unrecognised build string is not evidence of a broken one, and a false
+    'your Docker is broken' sends people to reinstall for nothing."""
+    import runtime
+
+    for output in ("", None, "dev", "29.1"):
+        runtime._warn_broken_image_mounts(output, "./innate-sim up")
+    assert warnings == []

--- a/tests/test_broken_image_mount_versions.py
+++ b/tests/test_broken_image_mount_versions.py
@@ -32,7 +32,7 @@ def warnings(monkeypatch):
 def test_a_broken_daemon_is_named_before_it_fails(warnings, version):
     import runtime
 
-    runtime._warn_broken_image_mounts(version, "./innate-sim up")
+    runtime._warn_broken_image_mounts(version)
     assert len(warnings) == 1
     assert version in warnings[0]
     assert "51687" in warnings[0]
@@ -42,7 +42,7 @@ def test_a_broken_daemon_is_named_before_it_fails(warnings, version):
 def test_a_working_daemon_says_nothing(warnings, version):
     import runtime
 
-    runtime._warn_broken_image_mounts(version, "./innate-sim up")
+    runtime._warn_broken_image_mounts(version)
     assert warnings == []
 
 
@@ -53,5 +53,5 @@ def test_an_unparseable_version_says_nothing(warnings):
     import runtime
 
     for output in ("", None, "dev", "29.1"):
-        runtime._warn_broken_image_mounts(output, "./innate-sim up")
+        runtime._warn_broken_image_mounts(output)
     assert warnings == []


### PR DESCRIPTION
Closes INN-789.

## The short version

INN-789 is real but its conclusion was wrong. This is not "Docker 29" — it is
**29.0.0 – 29.1.3**, an upstream bug ([moby#51687](https://github.com/moby/moby/issues/51687))
that was fixed in **29.1.4** back in January. So the launcher gets a diagnosis,
not the proposed short-alias workaround.

## What actually breaks

Docker 29.0.0 ([PR #50268](https://github.com/moby/moby/pull/50268)) began naming an image
mount's layer directory after the **hex** of the whole `<digest>,src=<ref>,dst=<target>`
spec — twice its length, against `NAME_MAX = 255`, so the spec must be ≤ 127 chars.

Fixed overhead is 74 (64-char digest + `,src=` + `,dst=`), leaving ~53 for ref + target.
Our asset ref is 111 chars (`ghcr.io/innate-inc/innate-os-sim-assets:` + `inputs-` + 64 hex)
and the spec runs 218, so `./innate-sim up` dies at container create with `file name too long`.

Fixed upstream by [#51827](https://github.com/moby/moby/pull/51827) /
[#51829](https://github.com/moby/moby/pull/51829) (hash the spec instead of embedding it),
milestone 29.1.4.

## Why a warning and not the workaround

The issue proposed making the launcher tag a short local alias and mount that. It works
mechanically, but it is permanent complexity — an explicit `docker pull` the launcher does
not do today, plus tag management and offline-path changes — to route around a bug that no
supported Docker has. There is also no partial fix available: the two viewer targets leave
~53 chars for digest + ref, and even the `:main` default is over budget. Shortening is not
a tuning knob.

So the preflight names the bug and the version that fixes it, and gets out of the way.
Warning rather than hard stop: every other verb works on these daemons, and a stale patch
release is not the launcher's call to make. On Linux the remedy mentions that a distro
package can be stuck on a broken patch with nothing newer to upgrade to — Ubuntu's
`docker.io` in particular — so the escape is switching to Docker's own repo.

Deliberately not folded into `_require_min_version`: that only parses major.minor, and a
major.minor check would warn every 29.1.x user forever.

```
[warn] Docker Engine 29.1.3 cannot mount the sim viewer's assets.
      29.0.0-29.1.3 fail every `type: image` mount with 'file name too long'
      (moby#51687), so `./innate-sim up` will die at container create. No launcher-side
      workaround exists -- the mount spec is over budget even for the shortest ref.
      Update Docker Engine to 29.1.4 or newer. Ubuntu's docker.io can sit on a
      broken patch with nothing newer to upgrade to -- if `apt` offers none, switch to
      Docker's own repo: `curl -fsSL https://get.docker.com | sudo sh`
      Details: https://github.com/moby/moby/issues/51687
```

## Verification

Real daemons in dind, the 111-char asset ref vs. a short alias, both image stores:

| Docker | overlay2 | containerd snapshotter |
|---|---|---|
| 28.4.0 | PASS | PASS |
| 29.0.0 | **FAIL** | — |
| 29.1.3 | **FAIL** | **FAIL** |
| 29.1.4 | PASS | PASS |
| 29.7.1 | PASS | PASS |

The short alias passed in every cell, including both failing ones — the fix mechanism was
sound, it is just unnecessary now.

Note this corrects INN-789's "same storage driver and snapshotter" reasoning: 29.1.3 fails
on **both** stores and 29.1.4 passes on both, so the image store never discriminated
anything. Only the version does. It also inverts "every dev breaks as they upgrade" —
upgrading past 29.1.3 is the fix.

`tests/test_broken_image_mount_versions.py` pins both ends of the window and the
unparseable-version silence. `pytest tests/` (46 passed) and `ruff check` / `ruff format
--check` are clean.