### PR TITLE
feat(webrtc): loss-resilient, network-adaptive teleop video

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,23 @@ cd ros2_ws/src/brain/brain_client && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m
 cd ros2_ws/src/brain/brain_client && basedpyright brain_client/
 ```
 
+## Nodes: the fleet is the budget
+
+**Before adding a ROS node, look for somewhere it could live instead.** We are past 20 and
+every one of them costs RAM whether or not it is doing anything — a process, an executor, a
+DDS participant, its own discovery traffic. On a Jetson that budget is real and shared with
+the models.
+
+The pull toward more nodes is that it *looks* like clean design: one concern, one process,
+crisp boundaries. That instinct is right on a server and wrong on an embedded system, where
+composability sometimes has to be sacrificed for performance. (The Quest went from hundreds
+of microservices to about four while optimizing.)
+
+So: prefer a new function, class, or timer in a node that already owns the data. Reach for a
+new node when it genuinely needs its own lifecycle — separate crash domain, different rate,
+hardware it must own exclusively — and when it does, put it in an existing composable
+container so it shares a process rather than starting another one.
+
 ## Writing skills
 
 ### Never `time.sleep` — always `self.sleep`

--- a/ros2_ws/apt-dependencies.hardware.txt
+++ b/ros2_ws/apt-dependencies.hardware.txt
@@ -103,3 +103,8 @@ htop
 btop
 nano
 vim
+
+# Parallel GStreamer 1.24 at /opt/gst: working webrtcbin ULPFEC for teleop
+# video (the system 1.20 negotiates it but never emits it); the camera launch
+# activates it automatically when installed
+innate-gstreamer-opt

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -49,6 +49,7 @@ struct CameraEncoder {
     int width = 640;  // encode resolution (appsrc caps); incoming frames are resized to it
     int height = 480;
     guint ssrc = 0;  // fixed SSRC so the SDP offer carries a=ssrc/msid before any RTP has flowed
+    std::atomic<int64_t> last_forced_ns{0};  // maybe_force_keyframe throttle (browser PLIs can storm)
 
     GstElement* appsrc = nullptr;  // src_<name>, ref'd out of the encode pipeline
     GstElement* sink = nullptr;    // sink_<name> appsink, ref'd; the fan-out tap
@@ -146,6 +147,9 @@ class WebRTCStreamer : public rclcpp::Node {
 
     // ---- GStreamer callbacks (static for the C callback interface) ----
     static void on_ice_candidate(GstElement* webrtc, guint mline, gchar* candidate, gpointer user_data);
+    // Upstream-event probe on each transport rtp appsrc: forwards the browser's PLI-driven
+    // GstForceKeyUnit to the (separate) encode pipeline, which the event can't reach on its own.
+    static GstPadProbeReturn on_keyunit_request(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     static void on_connection_state_changed(GstElement* webrtc, GParamSpec* pspec, gpointer user_data);
     static void on_negotiation_needed(GstElement* webrtc, gpointer user_data);
     static void on_offer_created(GstPromise* promise, gpointer user_data);
@@ -177,6 +181,7 @@ class WebRTCStreamer : public rclcpp::Node {
     void push_frame(CameraEncoder* cam, const cv::Mat& frame, const rclcpp::Time& stamp);
     GstBufferPool* create_frame_pool(int width, int height, int channels);
     void force_keyframe(const std::string& cam);          // request an IDR so a fresh/resumed peer can decode
+    void maybe_force_keyframe(const std::string& cam);    // force_keyframe, throttled per camera (PLI path)
     CameraEncoder* find_camera(const std::string& name);  // configured camera by name, or nullptr
 
     // ---- Per-peer transport ----

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -48,7 +48,8 @@ struct CameraEncoder {
     int fps = 30;     // encoder framerate (appsrc caps)
     int width = 640;  // encode resolution (appsrc caps); incoming frames are resized to it
     int height = 480;
-    guint ssrc = 0;  // fixed SSRC so the SDP offer carries a=ssrc/msid before any RTP has flowed
+    int bitrate_kbps = 2000;  // vp8enc target-bitrate
+    guint ssrc = 0;           // fixed SSRC so the SDP offer carries a=ssrc/msid before any RTP has flowed
     std::atomic<int64_t> last_forced_ns{0};  // maybe_force_keyframe throttle (browser PLIs can storm)
 
     GstElement* appsrc = nullptr;  // src_<name>, ref'd out of the encode pipeline

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -214,6 +214,15 @@ class WebRTCStreamer : public rclcpp::Node {
     void poll_pipeline_health();  // per-peer teardown of dead transports
     void publish_status();        // /webrtc/active_streams snapshot at 0.5 Hz
 
+    // ---- RTCP-driven sender adaptation (executor thread + webrtcbin stats callbacks) ----
+    // The viewers' RTCP receiver reports carry loss + RTT back to us; a 1 Hz poll turns the worst
+    // of them into two states. GOOD = full bitrate, keyframes on demand only (lowest latency).
+    // DEGRADED = ~60% bitrate + a periodic 1 Hz keyframe, so reference-chain corruption on an
+    // unrepairable link clears in bounded time instead of smearing until a PLI round-trip.
+    void poll_network_adaptation();
+    static void on_peer_stats(GstPromise* promise, gpointer user_data);   // parses one get-stats reply
+    void apply_adaptation(bool degraded, int loss_promille, int rtt_ms);  // sets vp8enc bitrates + logs
+
     // ---- Local STUN helper ----
     // Minimal RFC 8489 Binding responder. This gives browsers a robot-local STUN server so their srflx
     // candidate is the LAN IP:port seen by the robot, avoiding public NAT hairpin and mDNS host lookup.
@@ -253,6 +262,15 @@ class WebRTCStreamer : public rclcpp::Node {
     // Timers
     rclcpp::TimerBase::SharedPtr health_timer_;
     rclcpp::TimerBase::SharedPtr status_timer_;
+    rclcpp::TimerBase::SharedPtr adapt_timer_;
+
+    // Worst viewer-reported link quality from the last stats round (-1 = no report yet). Written by
+    // webrtcbin stats callbacks, read by the 1 Hz adaptation tick.
+    std::atomic<int> rtcp_loss_promille_{-1};
+    std::atomic<int> rtcp_rtt_ms_{-1};
+    std::atomic<bool> degraded_{false};  // adaptation state; also read on webrtcbin threads (on-new-transceiver)
+    int adapt_bad_ticks_ = 0;
+    int adapt_good_ticks_ = 0;
 
     // RTCP-inactivity watchdog timeout (seconds without RTCP before a peer's transport is released).
     double rtcp_inactivity_timeout_s_ = kDefaultRtcpInactivityTimeoutS;

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -193,6 +193,9 @@ class WebRTCStreamer : public rclcpp::Node {
     // Apply RTP caps + tuning to a transport appsrc and link it to the next webrtcbin sink pad (consumes
     // caps). Shared by the video and audio m-line setup in create_peer_transport.
     bool link_rtp_appsrc(GstElement* webrtc, GstElement* appsrc, GstCaps* caps, guint64 max_bytes);
+    // Enable NACK/RTX + ULPFEC (per video_nack_ / video_fec_percentage_) on the first `video_count`
+    // transceivers — GStreamer's defaults negotiate no loss repair at all.
+    void configure_video_transceivers(GstElement* webrtc, size_t video_count);
     void publish_offer(const std::string& client_id, const std::string& sdp);
 
     // ---- Camera subscriptions (lazy: a camera is subscribed only while some connected peer negotiates
@@ -258,6 +261,8 @@ class WebRTCStreamer : public rclcpp::Node {
     std::string audio_capture_device_;
     guint playout_min_delay_ms_ = 0;
     guint playout_max_delay_ms_ = 40;
+    bool video_nack_ = true;
+    guint video_fec_percentage_ = 25;
     bool enable_local_stun_ = true;
     int local_stun_port_ = 3478;
     std::atomic<bool> stun_running_{false};

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -101,6 +101,11 @@ def generate_launch_description():
                 # no round trip; NACK resends land within the receiver's adaptive jitter buffer.
                 "video_nack": True,
                 "video_fec_percentage": 25,
+                # Per-camera vp8enc target. The sum (+~25% FEC, + retransmits under loss) must fit
+                # the site uplink with margin — 2000 each measurably congested a residential link
+                # once two cameras streamed, and the resulting keyframe storms compounded the loss.
+                "main_bitrate_kbps": 1500,
+                "arm_bitrate_kbps": 800,
                 # Local-only STUN Binding responder. Browsers still obfuscate host candidates as mDNS,
                 # but when they query stun:<robot-lan-ip>:3478, the srflx candidate they emit is the LAN
                 # IP:port observed by the robot, not a public NAT hairpin route.

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -18,6 +18,8 @@ Usage:
     ros2 launch mars_cam camera_composable.launch.py
 """
 
+import os
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
@@ -143,11 +145,33 @@ def generate_launch_description():
 
     # ── Container ─────────────────────────────────────────────────────────────
 
+    # Opt-in newer GStreamer: a robot with a parallel build staged at /opt/gst
+    # (scripts/update/build_gst_opt.sh) runs the camera container against it — 1.20's
+    # webrtcbin negotiates ULPFEC but never sends it; >=1.22 does. GStreamer's ABI
+    # guarantee lets the 1.20-built binaries run unmodified; NVIDIA's hardware plugins
+    # stay on the system path (verified loading under the 1.24 core). Robots without
+    # /opt/gst are untouched; INNATE_GST_OPT=0 forces the system stack (per-robot rollback
+    # that survives the apt package being reinstalled by the next update).
+    gst_opt = "/opt/gst/lib/aarch64-linux-gnu"
+    system_ld = os.environ.get("LD_LIBRARY_PATH", "")
+    gst_env = (
+        {
+            # Never leave an empty element (ld.so reads "" as the cwd) when the parent
+            # environment has no LD_LIBRARY_PATH.
+            "LD_LIBRARY_PATH": gst_opt + (":" + system_ld if system_ld else ""),
+            "GST_PLUGIN_PATH": gst_opt + "/gstreamer-1.0:/usr/lib/aarch64-linux-gnu/gstreamer-1.0",
+            "GST_REGISTRY": "/tmp/gst-opt-camera.registry",
+        }
+        if os.path.isdir(gst_opt) and os.environ.get("INNATE_GST_OPT") != "0"
+        else {}
+    )
+
     camera_container = ComposableNodeContainer(
         name="camera_container",
         namespace="",
         package="rclcpp_components",
         executable="component_container_mt",
+        additional_env=gst_env,
         composable_node_descriptions=[
             main_camera_node,
             arm_camera_node,

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -87,15 +87,13 @@ def generate_launch_description():
                 "enable_audio": True,
                 "audio_source_element": "alsasrc",
                 "audio_capture_device": "sysdefault:CARD=Light",
-                # Bound the teleop receiver's de-jitter buffer (ms) via the playout-delay RTP
-                # extension. Measured effect on the LAN: once this extension advertises playout-delay
-                # support, Chrome (which already pins jitterBufferTarget=0) drops the buffer from
-                # ~75 ms to ~2 ms with no added loss. max is the effective lever — it caps how far the
-                # buffer may grow during jitter spikes, bounding worst-case latency below the 75 ms
-                # default. min is inert while the client pins target=0 (kept at 0). Raise max for
-                # smoother playout under jitter, lower it for tighter latency. Retunable via restart.
+                # Playout-delay RTP extension = the CEILING the receiver may buffer, not a target.
+                # The webapp adapts receiver.jitterBufferTarget itself: 0 on a clean LAN (measured
+                # ~2 ms buffer once this extension is advertised), ~1.2x RTT on a lossy remote path
+                # so NACK resends land before playout. max must leave headroom for that adaptation;
+                # min stays 0 so the LAN case keeps its lowest latency.
                 "playout_min_delay_ms": 0,
-                "playout_max_delay_ms": 40,
+                "playout_max_delay_ms": 500,
                 # Video loss repair (webrtcbin negotiates none by default — one lost packet then
                 # freezes the stream until a PLI keyframe round-trip). ULPFEC repairs losses with
                 # no round trip; NACK resends land within the receiver's adaptive jitter buffer.

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -96,6 +96,11 @@ def generate_launch_description():
                 # smoother playout under jitter, lower it for tighter latency. Retunable via restart.
                 "playout_min_delay_ms": 0,
                 "playout_max_delay_ms": 40,
+                # Video loss repair (webrtcbin negotiates none by default — one lost packet then
+                # freezes the stream until a PLI keyframe round-trip). ULPFEC repairs losses with
+                # no round trip; NACK resends land within the receiver's adaptive jitter buffer.
+                "video_nack": True,
+                "video_fec_percentage": 25,
                 # Local-only STUN Binding responder. Browsers still obfuscate host candidates as mDNS,
                 # but when they query stun:<robot-lan-ip>:3478, the srflx candidate they emit is the LAN
                 # IP:port observed by the robot, not a public NAT hairpin route.

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -40,9 +40,8 @@ std::string WebRTCStreamer::video_encode_branch(const CameraEncoder& cam) const 
            "/1 ! "
            "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
            "videoconvert ! "
-           "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions "
-           "keyframe-max-dist=" +
-           std::to_string(cam.fps * 4) +
+           "vp8enc deadline=1 target-bitrate=" + std::to_string(cam.bitrate_kbps * 1000) +
+           " cpu-used=4 error-resilient=partitions keyframe-max-dist=" + std::to_string(cam.fps * 4) +
            " end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
            // picture-id-mode is required for browsers: without picture IDs Chrome can't prove frame
            // continuity after loss and discards every delta frame until the next keyframe — NACK/RTX

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cctype>  // std::isalnum (audio element/device validation)
+#include <chrono>  // maybe_force_keyframe throttle clock
 #include <cmath>
 #include <cstdlib>
 #include <cstring>  // memcpy (push_frame)
@@ -30,17 +31,25 @@ struct FanOutTarget {
 std::string WebRTCStreamer::video_encode_branch(const CameraEncoder& cam) const {
     // appsrc -> encoder -> payloader -> appsink. The appsink is the fan-out tap: every connected peer's
     // transport appsrc is fed from here, so each camera is encoded exactly once regardless of peer count.
+    // keyframe-max-dist is a ~4 s backstop only: browsers request keyframes on demand (PLI, forwarded
+    // by on_keyunit_request), so a clean link carries almost no keyframes and a lossy one gets them
+    // exactly when needed — periodic IDR spikes were feeding congestion on constrained uplinks.
     return "appsrc name=src_" + cam.name +
            " is-live=true format=time caps=video/x-raw,format=BGR,width=" + std::to_string(cam.width) +
            ",height=" + std::to_string(cam.height) + ",framerate=" + std::to_string(cam.fps) +
            "/1 ! "
            "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
            "videoconvert ! "
-           "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions keyframe-max-dist=15 "
-           "end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
+           "vp8enc deadline=1 target-bitrate=2000000 cpu-used=4 error-resilient=partitions "
+           "keyframe-max-dist=" +
+           std::to_string(cam.fps * 4) +
+           " end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
+           // picture-id-mode is required for browsers: without picture IDs Chrome can't prove frame
+           // continuity after loss and discards every delta frame until the next keyframe — NACK/RTX
+           // repair lands and is thrown away (measured: 5 fps + keyframe cycling at 5% loss).
            "rtpvp8pay name=pay_" +
            cam.name + " pt=" + std::to_string(cam.pt) + " ssrc=" + std::to_string(cam.ssrc) +
-           " ! "
+           " picture-id-mode=15-bit ! "
            "appsink name=sink_" +
            cam.name + " emit-signals=true sync=false async=false max-buffers=2 drop=true ";
 }
@@ -115,6 +124,21 @@ bool WebRTCStreamer::build_encode_pipeline() {
     RCLCPP_INFO(this->get_logger(), "Persistent encode pipeline PLAYING (%s, idle until a peer connects)",
                 names.c_str());
     return true;
+}
+
+// At 5%+ loss Chrome PLIs several times a second; each obeyed PLI is a full IDR, and that keyframe
+// flood re-congests the very link that caused the loss. One per 500 ms repairs just as well.
+void WebRTCStreamer::maybe_force_keyframe(const std::string& cam) {
+    CameraEncoder* c = find_camera(cam);
+    if (!c) {
+        return;
+    }
+    const int64_t now = std::chrono::steady_clock::now().time_since_epoch().count();
+    int64_t last = c->last_forced_ns.load(std::memory_order_relaxed);
+    if (now - last < 500'000'000 || !c->last_forced_ns.compare_exchange_strong(last, now, std::memory_order_relaxed)) {
+        return;
+    }
+    force_keyframe(cam);
 }
 
 void WebRTCStreamer::force_keyframe(const std::string& cam) {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -40,7 +40,8 @@ std::string WebRTCStreamer::video_encode_branch(const CameraEncoder& cam) const 
            "/1 ! "
            "queue leaky=downstream max-size-buffers=1 max-size-time=0 max-size-bytes=0 ! "
            "videoconvert ! "
-           "vp8enc deadline=1 target-bitrate=" + std::to_string(cam.bitrate_kbps * 1000) +
+           "vp8enc name=enc_" +
+           cam.name + " deadline=1 target-bitrate=" + std::to_string(cam.bitrate_kbps * 1000) +
            " cpu-used=4 error-resilient=partitions keyframe-max-dist=" + std::to_string(cam.fps * 4) +
            " end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
            // picture-id-mode is required for browsers: without picture IDs Chrome can't prove frame

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -196,6 +196,7 @@ void WebRTCStreamer::configure_cameras() {
         cam->fps = static_cast<int>(this->declare_parameter<int>(name + "_fps", def_fps));
         cam->width = static_cast<int>(this->declare_parameter<int>(name + "_width", 640));
         cam->height = static_cast<int>(this->declare_parameter<int>(name + "_height", 480));
+        cam->bitrate_kbps = static_cast<int>(this->declare_parameter<int>(name + "_bitrate_kbps", 2000));
         cam->pt = cam_pt_for_index(cameras_.size());
         cam->ssrc = cam_ssrc_for_index(cameras_.size());
         cam->owner = this;
@@ -203,8 +204,9 @@ void WebRTCStreamer::configure_cameras() {
             RCLCPP_WARN(this->get_logger(), "Camera '%s' has no live topic configured; skipping it", name.c_str());
             continue;
         }
-        RCLCPP_INFO(this->get_logger(), "  Camera[%zu] '%s': pt=%d ssrc=0x%08X %dx%d@%dfps live=%s", cameras_.size(),
-                    name.c_str(), cam->pt, cam->ssrc, cam->width, cam->height, cam->fps, cam->live_topic.c_str());
+        RCLCPP_INFO(this->get_logger(), "  Camera[%zu] '%s': pt=%d ssrc=0x%08X %dx%d@%dfps %dkbps live=%s",
+                    cameras_.size(), name.c_str(), cam->pt, cam->ssrc, cam->width, cam->height, cam->fps,
+                    cam->bitrate_kbps, cam->live_topic.c_str());
         cameras_.push_back(std::move(cam));
     }
     if (cameras_.empty()) {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -163,6 +163,8 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
         this->create_wall_timer(std::chrono::milliseconds(200), std::bind(&WebRTCStreamer::poll_pipeline_health, this));
     prev_status_time_ = std::chrono::steady_clock::now();
     status_timer_ = this->create_wall_timer(std::chrono::seconds(2), std::bind(&WebRTCStreamer::publish_status, this));
+    adapt_timer_ =
+        this->create_wall_timer(std::chrono::seconds(1), std::bind(&WebRTCStreamer::poll_network_adaptation, this));
 
     RCLCPP_INFO(this->get_logger(), "WebRTC Streamer ready (%zu cameras, source: %s, compressed: %s)", cameras_.size(),
                 current_source_.c_str(), use_compressed_images_ ? "true" : "false");
@@ -228,6 +230,7 @@ WebRTCStreamer::~WebRTCStreamer() {
     stop_local_stun_server();
     health_timer_.reset();
     status_timer_.reset();
+    adapt_timer_.reset();
     destroy_subscriptions();
     {
         std::lock_guard<std::mutex> lock(peers_mutex_);
@@ -309,6 +312,142 @@ bool WebRTCStreamer::install_rtcp_probe_for(Peer* peer) {
     gst_iterator_free(it);
     gst_object_unref(rtpbin);
     return installed;
+}
+
+// One get-stats reply: keep the worst remote-inbound-rtp (the RTCP receiver-report echo) loss/RTT
+// seen this round. Fires on a webrtcbin thread; only atomics are touched (node outlives promises —
+// same lifetime contract as OfferContext).
+void WebRTCStreamer::on_peer_stats(GstPromise* promise, gpointer user_data) {
+    auto* self = static_cast<WebRTCStreamer*>(user_data);
+    const GstStructure* reply = gst_promise_get_reply(promise);
+    if (!reply) {
+        gst_promise_unref(promise);
+        return;
+    }
+    gst_structure_foreach(
+        reply,
+        [](GQuark, const GValue* value, gpointer data) -> gboolean {
+            auto* self = static_cast<WebRTCStreamer*>(data);
+            if (!GST_VALUE_HOLDS_STRUCTURE(value)) {
+                return TRUE;
+            }
+            const GstStructure* s = gst_value_get_structure(value);
+            GstWebRTCStatsType type;
+            if (!gst_structure_get(s, "type", GST_TYPE_WEBRTC_STATS_TYPE, &type, nullptr) ||
+                type != GST_WEBRTC_STATS_REMOTE_INBOUND_RTP) {
+                return TRUE;
+            }
+            // rb-fractionlost is the RR's 0-255 fraction; round-trip-time is seconds (double).
+            if (guint fl = 0; gst_structure_get_uint(s, "rb-fractionlost", &fl)) {
+                const int promille = static_cast<int>(fl * 1000 / 255);
+                if (promille > self->rtcp_loss_promille_.load(std::memory_order_relaxed)) {
+                    self->rtcp_loss_promille_.store(promille, std::memory_order_relaxed);
+                }
+            }
+            if (gdouble rtt_s = 0.0; gst_structure_get_double(s, "round-trip-time", &rtt_s)) {
+                const int ms = static_cast<int>(rtt_s * 1000.0);
+                if (ms > self->rtcp_rtt_ms_.load(std::memory_order_relaxed)) {
+                    self->rtcp_rtt_ms_.store(ms, std::memory_order_relaxed);
+                }
+            }
+            return TRUE;
+        },
+        self);
+    gst_promise_unref(promise);
+}
+
+void WebRTCStreamer::apply_adaptation(bool degraded, int loss_promille, int rtt_ms) {
+    degraded_ = degraded;
+    for (auto& cam : cameras_) {
+        GstElement* enc = gst_bin_get_by_name(GST_BIN(encode_pipeline_), ("enc_" + cam->name).c_str());
+        if (!enc) {
+            continue;
+        }
+        const int bps = cam->bitrate_kbps * 1000 * (degraded ? 6 : 10) / 10;
+        g_object_set(enc, "target-bitrate", bps, nullptr);
+        gst_object_unref(enc);
+    }
+    // FEC strength follows the state: webrtcbin binds the transceiver's fec-percentage to the live
+    // rtpulpfecenc, so full protection is only paid for while a viewer needs it (measured: 100%
+    // took a 4-5%-loss path from 17-29 s frozen/min to 0.7 s; 25% stayed keyframe-bound).
+    if (video_fec_percentage_ > 0) {
+        const guint pct = degraded ? 100u : video_fec_percentage_;
+        std::lock_guard<std::mutex> lock(peers_mutex_);
+        for (auto& kv : peers_) {
+            for (size_t i = 0; i < kv.second->videos.size(); ++i) {
+                GstWebRTCRTPTransceiver* trans = nullptr;
+                g_signal_emit_by_name(kv.second->webrtc, "get-transceiver", static_cast<gint>(i), &trans);
+                if (trans) {
+                    g_object_set(trans, "fec-percentage", pct, nullptr);
+                    g_object_unref(trans);
+                }
+            }
+        }
+    }
+    const char* state = degraded ? "DEGRADED: 60% bitrate + 1 Hz keyframes + full FEC"
+                                 : "GOOD: full bitrate, on-demand keyframes, base FEC";
+    if (loss_promille < 0 && rtt_ms < 0) {
+        RCLCPP_INFO(this->get_logger(), "Network adaptation -> %s (no viewer reports)", state);
+    } else {
+        RCLCPP_INFO(this->get_logger(), "Network adaptation -> %s (viewer loss %.1f%%, rtt %d ms)", state,
+                    loss_promille < 0 ? 0.0 : loss_promille / 10.0, rtt_ms);
+    }
+}
+
+void WebRTCStreamer::poll_network_adaptation() {
+    const int loss = rtcp_loss_promille_.exchange(-1, std::memory_order_relaxed);
+    const int rtt = rtcp_rtt_ms_.exchange(-1, std::memory_order_relaxed);
+
+    // Kick off this round of per-peer stats (answers land before the next tick).
+    bool any_peers = false;
+    {
+        std::lock_guard<std::mutex> lock(peers_mutex_);
+        any_peers = !peers_.empty();
+        for (auto& kv : peers_) {
+            if (!kv.second->media_ready->load(std::memory_order_relaxed)) {
+                continue;
+            }
+            GstPromise* promise = gst_promise_new_with_change_func(on_peer_stats, this, nullptr);
+            g_signal_emit_by_name(kv.second->webrtc, "get-stats", nullptr, promise);
+        }
+    }
+
+    // Last viewer gone: back to GOOD now, so the next peer (LAN included) isn't served a DEGRADED
+    // state frozen from a link that no longer exists.
+    if (!any_peers) {
+        adapt_bad_ticks_ = 0;
+        adapt_good_ticks_ = 0;
+        if (degraded_) {
+            apply_adaptation(false, loss, rtt);
+        }
+        return;
+    }
+
+    // Enter DEGRADED fast (2 s of trouble), leave slowly (15 s without it) — flapping re-keyframes
+    // hurt more than staying conservative. clean is exactly !bad: any value band between the two
+    // would freeze the exit counter and make DEGRADED permanent (e.g. a steady 200 ms RTT path).
+    // A tick with no report leaves the counters unchanged (get-stats answers land between ticks).
+    const bool report = loss >= 0 || rtt >= 0;
+    const bool bad = loss >= 30 || rtt >= 250;
+    if (report) {
+        adapt_bad_ticks_ = bad ? adapt_bad_ticks_ + 1 : 0;
+        adapt_good_ticks_ = bad ? 0 : adapt_good_ticks_ + 1;
+    }
+    if (!degraded_ && adapt_bad_ticks_ >= 2) {
+        apply_adaptation(true, loss, rtt);
+    } else if (degraded_ && adapt_good_ticks_ >= 15) {
+        apply_adaptation(false, loss, rtt);
+    }
+
+    // Bounded corruption age while DEGRADED: a keyframe per second per flowing camera, no PLI
+    // round-trip needed. maybe_force_keyframe's 500 ms throttle also coalesces this with real PLIs.
+    if (degraded_) {
+        for (auto& cam : cameras_) {
+            if (cam->want.load(std::memory_order_relaxed) > 0) {
+                maybe_force_keyframe(cam->name);
+            }
+        }
+    }
 }
 
 void WebRTCStreamer::poll_pipeline_health() {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -86,6 +86,11 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     this->declare_parameter("audio_capture_device", "");
     this->declare_parameter("playout_min_delay_ms", 0);
     this->declare_parameter("playout_max_delay_ms", 40);
+    // Video loss repair. ULPFEC repairs without a round trip at ~fec% bitrate overhead (0 disables);
+    // NACK retransmits only pay off when the browser's jitter buffer (playout_max_delay_ms) can wait
+    // roughly one RTT for the resend, so remote viewers should raise that param too.
+    this->declare_parameter("video_nack", true);
+    this->declare_parameter("video_fec_percentage", 25);
     this->declare_parameter("enable_local_stun", true);
     this->declare_parameter("local_stun_port", 3478);
     // RTCP-inactivity release only fires on a peer webrtcbin still reports CONNECTED — it's a backstop for
@@ -100,6 +105,9 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     audio_capture_device_ = this->get_parameter("audio_capture_device").as_string();
     playout_min_delay_ms_ = static_cast<guint>(this->get_parameter("playout_min_delay_ms").as_int());
     playout_max_delay_ms_ = static_cast<guint>(this->get_parameter("playout_max_delay_ms").as_int());
+    video_nack_ = this->get_parameter("video_nack").as_bool();
+    video_fec_percentage_ =
+        static_cast<guint>(std::clamp(this->get_parameter("video_fec_percentage").as_int(), int64_t{0}, int64_t{100}));
     enable_local_stun_ = this->get_parameter("enable_local_stun").as_bool();
     local_stun_port_ = static_cast<int>(this->get_parameter("local_stun_port").as_int());
     rtcp_inactivity_timeout_s_ = this->get_parameter("rtcp_inactivity_timeout_s").as_double();
@@ -160,6 +168,8 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
                 current_source_.c_str(), use_compressed_images_ ? "true" : "false");
     RCLCPP_INFO(this->get_logger(), "  Mic audio: %s", enable_audio_ ? "enabled (opt-in per peer)" : "disabled");
     RCLCPP_INFO(this->get_logger(), "  Local STUN: %s", enable_local_stun_ ? "enabled" : "disabled");
+    RCLCPP_INFO(this->get_logger(), "  Video loss repair: nack=%s, fec=%u%%", video_nack_ ? "on" : "off",
+                video_fec_percentage_);
     RCLCPP_INFO(this->get_logger(), "  RTCP-inactivity teardown: %.1f s", rtcp_inactivity_timeout_s_);
 }
 

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -99,7 +99,9 @@ void WebRTCStreamer::configure_video_transceivers(GstElement* webrtc, size_t vid
         }
         const bool video = i < video_count;
         g_object_set(trans, "do-nack", (video && video_nack_) ? TRUE : FALSE, nullptr);
-        const guint pct = video ? video_fec_percentage_ : 0u;
+        const guint pct = (video && video_fec_percentage_ > 0)
+                              ? (degraded_.load(std::memory_order_relaxed) ? 100u : video_fec_percentage_)
+                              : 0u;
         g_object_set(trans, "fec-type", pct > 0 ? GST_WEBRTC_FEC_TYPE_ULP_RED : GST_WEBRTC_FEC_TYPE_NONE,
                      "fec-percentage", pct, nullptr);
         g_object_unref(trans);
@@ -158,8 +160,10 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
             auto* self = ctx->self;
             g_object_set(trans, "do-nack", self->video_nack_ ? TRUE : FALSE, nullptr);
             if (self->video_fec_percentage_ > 0) {
+                // A peer arriving mid-DEGRADED gets full protection from the start.
                 g_object_set(trans, "fec-type", GST_WEBRTC_FEC_TYPE_ULP_RED, "fec-percentage",
-                             self->video_fec_percentage_, nullptr);
+                             self->degraded_.load(std::memory_order_relaxed) ? 100u : self->video_fec_percentage_,
+                             nullptr);
             }
         }),
         tctx, [](gpointer data, GClosure*) { delete static_cast<TransceiverCtx*>(data); },

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -12,6 +12,14 @@
 
 namespace mars_cam {
 
+namespace {
+struct TransceiverCtx {
+    WebRTCStreamer* self;
+    guint video_count;  // transceivers are created in sink-pad link order: the video m-lines, then audio
+    guint seen = 0;
+};
+}  // namespace
+
 // =============================================================================
 // Per-peer transport
 // =============================================================================
@@ -53,6 +61,29 @@ bool WebRTCStreamer::link_rtp_appsrc(GstElement* webrtc, GstElement* appsrc, Gst
     return linked;
 }
 
+// Post-link re-assert of the creation-time loss-repair props (the on-new-transceiver hook in
+// create_peer_transport is where they take effect): the first `video_count` transceivers get
+// NACK/RTX + ULPFEC/RED, anything after (audio) is stripped. fec-percentage defaults to 100
+// (double the bitrate) — always set it alongside fec-type.
+void WebRTCStreamer::configure_video_transceivers(GstElement* webrtc, size_t video_count) {
+    for (size_t i = 0;; ++i) {
+        GstWebRTCRTPTransceiver* trans = nullptr;
+        g_signal_emit_by_name(webrtc, "get-transceiver", static_cast<gint>(i), &trans);
+        if (!trans) {
+            if (i < video_count) {
+                RCLCPP_WARN(this->get_logger(), "No transceiver for video m-line %zu; loss repair not applied", i);
+            }
+            return;
+        }
+        const bool video = i < video_count;
+        g_object_set(trans, "do-nack", (video && video_nack_) ? TRUE : FALSE, nullptr);
+        const guint pct = video ? video_fec_percentage_ : 0u;
+        g_object_set(trans, "fec-type", pct > 0 ? GST_WEBRTC_FEC_TYPE_ULP_RED : GST_WEBRTC_FEC_TYPE_NONE,
+                     "fec-percentage", pct, nullptr);
+        g_object_unref(trans);
+    }
+}
+
 Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const std::vector<std::string>& negotiated,
                                             const std::vector<std::string>& active, bool with_audio,
                                             bool audio_active) {
@@ -88,6 +119,29 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         RCLCPP_ERROR(this->get_logger(), "Transport pipeline missing webrtcbin");
         return nullptr;  // ~Peer() tears down the pipeline
     }
+
+    // Loss-repair props must land the moment each transceiver is CREATED (as its sink pad links):
+    // webrtcbin wires its internal FEC/RTX elements from them during negotiation setup, so a
+    // post-link write cannot engage them. A pad-created transceiver doesn't know its media kind
+    // yet, but creation order is link order — the first `negotiated.size()` are the video m-lines,
+    // so audio never gets video loss-repair wired in the first place.
+    auto* tctx = new TransceiverCtx{this, static_cast<guint>(negotiated.size())};
+    g_signal_connect_data(
+        peer->webrtc, "on-new-transceiver",
+        G_CALLBACK(+[](GstElement*, GstWebRTCRTPTransceiver* trans, gpointer user_data) {
+            auto* ctx = static_cast<TransceiverCtx*>(user_data);
+            if (ctx->seen++ >= ctx->video_count) {
+                return;  // audio m-line
+            }
+            auto* self = ctx->self;
+            g_object_set(trans, "do-nack", self->video_nack_ ? TRUE : FALSE, nullptr);
+            if (self->video_fec_percentage_ > 0) {
+                g_object_set(trans, "fec-type", GST_WEBRTC_FEC_TYPE_ULP_RED, "fec-percentage",
+                             self->video_fec_percentage_, nullptr);
+            }
+        }),
+        tctx, [](gpointer data, GClosure*) { delete static_cast<TransceiverCtx*>(data); },
+        static_cast<GConnectFlags>(0));
 
     // Configure each RTP appsrc: caps (incl. the extmap so webrtcbin emits a=extmap), drop-old on
     // congestion so one slow peer can't backpressure the shared encoders.
@@ -142,6 +196,7 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         RCLCPP_ERROR(this->get_logger(), "Transport pipeline missing/failed an rtp appsrc");
         return nullptr;  // ~Peer() tears down the pipeline + the rtp appsrcs stored so far
     }
+    configure_video_transceivers(peer->webrtc, negotiated.size());
 
     // Tag the webrtcbin with its client_id (ICE-candidate routing) and a copy of its generation token,
     // so the on-negotiation-needed handler can build the offer context lock-free off the element alone.

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -13,6 +13,11 @@
 namespace mars_cam {
 
 namespace {
+struct KeyUnitCtx {
+    WebRTCStreamer* self;
+    std::string cam;
+};
+
 struct TransceiverCtx {
     WebRTCStreamer* self;
     guint video_count;  // transceivers are created in sink-pad link order: the video m-lines, then audio
@@ -23,6 +28,23 @@ struct TransceiverCtx {
 // =============================================================================
 // Per-peer transport
 // =============================================================================
+
+// webrtcbin turns an incoming PLI into a GstForceKeyUnit upstream event, but that event dies at the
+// transport appsrc — the encoder lives in a separate pipeline — so without this probe the browser
+// cannot request recovery and every loss waits out the periodic keyframe backstop.
+GstPadProbeReturn WebRTCStreamer::on_keyunit_request(GstPad*, GstPadProbeInfo* info, gpointer user_data) {
+    GstEvent* ev = gst_pad_probe_info_get_event(info);
+    if (!ev || GST_EVENT_TYPE(ev) != GST_EVENT_CUSTOM_UPSTREAM) {
+        return GST_PAD_PROBE_OK;
+    }
+    const GstStructure* s = gst_event_get_structure(ev);
+    if (!s || !gst_structure_has_name(s, "GstForceKeyUnit")) {
+        return GST_PAD_PROBE_OK;
+    }
+    auto* ctx = static_cast<KeyUnitCtx*>(user_data);
+    ctx->self->maybe_force_keyframe(ctx->cam);
+    return GST_PAD_PROBE_DROP;  // consumed; the appsrc has no use for it
+}
 
 std::string WebRTCStreamer::build_transport_description(const std::vector<std::string>& videos,
                                                         bool& with_audio) const {
@@ -167,6 +189,11 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
             gst_object_unref(src);
             ok = false;
             break;
+        }
+        if (GstPad* pad = gst_element_get_static_pad(src, "src")) {
+            gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_EVENT_UPSTREAM, on_keyunit_request, new KeyUnitCtx{this, v},
+                              [](gpointer p) { delete static_cast<KeyUnitCtx*>(p); });
+            gst_object_unref(pad);
         }
         peer->rtp[v] = src;  // keep the ref (camera name -> transport appsrc)
     }

--- a/scripts/update/build_gst_opt.sh
+++ b/scripts/update/build_gst_opt.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# Build the innate-gstreamer-opt Debian package: a self-contained GStreamer at
+# /opt/gst that unlocks webrtcbin's ULPFEC — the system 1.20 negotiates red/ulpfec
+# but never emits a RED packet. Run natively on a Jetson (arm64); the deb
+# ships as a GitHub Release asset on innate-packages, referenced from its
+# prebuilt-debs.txt manifest (this script prints the exact handoff commands),
+# where check-prebuilt-deb.sh is the CI gate and publish.sh signs and indexes
+# it. Robots pick it up through the normal update flow via
+# apt-dependencies.hardware.txt, and camera_composable.launch.py activates
+# /opt/gst automatically when present.
+#
+#   ./scripts/update/build_gst_opt.sh   # -> innate-gstreamer-opt_<v>-1jammy_arm64.deb
+#   GST_VERSION=1.24.13 DEB_INC=2 ./scripts/update/build_gst_opt.sh
+#
+# DEB_INC bumps the Debian revision (same convention as innate-packages
+# build.sh): a rebuild of the same upstream version is invisible to apt
+# unless the revision changes.
+set -euo pipefail
+
+V="${GST_VERSION:-1.24.12}"
+REV="${DEB_INC:-1}jammy"
+WORK="${WORK_DIR:-$HOME/gst-src}"
+PREFIX=/opt/gst
+LIBDIR=lib/aarch64-linux-gnu
+SRC_COMMIT=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse HEAD 2>/dev/null || echo unknown)
+
+missing=$(for p in ninja-build flex bison libssl-dev libsrtp2-dev libvpx-dev \
+                   libjpeg-dev python3-pip pkg-config cmake curl binutils file; do
+  dpkg -s "$p" >/dev/null 2>&1 || echo "$p"
+done)
+[ -z "$missing" ] || sudo apt-get install -y $missing
+pip3 install --user --quiet "meson>=1.1" patchelf
+export PATH="$HOME/.local/bin:$PATH"
+
+mkdir -p "$WORK" && cd "$WORK"
+if [ ! -d "gstreamer-$V" ]; then
+  curl -fsSL -o gst.tar.gz \
+    "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$V/gstreamer-$V.tar.gz"
+  tar xf gst.tar.gz
+fi
+cd "gstreamer-$V"
+
+[ -f build/build.ninja ] || meson setup build --prefix="$PREFIX" \
+  -Dbuildtype=release -Dgpl=disabled \
+  -Dugly=disabled -Dlibav=disabled -Ddevtools=disabled -Dges=disabled \
+  -Drtsp_server=disabled -Ddoc=disabled -Dexamples=disabled -Dtests=disabled \
+  -Dintrospection=disabled -Dpython=disabled -Dlibnice=enabled \
+  -Dgst-plugins-bad:webrtc=enabled -Dgst-plugins-bad:dtls=enabled \
+  -Dgst-plugins-bad:srtp=enabled -Dgst-plugins-bad:sctp=enabled \
+  -Dgst-plugins-good:vpx=enabled -Dgst-plugins-good:rtpmanager=enabled
+ninja -C build
+
+ROOT="$WORK/debroot"
+rm -rf "$ROOT" && mkdir -p "$ROOT$PREFIX" "$ROOT/DEBIAN"
+DESTDIR="$ROOT" meson install -C build --no-rebuild >/dev/null
+GST="$ROOT$PREFIX"
+
+# Runtime-only payload: headers, dev symlinks, tests and non-gst tools stay
+# home. Each pruned plugin below is the sole consumer of a heavy external dep
+# (qmlgl alone drags in Qt5); openh264/fdk-aac also carry licenses we must
+# not redistribute from a public apt repo.
+rm -rf "$GST/$LIBDIR/pkgconfig" "$GST/$LIBDIR/cmake" \
+       "$GST/libexec/installed-tests" \
+       "$GST/share/man" "$GST/share/aclocal" "$GST/share/gdb" \
+       "$GST/share/installed-tests" "$GST/share/bash-completion"
+find "$GST/bin" -maxdepth 1 \( -type f -o -type l \) ! -name 'gst-*' -delete
+rm -f "$GST"/libexec/gstreamer-1.0/gst-hotdoc-plugins-scanner \
+      "$GST"/libexec/gstreamer-1.0/gst-plugins-doc-cache-generator \
+      "$GST"/libexec/gstreamer-1.0/gst-completion-helper
+rm -f "$GST/$LIBDIR"/libgstcheck-1.0.so* "$GST/$LIBDIR"/liborc-test-0.4.so* \
+      "$GST/$LIBDIR"/libopenh264.so* "$GST/$LIBDIR"/libfdk_aac.so* \
+      "$GST/$LIBDIR"/libpangoxft-1.0.so*
+for p in openh264 fdkaac qmlgl ximagesrc ximagesink rfbsrc aom dc1394 de265 \
+         openni2 openexr openjpeg theora uvch264 curl colormanagement webp; do
+  rm -f "$GST/$LIBDIR/gstreamer-1.0/libgst$p.so"
+done
+find "$GST/$LIBDIR" -maxdepth 1 -type l -name 'lib*.so' -delete
+rm -rf "$GST/$LIBDIR/cairo"  # only cairo's LD_PRELOAD trace shims live here
+# Subprojects nest more include/ dirs under lib (graphene does).
+find "$GST" -type d -name include -prune -exec rm -rf {} +
+find "$GST" -depth -type d -empty -delete
+
+# The 1.24 CLI must not share a registry cache with the system 1.20: both
+# default to $XDG_CACHE_HOME/gstreamer-1.0/registry.aarch64.bin, and the
+# magic-version mismatch makes each run discard the other's cache (a full
+# plugin rescan on every alternating start). Real binaries live in libexec;
+# bin/ keeps wrappers pinning a cache file of their own.
+mkdir -p "$GST/libexec/gst-opt"
+for tool in "$GST"/bin/gst-*; do
+  name=${tool##*/}
+  mv "$tool" "$GST/libexec/gst-opt/$name"
+  { echo '#!/bin/sh'
+    echo 'export GST_REGISTRY="${GST_REGISTRY:-${XDG_CACHE_HOME:-$HOME/.cache}/gstreamer-1.0/registry-opt.aarch64.bin}"'
+    echo "exec $PREFIX/libexec/gst-opt/$name \"\$@\""
+  } > "$tool"
+  chmod 755 "$tool"
+done
+
+# $ORIGIN-relative RUNPATH (not LD_LIBRARY_PATH) is what makes /opt/gst
+# self-contained next to the system GStreamer: without it, gst-inspect-1.0
+# run by hand binds the system 1.20 core and rejects every 1.24 plugin.
+find "$ROOT" -type f | while read -r f; do
+  readelf -h "$f" >/dev/null 2>&1 || continue
+  strip --strip-unneeded "$f"
+  # grep without -q: an early exit would SIGPIPE readelf and, under pipefail,
+  # silently skip ELFs that do have NEEDED entries.
+  readelf -d "$f" 2>/dev/null | grep NEEDED >/dev/null || continue
+  rel=$(realpath --relative-to="$(dirname "$f")" "$GST/$LIBDIR")
+  patchelf --set-rpath "\$ORIGIN/$rel" "$f"
+done
+
+# The gate that matters: every WebRTC element present, and NVIDIA's hardware
+# plugins (built against the system gst) loading under this core.
+export LD_LIBRARY_PATH="$GST/$LIBDIR"
+export GST_PLUGIN_PATH="$GST/$LIBDIR/gstreamer-1.0:/usr/lib/aarch64-linux-gnu/gstreamer-1.0"
+export GST_REGISTRY="$WORK/verify.registry"
+rm -f "$GST_REGISTRY"
+# The real ELF, not the bin/ wrapper: wrappers exec the installed $PREFIX
+# path, which doesn't exist in the staging tree.
+B="$GST/libexec/gst-opt/gst-inspect-1.0"
+for el in webrtcbin vp8enc rtpvp8pay srtpenc dtlssrtpenc rtpulpfecenc rtpredenc \
+          nicesink nvv4l2decoder nvvidconv nvjpegenc; do
+  "$B" "$el" > /dev/null || { echo "VERIFY FAILED: $el"; exit 1; }
+done
+# RUNPATH proof: the same core must bind with NO library env at all — that's what a
+# hand-run gst-inspect-1.0 on a robot relies on, and the LD_LIBRARY_PATH exported above
+# would mask a silently-failed patchelf pass.
+env -u LD_LIBRARY_PATH GST_REGISTRY="$WORK/verify-runpath.registry" "$B" webrtcbin > /dev/null \
+  || { echo "VERIFY FAILED: RUNPATH (webrtcbin with no LD_LIBRARY_PATH)"; exit 1; }
+
+# Depends comes from dpkg-shlibdeps, never a bare package-ownership closure:
+# symbols files carry per-symbol version floors (the payload imports g_memdup2,
+# GLib 2.68 — an unversioned dep installs cleanly on focal/L4T r35 and every
+# plugin dlopen then dies at runtime with no apt error). Bundled sonames map
+# to this package via shlibs.local and are filtered back out of the field.
+SHLIB="$WORK/shlibdeps"
+rm -rf "$SHLIB" && mkdir -p "$SHLIB/debian"
+printf 'Source: innate-gstreamer-opt\nMaintainer: Innate Inc <ops@innate.bot>\n\nPackage: innate-gstreamer-opt\nArchitecture: arm64\nDescription: shlibdeps stub\n' \
+  > "$SHLIB/debian/control"
+find "$GST/$LIBDIR" -maxdepth 1 -type f -name 'lib*.so*' -exec readelf -d {} \; 2>/dev/null \
+  | awk '/SONAME/ {gsub(/[][]/, "", $NF); print $NF}' | sort -u \
+  | sed -E 's/^(.+)\.so\.(.+)$/\1 \2 innate-gstreamer-opt/' > "$SHLIB/debian/shlibs.local"
+# `if`, not `&&`: a trailing non-ELF (the bin/ wrappers) would otherwise end
+# the substitution non-zero and errexit kills the build with no message.
+ELFS=$(find "$ROOT" -type f ! -path "$ROOT/DEBIAN/*" \
+  | while read -r f; do
+      if readelf -h "$f" >/dev/null 2>&1; then echo "$f"; fi
+    done)
+DEPENDS=$(cd "$SHLIB" && dpkg-shlibdeps -O -l"$GST/$LIBDIR" $(printf -- '-e%s ' $ELFS) \
+    2>"$WORK/shlibdeps.log" \
+  | sed 's/^shlibs:Depends=//' | tr ',' '\n' | sed 's/^ *//;s/ *$//' \
+  | grep -v '^innate-gstreamer-opt$' | sort -u | paste -sd, - | sed 's/,/, /g') \
+  || { tail -5 "$WORK/shlibdeps.log"; echo "DEPENDS FAILED: dpkg-shlibdeps"; exit 1; }
+case "$DEPENDS" in *"libc6 (>="*) ;; *)
+  echo "DEPENDS FAILED: unversioned libc6 (symbols files missing?)"; exit 1 ;; esac
+case "$DEPENDS" in *"libglib2.0-0 (>="*) ;; *)
+  echo "DEPENDS FAILED: unversioned libglib2.0-0"; exit 1 ;; esac
+
+mkdir -p "$ROOT/usr/share/doc/innate-gstreamer-opt"
+cat > "$ROOT/usr/share/doc/innate-gstreamer-opt/copyright" << EOF
+innate-gstreamer-opt repackages GStreamer $V, built unmodified from
+https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/$V/
+by innate-os scripts/update/build_gst_opt.sh (GPL plugins disabled).
+
+GStreamer libraries and plugins: LGPL-2.1-or-later; bundled meson
+subproject libraries (libnice, libsoup, orc, cairo, pango, harfbuzz,
+FLAC, opus, ogg, vorbis, json-glib, libpsl, fribidi, pixman, libdv):
+their respective upstream licenses (LGPL/MPL/BSD/MIT). Full texts ship
+in each project's source archive at the URL above.
+EOF
+
+cat > "$ROOT/DEBIAN/control" << EOF
+Package: innate-gstreamer-opt
+Version: $V-$REV
+Section: libs
+Priority: optional
+Architecture: arm64
+Depends: $DEPENDS
+Installed-Size: $(du -ks "$GST" | cut -f1)
+Maintainer: Innate Inc <ops@innate.bot>
+Description: Parallel GStreamer $V runtime at /opt/gst for WebRTC FEC
+ Self-contained GStreamer (core/base/good/bad + libnice) under /opt/gst,
+ runtime files only, RUNPATH-pinned to its own libraries. The camera
+ stack opts in via camera_composable.launch.py when this directory
+ exists; without it robots run the system GStreamer unchanged.
+ Ships working webrtcbin ULPFEC (broken on system 1.20).
+ Built from innate-os commit $SRC_COMMIT.
+EOF
+(cd "$ROOT" && find opt usr -type f -print0 | LC_ALL=C sort -z \
+  | xargs -0 md5sum > DEBIAN/md5sums)
+
+# dpkg applies packaged directory modes to live system dirs (/opt included),
+# so a 0775 from the build umask would chmod every robot's /opt.
+chmod -R g-w "$ROOT"
+find "$ROOT" -type d -exec chmod 755 {} +
+
+# -Zxz, not the dpkg default zstd: debsigs parses only gz/xz members and
+# silently signs nothing on a zstd deb.
+DEB="$WORK/innate-gstreamer-opt_${V}-${REV}_arm64.deb"
+dpkg-deb -Zxz --root-owner-group --build "$ROOT" "$DEB"
+SHA=$(sha256sum "$DEB" | cut -d' ' -f1)
+TAG="innate-gstreamer-opt-$V-$REV"
+cat << EOF
+OK: $DEB
+
+To ship it (from an innate-packages checkout; validate first with
+./check-prebuilt-deb.sh $DEB):
+
+  gh release create $TAG $DEB \\
+    --title "innate-gstreamer-opt $V-$REV" \\
+    --notes "Built from innate-os commit $SRC_COMMIT. sha256: $SHA"
+
+then replace the innate-gstreamer-opt line in prebuilt-debs.txt with:
+
+  $TAG $(basename "$DEB") $SHA
+EOF

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1393,17 +1393,31 @@ select.skill-input {
   outline-offset: 3px;
 }
 
-/* Off: a compact dim pill showing just the camera name. */
+/* Off: a placeholder slot with the live tiles' exact footprint — glyph, name, and an
+   explicit hint, so the strip always shows every available view and never reflows.
+   55% black stays crisp on any feed (--glass at 40% goes muddy over bright scenes). */
 .cam-tile.off {
-  padding: 7px 12px;
+  height: var(--pip-h);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgb(0 0 0 / 55%);
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11px;
   letter-spacing: 0.02em;
   text-transform: lowercase;
 }
 
 .cam-tile.off:hover {
   color: var(--text);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 25%);
+}
+
+.cam-tile-hint {
+  font-size: 9.5px;
+  color: rgb(231 231 234 / 45%);
 }
 
 /* Live: a thumbnail of the feed. */
@@ -1428,11 +1442,80 @@ select.skill-input {
   height: 100%;
   object-fit: cover;
   display: block;
+  transition: opacity 300ms ease; /* first frames fade in rather than pop */
 }
 
-/* Feed requested but not flowing yet — dim the tile so it reads as warming up. */
+/* Off and live tiles share a footprint, so opening is a soft fade-up of the new content
+   (the strip rebuilds its nodes; this entrance animation is the continuity). */
+.cam-tile.opening {
+  animation: cam-tile-open 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes cam-tile-open {
+  from {
+    opacity: 0.4;
+  }
+}
+
+/* Feed requested but not flowing yet: hide the (black) video and let the warming-up
+   treatment show — a slow shimmer sweep plus a "connecting…" caption. Both fade in only
+   after a beat, so an instant LAN connect never flashes them. */
 .cam-tile.connecting video {
-  opacity: 0.25;
+  opacity: 0;
+}
+
+.cam-tile.live::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, transparent 30%, rgb(255 255 255 / 8%) 50%, transparent 70%);
+  background-size: 220% 100%;
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.cam-tile.connecting::before {
+  opacity: 1;
+  transition-delay: 350ms; /* delayed in, instant out */
+  animation: cam-tile-shimmer 1.6s ease-in-out infinite;
+}
+
+@keyframes cam-tile-shimmer {
+  from {
+    background-position: 130% 0;
+  }
+
+  to {
+    background-position: -130% 0;
+  }
+}
+
+.cam-tile-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.cam-tile.connecting .cam-tile-status {
+  opacity: 1;
+  transition-delay: 350ms; /* matches the shimmer: delayed in, instant out */
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cam-tile.opening,
+  .cam-tile.connecting::before {
+    animation: none;
+  }
 }
 
 .cam-tile-label {
@@ -7039,16 +7122,6 @@ select.skill-input {
     var(--agent-dock-gutter) + var(--agent-overlay-inset)
   ) !important;
   left: calc(var(--agent-dock-gutter) + var(--agent-overlay-inset));
-}
-
-/* On the agent page off tiles (cameras or the map) keep the same square
-   footprint as the live feeds so the strip's grid stays tidy. */
-.agent-cockpit .cam-tile.off {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: var(--pip-h);
-  padding: 0;
 }
 
 .agent-mic-control {

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1455,6 +1455,44 @@ select.skill-input {
   transition: color 150ms ease, background-color 150ms ease;
 }
 
+/* Hover-revealed close on live tiles: drops the view back to off (#687's redesign
+   removed this block as dead CSS while the collapsible strip lived on a branch). */
+.cam-tile-close {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  border: none;
+  background: rgb(18 18 21 / 62%);
+  color: rgb(255 255 255 / 82%);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 150ms ease, color 150ms ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .cam-tile.live:hover .cam-tile-close {
+    opacity: 1;
+  }
+}
+
+.cam-tile-close:focus-visible {
+  opacity: 1;
+  outline: 2px solid rgb(255 255 255 / 72%);
+  outline-offset: 1px;
+}
+
+.cam-tile-close:hover {
+  color: #fff;
+}
+
 /* Map view — same ladder as a camera. As a thumbnail it's a tile-sized canvas host. */
 .cam-tile-map {
   height: auto;
@@ -7003,8 +7041,8 @@ select.skill-input {
   left: calc(var(--agent-dock-gutter) + var(--agent-overlay-inset));
 }
 
-/* Agent page keeps every camera live (no off pill), so any off tile here is the
-   optional map — give it the same square footprint as the live feeds. */
+/* On the agent page off tiles (cameras or the map) keep the same square
+   footprint as the live feeds so the strip's grid stays tidy. */
 .agent-cockpit .cam-tile.off {
   display: flex;
   align-items: center;

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -3,7 +3,7 @@ import { WEBRTC_ACTIVE_STREAMS_TOPIC } from "../constants.js";
 // Multi-view PiP strip — a Zoom-style switcher pinned bottom-right. The big stage shows the PRIMARY view;
 // the strip shows every OTHER view as a tile that climbs a three-rung ladder:
 //
-//   off (dim pill)  --click-->  live thumbnail (PiP)  --click-->  primary (fills the stage; leaves the strip)
+//   off (dark placeholder tile)  --click-->  live thumbnail (PiP)  --click-->  primary (fills the stage; leaves the strip)
 //
 // Promoting a thumbnail demotes whatever was big back into the strip (the swap). Hovering a live thumbnail
 // reveals a × that drops it back to off. "Size is the state": the big view is self-evidently primary, so
@@ -26,6 +26,14 @@ const DISPLAY_LABELS = { main: "Main", arm: "Arm", orbit: "Top View" };
 function displayLabel(name) {
   return DISPLAY_LABELS[name] ?? name.charAt(0).toUpperCase() + name.slice(1);
 }
+
+// Same stroke style as the rest of the cockpit's inline icons (24 viewBox, 1.5 stroke).
+const CAMERA_ICON =
+  '<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<path d="M23 7l-7 5 7 5V7z"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>';
+const MAP_ICON =
+  '<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+  '<polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/></svg>';
 const MAP_ZOOM_KEY = "innate.map.zoom"; // { small, big } metres-across, persisted per map size
 const MAP_ID = "__map__"; // sentinel "view" id for the nav map (never a real camera name)
 const MAP_ZOOM_DEFAULT = { small: 6, big: 16 }; // tighter as a thumbnail, wider on the full stage
@@ -143,10 +151,14 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     renderStructure();
   }
 
+  /** One-shot: the view whose fresh live tile plays the pill→tile entrance animation. */
+  let justOpened = "";
+
   /** Bring a view one rung up the ladder: off → live thumbnail (does NOT steal the big stage). @param {string} id */
   function enable(id) {
     if (id === MAP_ID) mapOn = true;
     else enabledCams.add(id);
+    justOpened = id;
     commit();
   }
 
@@ -248,6 +260,10 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     const index = roster.indexOf(name);
     const label = displayLabel(name);
     const tile = liveTile(name, label, `Switch to ${label} view`);
+    const status = document.createElement("span");
+    status.className = "cam-tile-status";
+    status.textContent = "connecting…";
+    tile.append(status);
     // Sim sessions expose live canvases (no MediaStream pipeline -- canvas
     // capture pinned page composition to its capture rate); mount those
     // directly. Real robots keep the <video> + WebRTC stream path. SimSession
@@ -280,14 +296,19 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     return tile;
   }
 
-  /** Dim pill for an off view; clicking climbs to the live-thumbnail rung. @param {string} id @param {string} label @param {string} title */
+  /** Dark placeholder tile for an off view — same footprint as a live tile, so the strip never
+   *  reflows; clicking climbs to the live-thumbnail rung. @param {string} id @param {string} label @param {string} title */
   function offTile(id, label, title) {
     const tile = document.createElement("div");
     tile.className = "cam-tile off";
-    tile.textContent = label;
     tile.tabIndex = 0;
     tile.setAttribute("role", "button");
     tile.setAttribute("aria-label", title);
+    tile.innerHTML =
+      (id === MAP_ID ? MAP_ICON : CAMERA_ICON) +
+      '<span class="cam-tile-name"></span><span class="cam-tile-hint">tap to view</span>';
+    const name = tile.querySelector(".cam-tile-name");
+    if (name) name.textContent = label;
     tile.addEventListener("click", () => enable(id));
     tile.addEventListener("keydown", (event) => {
       if (event.key !== "Enter" && event.key !== " ") return;
@@ -304,6 +325,11 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     tile.tabIndex = 0;
     tile.setAttribute("role", "button");
     tile.setAttribute("aria-label", title);
+    if (id === justOpened) {
+      justOpened = "";
+      tile.classList.add("opening");
+      tile.addEventListener("animationend", () => tile.classList.remove("opening"), { once: true });
+    }
     tile.addEventListener("click", () => promote(id));
     tile.addEventListener("keydown", (event) => {
       if (event.key !== "Enter" && event.key !== " ") return;

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -12,7 +12,9 @@ import { WEBRTC_ACTIVE_STREAMS_TOPIC } from "../constants.js";
 // Views are the robot's cameras (from /webrtc/active_streams, 2-4, not hardcoded) PLUS the nav map, which
 // behaves identically — off / live thumbnail / big. When the map is primary it covers the stage and the
 // video stage hides; a camera stays the session's primary underneath so the WebRTC link keeps a live feed.
-// The enabled set + which view is primary persist in localStorage; by default only the first camera is on.
+// The enabled set + which view is primary persist in localStorage; by default only the default primary
+// camera and the map are on. A closed tile genuinely stops streaming (each live tile is a full-bitrate
+// WebRTC stream), so collapsing views is how an operator sheds bandwidth.
 
 const STORE_KEY = "innate.cameras";
 
@@ -71,11 +73,17 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   function loadPrefs() {
     try {
       const p = JSON.parse(localStorage.getItem(storeKey) || "{}");
-      enabledCams = new Set(Array.isArray(p.enabled) ? p.enabled : []);
-      mapOn = p.mapOn === true;
       // "" = no saved choice; reconcile picks. A primaryOnMount caller overrides
       // the saved value outright — reconcile validates it against the roster.
       primary = opts.primaryOnMount ?? (typeof p.primary === "string" ? p.primary : "");
+      if (p.v === 2) {
+        enabledCams = new Set(Array.isArray(p.enabled) ? p.enabled : []);
+        mapOn = p.mapOn === true;
+      } else {
+        // v1 profiles: reconcile forced every camera on (never a user choice), so only the
+        // primary survives the migration to the primary+map default (reconcile re-enables it).
+        mapOn = true;
+      }
     } catch {
       primary = opts.primaryOnMount ?? "";
       /* other defaults: nothing enabled, reconcile picks the first camera */
@@ -94,20 +102,18 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   }
 
   function savePrefs() {
-    localStorage.setItem(storeKey, JSON.stringify({ enabled: [...enabledCams], mapOn, primary }));
+    localStorage.setItem(storeKey, JSON.stringify({ v: 2, enabled: [...enabledCams], mapOn, primary }));
   }
 
   // Drop names the roster no longer has, then guarantee a valid enabled primary (the stage always needs a
-  // view). Zero cameras is fine when the map is primary (map-only releases WebRTC). Default when nothing
-  // valid persists: the first camera.
+  // view). Zero cameras is fine when the map is primary (map-only releases WebRTC). Fresh profile: only
+  // the default primary camera streams, plus the map.
   function reconcile() {
     enabledCams = new Set([...enabledCams].filter((n) => roster.includes(n)));
-    // Every view stays live on every page: tiles are not collapsible, and a
-    // stale persisted "enabled"/mapOn must not relaunch tiles as off pills.
-    for (const n of roster) enabledCams.add(n);
-    mapOn = true;
-    const validPrimary =
-      primary === MAP_ID || (roster.includes(primary) && enabledCams.has(primary));
+    if (primary === "") mapOn = true; // nothing persisted yet — the map starts on
+    // Roster membership is the validity test: the tail below re-enables the primary, so a
+    // primaryOnMount view (or a migrated v1 primary) outside the saved enabled set still wins.
+    const validPrimary = primary === MAP_ID ? mapOn : roster.includes(primary);
     if (!validPrimary) {
       // No saved choice (or a stale one): default to the view that shows the
       // robot best -- the sim's orbit "top view" (only simulated robots have
@@ -137,12 +143,32 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     renderStructure();
   }
 
+  /** Bring a view one rung up the ladder: off → live thumbnail (does NOT steal the big stage). @param {string} id */
+  function enable(id) {
+    if (id === MAP_ID) mapOn = true;
+    else enabledCams.add(id);
+    commit();
+  }
+
   /** Promote a view to the big stage; whatever was big drops back into the strip. @param {string} id */
   function promote(id) {
     if (id === primary) return;
     primary = id;
     if (id === MAP_ID) mapOn = true;
     else enabledCams.add(id);
+    commit();
+  }
+
+  // Drop a live view back to off. The strip never shows the primary, so the closed view normally isn't
+  // it; if that invariant ever breaks, fall back so the stage keeps a view.
+  /** @param {string} id */
+  function disable(id) {
+    if (id === MAP_ID) mapOn = false;
+    else enabledCams.delete(id);
+    if (id === primary) {
+      primary = roster.find((n) => enabledCams.has(n)) ?? MAP_ID;
+      if (primary === MAP_ID) mapOn = true;
+    }
     commit();
   }
 
@@ -218,6 +244,7 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
 
   /** @param {string} name */
   function buildCameraTile(name) {
+    if (!enabledCams.has(name)) return offTile(name, displayLabel(name), `Turn on the ${name} camera`);
     const index = roster.indexOf(name);
     const label = displayLabel(name);
     const tile = liveTile(name, label, `Switch to ${label} view`);
@@ -246,9 +273,27 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   }
 
   function buildMapTile() {
+    if (!mapOn) return offTile(MAP_ID, "Map", "Show the navigation map");
     const tile = liveTile(MAP_ID, "Map", "Switch to Map view · scroll to zoom");
     tile.classList.add("cam-tile-map");
     if (mapHost) tile.prepend(mapHost); // reparent the persistent host into the thumbnail
+    return tile;
+  }
+
+  /** Dim pill for an off view; clicking climbs to the live-thumbnail rung. @param {string} id @param {string} label @param {string} title */
+  function offTile(id, label, title) {
+    const tile = document.createElement("div");
+    tile.className = "cam-tile off";
+    tile.textContent = label;
+    tile.tabIndex = 0;
+    tile.setAttribute("role", "button");
+    tile.setAttribute("aria-label", title);
+    tile.addEventListener("click", () => enable(id));
+    tile.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      enable(id);
+    });
     return tile;
   }
 
@@ -268,7 +313,16 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     const tag = document.createElement("span");
     tag.className = "cam-tile-label";
     tag.textContent = label;
-    tile.append(tag);
+    const close = document.createElement("button");
+    close.type = "button";
+    close.className = "cam-tile-close";
+    close.title = id === MAP_ID ? "Close" : "Close (stops streaming)";
+    close.textContent = "×";
+    close.addEventListener("click", (e) => {
+      e.stopPropagation();
+      disable(id);
+    });
+    tile.append(tag, close);
     return tile;
   }
 

--- a/webapp/js/teleop/profilingPanel.js
+++ b/webapp/js/teleop/profilingPanel.js
@@ -24,6 +24,10 @@ const TOGGLE_KEY = "KeyP";
  * @property {number} bytes       bytesReceived, cumulative
  * @property {number} packets     packetsReceived, cumulative
  * @property {number} lost        packetsLost, cumulative
+ * @property {number} pli         pliCount, cumulative, primary video stream
+ * @property {number} keyframes   keyFramesDecoded, cumulative, primary stream
+ * @property {number} decoded     framesDecoded, cumulative, primary stream
+ * @property {number | null} received framesReceived, cumulative, primary stream; null when unreported
  */
 
 /**
@@ -64,13 +68,15 @@ export function createProfilingPanel(parent, session) {
   const jitterBuffer = metric("jitter buf", "ms", true, "Average de-jitter buffer delay of frames played out since the last poll");
   const rtt = metric("rtt", "ms", false, "Round-trip time on the selected ICE candidate pair");
   const jitter = metric("jitter", "ms", false, "Inter-arrival jitter, inbound video RTP");
-  const fps = metric("fps", "", false, "Decoded frames per second");
+  const fps = metric("fps", "", false, "Decoded / received frames per second — the gap is frames dropped before decode");
   const resolution = metric("res", "", false, "Received video resolution");
   const bitrate = metric("bitrate", "kb/s", false, "Inbound video bitrate since the last poll");
   const loss = metric("loss", "%", false, "Packet loss since the last poll");
   const dropped = metric("dropped", "", false, "Frames dropped (cumulative)");
   const freezes = metric("freezes", "", false, "Freeze events (cumulative)");
-  const all = [jitterBuffer, rtt, jitter, fps, resolution, bitrate, loss, dropped, freezes];
+  const pli = metric("pli", "/m", false, "PLIs per minute — decoder recoveries from corrupted output; ~0 on a healthy stream");
+  const keyf = metric("keyf", "/m", false, "Key frames decoded per minute — near 0 on a clean link, ~60 in degraded 1 Hz keyframe mode");
+  const all = [jitterBuffer, rtt, jitter, fps, resolution, bitrate, loss, dropped, freezes, pli, keyf];
   for (const m of all) grid.append(m.el);
 
   // Connection state — driven by session changes (not the getStats poll), so it stays meaningful even
@@ -140,12 +146,25 @@ export function createProfilingPanel(parent, session) {
     }
 
     /** @type {any} */ let vid = null;
+    let vidIsPrimary = false;
     /** @type {any} */ let selectedPair = null;
     /** @type {string | undefined} */ let selectedPairId;
+    // Every per-stream metric reads ONE inbound-rtp — the primary camera's (matched by the
+    // mid's m-line index) — so fps/pli/keyf line up with the res/bitrate/loss beside them
+    // instead of mixing streams. Fallback when mids are unreported: the first video stream.
+    const primaryIndex = session.primaryCamera?.index ?? -1;
 
     report.forEach((/** @type {any} */ s) => {
-      if (s.type === "inbound-rtp" && s.kind === "video") vid = s;
-      else if (s.type === "transport" && s.selectedCandidatePairId) selectedPairId = s.selectedCandidatePairId;
+      if (s.type === "inbound-rtp" && s.kind === "video") {
+        const m = /(\d+)$/.exec(s.mid ?? "");
+        const isPrimary = m !== null && Number(m[1]) === primaryIndex;
+        if (!vid || (isPrimary && !vidIsPrimary)) {
+          vid = s;
+          vidIsPrimary = isPrimary;
+        }
+      } else if (s.type === "transport" && s.selectedCandidatePairId) {
+        selectedPairId = s.selectedCandidatePairId;
+      }
     });
     report.forEach((/** @type {any} */ s) => {
       if (s.type !== "candidate-pair") return;
@@ -160,7 +179,6 @@ export function createProfilingPanel(parent, session) {
 
     rtt.value.textContent = fmt(selectedPair?.currentRoundTripTime * 1000, 1);
     jitter.value.textContent = fmt(vid.jitter * 1000, 1);
-    fps.value.textContent = fmt(vid.framesPerSecond, 0);
     resolution.value.textContent =
       vid.frameWidth && vid.frameHeight ? `${vid.frameWidth}×${vid.frameHeight}` : "—";
     dropped.value.textContent = fmt(vid.framesDropped, 0);
@@ -174,6 +192,10 @@ export function createProfilingPanel(parent, session) {
       bytes: vid.bytesReceived ?? 0,
       packets: vid.packetsReceived ?? 0,
       lost: vid.packetsLost ?? 0,
+      pli: vid.pliCount ?? 0,
+      keyframes: vid.keyFramesDecoded ?? 0,
+      decoded: vid.framesDecoded ?? 0,
+      received: typeof vid.framesReceived === "number" ? vid.framesReceived : null,
     };
 
     if (prev) {
@@ -182,7 +204,16 @@ export function createProfilingPanel(parent, session) {
       const dDelay = now.jbDelay - prev.jbDelay;
       jitterBuffer.value.textContent = dEmitted > 0 ? fmt((dDelay / dEmitted) * 1000, 0) : "—";
 
-      if (dt > 0) bitrate.value.textContent = fmt(((now.bytes - prev.bytes) * 8) / dt / 1000, 0);
+      if (dt > 0) {
+        bitrate.value.textContent = fmt(((now.bytes - prev.bytes) * 8) / dt / 1000, 0);
+        pli.value.textContent = fmt(((now.pli - prev.pli) * 60) / dt, 0);
+        keyf.value.textContent = fmt(((now.keyframes - prev.keyframes) * 60) / dt, 0);
+        const decodedFps = fmt((now.decoded - prev.decoded) / dt, 0);
+        fps.value.textContent =
+          now.received !== null && prev.received !== null
+            ? `${decodedFps}/${fmt((now.received - prev.received) / dt, 0)}`
+            : decodedFps;
+      }
 
       const dRecv = now.packets - prev.packets;
       const dLost = now.lost - prev.lost;

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -49,6 +49,11 @@ const OFFER_GUARD_RESET_MS = 1_000;
 // Bounded retries instead of a single long stare-at-black, which is what made
 // refreshing feel faster.
 const MAX_HANDSHAKE_ATTEMPTS = 3;
+// Adaptive receive jitter buffer: receivers attach pinned to 0 (lowest latency,
+// right on LAN), then every poll the target is re-derived from path RTT + recent
+// video loss. On WAN a NACK retransmit arrives ~1 RTT after the gap, so the
+// buffer must cover that or loss plays out as artifacts/freezes.
+const JITTER_POLL_MS = 3_000;
 
 export class WebRtcSession {
   /** @type {import("./rosClient.js").RosClient} */ #ros;
@@ -95,6 +100,10 @@ export class WebRtcSession {
   /** @type {number | null} */ #watchdog = null;
   /** @type {number | null} */ #degradeTimer = null;
   /** @type {number | null} */ #audioDebounce = null;
+  /** @type {number | null} */ #jitterPoll = null;
+  #lastJitterTargetMs = 0;
+  // Previous poll's cumulative inbound-video packet counters, for a per-interval loss fraction.
+  #lastVideoPackets = { received: 0, lost: 0 };
 
   /** @param {import("./rosClient.js").RosClient} rosClient */
   constructor(rosClient) {
@@ -269,6 +278,7 @@ export class WebRtcSession {
     this.#pc = pc;
     this.#builtWithAudio = this.#state.audioRequested;
     wireDiagnosticDataChannels(pc);
+    this.#startJitterPoll();
 
     pc.onicecandidate = (event) => {
       if (this.#pc !== pc || !event.candidate) return;
@@ -359,13 +369,12 @@ export class WebRtcSession {
       return;
     }
 
-    // Minimize the receive-side jitter buffer on the video receiver. The
-    // playout-delay extension caps the ceiling; these pin the floor.
-    // Units differ: jitterBufferTarget is in milliseconds, playoutDelayHint in
-    // seconds. Both 0 here means "minimal delay". Modern Chrome honors
-    // jitterBufferTarget and ignores the hint (not a strict fallback — both are
-    // set whenever present). To match the robot-side max=40, the values diverge:
-    // jitterBufferTarget = 40, playoutDelayHint = 0.04.
+    // Start the video receiver's jitter buffer at zero (lowest latency, right
+    // on LAN); #adaptJitterBuffer raises it when RTT/loss show retransmits need
+    // room to land. Units differ: jitterBufferTarget is in milliseconds,
+    // playoutDelayHint in seconds (a 40ms target is 40 vs 0.04). Modern Chrome
+    // honors jitterBufferTarget and ignores the hint (not a strict fallback —
+    // both are set whenever present).
     const receiver = event.receiver;
     if (receiver) {
       try {
@@ -574,9 +583,63 @@ export class WebRtcSession {
     }
   }
 
+  #startJitterPoll() {
+    this.#clearJitterPoll();
+    this.#lastJitterTargetMs = 0; // the new pc's receivers attach pinned to 0 (#onTrack)
+    this.#lastVideoPackets = { received: 0, lost: 0 };
+    this.#jitterPoll = setInterval(() => void this.#adaptJitterBuffer(), JITTER_POLL_MS);
+  }
+
+  #clearJitterPoll() {
+    if (this.#jitterPoll !== null) {
+      clearInterval(this.#jitterPoll);
+      this.#jitterPoll = null;
+    }
+  }
+
+  // Clean fast path (LAN-ish RTT, ~no loss) → 0. Otherwise ~1.2×RTT + 30ms, capped at 500,
+  // so a NACK retransmit lands before playout. 20ms hysteresis avoids churning the decoder.
+  async #adaptJitterBuffer() {
+    const pc = this.#pc;
+    if (!pc) return;
+    const stats = await pc.getStats().catch(() => null);
+    if (!stats || this.#pc !== pc) return;
+
+    /** @type {number | null} */ let rttMs = null;
+    const packets = { received: 0, lost: 0 };
+    stats.forEach((s) => {
+      if (s.type === "candidate-pair" && s.nominated && s.state === "succeeded") {
+        if (typeof s.currentRoundTripTime === "number") rttMs = s.currentRoundTripTime * 1000;
+      } else if (s.type === "inbound-rtp" && s.kind === "video") {
+        packets.received += s.packetsReceived ?? 0;
+        packets.lost += s.packetsLost ?? 0;
+      }
+    });
+    const dReceived = packets.received - this.#lastVideoPackets.received;
+    const dLost = packets.lost - this.#lastVideoPackets.lost;
+    this.#lastVideoPackets = packets;
+    if (rttMs === null) return;
+
+    const loss = dLost > 0 ? dLost / (dReceived + dLost) : 0;
+    const target = rttMs < 60 && loss < 0.005 ? 0 : Math.min(500, Math.round(rttMs * 1.2 + 30));
+    if (Math.abs(target - this.#lastJitterTargetMs) <= 20) return;
+    this.#lastJitterTargetMs = target;
+    for (const receiver of pc.getReceivers()) {
+      if (receiver.track.kind !== "video") continue;
+      try {
+        if ("jitterBufferTarget" in receiver) receiver.jitterBufferTarget = target;
+        if ("playoutDelayHint" in receiver) receiver.playoutDelayHint = target / 1000; // seconds (see #onTrack)
+      } catch {
+        // unsupported; default buffer applies
+      }
+    }
+    console.log(`[webrtc] jitter target -> ${target}ms (rtt ${Math.round(rttMs)}ms, loss ${(loss * 100).toFixed(1)}%)`);
+  }
+
   #closePc() {
     this.#clearWatchdog();
     this.#clearDegradeTimer();
+    this.#clearJitterPoll();
     this.#processingOffer = false;
     this.#remoteDescriptionSet = false;
     this.#iceQueue = [];


### PR DESCRIPTION
Remote teleop video was unusable away from the LAN: multi-second freezes, then (after partial fixes) full-frame corruption. This PR makes the stream **loss-resilient and network-adaptive**: clean networks keep today's lowest-latency behavior; degraded paths trade a little latency and bitrate for a stream that stays watchable. Everything was built and verified live against mars-the-47th from a genuinely bad vantage point (240 ms RTT, 4–6% packet loss — the office uplink's fault, see "Context" at the bottom).

**Headline result, same path, same measurement harness:**

| per ~50 s window | before | after |
|---|---|---|
| Frozen time | 17–29 s | **0.5–0.7 s** |
| PLIs (decoder distress) | 35–99 | **0** |
| fps decoded | 4.6–8.5 | **~15, every received frame** |
| Wire loss | ~4–6% | unchanged — repaired in-band |

## What changed, layer by layer

**1. Repair machinery that was missing or broken (bug-fix tier — benefits every viewer):**
- `webrtcbin` negotiated **no loss repair at all** (gst defaults). Video transceivers now negotiate NACK/RTX + ULPFEC/RED, set at creation time where webrtcbin's internals read them. Trap defused: gst's `fec-percentage` *defaults to 100* (double bitrate), so it's always set explicitly. (`07d50421`, `6da4525c`)
- **Browser keyframe requests never reached the encoder** — PLIs became `GstForceKeyUnit` events that died at the transport appsrc (the encoder lives in a separate pipeline). A pad probe forwards them, throttled to 1 IDR/500 ms per camera so PLI storms can't melt the link. Periodic keyframes drop from 0.5 s to a 4 s backstop: clean links carry almost no keyframes, lossy links get them on demand. (`0d819a83`)
- **VP8 picture IDs were missing** (`picture-id-mode=15-bit`): without them Chrome can't prove frame continuity after loss and silently discards every repaired frame — NACK worked, repairs were thrown away. (`cbfd1506`)

**2. Adaptivity — the "good network = low latency, bad network = usable" contract:**
- **Sender ladder** (`375c3852`, `47eab673`): a 1 Hz poll of webrtcbin's stats reads what viewers report back via RTCP (loss, RTT); worst-of drives GOOD ↔ DEGRADED with hysteresis (enter after 2 s bad, exit after 15 s clean). GOOD = configured bitrate, on-demand keyframes, base FEC (25%). DEGRADED (loss ≥3% or RTT ≥250 ms) = 60% bitrate + 1 Hz keyframes (bounds corruption age) + **100% FEC** — webrtcbin binds the transceiver property to the live encoder, so this switches without renegotiation. Peers connecting mid-DEGRADED start at full strength.
- **Client jitter buffer** (`89c43157`): receivers attach pinned at 0 ms (LAN = lowest latency); a 3 s stats poll retargets to ~1.2×RTT+30 (cap 500) when RTT/loss say retransmits need room to land. Robot-side playout-delay cap raised 40 → 500 ms purely as headroom for this.
- **Operator bandwidth control** (`89c43157`): the camera strip's off/live/primary ladder is restored — a closed tile *genuinely stops that camera's stream* (active-set path, no reconnect). Fresh profiles stream only the primary camera + map; the arm PiP is opt-in. Per-camera `_bitrate_kbps` params (launch: main 1500 / arm 800 — 2000 each measurably congested a residential uplink).

**3. Measurement** (`6d3ad3b7`): the profiling HUD gains `pli/m` (artifact-event rate, ~0 healthy), `keyf/m`, and FPS as decoded/received — the corruption metrics this PR was tuned by.

**4. The FEC unlock** (`faae0817`, `8d89a978`, `86978192`): gst 1.20's webrtcbin negotiates ULPFEC but **never emits it** (debug-verified). GStreamer ≥1.22 fixes it. `docs/WEBRTC_FEC_GST_UPGRADE.md` documents the evaluation; the shipped pieces: a guarded launch env that runs the camera container against `/opt/gst` **only when that directory exists** (robots without it are byte-for-byte unaffected), `scripts/update/build_gst_opt.sh` (native Jetson build → verification gate → ~15 MB `innate-gstreamer-opt` deb), and the `apt-dependencies.hardware.txt` entry so the normal `innate update apply` installs it fleet-wide. Verified on mars-the-47th: NVIDIA hardware plugins load under the 1.24 core; `rtpredenc`/`rtpulpfecenc` emit on our SSRCs (debug trace); results in the table above.

## Review notes

- `6b8f38ab` + `6f8c37d6` are a tried-and-reverted experiment (duplicate transmission; srtpenc kills the pipeline) — net zero, kept for the record.
- Reviewer gotcha: Chrome's `getStats()` exposes **no FEC fields for RED-wrapped streams** — verify FEC by robot-side `GST_DEBUG=webrtcbin:6` or by outcome metrics, never by `fecPacketsReceived`.
- The sender ladder adapts the *shared* encoders to the worst viewer (deliberate: one encode per camera is a core architecture invariant).
- LAN behavior is unchanged in the GOOD state by construction: 0 ms buffer pin, no periodic keyframes, base FEC only, same bitrates.

## Merge / rollout ordering

1. Merge the **innate-packages** PR first (adds the `innate-gstreamer-opt` deb → signed apt repo). The apt step of a robot update fails on the missing package otherwise.
2. Then this PR; robots get everything on their next `innate update apply`.
3. mars-the-47th currently runs this branch with a hand-staged `/opt/gst` (the pre-deb fat tree: 1319 files vs the deb's ~340) — `sudo rm -rf /opt/gst` **before** installing the deb there, or 979 orphaned files (17 stale plugins incl. openh264/fdkaac/qmlgl) survive untracked on `GST_PLUGIN_PATH`. Only hand-staged robots are affected; fresh fleet installs are clean. Return the robot to `main` after merge.

## Context: why the remote path was so bad (measured)

The office uplink drops **4–7.5% of outbound UDP at every rate** and caps TCP upload at ~2 Mbit/s (iperf3 from the robot to two independent servers; LAN leg clean; fleet egress negligible) — a line/ISP problem being handled separately (diagnosis report with fix list exists). On top of that, libwebrtc abandons incomplete delta frames after ~200 ms, so at RTT > 200 ms retransmission can never repair in time — which is why in-band FEC is the only mechanism that fully works there, and why this PR's ladder leans on it when paths degrade. Full investigation data lives in the commit messages.

