### PR TITLE
feat(sim): report anonymous simulator usage

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,17 @@
 # GEMINI_MODEL overrides the brain's model (default gemini-3.6-flash).
 # GEMINI_MODEL=
 
+# --- Usage telemetry ---
+# The simulator reports that it is running — an anonymous install id, the sim
+# version, your OS and CPU/RAM, how well the sim keeps up, and which features
+# you used (drove it, ran a skill, ran the agent, finished a challenge). It
+# never includes your prompts, your code, or a raw hardware identifier: the
+# machine id is salted and hashed before it leaves your computer. Without a
+# service key it is fully anonymous.
+#
+# Turn it off completely:
+# INNATE_TELEMETRY=0
+
 # --- Cloud endpoints (all read from the environment; set by default) ---
 # TELEMETRY_URL=https://logs.svc.innate.bot
 # UNINAVID_WS_URL=wss://uninavid-v1.svc.innate.bot

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Innate OS is currently based on ROS 2, the reference framework for robotics oper
 - **[mars_nav](ros2_ws/src/mars_bot/mars_nav)** - Nav2-based navigation, SLAM mapping, and the mode manager that switches between `mapfree`, `mapping`, and `navigation`.
 - **[brain_client](ros2_ws/src/brain/brain_client)** - bridge to the Innate cloud brain, websocket client, skills action server, and user input manager.
 - **[manipulation](ros2_ws/src/brain/manipulation)** - records and replays manipulation demonstrations and runs learned or scripted manipulation policies.
-- **[innate_logger](ros2_ws/src/cloud/innate_logger)** - uploads robot logs and telemetry to the Innate cloud.
+- **[innate_logger](ros2_ws/src/cloud/innate_logger)** - uploads robot logs and telemetry to the Innate cloud, and anonymous simulator usage (opt out with `INNATE_TELEMETRY=0`).
 - **[innate_training_node](ros2_ws/src/cloud/innate_training_node)** - collects training episodes and pushes them to the training cloud.
 - **[innate_uninavid](ros2_ws/src/cloud/innate_uninavid)** - UniNaVid vision-language navigation client.
 

--- a/ros2_ws/src/README.md
+++ b/ros2_ws/src/README.md
@@ -21,7 +21,7 @@ drivers, control, navigation, and simulation).
 | --- | --- |
 | [`clients`](cloud/clients) | Cloud client libraries: auth, proxy, and training. |
 | [`innate_cloud_msgs`](cloud/innate_cloud_msgs) | Message/service definitions for cloud training. |
