### PR TITLE
fix(ci): cap the make jobs too — the package cap alone still ran 24 g++

### DIFF
--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -63,11 +63,12 @@ COPY workspace /root/innate-os/workspace
 # Python source; only proxy/ is required (not the JS frontend / node_modules).
 COPY webapp/proxy /root/innate-os/webapp/proxy
 
+# Copied rather than inherited: until a main build republishes the base, it does
+# not carry this yet.
+COPY ci/build_workspace.sh /usr/local/bin/build_workspace
+
 # Incremental rebuild. ccache (warm from the base) turns unchanged translation
 # units into cache hits; only changed packages truly recompile.
-# --parallel-workers is capped at 3: E2_HIGHCPU_8 has 8 vCPUs but only 8 GB RAM,
-# and >3 concurrent C++ link jobs can OOM with no useful error.
-#
 # Before building, prune build/ + install/ dirs of packages that no longer exist
 # in src — otherwise a deleted package's stale artifacts could keep dependents
 # linking and CI would pass while the post-merge main build breaks. Residual
@@ -90,10 +91,7 @@ RUN . /opt/ros/humble/setup.sh && \
     rm /tmp/current-pkgs.txt && \
     { rosdep install --from-paths src --ignore-src -r -y || \
         echo "WARNING: rosdep install exited non-zero; if the build below fails on a missing system dep, check the rosdep output above." >&2; } && \
-    colcon build --parallel-workers "$(( $(nproc) < 3 ? $(nproc) : 3 ))" --cmake-args \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    build_workspace
 
 # Shared test entrypoint script (used by docker-compose.test.yml and Cloud Build).
 # Placed after the build so editing it does not invalidate the colcon build cache.

--- a/ci/Dockerfile.test-base
+++ b/ci/Dockerfile.test-base
@@ -104,20 +104,17 @@ RUN cd /root/innate-os/ros2_ws/src && \
         vcs import --input dependencies.repos; \
     fi
 
+COPY ci/build_workspace.sh /usr/local/bin/build_workspace
+
 # Full build with ccache. ccache writes to /root/.ccache (a REAL dir, NOT a
 # --mount=type=cache) so the populated cache is baked into the image layer and
-# carried into ci/Dockerfile.test via FROM. --parallel-workers is capped at 3:
-# E2_HIGHCPU_8 has 8 vCPUs but only 8 GB RAM, and >3 concurrent C++ link jobs
-# (mars_cam etc.) can OOM with no useful error.
+# carried into ci/Dockerfile.test via FROM.
 # mars_cam/nav/control build fine on non-Jetson: cam's VPI stereo component is
 # guarded by if(VPI_FOUND), nav's only Jetson dep (python3-cupy) is runtime-only.
 WORKDIR /root/innate-os/ros2_ws
 RUN . /opt/ros/humble/setup.sh && \
-    rosdep install --from-paths src --ignore-src -r -y || true && \
-    colcon build --parallel-workers "$(( $(nproc) < 3 ? $(nproc) : 3 ))" --cmake-args \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    { rosdep install --from-paths src --ignore-src -r -y || true; } && \
+    build_workspace
 
 WORKDIR /root/innate-os
 CMD ["bash"]

--- a/ci/Dockerfile.test-base.dockerignore
+++ b/ci/Dockerfile.test-base.dockerignore
@@ -18,3 +18,5 @@ ros2_ws/log/
 !config/**
 !workspace/
 !workspace/**
+!ci/
+!ci/build_workspace.sh

--- a/ci/Dockerfile.test.dockerignore
+++ b/ci/Dockerfile.test.dockerignore
@@ -18,6 +18,7 @@ ros2_ws/log/
 !workspace/**
 !ci/
 !ci/run_integration_tests.sh
+!ci/build_workspace.sh
 
 # The webapp front-door proxy (Python) runs its no-ROS pytest bucket in
 # run_integration_tests.sh. Re-include webapp/ whole (1.3M, no node_modules):

--- a/ci/build_workspace.sh
+++ b/ci/build_workspace.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# colcon build with both parallelism caps, sampling memory and load throughout.
+# Run from ros2_ws with ROS sourced; extra args pass through to colcon.
+#
+# colcon injects make -j$(nproc) per package unless MAKEFLAGS carries a -j.
+set -u
+
+MAKE_JOBS=3
+PACKAGE_WORKERS=$(( $(nproc) < 3 ? $(nproc) : 3 ))
+SAMPLE_INTERVAL=5
+
+sample_resources() {
+    while :; do
+        awk '/^MemTotal:/{t=$2} /^MemAvailable:/{a=$2} /^MemFree:/{f=$2}
+             END {if (a == "") a = f; printf "SAMPLE used_MiB=%d total_MiB=%d", (t-a)/1024, t/1024}' \
+            /proc/meminfo
+        printf ' load1=%s runnable=%s' \
+            "$(cut -d' ' -f1 /proc/loadavg)" "$(cut -d' ' -f4 /proc/loadavg)"
+        printf ' compilers=%s\n' \
+            "$(grep -lxE 'cc1plus|cc1|lto1|ld' /proc/[0-9]*/comm 2>/dev/null | wc -l)"
+        sleep "$SAMPLE_INTERVAL"
+    done
+}
+
+sample_resources &
+sampler=$!
+
+MAKEFLAGS="-j${MAKE_JOBS} -l$(nproc)" \
+    colcon build --parallel-workers "$PACKAGE_WORKERS" "$@" --cmake-args \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+rc=$?
+
+kill "$sampler" 2>/dev/null || true
+echo  # the kill lands mid-printf, so close the truncated sample line
+exit "$rc"

