### PR TITLE
feat(brain): move the local brain and Gemini STT to 3.7 Flash

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,7 +15,7 @@
 # service key), talking to Google directly.
 # GEMINI_API_KEY=
 
-# GEMINI_MODEL overrides the brain's model (default gemini-3.6-flash).
+# GEMINI_MODEL overrides the brain's model (default gemini-3.7-flash).
 # GEMINI_MODEL=
 
 # --- Cloud endpoints (all read from the environment; set by default) ---

--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -206,7 +206,7 @@
 #     scan_stale_after_sec: 10.0    # seconds without a lidar scan before flagging stale
 #     send_arm_camera_image: true   # also send the arm wrist camera image to the model
 #     log_everything: true          # log every turn's full input
-#     gemini_model: "gemini-3.6-flash"
+#     gemini_model: "gemini-3.7-flash"
 #     idle_turn_interval: 3.0       # seconds between looks when no skill is running
 #     supervision_turn_interval: 5.0  # seconds between looks while a skill runs
 
@@ -237,7 +237,7 @@
 #     stt_realtime_vad_threshold: 0.3       # realtime pair: vendor VAD sensitivity
 #     stt_realtime_vad_silence_secs: 0.7    # realtime pair: vendor silence that ends a turn
 #     elevenlabs_batch_stt_model: "scribe_v2"
