### PR TITLE
feat(logger): why the robot went down, not just that it did (INN-769)

### DIFF
--- a/config/journald/innate.conf
+++ b/config/journald/innate.conf
@@ -1,0 +1,17 @@
+# Installed to /etc/systemd/journald.conf.d/innate.conf by post_update.sh.
+#
+# The boot sentinel (INN-769) attributes a reset by reading the *previous*
+# boot's journal tail, which only exists if the journal survives the reset.
+# Ubuntu's Storage=auto keeps everything in tmpfs until /var/log/journal is
+# created, so a stock robot answers `journalctl -b -1` with nothing at all.
+[Journal]
+Storage=persistent
+
+# Sized to hold weeks of boots without ever being the reason the rootfs fills:
+# a robot's disk is the one thing this instrumentation must not put at risk.
+SystemMaxUse=512M
+SystemMaxFileSize=64M
+# A month of data is the deliverable, and a robot that reboots often is exactly
+# the one worth reading — so cap the count high enough that the interesting
+# unit does not roll its own history away.
+SystemMaxFiles=50

--- a/config/systemd/innate-boot-sentinel.service
+++ b/config/systemd/innate-boot-sentinel.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Innate ungraceful-shutdown sentinel (INN-769)
+Documentation=https://linear.app/innate/issue/INN-769
+# Default dependencies are deliberately left ON. DefaultDependencies=no would
+# drop the implicit Conflicts=shutdown.target, systemd would then never stop
+# this unit at shutdown, ExecStop would never run, and every single shutdown on
+# the fleet would be recorded as ungraceful.
+#
+# Ordered early on purpose: units stop in reverse of the order they started, so
+# starting right after the filesystems puts the flag clear late in shutdown
+# rather than early. Reverse-order stopping only holds along real ordering
+# edges, and there is none between this and ros-app -- those stop jobs run in
+# parallel -- so this is a tendency, not a guarantee. The residual case is a
+# hang *after* ExecStop and a hard reset out of it, recorded as clean. Narrow
+# enough to accept; the flag is not the only mechanism.
+After=local-fs.target
+RequiresMountsFor=/var/lib
+
+[Service]
+Type=oneshot
+# Without this the unit counts as inactive the moment ExecStart returns, and an
+# inactive unit is not stopped at shutdown -- so ExecStop never runs.
+RemainAfterExit=yes
+ExecStart=/usr/bin/python3 /home/jetson1/innate-os/scripts/boot_sentinel.py boot
+ExecStop=/usr/bin/python3 /home/jetson1/innate-os/scripts/boot_sentinel.py shutdown
+# journalctl on a large journal is the only slow part of either path, and
+# holding up a shutdown to record it would be a poor trade.
+TimeoutStartSec=60
+TimeoutStopSec=15
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/logger_node.py
@@ -23,7 +23,7 @@ from rclpy.node import Node
 from sensor_msgs.msg import BatteryState
 from std_msgs.msg import String
 
-from innate_logger import disks, host
+from innate_logger import disks, host, shutdowns
 from innate_logger.client import TelemetryClient
 
 DEFAULT_TELEMETRY_URL = "https://logs.svc.innate.bot"
@@ -111,6 +111,10 @@ class LoggerNode(Node):
         self._version: str | None = None
         self._latest_arm: ArmStatus | None = None
         self._pending_disks: dict[str, object] | None = None
+        # The boot sentinel's verdict on the last shutdown, sent once per boot.
+        # Nothing orders that unit against this node, so the report may not be
+        # on disk yet when we start -- keep looking until it lands and is sent.
+        self._boot_reported: bool = False
 
         # None means "not yet", which is what the boot delay is measured against.
         self._started: float = time.monotonic()
@@ -266,6 +270,10 @@ class LoggerNode(Node):
         if sent_disks is not None:
             vitals["disks"] = sent_disks
 
+        sent_boot = None if self._boot_reported else shutdowns.report()
+        if sent_boot is not None:
+            vitals["boot"] = sent_boot
+
         summary = f"cpu {cpu_usage:.0f}% | mem {vitals['memory_percent']}%"
 
         if self._elapsed(self._last_detail) >= self._seconds("detail_interval"):
@@ -314,6 +322,10 @@ class LoggerNode(Node):
         # mid-flight and was never sent.
         if self._pending_disks is sent_disks:
             self._pending_disks = None
