### PR TITLE
feat(sim): show the face of Mars as the default start view and default to agent mode

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -271,12 +271,6 @@ class BrainClientNode(Node):
         self.publish_agent_status()
         self._agent_status_heartbeat = self.create_timer(3.0, self.publish_agent_status)
 
-        # Without a backend, auto-activating would boot false-active: mic,
-        # camera and gaze on around a heartbeat-only loop.
-        if self.config.simulator_mode and self.brain.available and self.state.current_directive is not None:
-            self.get_logger().info("[BrainClient] Auto-activating brain in simulator mode")
-            self.lifecycle.activate_brain()
-
     # ================= status =================
     def _stop_robot(self) -> None:
         stop = Twist()

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
     simulator_mode_arg = DeclareLaunchArgument(
         "simulator_mode",
         default_value="False",
-        description="Flag to enable simulator mode (auto-activates brain)",
+        description="Enable simulator-specific behavior",
     )
     current_nav_mode_topic_arg = DeclareLaunchArgument(
         "current_nav_mode_topic",

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
@@ -34,7 +34,7 @@ def generate_launch_description():
     simulator_mode_arg = DeclareLaunchArgument(
         "simulator_mode",
         default_value="True",
-        description="Flag to enable simulator mode (auto-activates brain)",
+        description="Enable simulator-specific behavior",
     )
     current_nav_mode_topic_arg = DeclareLaunchArgument(
         "current_nav_mode_topic",

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -82,9 +82,9 @@ const SHADOW_BOX_STEP_M = 0.25; // quantised, so the box does not resize every f
 const SHADOW_MARGIN_M = 0.5; // the robot's own extent plus the throw of its shadow
 const SHADOW_MAP_PX = 2048;
 
-// Chase-cam framing used when a pose is snapped in (see spawnAt below).
-const CHASE_DISTANCE = 1.8; // meters behind the robot
-const CHASE_HEIGHT = 1.1; // meters above the ground
+// Initial orbit framing used when a pose is snapped in (see spawnAt below).
+const INITIAL_ORBIT_POSITION = { forward: 0.61, left: 0.02, height: 0.25 };
+const INITIAL_ORBIT_TARGET = { forward: -0.01, left: 0, height: 0.13 };
 
 // Robot-mounted camera views: frames, axis conventions, FOV and near plane
 // match the driver's cameras (mars_sim_driver.core's CAMERAS).
@@ -157,6 +157,8 @@ export class SimScene {
     this.fixedSize = opts.fixedSize ?? null;
     const w = this.fixedSize?.width ?? window.innerWidth;
     const h = this.fixedSize?.height ?? window.innerHeight;
+    // Pre-pose orbit framing would flash before spawnAt replaces it.
+    canvas.style.visibility = "hidden";
     this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
     this.renderer.setPixelRatio(this.fixedSize ? 1 : Math.min(window.devicePixelRatio, 2));
     this.renderer.setSize(w, h, !this.fixedSize);
@@ -829,9 +831,9 @@ export class SimScene {
   }
 
   /**
-   * Place the robot at a pose immediately and frame the camera zoomed in
-   * behind it (chase-cam), rather than following the incremental delta used
-   * by setPose. Use once — e.g. on spawn or reset — before driving resumes.
+   * Place the robot at a pose immediately and frame the camera facing its
+   * front, rather than following the incremental delta used by setPose.
+   * Use once — e.g. on spawn or reset — before driving resumes.
    */
   spawnAt(x: number, y: number, yaw: number): void {
     this.spawned = true;
@@ -841,9 +843,20 @@ export class SimScene {
 
     const forwardX = Math.cos(yaw);
     const forwardY = Math.sin(yaw);
-    this.camera.position.set(x - forwardX * CHASE_DISTANCE, y - forwardY * CHASE_DISTANCE, CHASE_HEIGHT);
-    this.controls.target.set(x, y, 0.5);
+    const leftX = -forwardY;
+    const leftY = forwardX;
+    this.camera.position.set(
+      x + forwardX * INITIAL_ORBIT_POSITION.forward + leftX * INITIAL_ORBIT_POSITION.left,
+      y + forwardY * INITIAL_ORBIT_POSITION.forward + leftY * INITIAL_ORBIT_POSITION.left,
+      INITIAL_ORBIT_POSITION.height,
+    );
+    this.controls.target.set(
+      x + forwardX * INITIAL_ORBIT_TARGET.forward + leftX * INITIAL_ORBIT_TARGET.left,
+      y + forwardY * INITIAL_ORBIT_TARGET.forward + leftY * INITIAL_ORBIT_TARGET.left,
+      INITIAL_ORBIT_TARGET.height,
+    );
     this.controls.update();
+    this.renderer.domElement.style.visibility = "";
 
     this.followPrevXY = [x, y];
   }

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -30,6 +30,7 @@ export const THUMB_H = 240;
  * still-watchable worst case. */
 const DELAY_MIN_S = 0.025;
 const DELAY_MAX_S = 0.25;
+const DEFAULT_CAMERA = "orbit";
 
 /** Advance `samples` past renderT and return the bracketing pair plus the
  * clamped interpolation factor (holds the last sample during a gap instead
@@ -68,9 +69,9 @@ export class SimSession {
   #listeners = new Set<(state: SimSessionState) => void>();
 
   #roster = ["main", "arm", "orbit"];
-  #activeCams = ["main"];
-  #primaryIndex = 0;
-  #primaryName = "main";
+  #activeCams = [DEFAULT_CAMERA];
+  #primaryIndex = this.#roster.indexOf(DEFAULT_CAMERA);
+  #primaryName = DEFAULT_CAMERA;
 
   #controller: WorldStateController | null = null;
   #scanFeed: RosbridgePhysicsController | null = null;


### PR DESCRIPTION
Problem: 
- the default angle of Mars is seeing his back
- we introduce unnecessary friction just to see the face

Solution:
 - show a better intimate view of the face
 - this will also a prereq for the new onboarding where the first interaction a person will have is talking to Mars in sim
 - this also defaults to agent mode VS telop
 
 
 New default cam view:
<img width="3024" height="1816" alt="new-angle" src="https://github.com/user-attachments/assets/af40e061-f6e6-4bd4-9a2a-7ca0170cfeec" />

 

