### PR TITLE
feat(teleop): make joystick feel more like a joystick

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1124,12 +1124,23 @@ select.skill-input {
   color: var(--muted);
 }
 
+/* Stick overlay. Chrome vars from joystick.js; forward-strength ignores sign. */
 .overlay-joystick {
+  --joystick-throw: 0;
+  --joystick-strafe: 0;
+  --joystick-forward: 0;
+  --joystick-forward-strength: abs(var(--joystick-forward));
+  --joystick-hit-size: 264px;
+  --joystick-pad-size: 184px;
   left: 50%;
   bottom: 84px;
   transform: translateX(-50%);
-  border-radius: 50%;
-  padding: 9px;
+  display: grid;
+  place-items: end center;
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
 }
 
 /* Bottom-center bar: holds the speak pill + the Skills menu as separate pills.
@@ -1733,67 +1744,124 @@ select.skill-input {
 }
 
 /* ---- joystick ------------------------------------------------------------ */
+/* Geometry (joystick.js): pad r=92, knob r=34; hit size = pad + margin.
+   Hit target is the root; pad + knob are siblings (nested glass kills blur). */
 
-.joystick {
-  display: block;
+.joystick-hit-target {
+  display: grid;
+  grid-template-rows: 1fr var(--joystick-pad-size);
+  justify-items: center;
+  width: var(--joystick-hit-size);
+  height: var(--joystick-hit-size);
   touch-action: none;
-  cursor: crosshair;
+  cursor: grab;
 }
 
-.joy-rim {
-  fill: none;
-  stroke: var(--hairline-strong);
-  stroke-width: 1;
-  transition: stroke 150ms ease;
+.joystick-hit-target.engaged {
+  cursor: grabbing;
 }
 
-.joystick.engaged .joy-rim {
-  stroke: rgb(255 255 255 / 26%);
+.joystick-hit-target > * {
+  grid-area: 2 / 1;
+  place-self: center;
 }
 
-.joystick.at-edge .joy-rim {
-  stroke: var(--accent-dim);
+.joystick-pad {
+  position: relative;
+  width: var(--joystick-pad-size);
+  height: var(--joystick-pad-size);
+  border-radius: 50%;
+  pointer-events: none;
+  /* White pool shifts with direction: top = forward, bottom = backward. */
+  background:
+    radial-gradient(
+      circle at 50% calc(50% - var(--joystick-forward) * 58%),
+      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.72)) 0%,
+      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.36)) 36%,
+      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.12)) 58%,
+      transparent 76%
+    ),
+    rgb(8 8 10 / 38%);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1.25px solid
+    rgb(255 255 255 / calc(0.28 + var(--joystick-forward-strength) * 0.5));
 }
 