-| [`innate_logger`](cloud/innate_logger) | Logs robot vitals, directives, and chat to the cloud. |
+| [`innate_logger`](cloud/innate_logger) | Logs robot vitals, directives, and chat to the cloud; `sim_logger_node` reports anonymous simulator usage. |
 | [`innate_training_node`](cloud/innate_training_node) | Training job management, status publishing, and file transfer. |
 | [`innate_uninavid`](cloud/innate_uninavid) | Bridges compressed camera images to a cloud websocket and publishes `cmd_vel` in response. |
 

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/sim_client.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/sim_client.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Usage telemetry transport for the simulator.
+
+Differs from :mod:`innate_logger.client` in the three ways the sim differs
+from a robot: authentication is optional (most sim users have no service
+key), being offline is a normal steady state rather than a boot transient,
+and no network call may ever run on the ROS executor.
+
+Everything here therefore lives on one background thread: auth, HTTP, backoff
+and the spool. Callers only ever touch the queue.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+# Backoff between failed flushes. Offline sims sit at the ceiling rather than
+# retrying every heartbeat for hours.
+_BACKOFF_START_S = 5.0
+_BACKOFF_MAX_S = 300.0
+
+# The spool holds events only. Heartbeats are dropped when offline: a stale
+# "I was alive 3 days ago" adds nothing a gap in the series does not already
+# show, and they would crowd out the events worth keeping.
+_SPOOL_MAX_EVENTS = 2000
+# One flush's worth, matching the server's per-request cap.
+_SPOOL_BATCH = 500
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class SimAuth:
+    """A bearer token for the telemetry endpoints, however it was obtained.
+
+    Two sources, picked by whether the install has a service key:
+    :class:`auth_client.AuthProvider` for keyed installs, or an anonymous
+    token minted against the install id for everyone else. Both are refreshed
+    lazily and only ever from the uploader thread.
+    """
+
+    def __init__(self, issuer_url: str, install_id: str, service_key: str = "") -> None:
+        self._issuer_url = issuer_url.rstrip("/")
+        self._install_id = install_id
+        self._provider: Any | None = None
+        self._anon_token: str | None = None
+        # Anonymous tokens are re-minted a little early rather than on 401, so
+        # a heartbeat is not spent discovering the expiry.
+        self._anon_expires_at: float = 0.0
+
+        if service_key:
+            from auth_client import AuthProvider
+
+            self._provider = AuthProvider(issuer_url=self._issuer_url, service_key=service_key)
+
+    @property
+    def anonymous(self) -> bool:
+        return self._provider is None
+
+    def token(self) -> str:
+        """Return a usable bearer token, fetching one if needed.
+
+        Raises whatever the underlying transport raises; the caller treats any
+        failure as "still offline".
+        """
+        if self._provider is not None:
+            return str(self._provider.token)
+
+        if self._anon_token and time.monotonic() < self._anon_expires_at:
+            return self._anon_token
+
+        return self._mint_anonymous()
+
+    def invalidate(self) -> None:
+        """Force the next :meth:`token` call to fetch a fresh one."""
+        if self._provider is not None:
+            self._provider.token_needs_renewal = True
+        else:
+            self._anon_token = None
+            self._anon_expires_at = 0.0
+
+    def _mint_anonymous(self) -> str:
+        request = Request(
+            f"{self._issuer_url}/v1/sim/token",
+            data=json.dumps({"install_id": self._install_id}).encode("utf-8"),
+            headers={"Content-Type": "application/json", "User-Agent": "innate-sim"},
+            method="POST",
+        )
+        with urlopen(request, timeout=10.0) as response:
+            body = json.loads(response.read().decode("utf-8"))
+
+        self._anon_token = str(body["token"])
+        # Well inside the issuer's expiry (10 min) without assuming its value.
+        self._anon_expires_at = time.monotonic() + 240.0
+        return self._anon_token
+
+
+class EventSpool:
+    """Events that have not reached the cloud yet, kept across restarts.
+
+    Single-writer by construction — only the uploader thread touches the file
+    — so it needs no locking. That is why challenge events arrive over a ROS
+    topic instead of being written here by the world server, which is a
+    different process on the other side of the container boundary.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._pending: list[dict[str, Any]] = []
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            lines = self.path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return
+        for line in lines:
+            try:
+                self._pending.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue  # a torn last line from a hard kill
+        if self._pending:
+            logger.info("Recovered %d spooled sim events", len(self._pending))
+
+    def add(self, event: dict[str, Any]) -> None:
+        self._pending.append(event)
+        # Oldest out first: a full spool means a long offline stretch, and the
+        # recent events describe what the user is doing now.
+        if len(self._pending) > _SPOOL_MAX_EVENTS:
+            del self._pending[: len(self._pending) - _SPOOL_MAX_EVENTS]
+        self._persist()
+
+    def batch(self) -> list[dict[str, Any]]:
+        return self._pending[:_SPOOL_BATCH]
+
+    def drop(self, count: int) -> None:
+        del self._pending[:count]
+        self._persist()
+
+    def __len__(self) -> int:
+        return len(self._pending)
+
+    def _persist(self) -> None:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.write_text(
+                "".join(json.dumps(e) + "\n" for e in self._pending), encoding="utf-8"
+            )
+        except OSError as exc:
+            logger.debug("Could not persist sim spool: %s", exc)
+
+
+class SimTelemetryUploader:
+    """Owns the only thread allowed to do network I/O for sim telemetry."""
+
+    def __init__(
+        self,
+        telemetry_url: str,
+        auth: SimAuth,
+        spool_path: Path,
+        identity: dict[str, Any],
+    ) -> None:
+        self.base_url = telemetry_url.rstrip("/")
+        self._auth = auth
+        self._identity = identity
+        self._spool = EventSpool(spool_path)
+        self._heartbeats: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=4)
+        self._new_events: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=256)
+        self._stop = threading.Event()
+        self._wake = threading.Event()
+        self._backoff = _BACKOFF_START_S
+        self._online: bool | None = None
+        self._thread = threading.Thread(target=self._run, daemon=True, name="sim-telemetry")
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self, timeout: float = 3.0) -> None:
+        """Ask the thread to make one last flush attempt, then give up.
+
+        Bounded because this runs during node shutdown: an offline sim must not
+        hang the exit waiting for a connection that will not happen.
+        """
+        self._stop.set()
+        self._wake.set()
+        self._thread.join(timeout=timeout)
+
+    def heartbeat(self, vitals: dict[str, Any]) -> None:
+        """Queue a heartbeat. Dropped rather than spooled when offline."""
+        try:
+            self._heartbeats.put_nowait({**self._identity, **vitals, "occurred_at": _utc_now_iso()})
+        except queue.Full:
+            pass  # the uploader is behind; the next tick supersedes this one anyway
+        self._wake.set()
+
+    def event(self, name: str, payload: dict[str, Any] | None = None, occurred_at: str | None = None) -> None:
+        """Queue an event. Spooled if it cannot be sent now."""
+        try:
+            self._new_events.put_nowait(
+                {
+                    **self._identity,
+                    "event": name,
+                    "payload": payload or {},
+                    "occurred_at": occurred_at or _utc_now_iso(),
+                }
+            )
+        except queue.Full:
+            logger.debug("Sim event queue full, dropping %s", name)
+        self._wake.set()
+
+    # ── Uploader thread ──────────────────────────────────────────────
+
+    def _run(self) -> None:
+        while True:
+            stopping = self._stop.is_set()
+            self._drain_new_events()
+
+            sent_any = self._flush_events()
+            sent_any = self._flush_heartbeats() or sent_any
+
+            if stopping:
+                return
+
+            # Idle wait when healthy; backoff when the last attempt failed.
+            wait = self._backoff if self._online is False else 1.0
+            self._wake.wait(timeout=wait)
+            self._wake.clear()
+            del sent_any
+
+    def _drain_new_events(self) -> None:
+        while True:
+            try:
+                self._spool.add(self._new_events.get_nowait())
+            except queue.Empty:
+                return
+
+    def _flush_events(self) -> bool:
+        if not len(self._spool):
+            return False
+        batch = self._spool.batch()
+        if not self._post("/log/sim/events", {"events": batch}):
+            return False
+        self._spool.drop(len(batch))
+        return True
+
+    def _flush_heartbeats(self) -> bool:
+        sent = False
+        while True:
+            try:
+                beat = self._heartbeats.get_nowait()
+            except queue.Empty:
+                return sent
+            if not self._post("/log/sim/heartbeat", beat):
+                return sent  # still offline; the rest are stale by now
+            sent = True
+
+    def _post(self, endpoint: str, payload: dict[str, Any]) -> bool:
+        try:
+            token = self._auth.token()
+        except Exception as exc:  # noqa: BLE001 -- offline is ordinary here
+            self._went_offline("auth unavailable: %s", exc)
+            return False
+
+        body = json.dumps(payload).encode("utf-8")
+        for attempt in range(2):
+            try:
+                request = Request(
+                    f"{self.base_url}{endpoint}",
+                    data=body,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {token}",
+                        "User-Agent": "innate-sim",
+                    },
+                    method="POST",
+                )
+                with urlopen(request, timeout=10.0) as response:
+                    if response.status == 200:
+                        self._went_online()
+                        return True
+                    self._went_offline("telemetry returned HTTP %s", response.status)
+                    return False
+            except HTTPError as exc:
+                if exc.code == 401 and attempt == 0:
+                    self._auth.invalidate()
+                    try:
+                        token = self._auth.token()
+                    except Exception as auth_exc:  # noqa: BLE001
+                        self._went_offline("auth unavailable: %s", auth_exc)
+                        return False
+                    continue
+                # 429 is the server asking for quiet; the backoff already does that.
+                self._went_offline("telemetry HTTP %d %s", exc.code, exc.reason)
+                return False
+            except (URLError, OSError) as exc:
+                self._went_offline("telemetry unreachable: %s", exc)
+                return False
+        return False
+
+    def _went_online(self) -> None:
+        if self._online is not True:
+            logger.info("Sim telemetry connected to %s", self.base_url)
+        self._online = True
+        self._backoff = _BACKOFF_START_S
+
+    def _went_offline(self, message: str, *args: Any) -> None:
+        # Debug, not warning: running the sim with no connectivity is a
+        # supported mode, and an every-few-seconds warning reads to a user as
+        # though the simulator itself is broken.
+        logger.debug("Sim telemetry offline (" + message + ")", *args)
+        if self._online is not False:
+            logger.info("Sim telemetry offline — events will be sent when connectivity returns")
+        self._online = False
+        self._backoff = min(self._backoff * 2, _BACKOFF_MAX_S)

--- a/ros2_ws/src/cloud/innate_logger/innate_logger/sim_logger_node.py
+++ b/ros2_ws/src/cloud/innate_logger/innate_logger/sim_logger_node.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""ROS 2 node that reports simulator usage to the Innate cloud.
+
+The sim counterpart to :mod:`innate_logger.logger_node`, which it deliberately
+does not share code with: that node reports battery and diagnostics a sim does
+not have, requires a service key most sim users do not have, and blocks on
+auth at startup because a booting robot will get a network eventually. Here,
+offline is a place users live.
+
+Nothing in this node blocks the executor. Callbacks only ever enqueue; all
+network I/O belongs to :class:`SimTelemetryUploader`'s thread.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import uuid
+from pathlib import Path
+
+import psutil
+import rclpy
+from dotenv import find_dotenv, load_dotenv
+from geometry_msgs.msg import Twist
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from std_msgs.msg import String
+
+from innate_logger.sim_client import SimAuth, SimTelemetryUploader
+
+DEFAULT_TELEMETRY_URL = "https://logs.svc.innate.bot"
+DEFAULT_AUTH_ISSUER_URL = "https://auth-v1.svc.innate.bot"
+
+# Nothing a sim reports changes on a robot's 5 s timescale, and a slower beat
+# keeps an idle sim from dominating the events table.
+HEARTBEAT_INTERVAL_S = 30.0
+
+# /odom's nominal rate in the sim driver (mars_sim_driver.node.ODOM_HZ). The
+# ratio of observed to nominal is the sim's real-time factor: when a machine
+# cannot keep up, the driver's timers slip and this falls away from 1.0. It is
+# the closest thing the sim has to a battery gauge.
+ODOM_NOMINAL_HZ = 30.0
+
+# One teleop event per this many seconds. A joystick publishes at 20 Hz and the
+# funnel only asks whether the user ever drove the robot.
+TELEOP_EVENT_INTERVAL_S = 300.0
+
+# Where unsent events wait. Under ~/.ros, which the launcher already persists
+# to the host, so a container restart does not lose them.
+SPOOL_PATH = Path.home() / ".ros" / "innate-sim-telemetry.jsonl"
+
+
+def _env_flag_disabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"0", "false", "no", "off"}
+
+
+class SimLoggerNode(Node):
+    """Reports that this simulator install is alive, and what it is doing."""
+
+    def __init__(self) -> None:
+        super().__init__("sim_logger_node")
+
+        env_path = find_dotenv(usecwd=True)
+        if env_path:
+            load_dotenv(env_path)
+
+        if _env_flag_disabled("INNATE_TELEMETRY"):
+            self.get_logger().info("Sim telemetry disabled by INNATE_TELEMETRY")
+            self._uploader = None
+            return
+
+        install_id = os.getenv("INNATE_SIM_INSTALL_ID", "").strip()
+        if not install_id:
+            # Set by the launcher for every run. Absent means someone started
+            # the stack by hand, and inventing one here would register a new
+            # install on every launch.
+            self.get_logger().info("No INNATE_SIM_INSTALL_ID — sim telemetry disabled")
+            self._uploader = None
+            return
+
+        self._session_id = str(uuid.uuid4())
+        self._uploader = SimTelemetryUploader(
+            telemetry_url=os.getenv("TELEMETRY_URL", DEFAULT_TELEMETRY_URL),
+            auth=SimAuth(
+                issuer_url=os.getenv("INNATE_AUTH_URL", DEFAULT_AUTH_ISSUER_URL),
+                install_id=install_id,
+                service_key=os.getenv("INNATE_SERVICE_KEY", "").strip(),
+            ),
+            spool_path=SPOOL_PATH,
+            identity={
+                "install_id": install_id,
+                "device_hash": os.getenv("INNATE_SIM_DEVICE_HASH", "").strip() or None,
+                "session_id": self._session_id,
+                "source": "sim",
+            },
+        )
+        self._uploader.start()
+
+        self._odom_count = 0
+        self._last_teleop_event = 0.0
+        self._started_at = self.get_clock().now()
+
+        self.create_subscription(Odometry, "/odom", self._on_odom, _best_effort_qos())
+        self.create_subscription(Twist, "/cmd_vel_teleop", self._on_teleop, _best_effort_qos())
+        self.create_subscription(String, "/brain/set_directive", self._on_directive, 10)
+        self.create_subscription(String, "/brain/skill_status_update", self._on_skill_status, 10)
+        # Challenge outcomes, published by the world server over rosbridge
+        # (mars_sim_driver.challenges.TelemetryEventBridge).
+        self.create_subscription(String, "/sim/telemetry_event", self._on_sim_event, 10)
+
+        self.create_timer(HEARTBEAT_INTERVAL_S, self._on_heartbeat)
+
+        self._uploader.event("sim_started", self._build_info())
+        self.get_logger().info(f"Sim telemetry started (install {install_id[:8]}…)")
+
+    # ── Callbacks ───────────────────────────────────────────────────
+
+    def _on_odom(self, _msg: Odometry) -> None:
+        self._odom_count += 1
+
+    def _on_teleop(self, _msg: Twist) -> None:
+        now = self._monotonic()
+        if now - self._last_teleop_event < TELEOP_EVENT_INTERVAL_S:
+            return
+        self._last_teleop_event = now
+        self._emit("teleop_used")
+
+    def _on_directive(self, msg: String) -> None:
+        # The directive text is the user's own prompt, so only its presence and
+        # length are reported.
+        self._emit("agent_started", {"directive_chars": len(msg.data)})
+
+    def _on_skill_status(self, msg: String) -> None:
+        try:
+            status = json.loads(msg.data)
+        except json.JSONDecodeError:
+            return
+        if status.get("status") not in {"started", "running"}:
+            return
+        self._emit("skill_invoked", {"skill": str(status.get("skill") or status.get("name") or "")})
+
+    def _on_sim_event(self, msg: String) -> None:
+        try:
+            frame = json.loads(msg.data)
+        except json.JSONDecodeError:
+            return
+        name = str(frame.get("event") or "")
+        if not name:
+            return
+        payload = frame.get("payload")
+        self._emit(name, payload if isinstance(payload, dict) else None)
+
+    def _on_heartbeat(self) -> None:
+        if self._uploader is None:
+            return
+
+        observed_hz = self._odom_count / HEARTBEAT_INTERVAL_S
+        self._odom_count = 0
+
+        self._uploader.heartbeat(
+            {
+                **self._build_info(),
+                "cpu_usage": psutil.cpu_percent(interval=None),
+                "ram_gb": round(psutil.virtual_memory().total / 1024**3, 1),
+                "cpu_count": psutil.cpu_count(),
+                # None rather than 0.0 before /odom has ever arrived, so an
+                # unstarted sim is not indistinguishable from a stalled one.
+                "real_time_factor": (
+                    round(min(observed_hz / ODOM_NOMINAL_HZ, 1.0), 3) if observed_hz else None
+                ),
+                "uptime_s": round(
+                    (self.get_clock().now() - self._started_at).nanoseconds / 1e9, 1
+                ),
+            }
+        )
+
+    # ── Helpers ─────────────────────────────────────────────────────
+
+    def _build_info(self) -> dict[str, object]:
+        """Which build of the sim this is, as resolved by the host launcher.
+
+        None of it can be worked out in here: the container has no .git, and
+        the image tag is a compose-level fact.
+        """
+        return {
+            "commit": os.getenv("INNATE_SIM_COMMIT", "").strip() or None,
+            "image_ref": os.getenv("INNATE_SIM_IMAGE_REF", "").strip() or None,
+            "launcher_version": os.getenv("INNATE_SIM_LAUNCHER_VERSION", "").strip() or None,
+            "platform": os.getenv("INNATE_SIM_PLATFORM", "").strip() or platform.system().lower(),
+            "platform_release": os.getenv("INNATE_SIM_PLATFORM_RELEASE", "").strip() or None,
+            "brain_backend": os.getenv("INNATE_SIM_BRAIN_BACKEND", "").strip() or None,
+        }
+
+    def _emit(self, name: str, payload: dict[str, object] | None = None) -> None:
+        if self._uploader is not None:
+            self._uploader.event(name, payload)
+
+    def _monotonic(self) -> float:
+        return self.get_clock().now().nanoseconds / 1e9
+
+    def shutdown(self) -> None:
+        if self._uploader is None:
+            return
+        self._uploader.event("sim_stopped")
+        self._uploader.stop()
+
+
+def _best_effort_qos() -> QoSProfile:
+    """Match the sim driver's sensor streams, and never queue a backlog.
+
+    Counting /odom for the real-time factor means the arrival rate must be the
+    true one — a reliable queue would replay a burst after any hiccup and hide
+    exactly the stall being measured.
+    """
+    return QoSProfile(
+        reliability=QoSReliabilityPolicy.BEST_EFFORT,
+        durability=QoSDurabilityPolicy.VOLATILE,
+        history=QoSHistoryPolicy.KEEP_LAST,
+        depth=1,
+    )
+
+
+def main(args: list[str] | None = None) -> None:
+    rclpy.init(args=args)
+    node = SimLoggerNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.shutdown()
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/cloud/innate_logger/launch/sim_logger.launch.py
+++ b/ros2_ws/src/cloud/innate_logger/launch/sim_logger.launch.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Launch file for the innate_logger sim usage node."""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description() -> LaunchDescription:
+    log_level = LaunchConfiguration("log_level")
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "log_level",
+                default_value="info",
+                description="Node log level. 'debug' also reports every failed telemetry attempt.",
+            ),
+            Node(
+                package="innate_logger",
+                executable="sim_logger_node",
+                name="sim_logger_node",
+                output="screen",
+                # Everything comes from the environment: the launcher writes
+                # INNATE_SIM_* into the .env the container mounts.
+                parameters=[],
+                arguments=["--ros-args", "--log-level", ["sim_logger_node:=", log_level]],
+            ),
+        ]
+    )