-#     gemini_stt_model: "gemini-3.6-flash"
+#     gemini_stt_model: "gemini-3.7-flash"
 #     elevenlabs_stt_model: "scribe_v2_realtime"
 #     openai_realtime_model: "gpt-4o-realtime-preview"
 #     openai_transcribe_model: "gpt-4o-mini-transcribe"

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -93,11 +93,12 @@ def build_tools(
     its dispatch map from the same pairs, so the declared names and the
     dispatched names can never diverge.
 
-    While a skill runs, the robot's only action is stopping it, so the
-    declarations collapse. The shape depends on whether the user just spoke:
-    offered any no-op tool, the model calls it and goes silent, so a turn
-    carrying a user message gets stop_current_skill ALONE — plain text becomes
-    the reply channel, and the description steers stop away from questions.
+    A turn carrying user speech never gets a no-op tool: offered one, the
+    model calls it and goes silent instead of replying — 3.7-flash took wait
+    on ~60% of spoken turns (3.6-flash was immune), and dropping it restores
+    97%. So a user turn loses wait, and while a skill runs it collapses to
+    stop_current_skill ALONE — plain text becomes the reply channel, and the
+    description steers stop away from questions.
     """
     if running_skill_name is not None:
         stop = {
@@ -115,7 +116,8 @@ def build_tools(
     declarations = [_declaration(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)
-    declarations.append(_WAIT_DECLARATION)
+    if not user_spoke:
+        declarations.append(_WAIT_DECLARATION)
     return [{"functionDeclarations": declarations}]
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -98,10 +98,9 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     # --- Local brain (Gemini) ---
     "gemini_model": "gemini-3.7-flash",
     # "low" | "medium" | "high"; "" = model default. 3.7-flash dropped 3.6's
-    # "minimal", and at "low" it answers a user who speaks to it only ~half
-    # the time (6/12 probes, vs 12/12 at the default) — silence costs more
-    # than the ~0.8s the default level adds.
-    "gemini_thinking_level": "",
+    # "minimal", so "low" is the fastest level it offers; it only keeps the
+    # robot answering because build_tools stops offering wait on user turns.
+    "gemini_thinking_level": "low",
     "idle_turn_interval": 3.0,
     "supervision_turn_interval": 5.0,
     "history_max_entries": 60,

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -97,10 +97,11 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "height_cam": 0.19663,
     # --- Local brain (Gemini) ---
     "gemini_model": "gemini-3.7-flash",
-    # "low" | "medium" | "high"; "" = model default. 3.7-flash dropped
-    # "minimal" (3.6's floor, measured 3x faster there), so "low" is the
-    # fastest turn available; if multi-turn discipline regresses, "" here.
-    "gemini_thinking_level": "low",
+    # "low" | "medium" | "high"; "" = model default. 3.7-flash dropped 3.6's
+    # "minimal", and at "low" it answers a user who speaks to it only ~half
+    # the time (6/12 probes, vs 12/12 at the default) — silence costs more
+    # than the ~0.8s the default level adds.
+    "gemini_thinking_level": "",
     "idle_turn_interval": 3.0,
     "supervision_turn_interval": 5.0,
     "history_max_entries": 60,

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -40,7 +40,7 @@ class BrainConfig:
 
     # --- Local brain (Gemini) ---
     gemini_model: str
-    gemini_thinking_level: str  # "low" | "high"; "" = model default
+    gemini_thinking_level: str  # "low" | "medium" | "high"; "" = model default
     idle_turn_interval: float  # seconds between looks when no skill is running
     supervision_turn_interval: float  # seconds between looks while a skill runs
     history_max_entries: int  # conversation entries kept for the model
@@ -96,15 +96,11 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "x_cam": 0.0197,
     "height_cam": 0.19663,
     # --- Local brain (Gemini) ---
-    "gemini_model": "gemini-3.6-flash",
-    # "minimal" | "low" | "medium" | "high"; "" = model default.
-    # Measured on 3.6-flash (2026-08): minimal is ~3x faster than the
-    # default level (0.96s vs 3.08s median turn) and passed the same
-    # single-turn discipline probes (wait on idle, ignore STT noise,
-    # tool choice, go_to_point_in_view grounding). An earlier model's "low"
-    # measurably hurt multi-turn instruction-following (skill re-runs,
-    # chatter) — if that resurfaces, revert to "" here.
-    "gemini_thinking_level": "minimal",
+    "gemini_model": "gemini-3.7-flash",
+    # "low" | "medium" | "high"; "" = model default. 3.7-flash dropped
+    # "minimal" (3.6's floor, measured 3x faster there), so "low" is the
+    # fastest turn available; if multi-turn discipline regresses, "" here.
+    "gemini_thinking_level": "low",
     "idle_turn_interval": 3.0,
     "supervision_turn_interval": 5.0,
     "history_max_entries": 60,

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/batch_stt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/batch_stt.py
@@ -223,7 +223,8 @@ def gemini_transcriber(rest: GeminiRest, model: str, language: str) -> Transcrib
                     ],
                 }
             ],
-            "generationConfig": {"temperature": 0.0, "thinkingConfig": {"thinkingLevel": "minimal"}},
+            # "low" is the floor on 3.7-flash: it dropped 3.6's "minimal" level.
+            "generationConfig": {"temperature": 0.0, "thinkingConfig": {"thinkingLevel": "low"}},
         }
         response = rest.post(GENERATE_PATH.format(model=model), body, timeout=TRANSCRIBE_TIMEOUT_SECS)
         # candidates can be [] outright (blocked or empty response), not just absent.

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
@@ -59,7 +59,7 @@ class InputManagerNode(Node):
         self.declare_parameter("stt_realtime_vad_silence_secs", 0.7)
         self.declare_parameter("stt_energy_threshold", 0.01)
         self.declare_parameter("elevenlabs_batch_stt_model", "scribe_v2")
-        self.declare_parameter("gemini_stt_model", "gemini-3.6-flash")
+        self.declare_parameter("gemini_stt_model", "gemini-3.7-flash")
         self.declare_parameter("elevenlabs_stt_model", "scribe_v2_realtime")
         self.declare_parameter("openai_realtime_model", "gpt-4o-realtime-preview")
         self.declare_parameter("openai_realtime_url", "wss://api.openai.com/v1/realtime")

--- a/ros2_ws/src/brain/brain_client/innate/gemini.py
+++ b/ros2_ws/src/brain/brain_client/innate/gemini.py
@@ -12,7 +12,7 @@ from innate_proxy import ProxyClient
 
 SERVICE = "gemini"
 ENDPOINT = "/v1/chat/completions"
-MODEL = "gemini-3.5-flash"
+MODEL = "gemini-3.7-flash"
 
 
 def make_client():

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
@@ -57,7 +57,7 @@ def generate_launch_description():
     )
     gemini_model_arg = DeclareLaunchArgument(
         "gemini_model",
-        default_value=get_env("GEMINI_MODEL", "gemini-3.6-flash"),
+        default_value=get_env("GEMINI_MODEL", "gemini-3.7-flash"),
         description="Gemini model powering the local brain",
     )
 

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     )
     gemini_model_arg = DeclareLaunchArgument(
         "gemini_model",
-        default_value=get_env("GEMINI_MODEL", "gemini-3.6-flash"),
+        default_value=get_env("GEMINI_MODEL", "gemini-3.7-flash"),
         description="Gemini model powering the local brain",
     )
 

--- a/ros2_ws/src/brain/brain_client/launch/input_manager.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/input_manager.launch.py
@@ -67,7 +67,7 @@ def generate_launch_description():
     )
     gemini_stt_model_arg = DeclareLaunchArgument(
         "gemini_stt_model",
-        default_value="gemini-3.6-flash",
+        default_value="gemini-3.7-flash",
         description="Gemini model for batch utterance transcription",
     )
     elevenlabs_stt_model_arg = DeclareLaunchArgument(

--- a/ros2_ws/src/brain/brain_client/test/test_batch_stt.py
+++ b/ros2_ws/src/brain/brain_client/test/test_batch_stt.py
@@ -20,7 +20,7 @@ from brain_client.inputs.batch_stt import (
 
 WAV = b"RIFF-not-really-a-wav"
 
-GEMINI_MODEL = "gemini-3.6-flash"
+GEMINI_MODEL = "gemini-3.7-flash"
 
 
 def gemini_rest(response: dict, calls: list | None = None) -> GeminiRest:

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -130,6 +130,13 @@ def test_build_tools_with_no_skills_still_offers_wait():
     assert [d["name"] for d in declarations] == ["wait"]
 
 
+def test_build_tools_with_user_speech_drops_wait():
+    # Same rule as the running-skill case: a no-op tool on a spoken turn is
+    # taken instead of replying, so an idle user turn declares skills only.
+    declarations = build_tools(assign_tool_names([WAVE_SKILL]), None, user_spoke=True)[0]["functionDeclarations"]
+    assert [d["name"] for d in declarations] == ["wave"]
+
+
 def test_unknown_param_type_falls_back_to_annotated_string():
     skill = {"id": "s", "name": "s", "guidelines": "g", "inputs": {"blob": {"type": "list[str]", "required": True}}}
     schema = build_tools(assign_tool_names([skill]), None)[0]["functionDeclarations"][0]["parameters"]["properties"][

--- a/webapp/js/brain/demo.js
+++ b/webapp/js/brain/demo.js
@@ -103,7 +103,7 @@ export function startDemo(h) {
       body: {
         systemInstruction: { parts: [{ text: DEMO_SYSTEM }] },
         contents: [...contents.map((c) => ({ ...c })), userContent],
-        generationConfig: { thinkingConfig: { includeThoughts: true, thinkingLevel: "low" } },
+        generationConfig: { thinkingConfig: { includeThoughts: true } },
         tools: [{ functionDeclarations: TOOLS.map((name) => ({ name, description: `demo declaration for ${name}` })) }],
       },
     });

--- a/webapp/js/brain/demo.js
+++ b/webapp/js/brain/demo.js
@@ -39,7 +39,7 @@ export function startDemo(h) {
   const D = { turn: 0, history: 6, queued: [], running: null, streak: 0, inFlight: false, nextIn: 3, uptime: 47 };
   const snap = () =>
     h.onTrace({
-      ev: "snapshot", active: true, backend: "innate-proxy", model: "gemini-3.6-flash",
+      ev: "snapshot", active: true, backend: "innate-proxy", model: "gemini-3.7-flash",
       turn: D.turn, in_flight: D.inFlight, queued: D.queued, next_in: D.nextIn,
       streak: D.streak, running: D.running, history: D.history, uptime: D.uptime++,
     });
@@ -103,7 +103,7 @@ export function startDemo(h) {
       body: {
         systemInstruction: { parts: [{ text: DEMO_SYSTEM }] },
         contents: [...contents.map((c) => ({ ...c })), userContent],
-        generationConfig: { thinkingConfig: { includeThoughts: true, thinkingLevel: "minimal" } },
+        generationConfig: { thinkingConfig: { includeThoughts: true, thinkingLevel: "low" } },
         tools: [{ functionDeclarations: TOOLS.map((name) => ({ name, description: `demo declaration for ${name}` })) }],
       },
     });

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -309,11 +309,11 @@ export const SETTINGS_PAGES = [
         title: "AI models",
         note: "The brain and the speech-to-text path use separate models. The transcribe backend picks which STT model knob applies.",
         knobs: [
-          { path: ["brain_client_node", P, "gemini_model"], label: "Brain model", default: "gemini-3.6-flash", type: "string", doc: "Gemini model powering the local brain", subsection: "Brain" },
+          { path: ["brain_client_node", P, "gemini_model"], label: "Brain model", default: "gemini-3.7-flash", type: "string", doc: "Gemini model powering the local brain", subsection: "Brain" },
           { path: ["input_manager_node", P, "stt_backend"], label: "Transcribe backend", default: "elevenlabs_batch", type: "string", options: STT_BACKEND_OPTIONS, doc: "Which service transcribes the microphone", subsection: "Speech to text" },
           { path: ["input_manager_node", P, "stt_vad_engine"], label: "VAD engine", default: "silero", type: "string", options: VAD_ENGINE_OPTIONS, doc: "How batch backends detect speech on the robot", subsection: "Speech to text" },
           { path: ["input_manager_node", P, "elevenlabs_batch_stt_model"], label: "Scribe batch model", default: "scribe_v2", type: "string", doc: "ElevenLabs model for the elevenlabs_batch backend", subsection: "Speech to text" },
-          { path: ["input_manager_node", P, "gemini_stt_model"], label: "Gemini STT model", default: "gemini-3.6-flash", type: "string", doc: "Gemini model for the gemini backend", subsection: "Speech to text" },
+          { path: ["input_manager_node", P, "gemini_stt_model"], label: "Gemini STT model", default: "gemini-3.7-flash", type: "string", doc: "Gemini model for the gemini backend", subsection: "Speech to text" },
           { path: ["input_manager_node", P, "elevenlabs_stt_model"], label: "Scribe realtime model", default: "scribe_v2_realtime", type: "string", doc: "ElevenLabs model for the elevenlabs (realtime) backend", subsection: "Speech to text" },
           { path: ["input_manager_node", P, "stt_language"], label: "Language", default: "en", type: "string", doc: "Transcription language code", subsection: "Speech to text" },
           { path: ["input_manager_node", P, "stt_vad_threshold"], label: "VAD threshold", default: 0.2, type: "float", doc: "Lower is more sensitive to speech (batch backends, silero engine)", subsection: "Speech to text" },

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -330,7 +330,7 @@ class MicroInput(InputDevice):
 
     def _connect_gemini(self) -> str:
         """Start a batch-transcription session on Gemini. Returns the model id."""
-        model = self.proxy.config.get("gemini_stt_model", "gemini-3.6-flash")
+        model = self.proxy.config.get("gemini_stt_model", "gemini-3.7-flash")
 
         rest = pick_rest(self.proxy)
         if rest is None:


### PR DESCRIPTION
Answers the question "are we on 3.7 yet?" — we weren't. The brain agent loop and the Gemini STT backend ran `gemini-3.6-flash`, and the `innate.gemini` skills helper was still on `gemini-3.5-flash`. All three now run [`gemini-3.7-flash`](https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash) (stable since August 2026).

**The upgrade is not free, and the interesting part is not latency.** 3.7 Flash dropped the `minimal` thinking level we ran at, and — with our current tools — it answers a person who speaks to it far less reliably than 3.6 does. Both problems are fixed here, but the second one costs something; see the tradeoff below.

## How this was measured

The harness drives the shipped code — `build_system_prompt`, tool declarations built from the 23-skill workspace roster, `GeminiContext`'s body assembly and SSE parsing — with two 640x480 sim camera frames (head + wrist), ~7.9k prompt tokens, streaming, against the real API. Only the model id and thinking level vary between conditions; conditions are shuffled per trial so drift and ordering can't favour one. Probes cover 5 user utterances x 3 history variants (none / model-called-wait / model-spoke).

## Finding 1 — 3.7 goes silent when the user speaks

Counting how often the robot answers a person talking to it (n=60 per condition; a miss = it called `wait` and said nothing — verified from raw parts, no text hidden behind `thought: true`):

| condition | answers the user |
|---|---|
| 3.6 @ `minimal` (before) | **58/60 (97%)** |
| 3.7 @ `low` | 34/60 (57%) |
| 3.7 @ default | 34/60 (57%) |
| 3.7 @ `high` | 13/30 (43%) |

**The thinking level is not the cause** — every level fails. The attractor is the `wait` tool: offered a no-op, 3.7 takes it instead of replying. Drop `wait` from a turn carrying user speech and 3.7 answers **29/30 at `low`, 30/30 at default**, with 3.6 unaffected (30/30 either way).

`build_tools` already did exactly this while a skill is running, for exactly this reason ("offered any no-op tool, the model calls it and goes silent") — this PR extends the rule to idle turns. With that in place the thinking level goes back to `low`, 3.7's fastest.

**The tradeoff, measured, not assumed:** `wait` is also how the robot ignores stray STT fragments. Dropping it on spoken turns takes noise discipline from 88% to 74% (n=24; the extra chatter is almost entirely the robot answering its own speech echoed back). Ignoring a real person two turns in five is worse than occasionally answering an echo — but if the team disagrees, the lever is one `if` in `build_tools`.

## Finding 2 — speed

Median / p90 of the full turn; *spoken reaction* is time to the first spoken token, which is when the robot starts talking:

| condition | idle turn | spoken reaction | thought tokens |
|---|---|---|---|
| 3.6 @ `minimal` (before) | 1.59s / 2.00s | **1.59s** / 1.81s | 0 |
| 3.6 @ `low` | 1.54s / 1.64s | 1.70s / 2.00s | 0 |
| **3.7 @ `low` (shipped)** | 1.93s / 4.03s | **2.46s** / 4.12s | 36 |
| 3.7 @ default | 1.93s / 2.11s | 2.47s / 2.90s | 108 |

3.7 is a modest latency regression, not a win: roughly +0.3s idle and +0.85s on a spoken reaction, because `minimal` is exactly what it removed. That is the price of the upgrade; nothing in the config buys it back.

The Gemini STT path keeps an explicit `low` (it can't use `minimal` either): 2.39s / 3.20s / 5.03s for short/mid/long utterances vs 2.51s / 3.16s / 5.50s on 3.6 at `minimal` — no regression.

## The Innate proxy needs no change

`GeminiAdapter` is model-agnostic by construction — the model lives in the caller's path or body, never in the adapter. Verified against the current `origin/main` proxy with a fake upstream (real adapter, real `services.yaml`):

| check | result |
|---|---|
| `main.py` endpoint validation accepts `v1beta/models/gemini-3.7-flash:{generate,streamGenerate}Content` | pass |
| native `generateContent` → upstream path untouched, key in `x-goog-api-key` | pass |
| native `streamGenerateContent` → `alt=sse` added, SSE relayed, `thinkingConfig` forwarded intact | pass |
| OpenAI-compat `/v1/chat/completions` → rewritten to `/v1beta/openai/chat/completions`, `model` kept as `gemini-3.7-flash` | pass |

No Live API usage anywhere in the repo (3.7 doesn't support it), so nothing else to adapt.

## Deliberately left behind

- `workspace/innate_skills/chess/` pins its own cascade (`gemini-3.1-pro-preview` → `gemini-3.6-flash`) and drives it with `thinking_budget`, which Gemini 3 docs no longer describe. Retuning that needs a board in front of the robot.
- `webapp/debug/reaction-latency.html` is a record of a measurement taken on 3.6 — left as-is rather than rewritten.
- `innate-cloud-agent` (the hosted brain) is still on `gemini-3.5-flash` / `gemini-3.1-flash-lite`. Separate repo, separate deploy.

## Verified

- `ruff check` + `ruff format --check` on `brain_client` — clean; `pre-commit -c .config/pre-commit-config.yaml` on the changed files — all hooks pass
- `pytest test/` in a ROS container — 237 passed (one new test covers the wait-tool rule)
- `basedpyright brain_client/` — 15 errors, all pre-existing in files this PR doesn't touch
- All probes ran against the real Gemini API over the direct path, so proxy latency isn't in the numbers. The harness is not checked in — say the word and it goes under `tools/` so the next model bump is one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)