### PR TITLE
chore(config): bump minimum_app_version to 1.4.0

### DIFF
--- a/config/os_config.yaml
+++ b/config/os_config.yaml
@@ -2,4 +2,4 @@
 # This file is git-tracked and applies to all robots
 # This file is managed by Innate. Editing this file is not recommended.
 
-minimum_app_version: "1.1.0"
+minimum_app_version: "1.4.0"


### PR DESCRIPTION
Bumps `minimum_app_version` in `config/os_config.yaml` from `1.1.0` to `1.4.0`.