--- a/ros2_ws/src/cloud/innate_logger/package.xml
+++ b/ros2_ws/src/cloud/innate_logger/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>innate_logger</name>
   <version>0.1.0</version>
-  <description>ROS 2 node for logging robot vitals, directives, and chat to the cloud.</description>
+  <description>ROS 2 nodes for logging robot vitals and simulator usage to the cloud.</description>
   <maintainer email="eng@innate.bot">Innate Engineering</maintainer>
   <license>Apache-2.0</license>
 
@@ -11,6 +11,8 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>mars_msgs</depend>
   <depend>cloud_clients</depend>
 

--- a/ros2_ws/src/cloud/innate_logger/setup.py
+++ b/ros2_ws/src/cloud/innate_logger/setup.py
@@ -14,17 +14,21 @@ setup(
             ["resource/" + package_name],
         ),
         ("share/" + package_name, ["package.xml"]),
-        ("share/" + package_name + "/launch", ["launch/logger.launch.py"]),
+        (
+            "share/" + package_name + "/launch",
+            ["launch/logger.launch.py", "launch/sim_logger.launch.py"],
+        ),
     ],
     install_requires=["setuptools"],
     zip_safe=True,
     maintainer="Innate Engineering",
     maintainer_email="eng@innate.bot",
-    description="ROS 2 node for logging robot vitals, directives, and chat to the cloud.",
+    description="ROS 2 nodes for logging robot vitals and simulator usage to the cloud.",
     license="Apache-2.0",
     entry_points={
         "console_scripts": [
             "logger_node = innate_logger.logger_node:main",
+            "sim_logger_node = innate_logger.sim_logger_node:main",
         ],
     },
 )

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/challenges.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/challenges.py
@@ -41,6 +41,7 @@ import json
 import math
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -293,10 +294,16 @@ class ChallengeEngine:
     """
 
     def __init__(
-        self, sim, sim_lock: threading.Lock, roots: list[Path] | None = None, progress_path: Path | None = None
+        self,
+        sim,
+        sim_lock: threading.Lock,
+        roots: list[Path] | None = None,
+        progress_path: Path | None = None,
+        telemetry: "TelemetryEventBridge | None" = None,
     ):
         self.sim = sim
         self.sim_lock = sim_lock
+        self.telemetry = telemetry
         # Tracked source dir plus anything the asset bundle shipped, like the
         # props (core.VirtualMars): a pack can carry its scenarios with it.
         if roots is None:  # an explicitly empty list means "load nothing"
@@ -363,6 +370,16 @@ class ChallengeEngine:
             self._save_progress()
         except OSError as exc:
             print(f"[challenges] could not write {self.progress_path}: {exc}", flush=True)
+        if self.telemetry is not None:
+            # "passed" is the funnel's completion stage, so it gets the name the
+            # dashboard counts; the other outcomes keep theirs.
+            name = "completed" if result == "passed" else result
+            self.telemetry.emit(
+                f"challenge_{name}",
+                challenge_id=challenge_id,
+                time_s=round(time_s, 1) if time_s is not None else None,
+                attempts=entry.get("attempts", 0),
+            )
 
     # -- commands (observer connection threads) --
 
@@ -417,6 +434,8 @@ class ChallengeEngine:
                 entry = self.progress.setdefault(challenge_id, {"attempts": 0, "passed": False, "best_time_s": None})
                 entry["attempts"] += 1
                 self.active = challenge  # last: judging starts here
+        if self.telemetry is not None:
+            self.telemetry.emit("challenge_started", challenge_id=challenge_id)
         return True
 
     def abort(self) -> None:
@@ -586,6 +605,64 @@ class SkillEventBridge:
                                 self.engine.post_event(json.loads(frame["msg"]["data"]))
                         except Exception as exc:  # noqa: BLE001 -- junk on the bus; keep listening
                             print(f"[challenges] ignoring skill event: {exc!r}", flush=True)
+            except Exception:  # noqa: BLE001,S110 -- rosbridge down/restarting; retry
+                pass
+            time.sleep(5)
+
+
+class TelemetryEventBridge:
+    """Publishes challenge outcomes onto the ROS bus for the usage logger.
+
+    Its own websocket rather than SkillEventBridge's: that one blocks forever
+    iterating inbound frames, and websockets.sync connections are not safe to
+    write to from a second thread.
+
+    Challenge results live in the world server, which runs on the host and
+    outside ROS, while the logger node runs inside the container. Publishing a
+    plain topic hands the problem to rosbridge, which both already speak --
+    a shared spool file would need locking across the host/container
+    filesystem boundary, where flock is not dependable.
+    """
+
+    TOPIC = "/sim/telemetry_event"
+    # Dropping the oldest is right for telemetry: a backlog means rosbridge has
+    # been down a while, and the recent events are the informative ones.
+    MAX_PENDING = 256
+
+    def __init__(self, url: str = "ws://127.0.0.1:9090"):
+        self.url = url
+        self._pending: deque[dict] = deque(maxlen=self.MAX_PENDING)
+        self._wake = threading.Event()
+        threading.Thread(target=self._run, daemon=True).start()
+
+    def emit(self, event: str, **payload: object) -> None:
+        """Queue an event. Never raises -- telemetry cannot fail the sim."""
+        self._pending.append({"event": event, "payload": payload, "occurred_at": time.time()})
+        self._wake.set()
+
+    def _run(self) -> None:
+        try:
+            from websockets.sync.client import connect
+        except ImportError:
+            return
+        while True:
+            try:
+                with connect(self.url, open_timeout=5) as ws:
+                    ws.send(json.dumps({"op": "advertise", "topic": self.TOPIC, "type": "std_msgs/String"}))
+                    while True:
+                        while self._pending:
+                            frame = self._pending.popleft()
+                            ws.send(
+                                json.dumps(
+                                    {
+                                        "op": "publish",
+                                        "topic": self.TOPIC,
+                                        "msg": {"data": json.dumps(frame)},
+                                    }
+                                )
+                            )
+                        self._wake.wait(timeout=5)
+                        self._wake.clear()
             except Exception:  # noqa: BLE001,S110 -- rosbridge down/restarting; retry
                 pass
             time.sleep(5)

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -35,7 +35,7 @@ try:
 except ImportError:  # view-only feature; the sim must not die without it
     ws_serve = None
 
-from .challenges import ChallengeEngine, SkillEventBridge
+from .challenges import ChallengeEngine, SkillEventBridge, TelemetryEventBridge
 from .core import CAMERA_HEIGHT, CAMERA_WIDTH, VirtualMars, encode_jpeg, release_freed_heap
 
 # Depth renders at the pointcloud grid: identical published cloud, 16x less fill.
@@ -98,7 +98,9 @@ class WorldServer:
         self.state_cond = threading.Condition()
         # Challenge judge: evaluated on each published state, driven by
         # observer commands, fed skill events by SkillEventBridge (main()).
-        self.challenges = ChallengeEngine(sim, self.lock)
+        # Challenge outcomes go back out over rosbridge for the usage logger,
+        # which runs in the container and cannot see this process.
+        self.challenges = ChallengeEngine(sim, self.lock, telemetry=TelemetryEventBridge())
         self._challenge_error_at = 0.0  # last throttled challenge-failure log
 
     # --- physics (side thread; MuJoCo stepping is pure CPU) ---

--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -140,6 +140,12 @@ tmux new-window -t "$SESSION_NAME" -n foxglove
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:foxglove" "ros2 launch foxglove_bridge foxglove_bridge_launch.xml send_buffer_limit:=2000000 max_qos_depth:=1" C-m
 echo "Started Foxglove bridge (ws :${SIM_FOXGLOVE_PORT:-8765})..."
 
+# Shares the foxglove window: both are passive observers, and neither prints
+# anything worth its own pane.
+tmux split-window -t "${TMUX_TARGET_PREFIX}:foxglove" -h
+tmux send-keys -t "${TMUX_TARGET_PREFIX}:foxglove.1" "ros2 launch innate_logger sim_logger.launch.py" C-m
+echo "Started sim usage logger..."
+
 # Select the rosbridge-app window
 tmux select-window -t "${TMUX_TARGET_PREFIX}:rosbridge-app"
 

--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -143,7 +143,10 @@ echo "Started Foxglove bridge (ws :${SIM_FOXGLOVE_PORT:-8765})..."
 # Shares the foxglove window: both are passive observers, and neither prints
 # anything worth its own pane.
 tmux split-window -t "${TMUX_TARGET_PREFIX}:foxglove" -h
-tmux send-keys -t "${TMUX_TARGET_PREFIX}:foxglove.1" "ros2 launch innate_logger sim_logger.launch.py" C-m
+# The cd is load-bearing: compose mounts the generated env as a FILE at
+# ~/innate-os/.env rather than passing env_file, so the node's find_dotenv has
+# to be able to walk up to it.
+tmux send-keys -t "${TMUX_TARGET_PREFIX}:foxglove.1" "cd ~/innate-os && ros2 launch innate_logger sim_logger.launch.py" C-m
 echo "Started sim usage logger..."
 
 # Select the rosbridge-app window

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -48,6 +48,8 @@ DOWN_LOG_PATH = LOG_DIR / "down.log"
 ROS_INSTALL_STATE_PATH = STATE_DIR / "ros-install.inputs.sha256"
 OS_SESSION_READY_POLL_SECONDS = 0.25
 GENERATED_OS_ENV_PATH = STATE_DIR / "innate-os.env"
+# The UUID this checkout reports usage under (see identity.install_id).
+INSTALL_ID_PATH = STATE_DIR / "install-id"
 # How brain_client reaches Gemini: through the Innate proxy with a service key,
 # straight at Google with a Gemini key, or not at all.
 INNATE_BACKEND = "innate"
@@ -618,10 +620,48 @@ def write_env_file(path: Path, values: dict[str, str]) -> None:
 def build_os_env(config: dict[str, object]) -> Path:
     raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
     os_env: dict[str, str] = dict(raw_env)
+    os_env.update(sim_identity_env(config))
 
     ensure_state_dir()
     write_env_file(GENERATED_OS_ENV_PATH, os_env)
     return GENERATED_OS_ENV_PATH
+
+
+def sim_identity_env(config: dict[str, object]) -> dict[str, str]:
+    """Who/what/where for the usage logger inside the container.
+
+    Imported lazily: identity imports this module for its paths, so a
+    module-level import would be circular.
+    """
+    import identity
+
+    if not identity.telemetry_enabled(dict(config["raw_env"])):  # type: ignore[arg-type]
+        return {"INNATE_TELEMETRY": "0"}
+
+    # Checked before install_id(), which creates the file it asks about.
+    first_run = not INSTALL_ID_PATH.exists()
+    if first_run:
+        log(
+            f"{CYAN}Innate collects anonymous simulator usage{NC} (version, platform, "
+            "performance, which features were used) to see how onboarding is going. "
+            f"No prompts or code. Opt out with {YELLOW}INNATE_TELEMETRY=0{NC} in .env."
+        )
+
+    os_image = str(config.get("os_image") or "")
+    return {
+        "INNATE_SIM_INSTALL_ID": identity.install_id(),
+        "INNATE_SIM_DEVICE_HASH": identity.device_hash(),
+        # The container has no .git, so a commit read in there is always
+        # "unknown" -- resolve it out here where the repo actually is.
+        "INNATE_SIM_COMMIT": identity.repo_commit(),
+        "INNATE_SIM_LAUNCHER_VERSION": identity.launcher_version(),
+        # Empty when running the locally built deps-image, which is itself the
+        # useful distinction: prebuilt users versus source-tree users.
+        "INNATE_SIM_IMAGE_REF": os_image or LOCAL_OS_IMAGE,
+        "INNATE_SIM_PLATFORM": identity.host_platform(),
+        "INNATE_SIM_PLATFORM_RELEASE": identity.platform_release(),
+        "INNATE_SIM_BRAIN_BACKEND": str(config.get("brain_backend") or ""),
+    }
 
 
 if __name__ == "__main__":

--- a/sim/launcher/identity.py
+++ b/sim/launcher/identity.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Who is running this simulator, and which build of it.
+
+Everything here is resolved on the *host*. The container sees a handful of
+mounted subdirectories, not the repo — no `.git`, and its own throwaway
+`/etc/machine-id` and network interfaces. Anything derived from those inside
+the container would be wrong in a way that quietly inflates install counts, so
+the launcher computes them once and passes them down through the generated env
+file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import re
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+from config import (
+    INSTALL_ID_PATH,
+    REPO_ROOT,
+    ensure_state_dir,
+)
+
+# Domain separation, not a secret — this is an open-source repo, so the salt is
+# public by construction. It is safe here because the inputs are 128-bit random
+# machine UUIDs: unlike a MAC address (a ~48-bit space with a known vendor
+# prefix, brute-forceable in seconds) they cannot be recovered from the digest.
+# That is the reason to hash a machine id rather than a MAC.
+_DEVICE_SALT = "innate-sim-device-v1"
+
+_IOREG_UUID_RE = re.compile(r'"IOPlatformUUID"\s*=\s*"([^"]+)"')
+
+
+def install_id() -> str:
+    """A UUID identifying this checkout, created on first use.
+
+    Persisted beside the launcher's other state, so it survives restarts but
+    not a fresh clone — which is the intent. Counting *machines* is
+    :func:`device_hash`'s job.
+    """
+    ensure_state_dir()
+    if INSTALL_ID_PATH.exists():
+        existing = INSTALL_ID_PATH.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+
+    fresh = str(uuid.uuid4())
+    INSTALL_ID_PATH.write_text(f"{fresh}\n", encoding="utf-8")
+    return fresh
+
+
+def _machine_id() -> str:
+    """The host OS's own stable machine identifier, or "" if unavailable.
+
+    Deliberately not a MAC address: those change with the active interface, are
+    randomised per-container by Docker, and are personal data.
+    """
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.run(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        found = _IOREG_UUID_RE.search(out)
+        return found.group(1) if found else ""
+
+    for path in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
+        try:
+            value = Path(path).read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if value:
+            return value
+
+    return ""
+
+
+def device_hash() -> str:
+    """A stable, non-reversible id for this machine, or "" if undeterminable.
+
+    Two checkouts on one laptop share this, so installs can be collapsed into
+    devices. Under WSL the distro's machine-id differs from Windows' own, so a
+    user running both is counted as two devices.
+    """
+    machine = _machine_id()
+    if not machine:
+        return ""
+    return hashlib.sha256(f"{_DEVICE_SALT}:{machine}".encode("utf-8")).hexdigest()[:16]
+
+
+def host_platform() -> str:
+    """darwin | wsl | linux | windows | <sys.platform>."""
+    if sys.platform == "darwin":
+        return "darwin"
+    if sys.platform.startswith("win"):
+        return "windows"
+    if sys.platform.startswith("linux"):
+        # WSL is worth separating out: its filesystem and network latency make
+        # it the platform most likely to show a poor real-time factor.
+        return "wsl" if "microsoft" in platform.uname().release.lower() else "linux"
+    return sys.platform
+
+
+def platform_release() -> str:
+    return f"{platform.system()} {platform.release()}"[:128]
+
+
+def _git(*args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def repo_commit() -> str:
+    """Short HEAD of the checkout, or "" outside a git tree."""
+    return _git("rev-parse", "--short", "HEAD")
+
+
+def launcher_version() -> str:
+    """A human-readable version for the checkout (tag if there is one)."""
+    return _git("describe", "--tags", "--always", "--dirty")
+
+
+def telemetry_enabled(env: dict[str, str]) -> bool:
+    """Opt-out switch, honoured from the shell as well as `.env`.
+
+    Anything but a clear "off" counts as on, so a typo does not silently
+    disable reporting.
+    """
+    raw = (os.environ.get("INNATE_TELEMETRY") or env.get("INNATE_TELEMETRY") or "").strip().lower()
+    return raw not in {"0", "false", "no", "off"}


### PR DESCRIPTION
The reporting side of sim usage tracking. Robot behaviour is unchanged — `logger_node` is untouched.

## Why

The sim already ships the `innate_logger` package and colcon already builds it. It is simply never launched. But that node is also the wrong node for the sim: it reports battery and diagnostics that do not exist here, it *requires* a service key most sim users do not have (`raise RuntimeError` — a crashed tmux pane), and it blocks on auth at startup. That last one is correct for a robot, whose cold boot will eventually get DNS and a valid clock. A sim user on a plane is not a transient.

## What

**`sim_logger_node`** — a separate node, deliberately not shared code with `logger_node`.

- **Nothing blocks the executor.** Callbacks only enqueue; all auth, HTTP and backoff live on the uploader thread. (The existing node does a synchronous 5 s `urlopen` from a timer callback, which is tolerable on a robot and not here.)
- **Offline is an ordinary state.** Backs off to 5 minutes instead of retrying every heartbeat, and logs at debug — an unconnected sim spamming "telemetry unreachable" every 20 s reads to a user as though the simulator is broken.
- **Events spool to disk; heartbeats do not.** A stale "alive 3 days ago" says nothing that a gap in the series does not already, and would crowd out the events worth keeping. The spool survives container restarts.
- Works keyed (`AuthProvider`) or anonymous (mints against the install id).

**Identity and version come from the host launcher** via the generated `.env`, because none of it is knowable inside the container:

- It has no `.git` — compose mounts subdirectories, so `git rev-parse` in there returns `"unknown"` for *every* sim user today.
- Docker randomises the container MAC per run, so a MAC read in there would inflate the device count rather than establish it.

So `sim/launcher/identity.py` hashes the **OS machine id** on the host instead (`IOPlatformUUID` / `/etc/machine-id`): stable across re-clones, and — unlike a MAC's ~48-bit space — not brute-forceable back out of the digest. Raw identifiers never leave the machine. `install_id` (per checkout) and `device_hash` (per machine) together answer both "how many installs" and "how many actual people".

**Real-time factor** stands where battery does for a robot: observed `/odom` rate against the driver's nominal 30 Hz. It is the signal that says the sim is unusable on someone's machine — which, given the known WSL latency pain, is the number I would look at first.

**Challenge outcomes** reach the node over rosbridge (`/sim/telemetry_event`) rather than a shared spool file. The engine lives in the host-side world server, the node lives in the container, and `flock` across that filesystem boundary is not dependable. The world server already speaks rosbridge, so this reuses machinery that exists.

## Privacy

Announced on first run, documented in `.env.template`, disabled by `INNATE_TELEMETRY=0`. No prompts, no code, no raw hardware identifiers.

## Testing

Both risky paths exercised against a real HTTP server (`SimTelemetryUploader`, `SimAuth`):

- offline → 5 events spooled to disk, heartbeat correctly dropped, nothing delivered
- reconnect → spool drains, heartbeat delivered
- restart mid-outage → spooled event survives and is delivered on the next connection
- anonymous auth → mints once, caches, re-mints after `invalidate()`, sends the right `install_id`

`identity.py` verified on this machine (macOS): resolves a stable device hash, platform, commit and `git describe`, and honours the opt-out. Python/zsh syntax clean.

**Not yet run:** the node itself inside a live sim. Wants a `./innate-sim up` before merge to confirm the launch line, that `/odom` counting gives a sane RTF, and that the challenge bridge round-trips.

## Ships with

- innate-inc/innate-cloud#85 — tables and endpoints (**merge and deploy first**)
- innate-inc/dashboard `feat/sim-usage-view` — the Sim view
