### PR TITLE
feat(sim): expose rosbridge and leader UDP so a phone can teleop

### DIFF
--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -83,6 +83,9 @@ tmux new-window -t "$SESSION_NAME" -n sim-driver
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:sim-driver" "ros2 launch mars_sim_driver sim_driver.launch.py" C-m
 echo "Started virtual MARS driver (MuJoCo)..."
 settle_after_launch
+tmux split-window -t "${TMUX_TARGET_PREFIX}:sim-driver" -h
+tmux send-keys -t "${TMUX_TARGET_PREFIX}:sim-driver.1" "ros2 launch mars_control udp_leader_receiver.launch.py" C-m
+echo "Started UDP leader receiver (:9999/udp)..."
 
 # === Window 3: Nav + Brain ===
 # The REAL navigation stack (mode manager, router, namespaced planners, AMCL,

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -64,7 +64,9 @@ services:
       # internet probes that open, send nothing, and disconnect, spamming the
       # rws log. Set SIM_ROSBRIDGE_BIND=0.0.0.0 to let LAN devices (e.g. a
       # phone/laptop opening the sim viewer) reach it.
-      - "${SIM_ROSBRIDGE_BIND:-127.0.0.1}:9090:9090"
+      - "9090:9090"
+      # UDP leader receiver.
+      - "9999:9999/udp"
       # webapp front door (replaces the deprecated sim/frontend UI): the in-container
       # python server binds 443 (https) + 80 (http), both serving the full app.
       # Override the published side (e.g. SIM_HTTPS_PORT=8443 ./innate-sim up) to


### PR DESCRIPTION
- Starts the UDP leader-arm receiver in sim, the same node the real robot already runs, listening on port 9999
- Publishes that UDP port out of Docker so a phone on the LAN can send arm-follow packets into the container
- Opens rosbridge on all interfaces (0.0.0.0:9090) so the native phone app can publish drive commands to /joystick