### PR TITLE
fix(audio): play startup sound at RT priority to stop boot-time popping

### DIFF
--- a/scripts/launch_ros_in_tmux.sh
+++ b/scripts/launch_ros_in_tmux.sh
@@ -179,8 +179,18 @@ if [ "$SERVICE_KEY_MISSING" = true ]; then
     echo ""
 fi
 
-# Play five seconds after the ordered speaker keep-alive service (backgrounded)
-(sleep 5 && XDG_RUNTIME_DIR=/run/user/1000 gst-play-1.0 "$INNATE_OS_ROOT/config/sounds/turnon.mp3" >/dev/null 2>&1) &
+# Play five seconds after the ordered speaker keep-alive service (backgrounded).
+# SCHED_FIFO so the boot import storm can't starve the player past dmix's ~85 ms
+# buffer (audible pops); rtprio 30 stays under zenoh's watchdog at 48. GST_DEBUG=2
+# keeps warnings (incl. underruns) in data/ to confirm the diagnosis at real boots.
+(
+    sleep 5
+    rt=()
+    chrt -f 30 true 2>/dev/null && rt=(chrt -f 30)
+    XDG_RUNTIME_DIR=/run/user/1000 GST_DEBUG=2 "${rt[@]}" gst-play-1.0 \
+        "$INNATE_OS_ROOT/config/sounds/turnon.mp3" \
+        >/dev/null 2>"$INNATE_OS_ROOT/data/startup_sound_gst.log"
+) &
 disown
 
 # Every pane has sourced the env file by now, so drop it: the service key should

--- a/scripts/launch_ros_in_tmux.sh
+++ b/scripts/launch_ros_in_tmux.sh
@@ -179,12 +179,12 @@ if [ "$SERVICE_KEY_MISSING" = true ]; then
     echo ""
 fi
 
-# Play five seconds after the ordered speaker keep-alive service (backgrounded).
-# SCHED_FIFO so the boot import storm can't starve the player past dmix's ~85 ms
-# buffer (audible pops); rtprio 30 stays under zenoh's watchdog at 48. GST_DEBUG=2
-# keeps warnings (incl. underruns) in data/ to confirm the diagnosis at real boots.
+# Play ten seconds after launch, past the worst of the node import storm
+# (backgrounded). SCHED_FIFO so that storm can't starve the player past dmix's
+# ~85 ms buffer (audible pops); rtprio 30 stays under zenoh's watchdog at 48.
+# GST_DEBUG=2 keeps warnings (incl. underruns) in data/ to confirm at real boots.
 (
-    sleep 5
+    sleep 10
     rt=()
     chrt -f 30 true 2>/dev/null && rt=(chrt -f 30)
     XDG_RUNTIME_DIR=/run/user/1000 GST_DEBUG=2 "${rt[@]}" gst-play-1.0 \


### PR DESCRIPTION
## Problem

Users hear popping while `turnon.mp3` plays at cold boot.

## Diagnosis

- The sound fires at boot **t≈22–29 s** — the peak of the ROS import storm (~30 python processes importing from cold disk cache simultaneously).
- Playback path is `gst-play` → alsasink → ALSA `default` → **dmix**, whose 4096-frame buffer at 48 kHz gives only **~85 ms of cushion**. Starve the player longer than that and the speaker plays stale samples → the pop. (Validated by force-stalling a playback with SIGSTOP: each stall produces an ALSA underrun.)
- Steady-state load does **not** reproduce it: zero underruns under synthetic CPU hogs, fork storms, disk floods, and memory churn — only the cold-boot window bites.
- Ruled out via boot journal timeline: `nvpmodel`/`jetson_clocks` finish at t=12.4 s and the amp keep-alive (I2S clock) starts at t=12.3 s, both well before the sound.

## Fix

Wrap the player in `chrt -f 30` — an RT thread preempts the import storm, so it can't be starved past the dmix buffer. `jetson1` already has `rtprio 50` (installed for zenoh's watchdog at 48), and the limit applies in the boot path because `ros-app.service` goes through `sudo -u jetson1` (PAM limits). Falls back to normal priority if `chrt` is denied. `GST_DEBUG=2` warnings are kept in `data/startup_sound_gst.log` so future pop reports can be checked for underruns.

## Verification

One cold boot after the change: no audible pops, and `grep -ciE 'underrun|xrun' data/startup_sound_gst.log` → 0. (Popping was intermittent before, so more boots will firm this up — the log makes each one checkable.)

## Not included

`shutdown-sound.service` has the same exposure but needs `LimitRTPRIO=` in the unit (systemd doesn't apply PAM limits) — left for a follow-up.