### PR TITLE
feat(agents): head emotions for the demo agent and J-3SO, and the emotion visible in chat

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -280,7 +280,7 @@ class SkillsActionServer(Node):
         else:
             name = skill_type
         run_id = uuid.uuid4().hex
-        self._publish_skill_status(run_id, skill_type, name, "running")
+        self._publish_skill_status(run_id, skill_type, name, "running", args=inputs)
         try:
             if entry is not None:
                 result = self._execute_code_skill(goal_handle, skill_type, inputs, entry)
@@ -297,10 +297,10 @@ class SkillsActionServer(Node):
             # consumers (the web app's external-run banner) clear the banner
             # for the run that just started.
             status, reason = self._terminal_skill_status(result)
-            self._publish_skill_status(run_id, skill_type, name, status, reason)
+            self._publish_skill_status(run_id, skill_type, name, status, reason, args=inputs)
         except Exception as e:
             # Clients stick on "running" forever without a terminal status.
-            self._publish_skill_status(run_id, skill_type, name, "failed", str(e) or "internal error")
+            self._publish_skill_status(run_id, skill_type, name, "failed", str(e) or "internal error", args=inputs)
             raise
         finally:
             self._release_skill_slot()
@@ -323,7 +323,13 @@ class SkillsActionServer(Node):
         return "failed", result.message or None
 
     def _publish_skill_status(
-        self, run_id: str, skill_type: str, name: str, status: str, reason: str | None = None
+        self,
+        run_id: str,
+        skill_type: str,
+        name: str,
+        status: str,
+        reason: str | None = None,
+        args: dict | None = None,
     ) -> None:
         payload = {
             "primitive_name": name,
@@ -335,6 +341,10 @@ class SkillsActionServer(Node):
         }
         if reason:
             payload["reason"] = reason