--- a/ci/run_integration_tests.sh
+++ b/ci/run_integration_tests.sh
@@ -130,10 +130,6 @@ echo "=== integration tests: --symlink-install ==="
 # removed `setup.py develop`, after which none of these pins stay load-bearing.
 python3 -m pip install --quiet 'setuptools<80'
 rm -rf build install log
-colcon build --symlink-install \
-  --parallel-workers "$(( $(nproc) < 3 ? $(nproc) : 3 ))" --cmake-args \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+build_workspace --symlink-install
 source install/setup.bash
 run_ros_integration_tests


### PR DESCRIPTION
## Summary

- Every push to main since 06:46 UTC today died with Cloud Build `INTERNAL_ERROR` ~57 min in (`a7577f57`, `41d9eae0`, `3d0cb86b`). All three stopped at the same place — `manipulation` + `mars_cam` + `mars_nav` compiling together — then went totally silent: no colcon `[Processing: …]` heartbeat, no BuildKit progress, no error. The worker was gone, not the compile.
- `--parallel-workers 3` caps *packages*, not compile jobs. colcon-cmake appends `-j$(nproc) -l$(nproc)` per package unless `MAKEFLAGS` already carries a `-j` ([`task/cmake/build.py:305-315`](https://github.com/colcon/colcon-cmake/blob/master/colcon_cmake/task/cmake/build.py)), so the real peak was **3 × 8 = up to 24 concurrent g++/ld on an 8 GB E2_HIGHCPU_8**. The comment on that line claimed the package cap was what prevented this; that misreading is what let the bug through, so it's rewritten rather than extended.
- Sets `MAKEFLAGS="-j3 -l8"` on the colcon RUN in **both** `ci/Dockerfile.test-base` and `ci/Dockerfile.test`. Peak drops to 9. The thin PR layer runs the identical uncapped invocation, so a PR touching several heavy C++ packages could wedge the same way — capping only the base would have been a half-fix.
- Only main hit this: PRs pull the published base and rebuild incrementally. Side effect worth knowing — `ghcr.io/innate-inc/innate-os-test-base:main` went stale at 05:46 and every PR since has been validated against it.

Not in this PR, but found while digging: the GHA job sat silent for the full hour because `gcloud beta builds submit` log streaming failed immediately with `Unknown error encountered. (One or more of the resources specified does not exist or the user does not have permission to access it.)`. The same command streams fine under my own credentials, so the WIF service account most likely lacks Cloud Logging read. That's why this failure was opaque from GitHub rather than showing the hang. Separate follow-up.

Also unwired, and separately documented as required in both the workflow and the cloudbuild config: `vars.GCP_CLOUD_BUILD_WORKER_POOL` is unset, so `pool_flag=""` and everything runs on the default gVisor pool.

## Validation

Submitted this branch to Cloud Build with `_PUBLISH_BASE=true` — [`14b579c8`](https://console.cloud.google.com/cloud-build/builds;region=us-central1/14b579c8-52e6-45c7-93fe-68ba3e792c0c?project=59581386846), **SUCCESS in 13m4s**, all three steps. It walked through both fatal windows:

```
#25 199.9  [Processing: manipulation, mars_arm, mars_cam]   <- where 3d0cb86b and a7577f57 died
#25 247.4  [Processing: manipulation, mars_cam, mars_nav]   <- where 41d9eae0 died
#25 279.2  Finished <<< mars_cam [2min 7s]
#25 320.0  Summary: 23 packages finished [5min 17s]
```

Cost of the cap: colcon 4m26s -> 5m17s (~19%) against the last known-good main build. Integration tests passed inside the resulting image.

That run also republished `innate-os-test-base:{main,buildcache}` at `sha256:7b7e23cf…`, un-staling ghcr. The workspace content of that image matches `origin/main` exactly — this branch differs from main only in the two Dockerfiles — so nothing drifted into the published base.

- [x] I ran the relevant local validation, or explained why it was skipped.
- [x] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — n/a, CI-only change.
- [x] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — n/a, no asset changes.