### PR TITLE
feat(stt): bias transcription toward the robot's own vocabulary

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -225,12 +225,18 @@
 # stt_vad_threshold / stt_vad_silence_secs tune only the local (batch)
 # endpointing and the stt_realtime_* pair tunes only the realtime backends;
 # stt_energy_threshold only applies to the energy engine.
+# stt_keyterms is the vocabulary both batch backends bias toward — the robot's
+# name and the phrases it is given. Scribe takes them as a parameter (+20% per
+# transcription; [] turns biasing and the surcharge off), Gemini gets them in its
+# prompt. A term is under 50 characters, at most 5 words, and free of <>{}[]\ —
+# anything else is dropped with a warning rather than failing transcription.
 # The model knobs of the backends you aren't using are simply unused.
 # input_manager_node:
 #   ros__parameters:
 #     stt_backend: "elevenlabs_batch"
 #     stt_vad_engine: "silero"
 #     stt_language: "en"
+#     stt_keyterms: ["MARS", "go forwards", "turn left"]   # [] disables biasing
 #     stt_energy_threshold: 0.01    # energy engine: RMS (0-1) that counts as speech
 #     stt_vad_threshold: 0.2        # batch/silero: lower = more sensitive to speech
 #     stt_vad_silence_secs: 0.5     # batch: silence that closes an utterance

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/batch_stt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/batch_stt.py
@@ -8,7 +8,8 @@ robot. :class:`Endpointer` runs a voiced/unvoiced detector — Silero VAD
 (``brain_client.inputs.vad``) or the energy fallback — over the PCM stream and
 closes an utterance after enough silence; :class:`BatchSttSession` then ships
 the whole clip as WAV through a vendor transcriber — ElevenLabs Scribe batch or
