### PR TITLE
feat(sim): chase and top-down camera modes for the sim stage

### DIFF
--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -1742,9 +1742,18 @@ def _extract_bundle_from_image(config: dict[str, object], image: str, destinatio
     if marker.exists() and marker.read_text().split()[:1] == [image_id] and destination.is_dir():
         return
 
-    container = capture_command_output(["docker", "create", image], cwd=os_repo, env=env).strip()
+    # The command is never run -- but `docker create` refuses without one, and
+    # the bundle image is a bare FROM scratch carrying no CMD to inherit.
+    created = capture_command_output(["docker", "create", image, "/bundle"], cwd=os_repo, env=env).strip()
+    # capture_command_output falls back to stderr, so a failure here arrives
+    # looking like a container id and `docker cp` reports the daemon's error
+    # as the name of a container it cannot find. Insist it looks like an id.
+    container = created if re.fullmatch(r"[0-9a-f]{12,64}", created) else ""
     if not container:
-        raise StackError(f"Could not create a container from {shorten_docker_image_ref(image)} to read the bundle.")
+        detail = f"\n  docker said: {created}" if created else ""
+        raise StackError(
+            f"Could not create a container from {shorten_docker_image_ref(image)} to read the bundle.{detail}"
+        )
     staging = destination.parent / f".{destination.name}.tmp"
     shutil.rmtree(staging, ignore_errors=True)
     try:

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -86,6 +86,28 @@ const SHADOW_MAP_PX = 2048;
 const INITIAL_ORBIT_POSITION = { forward: 0.61, left: 0.02, height: 0.25 };
 const INITIAL_ORBIT_TARGET = { forward: -0.01, left: 0, height: 0.13 };
 
+// How the orbit camera behaves. Orthogonal to CameraView, which picks WHICH
+// camera renders: every mode here drives the same orbit camera.
+//   free  -- drag to orbit; the camera pans with the robot but never turns.
+//   chase -- pinned above and behind the robot, turning with it.
+//   top   -- the whole apartment from above, indifferent to where the robot is.
+export type CameraMode = "free" | "chase" | "top";
+// Chase framing, in the robot's own frame: back far enough to keep the robot
+// small in shot, high enough to see the floor it is about to drive over.
+const CHASE_BACK_M = 2.0;
+const CHASE_HEIGHT_M = 1.5;
+const CHASE_TARGET_HEIGHT_M = 0.35;
+// Exponential follow rate. A hard pin makes every wheel wobble a camera
+// shake; this lags the robot slightly and the turn reads as a turn.
+const CHASE_LAG_HZ = 4.0;
+// Near-nadir, not nadir: straight down leaves the camera's roll undefined
+// (up is +Z, and lookAt has nothing to resolve it against).
+const TOP_TILT = new THREE.Vector3(0, -0.35, 1).normalize();
+const TOP_FIT_MARGIN = 1.15;
+// No layout to frame (bare stage, failed manifest): fall back to a fixed
+// height over the robot rather than leaving the camera wherever it was.
+const TOP_FALLBACK_HEIGHT_M = 12;
+
 // Robot-mounted camera views: frames, axis conventions, FOV and near plane
 // match the driver's cameras (mars_sim_driver.core's CAMERAS).
 export type CameraView = "orbit" | "main" | "arm";
@@ -149,6 +171,11 @@ export class SimScene {
   private props: PropLibrary;
   // While true a placement drag owns the pointer and orbit stays off.
   private placementMode = false;
+  private cameraMode: CameraMode = "free";
+  // Whole-apartment extent, kept from the layout so "top" can reframe on every
+  // entry -- frameLayout only ever runs once, and only before the first pose.
+  private layoutBounds?: THREE.Box3;
+  private chaseClock = new THREE.Clock();
 
   /** Fixed render size (offscreen use, e.g. SimSession); null = track the window. */
   private fixedSize: { width: number; height: number } | null = null;
@@ -475,14 +502,18 @@ export class SimScene {
   }
 
   /**
-   * Frame the orbit camera on the placeholder layout so the wireframe reads as
-   * an apartment from the first frame. No-op once a real pose has arrived --
-   * spawnAt's chase framing wins; this is only for the pre-pose gap.
+   * Record the apartment's extent (the "top" camera mode's framing, for the
+   * rest of the session) and frame the orbit camera on the placeholder layout,
+   * so the wireframe reads as an apartment from the first frame. The framing
+   * half is skipped once a real pose has arrived -- spawnAt's close framing
+   * wins; that half is only for the pre-pose gap.
    */
   frameLayout(layout: ApartmentLayout): void {
-    if (this.spawned || layout.rooms.length === 0) return;
+    if (layout.rooms.length === 0) return;
     const bounds = new THREE.Box3().setFromObject(layout.group);
     if (bounds.isEmpty()) return;
+    this.layoutBounds = bounds;
+    if (this.spawned) return;
 
     const center = bounds.getCenter(new THREE.Vector3());
     const size = bounds.getSize(new THREE.Vector3());
@@ -732,8 +763,52 @@ export class SimScene {
     this.applyControlsEnabled();
   }
 
+  /** Pick how the orbit camera behaves; see CameraMode. Entering "top" frames
+   * the apartment once, after which it is an ordinary orbit you can drag. */
+  setCameraMode(mode: CameraMode): void {
+    if (mode === this.cameraMode) return;
+    this.cameraMode = mode;
+    if (mode === "chase") this.chaseClock.getDelta(); // drop the idle gap, or the first frame snaps
+    if (mode === "top") this.frameFromAbove();
+    this.applyControlsEnabled();
+  }
+
   private applyControlsEnabled(): void {
-    this.controls.enabled = this.activeView === "orbit" && !this.placementMode;
+    // Chase owns the camera every frame, so dragging it would fight the follow
+    // and lose; the other modes leave it where the pointer put it.
+    this.controls.enabled = this.activeView === "orbit" && !this.placementMode && this.cameraMode !== "chase";
+  }
+
+  /** Look down on the whole apartment (or, lacking a layout, on the robot). */
+  private frameFromAbove(): void {
+    const bounds = this.layoutBounds;
+    const center = bounds?.getCenter(new THREE.Vector3()) ?? new THREE.Vector3(...this.robotXY, 0);
+    let distance = TOP_FALLBACK_HEIGHT_M;
+    if (bounds) {
+      const size = bounds.getSize(new THREE.Vector3());
+      const fov = (this.camera.fov * Math.PI) / 180;
+      distance = (Math.max(size.x, size.y) / 2 / Math.tan(fov / 2)) * TOP_FIT_MARGIN;
+    }
+    this.camera.position.copy(center).addScaledVector(TOP_TILT, Math.min(distance, this.controls.maxDistance));
+    this.controls.target.copy(center);
+    this.controls.update();
+  }
+
+  /** Ease the camera toward its perch behind the robot. Frame-rate independent:
+   * the same lag whether the tab renders at 30fps or 120. */
+  private updateChase(): void {
+    const [x, y] = this.robotXY;
+    const yaw = this.robotRoot.rotation.z;
+    const desired = new THREE.Vector3(
+      x - Math.cos(yaw) * CHASE_BACK_M,
+      y - Math.sin(yaw) * CHASE_BACK_M,
+      CHASE_HEIGHT_M,
+    );
+    const target = new THREE.Vector3(x, y, CHASE_TARGET_HEIGHT_M);
+    const alpha = 1 - Math.exp(-CHASE_LAG_HZ * Math.min(this.chaseClock.getDelta(), 0.1));
+    this.camera.position.lerp(desired, alpha);
+    this.controls.target.lerp(target, alpha);
+    this.camera.lookAt(this.controls.target);
   }
 
   /** Intersect a canvas pointer position with the floor plane (z=0) through
@@ -868,21 +943,25 @@ export class SimScene {
     this.robotXY = [x, y];
     this.updateShadowVolume();
 
-    if (this.followCamera) {
-      const [prevX, prevY] = this.followPrevXY;
+    // Recorded even when nothing consumes it: a mode that parks the follow
+    // (chase, top) must not hand free-orbit the whole distance travelled while
+    // it was away as one jump.
+    const [prevX, prevY] = this.followPrevXY;
+    this.followPrevXY = [x, y];
+    if (this.followCamera && this.cameraMode === "free") {
       const dx = x - prevX;
       const dy = y - prevY;
       this.camera.position.x += dx;
       this.camera.position.y += dy;
       this.controls.target.x += dx;
       this.controls.target.y += dy;
-      this.followPrevXY = [x, y];
     }
   }
 
   render(): void {
     const robotCam = this.activeView !== "orbit" ? this.robotCameras.get(this.activeView) : undefined;
-    if (!robotCam) this.controls.update();
+    if (!robotCam && this.cameraMode === "chase") this.updateChase();
+    else if (!robotCam) this.controls.update();
     // Fat lines need the current drawing-buffer size to size their width in px.
     this.placeholderMat?.resolution.copy(this.renderer.getDrawingBufferSize(this.tmpSize));
     this.renderer.render(this.scene, robotCam ?? this.camera);

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -818,8 +818,14 @@ export class SimScene {
     let distance = TOP_FALLBACK_HEIGHT_M;
     if (bounds) {
       const size = bounds.getSize(new THREE.Vector3());
-      const fov = (this.camera.fov * Math.PI) / 180;
-      distance = (Math.max(size.x, size.y) / 2 / Math.tan(fov / 2)) * TOP_FIT_MARGIN;
+      // Each world axis against the FOV it actually falls under -- looking down
+      // with up=+Z puts world X across the screen and Y up it. Fitting both to
+      // the vertical FOV (what frameLayout does, for a stage it knows is
+      // landscape) crops the apartment sideways on a stage narrower than tall.
+      const vFov = (this.camera.fov * Math.PI) / 180;
+      const hFov = 2 * Math.atan(Math.tan(vFov / 2) * this.camera.aspect);
+      const fit = Math.max(size.x / 2 / Math.tan(hFov / 2), size.y / 2 / Math.tan(vFov / 2));
+      distance = fit * TOP_FIT_MARGIN;
     }
     this.cameraTween = {
       fromPos: this.camera.position.clone(),

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -92,10 +92,11 @@ const INITIAL_ORBIT_TARGET = { forward: -0.01, left: 0, height: 0.13 };
 //   chase -- pinned above and behind the robot, turning with it.
 //   top   -- the whole apartment from above, indifferent to where the robot is.
 export type CameraMode = "free" | "chase" | "top";
-// Chase framing, in the robot's own frame: back far enough to keep the robot
-// small in shot, high enough to see the floor it is about to drive over.
-const CHASE_BACK_M = 2.0;
-const CHASE_HEIGHT_M = 1.5;
+// Chase framing, in the robot's own frame. Close over the shoulder: ~1.4m out
+// at a 28 degree depression, which fills about a third of the frame height
+// with robot and still shows the floor it is about to drive over.
+const CHASE_BACK_M = 1.2;
+const CHASE_HEIGHT_M = 1.0;
 const CHASE_TARGET_HEIGHT_M = 0.35;
 // Exponential follow rate. A hard pin makes every wheel wobble a camera
 // shake; this lags the robot slightly and the turn reads as a turn.
@@ -104,6 +105,8 @@ const CHASE_LAG_HZ = 4.0;
 // (up is +Z, and lookAt has nothing to resolve it against).
 const TOP_TILT = new THREE.Vector3(0, -0.35, 1).normalize();
 const TOP_FIT_MARGIN = 1.15;
+// Long enough to read as the camera pulling back rather than cutting.
+const TOP_TWEEN_S = 0.8;
 // No layout to frame (bare stage, failed manifest): fall back to a fixed
 // height over the robot rather than leaving the camera wherever it was.
 const TOP_FALLBACK_HEIGHT_M = 12;
@@ -172,10 +175,22 @@ export class SimScene {
   // While true a placement drag owns the pointer and orbit stays off.
   private placementMode = false;
   private cameraMode: CameraMode = "free";
+  /** Notified on every mode change, including one the user caused by grabbing
+   * the camera out of chase -- so a mode switch in the UI can reflect it. */
+  onCameraModeChange?: (mode: CameraMode) => void;
   // Whole-apartment extent, kept from the layout so "top" can reframe on every
   // entry -- frameLayout only ever runs once, and only before the first pose.
   private layoutBounds?: THREE.Box3;
-  private chaseClock = new THREE.Clock();
+  private cameraClock = new THREE.Clock();
+  // True between OrbitControls' start/end: the pointer or wheel owns the camera.
+  private userDriving = false;
+  private cameraTween?: {
+    fromPos: THREE.Vector3;
+    toPos: THREE.Vector3;
+    fromTarget: THREE.Vector3;
+    toTarget: THREE.Vector3;
+    t: number;
+  };
 
   /** Fixed render size (offscreen use, e.g. SimSession); null = track the window. */
   private fixedSize: { width: number; height: number } | null = null;
@@ -218,6 +233,22 @@ export class SimScene {
     this.controls.minDistance = 0.5;
     this.controls.maxDistance = 30;
     this.controls.update();
+    // Grabbing the camera is a statement that you want it: a drag or a wheel
+    // takes chase off and abandons a fly-out mid-arc. "start"/"end" bracket
+    // user input only, so this cannot fire for our own per-frame update() or
+    // for a programmatic reframe (spawnAt) -- and a click that never moves
+    // anything gets a "start" with no "change", so it leaves chase alone.
+    this.controls.addEventListener("start", () => {
+      this.userDriving = true;
+    });
+    this.controls.addEventListener("end", () => {
+      this.userDriving = false;
+    });
+    this.controls.addEventListener("change", () => {
+      if (!this.userDriving) return;
+      this.cameraTween = undefined;
+      if (this.cameraMode === "chase") this.setCameraMode("free");
+    });
 
     this.addLights();
     this.addGround();
@@ -763,24 +794,25 @@ export class SimScene {
     this.applyControlsEnabled();
   }
 
-  /** Pick how the orbit camera behaves; see CameraMode. Entering "top" frames
-   * the apartment once, after which it is an ordinary orbit you can drag. */
+  /** Pick how the orbit camera behaves; see CameraMode. "top" flies out to the
+   * apartment framing, after which it is an ordinary orbit you can drag. */
   setCameraMode(mode: CameraMode): void {
     if (mode === this.cameraMode) return;
     this.cameraMode = mode;
-    if (mode === "chase") this.chaseClock.getDelta(); // drop the idle gap, or the first frame snaps
-    if (mode === "top") this.frameFromAbove();
+    this.cameraTween = undefined;
+    this.cameraClock.getDelta(); // drop the gap since the last frame, or the first step is a jump
+    if (mode === "top") this.flyToOverview();
     this.applyControlsEnabled();
+    this.onCameraModeChange?.(mode);
   }
 
   private applyControlsEnabled(): void {
-    // Chase owns the camera every frame, so dragging it would fight the follow
-    // and lose; the other modes leave it where the pointer put it.
-    this.controls.enabled = this.activeView === "orbit" && !this.placementMode && this.cameraMode !== "chase";
+    this.controls.enabled = this.activeView === "orbit" && !this.placementMode;
   }
 
-  /** Look down on the whole apartment (or, lacking a layout, on the robot). */
-  private frameFromAbove(): void {
+  /** Start the pull-back onto the whole apartment (or, lacking a layout, onto
+   * the robot). */
+  private flyToOverview(): void {
     const bounds = this.layoutBounds;
     const center = bounds?.getCenter(new THREE.Vector3()) ?? new THREE.Vector3(...this.robotXY, 0);
     let distance = TOP_FALLBACK_HEIGHT_M;
@@ -789,14 +821,42 @@ export class SimScene {
       const fov = (this.camera.fov * Math.PI) / 180;
       distance = (Math.max(size.x, size.y) / 2 / Math.tan(fov / 2)) * TOP_FIT_MARGIN;
     }
-    this.camera.position.copy(center).addScaledVector(TOP_TILT, Math.min(distance, this.controls.maxDistance));
-    this.controls.target.copy(center);
-    this.controls.update();
+    this.cameraTween = {
+      fromPos: this.camera.position.clone(),
+      toPos: center.clone().addScaledVector(TOP_TILT, Math.min(distance, this.controls.maxDistance)),
+      fromTarget: this.controls.target.clone(),
+      toTarget: center,
+      t: 0,
+    };
+  }
+
+  /** Swing the camera along its arc to the tween's destination.
+   *
+   * The offset from the target is slerped and its length lerped, rather than
+   * lerping the position outright: a straight line from a close chase to a
+   * ceiling-height overview cuts through the apartment on the way. */
+  private advanceTween(dt: number): void {
+    const tween = this.cameraTween;
+    if (!tween) return;
+    tween.t = Math.min(1, tween.t + dt / TOP_TWEEN_S);
+    const k = tween.t * tween.t * (3 - 2 * tween.t); // smoothstep: no jerk at either end
+    const from = tween.fromPos.clone().sub(tween.fromTarget);
+    const to = tween.toPos.clone().sub(tween.toTarget);
+    const radius = THREE.MathUtils.lerp(from.length(), to.length(), k);
+    from.normalize();
+    to.normalize();
+    // Identity at k=0, the full from->to rotation at k=1.
+    const swing = new THREE.Quaternion().setFromUnitVectors(from, to).slerp(new THREE.Quaternion(), 1 - k);
+    const offset = from.applyQuaternion(swing).multiplyScalar(radius);
+    this.controls.target.lerpVectors(tween.fromTarget, tween.toTarget, k);
+    this.camera.position.copy(this.controls.target).add(offset);
+    this.camera.lookAt(this.controls.target);
+    if (tween.t >= 1) this.cameraTween = undefined;
   }
 
   /** Ease the camera toward its perch behind the robot. Frame-rate independent:
    * the same lag whether the tab renders at 30fps or 120. */
-  private updateChase(): void {
+  private updateChase(dt: number): void {
     const [x, y] = this.robotXY;
     const yaw = this.robotRoot.rotation.z;
     const desired = new THREE.Vector3(
@@ -805,10 +865,18 @@ export class SimScene {
       CHASE_HEIGHT_M,
     );
     const target = new THREE.Vector3(x, y, CHASE_TARGET_HEIGHT_M);
-    const alpha = 1 - Math.exp(-CHASE_LAG_HZ * Math.min(this.chaseClock.getDelta(), 0.1));
+    const alpha = 1 - Math.exp(-CHASE_LAG_HZ * dt);
     this.camera.position.lerp(desired, alpha);
     this.controls.target.lerp(target, alpha);
     this.camera.lookAt(this.controls.target);
+  }
+
+  /** One camera step, whoever owns it this frame. */
+  private stepCamera(): void {
+    const dt = Math.min(this.cameraClock.getDelta(), 0.1);
+    if (this.cameraMode === "chase") this.updateChase(dt);
+    else if (this.cameraTween) this.advanceTween(dt);
+    else this.controls.update();
   }
 
   /** Intersect a canvas pointer position with the floor plane (z=0) through
@@ -960,8 +1028,7 @@ export class SimScene {
 
   render(): void {
     const robotCam = this.activeView !== "orbit" ? this.robotCameras.get(this.activeView) : undefined;
-    if (!robotCam && this.cameraMode === "chase") this.updateChase();
-    else if (!robotCam) this.controls.update();
+    if (!robotCam) this.stepCamera();
     // Fat lines need the current drawing-buffer size to size their width in px.
     this.placeholderMat?.resolution.copy(this.renderer.getDrawingBufferSize(this.tmpSize));
     this.renderer.render(this.scene, robotCam ?? this.camera);

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -318,6 +318,14 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
 
   const scene = new SimScene(canvas, { fixedSize: { width: parent.clientWidth || 1280, height: parent.clientHeight || 720 } });
   scene.followCamera = true;
+  // The scene takes chase off when the camera is dragged, so the switch has to
+  // follow the scene rather than be the only thing that knows the mode.
+  scene.onCameraModeChange = (mode) => {
+    const index = CAMERA_MODES.indexOf(mode);
+    if (index < 0) return;
+    cameraMode = index;
+    refreshCameraSwitch();
+  };
 
   // Placement drag (mode "place"): while a prop is armed the orbit controls
   // are off -- press marks the spot on the floor, drag points the yaw (arrow

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -5,7 +5,7 @@
 // context and blitted out.
 
 import * as THREE from "three";
-import { SimScene, type CameraView } from "./scene";
+import { SimScene, type CameraMode, type CameraView } from "./scene";
 import type { PropInfo } from "./props";
 import { LoadQueue } from "./loadQueue";
 import { THUMB_H, THUMB_W, type SimSession } from "./simSession";
@@ -152,6 +152,41 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   const divider = document.createElement("span");
   divider.style.cssText = "width:1px;align-self:stretch;margin:2px 2px;background:rgba(255,255,255,.18);";
   propControls.appendChild(divider);
+
+  // How the orbit camera behaves (SimScene.CameraMode). The prop-placement
+  // switch above is the same control with two segments; this one generalises
+  // it, since three modes do not fit a knob that only knows left and right.
+  // Click a label to pick it, or anywhere else to cycle.
+  const CAMERA_MODES = ["free", "chase", "top"] as const satisfies readonly CameraMode[];
+  const cameraSwitch = document.createElement("button");
+  cameraSwitch.type = "button";
+  cameraSwitch.title = "Camera: free orbit, chased from behind, or the whole apartment from above";
+  cameraSwitch.style.cssText = modeSwitch.style.cssText;
+  const cameraKnob = document.createElement("span");
+  cameraKnob.style.cssText =
+    `position:absolute;top:2px;bottom:2px;left:2px;width:calc(${100 / CAMERA_MODES.length}% - 2px);` +
+    "border-radius:999px;background:rgba(0,255,136,.28);transition:transform .15s ease;pointer-events:none;";
+  const cameraLabels = CAMERA_MODES.map((mode) => {
+    const el = document.createElement("span");
+    el.textContent = mode;
+    el.style.cssText = dropLabel.style.cssText;
+    return el;
+  });
+  cameraSwitch.append(cameraKnob, ...cameraLabels);
+  let cameraMode = 0;
+  const refreshCameraSwitch = () => {
+    cameraKnob.style.transform = `translateX(${cameraMode * 100}%)`;
+    cameraLabels.forEach((el, i) => (el.style.color = i === cameraMode ? ON_FG : OFF_FG));
+  };
+  cameraSwitch.onclick = (e) => {
+    const picked = cameraLabels.indexOf(e.target as HTMLSpanElement);
+    cameraMode = picked >= 0 ? picked : (cameraMode + 1) % CAMERA_MODES.length;
+    refreshCameraSwitch();
+    scene.setCameraMode(CAMERA_MODES[cameraMode]);
+  };
+  refreshCameraSwitch();
+  propControls.appendChild(cameraSwitch);
+
   addChip("lidar", (on) => session.setLidarVisible(on));
   addChip("collisions", (on) => session.setCollisionHullsVisible(on));
   debugStack.appendChild(propControls);


### PR DESCRIPTION
## Summary

A camera-mode switch on the sim stage, in the overlay row next to `lidar`/`collisions`:

```
free │ chase │ top
```

- **chase** — pinned ~1.4m behind and above the robot at a 28° depression, turning with it. Eased rather than rigidly pinned: a hard follow turns every wheel wobble into camera shake, and the lag is what makes a turn read as a turn. Frame-rate independent, so it looks the same at 30fps and 120.
- **top** — the whole apartment from above, flown to over 0.8s along an arc (the offset from the target is slerped while its length is lerped, so the camera swings up and pulls back rather than dollying diagonally through the apartment).
- **free** — unchanged: drag to orbit, pans with the robot.

Before this the orbit camera panned with the robot but never turned with it, so driving down a corridor showed the robot's flank and watching a navigation run meant dragging the camera along by hand. There was also no way to see the apartment as a whole once a pose had arrived — `spawnAt` frames close on the robot and nothing framed back out.

### Design note

`CameraMode` is deliberately a separate axis from the existing `CameraView`. `CameraView` picks *which* camera renders — the orbit camera vs the robot's own head/wrist lenses — and its members are eligible as PiP thumbnail sources and as `primaryCamera` values. Chase and top are neither; they are how the orbit camera behaves. Folding them into `CameraView` would have made them offerable as robot camera feeds, which they aren't.

Reaching for the camera during chase releases it, since chase can't both follow and be dragged. That hangs off OrbitControls' `start`/`end` bracket rather than `change` alone, so it fires for real input only: the per-frame `update()` and programmatic reframes (`spawnAt` on reset) can't trigger it, and a click that moves nothing gets a `start` with no `change` and leaves chase alone. The same gesture abandons a fly-out mid-arc. Because the scene can now change mode without the UI asking, `SimScene` reports mode changes back and the switch follows the scene.

## Also here: a launcher fix, independent of the above

`./innate-sim up` on a branch CI has not published a viewer bundle for built the image and then died:

```
Error response from daemon: No such container: Error response from daemon
```

Two faults, stacked. The bundle image is `FROM scratch` carrying only `/bundle`, so it has no `CMD` — and `docker create` refuses an image with no command even for a container that will never be started, which is the whole point of this one. It is now given one; it is never executed.

The unreadable error is the second fault. `capture_command_output` is a probe helper that falls back to stderr, so docker's refusal came back looking like a container id and went straight to `docker cp`, which duly could not find a container by that name. The id is now checked for being an id, and docker's actual complaint is quoted.

This path has never worked (it arrived with #661): it only runs when no published bundle matches the tree, and CI publishes one for every pushed commit, so the window is a branch touching `sim/viewer` before its bundle lands. Happy to split it out if you would rather it went in on its own — it unblocks anyone on such a branch.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
- [x] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`.
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — no asset changes.

- `tsc --noEmit` on `sim/viewer`: clean.
- `pre-commit run --all-files -c .config/pre-commit-config.yaml`: clean.
- `./innate-sim down && ./innate-sim up`: full cycle, stack healthy. This exercised the local viewer-bundle build and extraction end to end — the path the fix above repairs — and installed a bundle whose `.installed-tag` matches the working tree's inputs hash.

**Not validated: how any of it looks in motion.** The framing numbers (1.2m back, 1.0m up), the 0.8s fly-out, and the 4Hz chase easing are considered first guesses, not tuned values. Worth someone driving it before merge.
