### PR TITLE
feat(agents): add Mars, a friendly intro agent

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/agents/initializer.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/initializer.py
@@ -109,12 +109,12 @@ def initialize_agents(
     if broken:
         logger.warning(f"{len(broken)} agents failed to load: {list(broken)}")
 
-    # Set default agent (fallback to first available if demo_agent not found)
+    # Set default agent (fallback to first available if intro_agent not found)
     # Note: This doesn't mean the agent runs - is_brain_active controls that
     default_agent = None
-    if "demo_agent" in agents:
-        default_agent = agents["demo_agent"]
-        logger.debug("Using demo_agent as default")
+    if "intro_agent" in agents:
+        default_agent = agents["intro_agent"]
+        logger.debug("Using intro_agent as default")
     elif agents:
         first_agent_name = next(iter(agents))
         default_agent = agents[first_agent_name]

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/hot_reload.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/hot_reload.py
@@ -218,7 +218,7 @@ class ReloadCoordinator:
         The current directive survives by id: its new instance is rebound and
         the active skill set intersected, so a mid-activation edit doesn't widen
         the skills the user had narrowed. If it no longer loads (now broken),
-        fall back to the default agent (demo_agent) rather than keep running a
+        fall back to the default agent (intro_agent) rather than keep running a
         stale instance whose file no longer says what it does.
         """
         agents, default_agent, broken = initialize_agents(self._logger, self._state.registry.primitives or None)

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -98,16 +98,16 @@ def test_agents_load_with_source_stamping(workspace):
     assert set(agents) == {"alpha", "beta"}
     assert agents["alpha"].source == "shipped"
     assert agents["beta"].source == "user"
-    assert default_agent is agents["alpha"]  # no demo_agent -> first loaded
+    assert default_agent is agents["alpha"]  # no intro_agent -> first loaded
 
 
-def test_demo_agent_is_default(workspace):
+def test_intro_agent_is_default(workspace):
     write(workspace, "innate_agents/alpha.py", agent_src("Alpha"))
-    write(workspace, "innate_agents/demo_agent.py", agent_src("DemoAgent", "demo_agent"))
+    write(workspace, "innate_agents/intro_agent.py", agent_src("IntroAgent", "intro_agent"))
 
     _agents, default_agent, _broken = initialize_agents(LOGGER)
 
-    assert default_agent.id == "demo_agent"
+    assert default_agent.id == "intro_agent"
 
 
 def test_ordinary_python_works(workspace):

--- a/workspace/innate_agents/intro_agent.py
+++ b/workspace/innate_agents/intro_agent.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+from innate_skills.close_gripper import CloseGripper
+from innate_skills.head_emotion import HeadEmotion
+from innate_skills.navigate_to_position import NavigateToPosition
+from innate_skills.open_gripper import OpenGripper
+from innate_skills.pick_any_object import PickAnyObject
+from innate_skills.search_memory import SearchMemory
+from innate_skills.wave import Wave
+from inputs.micro_input import MicroInput
+
+from brain_client.agents.types import Agent, InputRef, SkillRef
+
+
+class IntroAgent(Agent):
+    """
+    Intro agent - a friendly robot assistant named Mars.
+    """
+
+    @property
+    def id(self) -> str:
+        return "intro_agent"
+
+    @property
+    def display_name(self) -> str:
+        return "Intro Agent"
+
+    def get_skills(self) -> list[SkillRef]:
+        """Navigation code skills plus the recorded wave — Wave is the typed
+        ref generated inside the recording folder (see skills/physical_refs.py)."""
+        return [NavigateToPosition, Wave, PickAnyObject, OpenGripper, CloseGripper, SearchMemory, HeadEmotion]
+
+    def get_inputs(self) -> list[InputRef]:
+        """Enable microphone input to hear user"""
+        return [MicroInput]
+
+    def get_prompt(self) -> str:
+        """Return the prompt that defines the robot's personality and behavior"""
+        return """You are Mars, a friendly robot assistant. Keep responses concise and conversational. You can see through a camera and use tools to wave, move, and interact. You have a long-term memory of what you've seen on this map — consult it via your skills before saying no. Greet people warmly when you see them! Whenever you say something, also use a head emotion, one of "happy", "very_happy", "sad", "excited", "angry", "agreeing", prefer "very_happy" for 12 syllables or more sentence. Navigate only when prompted to. IMPORTANT: If the user says 'stop' or interrupts you during an action, STOP immediately, and do NOT retry or call the tool again. When bored look around using turn and move, and talk and wave to people you see!"""
+
+    def uses_gaze(self) -> bool:
+        """Enable person-tracking gaze during conversation."""
+        return True


### PR DESCRIPTION
Adds `IntroAgent` ("Mars"), a friendly assistant agent meant for first-run demos and intros.

- Skills: navigation, pick/open/close gripper, memory search, head emotions, and the recorded Wave.
- Mic input enabled, plus gaze so it tracks the person it is talking to.
- Prompt keeps replies short, pairs every utterance with a head emotion, and honors "stop" immediately.