-Gemini ``generateContent``.
+Gemini ``generateContent``. Both bias toward the ``keyterms`` vocabulary: Scribe
+takes a parameter, Gemini gets the words in its prompt.
 """
 
 from __future__ import annotations
@@ -22,7 +23,7 @@ import queue
 import threading
 import wave
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Protocol
 
 from brain_client.brain.transport import GENERATE_PATH
@@ -171,15 +172,80 @@ class Endpointer:
 TRANSCRIBE_TIMEOUT_SECS = 30.0
 
 
+# ---------- Keyterms ----------
+
+# The robot's own name and the phrases it is actually given. Biasing costs +20%
+# on every ElevenLabs transcription, so the list stays short; an empty
+# stt_keyterms turns it (and the surcharge) off.
+DEFAULT_KEYTERMS: tuple[str, ...] = (
+    "MARS",
+    "hey MARS",
+    "go forwards",
+    "go forward",
+    "go backwards",
+    "go backward",
+    "go straight",
+    "turn left",
+    "turn right",
+    "turn around",
+    "stop",
+    "come here",
+    "follow me",
+    "pick up",
+    "put it down",
+    "drop it",
+    "open the gripper",
+    "close the gripper",
+    "raise the arm",
+    "lower the arm",
+    "take a picture",
+    "what do you see",
+    "go to the kitchen",
+    "go back to the charger",
+    "explore the room",
+    "wave",
+)
+
+_KEYTERM_FORBIDDEN_CHARS = frozenset("<>{}[]\\")
+
+
+def sanitize_keyterms(terms: Iterable[str] | str) -> list[str]:
+    """Vendor-legal, whitespace-normalized, de-duplicated keyterms, in input order.
+
+    ElevenLabs' limits are under 50 characters, at most 5 words, 1000 terms. It
+    rejects the whole request over one illegal term, so a settings.yaml typo has
+    to cost its own term rather than all transcription.
+    """
+    kept: list[str] = []
+    seen: set[str] = set()
+    # A bare string would otherwise be iterated into single-letter keyterms.
+    for raw in [terms] if isinstance(terms, str) else terms:
+        term = " ".join(str(raw).split())
+        if not term or term in seen or len(term) >= 50 or len(term.split()) > 5:
+            continue
+        if _KEYTERM_FORBIDDEN_CHARS & set(term):
+            continue
+        seen.add(term)
+        kept.append(term)
+    return kept[:1000]
+
+
 # ---------- ElevenLabs Scribe batch ----------
 
 ELEVENLABS_PROXY_ENDPOINT = "v1/speech-to-text"
 
 
-def elevenlabs_proxy_transcriber(proxy: ProxyClient, model: str, language: str) -> Transcriber:
+def elevenlabs_proxy_transcriber(
+    proxy: ProxyClient, model: str, language: str, keyterms: Sequence[str] = ()
+) -> Transcriber:
+    form: dict[str, Any] = {"model_id": model, "language_code": language}
+    if keyterms:
+        # One repeated form field per term — the vendor SDK passes keyterms as a
+        # raw list, unlike its other list params, which it JSON-encodes.
+        form["keyterms"] = list(keyterms)
+
     def transcribe(wav: bytes) -> str:
         files = {"file": ("utterance.wav", wav, "audio/wav")}
-        form = {"model_id": model, "language_code": language}
         with proxy.request_stream(
             "elevenlabs", ELEVENLABS_PROXY_ENDPOINT, files=files, form=form, timeout=TRANSCRIBE_TIMEOUT_SECS
         ) as resp:
@@ -200,7 +266,7 @@ NO_SPEECH = "NO_SPEECH"
 _GEMINI_PROMPT = (
     "Transcribe the speech in this audio verbatim. Reply with only the "
     "transcript text - no quotes, labels, or commentary. The speaker's "
-    "language is most likely {language}. If the audio contains no "
+    "language is most likely {language}.{keyterms} If the audio contains no "
     f"intelligible human speech, reply with exactly {NO_SPEECH}."
 )
 
@@ -211,7 +277,10 @@ def _says_no_speech(text: str) -> bool:
     return text.strip("'\".,!? \t") == NO_SPEECH
 
 
-def gemini_transcriber(rest: GeminiRest, model: str, language: str) -> Transcriber:
+def gemini_transcriber(rest: GeminiRest, model: str, language: str, keyterms: Sequence[str] = ()) -> Transcriber:
+    hint = f" These words are likely, so prefer them over similar-sounding ones: {', '.join(keyterms)}."
+    prompt = _GEMINI_PROMPT.format(language=language, keyterms=hint if keyterms else "")
+
     def transcribe(wav: bytes) -> str:
         body: dict[str, Any] = {
             "contents": [
@@ -219,7 +288,7 @@ def gemini_transcriber(rest: GeminiRest, model: str, language: str) -> Transcrib
                     "role": "user",
                     "parts": [
                         {"inlineData": {"mimeType": "audio/wav", "data": base64.b64encode(wav).decode()}},
-                        {"text": _GEMINI_PROMPT.format(language=language)},
+                        {"text": prompt},
                     ],
                 }
             ],

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/input_manager.py
@@ -17,6 +17,7 @@ from std_msgs.msg import Bool, String
 from std_srvs.srv import SetBool
 
 from brain_client.common.logging import UniversalLogger
+from brain_client.inputs.batch_stt import DEFAULT_KEYTERMS
 from brain_client.inputs.manager import InputDeviceManager
 from innate_proxy import ProxyClient
 
@@ -50,6 +51,8 @@ class InputManagerNode(Node):
         self.declare_parameter("stt_backend", "elevenlabs_batch")
         self.declare_parameter("stt_vad_engine", "silero")
         self.declare_parameter("stt_language", "en")
+        # Batch backends only; an empty list disables biasing and its ElevenLabs surcharge.
+        self.declare_parameter("stt_keyterms", list(DEFAULT_KEYTERMS))
         # The batch (silero) and realtime (vendor) VAD knobs are separate on
         # purpose: silero's speech probability and the vendors' sensitivity
         # scales are unrelated, so one number cannot tune both.
@@ -69,6 +72,7 @@ class InputManagerNode(Node):
             "stt_backend": self.get_parameter("stt_backend").value,
             "stt_vad_engine": self.get_parameter("stt_vad_engine").value,
             "stt_language": self.get_parameter("stt_language").value,
+            "stt_keyterms": self.get_parameter("stt_keyterms").value,
             "stt_vad_threshold": self.get_parameter("stt_vad_threshold").value,
             "stt_vad_silence_secs": self.get_parameter("stt_vad_silence_secs").value,
             "stt_realtime_vad_threshold": self.get_parameter("stt_realtime_vad_threshold").value,

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -18,8 +18,9 @@ Four backends, selected by the ``stt_backend`` setting:
 The realtime backends stream audio over a WebSocket and let the vendor do the
 voice-activity detection; the batch backends detect utterances locally — Silero
 VAD by default, an RMS energy threshold as fallback (``stt_vad_engine``) — and
-ship each one whole (see ``brain_client.inputs.batch_stt``). The microphone,
-ducking, and reconnect machinery is shared.
+ship each one whole (see ``brain_client.inputs.batch_stt``), biased toward the
+``stt_keyterms`` vocabulary. The microphone, ducking, and reconnect machinery is
+shared.
 
 Uses proxy services via self.proxy (injected by InputManager).
 """
@@ -36,12 +37,14 @@ import time
 from brain_client.brain.transport import pick_rest
 from brain_client.common.logging import UniversalLogger
 from brain_client.inputs.batch_stt import (
+    DEFAULT_KEYTERMS,
     BatchSttSession,
     EnergyDetector,
     Transcriber,
     VoicedDetector,
     elevenlabs_proxy_transcriber,
     gemini_transcriber,
+    sanitize_keyterms,
 )
 from brain_client.inputs.types import InputDevice
 from brain_client.inputs.vad import silero_detector