-.joy-tick {
-  stroke: var(--hairline-strong);
-  stroke-width: 1;
+.joystick-direction {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  color: rgb(255 255 255 / calc(0.38 + var(--joystick-direction-strength) * 0.52));
+  opacity: calc(0.35 + var(--joystick-direction-strength) * 0.65);
 }
 
-.joy-trace {
-  stroke: var(--accent);
-  stroke-width: 1;
-  opacity: 0;
-  transition: opacity 150ms ease;
+.joystick-direction::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-left: 1.5px solid currentColor;
+  border-top: 1.5px solid currentColor;
+  transform: rotate(45deg);
 }
 
-.joystick.engaged .joy-trace,
-.joystick.mirroring .joy-trace {
-  opacity: 0.35;
+.joystick-direction-forward {
+  --joystick-direction-strength: max(0, var(--joystick-forward));
+  top: 10%;
+  left: 50%;
+  transform: translate(-50%, 0);
 }
 
-.joy-knob-group {
-  transition: transform 130ms ease-out;
+.joystick-direction-backward {
+  --joystick-direction-strength: max(0, calc(-1 * var(--joystick-forward)));
+  bottom: 10%;
+  left: 50%;
+  transform: translate(-50%, 0) rotate(180deg);
 }
 
-.joystick.engaged .joy-knob-group {
+.joystick-direction-right {
+  --joystick-direction-strength: max(0, var(--joystick-strafe));
+  right: 10%;
+  top: 50%;
+  transform: translate(0, -50%) rotate(90deg);
+}
+
+.joystick-direction-left {
+  --joystick-direction-strength: max(0, calc(-1 * var(--joystick-strafe)));
+  left: 10%;
+  top: 50%;
+  transform: translate(0, -50%) rotate(-90deg);
+}
+
+.joystick-knob {
+  width: calc(var(--joystick-pad-size) * 34 / 92);
+  height: calc(var(--joystick-pad-size) * 34 / 92);
+  border-radius: 50%;
+  box-sizing: content-box;
+  pointer-events: none;
+  background: rgb(245 245 248 / 28%);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-style: solid;
+  border-color: color-mix(
+    in srgb,
+    rgb(255 255 255 / 48%) calc((1 - var(--joystick-forward-strength)) * 100%),
+    var(--accent) calc(var(--joystick-forward-strength) * 100%)
+  );
+  border-width:
+    calc(1.5px + var(--joystick-throw) * 1.5px + var(--joystick-forward-strength) * 1.25px);
+  box-shadow: 0 0 calc(var(--joystick-forward-strength) * 10px)
+    color-mix(
+      in srgb,
+      var(--accent) calc(var(--joystick-forward-strength) * 45%),
+      transparent
+    );
+  transition: transform 130ms cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+
+.overlay-joystick:has(.joystick-hit-target.engaged) .joystick-knob,
+.overlay-joystick:has(.joystick-hit-target.mirroring) .joystick-knob {
   transition: none;
-}
-
-.joy-knob {
-  fill: #b9b9c1;
-  transition: fill 150ms ease;
-}
-
-.joystick.engaged .joy-knob {
-  fill: var(--accent);
-}
-
-/* keyboard drive mirrored on the stick: hollow accent dot */
-.joystick.mirroring .joy-knob {
-  fill: var(--accent-faint);
-  stroke: var(--accent);
-  stroke-width: 1;
 }
 
 /* ---- WASD chips ----------------------------------------------------------- */
@@ -6507,9 +6575,9 @@ select.skill-input {
   }
 
   /* Full-size joystick swallows half a phone screen. */
-  .overlay-joystick svg {
-    width: 150px;
-    height: 150px;
+  .overlay-joystick {
+    --joystick-hit-size: 150px;
+    --joystick-pad-size: calc(150px * 184 / 264);
   }
 
   /* The panel already shows the running state; the chip collides with it. */
@@ -7074,10 +7142,9 @@ select.skill-input {
      order alone keeps the joystick / WASD chips / head tilt painting on top
      (same trick as .cam-map-host.big). An explicit z-index here would let the
      opaque video cover the controls. */
-  /* Grow with the scene, but never reach the joystick: it is 198px wide and
-     centred, so its right edge is 50% + 99px — the second term keeps a 12px
-     gap clear of it at any width. */
-  width: min(360px, calc(50% - 132px));
+  /* Grow with the scene, but never reach the joystick: ~264px wide (pad +
+     hit margin) and centred — keep a 12px gap clear of its right edge. */
+  width: min(360px, calc(50% - 144px));
   aspect-ratio: 4 / 3;
   overflow: hidden;
   border: 1px solid var(--hairline-strong);

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1844,12 +1844,6 @@ select.skill-input {
   );
   border-width:
     calc(1.5px + var(--joystick-throw) * 1.5px + var(--joystick-forward-strength) * 1.25px);
-  box-shadow: 0 0 calc(var(--joystick-forward-strength) * 10px)
-    color-mix(
-      in srgb,
-      var(--accent) calc(var(--joystick-forward-strength) * 45%),
-      transparent
-    );
   transition: transform 130ms cubic-bezier(0.215, 0.61, 0.355, 1);
 }
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1124,7 +1124,6 @@ select.skill-input {
   color: var(--muted);
 }
 
-/* No overlay glass — pad/knob blur the camera. */
 .overlay-joystick {
   --joystick-throw: 0;
   --joystick-strafe: 0;

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1843,7 +1843,7 @@ select.skill-input {
     var(--accent) calc(var(--joystick-forward-strength) * 100%)
   );
   border-width:
-    calc(1.5px + var(--joystick-throw) * 1.5px + var(--joystick-forward-strength) * 1.25px);
+    calc(1.5px + var(--joystick-throw) * 3.5px + var(--joystick-forward-strength) * 1.25px);
   transition: transform 130ms cubic-bezier(0.215, 0.61, 0.355, 1);
 }
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1770,10 +1770,11 @@ select.skill-input {
   background:
     radial-gradient(
       circle at 50% calc(50% - var(--joystick-forward) * 58%),
-      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.72)) 0%,
-      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.36)) 36%,
-      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.12)) 58%,
-      transparent 76%
+      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.88)) 0%,
+      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.56)) 22%,
+      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.3)) 40%,
+      rgb(255 255 255 / calc(var(--joystick-forward-strength) * 0.12)) 55%,
+      rgb(255 255 255 / 0%) 72%
     ),
     rgb(8 8 10 / 38%);
   backdrop-filter: blur(6px);

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -7136,8 +7136,7 @@ select.skill-input {
      order alone keeps the joystick / WASD chips / head tilt painting on top
      (same trick as .cam-map-host.big). An explicit z-index here would let the
      opaque video cover the controls. */
-  /* Grow with the scene, but never reach the joystick: ~264px wide (pad +
-     hit margin) and centred — keep a 12px gap clear of its right edge. */
+  /* Grow to 360px; on narrow scenes, stop at the centred 264px joystick hit target. */
   width: min(360px, calc(50% - 144px));
   aspect-ratio: 4 / 3;
   overflow: hidden;

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1841,7 +1841,7 @@ select.skill-input {
   border-color: color-mix(
     in srgb,
     rgb(255 255 255 / 48%) calc((1 - var(--joystick-forward-strength)) * 100%),
-    var(--accent) calc(var(--joystick-forward-strength) * 100%)
+    #eead55 calc(var(--joystick-forward-strength) * 100%)
   );
   border-width:
     calc(1.5px + var(--joystick-throw) * 3.5px + var(--joystick-forward-strength) * 1.25px);

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1135,8 +1135,6 @@ select.skill-input {
   left: 50%;
   bottom: 84px;
   transform: translateX(-50%);
-  display: grid;
-  place-items: end center;
   background: transparent;
   backdrop-filter: none;
   -webkit-backdrop-filter: none;

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -6577,7 +6577,7 @@ select.skill-input {
   /* Full-size joystick swallows half a phone screen. */
   .overlay-joystick {
     --joystick-hit-size: 150px;
-    --joystick-pad-size: calc(150px * 184 / 264);
+    --joystick-pad-size: 120px;
   }
 
   /* The panel already shows the running state; the chip collides with it. */

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1124,7 +1124,7 @@ select.skill-input {
   color: var(--muted);
 }
 
-/* Stick overlay. Chrome vars from joystick.js; forward-strength ignores sign. */
+/* No overlay glass — pad/knob blur the camera. */
 .overlay-joystick {
   --joystick-throw: 0;
   --joystick-strafe: 0;
@@ -1742,8 +1742,6 @@ select.skill-input {
 }
 
 /* ---- joystick ------------------------------------------------------------ */
-/* Geometry (joystick.js): pad r=92, knob r=34; hit size = pad + margin.
-   Hit target is the root; pad + knob are siblings (nested glass kills blur). */
 
 .joystick-hit-target {
   display: grid;
@@ -1770,7 +1768,6 @@ select.skill-input {
   height: var(--joystick-pad-size);
   border-radius: 50%;
   pointer-events: none;
-  /* White pool shifts with direction: top = forward, bottom = backward. */
   background:
     radial-gradient(
       circle at 50% calc(50% - var(--joystick-forward) * 58%),

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1749,10 +1749,11 @@ select.skill-input {
   width: var(--joystick-hit-size);
   height: var(--joystick-hit-size);
   touch-action: none;
-  cursor: grab;
+  cursor: default;
 }
 
-.joystick-hit-target.engaged {
+.joystick-hit-target.engaged,
+.joystick-hit-target.engaged .joystick-pad {
   cursor: grabbing;
 }
 
@@ -1766,7 +1767,7 @@ select.skill-input {
   width: var(--joystick-pad-size);
   height: var(--joystick-pad-size);
   border-radius: 50%;
-  pointer-events: none;
+  cursor: grab;
   background:
     radial-gradient(
       circle at 50% calc(50% - var(--joystick-forward) * 58%),

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -1,32 +1,28 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// On-screen joystick. Pointer events with capture give one code path for
-// mouse + touch (touch-action: none in CSS). The math is ported from the
-// mobile stick — knob clamped to outer radius minus knob radius, values
-// normalized to that distance, -y flip into robot frame before setInput —
-// but the rendering is original: a hairline rim with four cardinal ticks,
-// a small dot for the knob, a faint displacement trace while engaged.
+// On-screen joystick. HTML glass pad + knob over a larger pointer surface.
+// Latch only — DriveController owns the /joystick heartbeat.
 //
-// The heartbeat lives in DriveController, NOT here: this module only latches
-// values and reports engage/release.
+// Chrome vars on the overlay (eased −1..1 / 0..1):
+//   --joystick-throw    magnitude
+//   --joystick-strafe   +right / −left
+//   --joystick-forward  +forward / −backward
+// Display size is CSS-only (--joystick-hit-size / --joystick-pad-size).
 
-const SIZE = 180;
-const CENTER = SIZE / 2;
-const OUTER_R = 84;
-const KNOB_R = 13;
-const MAX_DIST = OUTER_R - KNOB_R;
-const SVG_NS = "http://www.w3.org/2000/svg";
-const TOGGLE_KEY = "KeyJ"; // press j to hide/show the on-screen joystick
+// Geometry: pad r=92, knob r=34 (CSS pad*34/92). Hit margin is CSS-only.
+const PAD_RADIUS = 92; // knob center reaches the rim at full throw
+const PAD_SIZE = PAD_RADIUS * 2;
+const TOGGLE_KEY = "KeyJ";
 
-/**
- * @param {string} tag
- * @param {Record<string, string>} attrs
- */
-function svgEl(tag, attrs) {
-  const el = document.createElementNS(SVG_NS, tag);
-  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
-  return el;
+/** @param {number} t */
+function easeThrow(t) {
+  return t ** 0.65;
+}
+
+/** @param {number} v */
+function easedAxis(v) {
+  return Math.sign(v) * easeThrow(Math.abs(v) / PAD_RADIUS);
 }
 
 /**
@@ -35,89 +31,68 @@ function svgEl(tag, attrs) {
  * @returns {{ destroy: () => void }}
  */
 export function createJoystick(parent, driveController) {
-  const svg = /** @type {SVGSVGElement} */ (
-    svgEl("svg", {
-      class: "joystick",
-      viewBox: `0 0 ${SIZE} ${SIZE}`,
-      width: String(SIZE),
-      height: String(SIZE),
-      role: "application",
-      "aria-label": "Drive joystick",
-    })
-  );
-
-  // SVG tooltips come from a <title> child, not the title attribute.
-  const tooltip = svgEl("title", {});
-  tooltip.textContent = "drag to drive — /joystick · press j to hide";
-  svg.appendChild(tooltip);
-  svg.appendChild(svgEl("circle", { class: "joy-rim", cx: String(CENTER), cy: String(CENTER), r: String(OUTER_R) }));
-
-  // Four faint cardinal ticks just inside the rim.
-  const tickIn = OUTER_R - 7;
-  const tickOut = OUTER_R - 1;
-  for (const [dx, dy] of [[0, -1], [0, 1], [-1, 0], [1, 0]]) {
-    svg.appendChild(
-      svgEl("line", {
-        class: "joy-tick",
-        x1: String(CENTER + dx * tickIn),
-        y1: String(CENTER + dy * tickIn),
-        x2: String(CENTER + dx * tickOut),
-        y2: String(CENTER + dy * tickOut),
-      }),
-    );
+  const pad = document.createElement("div");
+  pad.className = "joystick-pad";
+  for (const direction of ["forward", "backward", "right", "left"]) {
+    const marker = document.createElement("span");
+    marker.className = `joystick-direction joystick-direction-${direction}`;
+    pad.appendChild(marker);
   }
 
-  const trace = svgEl("line", {
-    class: "joy-trace",
-    x1: String(CENTER),
-    y1: String(CENTER),
-    x2: String(CENTER),
-    y2: String(CENTER),
-  });
-  svg.appendChild(trace);
+  const knob = document.createElement("div");
+  knob.className = "joystick-knob";
 
-  // Knob in a translated group so CSS can transition the release snap-back.
-  const knobGroup = /** @type {SVGGElement} */ (svgEl("g", { class: "joy-knob-group" }));
-  knobGroup.appendChild(svgEl("circle", { class: "joy-knob", cx: String(CENTER), cy: String(CENTER), r: String(KNOB_R) }));
-  svg.appendChild(knobGroup);
+  const hitTarget = document.createElement("div");
+  hitTarget.className = "joystick-hit-target";
+  hitTarget.setAttribute("role", "application");
+  hitTarget.setAttribute("aria-label", "Drive joystick");
+  hitTarget.title = "drag to drive — /joystick · press j to hide";
+  // Siblings so each backdrop-filter samples the camera, not the other glass.
+  hitTarget.append(pad, knob);
 
   let pointerEngaged = false;
 
-  /**
-   * Place the knob at a screen-frame displacement from center (clamped).
-   * @param {number} dx
-   * @param {number} dy
-   */
-  function setKnob(dx, dy) {
-    knobGroup.style.transform = `translate(${dx}px, ${dy}px)`;
-    trace.setAttribute("x2", String(CENTER + dx));
-    trace.setAttribute("y2", String(CENTER + dy));
-    svg.classList.toggle("at-edge", Math.hypot(dx, dy) >= MAX_DIST - 0.5);
+  /** @param {number} dx @param {number} dy */
+  function clampToPad(dx, dy) {
+    const dist = Math.hypot(dx, dy);
+    const t = Math.min(1, dist / PAD_RADIUS);
+    if (dist > PAD_RADIUS) {
+      const s = PAD_RADIUS / dist;
+      dx *= s;
+      dy *= s;
+    }
+    return { dx, dy, t };
   }
 
-  /**
-   * @param {PointerEvent} e
-   * @returns {{ dx: number, dy: number }} clamped screen-frame displacement
-   */
-  function displacementFrom(e) {
-    const rect = svg.getBoundingClientRect();
-    const scale = SIZE / rect.width;
-    let dx = (e.clientX - rect.left - rect.width / 2) * scale;
-    let dy = (e.clientY - rect.top - rect.height / 2) * scale;
-    const dist = Math.hypot(dx, dy);
-    if (dist > MAX_DIST && dist > 0) {
-      dx *= MAX_DIST / dist;
-      dy *= MAX_DIST / dist;
-    }
-    return { dx, dy };
+  /** @param {number} dx @param {number} dy screen-frame pad units */
+  function setKnob(dx, dy) {
+    const p = clampToPad(dx, dy);
+    const throwAmt = easeThrow(p.t);
+    parent.style.setProperty("--joystick-throw", String(throwAmt));
+    parent.style.setProperty("--joystick-strafe", String(easedAxis(p.dx)));
+    parent.style.setProperty("--joystick-forward", String(easedAxis(-p.dy))); // screen-up → forward
+    // Scale from the visible pad — hit target may be larger and bottom-aligned.
+    const toCss = (pad.clientWidth || PAD_SIZE) / PAD_SIZE;
+    knob.style.transform =
+      `translate(${p.dx * toCss}px, ${p.dy * toCss}px) scale(${1 + throwAmt * 0.05})`;
+    return p;
+  }
+
+  /** @param {PointerEvent} e */
+  function pointerOffset(e) {
+    const rect = pad.getBoundingClientRect();
+    const toPad = PAD_SIZE / rect.width;
+    return {
+      dx: (e.clientX - rect.left - rect.width / 2) * toPad,
+      dy: (e.clientY - rect.top - rect.height / 2) * toPad,
+    };
   }
 
   /** @param {PointerEvent} e */
   function update(e) {
-    const { dx, dy } = displacementFrom(e);
-    setKnob(dx, dy);
-    // Normalize and flip into robot frame (screen y grows downward).
-    driveController.setInput("joystick", dx / MAX_DIST, -dy / MAX_DIST, true);
+    const { dx, dy } = pointerOffset(e);
+    const p = setKnob(dx, dy);
+    driveController.setInput("joystick", p.dx / PAD_RADIUS, -p.dy / PAD_RADIUS, true);
   }
 
   /** @param {PointerEvent} e */
@@ -125,11 +100,11 @@ export function createJoystick(parent, driveController) {
     if (pointerEngaged) return;
     pointerEngaged = true;
     try {
-      svg.setPointerCapture(e.pointerId);
+      hitTarget.setPointerCapture(e.pointerId);
     } catch {
-      // Capture can fail for synthetic/stale pointers; degrade gracefully.
+      // synthetic/stale pointers
     }
-    svg.classList.add("engaged");
+    hitTarget.classList.add("engaged");
     update(e);
   }
 
@@ -141,24 +116,22 @@ export function createJoystick(parent, driveController) {
   function release() {
     if (!pointerEngaged) return;
     pointerEngaged = false;
-    svg.classList.remove("engaged");
+    hitTarget.classList.remove("engaged");
     setKnob(0, 0);
     driveController.setInput("joystick", 0, 0, false);
   }
 
-  svg.addEventListener("pointerdown", onPointerDown);
-  svg.addEventListener("pointermove", onPointerMove);
-  svg.addEventListener("pointerup", release);
-  svg.addEventListener("pointercancel", release);
-  svg.addEventListener("lostpointercapture", release);
+  hitTarget.addEventListener("pointerdown", onPointerDown);
+  hitTarget.addEventListener("pointermove", onPointerMove);
+  hitTarget.addEventListener("pointerup", release);
+  hitTarget.addEventListener("pointercancel", release);
+  hitTarget.addEventListener("lostpointercapture", release);
 
-  // Hide/show with the j key. Releasing on hide clears any latched command so
-  // the robot never keeps driving from a joystick the operator can't see.
   let hidden = false;
   function toggleHidden() {
     hidden = !hidden;
     if (hidden) release();
-    svg.style.display = hidden ? "none" : "";
+    hitTarget.hidden = hidden;
   }
 
   /** @param {KeyboardEvent} e */
@@ -172,25 +145,25 @@ export function createJoystick(parent, driveController) {
   }
   window.addEventListener("keydown", onKeyDown);
 
-  // Mirror keyboard drive so the knob always shows what the robot was told.
   const unsubActive = driveController.onActiveChange((state) => {
     if (pointerEngaged) return;
-    svg.classList.toggle("mirroring", state.source === "keyboard");
-    if (state.source === "keyboard") {
-      setKnob(state.x * MAX_DIST, -state.y * MAX_DIST);
-    } else if (state.source === null) {
-      setKnob(0, 0);
-    }
+    const mirroring = state.source === "keyboard";
+    hitTarget.classList.toggle("mirroring", mirroring);
+    if (mirroring) setKnob(state.x * PAD_RADIUS, -state.y * PAD_RADIUS);
+    else if (state.source === null) setKnob(0, 0);
   });
 
-  parent.appendChild(svg);
+  parent.appendChild(hitTarget);
 
   return {
     destroy() {
       release();
       window.removeEventListener("keydown", onKeyDown);
       unsubActive();
-      svg.remove();
+      hitTarget.remove();
+      parent.style.removeProperty("--joystick-throw");
+      parent.style.removeProperty("--joystick-strafe");
+      parent.style.removeProperty("--joystick-forward");
     },
   };
 }

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -1,11 +1,10 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// DriveController owns the /joystick heartbeat; this module only latches input.
-// CSS feedback is eased; drive input stays linear −1..1.
-// Display sizing is CSS-only.
+// DriveController publishes /joystick and owns its heartbeat; this module reports normalized input.
+// Visual easing does not alter the linear −1..1 drive input.
 
-const PAD_RADIUS = 92; // knob center reaches the rim at full throw
+const PAD_RADIUS = 92; // At full input, the knob center reaches the rim; CSS controls rendered size.
 const PAD_SIZE = PAD_RADIUS * 2;
 const TOGGLE_KEY = "KeyJ";
 

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -87,6 +87,8 @@ export function createJoystick(parent, driveController) {
   /** @param {PointerEvent} e */
   function onPointerDown(e) {
     if (pointerEngaged) return;
+    const { dx, dy } = pointerOffset(e);
+    if (Math.hypot(dx, dy) > PAD_RADIUS) return;
     pointerEngaged = true;
     try {
       hitTarget.setPointerCapture(e.pointerId);

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -121,7 +121,7 @@ export function createJoystick(parent, driveController) {
   hitTarget.addEventListener("pointercancel", release);
   hitTarget.addEventListener("lostpointercapture", release);
 
-  // Hiding must release latched drive input.
+  // Clear latched drive on hide so a hidden joystick can't keep driving.
   let hidden = false;
   function toggleHidden() {
     hidden = !hidden;

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -1,16 +1,10 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// On-screen joystick. HTML glass pad + knob over a larger pointer surface.
-// Latch only — DriveController owns the /joystick heartbeat.
-//
-// Chrome vars on the overlay (eased −1..1 / 0..1):
-//   --joystick-throw    magnitude
-//   --joystick-strafe   +right / −left
-//   --joystick-forward  +forward / −backward
-// Display size is CSS-only (--joystick-hit-size / --joystick-pad-size).
+// DriveController owns the /joystick heartbeat; this module only latches input.
+// CSS feedback is eased; drive input stays linear −1..1.
+// Display sizing is CSS-only.
 
-// Geometry: pad r=92, knob r=34 (CSS pad*34/92). Hit margin is CSS-only.
 const PAD_RADIUS = 92; // knob center reaches the rim at full throw
 const PAD_SIZE = PAD_RADIUS * 2;
 const TOGGLE_KEY = "KeyJ";
@@ -102,7 +96,7 @@ export function createJoystick(parent, driveController) {
     try {
       hitTarget.setPointerCapture(e.pointerId);
     } catch {
-      // synthetic/stale pointers
+      // Synthetic/stale pointers may not be capturable.
     }
     hitTarget.classList.add("engaged");
     update(e);
@@ -127,6 +121,7 @@ export function createJoystick(parent, driveController) {
   hitTarget.addEventListener("pointercancel", release);
   hitTarget.addEventListener("lostpointercapture", release);
 
+  // Hiding must release latched drive input.
   let hidden = false;
   function toggleHidden() {
     hidden = !hidden;

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -137,11 +137,12 @@ export function createJoystick(parent, driveController) {
 
   parent.appendChild(hitTarget);
 
+  // Show keyboard commands on the joystick knob.
   const unsubActive = driveController.onActiveChange((state) => {
     if (pointerEngaged) return;
-    const mirroring = state.source === "keyboard";
-    hitTarget.classList.toggle("mirroring", mirroring);
-    if (mirroring) setKnob(state.x * PAD_RADIUS, -state.y * PAD_RADIUS);
+    const keyboardActive = state.source === "keyboard";
+    hitTarget.classList.toggle("mirroring", keyboardActive);
+    if (keyboardActive) setKnob(state.x * PAD_RADIUS, -state.y * PAD_RADIUS);
     else if (state.source === null) setKnob(0, 0);
   });
 

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -2,20 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
 // DriveController publishes /joystick and owns its heartbeat; this module reports normalized input.
-// Visual easing does not alter the linear −1..1 drive input.
 
 const PAD_RADIUS = 92; // At full input, the knob center reaches the rim; CSS controls rendered size.
 const PAD_SIZE = PAD_RADIUS * 2;
 const TOGGLE_KEY = "KeyJ";
 
-/** @param {number} t */
-function easeThrow(t) {
-  return t ** 0.65;
-}
-
-/** @param {number} v */
-function easedAxis(v) {
-  return Math.sign(v) * easeThrow(Math.abs(v) / PAD_RADIUS);
+// Helps small movements read clearly via pad glow, direction markers, and knob border/size.
+/** @param {number} value */
+function strengthenVisualFeedback(value) {
+  return Math.sign(value) * Math.abs(value) ** 0.85;
 }
 
 /**
@@ -60,10 +55,10 @@ export function createJoystick(parent, driveController) {
   /** @param {number} dx @param {number} dy screen-frame pad units */
   function setKnob(dx, dy) {
     const p = clampToPad(dx, dy);
-    const throwAmt = easeThrow(p.t);
+    const throwAmt = strengthenVisualFeedback(p.t);
     parent.style.setProperty("--joystick-throw", String(throwAmt));
-    parent.style.setProperty("--joystick-strafe", String(easedAxis(p.dx)));
-    parent.style.setProperty("--joystick-forward", String(easedAxis(-p.dy))); // screen-up → forward
+    parent.style.setProperty("--joystick-strafe", String(strengthenVisualFeedback(p.dx / PAD_RADIUS)));
+    parent.style.setProperty("--joystick-forward", String(strengthenVisualFeedback(-p.dy / PAD_RADIUS))); // screen-up → forward
     // Scale from the visible pad — hit target may be larger and bottom-aligned.
     const toCss = (pad.clientWidth || PAD_SIZE) / PAD_SIZE;
     knob.style.transform =

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -145,6 +145,8 @@ export function createJoystick(parent, driveController) {
   }
   window.addEventListener("keydown", onKeyDown);
 
+  parent.appendChild(hitTarget);
+
   const unsubActive = driveController.onActiveChange((state) => {
     if (pointerEngaged) return;
     const mirroring = state.source === "keyboard";
@@ -152,8 +154,6 @@ export function createJoystick(parent, driveController) {
     if (mirroring) setKnob(state.x * PAD_RADIUS, -state.y * PAD_RADIUS);
     else if (state.source === null) setKnob(0, 0);
   });
-
-  parent.appendChild(hitTarget);
 
   return {
     destroy() {

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -58,7 +58,7 @@ export function createJoystick(parent, driveController) {
     const throwAmt = strengthenVisualFeedback(p.t);
     parent.style.setProperty("--joystick-throw", String(throwAmt));
     parent.style.setProperty("--joystick-strafe", String(strengthenVisualFeedback(p.dx / PAD_RADIUS)));
-    parent.style.setProperty("--joystick-forward", String(strengthenVisualFeedback(-p.dy / PAD_RADIUS))); // screen-up → forward
+    parent.style.setProperty("--joystick-forward", String(strengthenVisualFeedback(-p.dy / PAD_RADIUS)));
     // Scale from the visible pad — hit target may be larger and bottom-aligned.
     const toCss = (pad.clientWidth || PAD_SIZE) / PAD_SIZE;
     knob.style.transform =
@@ -80,6 +80,7 @@ export function createJoystick(parent, driveController) {
   function update(e) {
     const { dx, dy } = pointerOffset(e);
     const p = setKnob(dx, dy);
+    // Screen Y grows downward; negate it so dragging up maps to forward motion.
     driveController.setInput("joystick", p.dx / PAD_RADIUS, -p.dy / PAD_RADIUS, true);
   }
 


### PR DESCRIPTION
I thought the current joystick looked and slightly worked differently(not in an ideal way) then most other mobile UI joysticks. 
No drive-stack changes: ROS publishing, heartbeat, arbitration, smoothing, speed modes, and maximum commanded speed remain unchanged.

# Joystick feel

https://github.com/user-attachments/assets/6be5c137-74dd-46f4-b712-47e36d289202

### Problem:
- knob didnt extend pass the boundary
- knob was smaller than usual
- visual feedback feels very binary. joystick knob turns orange right when you click


### Solution:

- make knob extend pass boundary(similair to game joysticks)
- make it feel like a joystick you'd find in a first person shooter mobile game app
- make visual feedback more dynamic(knob border grows as you get closer to the max speed)
- directional white glow makes it more obvious your moving forward or backwards versus just turning
- orange border on knob indicating your at max speed(only for forward/reverse)

# Comparing UI

https://github.com/user-attachments/assets/35d4f968-75ac-4d48-941e-dc3f256e093a