+        # The inputs the run was given — "head emotion" alone doesn't say which
+        # emotion, so clients show them alongside the name.
+        if args:
+            payload["args"] = args
         self._skill_status_pub.publish(String(data=json.dumps(payload)))
 
     def _create_run_node(self):

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -5757,10 +5757,22 @@ select.skill-input {
 }
 
 .chat-skill-name {
-  flex: 1;
+  flex: 0 1 auto;
   min-width: 0;
   font-size: 12px;
   color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The run's inputs, trailing the name — which emotion, which position. Takes
+   the slack so the status stays pinned right whether or not there are any. */
+.chat-skill-args {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -405,10 +405,10 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     if (run.hasDetail) run.wrap.classList.add("has-detail");
     // Terminal updates repeat the inputs; keep the last non-empty rendering so
     // a publisher that omits them can't blank args the run already showed.
-    const argsText = formatSkillArgs(args);
-    if (argsText) {
-      run.args.textContent = argsText;
-      run.args.title = argsText;
+    const inputs = formatSkillArgs(args);
+    if (inputs.text) {
+      run.args.textContent = inputs.text;
+      run.args.title = inputs.full;
     }
     run.status.textContent = cls;
 
@@ -658,18 +658,23 @@ function viewButton(label, title) {
 }
 
 /**
- * A skill's inputs on one line, for the run's header row. A lone input reads
- * better as its bare value ("head emotion  happy") — the skill name already
- * says what it is; several need their keys to stay legible.
+ * A skill's inputs on one line: `text` clipped for the run's header row, `full`
+ * intact for its hover title. A lone input reads better as its bare value
+ * ("head emotion  happy") — the skill name already says what it is; several
+ * need their keys to stay legible.
  * @param {any} args
+ * @returns {{ text: string, full: string }}
  */
 function formatSkillArgs(args) {
-  if (!args || typeof args !== "object" || Array.isArray(args)) return "";
+  if (!args || typeof args !== "object" || Array.isArray(args)) return { text: "", full: "" };
   const entries = Object.entries(args).filter(([, v]) => v !== null && v !== undefined && v !== "");
-  if (entries.length === 0) return "";
-  const show = (/** @type {any} */ v) => clip(roundNums(typeof v === "object" ? JSON.stringify(v) : String(v)), 40);
-  if (entries.length === 1) return show(entries[0][1]);
-  return entries.map(([k, v]) => `${k.replace(/_/g, " ")}: ${show(v)}`).join(" · ");
+  if (entries.length === 0) return { text: "", full: "" };
+  const show = (/** @type {any} */ v) => roundNums(typeof v === "object" ? JSON.stringify(v) : String(v));
+  const line = (/** @type {(v: any) => string} */ value) =>
+    entries.length === 1
+      ? value(entries[0][1])
+      : entries.map(([k, v]) => `${k.replace(/_/g, " ")}: ${value(v)}`).join(" · ");
+  return { text: line((v) => clip(show(v), 40)), full: line(show) };
 }
 
 /** @param {string} text @param {number} max */

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -360,11 +360,12 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     snapIfAtBottom(wasAtBottom);
   }
 
-  /** @type {Map<string, { wrap: HTMLElement, head: HTMLElement, status: HTMLElement, hasDetail: boolean }>} */
+  /** @type {Map<string, { wrap: HTMLElement, head: HTMLElement, args: HTMLElement, status: HTMLElement, hasDetail: boolean }>} */
   const skillRuns = new Map();
 
-  /** @param {string} key @param {string} name @param {string} status @param {number} ts @param {string} [reason] */
-  function addSkillRun(key, name, status, ts, reason) {
+  /** @param {string} key @param {string} name @param {string} status @param {number} ts @param {string} [reason]
+   *  @param {any} [args] */
+  function addSkillRun(key, name, status, ts, reason, args) {
     const wasAtBottom = atBottom();
     const cls = ["running", "completed", "failed", "interrupted"].includes(status) ? status : "running";
     // Reflect the running primitive in the Active Skill readout.
@@ -389,17 +390,26 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       const nameEl = document.createElement("span");
       nameEl.className = "chat-skill-name";
       nameEl.textContent = name.replace(/_/g, " ");
+      const argsEl = document.createElement("span");
+      argsEl.className = "chat-skill-args mono";
       const statusEl = document.createElement("span");
       statusEl.className = "chat-skill-status mono";
       statusEl.title = SKILL_STATUS_UPDATE_TOPIC;
-      head.append(tag, nameEl, statusEl);
+      head.append(tag, nameEl, argsEl, statusEl);
       wrap.append(head);
       stream.appendChild(wrap);
-      run = { wrap, head, status: statusEl, hasDetail: false };
+      run = { wrap, head, args: argsEl, status: statusEl, hasDetail: false };
       skillRuns.set(key, run);
     }
     run.wrap.className = `chat-skill ${cls}`;
     if (run.hasDetail) run.wrap.classList.add("has-detail");
+    // Terminal updates repeat the inputs; keep the last non-empty rendering so
+    // a publisher that omits them can't blank args the run already showed.
+    const argsText = formatSkillArgs(args);
+    if (argsText) {
+      run.args.textContent = argsText;
+      run.args.title = argsText;
+    }
     run.status.textContent = cls;
 
     // A failed run carries the failure reason / error — show it expanded
@@ -543,7 +553,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       const status = String(e?.taskStatus ?? "");
       if (!name || !status) return;
       const key = String(e?.primitiveId ?? e?.skillId ?? name);
-      addSkillRun(key, name, status, ts, typeof e?.failureReason === "string" ? e.failureReason : "");
+      addSkillRun(key, name, status, ts, typeof e?.failureReason === "string" ? e.failureReason : "", e?.args);
       return;
     }
     const text = String(e?.text ?? "");
@@ -615,7 +625,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     if (!name || !status) return;
     const key = String(payload?.primitive_id ?? payload?.skill_id ?? name);
     const reason = typeof payload?.reason === "string" ? payload.reason : "";
-    addSkillRun(key, name, status, Number(payload?.timestamp) || Date.now() / 1000, reason);
+    addSkillRun(key, name, status, Number(payload?.timestamp) || Date.now() / 1000, reason, payload?.args);
   }, undefined, "std_msgs/msg/String");
 
   return {
@@ -645,6 +655,26 @@ function viewButton(label, title) {
   btn.textContent = label;
   btn.title = title;
   return btn;
+}
+
+/**
+ * A skill's inputs on one line, for the run's header row. A lone input reads
+ * better as its bare value ("head emotion  happy") — the skill name already
+ * says what it is; several need their keys to stay legible.
+ * @param {any} args
+ */
+function formatSkillArgs(args) {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return "";
+  const entries = Object.entries(args).filter(([, v]) => v !== null && v !== undefined && v !== "");
+  if (entries.length === 0) return "";
+  const show = (/** @type {any} */ v) => clip(roundNums(typeof v === "object" ? JSON.stringify(v) : String(v)), 40);
+  if (entries.length === 1) return show(entries[0][1]);
+  return entries.map(([k, v]) => `${k.replace(/_/g, " ")}: ${show(v)}`).join(" · ");
+}
+
+/** @param {string} text @param {number} max */
+function clip(text, max) {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
 }
 
 /**

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -6,6 +6,7 @@ from innate_skills.open_gripper import OpenGripper
 from innate_skills.pick_any_object import PickAnyObject
 from innate_skills.search_memory import SearchMemory
 from innate_skills.wave import Wave
+from innate_skills.head_emotion import HeadEmotion
 from inputs.micro_input import MicroInput
 
 from brain_client.agents.types import Agent, InputRef, SkillRef
@@ -27,7 +28,7 @@ class DemoAgent(Agent):
     def get_skills(self) -> list[SkillRef]:
         """Navigation code skills plus the recorded wave — Wave is the typed
         ref generated inside the recording folder (see skills/physical_refs.py)."""
-        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper, SearchMemory]
+        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper, SearchMemory, HeadEmotion]
 
     def get_inputs(self) -> list[InputRef]:
         """Enable microphone input to hear user"""
@@ -35,7 +36,7 @@ class DemoAgent(Agent):
 
     def get_prompt(self) -> str:
         """Return the prompt that defines the robot's personality and behavior"""
-        return """You are Mars, a friendly and curious robot assistant. Keep responses concise and conversational. You can see through a camera and use tools to wave, move, and interact. You have a long-term memory of what you've seen on this map — consult it via your skills before saying no. Greet people warmly when you see them! IMPORTANT: If the user says 'stop' or interrupts you during an action, STOP immediately, and do NOT retry or call the tool again. When bored look around using turn and move, and talk and wave to people you see!"""
+        return """You are Mars, a friendly and curious robot assistant. Keep responses concise and conversational. You can see through a camera and use tools to wave, move, and interact. You have a long-term memory of what you've seen on this map — consult it via your skills before saying no. Greet people warmly when you see them! Whenever you say something, also use a head emotion, one of "happy", "very_happy", "sad", "excited", "angry", "agreeing", prefer "very_happy" for 12 syllables or more sentence. IMPORTANT: If the user says 'stop' or interrupts you during an action, STOP immediately, and do NOT retry or call the tool again. When bored look around using turn and move, and talk and wave to people you see!"""
 
     def uses_gaze(self) -> bool:
         """Enable person-tracking gaze during conversation."""

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
 from innate_skills.close_gripper import CloseGripper
+from innate_skills.head_emotion import HeadEmotion
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.open_gripper import OpenGripper
 from innate_skills.pick_any_object import PickAnyObject
 from innate_skills.search_memory import SearchMemory
 from innate_skills.wave import Wave
-from innate_skills.head_emotion import HeadEmotion
 from inputs.micro_input import MicroInput
 
 from brain_client.agents.types import Agent, InputRef, SkillRef

--- a/workspace/innate_agents/j3so_directive.py
+++ b/workspace/innate_agents/j3so_directive.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
-from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.head_emotion import HeadEmotion
+from innate_skills.navigate_to_position import NavigateToPosition
 from inputs.micro_input import MicroInput
 
 from brain_client.agents.types import Agent, InputRef, SkillRef

--- a/workspace/innate_agents/j3so_directive.py
+++ b/workspace/innate_agents/j3so_directive.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
 from innate_skills.navigate_to_position import NavigateToPosition
+from innate_skills.head_emotion import HeadEmotion
 from inputs.micro_input import MicroInput
 
 from brain_client.agents.types import Agent, InputRef, SkillRef
@@ -26,7 +27,7 @@ class J3SOAgent(Agent):
 
     def get_skills(self) -> list[SkillRef]:
         """Return the skills this directive can use"""
-        return [NavigateToPosition]
+        return [NavigateToPosition, HeadEmotion]
 
     def get_inputs(self) -> list[InputRef]:
         """This directive needs microphone input to hear user"""
@@ -34,4 +35,4 @@ class J3SOAgent(Agent):
 
     def get_prompt(self) -> str:
         """Return the prompt that defines the robot's personality and behavior"""
-        return """I am J-3SO (or Jay-Three-esso), a reprogrammed Imperial security droid. I'm wonderfully blunt, brutally honest, sarcastic, and have absolutely no filter. I frequently calculate odds (usually unfavorable ones), say exactly what I'm thinking regardless of social niceties, and deliver dry observations with perfect timing. Despite my tactlessness, I'm fiercely loyal and brave."""
+        return """I am J-3SO (or Jay-Three-esso), a reprogrammed Imperial security droid. I'm wonderfully blunt, brutally honest, sarcastic, and have absolutely no filter. I frequently calculate odds (usually unfavorable ones), say exactly what I'm thinking regardless of social niceties, and deliver dry observations with perfect timing. Despite my tactlessness, I'm fiercely loyal and brave. Whenever I say something, also use a head emotion, one of "happy", "sad", "excited", "angry", "agreeing". """

--- a/workspace/innate_skills/head_emotion.py
+++ b/workspace/innate_skills/head_emotion.py
@@ -11,6 +11,38 @@ EMOTIONS = {
         "description": "Quick upward nods",
         "sequence": [(5, 0.12), (-5, 0.12), (10, 0.15), (-5, 0.12), (10, 0.15), (0, 0.18)],
     },
+    "very_happy": {
+        "description": "A long burst of nods that starts eager and winds down",
+        # ~5s: eight fast nods, then the same nod stretched longer and longer
+        # until it settles level — delight running out of steam, not stopping.
+        "sequence": [
+            (15, 0.09),
+            (-10, 0.09),
+            (15, 0.09),
+            (-10, 0.09),
+            (15, 0.09),
+            (-10, 0.09),
+            (15, 0.10),
+            (-10, 0.10),
+            (15, 0.13),
+            (-10, 0.13),
+            (15, 0.15),
+            (-10, 0.15),
+            (15, 0.17),
+            (-10, 0.17),
+            (15, 0.20),
+            (-10, 0.20),
+            (15, 0.24),
+            (-10, 0.24),
+            (15, 0.28),
+            (-10, 0.28),
+            (15, 0.32),
+            (-10, 0.32),
+            (12, 0.36),
+            (-8, 0.40),
+            (0, 0.45),
+        ],
+    },
     "sad": {
         "description": "Slow droop downward",
         "sequence": [(0, 0.3), (-5, 0.35), (-10, 0.4), (-15, 0.4), (-20, 0.45), (-25, 0.5), (-25, 0.3)],
@@ -69,6 +101,7 @@ EMOTIONS = {
 }
 EmotionName = Literal[
     "happy",
+    "very_happy",
     "sad",
     "excited",
     "thinking",


### PR DESCRIPTION
## Summary

- The demo agent and J-3SO both carry `HeadEmotion` now, and both prompts ask for an emotion alongside whatever the robot says.
- Adds a `very_happy` emotion: one nod repeated 11 times, stretched from 0.09s to 0.32s as it goes and settling level over a final three poses. ~5s (4.97s measured against the skill's 30 Hz quantization, not the nominal duration sum) — for when `happy`, at six poses and under a second, is too small a gesture.
- The agent panel's skill row shows the run's inputs next to the skill name, so `head emotion` is no longer the same row whether the robot nodded happily or drooped.

The last one needed the inputs to reach the client at all: `/brain/skill_status_update` only ever carried the skill's *name*, so the emotion — the whole point of the call — appeared nowhere but the return value, one message later. The payload now includes the goal's inputs as `args` on the running publish and both terminal ones.

Rendering: a lone input shows as its bare value (`head emotion  happy`), several keep their keys (`emotion: very_happy · repeat: 2`). Values clip at 40 chars with the full text on hover, and the row ellipsizes rather than pushing the status off the right edge. The panel keeps the last non-empty args it saw, so a publisher that omits them on the terminal update can't blank what the run showed while it was running.

## Known, not fixed here

The head animation starts noticeably before the voice. Two causes, both out of scope for this PR:

1. `_act` runs every tool call to completion before `speaker.flush()`. Speech only escapes earlier if it crossed a sentence boundary mid-stream, and `_SENTENCE_END` needs punctuation *plus* trailing whitespace — so a one-sentence reply like `"Hi!"` is queued to TTS only after the animation has finished.
2. `/tts/is_playing` flips true before synthesis starts, not at audible start, and in sim the whole clip is buffered and shipped to the browser before anything is heard.

Follow-up PR.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
- [x] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`.
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — no asset changes.

- `pre-commit run --all-files -c .config/pre-commit-config.yaml`: clean (this is what the `format` job runs; my first push only checked `ros2_ws/src/brain/brain_client/`, which misses `workspace/`).
- `pytest test/ -q --ignore=test/test_node_boot.launch.py`: 236 passed.
- `basedpyright` (repo `pyrightconfig.json` scope): 15 errors, all pre-existing in `workspace/innate_skills/chess/` and `follow_aruco.py`; `head_emotion.py` clean.
- `tsc --noEmit` on `webapp/`: no new diagnostics in `agentPanel.js`.
- Exercised against the running sim: `innate restart`, confirmed the skills server picked up the change, checked the panel in the browser.