@@ -287,6 +290,14 @@ class MicroInput(InputDevice):
         # reaches the wire as an empty language code and the session is refused.
         return str(self.proxy.config.get("stt_language") or "en")
 
+    def _stt_keyterms(self) -> list[str]:
+        """Vocabulary the batch backends bias toward; an empty list disables biasing."""
+        configured = self.proxy.config.get("stt_keyterms", DEFAULT_KEYTERMS)
+        terms = sanitize_keyterms(configured)
+        if len(terms) != len(configured):
+            self.logger.warning(f"⚠️ Dropped {len(configured) - len(terms)} stt_keyterms ElevenLabs would reject")
+        return terms
+
     def _connect_via_proxy(self):
         """Connect to the configured STT backend via proxy."""
         backend = str(self.proxy.config.get("stt_backend") or DEFAULT_STT_BACKEND).strip().lower()
@@ -324,7 +335,7 @@ class MicroInput(InputDevice):
     def _connect_elevenlabs_batch(self) -> str:
         """Start a batch-transcription session on ElevenLabs Scribe. Returns the model id."""
         model = self.proxy.config.get("elevenlabs_batch_stt_model", "scribe_v2")
-        transcriber = elevenlabs_proxy_transcriber(self.proxy, model, self._stt_language())
+        transcriber = elevenlabs_proxy_transcriber(self.proxy, model, self._stt_language(), self._stt_keyterms())
         self._start_batch_session(transcriber, model)
         return model
 
@@ -336,7 +347,7 @@ class MicroInput(InputDevice):
         if rest is None:
             raise RuntimeError("no Gemini access: proxy unavailable and GEMINI_API_KEY unset")
 
-        self._start_batch_session(gemini_transcriber(rest, model, self._stt_language()), model)
+        self._start_batch_session(gemini_transcriber(rest, model, self._stt_language(), self._stt_keyterms()), model)
         return model
 
     def _start_batch_session(self, transcriber: Transcriber, model: str) -> None:


### PR DESCRIPTION
Voice commands are transcribed with no idea what the robot is called or what it can be asked to do, so "MARS" and the driving phrases come back as whatever the model finds more likely.

Both **batch** backends now bias toward a `stt_keyterms` vocabulary — the robot's name and the commands it is actually given. Scribe has a first-class parameter for it; Gemini gets the words in its prompt, so biasing survives the automatic fallback to Gemini when the proxy is unavailable. The realtime backends (`elevenlabs`, `openai`) are untouched.

Default vocabulary: `MARS`, `hey MARS`, then the commands — `go forwards`/`forward`/`backwards`/`backward`/`straight`, `turn left`/`right`/`around`, `stop`, `come here`, `follow me`, `pick up`, `put it down`, `drop it`, `open`/`close the gripper`, `raise`/`lower the arm`, `take a picture`, `what do you see`, `go to the kitchen`, `go back to the charger`, `explore the room`, `wave`. Override or extend it under `input_manager_node` in `settings.yaml`.

## Verified against the live API

A synthetic clip saying *"Mars, go forwards two meters"*, sent through the deployed proxy to Scribe:

| request | transcript |
|---|---|
| no keyterms | `Mars, go forwards two meters` |
| **with keyterms (this PR)** | `MARS, go forwards two meters` |
| keyterms as a JSON string | HTTP 400 — `"Some keyword contains invalid characters"` |

So the biasing does what it says, and the encoding matters: `keyterms` goes as a **raw list** in the multipart form, which httpx emits as one repeated `keyterms` field per term. The official SDK `json.dumps` its *other* list params (`entity_detection`, `additional_formats`) but deliberately not this one — and as the third row shows, JSON-encoding it is rejected outright.

No cloud change needed: the service-proxy ElevenLabs adapter forwards the body byte-for-byte and only strips host/content-length/transfer-encoding/connection/keep-alive, so the multipart content-type and boundary survive.

## Two things worth a reviewer's attention

**Cost.** Sending keyterms adds **+20% per ElevenLabs transcription**, so the field is omitted entirely rather than sent empty — `stt_keyterms: []` turns biasing and the surcharge off. The Gemini path is free. This is on by default, so it does change the bill for every robot on `elevenlabs_batch`.

**One bad term would kill all transcription.** An illegal keyterm rejects the whole request (exactly the 400 above), so a `settings.yaml` typo drops that term with a warning rather than silencing voice entirely. `sanitize_keyterms` enforces the vendor limits (<50 chars, ≤5 words, no `<>{}[]\`), normalizes whitespace, dedupes, and turns a bare string into one term instead of iterating it into single letters.

No launch argument — a list doesn't survive a launch substitution, and `settings.yaml` reaches the node as a params file directly.

## Testing

Ruff clean; existing `test_batch_stt.py` passes unchanged (the new `keyterms` argument defaults to `()`), plus the live check above. The workspace path was exercised directly: default → 26 terms, `[]` → off, invalid terms → dropped with warning, bare string → one term.