### PR TITLE
Compact and group Agent activity logs

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/common/enums.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/common/enums.py
@@ -10,3 +10,11 @@ class StrEnum(str, Enum):
 
     __str__ = str.__str__
     __format__ = str.__format__
+
+
+class SkillResult(Enum):
+    """A skill run's outcome. The values are wire-visible — never change them."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    CANCELLED = "cancelled"

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -346,7 +346,7 @@ class BrainClientNode(Node):
         if not self.state.is_brain_active:
             self.get_logger().warn("[BrainClient] Brain is not active. Skipping chat_in message.")
             return
-        self.chat.history.append(data)
+        self.chat.append(data)
         self.brain.on_user_message(data["text"])
         self.get_logger().info(f"User message: {data['text']}")
 
@@ -453,7 +453,7 @@ class BrainClientNode(Node):
         if entry is None:
             self.get_logger().warn("[BrainClient] Ignoring incomplete /brain/skill_status_update payload.")
             return
-        self.chat.history.append(entry)
+        self.chat.append(dict(entry))
 
     # ================= service handlers =================
     def _svc_get_chat_history(self, request, response):

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -45,6 +45,7 @@ from brain_client.skills.hot_reload import ReloadCoordinator
 from brain_client.skills.roster import SkillRoster
 from brain_client.skills.runner import PrimitiveRunner
 from brain_client.skills.workspace_import import format_load_error, unique_key
+from brain_client.transport.activity import task_status_history_entry
 from brain_client.transport.chat import ChatManager
 from brain_client.transport.tts import TTSHandler
 
@@ -238,6 +239,7 @@ class BrainClientNode(Node):
         self.create_subscription(String, "/brain/set_directive", self._on_set_directive, 10)
         self.create_subscription(String, "/brain/set_active_skills", self._on_set_active_skills, 10)
         self.create_subscription(String, "/brain/manual_skill_event", self._on_manual_skill_event, 10)
+        self.create_subscription(String, "/brain/skill_status_update", self._on_skill_status_update, 10)
 
     def _create_services(self) -> None:
         self.create_service(GetChatHistory, "/brain/get_chat_history", self._svc_get_chat_history)
@@ -415,6 +417,9 @@ class BrainClientNode(Node):
         primitive_name = payload.get("skill_name") or self.state.registry.name_for(skill_id)
         primitive_id = payload.get("primitive_id") or f"manual_{skill_id}_{int(time.time() * 1000)}"
         reason = payload.get("reason")
+        event_timestamp = payload.get("timestamp")
+        if not isinstance(event_timestamp, (int, float)):
+            event_timestamp = None
 
         self.get_logger().info(f"Manual skill event: {status} {primitive_name} ({skill_id})")
         # The runner mirrors the run into the skill slot (under its slot lock,
@@ -434,18 +439,21 @@ class BrainClientNode(Node):
             status=status,
             skill_id=skill_id,
             reason=reason,
+            timestamp=event_timestamp,
         )
-        self.chat.history.append(
-            {
-                "sender": "task_activated",
-                "text": primitive_name,
-                "timestamp": payload.get("timestamp", time.time()),
-                "taskStatus": status,
-                "primitiveId": primitive_id,
-                "skillId": skill_id,
-                **({"failureReason": reason} if reason else {}),
-            }
-        )
+
+    def _on_skill_status_update(self, msg: String) -> None:
+        """Persist every skill call so the Activity view survives a refresh."""
+        try:
+            payload = json.loads(msg.data)
+        except (json.JSONDecodeError, TypeError):
+            self.get_logger().warn("[BrainClient] Ignoring malformed /brain/skill_status_update JSON.")
+            return
+        entry = task_status_history_entry(payload)
+        if entry is None:
+            self.get_logger().warn("[BrainClient] Ignoring incomplete /brain/skill_status_update payload.")
+            return
+        self.chat.history.append(entry)
 
     # ================= service handlers =================
     def _svc_get_chat_history(self, request, response):

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -45,6 +45,7 @@ from brain_client.skills.types import (
     normalize_skill_result,
     swap_run_cancel,
 )
+from brain_client.transport.activity import successful_code_output, task_status_payload
 
 # result status -> (goal-handle finalize method, ExecuteSkill success flag)
 _FINALIZE = {
@@ -297,7 +298,8 @@ class SkillsActionServer(Node):
             # consumers (the web app's external-run banner) clear the banner
             # for the run that just started.
             status, reason = self._terminal_skill_status(result)
-            self._publish_skill_status(run_id, skill_type, name, status, reason, args=inputs)
+            output = successful_code_output(result, entry is not None)
+            self._publish_skill_status(run_id, skill_type, name, status, reason, args=inputs, output=output)
         except Exception as e:
             # Clients stick on "running" forever without a terminal status.
             self._publish_skill_status(run_id, skill_type, name, "failed", str(e) or "internal error", args=inputs)
@@ -330,21 +332,21 @@ class SkillsActionServer(Node):
         status: str,
         reason: str | None = None,
         args: dict | None = None,
+        output: str | None = None,
     ) -> None:
-        payload = {
-            "primitive_name": name,
-            "skill_name": name,
-            "skill_id": skill_type,
-            "primitive_id": run_id,
-            "status": status,
-            "timestamp": time.time(),
-        }
-        if reason:
-            payload["reason"] = reason
-        # The inputs the run was given — "head emotion" alone doesn't say which
-        # emotion, so clients show them alongside the name.
-        if args:
-            payload["args"] = args
+        # Keep successful code-skill output on its authoritative run row. The
+        # legacy chat_out copy remains for older clients and is deduped by the
+        # current webapp. Inputs stay beside the name so a call such as "head
+        # emotion" still says which emotion it received.
+        payload = task_status_payload(
+            name,
+            run_id,
+            status,
+            skill_id=skill_type,
+            reason=reason,
+            args=args,
+            output=output,
+        )
         self._skill_status_pub.publish(String(data=json.dumps(payload)))
 
     def _create_run_node(self):

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -334,10 +334,8 @@ class SkillsActionServer(Node):
         args: dict | None = None,
         output: str | None = None,
     ) -> None:
-        # Keep successful code-skill output on its authoritative run row. The
-        # legacy chat_out copy remains for older clients and is deduped by the
-        # current webapp. Inputs stay beside the name so a call such as "head
-        # emotion" still says which emotion it received.
+        # Output rides the terminal status so it stays on the run's own row; the
+        # legacy chat_out echo remains for older clients (the webapp dedupes it).
         payload = task_status_payload(
             name,
             run_id,

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -253,7 +253,10 @@ class PrimitiveRunner:
         if event not in PRIMITIVE_LIFECYCLE_STATUSES:
             self._logger.warn(f"Unknown substep event: {event}")
             return
+        # Foreign JSON — a non-string output must not abort the status publish.
         output = substep.get("output")
+        if not isinstance(output, str):
+            output = None
         self._chat.publish_task_status(
             primitive_name=substep.get("name", ""),
             primitive_id=substep.get("primitive_id"),

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/runner.py
@@ -21,6 +21,7 @@ from std_srvs.srv import Trigger
 from brain_client.core.state import RunningSkill
 from brain_client.skills.lifecycle import PRIMITIVE_LIFECYCLE_STATUSES, decode_substep_feedback
 from brain_client.skills.types import SkillResult
+from brain_client.transport.activity import successful_code_output
 from brain_client.transport.chat import Sender
 
 
@@ -252,14 +253,15 @@ class PrimitiveRunner:
         if event not in PRIMITIVE_LIFECYCLE_STATUSES:
             self._logger.warn(f"Unknown substep event: {event}")
             return
+        output = substep.get("output")
         self._chat.publish_task_status(
             primitive_name=substep.get("name", ""),
             primitive_id=substep.get("primitive_id"),
             status=event,
             skill_id=substep.get("skill_id"),
             reason=substep.get("reason"),
+            output=output if event == "completed" else None,
         )
-        output = substep.get("output")
         if event == "completed" and output and output.strip():
             self._chat.emit(Sender.SKILL_OUTPUT, output, speak=False)
 
@@ -363,14 +365,14 @@ class PrimitiveRunner:
 
     def _emit_skill_output(self, result, is_code: bool) -> None:
         """Surface a successful code skill's output in the chat (never spoken)."""
-        if is_code and result.success and result.success_type == SkillResult.SUCCESS.value and result.message.strip():
-            self._chat.emit(Sender.SKILL_OUTPUT, result.message, speak=False)
+        output = successful_code_output(result, is_code)
+        if output is not None:
+            self._chat.emit(Sender.SKILL_OUTPUT, output, speak=False)
 
     def _classify_result(self, result, is_code: bool) -> tuple[str | None, str | None]:
         """Map an action result to the brain-facing (status, detail) event."""
         if result.success and result.success_type == SkillResult.SUCCESS.value:
-            output = result.message if is_code and result.message.strip() else None
-            return "completed", output
+            return "completed", successful_code_output(result, is_code)
         if result.success_type == SkillResult.CANCELLED.value:
             return "interrupted", None
         if not result.success or result.success_type == SkillResult.FAILURE.value:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -21,6 +21,7 @@ from std_msgs.msg import String
 from typing_extensions import Self
 
 from brain_client.common.dynamic_loader import class_name_to_snake_case
+from brain_client.common.enums import SkillResult
 from brain_client.common.logging import UniversalLogger
 from brain_client.common.script_paths import Source
 
@@ -38,12 +39,6 @@ SkillReturn = Union[None, str, "SkillOutput"]
 
 TTS_TOPIC = "/brain/tts"
 TTS_STATUS_TOPIC = "/tts/is_playing"
-
-
-class SkillResult(Enum):
-    SUCCESS = "success"
-    FAILURE = "failure"
-    CANCELLED = "cancelled"
 
 
 class SkillFailed(Exception):

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/activity.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/activity.py
@@ -1,11 +1,43 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
-"""Small, dependency-free helpers for Agent activity events."""
+"""Small, ROS-free helpers for Agent activity events."""
 
 from __future__ import annotations
 
 import time
 from typing import Any
+
+from typing_extensions import NotRequired, TypedDict
+
+from brain_client.common.enums import SkillResult
+
+
+class TaskStatusPayload(TypedDict):
+    """The /brain/skill_status_update wire format (JSON on a String topic)."""
+
+    primitive_name: str
+    primitive_id: str | None
+    skill_name: str
+    skill_id: str | None
+    status: str
+    timestamp: float
+    reason: NotRequired[str]
+    args: NotRequired[dict]
+    output: NotRequired[str]
+
+
+class TaskHistoryEntry(TypedDict):
+    """The chat-history shape the webapp replays a skill call from."""
+
+    sender: str
+    text: str
+    timestamp: float
+    taskStatus: str
+    primitiveId: NotRequired[str]
+    skillId: NotRequired[str]
+    args: NotRequired[dict]
+    failureReason: NotRequired[str]
+    output: NotRequired[str]
 
 
 def successful_code_output(result: Any, is_code: bool) -> str | None:
@@ -14,7 +46,7 @@ def successful_code_output(result: Any, is_code: bool) -> str | None:
     if (
         is_code
         and bool(getattr(result, "success", False))
-        and getattr(result, "success_type", None) == "success"
+        and getattr(result, "success_type", None) == SkillResult.SUCCESS.value
         and isinstance(message, str)
         and message.strip()
     ):
@@ -32,9 +64,9 @@ def task_status_payload(
     args: dict | None = None,
     output: str | None = None,
     timestamp: float | None = None,
-) -> dict:
+) -> TaskStatusPayload:
     """Build the JSON object shared by task-status publishers."""
-    payload = {
+    payload: TaskStatusPayload = {
         "primitive_name": primitive_name,
         "primitive_id": primitive_id,
         "skill_name": primitive_name,
@@ -46,12 +78,12 @@ def task_status_payload(
         payload["reason"] = reason
     if args:
         payload["args"] = args
-    if output and output.strip():
+    if isinstance(output, str) and output.strip():
         payload["output"] = output
     return payload
 
 
-def task_status_history_entry(payload: Any) -> dict | None:
+def task_status_history_entry(payload: Any) -> TaskHistoryEntry | None:
     """Convert a live skill-status payload into the chat-history shape."""
     if not isinstance(payload, dict):
         return None
@@ -63,7 +95,7 @@ def task_status_history_entry(payload: Any) -> dict | None:
     timestamp = payload.get("timestamp")
     if not isinstance(timestamp, (int, float)):
         timestamp = time.time()
-    entry = {
+    entry: TaskHistoryEntry = {
         "sender": "task_activated",
         "text": name,
         "timestamp": timestamp,

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/activity.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/activity.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Small, dependency-free helpers for Agent activity events."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+def successful_code_output(result: Any, is_code: bool) -> str | None:
+    """Return the exact user-facing output for a successful code skill."""
+    message = getattr(result, "message", "")
+    if (
+        is_code
+        and bool(getattr(result, "success", False))
+        and getattr(result, "success_type", None) == "success"
+        and isinstance(message, str)
+        and message.strip()
+    ):
+        return message
+    return None
+
+
+def task_status_payload(
+    primitive_name: str,
+    primitive_id: str | None,
+    status: str,
+    *,
+    skill_id: str | None = None,
+    reason: str | None = None,
+    args: dict | None = None,
+    output: str | None = None,
+    timestamp: float | None = None,
+) -> dict:
+    """Build the JSON object shared by task-status publishers."""
+    payload = {
+        "primitive_name": primitive_name,
+        "primitive_id": primitive_id,
+        "skill_name": primitive_name,
+        "skill_id": skill_id or primitive_id,
+        "status": status,
+        "timestamp": time.time() if timestamp is None else timestamp,
+    }
+    if reason:
+        payload["reason"] = reason
+    if args:
+        payload["args"] = args
+    if output and output.strip():
+        payload["output"] = output
+    return payload
+
+
+def task_status_history_entry(payload: Any) -> dict | None:
+    """Convert a live skill-status payload into the chat-history shape."""
+    if not isinstance(payload, dict):
+        return None
+    name = payload.get("primitive_name") or payload.get("skill_name") or payload.get("skill_id")
+    status = payload.get("status")
+    if not isinstance(name, str) or not name or not isinstance(status, str) or not status:
+        return None
+
+    timestamp = payload.get("timestamp")
+    if not isinstance(timestamp, (int, float)):
+        timestamp = time.time()
+    entry = {
+        "sender": "task_activated",
+        "text": name,
+        "timestamp": timestamp,
+        "taskStatus": status,
+    }
+    primitive_id = payload.get("primitive_id")
+    skill_id = payload.get("skill_id")
+    if primitive_id is not None:
+        entry["primitiveId"] = primitive_id
+    if skill_id is not None:
+        entry["skillId"] = skill_id
+    if payload.get("args") is not None:
+        entry["args"] = payload["args"]
+    reason = payload.get("reason")
+    if isinstance(reason, str) and reason:
+        entry["failureReason"] = reason
+    output = payload.get("output")
+    if isinstance(output, str) and output.strip():
+        entry["output"] = output
+    return entry

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/chat.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/chat.py
@@ -16,6 +16,7 @@ import time
 
 from brain_client.brain.context import split_tool_narration
 from brain_client.common.enums import StrEnum
+from brain_client.transport.activity import task_status_payload
 
 _SENTENCE_END = re.compile(r"(?<=[.!?…])\s+")
 
@@ -76,18 +77,19 @@ class ChatManager:
         status: str,
         skill_id: str | None = None,
         reason: str | None = None,
+        output: str | None = None,
+        timestamp: float | None = None,
     ) -> None:
         """Publish a local task-status update for the controller-app UI."""
-        payload = {
-            "primitive_name": primitive_name,
-            "primitive_id": primitive_id,
-            "skill_name": primitive_name,
-            "skill_id": skill_id or primitive_id,
-            "status": status,
-            "timestamp": time.time(),
-        }
-        if reason:
-            payload["reason"] = reason
+        payload = task_status_payload(
+            primitive_name,
+            primitive_id,
+            status,
+            skill_id=skill_id,
+            reason=reason,
+            output=output,
+            timestamp=timestamp,
+        )
         from std_msgs.msg import String  # deferred: keeps the module importable without ROS
 
         self._task_status_pub.publish(String(data=json.dumps(payload)))

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/chat.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/chat.py
@@ -20,6 +20,10 @@ from brain_client.transport.activity import task_status_payload
 
 _SENTENCE_END = re.compile(r"(?<=[.!?…])\s+")
 
+# Skill statuses persist here too (~2 entries per run), so an uncapped list grows
+# RSS and the get_chat_history blob without bound over a long autonomous session.
+_MAX_HISTORY_ENTRIES = 1000
+
 
 class Sender(StrEnum):
     """Chat-entry senders — the webapp switches on these exact values."""
@@ -42,6 +46,12 @@ class ChatManager:
     def entry(sender: Sender, text: str) -> dict:
         return {"sender": sender, "text": text, "timestamp": time.time()}
 
+    def append(self, entry: dict) -> None:
+        """Record ``entry`` in the bounded history, dropping the oldest past the cap."""
+        self.history.append(entry)
+        if len(self.history) > _MAX_HISTORY_ENTRIES:
+            del self.history[: len(self.history) - _MAX_HISTORY_ENTRIES]
+
     def emit(self, sender: Sender, text: str, speak: bool | None = None) -> None:
         """Append a chat entry, publish it, and (for robot speech) speak it.
 
@@ -49,7 +59,7 @@ class ChatManager:
         behaviour where thoughts/anticipation were published but not spoken.
         """
         chat_entry = self.entry(sender, text)
-        self.history.append(chat_entry)
+        self.append(chat_entry)
         self._logger.debug(f"chat_out: {chat_entry}")
         from std_msgs.msg import String  # deferred: keeps the module importable without ROS
 

--- a/ros2_ws/src/brain/brain_client/test/test_activity_protocol.py
+++ b/ros2_ws/src/brain/brain_client/test/test_activity_protocol.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Protocol-level coverage for compact Agent skill activity."""
+
+from types import SimpleNamespace
+
+from brain_client.transport.activity import (
+    successful_code_output,
+    task_status_history_entry,
+    task_status_payload,
+)
+
+
+def result(*, success=True, success_type="success", message="done"):
+    return SimpleNamespace(success=success, success_type=success_type, message=message)
+
+
+def test_successful_code_output_is_preserved_verbatim():
+    assert successful_code_output(result(message="  result 1.2345\n"), True) == "  result 1.2345\n"
+
+
+def test_output_is_omitted_for_non_success_cases():
+    assert successful_code_output(result(message="   "), True) is None
+    assert successful_code_output(result(success=False, success_type="failure"), True) is None
+    assert successful_code_output(result(success_type="cancelled"), True) is None
+    assert successful_code_output(result(), False) is None
+
+
+def test_nested_completion_payload_carries_output_and_omits_blank_output():
+    completed = task_status_payload(
+        "inspect shelf",
+        "child-1",
+        "completed",
+        skill_id="local/inspect_shelf",
+        output="found two items",
+        timestamp=12.5,
+    )
+    assert completed["output"] == "found two items"
+    assert completed["timestamp"] == 12.5
+
+    blank = task_status_payload("inspect shelf", "child-2", "completed", output="  ", timestamp=13)
+    assert "output" not in blank
+
+
+def test_status_history_keeps_call_identity_inputs_failure_and_output():
+    entry = task_status_history_entry(
+        {
+            "primitive_name": "inspect shelf",
+            "primitive_id": "run-1",
+            "skill_id": "local/inspect_shelf",
+            "status": "completed",
+            "timestamp": 42,
+            "args": {"shelf": 2},
+            "reason": "exact 192.168.1.10 trace",
+            "output": "found two items",
+        }
+    )
+    assert entry == {
+        "sender": "task_activated",
+        "text": "inspect shelf",
+        "timestamp": 42,
+        "taskStatus": "completed",
+        "primitiveId": "run-1",
+        "skillId": "local/inspect_shelf",
+        "args": {"shelf": 2},
+        "failureReason": "exact 192.168.1.10 trace",
+        "output": "found two items",
+    }

--- a/ros2_ws/src/brain/brain_client/test/test_runner_deactivation.py
+++ b/ros2_ws/src/brain/brain_client/test/test_runner_deactivation.py
@@ -208,3 +208,29 @@ def test_generation_is_captured_at_claim_time_so_a_mid_send_disown_orphans_the_g
     assert cancelled == [True]
     assert state.primitive_running is None
     assert runner._goal_handle is None
+
+
+def test_successful_code_output_keeps_the_legacy_chat_event_exactly_once():
+    runner, _ = make_runner(None)
+    emitted = []
+    runner._chat = SimpleNamespace(emit=lambda *args, **kwargs: emitted.append((args, kwargs)))
+    result = SimpleNamespace(success=True, success_type="success", message="  exact 1.2345 output  ")
+
+    runner._emit_skill_output(result, is_code=True)
+
+    assert len(emitted) == 1
+    assert emitted[0][0][1] == "  exact 1.2345 output  "
+    assert emitted[0][1] == {"speak": False}
+
+
+def test_legacy_chat_output_is_omitted_for_non_success_results():
+    runner, _ = make_runner(None)
+    emitted = []
+    runner._chat = SimpleNamespace(emit=lambda *args, **kwargs: emitted.append((args, kwargs)))
+
+    runner._emit_skill_output(SimpleNamespace(success=True, success_type="success", message=" "), True)
+    runner._emit_skill_output(SimpleNamespace(success=False, success_type="failure", message="no"), True)
+    runner._emit_skill_output(SimpleNamespace(success=True, success_type="cancelled", message="no"), True)
+    runner._emit_skill_output(SimpleNamespace(success=True, success_type="success", message="physical"), False)
+
+    assert emitted == []

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -5708,8 +5708,8 @@ select.skill-input {
   background: rgb(255 255 255 / 4%);
 }
 
-/* The status line (tag · name · status); becomes a disclosure when output or
-   a failure detail is available below it. */
+/* The status line (tag · name · status); becomes a disclosure when inputs,
+   output, or a failure detail are available below it. */
 .chat-skill-head {
   width: 100%;
   display: flex;
@@ -5735,11 +5735,27 @@ select.skill-input {
 
 .chat-skill-chevron {
   flex: 0 0 auto;
-  font-size: 9px;
-  opacity: 0.6;
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  line-height: 1;
+  color: rgb(231 231 234 / 78%);
+  background: rgb(255 255 255 / 5%);
+  border: 1px solid var(--hairline-strong);
+  border-radius: 50%;
+  transition: color 150ms ease, background 150ms ease, border-color 150ms ease;
 }
 
-/* Collapsible skill output or failure reason. */
+.chat-skill.has-detail .chat-skill-head:hover .chat-skill-chevron,
+.chat-skill.open .chat-skill-chevron {
+  color: #fff;
+  background: rgb(64 31 251 / 20%);
+  border-color: rgb(117 105 253 / 60%);
+}
+
+/* Collapsible skill inputs, output, or failure reason. */
 .chat-skill-detail {
   max-height: 0;
   overflow: hidden;
@@ -5759,6 +5775,30 @@ select.skill-input {
   border-top: 1px solid var(--hairline);
 }
 
+.chat-skill-detail-section + .chat-skill-detail-section {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--hairline);
+}
+
+.chat-skill-detail-label {
+  display: block;
+  margin-bottom: 3px;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.chat-skill-detail-value {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.chat-skill-detail-section.inputs .chat-skill-detail-value {
+  color: var(--muted);
+}
+
 .chat-skill-tag {
   flex: 0 0 auto;
   font-size: 9px;
@@ -5768,25 +5808,13 @@ select.skill-input {
 }
 
 .chat-skill-name {
-  flex: 0 1 auto;
-  min-width: 0;
-  font-size: 12px;
-  color: var(--text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* The run's inputs, trailing the name — which emotion, which position. Takes
-   the slack so the status stays pinned right whether or not there are any. */
-.chat-skill-args {
   flex: 1 1 auto;
   min-width: 0;
-  font-size: 11px;
-  color: var(--muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: 12px;
+  line-height: 1.25;
+  color: var(--text);
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .chat-skill-status {
@@ -6692,80 +6720,8 @@ select.skill-input {
   color: var(--ctl-accent);
 }
 
-.agent-stream-head {
-  min-height: 24px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0 2px -4px;
-}
-
 .agent-stream-label {
-  flex: 1;
-  margin: 0;
-}
-
-.agent-compact-toggle {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  min-height: 24px;
-  padding: 2px 4px 2px 7px;
-  font-size: 9px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgb(231 231 234 / 55%);
-  background: rgb(0 0 0 / 20%);
-  border: 1px solid var(--hairline);
-  border-radius: 999px;
-  transition: color 150ms ease, border-color 150ms ease, background 150ms ease;
-}
-
-.agent-compact-toggle:hover,
-.agent-compact-toggle:focus-visible {
-  color: #fff;
-  border-color: var(--hairline-strong);
-}
-
-.agent-compact-toggle:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.agent-compact-track {
-  position: relative;
-  width: 25px;
-  height: 14px;
-  border-radius: 999px;
-  background: rgb(255 255 255 / 12%);
-  transition: background 150ms ease;
-}
-
-.agent-compact-track > span {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: rgb(231 231 234 / 70%);
-  transition: transform 150ms ease, background 150ms ease;
-}
-
-.agent-compact-toggle.on {
-  color: #d7d2ff;
-  border-color: rgb(64 31 251 / 48%);
-  background: rgb(64 31 251 / 12%);
-}
-
-.agent-compact-toggle.on .agent-compact-track {
-  background: rgb(64 31 251 / 58%);
-}
-
-.agent-compact-toggle.on .agent-compact-track > span {
-  background: #fff;
-  transform: translateX(11px);
+  margin: 2px 2px -4px;
 }
 
 /* Over translucent glass the app's --muted grey reads too dim, so the agent
@@ -6803,23 +6759,23 @@ select.skill-input {
   padding: 4px 2px;
 }
 
-/* Compact is the onboarding view: finished reasoning and unpaired legacy
-   output disappear, but live processing and every skill-call header remain.
-   Switching to Detailed restores those debugging surfaces. */
-.agent-panel.compact-activity .agent-stream {
+/* The Agent activity stream is intentionally compact: finished reasoning and
+   unpaired legacy output disappear, but live processing and every skill-call
+   header remain. Individual skill calls disclose their own details. */
+.agent-panel .agent-stream {
   gap: 6px;
 }
 
-.agent-panel.compact-activity .chat-thoughts:not(.active):not(.open),
-.agent-panel.compact-activity .chat-skill.orphan-output:not(.open) {
+.agent-panel .chat-thoughts:not(.active),
+.agent-panel .chat-skill.orphan-output {
   display: none;
 }
 
-.agent-panel.compact-activity .chat-thoughts:not(.open) .chat-thoughts-list {
+.agent-panel .chat-thoughts:not(.open) .chat-thoughts-list {
   display: none;
 }
 
-.agent-panel.compact-activity .chat-skill-head {
+.agent-panel .chat-skill-head {
   padding-block: 5px;
 }
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -5721,6 +5721,7 @@ select.skill-input {
   color: inherit;
   background: transparent;
   border: 0;
+  cursor: default; /* overrides the global button pointer until a detail exists */
 }
 
 .chat-skill.has-detail .chat-skill-head {
@@ -6759,19 +6760,16 @@ select.skill-input {
   padding: 4px 2px;
 }
 
-/* The Agent activity stream is intentionally compact: finished reasoning and
-   unpaired legacy output disappear, but live processing and every skill-call
-   header remain. Individual skill calls disclose their own details. */
+/* The Agent activity stream is intentionally compact: finished reasoning
+   disappears, and a legacy output row hides only while it can still pair with
+   its status row. Live processing keeps its latest-thought preview and every
+   skill-call header remains. */
 .agent-panel .agent-stream {
   gap: 6px;
 }
 
 .agent-panel .chat-thoughts:not(.active),
 .agent-panel .chat-skill.orphan-output {
-  display: none;
-}
-
-.agent-panel .chat-thoughts:not(.open) .chat-thoughts-list {
   display: none;
 }
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -5708,17 +5708,29 @@ select.skill-input {
   background: rgb(255 255 255 / 4%);
 }
 
-/* The status line (tag · name · status); becomes a click target when a failed
-   run has an expandable error detail below it. */
+/* The status line (tag · name · status); becomes a disclosure when output or
+   a failure detail is available below it. */
 .chat-skill-head {
+  width: 100%;
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
+  font: inherit;
+  text-align: left;
+  color: inherit;
+  background: transparent;
+  border: 0;
 }
 
 .chat-skill.has-detail .chat-skill-head {
   cursor: pointer;
+}
+
+.chat-skill.has-detail .chat-skill-head:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+  border-radius: 8px;
 }
 
 .chat-skill-chevron {
@@ -5727,7 +5739,7 @@ select.skill-input {
   opacity: 0.6;
 }
 
-/* Collapsible failure reason / error trace. */
+/* Collapsible skill output or failure reason. */
 .chat-skill-detail {
   max-height: 0;
   overflow: hidden;
@@ -5738,7 +5750,6 @@ select.skill-input {
   white-space: pre-wrap;
   word-break: break-word;
   border-top: 0 solid var(--hairline);
-  transition: max-height 0.2s ease, padding 0.2s ease;
 }
 
 .chat-skill.open .chat-skill-detail {
@@ -6681,8 +6692,80 @@ select.skill-input {
   color: var(--ctl-accent);
 }
 
+.agent-stream-head {
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 2px -4px;
+}
+
 .agent-stream-label {
-  margin: 2px 2px -4px;
+  flex: 1;
+  margin: 0;
+}
+
+.agent-compact-toggle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 24px;
+  padding: 2px 4px 2px 7px;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(231 231 234 / 55%);
+  background: rgb(0 0 0 / 20%);
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  transition: color 150ms ease, border-color 150ms ease, background 150ms ease;
+}
+
+.agent-compact-toggle:hover,
+.agent-compact-toggle:focus-visible {
+  color: #fff;
+  border-color: var(--hairline-strong);
+}
+
+.agent-compact-toggle:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.agent-compact-track {
+  position: relative;
+  width: 25px;
+  height: 14px;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 12%);
+  transition: background 150ms ease;
+}
+
+.agent-compact-track > span {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgb(231 231 234 / 70%);
+  transition: transform 150ms ease, background 150ms ease;
+}
+
+.agent-compact-toggle.on {
+  color: #d7d2ff;
+  border-color: rgb(64 31 251 / 48%);
+  background: rgb(64 31 251 / 12%);
+}
+
+.agent-compact-toggle.on .agent-compact-track {
+  background: rgb(64 31 251 / 58%);
+}
+
+.agent-compact-toggle.on .agent-compact-track > span {
+  background: #fff;
+  transform: translateX(11px);
 }
 
 /* Over translucent glass the app's --muted grey reads too dim, so the agent
@@ -6710,9 +6793,6 @@ select.skill-input {
   border-color: var(--hairline-strong);
 }
 
-/* Latest thought, shown while the Thoughts block is collapsed (its default). */
-
-
 .agent-stream {
   flex: 1 1 auto;
   min-height: 0;
@@ -6721,6 +6801,26 @@ select.skill-input {
   flex-direction: column;
   gap: 10px;
   padding: 4px 2px;
+}
+
+/* Compact is the onboarding view: finished reasoning and unpaired legacy
+   output disappear, but live processing and every skill-call header remain.
+   Switching to Detailed restores those debugging surfaces. */
+.agent-panel.compact-activity .agent-stream {
+  gap: 6px;
+}
+
+.agent-panel.compact-activity .chat-thoughts:not(.active):not(.open),
+.agent-panel.compact-activity .chat-skill.orphan-output:not(.open) {
+  display: none;
+}
+
+.agent-panel.compact-activity .chat-thoughts:not(.open) .chat-thoughts-list {
+  display: none;
+}
+
+.agent-panel.compact-activity .chat-skill-head {
+  padding-block: 5px;
 }
 
 /* Reading surfaces are copy-paste material — chat history (discussion,

--- a/webapp/js/agent/activityView.js
+++ b/webapp/js/agent/activityView.js
@@ -2,31 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
 
-export const COMPACT_ACTIVITY_KEY = "innate.agentActivityCompact";
 export const SKILL_OUTPUT_LINK_WINDOW_SEC = 5;
-
-/**
- * Compact is the onboarding default. A saved explicit opt-out restores the
- * fuller debugging stream; unavailable storage must never break the panel.
- * @param {{ getItem: (key: string) => string | null } | null | undefined} storage
- */
-export function readCompactActivity(storage) {
-  try {
-    const saved = storage?.getItem(COMPACT_ACTIVITY_KEY);
-    return saved === null || saved === undefined ? true : saved !== "false";
-  } catch {
-    return true;
-  }
-}
-
-/** @param {{ setItem: (key: string, value: string) => void } | null | undefined} storage @param {boolean} compact */
-export function writeCompactActivity(storage, compact) {
-  try {
-    storage?.setItem(COMPACT_ACTIVITY_KEY, String(compact));
-  } catch {
-    // Private browsing / disabled storage: keep the in-memory toggle working.
-  }
-}
 
 /**
  * Status and chat_out are separate ROS topics, so allow a small amount of

--- a/webapp/js/agent/activityView.js
+++ b/webapp/js/agent/activityView.js
@@ -1,0 +1,58 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+
+export const COMPACT_ACTIVITY_KEY = "innate.agentActivityCompact";
+export const SKILL_OUTPUT_LINK_WINDOW_SEC = 5;
+
+/**
+ * Compact is the onboarding default. A saved explicit opt-out restores the
+ * fuller debugging stream; unavailable storage must never break the panel.
+ * @param {{ getItem: (key: string) => string | null } | null | undefined} storage
+ */
+export function readCompactActivity(storage) {
+  try {
+    const saved = storage?.getItem(COMPACT_ACTIVITY_KEY);
+    return saved === null || saved === undefined ? true : saved !== "false";
+  } catch {
+    return true;
+  }
+}
+
+/** @param {{ setItem: (key: string, value: string) => void } | null | undefined} storage @param {boolean} compact */
+export function writeCompactActivity(storage, compact) {
+  try {
+    storage?.setItem(COMPACT_ACTIVITY_KEY, String(compact));
+  } catch {
+    // Private browsing / disabled storage: keep the in-memory toggle working.
+  }
+}
+
+/**
+ * Status and chat_out are separate ROS topics, so allow a small amount of
+ * cross-topic reordering while refusing to attach a late output to a later run.
+ * @param {number} firstTs @param {number} secondTs @param {number} [windowSec]
+ */
+export function skillEventsAreAdjacent(firstTs, secondTs, windowSec = SKILL_OUTPUT_LINK_WINDOW_SEC) {
+  if (!Number.isFinite(firstTs) || !Number.isFinite(secondTs)) return false;
+  const delta = secondTs - firstTs;
+  return delta >= -1 && delta <= windowSec;
+}
+
+/**
+ * Find an exact-text legacy/status pair without guessing based on whichever
+ * skill happened to finish most recently.
+ * @param {{ text: string, ts: number }[]} candidates
+ * @param {string} text
+ * @param {number} ts
+ * @param {boolean} [candidateIsFirst]
+ */
+export function findMatchingOutputIndex(candidates, text, ts, candidateIsFirst = true) {
+  return candidates.findIndex(
+    (candidate) =>
+      candidate.text === text &&
+      (candidateIsFirst
+        ? skillEventsAreAdjacent(candidate.ts, ts)
+        : skillEventsAreAdjacent(ts, candidate.ts)),
+  );
+}

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -14,12 +14,7 @@
 // (it originated in the old teleop chat pane, since removed).
 
 import { copyText } from "../clipboard.js";
-import {
-  findMatchingOutputIndex,
-  readCompactActivity,
-  SKILL_OUTPUT_LINK_WINDOW_SEC,
-  writeCompactActivity,
-} from "./activityView.js";
+import { findMatchingOutputIndex, SKILL_OUTPUT_LINK_WINDOW_SEC } from "./activityView.js";
 import { createMicStream } from "./micStream.js";
 import {
   AGENT_STATUS_TOPIC,
@@ -136,26 +131,10 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   activeSkill.append(activeSkillLabel, activeSkillName);
 
   // ---- live stream (thoughts + chat + skill runs) -------------------------
-  const streamHead = document.createElement("div");
-  streamHead.className = "agent-stream-head";
   const streamLabel = document.createElement("p");
   streamLabel.className = "microlabel agent-stream-label";
   streamLabel.textContent = "Activity";
   streamLabel.title = `the brain's thoughts, chat, and skill runs — ${CHAT_OUT_TOPIC}`;
-
-  const compactToggle = document.createElement("button");
-  compactToggle.type = "button";
-  compactToggle.className = "agent-compact-toggle mono";
-  compactToggle.setAttribute("role", "switch");
-  compactToggle.setAttribute("aria-label", "Use compact activity view");
-  const compactLabel = document.createElement("span");
-  compactLabel.textContent = "Compact";
-  const compactTrack = document.createElement("span");
-  compactTrack.className = "agent-compact-track";
-  compactTrack.setAttribute("aria-hidden", "true");
-  compactTrack.appendChild(document.createElement("span"));
-  compactToggle.append(compactLabel, compactTrack);
-  streamHead.append(streamLabel, compactToggle);
 
   const stream = document.createElement("div");
   stream.className = "agent-stream";
@@ -174,57 +153,8 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   send.title = CHAT_IN_TOPIC;
   form.append(input, send);
 
-  panel.append(head, controls, activeSkill, streamHead, stream, form);
+  panel.append(head, controls, activeSkill, streamLabel, stream, form);
   root.append(panel);
-
-  let compactActivity = true;
-  try {
-    compactActivity = readCompactActivity(localStorage);
-  } catch {
-    // Accessing localStorage itself can throw on a locked-down origin.
-  }
-
-  /** @param {boolean} compact @param {boolean} [persist] */
-  function setCompactActivity(compact, persist = false) {
-    const wasAtBottom = atBottom();
-    compactActivity = compact;
-    panel.classList.toggle("compact-activity", compact);
-    compactToggle.classList.toggle("on", compact);
-    compactToggle.setAttribute("aria-checked", String(compact));
-    compactToggle.title = compact
-      ? "Compact view is on — show completed reasoning and legacy outputs"
-      : "Hide completed reasoning and legacy outputs";
-    if (compact) {
-      for (const block of stream.querySelectorAll(".chat-thoughts.open")) {
-        block.classList.remove("open");
-        const toggle = block.querySelector(".chat-thoughts-toggle");
-        const arrow = block.querySelector(".chat-thoughts-arrow");
-        toggle?.setAttribute("aria-expanded", "false");
-        if (arrow) arrow.textContent = "▾";
-      }
-      for (const block of stream.querySelectorAll(".chat-skill.open:not(.failed)")) {
-        block.classList.remove("open");
-        const head = block.querySelector(".chat-skill-head");
-        const arrow = block.querySelector(".chat-skill-chevron");
-        const detail = block.querySelector(".chat-skill-detail");
-        head?.setAttribute("aria-expanded", "false");
-        detail?.setAttribute("aria-hidden", "true");
-        if (detail instanceof HTMLElement) detail.hidden = true;
-        if (arrow) arrow.textContent = "▾";
-      }
-    }
-    if (persist) {
-      try {
-        writeCompactActivity(localStorage, compact);
-      } catch {
-        // Keep the toggle functional when the storage getter is blocked.
-      }
-    }
-    snapIfAtBottom(wasAtBottom);
-  }
-
-  compactToggle.addEventListener("click", () => setCompactActivity(!compactActivity, true));
-  setCompactActivity(compactActivity);
 
   // ---- directive roster + start/stop --------------------------------------
   // The dropdown ARMS a directive; Start activates it. While active, switching
@@ -363,7 +293,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   let thoughts = null;
   let lastTs = 0;
 
-  /** @typedef {{ wrap: HTMLElement, head: HTMLElement, args: HTMLElement, status: HTMLElement, detail: HTMLElement | null, chevron: HTMLElement | null }} SkillRunView */
+  /** @typedef {{ wrap: HTMLElement, head: HTMLElement, status: HTMLElement, detail: HTMLElement | null, chevron: HTMLElement | null, inputsText: string, resultText: string, resultLabel: string, roundResult: boolean }} SkillRunView */
   /** @typedef {{ text: string, ts: number }} LegacyOutputEcho */
   /** @typedef {{ run: SkillRunView, text: string, ts: number }} OrphanOutput */
   /** Authoritative status outputs awaiting their identical legacy chat copy. @type {LegacyOutputEcho[]} */
@@ -479,15 +409,23 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     const nameEl = document.createElement("span");
     nameEl.className = "chat-skill-name";
     nameEl.textContent = name.replace(/_/g, " ");
-    const argsEl = document.createElement("span");
-    argsEl.className = "chat-skill-args mono";
     const statusEl = document.createElement("span");
     statusEl.className = "chat-skill-status mono";
     statusEl.title = SKILL_STATUS_UPDATE_TOPIC;
-    head.append(tag, nameEl, argsEl, statusEl);
+    head.append(tag, nameEl, statusEl);
     wrap.append(head);
     /** @type {SkillRunView} */
-    const run = { wrap, head, args: argsEl, status: statusEl, detail: null, chevron: null };
+    const run = {
+      wrap,
+      head,
+      status: statusEl,
+      detail: null,
+      chevron: null,
+      inputsText: "",
+      resultText: "",
+      resultLabel: "Output",
+      roundResult: true,
+    };
     const toggleDetail = () => {
       if (!run.detail) return;
       const wasAtBottom = atBottom();
@@ -495,6 +433,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       run.head.setAttribute("aria-expanded", String(open));
       run.detail.setAttribute("aria-hidden", String(!open));
       run.detail.hidden = !open;
+      run.head.title = open ? "Close skill details" : "Open skill details";
       if (run.chevron) run.chevron.textContent = open ? "▴" : "▾";
       snapIfAtBottom(wasAtBottom);
     };
@@ -507,29 +446,67 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     return run;
   }
 
-  /** @param {SkillRunView} run @param {string} text @param {{ open?: boolean, title?: string, round?: boolean }} [opts] */
-  function attachSkillDetail(run, text, opts = {}) {
+  /** @param {SkillRunView} run */
+  function ensureSkillDetail(run) {
     if (!run.detail) {
       run.detail = document.createElement("div");
       run.detail.className = "chat-skill-detail";
       run.detail.id = `skill-detail-${crypto.randomUUID?.() ?? `${Date.now()}-${Math.random()}`}`;
       run.chevron = document.createElement("span");
       run.chevron.className = "chat-skill-chevron mono";
+      run.chevron.setAttribute("aria-hidden", "true");
+      run.chevron.textContent = "▾";
       run.head.appendChild(run.chevron);
       run.wrap.appendChild(run.detail);
       run.wrap.classList.add("has-detail");
       run.head.tabIndex = 0;
       run.head.setAttribute("role", "button");
       run.head.setAttribute("aria-controls", run.detail.id);
+      run.head.title = "Open skill details";
     }
-    run.detail.textContent = opts.round === false ? text : roundNums(text);
-    run.head.title = opts.title || "Show or hide skill details";
-    const open = !!opts.open;
+  }
+
+  /** @param {SkillRunView} run @param {{ open?: boolean }} [opts] */
+  function renderSkillDetail(run, opts = {}) {
+    ensureSkillDetail(run);
+    if (!run.detail) return;
+    /** @type {HTMLElement[]} */
+    const sections = [];
+    /** @param {string} label @param {string} text @param {string} kind */
+    const section = (label, text, kind) => {
+      const wrap = document.createElement("div");
+      wrap.className = `chat-skill-detail-section ${kind}`;
+      const labelEl = document.createElement("span");
+      labelEl.className = "chat-skill-detail-label mono";
+      labelEl.textContent = label;
+      const value = document.createElement("div");
+      value.className = `chat-skill-detail-value${kind === "inputs" ? " mono" : ""}`;
+      value.textContent = text;
+      wrap.append(labelEl, value);
+      return wrap;
+    };
+    if (run.inputsText) sections.push(section("Inputs", run.inputsText, "inputs"));
+    if (run.resultText) {
+      sections.push(
+        section(run.resultLabel, run.roundResult ? roundNums(run.resultText) : run.resultText, "result"),
+      );
+    }
+    run.detail.replaceChildren(...sections);
+    const open = opts.open ?? run.wrap.classList.contains("open");
     run.wrap.classList.toggle("open", open);
     run.head.setAttribute("aria-expanded", String(open));
     run.detail.setAttribute("aria-hidden", String(!open));
     run.detail.hidden = !open;
+    run.head.title = open ? "Close skill details" : "Open skill details";
     if (run.chevron) run.chevron.textContent = open ? "▴" : "▾";
+  }
+
+  /** @param {SkillRunView} run @param {string} text @param {{ open?: boolean, label?: string, round?: boolean }} [opts] */
+  function attachSkillDetail(run, text, opts = {}) {
+    run.resultText = text;
+    run.resultLabel = opts.label || "Output";
+    run.roundResult = opts.round !== false;
+    renderSkillDetail(run, { open: opts.open });
   }
 
   /** @param {string} text @param {number} ts */
@@ -545,11 +522,12 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       return;
     }
 
-    // Old history may contain output without its status row. Keep it reachable
-    // in Detailed mode, but never guess which output-less call it belongs to.
+    // Old history may contain output without its status row. Retain a hidden
+    // fallback briefly so a reordered authoritative status can reconcile it,
+    // but never guess which output-less call it belongs to or add standalone clutter.
     const run = createSkillRow("output");
     run.wrap.classList.add("completed", "orphan-output");
-    attachSkillDetail(run, text, { title: "Show or hide skill output" });
+    attachSkillDetail(run, text);
     stream.appendChild(run.wrap);
     orphanOutputs.push({ run, text, ts });
     lastTs = ts;
@@ -585,16 +563,16 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     // Terminal updates repeat the inputs; keep the last non-empty rendering so
     // a publisher that omits them can't blank args the run already showed.
     const inputs = formatSkillArgs(args);
-    if (inputs.text) {
-      run.args.textContent = inputs.text;
-      run.args.title = inputs.full;
+    if (inputs) {
+      run.inputsText = inputs;
+      renderSkillDetail(run);
     }
     run.status.textContent = cls;
 
     // A failed run carries the failure reason / error — show it expanded
     // in-place (collapsible so a long trace can be tucked away).
-    if (cls === "failed" && reason && !run.detail) {
-      attachSkillDetail(run, reason, { open: true, title: "Show or hide the failure reason", round: false });
+    if (cls === "failed" && reason) {
+      attachSkillDetail(run, reason, { open: true, label: "Error", round: false });
     }
 
     const outputText = typeof output === "string" && output.trim() ? output : "";
@@ -604,7 +582,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
         orphanOutputs[orphanIndex].run.wrap.remove();
         orphanOutputs.splice(orphanIndex, 1);
       }
-      attachSkillDetail(run, outputText, { title: "Show or hide skill output" });
+      attachSkillDetail(run, outputText);
       if (orphanIndex < 0) {
         pendingLegacyOutputs.push({ text: outputText, ts });
       }
@@ -837,28 +815,23 @@ function viewButton(label, title) {
 }
 
 /**
- * A skill's inputs on one line: `text` clipped for the run's header row, `full`
- * intact for its hover title. A lone input reads better as its bare value
- * ("head emotion  happy") — the skill name already says what it is; several
- * need their keys to stay legible.
+ * A skill's full inputs for its expanded detail. A lone input reads better as
+ * its bare value ("head emotion  happy") — the skill name already says what
+ * it is; several need their keys to stay legible.
  * @param {any} args
- * @returns {{ text: string, full: string }}
+ * @returns {string}
  */
 function formatSkillArgs(args) {
-  if (!args || typeof args !== "object" || Array.isArray(args)) return { text: "", full: "" };
+  if (!args || typeof args !== "object" || Array.isArray(args)) return "";
   const entries = Object.entries(args).filter(([, v]) => v !== null && v !== undefined && v !== "");
-  if (entries.length === 0) return { text: "", full: "" };
-  const show = (/** @type {any} */ v) => roundNums(typeof v === "object" ? JSON.stringify(v) : String(v));
+  if (entries.length === 0) return "";
+  const show = (/** @type {any} */ v) =>
+    typeof v === "number" ? roundNums(String(v)) : typeof v === "object" ? JSON.stringify(v) : String(v);
   const line = (/** @type {(v: any) => string} */ value) =>
     entries.length === 1
       ? value(entries[0][1])
       : entries.map(([k, v]) => `${k.replace(/_/g, " ")}: ${value(v)}`).join(" · ");
-  return { text: line((v) => clip(show(v), 40)), full: line(show) };
-}
-
-/** @param {string} text @param {number} max */
-function clip(text, max) {
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+  return line(show);
 }
 
 /**

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -14,6 +14,12 @@
 // (it originated in the old teleop chat pane, since removed).
 
 import { copyText } from "../clipboard.js";
+import {
+  findMatchingOutputIndex,
+  readCompactActivity,
+  SKILL_OUTPUT_LINK_WINDOW_SEC,
+  writeCompactActivity,
+} from "./activityView.js";
 import { createMicStream } from "./micStream.js";
 import {
   AGENT_STATUS_TOPIC,
@@ -130,10 +136,26 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   activeSkill.append(activeSkillLabel, activeSkillName);
 
   // ---- live stream (thoughts + chat + skill runs) -------------------------
+  const streamHead = document.createElement("div");
+  streamHead.className = "agent-stream-head";
   const streamLabel = document.createElement("p");
   streamLabel.className = "microlabel agent-stream-label";
-  streamLabel.textContent = "AI thoughts";
+  streamLabel.textContent = "Activity";
   streamLabel.title = `the brain's thoughts, chat, and skill runs — ${CHAT_OUT_TOPIC}`;
+
+  const compactToggle = document.createElement("button");
+  compactToggle.type = "button";
+  compactToggle.className = "agent-compact-toggle mono";
+  compactToggle.setAttribute("role", "switch");
+  compactToggle.setAttribute("aria-label", "Use compact activity view");
+  const compactLabel = document.createElement("span");
+  compactLabel.textContent = "Compact";
+  const compactTrack = document.createElement("span");
+  compactTrack.className = "agent-compact-track";
+  compactTrack.setAttribute("aria-hidden", "true");
+  compactTrack.appendChild(document.createElement("span"));
+  compactToggle.append(compactLabel, compactTrack);
+  streamHead.append(streamLabel, compactToggle);
 
   const stream = document.createElement("div");
   stream.className = "agent-stream";
@@ -152,8 +174,57 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   send.title = CHAT_IN_TOPIC;
   form.append(input, send);
 
-  panel.append(head, controls, activeSkill, streamLabel, stream, form);
+  panel.append(head, controls, activeSkill, streamHead, stream, form);
   root.append(panel);
+
+  let compactActivity = true;
+  try {
+    compactActivity = readCompactActivity(localStorage);
+  } catch {
+    // Accessing localStorage itself can throw on a locked-down origin.
+  }
+
+  /** @param {boolean} compact @param {boolean} [persist] */
+  function setCompactActivity(compact, persist = false) {
+    const wasAtBottom = atBottom();
+    compactActivity = compact;
+    panel.classList.toggle("compact-activity", compact);
+    compactToggle.classList.toggle("on", compact);
+    compactToggle.setAttribute("aria-checked", String(compact));
+    compactToggle.title = compact
+      ? "Compact view is on — show completed reasoning and legacy outputs"
+      : "Hide completed reasoning and legacy outputs";
+    if (compact) {
+      for (const block of stream.querySelectorAll(".chat-thoughts.open")) {
+        block.classList.remove("open");
+        const toggle = block.querySelector(".chat-thoughts-toggle");
+        const arrow = block.querySelector(".chat-thoughts-arrow");
+        toggle?.setAttribute("aria-expanded", "false");
+        if (arrow) arrow.textContent = "▾";
+      }
+      for (const block of stream.querySelectorAll(".chat-skill.open:not(.failed)")) {
+        block.classList.remove("open");
+        const head = block.querySelector(".chat-skill-head");
+        const arrow = block.querySelector(".chat-skill-chevron");
+        const detail = block.querySelector(".chat-skill-detail");
+        head?.setAttribute("aria-expanded", "false");
+        detail?.setAttribute("aria-hidden", "true");
+        if (detail instanceof HTMLElement) detail.hidden = true;
+        if (arrow) arrow.textContent = "▾";
+      }
+    }
+    if (persist) {
+      try {
+        writeCompactActivity(localStorage, compact);
+      } catch {
+        // Keep the toggle functional when the storage getter is blocked.
+      }
+    }
+    snapIfAtBottom(wasAtBottom);
+  }
+
+  compactToggle.addEventListener("click", () => setCompactActivity(!compactActivity, true));
+  setCompactActivity(compactActivity);
 
   // ---- directive roster + start/stop --------------------------------------
   // The dropdown ARMS a directive; Start activates it. While active, switching
@@ -292,6 +363,24 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   let thoughts = null;
   let lastTs = 0;
 
+  /** @typedef {{ wrap: HTMLElement, head: HTMLElement, args: HTMLElement, status: HTMLElement, detail: HTMLElement | null, chevron: HTMLElement | null }} SkillRunView */
+  /** @typedef {{ text: string, ts: number }} LegacyOutputEcho */
+  /** @typedef {{ run: SkillRunView, text: string, ts: number }} OrphanOutput */
+  /** Authoritative status outputs awaiting their identical legacy chat copy. @type {LegacyOutputEcho[]} */
+  let pendingLegacyOutputs = [];
+  /** Legacy chat copies that arrived before their authoritative status event. @type {OrphanOutput[]} */
+  let orphanOutputs = [];
+
+  /** Drop bookkeeping only after an entry is too old to match by definition. @param {number} referenceTs */
+  function pruneOutputQueues(referenceTs) {
+    pendingLegacyOutputs = pendingLegacyOutputs.filter(
+      (candidate) => referenceTs - candidate.ts <= SKILL_OUTPUT_LINK_WINDOW_SEC,
+    );
+    // A legacy output may precede its authoritative status by at most the
+    // one-second cross-topic reorder grace in skillEventsAreAdjacent().
+    orphanOutputs = orphanOutputs.filter((candidate) => referenceTs - candidate.ts <= 1);
+  }
+
   /** @param {boolean} active */
   function setThoughtsStatus(active) {
     if (!thoughts) return;
@@ -328,9 +417,15 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       toggle.append(label, status, arrow);
       const list = document.createElement("div");
       list.className = "chat-thoughts-list";
+      list.id = `thoughts-${crypto.randomUUID?.() ?? `${Date.now()}-${Math.random()}`}`;
+      toggle.setAttribute("aria-controls", list.id);
+      toggle.setAttribute("aria-expanded", "false");
       toggle.addEventListener("click", () => {
+        const wasAtBottom = atBottom();
         const open = wrap.classList.toggle("open");
+        toggle.setAttribute("aria-expanded", String(open));
         arrow.textContent = open ? "▴" : "▾";
+        snapIfAtBottom(wasAtBottom);
       });
       wrap.append(toggle, list);
       stream.appendChild(wrap);
@@ -369,13 +464,103 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     snapIfAtBottom(wasAtBottom);
   }
 
-  /** @type {Map<string, { wrap: HTMLElement, head: HTMLElement, args: HTMLElement, status: HTMLElement, hasDetail: boolean }>} */
+  /** @type {Map<string, SkillRunView>} */
   const skillRuns = new Map();
 
-  /** @param {string} key @param {string} name @param {string} status @param {number} ts @param {string} [reason]
-   *  @param {any} [args] */
-  function addSkillRun(key, name, status, ts, reason, args) {
+  /** @param {string} name @param {string} [tagText] @returns {SkillRunView} */
+  function createSkillRow(name, tagText = "skill") {
+    const wrap = document.createElement("div");
+    wrap.className = "chat-skill";
+    const head = document.createElement("div");
+    head.className = "chat-skill-head";
+    const tag = document.createElement("span");
+    tag.className = "chat-skill-tag mono";
+    tag.textContent = tagText;
+    const nameEl = document.createElement("span");
+    nameEl.className = "chat-skill-name";
+    nameEl.textContent = name.replace(/_/g, " ");
+    const argsEl = document.createElement("span");
+    argsEl.className = "chat-skill-args mono";
+    const statusEl = document.createElement("span");
+    statusEl.className = "chat-skill-status mono";
+    statusEl.title = SKILL_STATUS_UPDATE_TOPIC;
+    head.append(tag, nameEl, argsEl, statusEl);
+    wrap.append(head);
+    /** @type {SkillRunView} */
+    const run = { wrap, head, args: argsEl, status: statusEl, detail: null, chevron: null };
+    const toggleDetail = () => {
+      if (!run.detail) return;
+      const wasAtBottom = atBottom();
+      const open = run.wrap.classList.toggle("open");
+      run.head.setAttribute("aria-expanded", String(open));
+      run.detail.setAttribute("aria-hidden", String(!open));
+      run.detail.hidden = !open;
+      if (run.chevron) run.chevron.textContent = open ? "▴" : "▾";
+      snapIfAtBottom(wasAtBottom);
+    };
+    head.addEventListener("click", toggleDetail);
+    head.addEventListener("keydown", (event) => {
+      if (!run.detail || (event.key !== "Enter" && event.key !== " ")) return;
+      event.preventDefault();
+      toggleDetail();
+    });
+    return run;
+  }
+
+  /** @param {SkillRunView} run @param {string} text @param {{ open?: boolean, title?: string, round?: boolean }} [opts] */
+  function attachSkillDetail(run, text, opts = {}) {
+    if (!run.detail) {
+      run.detail = document.createElement("div");
+      run.detail.className = "chat-skill-detail";
+      run.detail.id = `skill-detail-${crypto.randomUUID?.() ?? `${Date.now()}-${Math.random()}`}`;
+      run.chevron = document.createElement("span");
+      run.chevron.className = "chat-skill-chevron mono";
+      run.head.appendChild(run.chevron);
+      run.wrap.appendChild(run.detail);
+      run.wrap.classList.add("has-detail");
+      run.head.tabIndex = 0;
+      run.head.setAttribute("role", "button");
+      run.head.setAttribute("aria-controls", run.detail.id);
+    }
+    run.detail.textContent = opts.round === false ? text : roundNums(text);
+    run.head.title = opts.title || "Show or hide skill details";
+    const open = !!opts.open;
+    run.wrap.classList.toggle("open", open);
+    run.head.setAttribute("aria-expanded", String(open));
+    run.detail.setAttribute("aria-hidden", String(!open));
+    run.detail.hidden = !open;
+    if (run.chevron) run.chevron.textContent = open ? "▴" : "▾";
+  }
+
+  /** @param {string} text @param {number} ts */
+  function addSkillOutput(text, ts) {
     const wasAtBottom = atBottom();
+    finalizeThoughts();
+    pruneOutputQueues(ts);
+
+    const echoIndex = findMatchingOutputIndex(pendingLegacyOutputs, text, ts);
+    if (echoIndex >= 0) {
+      pendingLegacyOutputs.splice(echoIndex, 1);
+      lastTs = ts;
+      return;
+    }
+
+    // Old history may contain output without its status row. Keep it reachable
+    // in Detailed mode, but never guess which output-less call it belongs to.
+    const run = createSkillRow("output");
+    run.wrap.classList.add("completed", "orphan-output");
+    attachSkillDetail(run, text, { title: "Show or hide skill output" });
+    stream.appendChild(run.wrap);
+    orphanOutputs.push({ run, text, ts });
+    lastTs = ts;
+    snapIfAtBottom(wasAtBottom);
+  }
+
+  /** @param {string} key @param {string} name @param {string} status @param {number} ts @param {string} [reason]
+   *  @param {any} [args] @param {string} [output] */
+  function addSkillRun(key, name, status, ts, reason, args, output) {
+    const wasAtBottom = atBottom();
+    pruneOutputQueues(ts);
     const cls = ["running", "completed", "failed", "interrupted"].includes(status) ? status : "running";
     // Reflect the running primitive in the Active Skill readout.
     if (cls === "running") {
@@ -389,29 +574,14 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     let run = skillRuns.get(key);
     if (!run) {
       finalizeThoughts();
-      const wrap = document.createElement("div");
-      wrap.className = "chat-skill";
-      const head = document.createElement("div");
-      head.className = "chat-skill-head";
-      const tag = document.createElement("span");
-      tag.className = "chat-skill-tag mono";
-      tag.textContent = "skill";
-      const nameEl = document.createElement("span");
-      nameEl.className = "chat-skill-name";
-      nameEl.textContent = name.replace(/_/g, " ");
-      const argsEl = document.createElement("span");
-      argsEl.className = "chat-skill-args mono";
-      const statusEl = document.createElement("span");
-      statusEl.className = "chat-skill-status mono";
-      statusEl.title = SKILL_STATUS_UPDATE_TOPIC;
-      head.append(tag, nameEl, argsEl, statusEl);
-      wrap.append(head);
-      stream.appendChild(wrap);
-      run = { wrap, head, args: argsEl, status: statusEl, hasDetail: false };
+      run = createSkillRow(name);
+      stream.appendChild(run.wrap);
       skillRuns.set(key, run);
     }
+    const wasOpen = run.wrap.classList.contains("open");
     run.wrap.className = `chat-skill ${cls}`;
-    if (run.hasDetail) run.wrap.classList.add("has-detail");
+    if (run.detail) run.wrap.classList.add("has-detail");
+    if (wasOpen) run.wrap.classList.add("open");
     // Terminal updates repeat the inputs; keep the last non-empty rendering so
     // a publisher that omits them can't blank args the run already showed.
     const inputs = formatSkillArgs(args);
@@ -423,22 +593,21 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
 
     // A failed run carries the failure reason / error — show it expanded
     // in-place (collapsible so a long trace can be tucked away).
-    if (cls === "failed" && reason && !run.hasDetail) {
-      run.hasDetail = true;
-      run.wrap.classList.add("has-detail", "open");
-      run.head.title = "Click to show/hide the failure reason";
-      const chevron = document.createElement("span");
-      chevron.className = "chat-skill-chevron mono";
-      chevron.textContent = "▴";
-      run.head.appendChild(chevron);
-      const detail = document.createElement("div");
-      detail.className = "chat-skill-detail";
-      detail.textContent = reason;
-      run.wrap.appendChild(detail);
-      run.head.addEventListener("click", () => {
-        const open = run.wrap.classList.toggle("open");
-        chevron.textContent = open ? "▴" : "▾";
-      });
+    if (cls === "failed" && reason && !run.detail) {
+      attachSkillDetail(run, reason, { open: true, title: "Show or hide the failure reason", round: false });
+    }
+
+    const outputText = typeof output === "string" && output.trim() ? output : "";
+    if (cls === "completed" && outputText) {
+      const orphanIndex = findMatchingOutputIndex(orphanOutputs, outputText, ts, false);
+      if (orphanIndex >= 0) {
+        orphanOutputs[orphanIndex].run.wrap.remove();
+        orphanOutputs.splice(orphanIndex, 1);
+      }
+      attachSkillDetail(run, outputText, { title: "Show or hide skill output" });
+      if (orphanIndex < 0) {
+        pendingLegacyOutputs.push({ text: outputText, ts });
+      }
     }
 
     lastTs = ts;
@@ -523,6 +692,8 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     stream.replaceChildren();
     thoughts = null;
     skillRuns.clear();
+    pendingLegacyOutputs = [];
+    orphanOutputs = [];
     lastTs = 0;
     for (const e of entries) replayEntry(e);
     historyLoaded = true;
@@ -539,7 +710,15 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       const status = String(e?.taskStatus ?? "");
       if (!name || !status) return;
       const key = String(e?.primitiveId ?? e?.skillId ?? name);
-      addSkillRun(key, name, status, ts, typeof e?.failureReason === "string" ? e.failureReason : "", e?.args);
+      addSkillRun(
+        key,
+        name,
+        status,
+        ts,
+        typeof e?.failureReason === "string" ? e.failureReason : "",
+        e?.args,
+        typeof e?.output === "string" ? e.output : "",
+      );
       return;
     }
     const text = String(e?.text ?? "");
@@ -548,6 +727,8 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       addThought(sender, text, ts);
     } else if (sender === "vision_agent_output") {
       return; // raw vision dumps — noisy, drop (matches live)
+    } else if (sender === "skill_output") {
+      addSkillOutput(text, ts);
     } else if (sender === "user" || sender === "robot") {
       addMessage(sender, text, ts);
     } else {
@@ -591,6 +772,8 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       addThought(sender, text, ts);
     } else if (sender === "vision_agent_output") {
       return; // raw vision dumps — noisy, drop
+    } else if (sender === "skill_output") {
+      addSkillOutput(text, ts);
     } else if (sender === "user" || sender === "robot") {
       addMessage(sender, text, ts);
     } else {
@@ -611,7 +794,15 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     if (!name || !status) return;
     const key = String(payload?.primitive_id ?? payload?.skill_id ?? name);
     const reason = typeof payload?.reason === "string" ? payload.reason : "";
-    addSkillRun(key, name, status, Number(payload?.timestamp) || Date.now() / 1000, reason, payload?.args);
+    addSkillRun(
+      key,
+      name,
+      status,
+      Number(payload?.timestamp) || Date.now() / 1000,
+      reason,
+      payload?.args,
+      typeof payload?.output === "string" ? payload.output : "",
+    );
   }, undefined, "std_msgs/msg/String");
 
   return {

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -293,13 +293,25 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   let thoughts = null;
   let lastTs = 0;
 
-  /** @typedef {{ wrap: HTMLElement, head: HTMLElement, status: HTMLElement, detail: HTMLElement | null, chevron: HTMLElement | null, inputsText: string, resultText: string, resultLabel: string, roundResult: boolean }} SkillRunView */
+  /** @typedef {{ wrap: HTMLElement, head: HTMLElement, status: HTMLElement, detail: HTMLElement | null, chevron: HTMLElement | null, inputsText: string, resultText: string, resultLabel: string }} SkillRunView */
   /** @typedef {{ text: string, ts: number }} LegacyOutputEcho */
   /** @typedef {{ run: SkillRunView, text: string, ts: number }} OrphanOutput */
   /** Authoritative status outputs awaiting their identical legacy chat copy. @type {LegacyOutputEcho[]} */
   let pendingLegacyOutputs = [];
   /** Legacy chat copies that arrived before their authoritative status event. @type {OrphanOutput[]} */
   let orphanOutputs = [];
+  /** Idle streams get no pruning events, so a timer surfaces a trailing orphan. */
+  const ORPHAN_REVEAL_MS = 1500;
+
+  /** @param {OrphanOutput} orphan */
+  function revealOrphan(orphan) {
+    const index = orphanOutputs.indexOf(orphan);
+    if (index < 0) return;
+    const wasAtBottom = atBottom();
+    orphanOutputs.splice(index, 1);
+    orphan.run.wrap.classList.remove("orphan-output");
+    snapIfAtBottom(wasAtBottom);
+  }
 
   /** Drop bookkeeping only after an entry is too old to match by definition. @param {number} referenceTs */
   function pruneOutputQueues(referenceTs) {
@@ -307,8 +319,11 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       (candidate) => referenceTs - candidate.ts <= SKILL_OUTPUT_LINK_WINDOW_SEC,
     );
     // A legacy output may precede its authoritative status by at most the
-    // one-second cross-topic reorder grace in skillEventsAreAdjacent().
-    orphanOutputs = orphanOutputs.filter((candidate) => referenceTs - candidate.ts <= 1);
+    // one-second cross-topic reorder grace in skillEventsAreAdjacent(); past
+    // that no status is coming, so the row surfaces instead of hiding forever.
+    for (const orphan of orphanOutputs.filter((candidate) => referenceTs - candidate.ts > 1)) {
+      revealOrphan(orphan);
+    }
   }
 
   /** @param {boolean} active */
@@ -397,15 +412,19 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   /** @type {Map<string, SkillRunView>} */
   const skillRuns = new Map();
 
-  /** @param {string} name @param {string} [tagText] @returns {SkillRunView} */
-  function createSkillRow(name, tagText = "skill") {
+  /** @param {string} name @returns {SkillRunView} */
+  function createSkillRow(name) {
     const wrap = document.createElement("div");
     wrap.className = "chat-skill";
-    const head = document.createElement("div");
+    // A real <button> gives the disclosure focus and Enter/Space for free;
+    // tabindex -1 keeps detail-less rows out of the tab order until one exists.
+    const head = document.createElement("button");
+    head.type = "button";
+    head.tabIndex = -1;
     head.className = "chat-skill-head";
     const tag = document.createElement("span");
     tag.className = "chat-skill-tag mono";
-    tag.textContent = tagText;
+    tag.textContent = "skill";
     const nameEl = document.createElement("span");
     nameEl.className = "chat-skill-name";
     nameEl.textContent = name.replace(/_/g, " ");
@@ -424,26 +443,25 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       inputsText: "",
       resultText: "",
       resultLabel: "Output",
-      roundResult: true,
     };
-    const toggleDetail = () => {
+    head.addEventListener("click", () => {
       if (!run.detail) return;
       const wasAtBottom = atBottom();
-      const open = run.wrap.classList.toggle("open");
-      run.head.setAttribute("aria-expanded", String(open));
-      run.detail.setAttribute("aria-hidden", String(!open));
-      run.detail.hidden = !open;
-      run.head.title = open ? "Close skill details" : "Open skill details";
-      if (run.chevron) run.chevron.textContent = open ? "▴" : "▾";
+      setDetailOpen(run, !run.wrap.classList.contains("open"));
       snapIfAtBottom(wasAtBottom);
-    };
-    head.addEventListener("click", toggleDetail);
-    head.addEventListener("keydown", (event) => {
-      if (!run.detail || (event.key !== "Enter" && event.key !== " ")) return;
-      event.preventDefault();
-      toggleDetail();
     });
     return run;
+  }
+
+  /** @param {SkillRunView} run @param {boolean} open */
+  function setDetailOpen(run, open) {
+    if (!run.detail) return;
+    run.wrap.classList.toggle("open", open);
+    run.head.setAttribute("aria-expanded", String(open));
+    run.detail.setAttribute("aria-hidden", String(!open));
+    run.detail.hidden = !open;
+    run.head.title = open ? "Close skill details" : "Open skill details";
+    if (run.chevron) run.chevron.textContent = open ? "▴" : "▾";
   }
 
   /** @param {SkillRunView} run */
@@ -459,8 +477,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       run.head.appendChild(run.chevron);
       run.wrap.appendChild(run.detail);
       run.wrap.classList.add("has-detail");
-      run.head.tabIndex = 0;
-      run.head.setAttribute("role", "button");
+      run.head.removeAttribute("tabindex");
       run.head.setAttribute("aria-controls", run.detail.id);
       run.head.title = "Open skill details";
     }
@@ -470,66 +487,66 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   function renderSkillDetail(run, opts = {}) {
     ensureSkillDetail(run);
     if (!run.detail) return;
-    /** @type {HTMLElement[]} */
-    const sections = [];
-    /** @param {string} label @param {string} text @param {string} kind */
-    const section = (label, text, kind) => {
-      const wrap = document.createElement("div");
-      wrap.className = `chat-skill-detail-section ${kind}`;
-      const labelEl = document.createElement("span");
-      labelEl.className = "chat-skill-detail-label mono";
-      labelEl.textContent = label;
-      const value = document.createElement("div");
-      value.className = `chat-skill-detail-value${kind === "inputs" ? " mono" : ""}`;
-      value.textContent = text;
-      wrap.append(labelEl, value);
-      return wrap;
+    const detail = run.detail;
+    // Update in place — these surfaces are copy-paste material, and a rebuild
+    // would wipe a selection when the terminal status repeats the inputs.
+    /** @param {string} kind @param {string} label @param {string} text */
+    const upsert = (kind, label, text) => {
+      let sectionEl = detail.querySelector(`:scope > .${kind}`);
+      if (!sectionEl) {
+        sectionEl = document.createElement("div");
+        sectionEl.className = `chat-skill-detail-section ${kind}`;
+        const labelEl = document.createElement("span");
+        labelEl.className = "chat-skill-detail-label mono";
+        const value = document.createElement("div");
+        value.className = `chat-skill-detail-value${kind === "inputs" ? " mono" : ""}`;
+        sectionEl.append(labelEl, value);
+        // Inputs always land before the result, so append order is document order.
+        detail.appendChild(sectionEl);
+      }
+      const [labelEl, value] = sectionEl.children;
+      if (labelEl.textContent !== label) labelEl.textContent = label;
+      if (value.textContent !== text) value.textContent = text;
     };
-    if (run.inputsText) sections.push(section("Inputs", run.inputsText, "inputs"));
-    if (run.resultText) {
-      sections.push(
-        section(run.resultLabel, run.roundResult ? roundNums(run.resultText) : run.resultText, "result"),
-      );
-    }
-    run.detail.replaceChildren(...sections);
-    const open = opts.open ?? run.wrap.classList.contains("open");
-    run.wrap.classList.toggle("open", open);
-    run.head.setAttribute("aria-expanded", String(open));
-    run.detail.setAttribute("aria-hidden", String(!open));
-    run.detail.hidden = !open;
-    run.head.title = open ? "Close skill details" : "Open skill details";
-    if (run.chevron) run.chevron.textContent = open ? "▴" : "▾";
+    if (run.inputsText) upsert("inputs", "Inputs", run.inputsText);
+    // Result text renders verbatim: the backend preserves skill output exactly,
+    // and roundNums would corrupt IPs and version strings.
+    if (run.resultText) upsert("result", run.resultLabel, run.resultText);
+    setDetailOpen(run, opts.open ?? run.wrap.classList.contains("open"));
   }
 
-  /** @param {SkillRunView} run @param {string} text @param {{ open?: boolean, label?: string, round?: boolean }} [opts] */
+  /** @param {SkillRunView} run @param {string} text @param {{ open?: boolean, label?: string }} [opts] */
   function attachSkillDetail(run, text, opts = {}) {
     run.resultText = text;
     run.resultLabel = opts.label || "Output";
-    run.roundResult = opts.round !== false;
     renderSkillDetail(run, { open: opts.open });
   }
 
   /** @param {string} text @param {number} ts */
   function addSkillOutput(text, ts) {
-    const wasAtBottom = atBottom();
-    finalizeThoughts();
     pruneOutputQueues(ts);
-
+    // A deduped echo renders nothing, so it must not tear down the live
+    // Thoughts block or advance lastTs — its status row already did both.
     const echoIndex = findMatchingOutputIndex(pendingLegacyOutputs, text, ts);
     if (echoIndex >= 0) {
       pendingLegacyOutputs.splice(echoIndex, 1);
-      lastTs = ts;
       return;
     }
 
-    // Old history may contain output without its status row. Retain a hidden
-    // fallback briefly so a reordered authoritative status can reconcile it,
-    // but never guess which output-less call it belongs to or add standalone clutter.
+    const wasAtBottom = atBottom();
+    finalizeThoughts();
+    // Old history may contain output without its status row. Hide it briefly so
+    // a reordered authoritative status can reconcile it, then surface it as its
+    // own row — unmatched output must not silently disappear.
     const run = createSkillRow("output");
     run.wrap.classList.add("completed", "orphan-output");
+    run.status.textContent = "completed";
     attachSkillDetail(run, text);
     stream.appendChild(run.wrap);
-    orphanOutputs.push({ run, text, ts });
+    /** @type {OrphanOutput} */
+    const orphan = { run, text, ts };
+    orphanOutputs.push(orphan);
+    setTimeout(() => revealOrphan(orphan), ORPHAN_REVEAL_MS);
     lastTs = ts;
     snapIfAtBottom(wasAtBottom);
   }
@@ -572,7 +589,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     // A failed run carries the failure reason / error — show it expanded
     // in-place (collapsible so a long trace can be tucked away).
     if (cls === "failed" && reason) {
-      attachSkillDetail(run, reason, { open: true, label: "Error", round: false });
+      attachSkillDetail(run, reason, { open: true, label: "Error" });
     }
 
     const outputText = typeof output === "string" && output.trim() ? output : "";
@@ -684,7 +701,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     const ts = Number(e?.timestamp) || Date.now() / 1000;
     const sender = String(e?.sender ?? "");
     if (sender === "task_activated") {
-      const name = String(e?.text ?? e?.skill_name ?? e?.skillId ?? "");
+      const name = String(e?.text || e?.skill_name || e?.skillId || "");
       const status = String(e?.taskStatus ?? "");
       if (!name || !status) return;
       const key = String(e?.primitiveId ?? e?.skillId ?? name);
@@ -767,7 +784,9 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     } catch {
       return;
     }
-    const name = String(payload?.primitive_name ?? payload?.skill_name ?? payload?.skill_id ?? "");
+    // || (not ??) so an empty name falls through to the id — a substep may
+    // publish name: "", and the history helper's `or` already skips it.
+    const name = String(payload?.primitive_name || payload?.skill_name || payload?.skill_id || "");
     const status = String(payload?.status ?? "");
     if (!name || !status) return;
     const key = String(payload?.primitive_id ?? payload?.skill_id ?? name);
@@ -826,12 +845,30 @@ function formatSkillArgs(args) {
   const entries = Object.entries(args).filter(([, v]) => v !== null && v !== undefined && v !== "");
   if (entries.length === 0) return "";
   const show = (/** @type {any} */ v) =>
-    typeof v === "number" ? roundNums(String(v)) : typeof v === "object" ? JSON.stringify(v) : String(v);
+    typeof v === "object" ? JSON.stringify(roundDeep(v)) : String(roundDeep(v));
   const line = (/** @type {(v: any) => string} */ value) =>
     entries.length === 1
       ? value(entries[0][1])
       : entries.map(([k, v]) => `${k.replace(/_/g, " ")}: ${value(v)}`).join(" · ");
   return line(show);
+}
+
+/**
+ * Round floats to 2 places wherever they nest, but never touch strings — an IP
+ * or version string must survive verbatim. Cosmetic only.
+ * @param {any} v
+ * @returns {any}
+ */
+function roundDeep(v) {
+  if (typeof v === "number") return Math.round(v * 100) / 100;
+  if (Array.isArray(v)) return v.map(roundDeep);
+  if (v && typeof v === "object") {
+    /** @type {Record<string, any>} */
+    const out = {};
+    for (const [k, x] of Object.entries(v)) out[k] = roundDeep(x);
+    return out;
+  }
+  return v;
 }
 
 /**

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -151,9 +151,9 @@ export const FORGET_MEMORY_SERVICE = "/brain/forget_memory";
 export const MEMORY_SEARCH_TOPIC = "/brain/memory_search";
 
 // Skill-execution status (std_msgs/String JSON: {primitive_name|skill_name,
-// status: running|completed|failed|interrupted, primitive_id, ...}), published
-// as the agent runs primitives. Separate from chat_out — the chat surfaces it so
-// operators can see which skills the agent is executing.
+// status: running|completed|failed|interrupted, primitive_id, args?, output?,
+// ...}), published as the agent runs primitives. Successful code-skill output
+// rides the terminal event so the app can keep it inside the matching call.
 export const SKILL_STATUS_UPDATE_TOPIC = "/brain/skill_status_update";
 
 // Per-step ACT inference timing breakdown (std_msgs/String carrying JSON), published

--- a/webapp/tests/activityView.test.js
+++ b/webapp/tests/activityView.test.js
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// Compact Agent-activity helpers — zero dependencies, plain node:
+// Agent-activity helpers — zero dependencies, plain node:
 //   node tests/activityView.test.js
 
 import assert from "node:assert/strict";
 import {
-  COMPACT_ACTIVITY_KEY,
   findMatchingOutputIndex,
-  readCompactActivity,
   skillEventsAreAdjacent,
-  writeCompactActivity,
 } from "../js/agent/activityView.js";
 
 let passed = 0;
@@ -19,31 +16,6 @@ function test(name, fn) {
   passed += 1;
   console.log(`ok - ${name}`);
 }
-
-test("compact mode defaults on and restores an explicit choice", () => {
-  const values = new Map();
-  const storage = {
-    getItem: (key) => values.get(key) ?? null,
-    setItem: (key, value) => values.set(key, value),
-  };
-  assert.equal(readCompactActivity(storage), true);
-  writeCompactActivity(storage, false);
-  assert.equal(values.get(COMPACT_ACTIVITY_KEY), "false");
-  assert.equal(readCompactActivity(storage), false);
-});
-
-test("blocked storage falls back to compact without throwing", () => {
-  const blocked = {
-    getItem() {
-      throw new Error("blocked");
-    },
-    setItem() {
-      throw new Error("blocked");
-    },
-  };
-  assert.equal(readCompactActivity(blocked), true);
-  assert.doesNotThrow(() => writeCompactActivity(blocked, false));
-});
 
 test("nearby cross-topic events pair despite slight reordering", () => {
   assert.equal(skillEventsAreAdjacent(100, 104.9), true);

--- a/webapp/tests/activityView.test.js
+++ b/webapp/tests/activityView.test.js
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Compact Agent-activity helpers — zero dependencies, plain node:
+//   node tests/activityView.test.js
+
+import assert from "node:assert/strict";
+import {
+  COMPACT_ACTIVITY_KEY,
+  findMatchingOutputIndex,
+  readCompactActivity,
+  skillEventsAreAdjacent,
+  writeCompactActivity,
+} from "../js/agent/activityView.js";
+
+let passed = 0;
+/** @param {string} name @param {() => void} fn */
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+test("compact mode defaults on and restores an explicit choice", () => {
+  const values = new Map();
+  const storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+  assert.equal(readCompactActivity(storage), true);
+  writeCompactActivity(storage, false);
+  assert.equal(values.get(COMPACT_ACTIVITY_KEY), "false");
+  assert.equal(readCompactActivity(storage), false);
+});
+
+test("blocked storage falls back to compact without throwing", () => {
+  const blocked = {
+    getItem() {
+      throw new Error("blocked");
+    },
+    setItem() {
+      throw new Error("blocked");
+    },
+  };
+  assert.equal(readCompactActivity(blocked), true);
+  assert.doesNotThrow(() => writeCompactActivity(blocked, false));
+});
+
+test("nearby cross-topic events pair despite slight reordering", () => {
+  assert.equal(skillEventsAreAdjacent(100, 104.9), true);
+  assert.equal(skillEventsAreAdjacent(100, 99.2), true);
+});
+
+test("late or invalid events cannot attach to an old skill run", () => {
+  assert.equal(skillEventsAreAdjacent(100, 105.1), false);
+  assert.equal(skillEventsAreAdjacent(100, 98.9), false);
+  assert.equal(skillEventsAreAdjacent(Number.NaN, 100), false);
+});
+
+test("fast outputs match by exact text instead of the latest completed call", () => {
+  const completed = [
+    { text: "output A", ts: 100 },
+    { text: "output B", ts: 100.1 },
+  ];
+  assert.equal(findMatchingOutputIndex(completed, "output A", 100.2), 0);
+  assert.equal(findMatchingOutputIndex(completed, "output B", 100.3), 1);
+  assert.equal(findMatchingOutputIndex(completed, "unknown", 100.4), -1);
+});
+
+test("an early legacy output can be reconciled when its status follows", () => {
+  const orphans = [{ text: "found cup", ts: 99.5 }];
+  assert.equal(findMatchingOutputIndex(orphans, "found cup", 100, false), 0);
+  assert.equal(findMatchingOutputIndex(orphans, "found cup", 101, false), -1);
+});
+
+console.log(`\n${passed} passed`);


### PR DESCRIPTION
## Summary

<img width="670" height="1288" alt="image" src="https://github.com/user-attachments/assets/949ff887-aef4-45e1-aeb1-3c03da842883" />


- Keep the Agent activity stream permanently compact: hide completed reasoning and unmatched legacy output while retaining live processing, chat, and every skill-call row.
- Group a skill call's inputs and output or error into one accessible disclosure. The collapsed row shows the complete wrapping skill name, status, and a clear chevron without ellipsizing the name.
- Include successful code-skill output in terminal status events and persist authoritative task rows so grouped calls survive history reloads, while reconciling the legacy `skill_output` echo for compatibility.

## Validation

- [x] Ran all seven webapp Node test files: 45 assertions passed.
- [x] Ran `test_activity_protocol.py`: 4 tests passed.
- [x] Ran JavaScript syntax checks, changed-file TypeScript filtering, Python compile checks, and `git diff --check`.
- [x] Browser-checked the real 360 px panel and 320–390 px phone layouts: no ellipsis or horizontal overflow; click, Enter, and Space disclosure controls work; Inputs plus Output/Error are preserved; compact visibility and bottom pinning hold; no console errors.
- [x] Simulator behavior, config, and assets are unchanged, so simulator startup and asset-pack checks are not applicable.