+
+        if sent_boot is not None:
+            self._boot_reported = True
+            self.get_logger().info(f"boot: {shutdowns.summarize(sent_boot)}")
 
 
 def main(args: list[str] | None = None) -> None:

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/shutdowns.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/shutdowns.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The boot sentinel's verdict on the last shutdown, for the vitals payload.
+
+Pure functions -- no ROS, no node state. All the work happens in
+``scripts/boot_sentinel.py``, which runs as root from a systemd unit at boot
+and at shutdown; this side only reads what it left behind. Splitting it that
+way is what keeps the node out of the journal-permission question entirely, and
+means the analysis has already happened by the time anything here runs.
+
+The drive's own ``unsafe_shutdowns`` (see disks.py) counts dirty cuts and the
+sentinel attributes them; neither replaces the other, and the two are worth
+comparing precisely because they are independent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# Written by scripts/boot_sentinel.py. Duplicated rather than shared: that
+# script is stdlib-only and runs before the ROS workspace exists to import from.
+REPORT_PATH = Path("/var/lib/innate/boot/last_boot.json")
+BOOT_ID_PATH = Path("/proc/sys/kernel/random/boot_id")
+
+
+def report() -> dict[str, Any] | None:
+    """This boot's record of the previous shutdown, or None if there isn't one.
+
+    None covers every way the sentinel can be absent -- never installed, unit
+    disabled, `innate build` without the `innate update` that installs it -- and
+    they are all the same thing to the caller: no verdict to send.
+    """
+    try:
+        loaded = json.loads(REPORT_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(loaded, dict):
+        return None
+
+    # A report from an earlier boot means the sentinel did not run for this one,
+    # so it describes a shutdown that has already been reported. Sending it
+    # again would count one reset twice, every boot, for as long as the unit
+    # stays broken -- which is exactly the direction that would mislead.
+    current = _boot_id()
+    if current is not None and loaded.get("boot_id") != current:
+        return None
+
+    # pstore_seen is bookkeeping for the sentinel's own deduplication across
+    # boots and means nothing to the cloud.
+    return {key: value for key, value in loaded.items() if key != "pstore_seen"}
+
+
+def summarize(record: dict[str, Any]) -> str:
+    """One log line: what the robot's own console should say about its last reset."""
+    cause = record.get("cause", "unknown")
+    counted = f"{record.get('ungraceful_count', '?')}/{record.get('boot_count', '?')} ungraceful"
+    if cause == "clean":
+        return f"last shutdown clean ({counted})"
+    detail = f"flag {record.get('flag_verdict')}, journal {record.get('journal_verdict')}"
+    return f"last shutdown {cause.upper()} — {detail} ({counted})"
+
+
+def _boot_id() -> str | None:
+    try:
+        return BOOT_ID_PATH.read_text().strip() or None
+    except OSError:
+        return None

--- a/scripts/boot_sentinel.py
+++ b/scripts/boot_sentinel.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Was the last shutdown graceful, and if not, what took the robot down?
+
+Storage selection for MARS turns on how often a robot resets without the SSD
+being told first (INN-769).  The drive's own ``unsafe_shutdowns`` counter,
+already on the wire via the logger's disk sweep, says *that* a cut was dirty
+but never *why* -- and the causes have nothing in common to fix.  A kernel
+panic is a software bug, a PCIe link-down is a connector loosening under
+vibration, a brownout is power-rail margin.  Counting them together gives one
+number nobody can act on.
+
+Three mechanisms run here, because each is blind where the others see:
+
+``flag``
+    A file written at boot and removed on clean shutdown.  Present at the next
+    boot means the last one never reached ``ExecStop``.  Cheap, and it catches
+    panics -- the one class expected to dominate.
+``journal``
+    The tail of the previous boot's journal.  It cannot see a cut that beat the
+    write to disk, but when the record survived it is the only thing that names
+    a cause.
+``pstore``
+    The kernel's own crash dump, which survives a reset precisely because it is
+    not a disk write.  A panic usually dies before journald flushes, so this is
+    where panics actually show up -- when the platform has ramoops at all.
+
+Both verdicts ship rather than one merged bool: they disagree in ways that are
+themselves the signal.  Flag-dirty against a journal with no complaint in it is
+the brownout / SYS_RESET signature -- the rail sagged or the carrier asserted
+reset, and userspace never learned anything was wrong.
+
+Run as root by innate-boot-sentinel.service: ``boot`` at start, ``shutdown`` at
+stop.  Stdlib only and no ROS -- this runs long before the workspace is sourced,
+and a robot whose colcon build is broken must still report its own resets.
+
+Exit status is always 0.  A ``oneshot`` unit whose ``ExecStart`` failed is a
+failed unit, and systemd does not run ``ExecStop`` for one of those -- so a
+crash in the analysis below would silently turn the *next* clean shutdown into
+a recorded dirty one.  The measurement must never be able to corrupt itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+STATE_DIR = Path("/var/lib/innate/boot")
+# Present for exactly as long as the system is up.  Its absence at boot is the
+# whole of mechanism 1.
+FLAG_PATH = STATE_DIR / "running"
+# What the logger node reads and ships as vitals["boot"].  Rewritten once per
+# boot; see shutdowns.py on the reading side.
+REPORT_PATH = STATE_DIR / "last_boot.json"
+
+BOOT_ID_PATH = Path("/proc/sys/kernel/random/boot_id")
+PSTORE_DIR = Path("/sys/fs/pstore")
+PERSISTENT_JOURNAL = Path("/var/log/journal")
+
+SCHEMA = 1
+# Enough tail to hold a panic trace and the shutdown sequence, small enough
+# that the read costs nothing at boot.
+TAIL_LINES = 400
+EVIDENCE_LINES = 5
+EVIDENCE_CHARS = 200
+_TIMEOUT = 30.0
+
+# Ordered: the first match wins, so the specific cause beats the general one.
+# All of these are matched against the *tail* of the previous boot -- something
+# that logged a soft lockup an hour before a clean reboot was survived, and is
+# not what ended that boot.
+FAULT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "kernel_panic",
+        re.compile(
+            r"Kernel panic - not syncing|Internal error: Oops|Unable to handle kernel|BUG: unable to handle|Fatal exception",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "watchdog",
+        re.compile(
+            r"watchdog: BUG: soft lockup|Watchdog detected hard LOCKUP|watchdog: Watchdog detected|tegra_wdt|hardware watchdog",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        # Bare "Link Down" is not usable here -- every ethernet interface logs
+        # it on unplug.  Only the PCIe-scoped spellings count.
+        "pcie_link_down",
+        re.compile(
+            r"PCIe link is down|PCIe link down|pcieport[^\n]*[Ll]ink [Dd]own|nvme[^\n]*controller is down|nvme[^\n]*Removing after probe failure",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "brownout",
+        re.compile(
+            r"soctherm[^\n]*OC ALARM|under-?voltage|VDD_[A-Z0-9_]+[^\n]*fault|input voltage[^\n]*low",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+# systemd-shutdown is the process that runs after everything else is stopped,
+# so anything it logged at all means the shutdown path was actually walked.
+# The target names carry a distribution-dependent prefix ("Reached target
+# System Shutdown", "Reached target Late Shutdown Services"), hence the gap.
+#
+# Every entry here has to be a *positive* record of shutting down. A false
+# clean is the one error that biases the deliverable downwards and cannot be
+# spotted afterwards in the data, so nothing merely suggestive belongs.
+CLEAN_PATTERN = re.compile(
+    r"systemd-shutdown\[|Reached target (?:\w+ )*(?:Power-?Off|Power Off|Reboot|Halt|Shutdown)"
+    r"|Shutting down\.|Syncing filesystems and block devices",
+    re.IGNORECASE,
+)
+
+FAULT_CAUSES = frozenset(name for name, _ in FAULT_PATTERNS)
+
+
+# ── Verdicts ────────────────────────────────────────────────────────
+
+
+def classify_journal(tail: str) -> tuple[str, list[str]]:
+    """Name the cause the previous boot's journal tail supports, with evidence.
+
+    ``truncated`` is a real answer, not a failure: the log simply stops, which
+    is what a surprise cut looks like from the filesystem's side.  Telling it
+    apart from a clean stop is the point -- ``clean`` requires a positive
+    record, never the absence of a complaint.
+    """
+    lines = tail.splitlines()
+    for cause, pattern in FAULT_PATTERNS:
+        matched = [line for line in lines if pattern.search(line)]
+        if matched:
+            return cause, _evidence(matched)
+    if any(CLEAN_PATTERN.search(line) for line in lines):
+        return "clean", []
+    return "truncated", []
+
+
+def resolve_cause(flag_verdict: str, journal_verdict: str) -> str:
+    """The single label the per-cause breakdown is grouped by.
+
+    The flag is authoritative for *graceful*: ``ExecStop`` demonstrably ran, so
+    the shutdown path was walked no matter what else is in the log.  It is the
+    journal that is authoritative for *why*, and only once the flag has already
+    established that something went wrong.
+    """
+    if flag_verdict == "graceful":
+        return "clean"
+    if journal_verdict in FAULT_CAUSES:
+        return journal_verdict
+    if flag_verdict == "ungraceful":
+        # Nothing in the log and no crash dump, but the flag survived: the
+        # power went away without the kernel getting a word in.
+        return "power_loss"
+    return "clean" if journal_verdict == "clean" else "unknown"
+
+
+def _evidence(lines: list[str]) -> list[str]:
+    """A few matched lines, trimmed -- enough to triage without shipping a log."""
+    return [line.strip()[:EVIDENCE_CHARS] for line in lines[:EVIDENCE_LINES]]
+
+
+# ── Sources ─────────────────────────────────────────────────────────
+
+
+def boot_id() -> str | None:
+    try:
+        return BOOT_ID_PATH.read_text().strip() or None
+    except OSError:
+        return None
+
+
+def journal_tail() -> str | None:
+    """The previous boot's last few hundred lines, or None if there is no such boot.
+
+    Distinguishing "no prior boot recorded" from "prior boot recorded nothing"
+    matters: with a volatile journal the second never happens and mechanism 2
+    is dead on every robot in the fleet, silently.
+
+    short-iso rather than cat: `-o cat` prints the message and nothing else, so
+    the syslog identifier goes with it -- and "systemd-shutdown", the strongest
+    clean-shutdown marker there is, lives in the identifier. The timestamps are
+    worth having in the evidence lines anyway.
+    """
+    return _run(["journalctl", "-b", "-1", "--no-pager", "-o", "short-iso", "-n", str(TAIL_LINES)])
+
+
+def journal_boots() -> int:
+    """How many boots the journal still holds -- 0 when it is volatile or empty."""
+    listing = _run(["journalctl", "--list-boots", "--no-pager", "-q"])
+    if not listing:
+        return 0
+    return len([line for line in listing.splitlines() if line.strip()])
+
+
+def pstore_records() -> list[tuple[str, str]]:
+    """Kernel crash dumps left in pstore, as (identity, first interesting line).
+
+    Read, never removed: systemd-pstore.service archives and clears this
+    directory on its own schedule, and racing it would cost the evidence.
+    Re-reporting across boots is handled by identity instead -- name plus mtime,
+    which a new dump changes and an archived-away one simply stops producing.
+    """
+    records: list[tuple[str, str]] = []
+    try:
+        entries = sorted(PSTORE_DIR.iterdir())
+    except OSError:
+        return records
+    for entry in entries:
+        if not entry.name.startswith("dmesg-"):
+            continue
+        try:
+            identity = f"{entry.name}:{int(entry.stat().st_mtime)}"
+            body = entry.read_text(errors="replace")
+        except OSError:
+            continue
+        records.append((identity, body))
+    return records
+
+
+def _run(command: list[str]) -> str | None:
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=_TIMEOUT)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout if result.returncode == 0 else None
+
+
+# ── State ───────────────────────────────────────────────────────────
+
+
+def read_report() -> dict[str, Any]:
+    try:
+        loaded = json.loads(REPORT_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def write_report(report: dict[str, Any]) -> None:
+    """Replace the report atomically, so a cut mid-write cannot leave a torn one."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    temporary = REPORT_PATH.with_suffix(".tmp")
+    _write_durable(temporary, json.dumps(report, indent=2, sort_keys=True) + "\n")
+    temporary.replace(REPORT_PATH)
+    # 0644: the logger node reads this as the robot user, not as root.
+    os.chmod(REPORT_PATH, 0o644)
+    _sync_directory(STATE_DIR)
+
+
+def write_flag(current_boot: str | None) -> None:
+    """Raise the sentinel, and make sure it is on the platter before returning.
+
+    An unflushed flag is worse than no flag: the event being measured is
+    precisely a power cut with writes still in cache, and a flag lost to one
+    turns a dirty shutdown into a recorded clean one.
+    """
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    _write_durable(FLAG_PATH, json.dumps({"boot_id": current_boot, "since": int(time.time())}) + "\n")
+    _sync_directory(STATE_DIR)
+
+
+def clear_flag() -> None:
+    FLAG_PATH.unlink(missing_ok=True)
+    _sync_directory(STATE_DIR)
+
+
+def _write_durable(path: Path, body: str) -> None:
+    with open(path, "w") as handle:
+        handle.write(body)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _sync_directory(path: Path) -> None:
+    """fsync the directory too -- the file's own fsync does not persist its name."""
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+# ── Commands ────────────────────────────────────────────────────────
+
+
+def on_boot() -> None:
+    current_boot = boot_id()
+    previous = read_report()
+
+    # `systemctl restart` inside a running session stops and starts the unit,
+    # which would clear the flag and then find it missing -- a clean shutdown
+    # that never happened, on a robot that never rebooted.  The kernel's boot
+    # id is what tells a restart apart from a boot.
+    if current_boot is not None and previous.get("boot_id") == current_boot:
+        write_flag(current_boot)
+        print("boot sentinel: same boot as the last record — restart, not a reboot")
+        return
+
+    flag_present = FLAG_PATH.exists()
+    first_run = not previous and not flag_present
+    if first_run:
+        # First run after install.  The last shutdown predates the sentinel, so
+        # there is nothing to say about it; saying "clean" would be a guess
+        # that biases the number this whole exercise exists to produce.
+        flag_verdict = "unknown"
+    else:
+        flag_verdict = "ungraceful" if flag_present else "graceful"
+
+    tail = journal_tail()
+    if tail is None:
+        journal_verdict, evidence = "no_prior_boot", []
+    else:
+        journal_verdict, evidence = classify_journal(tail)
+
+    reported_pstore = set(previous.get("pstore_seen", []))
+    fresh_pstore = [(identity, body) for identity, body in pstore_records() if identity not in reported_pstore]
+    if first_run and fresh_pstore:
+        # A dump already sitting in pstore on the sentinel's first ever run
+        # crashed some boot we were not here for, possibly months ago.  Counting
+        # it would date an old crash into the measurement window, so record it
+        # as seen and say nothing about it -- the same "does not know" the flag
+        # gives for this boot.
+        reported_pstore |= {identity for identity, _ in fresh_pstore}
+        fresh_pstore = []
+    if fresh_pstore:
+        # The kernel wrote a crash dump, which outranks anything inferred from
+        # a log that may have died before the flush.
+        journal_verdict, evidence = classify_journal("\n".join(body for _, body in fresh_pstore))
+        if journal_verdict not in FAULT_CAUSES:
+            journal_verdict = "kernel_panic"
+
+    cause = resolve_cause(flag_verdict, journal_verdict)
+    ungraceful = cause not in ("clean", "unknown")
+
+    report = {
+        "schema": SCHEMA,
+        "recorded_at": int(time.time()),
+        "boot_id": current_boot,
+        "flag_verdict": flag_verdict,
+        "journal_verdict": journal_verdict,
+        "cause": cause,
+        "evidence": evidence,
+        "pstore_records": len(fresh_pstore),
+        "boots_in_journal": journal_boots(),
+        "journal_persistent": PERSISTENT_JOURNAL.is_dir(),
+        # Cumulative, because a per-boot row is only delivered if telemetry
+        # happens to be reachable -- and the fleet spends real time offline.
+        # These are the same shape as the drive's own counters, and comparable
+        # against them.
+        "boot_count": int(previous.get("boot_count", 0)) + 1,
+        "ungraceful_count": int(previous.get("ungraceful_count", 0)) + (1 if ungraceful else 0),
+        "pstore_seen": sorted(reported_pstore | {identity for identity, _ in fresh_pstore}),
+    }
+    write_report(report)
+    write_flag(current_boot)
+    print(f"boot sentinel: last shutdown {cause} (flag {flag_verdict}, journal {journal_verdict})")
+
+
+def on_shutdown() -> None:
+    clear_flag()
+    print("boot sentinel: flag cleared, this shutdown will read as graceful")
+
+
+def main(argv: list[str]) -> int:
+    command = argv[1] if len(argv) > 1 else ""
+    if command not in ("boot", "shutdown"):
+        print(f"usage: {Path(argv[0]).name} boot|shutdown", file=sys.stderr)
+        return 2
+
+    try:
+        on_boot() if command == "boot" else on_shutdown()
+    except Exception as error:  # noqa: BLE001 — see the module docstring
+        print(f"boot sentinel: {command} failed: {error}", file=sys.stderr)
+        if command == "boot":
+            # Whatever else went wrong, the next boot still needs a flag to
+            # find -- otherwise one bad analysis blinds the mechanism for good.
+            try:
+                write_flag(boot_id())
+            except OSError as flag_error:
+                print(f"boot sentinel: could not raise the flag either: {flag_error}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/update/post_update.sh
+++ b/scripts/update/post_update.sh
@@ -11,6 +11,7 @@
 #   0b. Enable a disk-backed swap file (INN-530)
 #   0c. Use a headless (no-GUI) boot when no display is attached
 #   0d. Disable desktop/update daemons with no robot function
+#   0e. Persist the journal across reboots (INN-769)
 #   1. Systemd service files
 #   2. Helper scripts in /usr/local/bin
 #   3. Udev rules
@@ -417,6 +418,48 @@ if command -v snap >/dev/null 2>&1 && ls /var/lib/snapd/snaps/*.snap >/dev/null 
     log "  Keeping snapd (installed snaps present)"
 else
     disable_unit snapd.service snapd.socket
+fi
+
+# -----------------------------------------------------------------------------
+# 0e. Persist the journal across reboots (INN-769).
+# Ubuntu ships Storage=auto, which keeps the journal in tmpfs unless
+# /var/log/journal exists — so on a stock robot `journalctl -b -1` returns
+# nothing and every reset is unattributable. The boot sentinel's second
+# mechanism reads the previous boot's tail; without this it is silently dead on
+# the whole fleet. Capped so a log loop cannot eat the rootfs.
+# -----------------------------------------------------------------------------
+JOURNALD_CONF="/etc/systemd/journald.conf.d/innate.conf"
+if [ -f "$REPO_DIR/config/journald/innate.conf" ]; then
+    log "Configuring persistent journald..."
+    mkdir -p /etc/systemd/journald.conf.d
+    if ! cmp -s "$REPO_DIR/config/journald/innate.conf" "$JOURNALD_CONF"; then
+        cp "$REPO_DIR/config/journald/innate.conf" "$JOURNALD_CONF"
+        NEEDS_JOURNALD_RESTART=true
+    fi
+    if [ ! -d /var/log/journal ]; then
+        # mkdir first, then tmpfiles — not the other way around. Every stock
+        # tmpfiles.d line for this path is `h`/`z`/`a+`, i.e. adjust-existing;
+        # none of them create anything, and `--create` still exits 0 having
+        # done nothing. Ordered the other way the directory never appears, the
+        # flush below is a no-op, and the journal stays volatile until the next
+        # reboot — the silent-fleet-wide-failure this whole section exists to
+        # prevent. tmpfiles is still what sets the systemd-journal group and
+        # the adm ACL that let non-root read the journal.
+        mkdir -p /var/log/journal
+        systemd-tmpfiles --create --prefix /var/log/journal || true
+        NEEDS_JOURNALD_RESTART=true
+    fi
+    if [ "${NEEDS_JOURNALD_RESTART:-false}" = true ]; then
+        # SIGUSR1 is the flush-to-/var/log/journal signal, and is all that is
+        # needed to start persisting now: Storage=auto already persists once
+        # the directory exists, so the config file below only pins the caps.
+        # Deliberately not a restart — journald owns every running service's
+        # stdout, and restarting it mid-update severs those.
+        systemctl kill --kill-who=main --signal=SIGUSR1 systemd-journald 2>/dev/null || true
+        log "  Journal is now persistent (flushed to /var/log/journal)"
+    else
+        log "  Journal already persistent"
+    fi
 fi
 
 # Stop running services before updating (keep app.cpp alive during build)
@@ -952,6 +995,15 @@ fi
 # Add speaker-keepalive if the service file exists
 if [ -f "/etc/systemd/system/speaker-keepalive.service" ]; then
     SERVICES+=("speaker-keepalive.service")
+fi
+
+# Add the ungraceful-shutdown sentinel (INN-769). Deliberately kept out of
+# RESTART_SERVICES below: restarting it runs ExecStop then ExecStart, which
+# clears the flag and finds it missing — a clean shutdown that never happened.
+# (The sentinel also checks the kernel boot id for exactly this case, so a
+# restart is survivable; not asking for one is simply cheaper.)
+if [ -f "/etc/systemd/system/innate-boot-sentinel.service" ]; then
+    SERVICES+=("innate-boot-sentinel.service")
 fi
 
 # Add shutdown-sound if the service file exists (enable only, runs at shutdown)

--- a/tests/test_boot_sentinel.py
+++ b/tests/test_boot_sentinel.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""What the boot sentinel concludes from a journal tail, and from two verdicts.
+
+The number INN-769 exists to produce is a per-cause breakdown, so a classifier
+that quietly calls everything "power_loss" would still look like it worked
+while making the storage decision on noise. The cases worth pinning are the
+ones where the two mechanisms disagree, and the ones where absence of evidence
+must not read as evidence of a clean stop.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("boot_sentinel", REPO_ROOT / "scripts" / "boot_sentinel.py")
+assert _spec and _spec.loader
+boot_sentinel = importlib.util.module_from_spec(_spec)
+sys.modules["boot_sentinel"] = boot_sentinel
+_spec.loader.exec_module(boot_sentinel)
+
+
+CLEAN_TAIL = """
+ros-app.service: Deactivated successfully.
+Stopped Innate ROS application.
+Reached target Shutdown.
+systemd-shutdown[1]: Syncing filesystems and block devices.
+systemd-shutdown[1]: Powering off.
+"""
+
+PANIC_TAIL = """
+mars_arm: torque enabled
+Unable to handle kernel NULL pointer dereference at virtual address 0000000000000018
+Internal error: Oops: 96000004 [#1] PREEMPT SMP
+Kernel panic - not syncing: Attempted to kill init!
+"""
+
+# A robot that ran fine and then simply stopped logging: no complaint, no
+# shutdown sequence. This is what a surprise cut looks like from the disk.
+TRUNCATED_TAIL = """
+logger_node: vitals: cpu 44% | mem 53%
+mars_nav: goal reached
+logger_node: vitals: cpu 41% | mem 53%
+"""
+
+
+def test_a_shutdown_sequence_is_the_only_thing_that_reads_as_clean():
+    assert boot_sentinel.classify_journal(CLEAN_TAIL) == ("clean", [])
+
+
+def test_a_log_that_just_stops_is_truncated_not_clean():
+    verdict, evidence = boot_sentinel.classify_journal(TRUNCATED_TAIL)
+    assert verdict == "truncated"
+    assert evidence == []
+
+
+def test_a_panic_is_named_and_carries_its_own_evidence():
+    verdict, evidence = boot_sentinel.classify_journal(PANIC_TAIL)
+    assert verdict == "kernel_panic"
+    assert any("Kernel panic" in line for line in evidence)
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("watchdog: BUG: soft lockup - CPU#3 stuck for 26s!", "watchdog"),
+        ("tegra_wdt tegra_wdt: last reset is due to watchdog timeout", "watchdog"),
+        ("pcieport 0001:00:00.0: Link Down", "pcie_link_down"),
+        ("nvme nvme0: controller is down; will reset", "pcie_link_down"),
+        ("vdd-3v3-sys: under-voltage detected", "brownout"),
+    ],
+)
+def test_each_cause_has_its_own_marker(line, expected):
+    assert boot_sentinel.classify_journal(line)[0] == expected
+
+
+def test_an_ethernet_unplug_is_not_a_pcie_link_down():
+    """`Link Down` alone is what every NIC logs on unplug — far too broad to use."""
+    tail = "eth0: Link is Down\nigb 0000:01:00.0: eth0: PCIe Link Speed unchanged"
+    assert boot_sentinel.classify_journal(tail)[0] == "truncated"
+
+
+def test_a_panic_outranks_a_lockup_logged_alongside_it():
+    """Ordered patterns, so the specific cause wins over the general symptom."""
+    tail = "watchdog: BUG: soft lockup - CPU#0 stuck\nKernel panic - not syncing: hung"
+    assert boot_sentinel.classify_journal(tail)[0] == "kernel_panic"
+
+
+# ── resolve_cause: where the two mechanisms meet ────────────────────
+
+
+def test_the_flag_is_authoritative_for_graceful():
+    """ExecStop demonstrably ran, so the shutdown path was walked regardless."""
+    assert boot_sentinel.resolve_cause("graceful", "truncated") == "clean"
+    assert boot_sentinel.resolve_cause("graceful", "no_prior_boot") == "clean"
+
+
+def test_a_dirty_flag_against_a_quiet_journal_is_power_loss():
+    """The brownout / SYS_RESET signature: userspace never learned anything was wrong."""
+    assert boot_sentinel.resolve_cause("ungraceful", "truncated") == "power_loss"
+
+
+def test_the_journal_names_the_cause_once_the_flag_says_something_went_wrong():
+    assert boot_sentinel.resolve_cause("ungraceful", "kernel_panic") == "kernel_panic"
+    assert boot_sentinel.resolve_cause("ungraceful", "pcie_link_down") == "pcie_link_down"
+
+
+def test_the_first_boot_after_install_admits_it_does_not_know():
+    """Guessing "clean" here would bias the one number this exists to produce."""
+    assert boot_sentinel.resolve_cause("unknown", "no_prior_boot") == "unknown"
+    assert boot_sentinel.resolve_cause("unknown", "truncated") == "unknown"
+
+
+def test_a_crash_dump_still_names_the_cause_with_no_flag_to_go_on():
+    """pstore survives the reset that cost the journal its tail, and the flag its write."""
+    assert boot_sentinel.resolve_cause("unknown", "kernel_panic") == "kernel_panic"
+
+
+# ── on_boot: the state machine, against a scratch state dir ─────────
+
+OLD_DUMP = ("dmesg-ramoops-0:1700000000", "Kernel panic - not syncing: a crash from before we were here")
+NEW_DUMP = ("dmesg-ramoops-1:1800000000", "Kernel panic - not syncing: Attempted to kill init!")
+
+
+@pytest.fixture
+def sentinel(tmp_path, monkeypatch):
+    """The sentinel pointed at a scratch state dir, with pstore under our control."""
+    monkeypatch.setattr(boot_sentinel, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(boot_sentinel, "FLAG_PATH", tmp_path / "running")
+    monkeypatch.setattr(boot_sentinel, "REPORT_PATH", tmp_path / "last_boot.json")
+    monkeypatch.setattr(boot_sentinel, "pstore_records", list)
+    return boot_sentinel
+
+
+def _reboot(sentinel):
+    """Age the stored report so the next on_boot() reads as a new boot, not a restart."""
+    report = sentinel.read_report()
+    report["boot_id"] = "a-previous-boot"
+    sentinel.write_report(report)
+
+
+def test_a_crash_dump_predating_the_install_is_remembered_but_not_counted(sentinel, monkeypatch):
+    """It crashed a boot nobody was measuring; dating it into the window would inflate the rate."""
+    monkeypatch.setattr(sentinel, "pstore_records", lambda: [OLD_DUMP])
+
+    sentinel.on_boot()
+    report = sentinel.read_report()
+
+    assert report["cause"] == "unknown"
+    assert report["ungraceful_count"] == 0
+    assert report["pstore_seen"] == [OLD_DUMP[0]], "seen, so the next boot does not re-report it"
+
+
+def test_a_dump_that_appears_later_is_still_attributed(sentinel, monkeypatch):
+    monkeypatch.setattr(sentinel, "pstore_records", lambda: [OLD_DUMP])
+    sentinel.on_boot()
+    _reboot(sentinel)
+
+    monkeypatch.setattr(sentinel, "pstore_records", lambda: [OLD_DUMP, NEW_DUMP])
+    sentinel.on_boot()
+    report = sentinel.read_report()
+
+    assert report["cause"] == "kernel_panic"
+    assert report["ungraceful_count"] == 1
+
+
+def test_restarting_the_unit_does_not_invent_a_shutdown(sentinel):
+    """ExecStop then ExecStart within one boot would otherwise read as a clean cycle."""
+    sentinel.on_boot()
+    before = sentinel.read_report()
+
+    sentinel.on_shutdown()
+    sentinel.on_boot()
+
+    assert sentinel.read_report()["boot_count"] == before["boot_count"]
+    assert sentinel.FLAG_PATH.exists(), "and the flag must be back up"
+
+
+def test_a_clean_cycle_then_a_yanked_one(sentinel):
+    sentinel.on_boot()
+    sentinel.on_shutdown()
+    _reboot(sentinel)
+
+    sentinel.on_boot()
+    clean = sentinel.read_report()
+    assert (clean["flag_verdict"], clean["cause"]) == ("graceful", "clean")
+    assert clean["ungraceful_count"] == 0
+
+    # No on_shutdown() this time: the power went away and the flag survived.
+    _reboot(sentinel)
+    sentinel.on_boot()
+    yanked = sentinel.read_report()
+    assert (yanked["flag_verdict"], yanked["cause"]) == ("ungraceful", "power_loss")
+    assert yanked["ungraceful_count"] == 1
+    assert yanked["boot_count"] == 3


### PR DESCRIPTION
## Summary

Stacked on #646 — both touch `logger_node.py`, and #646's disk sweep is where the raw counter comes from. **Base is `feat/logger-smart-telemetry`, so the diff here is only this commit.** Rebases onto `main` trivially once #646 lands.

[INN-769](https://linear.app/innate/issue/INN-769) wants ungraceful resets per robot per year **broken down by cause**. #646 already ships the drive's own `unsafe_shutdowns` — which said 92% of R7-3's power cycles were dirty, but cannot say whether that was a kernel panic, a PCIe link-down, a brownout, or someone on the bench pulling the battery. Those have nothing in common to fix, and the decision rule branches on which it is. This adds the attribution.

A sentinel runs either side of every boot, as root, from systemd. Three mechanisms, because each is blind where the others see:

| | |
|---|---|
| **flag** | written at boot, removed on `ExecStop`. Present at the next boot ⇒ the last shutdown never walked the shutdown path. Catches everything, names nothing. |
| **journal** | the previous boot's tail — the only thing that names a cause when the record survived. |
| **pstore** | the kernel's own crash dump, which survives precisely because it is *not* a disk write. Where panics actually show up, since a panic usually dies before journald flushes. |

Both verdicts ship rather than one merged bool: flag-dirty against a journal with no complaint in it is the brownout / SYS_RESET signature, and collapsing that into "ungraceful" throws away the distinction the fix depends on.

Causes: `clean`, `kernel_panic`, `watchdog`, `pcie_link_down`, `brownout`, `power_loss`, `unknown`.

## Payload

Rides the existing `/log/vitals` body as `boot`, once per boot, on the same retry-until-POSTed path as the disk sweep:

```json
"boot": {"schema": 1, "recorded_at": 1786503374, "boot_id": "…",
         "flag_verdict": "ungraceful", "journal_verdict": "truncated",
         "cause": "power_loss", "evidence": [],
         "pstore_records": 0, "boots_in_journal": 25, "journal_persistent": true,
         "boot_count": 111, "ungraceful_count": 102}
```

`boot_count` / `ungraceful_count` are cumulative because a per-boot row only arrives if telemetry happens to be reachable, and the fleet spends real time offline. Same shape as the drive's counters, and directly comparable against them.

## Three ways this could have quietly lied, all handled

- **`DefaultDependencies=no` on the unit** would drop the implicit `Conflicts=shutdown.target`. systemd would then never stop the unit at shutdown, `ExecStop` would never run, and *every* shutdown on the fleet would record as ungraceful. Left on deliberately, with a comment saying why.
- **`-o cat` strips the syslog identifier**, taking `systemd-shutdown` with it — the strongest clean-shutdown marker there is could never have matched. Caught by running the classifier over this machine's 25 real boots. Now `-o short-iso`.
- **`systemd-tmpfiles --create` exits 0 having created nothing**: every stock `/var/log/journal` rule is `h`/`z`/`a+`, i.e. adjust-existing. `mkdir` has to come first, or the directory never appears and the journal stays volatile — the exact silent fleet-wide failure that section exists to prevent.

Related: Ubuntu's `Storage=auto` keeps the journal in tmpfs, so `journalctl -b -1` on a stock robot returns nothing and mechanism 2 is dead fleet-wide. `post_update.sh` now creates `/var/log/journal` and caps it at 512M.

Also handled: a `systemctl restart` would run `ExecStop` then `ExecStart` and read as a clean cycle that never happened (guarded on the kernel boot id); a crash dump already sitting in pstore at install time would date an old crash into the measurement window (remembered, not counted).

## Out of scope

SMART counters (#646, already shipping), power mode and arm-load at reset ([INN-790](https://linear.app/innate/issue/INN-790)), and the cloud-side rate math ([INN-791](https://linear.app/innate/issue/INN-791) is the ingest note — it will need a `boot` column).

## Validation

- [x] 19 new tests, 57 in `tests/` total, passing.
- [x] Classifier run against this machine's real `journalctl` history — 25 boots, clean reboots and hard cuts classified correctly. This is what caught the `-o cat` bug.
- [x] End-to-end state machine dry run against a scratch state dir: first install, unit restart, clean cycle, yanked cycle, counters, pstore dedup.
- [x] `systemd-analyze verify` on the unit; `ruff check` / `ruff format --check`; `bash -n` on `post_update.sh`.
- [x] `grep -h /var/log/journal /usr/lib/tmpfiles.d/*.conf` to confirm the tmpfiles ordering claim rather than assume it.
- [ ] **Not verified on a robot.** No hardware in this session. Wants one `innate update` on a dev unit, then a reboot and a yank, to confirm the unit is enabled and both records land.
- [ ] `shellcheck` not run — not installed locally.
- [ ] No simulator behavior, config, or assets changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLJuAAqNsunLRt6EEBEB9q