### PR TITLE
feat(webapp): Expression Studio — semantic pose axes + blind VLM judges

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -10,6 +10,11 @@ same modules:
   global costmap / traveled-path overlays, telemetry panels (pose, velocity,
   lidar, nav state, per-topic receive rates), and live strip charts (commanded
   vs measured velocity, nearest obstacle).
+- **Expression** (`/expression`) — the Expression Studio: author MARS body
+  language on semantic pose axes (approach, turn, rise, expand, reach,
+  attend), preview it on the full-robot 3D model, apply it to the live arm +
+  head, and score poses with blind VLM judges that are never told the target
+  emotion.
 - **Collect** (`collect/`) — record episodes (learned skills) and one-shot
   recorded movements; reuses the teleop cockpit with a recording HUD.
 - **Datasets** (`datasets/`) — browse a skill's episodes and replay them
@@ -68,7 +73,7 @@ js/
   shell.js              icon rail on every page
   railLayout.js         the rail's grouped roster (pure — tests/railLayout.test.js)
   teleop/               teleop modules (joystick, keyboard, head tilt, TTS, arm)
-  nav/ collect/ datasets/ training/ logging/      per-page modules
+  nav/ collect/ datasets/ training/ logging/ expression/      per-page modules
 ```
 
 ## Robot interface (rosbridge `ws://<robot>:9090`, rws)

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -14,7 +14,8 @@ same modules:
   language on semantic pose axes (approach, turn, rise, expand, reach,
   attend), preview it on the full-robot 3D model, apply it to the live arm +
   head, and score poses with blind VLM judges that are never told the target
-  emotion.
+  emotion. The axis basis itself is editable in-studio: sculpt a pose, then
+  capture it as an axis's ±1 extreme; edits persist and export with poses.
 - **Collect** (`collect/`) — record episodes (learned skills) and one-shot
   recorded movements; reuses the teleop cockpit with a recording HUD.
 - **Datasets** (`datasets/`) — browse a skill's episodes and replay them

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -11,11 +11,12 @@ same modules:
   lidar, nav state, per-topic receive rates), and live strip charts (commanded
   vs measured velocity, nearest obstacle).
 - **Expression** (`/expression`) — the Expression Studio: author MARS body
-  language on semantic pose axes (approach, turn, rise, expand, reach,
-  attend), preview it on the full-robot 3D model, apply it to the live arm +
-  head, and score poses with blind VLM judges that are never told the target
-  emotion. The axis basis itself is editable in-studio: sculpt a pose, then
-  capture it as an axis's ±1 extreme; edits persist and export with poses.
+  language on semantic pose axes split into shape (approach, expand, rise,
+  attend, askew) and stance (advance, orient, sidestep), preview it on the
+  full-robot 3D model, apply it to the live arm + head, and score poses with
+  blind VLM judges that are never told the target emotion. The axis basis
+  itself is editable in-studio: sculpt a pose, then capture it as an axis's
+  ±1 extreme; edits persist and export with poses.
 - **Collect** (`collect/`) — record episodes (learned skills) and one-shot
   recorded movements; reuses the teleop cockpit with a recording HUD.
 - **Datasets** (`datasets/`) — browse a skill's episodes and replay them

--- a/webapp/js/expression/judge.js
+++ b/webapp/js/expression/judge.js
@@ -1,0 +1,233 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Blind VLM judges for the Expression Studio. The absolute judge is never
+// told the target emotion — it distributes probability over a fixed label
+// vocabulary from the renders alone, so a pose scores on what an uninvolved
+// observer would read, not on priming. The pairwise judge does name the
+// target ("which looks more X?") because comparisons are what VLMs rate
+// reliably; A/B order is coin-flipped per call to kill position bias.
+//
+// Calls Gemini's generateContent directly (the brain's dev path —
+// generativelanguage.googleapis.com with an API key), straight from the
+// browser: this is bench tooling, the key stays in localStorage.
+
+const BASE_URL = "https://generativelanguage.googleapis.com";
+const DEFAULT_MODEL = "gemini-3.6-flash"; // the brain's default model
+const CONFIG_KEY = "innate.expression.judge";
+const API_KEY_KEY = "innate.geminiApiKey";
+
+// The perceptual vocabulary — a superset of the preset emotions plus the
+// readings poses collapse into when they fail (confused, aggressive,
+// neutral). Fixed so scores stay comparable across sessions.
+export const JUDGE_LABELS = [
+  "curious",
+  "excited",
+  "confident",
+  "affectionate",
+  "fearful",
+  "sad",
+  "suspicious",
+  "confused",
+  "aggressive",
+  "neutral",
+];
+
+/** @typedef {{ apiKey: string, model: string, judges: number }} JudgeConfig */
+/** @typedef {{ probabilities: Record<string, number>, cues: string[], impression: string }} Reading */
+/** @typedef {{ mean: Record<string, number>, runs: Reading[], errors: string[] }} PanelResult */
+
+/** @returns {JudgeConfig} */
+export function loadJudgeConfig() {
+  /** @type {any} */
+  let stored = {};
+  try {
+    stored = JSON.parse(localStorage.getItem(CONFIG_KEY) || "{}");
+  } catch {
+    stored = {};
+  }
+  return {
+    apiKey: localStorage.getItem(API_KEY_KEY) || "",
+    model: typeof stored.model === "string" && stored.model ? stored.model : DEFAULT_MODEL,
+    judges: Math.min(5, Math.max(1, Number(stored.judges) || 3)),
+  };
+}
+
+/** @param {JudgeConfig} cfg */
+export function saveJudgeConfig(cfg) {
+  localStorage.setItem(API_KEY_KEY, cfg.apiKey);
+  localStorage.setItem(CONFIG_KEY, JSON.stringify({ model: cfg.model, judges: cfg.judges }));
+}
+
+const ROBOT_CONTEXT =
+  "The images are renders of one single moment, from different viewpoints, of a small non-humanoid " +
+  "robot: a dark wheeled base, one small arm with an orange gripper claw, and a flat head unit on a " +
+  "neck that can only pitch up or down. The translucent blue figure is a person standing nearby; the " +
+  "robot may be reacting to them. One view is from the person's own eyes.";
+
+/** @param {{ dataUrl: string }[]} images */
+function imageParts(images) {
+  return images.map((img) => ({
+    inlineData: { mimeType: "image/jpeg", data: img.dataUrl.replace(/^data:image\/\w+;base64,/, "") },
+  }));
+}
+
+/**
+ * @param {JudgeConfig} cfg @param {object[]} parts @param {object} schema
+ * @param {number} temperature @returns {Promise<any>}
+ */
+async function generate(cfg, parts, schema, temperature) {
+  const res = await fetch(`${BASE_URL}/v1beta/models/${cfg.model}:generateContent`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-goog-api-key": cfg.apiKey },
+    body: JSON.stringify({
+      contents: [{ role: "user", parts }],
+      generationConfig: { temperature, responseMimeType: "application/json", responseSchema: schema },
+    }),
+    signal: AbortSignal.timeout(90_000),
+  });
+  if (!res.ok) {
+    const detail = (await res.text()).slice(0, 200);
+    throw new Error(`HTTP ${res.status}: ${detail}`);
+  }
+  const data = await res.json();
+  const text = (data?.candidates?.[0]?.content?.parts ?? [])
+    .map((/** @type {any} */ p) => p?.text || "")
+    .join("");
+  if (!text) throw new Error("empty judge response");
+  return JSON.parse(text);
+}
+
+const READING_SCHEMA = {
+  type: "OBJECT",
+  properties: {
+    probabilities: {
+      type: "OBJECT",
+      properties: Object.fromEntries(JUDGE_LABELS.map((l) => [l, { type: "NUMBER" }])),
+      required: JUDGE_LABELS,
+    },
+    cues: { type: "ARRAY", items: { type: "STRING" } },
+    impression: { type: "STRING" },
+  },
+  required: ["probabilities", "cues", "impression"],
+};
+
+/**
+ * One blind reading of a pose. The prompt never names a target emotion.
+ * @param {{ dataUrl: string }[]} images @param {JudgeConfig} cfg @returns {Promise<Reading>}
+ */
+export async function judgeBlind(images, cfg) {
+  const prompt =
+    `${ROBOT_CONTEXT}\n\n` +
+    "Judge ONLY the robot's body language: where it sits and faces relative to the person, its arm " +
+    "posture, gripper, and head pitch. Do not assume any intended emotion was designed in.\n\n" +
+    "Estimate the probability that a typical person seeing this robot would describe its attitude " +
+    `with each of these labels: ${JUDGE_LABELS.join(", ")}. Probabilities must sum to 1. ` +
+    'Also give "cues": 2-4 short physical observations that drove your reading, and "impression": ' +
+    "one sentence saying what the robot's stance communicates.";
+  const raw = await generate(cfg, [{ text: prompt }, ...imageParts(images)], READING_SCHEMA, 0.7);
+  return {
+    probabilities: normalize(raw?.probabilities),
+    cues: Array.isArray(raw?.cues) ? raw.cues.map(String).slice(0, 6) : [],
+    impression: String(raw?.impression || ""),
+  };
+}
+
+/**
+ * A panel of independent blind readings, averaged. Per-judge failures land in
+ * `errors` — one flaky call must not sink the panel.
+ * @param {{ dataUrl: string }[]} images @param {JudgeConfig} cfg
+ * @param {(done: number) => void} [onProgress] @returns {Promise<PanelResult>}
+ */
+export async function judgePanel(images, cfg, onProgress) {
+  /** @type {Reading[]} */
+  const runs = [];
+  /** @type {string[]} */
+  const errors = [];
+  let done = 0;
+  await Promise.all(
+    Array.from({ length: cfg.judges }, async () => {
+      try {
+        runs.push(await judgeBlind(images, cfg));
+      } catch (err) {
+        errors.push(err instanceof Error ? err.message : String(err));
+      }
+      onProgress?.(++done);
+    }),
+  );
+  const mean = Object.fromEntries(
+    JUDGE_LABELS.map((label) => [
+      label,
+      runs.length ? runs.reduce((sum, r) => sum + (r.probabilities[label] ?? 0), 0) / runs.length : 0,
+    ]),
+  );
+  return { mean, runs, errors };
+}
+
+/** @typedef {{ winner: "A" | "B", margin: "clear" | "slight", reason: string }} Verdict */
+
+const VERDICT_SCHEMA = {
+  type: "OBJECT",
+  properties: {
+    winner: { type: "STRING", enum: ["first", "second"] },
+    margin: { type: "STRING", enum: ["clear", "slight"] },
+    reason: { type: "STRING" },
+  },
+  required: ["winner", "margin", "reason"],
+};
+
+/**
+ * One pairwise comparison for a named target. Presentation order is
+ * coin-flipped and un-flipped in the verdict, so "first is better" bias
+ * cancels over a panel.
+ * @param {{ dataUrl: string }[]} imagesA @param {{ dataUrl: string }[]} imagesB
+ * @param {string} target @param {JudgeConfig} cfg @returns {Promise<Verdict>}
+ */
+export async function judgePair(imagesA, imagesB, target, cfg) {
+  const flipped = Math.random() < 0.5;
+  const [first, second] = flipped ? [imagesB, imagesA] : [imagesA, imagesB];
+  const prompt =
+    `${ROBOT_CONTEXT}\n\n` +
+    "You will see the robot in two different poses: first every view of pose ONE, then every view of " +
+    `pose TWO. Which pose would a typical person more likely describe as "${target}"? Judge only the ` +
+    "body language. Answer with the winner, whether the difference is clear or slight, and one " +
+    "sentence of reasoning based on posture.";
+  const raw = await generate(
+    cfg,
+    [
+      { text: prompt },
+      { text: "Pose ONE:" },
+      ...imageParts(first),
+      { text: "Pose TWO:" },
+      ...imageParts(second),
+    ],
+    VERDICT_SCHEMA,
+    0.3,
+  );
+  const pickedFirst = raw?.winner === "first";
+  return {
+    winner: pickedFirst !== flipped ? "A" : "B",
+    margin: raw?.margin === "clear" ? "clear" : "slight",
+    reason: String(raw?.reason || ""),
+  };
+}
+
+/**
+ * Coerce a raw probabilities object onto the label set: non-finite/negative
+ * become 0, then normalize to sum 1 (uniform if the judge returned nothing).
+ * @param {any} raw @returns {Record<string, number>}
+ */
+export function normalize(raw) {
+  /** @type {Record<string, number>} */
+  const out = {};
+  let sum = 0;
+  for (const label of JUDGE_LABELS) {
+    const v = Number(raw?.[label]);
+    out[label] = Number.isFinite(v) && v > 0 ? v : 0;
+    sum += out[label];
+  }
+  for (const label of JUDGE_LABELS) {
+    out[label] = sum > 0 ? out[label] / sum : 1 / JUDGE_LABELS.length;
+  }
+  return out;
+}

--- a/webapp/js/expression/main.js
+++ b/webapp/js/expression/main.js
@@ -1,0 +1,826 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Expression Studio — design MARS's body language from first principles.
+//
+// A pose is authored on semantic axes (approach, turn, rise, expand, reach,
+// attend — see model.js), previewed live on the full-robot 3D view, scored by
+// blind VLM judges that are never told the target emotion (judge.js), and
+// collected into an exportable library — the raw material for the next steps
+// (PCA over collected poses, motion dynamics, the runtime controller).
+//
+// The robot side rides the Arm SDK server's existing paths: the joint stream
+// topic for the arm, /mars/head/set_position for the head. Base offset is
+// preview-only for now — driving belongs to the runtime controller.
+
+import {
+  ACTUATORS,
+  AXES,
+  PRESETS,
+  exportPayload,
+  parseImport,
+  sanitizeOffsets,
+  sanitizeWeights,
+  synthesize,
+  zeroWeights,
+} from "./model.js";
+import { createExpressionViz } from "./viz.js";
+import { JUDGE_LABELS, judgePair, judgePanel, loadJudgeConfig, saveJudgeConfig } from "./judge.js";
+import { copyToButton, ICON_COPY } from "../clipboard.js";
+import { ARM_STATUS_TOPIC, HEAD_MAX_DEG, HEAD_MIN_DEG, HEAD_SET_POSITION_TOPIC } from "../constants.js";
+import { ros } from "../rosClient.js";
+
+const ARM_ACTION = "/armsdk/command";
+const ARM_ACTION_TYPE = "brain_messages/action/ExecuteArmCommand";
+const STREAM_TOPIC = "/armsdk/stream_joints";
+const ARM_STATE_TOPIC = "/mars/arm/state";
+const LIBRARY_KEY = "innate.expression.library";
+const MAX_POSES = 60;
+
+/** @typedef {import("./model.js").Pose} Pose */
+/** @typedef {import("./model.js").SavedPose} SavedPose */
+
+const deg = (/** @type {number} */ r) => (r * 180) / Math.PI;
+
+const STYLE_ID = "expression-style";
+const CSS = `
+.exs { padding: 18px 22px 26px; overflow-y: auto; height: 100%; font-size: 14px; }
+.exs-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 4px; }
+.exs-sub { color: var(--muted); font-size: 12px; letter-spacing: .04em; }
+.exs-banner { display: none; margin: 10px 0; padding: 10px 14px; border: 1px solid var(--hairline-strong);
+  border-radius: 9px; color: var(--muted); background: var(--panel); font-size: 13px; }
+.exs-banner.show { display: block; }
+.exs-toolbar { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin: 10px 0 16px; }
+.exs-toolbar .spacer { flex: 1; }
+.exs-grid { display: grid; grid-template-columns: minmax(400px, 1.35fr) minmax(320px, .85fr); gap: 14px; }
+.exs-bottom { display: grid; grid-template-columns: minmax(340px, 1.15fr) minmax(300px, .85fr); gap: 14px; margin-top: 14px; }
+@media (max-width: 1020px) { .exs-grid, .exs-bottom { grid-template-columns: 1fr; } }
+.exs-card { background: linear-gradient(180deg, rgb(255 255 255 / 2.5%), transparent 40%), var(--panel);
+  border: 1px solid var(--hairline); border-radius: 12px; padding: 14px 16px; }
+.exs-card h2 { font-size: 11px; margin: 0 0 10px; color: var(--muted); text-transform: uppercase;
+  letter-spacing: .09em; font-weight: 600; display: flex; align-items: center; gap: 8px; }
+.exs-card h2 .spacer { flex: 1; }
+.exs button { background: var(--panel); color: var(--text); border: 1px solid var(--hairline-strong);
+  border-radius: 8px; padding: 7px 12px; font: inherit; font-size: 13px; cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease; }
+.exs button:hover:not(:disabled) { border-color: var(--accent-dim); color: var(--accent); }
+.exs button:disabled { opacity: .38; cursor: wait; }
+.exs button.exs-go { border-color: rgb(86 194 140 / 45%); color: var(--ok); }
+.exs button.exs-go:hover:not(:disabled) { border-color: var(--ok); background: rgb(86 194 140 / 8%); }
+.exs button.exs-warn { border-color: rgb(217 106 90 / 45%); color: var(--danger); }
+.exs button.exs-warn:hover:not(:disabled) { border-color: var(--danger); background: rgb(217 106 90 / 8%); }
+.exs button.exs-mini { padding: 3px 9px; font-size: 12px; }
+.exs-pill { padding: 3px 12px; border-radius: 999px; font-size: 12px; border: 1px solid var(--hairline-strong);
+  color: var(--muted); font-family: var(--mono, ui-monospace, monospace); }
+.exs-pill.on { color: var(--ok); border-color: rgb(86 194 140 / 55%); }
+.exs-pill.off { color: var(--danger); border-color: rgb(217 106 90 / 55%); }
+.exs input[type="text"], .exs input[type="password"], .exs input[type="number"], .exs select {
+  background: var(--bg); color: var(--text); border: 1px solid var(--hairline-strong); border-radius: 7px;
+  padding: 5px 8px; font: inherit; font-size: 13px; }
+.exs input[type="number"] { width: 58px; }
+.exs input:focus, .exs select:focus { outline: none; border-color: var(--accent-dim); }
+.exs input[type="range"] { flex: 1; accent-color: var(--accent); min-width: 90px; }
+.exs label { font-size: 12px; color: var(--muted); display: inline-flex; align-items: center; gap: 6px; }
+.exs-row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin: 7px 0; }
+.exs-hint { color: var(--muted); font-size: 11.5px; margin-top: 6px; }
+
+/* --- viewport ----------------------------------------------------------- */
+.exs-viz { position: relative; padding: 0; overflow: hidden; min-height: 500px; }
+.exs-viz-canvas { position: absolute; inset: 0; }
+.exs-viz-canvas canvas { width: 100%; height: 100%; }
+.exs-viz-title { position: absolute; top: 12px; left: 14px; font-size: 11px; color: var(--muted);
+  text-transform: uppercase; letter-spacing: .09em; pointer-events: none; }
+.exs-viz-legend { position: absolute; top: 32px; left: 14px; font-size: 11px; color: var(--muted);
+  pointer-events: none; }
+.exs-viz-hint { position: absolute; top: 12px; right: 14px; font-size: 11px; color: var(--muted);
+  background: var(--glass); border: 1px solid var(--hairline); border-radius: 999px; padding: 3px 12px;
+  pointer-events: none; backdrop-filter: blur(6px); }
+.exs-viz-loading { position: absolute; inset: 0; display: grid; place-items: center;
+  color: var(--muted); font-size: 12px; letter-spacing: .05em; }
+.exs-chips { position: absolute; left: 12px; right: 12px; bottom: 12px; display: flex; flex-wrap: wrap;
+  gap: 6px; pointer-events: none; }
+.exs-chips span { background: var(--glass); border: 1px solid var(--hairline); border-radius: 8px;
+  padding: 4px 10px; font-family: var(--mono, ui-monospace, monospace); font-size: 12px; color: var(--text);
+  backdrop-filter: blur(6px); }
+.exs-chips b { color: var(--muted); font-weight: 500; margin-right: 6px; }
+.exs-chips .num { color: var(--accent); }
+.exs-copy { pointer-events: auto; background: var(--glass); color: var(--muted);
+  border: 1px solid var(--hairline-strong); border-radius: 6px; padding: 3px 7px; line-height: 0;
+  cursor: pointer; transition: color 120ms ease, border-color 120ms ease; }
+.exs-copy:hover { color: var(--accent); border-color: var(--accent-dim); }
+.exs-copy.copied { color: var(--ok); border-color: var(--ok); }
+
+/* --- axes --------------------------------------------------------------- */
+.exs-axis { margin: 9px 0; }
+.exs-axis-top { display: flex; align-items: baseline; gap: 8px; }
+.exs-axis-name { font-size: 12.5px; color: var(--text); width: 74px; }
+.exs-axis-val { margin-left: auto; font-family: var(--mono, ui-monospace, monospace); font-size: 12px;
+  color: var(--accent); width: 46px; text-align: right; }
+.exs-axis-track { display: flex; align-items: center; gap: 8px; }
+.exs-axis-end { font-size: 10.5px; color: var(--muted); width: 74px; letter-spacing: .02em; }
+.exs-axis-end.hi { text-align: right; }
+.exs-presets { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+.exs-presets button { padding: 4px 11px; font-size: 12.5px; border-radius: 999px; }
+.exs-presets button.active { border-color: var(--accent); color: var(--accent); background: var(--accent-faint); }
+.exs details { margin-top: 12px; border-top: 1px solid var(--hairline); padding-top: 10px; }
+.exs summary { cursor: pointer; font-size: 11px; color: var(--muted); text-transform: uppercase;
+  letter-spacing: .09em; font-weight: 600; }
+.exs-off-row { display: flex; align-items: center; gap: 8px; margin: 6px 0; }
+.exs-off-name { width: 104px; font-size: 12px; color: var(--muted); }
+.exs-off-val { width: 56px; text-align: right; font-family: var(--mono, ui-monospace, monospace);
+  font-size: 12px; color: var(--accent); }
+
+/* --- judge -------------------------------------------------------------- */
+.exs-views { display: flex; gap: 8px; margin: 8px 0; }
+.exs-views figure { margin: 0; flex: 1; min-width: 0; }
+.exs-views img { width: 100%; aspect-ratio: 1; object-fit: cover; border-radius: 8px;
+  border: 1px solid var(--hairline); display: block; background: var(--bg); }
+.exs-views figcaption { font-size: 10.5px; color: var(--muted); margin-top: 3px; text-align: center; }
+.exs-score { font-size: 15px; margin: 8px 0 4px; }
+.exs-score b { color: var(--accent); font-family: var(--mono, ui-monospace, monospace); }
+.exs-bars { margin: 6px 0; }
+.exs-bar { display: grid; grid-template-columns: 86px 1fr 44px; gap: 8px; align-items: center;
+  margin: 3px 0; font-size: 12px; }
+.exs-bar .lbl { color: var(--muted); text-align: right; }
+.exs-bar .track { display: block; height: 9px; border-radius: 5px; background: var(--bg); overflow: hidden;
+  border: 1px solid var(--hairline); }
+.exs-bar .fill { display: block; height: 100%; background: var(--hairline-strong); border-radius: 5px 0 0 5px;
+  transition: width 300ms ease; }
+.exs-bar.target .lbl { color: var(--accent); }
+.exs-bar.target .fill { background: var(--accent); }
+.exs-bar .num { font-family: var(--mono, ui-monospace, monospace); color: var(--text); }
+.exs-quotes { margin: 8px 0 0; font-size: 12px; color: var(--muted); line-height: 1.5; }
+.exs-quotes li { margin: 2px 0 2px 16px; }
+.exs-log { max-height: 150px; overflow-y: auto; background: var(--bg); border: 1px solid var(--hairline);
+  border-radius: 9px; padding: 8px 11px; font-size: 12px; line-height: 1.55; margin-top: 10px;
+  font-family: var(--mono, ui-monospace, monospace); color: var(--muted); white-space: pre-wrap; }
+.exs-log .ok { color: var(--ok); }
+.exs-log .err { color: var(--danger); }
+.exs-pin { display: inline-flex; align-items: center; gap: 7px; }
+.exs-pin img { width: 30px; height: 30px; border-radius: 6px; border: 1px solid var(--hairline); }
+
+/* --- library ------------------------------------------------------------ */
+.exs-lib { max-height: 420px; overflow-y: auto; margin-top: 8px; }
+.exs-lib-item { display: flex; align-items: center; gap: 10px; padding: 6px 8px; border-radius: 9px;
+  cursor: pointer; border: 1px solid transparent; }
+.exs-lib-item:hover { background: var(--accent-faint); border-color: var(--accent-dim); }
+.exs-lib-item img { width: 44px; height: 44px; border-radius: 8px; border: 1px solid var(--hairline);
+  background: var(--bg); object-fit: cover; }
+.exs-lib-item .noimg { width: 44px; height: 44px; border-radius: 8px; border: 1px dashed var(--hairline-strong); }
+.exs-lib-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.exs-lib-judge { font-size: 11px; color: var(--muted); font-family: var(--mono, ui-monospace, monospace); }
+.exs-lib-item button { opacity: 0; }
+.exs-lib-item:hover button { opacity: 1; }
+`;
+
+const PAGE_HTML = `
+  <div class="exs-head page-head">
+    <h1 class="page-title">Expression Studio</h1>
+    <span class="exs-sub">semantic pose axes · blind VLM judges · the body-language vocabulary bench</span>
+  </div>
+  <p class="exs-banner" data-el="banner">
+    robot connection lost — the studio keeps working (preview + judging are local); apply-to-robot resumes when it returns
+  </p>
+  <div class="exs-toolbar">
+    <span class="exs-pill" data-el="torquePill" title="servo torque state — /mars/arm/status">torque ?</span>
+    <button class="exs-go" data-el="torqueOn" title="Stiffen the servos so the arm holds and accepts poses">Torque on</button>
+    <button class="exs-warn" data-el="torqueOff" title="Go limp — also the abort path">Torque off</button>
+    <button data-el="sendPose" title="Stream the current pose to the robot once (arm joints + head; base offset is preview-only)">Send pose to robot</button>
+    <label title="Re-send the pose to the robot on every slider change (arm + head; base offset is preview-only)">
+      <input type="checkbox" data-el="live"> drive live</label>
+    <span class="spacer"></span>
+    <span data-el="robotMsg" class="exs-sub"></span>
+  </div>
+
+  <div class="exs-grid">
+    <div class="exs-card exs-viz">
+      <div class="exs-viz-canvas" data-el="viz"></div>
+      <span class="exs-viz-title">mars.urdf · expression preview</span>
+      <span class="exs-viz-legend">amber ring = home spot · <b style="color:#6b93d6">blue figure</b> = the person it expresses to</span>
+      <span class="exs-viz-hint">drag to orbit · scroll to zoom</span>
+      <div class="exs-viz-loading" data-el="vizLoading">loading model…</div>
+      <div class="exs-chips">
+        <span title="synthesized arm joints j1..j6 (rad)"><b>arm</b><span class="num" data-el="cJoints">—</span></span>
+        <span title="head pitch command (degrees, + = up)"><b>head</b><span class="num" data-el="cHead">—</span></span>
+        <span title="base offset from home: advance, sidestep (m), turn (deg)"><b>base</b><span class="num" data-el="cBase">—</span></span>
+        <button class="exs-copy" data-el="copyPose" title="Copy the full actuator pose as JSON">${ICON_COPY}</button>
+      </div>
+    </div>
+
+    <div class="exs-card">
+      <h2>Expression axes <span class="spacer"></span>
+        <button class="exs-mini" data-el="resetAxes" title="All axes to 0, offsets cleared — back to neutral">reset</button></h2>
+      <div data-el="axes"></div>
+      <div class="exs-presets" data-el="presets"></div>
+      <details>
+        <summary>Fine-tune · per-actuator offsets</summary>
+        <div data-el="offsets"></div>
+        <div class="exs-row"><button class="exs-mini" data-el="clearOffsets">clear offsets</button></div>
+        <div class="exs-hint">offsets add on top of the axes and export with the pose — use them to fix what the basis can't say, then fold recurring fixes back into the basis</div>
+      </details>
+    </div>
+  </div>
+
+  <div class="exs-bottom">
+    <div class="exs-card">
+      <h2>Blind VLM judges <span class="spacer"></span><span class="exs-sub" data-el="judgeStatus"></span></h2>
+      <div class="exs-row">
+        <label>key <input type="password" data-el="jKey" placeholder="Gemini API key" size="18"
+          title="Gemini API key (dev) — stored only in this browser's localStorage, used straight from the browser"></label>
+        <label>model <input type="text" data-el="jModel" size="14"></label>
+        <label>judges <input type="number" data-el="jCount" min="1" max="5" step="1"
+          title="Independent readings per evaluation — scores are averaged; VLM scores are noisy alone"></label>
+      </div>
+      <div class="exs-views" data-el="views"></div>
+      <div class="exs-row">
+        <button data-el="refreshViews" title="Re-render the three judge viewpoints from the current pose">Refresh views</button>
+        <label>target <select data-el="target"
+          title="What YOU are aiming for. Never sent to the judges — they distribute probability over all labels blind."></select></label>
+        <button class="exs-go" data-el="evalBtn" title="Render the views and ask the judge panel — blind — what the pose reads as">Evaluate</button>
+      </div>
+      <div data-el="result" hidden>
+        <div class="exs-score" data-el="score"></div>
+        <div class="exs-bars" data-el="bars"></div>
+        <ul class="exs-quotes" data-el="quotes"></ul>
+      </div>
+      <div class="exs-row" style="margin-top:10px">
+        <button data-el="pinBtn" title="Hold the current pose's renders as comparison side A">Pin as A</button>
+        <span class="exs-pin" data-el="pinInfo" hidden><img data-el="pinImg" alt=""><span class="exs-sub" data-el="pinName"></span></span>
+        <button data-el="abBtn" title="Ask the panel which of pinned (A) vs current (B) reads more as the target — order randomized per judge">A/B vs pinned</button>
+      </div>
+      <div class="exs-log" data-el="log"></div>
+    </div>
+
+    <div class="exs-card">
+      <h2>Pose library <span class="spacer"></span><span class="exs-sub" data-el="libCount"></span></h2>
+      <div class="exs-row">
+        <input type="text" data-el="poseName" placeholder="pose name" size="14">
+        <button class="exs-go" data-el="saveBtn" title="Save the current axes + offsets (with thumbnail and last judge score)">Save</button>
+        <button data-el="exportBtn" title="Download the library as JSON — weights AND synthesized actuator vectors, for the next pipeline steps">Export</button>
+        <button data-el="importBtn" title="Import a previously exported library JSON">Import</button>
+        <input type="file" data-el="importFile" accept="application/json" hidden>
+      </div>
+      <div class="exs-lib" data-el="lib"></div>
+      <div class="exs-hint">click a pose to load it · judged poses carry their blind score</div>
+    </div>
+  </div>`;
+
+/** @param {HTMLElement} stage */
+export function mount(stage) {
+  if (!document.getElementById(STYLE_ID)) {
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = CSS;
+    document.head.appendChild(style);
+  }
+
+  const root = document.createElement("div");
+  root.className = "exs";
+  root.innerHTML = PAGE_HTML;
+  stage.appendChild(root);
+
+  /** @param {string} name */
+  const el = (name) => /** @type {HTMLElement} */ (root.querySelector(`[data-el="${name}"]`));
+  /** @param {string} name */
+  const input = (name) => /** @type {HTMLInputElement} */ (el(name));
+
+  let destroyed = false;
+  /** @type {Awaited<ReturnType<typeof createExpressionViz>> | null} */
+  let viz = null;
+
+  // ---- pose state ---------------------------------------------------------
+  let weights = zeroWeights();
+  /** @type {import("./model.js").PoseDelta} */
+  let offsets = {};
+  const currentPose = () => synthesize(weights, offsets);
+
+  /** @type {HTMLInputElement[]} */
+  const axisSliders = [];
+  /** @type {HTMLElement[]} */
+  const axisVals = [];
+  /** @type {HTMLInputElement[]} */
+  const offsetSliders = [];
+  /** @type {HTMLElement[]} */
+  const offsetVals = [];
+
+  function applyPose() {
+    const pose = currentPose();
+    viz?.setPose(pose);
+    el("cJoints").textContent = [pose.j1, pose.j2, pose.j3, pose.j4, pose.j5, pose.j6]
+      .map((v) => v.toFixed(2))
+      .join(" ");
+    el("cHead").textContent = `${pose.head.toFixed(0)}°`;
+    el("cBase").textContent = `${pose.baseX.toFixed(2)} ${pose.baseY.toFixed(2)} ${deg(pose.baseYaw).toFixed(0)}°`;
+    markActivePreset();
+    if (input("live").checked) queueRobot(pose);
+  }
+
+  function refreshSliders() {
+    AXES.forEach((axis, i) => {
+      axisSliders[i].value = String(weights[axis.key]);
+      axisVals[i].textContent = weights[axis.key].toFixed(2);
+    });
+    ACTUATORS.forEach((a, i) => {
+      offsetSliders[i].value = String(offsets[a.key] ?? 0);
+      offsetVals[i].textContent = (offsets[a.key] ?? 0).toFixed(a.unit === "°" ? 0 : 2);
+    });
+  }
+
+  function markActivePreset() {
+    const chips = el("presets").querySelectorAll("button");
+    chips.forEach((chip, i) => {
+      const preset = PRESETS[i];
+      const active =
+        Object.keys(offsets).length === 0 &&
+        AXES.every((axis) => Math.abs((preset.weights[axis.key] ?? 0) - weights[axis.key]) < 0.005);
+      chip.classList.toggle("active", active);
+    });
+  }
+
+  // ---- axes UI ------------------------------------------------------------
+  AXES.forEach((axis, i) => {
+    const row = document.createElement("div");
+    row.className = "exs-axis";
+    row.title = axis.doc;
+    row.innerHTML = `
+      <div class="exs-axis-top"><span class="exs-axis-name">${axis.label}</span>
+        <span class="exs-axis-val">0.00</span></div>
+      <div class="exs-axis-track"><span class="exs-axis-end">${axis.negLabel}</span>
+        <input type="range" min="-1" max="1" step="0.01" value="0">
+        <span class="exs-axis-end hi">${axis.posLabel}</span></div>`;
+    const slider = /** @type {HTMLInputElement} */ (row.querySelector("input"));
+    const val = /** @type {HTMLElement} */ (row.querySelector(".exs-axis-val"));
+    slider.addEventListener("input", () => {
+      weights[axis.key] = +slider.value;
+      val.textContent = (+slider.value).toFixed(2);
+      applyPose();
+    });
+    slider.addEventListener("dblclick", () => {
+      weights[axis.key] = 0;
+      slider.value = "0";
+      val.textContent = "0.00";
+      applyPose();
+    });
+    axisSliders.push(slider);
+    axisVals.push(val);
+    el("axes").appendChild(row);
+  });
+
+  PRESETS.forEach((preset) => {
+    const chip = document.createElement("button");
+    chip.textContent = preset.label;
+    chip.title = preset.doc;
+    chip.addEventListener("click", () => {
+      weights = sanitizeWeights(preset.weights);
+      offsets = {};
+      refreshSliders();
+      applyPose();
+      input("poseName").value = preset.label;
+    });
+    el("presets").appendChild(chip);
+  });
+
+  ACTUATORS.forEach((a, i) => {
+    const half = (a.max - a.min) / 2;
+    const row = document.createElement("div");
+    row.className = "exs-off-row";
+    row.innerHTML = `<span class="exs-off-name">${a.label}</span>
+      <input type="range" min="${-half}" max="${half}" step="${a.step}" value="0">
+      <span class="exs-off-val">0</span>`;
+    const slider = /** @type {HTMLInputElement} */ (row.querySelector("input"));
+    const val = /** @type {HTMLElement} */ (row.querySelector(".exs-off-val"));
+    slider.addEventListener("input", () => {
+      const v = +slider.value;
+      if (v === 0) delete offsets[a.key];
+      else offsets[a.key] = v;
+      val.textContent = v.toFixed(a.unit === "°" ? 0 : 2);
+      applyPose();
+    });
+    offsetSliders.push(slider);
+    offsetVals.push(val);
+    el("offsets").appendChild(row);
+  });
+
+  el("resetAxes").addEventListener("click", () => {
+    weights = zeroWeights();
+    offsets = {};
+    refreshSliders();
+    applyPose();
+  });
+  el("clearOffsets").addEventListener("click", () => {
+    offsets = {};
+    refreshSliders();
+    applyPose();
+  });
+  el("copyPose").addEventListener("click", () => {
+    void copyToButton(JSON.stringify(currentPose(), null, 2), el("copyPose"), "copied");
+  });
+
+  // ---- viz ----------------------------------------------------------------
+  createExpressionViz(el("viz")).then(
+    (v) => {
+      if (destroyed) {
+        v.destroy();
+        return;
+      }
+      viz = v;
+      el("vizLoading").remove();
+      applyPose();
+      renderLibrary();
+    },
+    (err) => {
+      el("vizLoading").textContent = `3D model unavailable (${err?.message || err})`;
+    },
+  );
+
+  // ---- robot --------------------------------------------------------------
+  /** @type {number[] | null} */
+  let measuredJoints = null;
+  /** @type {Pose | null} */
+  let robotPending = null;
+  let robotBusy = false;
+  let lastHeadSent = NaN;
+
+  /** @param {Pose} pose */
+  function queueRobot(pose) {
+    robotPending = pose;
+    if (!robotBusy) void pumpRobot();
+  }
+
+  // Same pump as the Arm SDK sliders: keep feeding the stream's deadman until
+  // the arm converges (arm joints only — an obstructed gripper never will),
+  // capped so an obstructed arm isn't pushed forever.
+  async function pumpRobot() {
+    robotBusy = true;
+    /** @type {Pose | null} */
+    let lastSent = null;
+    let deadline = performance.now() + 5000;
+    while (!destroyed) {
+      let pose = robotPending;
+      robotPending = null;
+      if (pose) {
+        deadline = performance.now() + 5000;
+      } else {
+        if (!lastSent || !measuredJoints || performance.now() > deadline) break;
+        const sent = [lastSent.j1, lastSent.j2, lastSent.j3, lastSent.j4, lastSent.j5];
+        const err = Math.max(...sent.map((v, i) => Math.abs(v - (measuredJoints?.[i] ?? v))));
+        if (err < 0.03) break;
+        pose = lastSent;
+      }
+      lastSent = pose;
+      ros.publish(STREAM_TOPIC, { data: [pose.j1, pose.j2, pose.j3, pose.j4, pose.j5, pose.j6] });
+      const headDeg = Math.round(Math.min(HEAD_MAX_DEG, Math.max(HEAD_MIN_DEG, pose.head)));
+      if (headDeg !== lastHeadSent) {
+        ros.publish(HEAD_SET_POSITION_TOPIC, { data: headDeg });
+        lastHeadSent = headDeg;
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    robotBusy = false;
+  }
+
+  /** @param {string} name */
+  async function armCmd(name) {
+    el("robotMsg").textContent = `${name}…`;
+    try {
+      const { promise } = ros.sendActionGoal(ARM_ACTION, ARM_ACTION_TYPE, { command: name, params: "{}" });
+      const res = await promise;
+      el("robotMsg").textContent = res.success ? "" : res.message;
+    } catch (e) {
+      el("robotMsg").textContent = e instanceof Error ? e.message : String(e);
+    }
+  }
+  el("torqueOn").addEventListener("click", () => void armCmd("torque_on"));
+  el("torqueOff").addEventListener("click", () => {
+    input("live").checked = false;
+    void armCmd("torque_off");
+  });
+  el("sendPose").addEventListener("click", () => queueRobot(currentPose()));
+
+  const unsubs = [
+    ros.subscribe(
+      ARM_STATE_TOPIC,
+      (/** @type {any} */ m) => {
+        if (Array.isArray(m?.position)) measuredJoints = m.position.slice(0, 6);
+      },
+      100,
+      "sensor_msgs/msg/JointState",
+    ),
+    ros.subscribe(
+      ARM_STATUS_TOPIC,
+      (/** @type {any} */ m) => {
+        if (typeof m?.is_torque_enabled !== "boolean") return;
+        const pill = el("torquePill");
+        pill.textContent = "torque " + (m.is_torque_enabled ? "on" : "off");
+        pill.className = "exs-pill " + (m.is_torque_enabled ? "on" : "off");
+      },
+      undefined,
+      "mars_msgs/msg/ArmStatus",
+    ),
+  ];
+  const showBanner = () => el("banner").classList.toggle("show", ros.state !== "connected");
+  const unsubConn = ros.onStateChange(showBanner);
+  showBanner();
+
+  // ---- judge --------------------------------------------------------------
+  const judgeCfg = loadJudgeConfig();
+  input("jKey").value = judgeCfg.apiKey;
+  input("jModel").value = judgeCfg.model;
+  input("jCount").value = String(judgeCfg.judges);
+  for (const name of ["jKey", "jModel", "jCount"]) {
+    input(name).addEventListener("change", () => {
+      judgeCfg.apiKey = input("jKey").value.trim();
+      judgeCfg.model = input("jModel").value.trim() || judgeCfg.model;
+      judgeCfg.judges = Math.min(5, Math.max(1, +input("jCount").value || 3));
+      saveJudgeConfig(judgeCfg);
+    });
+  }
+  JUDGE_LABELS.forEach((label) => {
+    const opt = document.createElement("option");
+    opt.value = label;
+    opt.textContent = label;
+    el("target").appendChild(opt);
+  });
+  /** @type {HTMLSelectElement} */ (el("target")).value = "curious";
+
+  /** @type {{ key: string, label: string, dataUrl: string }[]} */
+  let lastShots = [];
+  /** @type {{ target: string, p: number, stamp: number } | null} */
+  let lastVerdict = null;
+  /** @type {{ shots: typeof lastShots, name: string } | null} */
+  let pinned = null;
+
+  function captureViews() {
+    if (!viz) return [];
+    lastShots = viz.snapshot(640);
+    el("views").innerHTML = lastShots
+      .map((s) => `<figure><img src="${s.dataUrl}" alt="${s.label}"><figcaption>${s.label}</figcaption></figure>`)
+      .join("");
+    return lastShots;
+  }
+  el("refreshViews").addEventListener("click", captureViews);
+
+  /** @param {string} msg @param {string} [cls] */
+  function log(msg, cls) {
+    const line = document.createElement("div");
+    if (cls) line.className = cls;
+    line.textContent = `${new Date().toLocaleTimeString()}  ${msg}`;
+    el("log").appendChild(line);
+    el("log").scrollTop = el("log").scrollHeight;
+  }
+
+  function requireJudge() {
+    if (!viz) {
+      log("3D view not ready yet", "err");
+      return false;
+    }
+    if (!judgeCfg.apiKey) {
+      log("set a Gemini API key first (stored only in this browser)", "err");
+      input("jKey").focus();
+      return false;
+    }
+    return true;
+  }
+
+  el("evalBtn").addEventListener("click", async () => {
+    if (!requireJudge()) return;
+    const shots = captureViews();
+    const target = /** @type {HTMLSelectElement} */ (el("target")).value;
+    const btn = /** @type {HTMLButtonElement} */ (el("evalBtn"));
+    btn.disabled = true;
+    el("judgeStatus").textContent = `judging 0/${judgeCfg.judges}…`;
+    try {
+      const panel = await judgePanel(shots, judgeCfg, (done) => {
+        el("judgeStatus").textContent = `judging ${done}/${judgeCfg.judges}…`;
+      });
+      if (destroyed) return;
+      el("judgeStatus").textContent = "";
+      if (!panel.runs.length) {
+        log(`all judges failed: ${panel.errors[0] || "unknown"}`, "err");
+        return;
+      }
+      renderPanel(panel, target);
+      const p = panel.mean[target] ?? 0;
+      lastVerdict = { target, p, stamp: Date.now() };
+      const top = JUDGE_LABELS.reduce((a, b) => (panel.mean[a] >= panel.mean[b] ? a : b));
+      log(
+        `blind panel ×${panel.runs.length}: P(${target})=${p.toFixed(2)} · top read: ${top} ${panel.mean[top].toFixed(2)}` +
+          (panel.errors.length ? ` · ${panel.errors.length} judge(s) failed` : ""),
+        top === target ? "ok" : undefined,
+      );
+    } catch (e) {
+      el("judgeStatus").textContent = "";
+      log(`judge error: ${e instanceof Error ? e.message : e}`, "err");
+    } finally {
+      btn.disabled = false;
+    }
+  });
+
+  /** @param {import("./judge.js").PanelResult} panel @param {string} target */
+  function renderPanel(panel, target) {
+    el("result").hidden = false;
+    const sorted = [...JUDGE_LABELS].sort((a, b) => panel.mean[b] - panel.mean[a]);
+    const p = panel.mean[target] ?? 0;
+    const runnerUp = sorted.find((l) => l !== target) ?? target;
+    el("score").innerHTML =
+      `P(<b>${target}</b>) = <b>${p.toFixed(2)}</b> ` +
+      `<span class="exs-sub">vs ${runnerUp} ${panel.mean[runnerUp].toFixed(2)} — target never shown to the judges</span>`;
+    el("bars").innerHTML = sorted
+      .filter((label) => panel.mean[label] >= 0.02 || label === target)
+      .map((label) => {
+        const spread =
+          panel.runs.length > 1
+            ? ` title="judges ranged ${Math.min(...panel.runs.map((r) => r.probabilities[label])).toFixed(2)}–${Math.max(...panel.runs.map((r) => r.probabilities[label])).toFixed(2)}"`
+            : "";
+        return `<div class="exs-bar${label === target ? " target" : ""}"${spread}>
+          <span class="lbl">${label}</span>
+          <span class="track"><span class="fill" style="width:${(panel.mean[label] * 100).toFixed(1)}%"></span></span>
+          <span class="num">${panel.mean[label].toFixed(2)}</span></div>`;
+      })
+      .join("");
+    const cues = [...new Set(panel.runs.flatMap((r) => r.cues))].slice(0, 5);
+    const impressions = panel.runs.map((r) => r.impression).filter(Boolean).slice(0, 3);
+    el("quotes").innerHTML = [
+      ...impressions.map((t) => `<li>“${t}”</li>`),
+      ...cues.map((t) => `<li class="exs-sub">cue: ${t}</li>`),
+    ].join("");
+  }
+
+  el("pinBtn").addEventListener("click", () => {
+    if (!viz) return;
+    const shots = captureViews();
+    pinned = { shots, name: input("poseName").value.trim() || "pinned" };
+    el("pinInfo").hidden = false;
+    /** @type {HTMLImageElement} */ (el("pinImg")).src = shots[1]?.dataUrl ?? shots[0]?.dataUrl ?? "";
+    el("pinName").textContent = pinned.name;
+    log(`pinned "${pinned.name}" as A`);
+  });
+
+  el("abBtn").addEventListener("click", async () => {
+    if (!requireJudge()) return;
+    if (!pinned) {
+      log("pin a pose as A first", "err");
+      return;
+    }
+    const current = captureViews();
+    const target = /** @type {HTMLSelectElement} */ (el("target")).value;
+    const btn = /** @type {HTMLButtonElement} */ (el("abBtn"));
+    btn.disabled = true;
+    el("judgeStatus").textContent = "comparing…";
+    try {
+      const pins = pinned;
+      const verdicts = await Promise.all(
+        Array.from({ length: judgeCfg.judges }, () => judgePair(pins.shots, current, target, judgeCfg)),
+      );
+      if (destroyed) return;
+      const bWins = verdicts.filter((v) => v.winner === "B").length;
+      const winner = bWins * 2 >= verdicts.length ? "current" : `pinned "${pins.name}"`;
+      log(
+        `A/B for "${target}": ${winner} wins ${Math.max(bWins, verdicts.length - bWins)}/${verdicts.length} — ${verdicts[0].reason}`,
+        winner === "current" ? "ok" : undefined,
+      );
+    } catch (e) {
+      log(`compare error: ${e instanceof Error ? e.message : e}`, "err");
+    } finally {
+      el("judgeStatus").textContent = "";
+      btn.disabled = false;
+    }
+  });
+
+  // ---- library ------------------------------------------------------------
+  /** @returns {SavedPose[]} */
+  function loadLibrary() {
+    try {
+      const raw = JSON.parse(localStorage.getItem(LIBRARY_KEY) || "[]");
+      return Array.isArray(raw) ? raw : [];
+    } catch {
+      return [];
+    }
+  }
+  /** @param {SavedPose[]} poses */
+  function saveLibrary(poses) {
+    try {
+      localStorage.setItem(LIBRARY_KEY, JSON.stringify(poses));
+    } catch {
+      // Quota — drop the heaviest payload (thumbnails) and retry once.
+      try {
+        localStorage.setItem(LIBRARY_KEY, JSON.stringify(poses.map((p) => ({ ...p, thumb: null }))));
+      } catch {
+        log("library save failed (storage full)", "err");
+      }
+    }
+  }
+  let library = loadLibrary();
+
+  /** Thumbnail for an arbitrary pose: pose in, snapshot, current pose back
+   * (the view eases home afterwards). @param {Pose} pose */
+  function thumbFor(pose) {
+    if (!viz) return null;
+    viz.setPose(pose);
+    const [shot] = viz.snapshot(160, ["quarter"]);
+    viz.setPose(currentPose());
+    return shot?.dataUrl ?? null;
+  }
+
+  function renderLibrary() {
+    el("libCount").textContent = library.length ? `${library.length} pose${library.length > 1 ? "s" : ""}` : "";
+    el("lib").innerHTML = "";
+    for (const pose of library) {
+      const item = document.createElement("div");
+      item.className = "exs-lib-item";
+      item.innerHTML = `${pose.thumb ? `<img src="${pose.thumb}" alt="">` : '<span class="noimg"></span>'}
+        <span class="exs-lib-name">${escapeHtml(pose.name)}
+          ${pose.judge ? `<div class="exs-lib-judge">${escapeHtml(pose.judge.target)} ${pose.judge.p.toFixed(2)}</div>` : ""}</span>
+        <button class="exs-mini exs-warn" title="Delete this pose">✕</button>`;
+      item.addEventListener("click", () => {
+        weights = sanitizeWeights(pose.weights);
+        offsets = sanitizeOffsets(pose.offsets);
+        refreshSliders();
+        applyPose();
+        input("poseName").value = pose.name;
+        log(`loaded "${pose.name}"`);
+      });
+      /** @type {HTMLButtonElement} */ (item.querySelector("button")).addEventListener("click", (e) => {
+        e.stopPropagation();
+        library = library.filter((p) => p.id !== pose.id);
+        saveLibrary(library);
+        renderLibrary();
+      });
+      el("lib").appendChild(item);
+    }
+  }
+
+  el("saveBtn").addEventListener("click", () => {
+    const name = input("poseName").value.trim() || `pose ${library.length + 1}`;
+    library.unshift({
+      id: crypto.randomUUID(),
+      name,
+      weights: { ...weights },
+      offsets: { ...offsets },
+      notes: "",
+      thumb: thumbFor(currentPose()),
+      judge: lastVerdict,
+    });
+    library = library.slice(0, MAX_POSES);
+    saveLibrary(library);
+    renderLibrary();
+    log(`saved "${name}"${lastVerdict ? ` with blind P(${lastVerdict.target})=${lastVerdict.p.toFixed(2)}` : ""}`, "ok");
+  });
+
+  el("exportBtn").addEventListener("click", () => {
+    const blob = new Blob([JSON.stringify(exportPayload(library), null, 2)], { type: "application/json" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "mars-expression-poses.json";
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+
+  el("importBtn").addEventListener("click", () => input("importFile").click());
+  input("importFile").addEventListener("change", async () => {
+    const file = input("importFile").files?.[0];
+    input("importFile").value = "";
+    if (!file) return;
+    try {
+      const entries = parseImport(await file.text());
+      for (const entry of entries) {
+        library.unshift({
+          id: crypto.randomUUID(),
+          name: entry.name,
+          weights: entry.weights,
+          offsets: entry.offsets,
+          notes: entry.notes,
+          thumb: thumbFor(synthesize(entry.weights, entry.offsets)),
+          judge: null,
+        });
+      }
+      library = library.slice(0, MAX_POSES);
+      saveLibrary(library);
+      renderLibrary();
+      log(`imported ${entries.length} pose(s)`, "ok");
+    } catch (e) {
+      log(`import failed: ${e instanceof Error ? e.message : e}`, "err");
+    }
+  });
+
+  /** @param {string} s */
+  function escapeHtml(s) {
+    return s.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+  }
+
+  refreshSliders();
+  applyPose();
+  renderLibrary();
+  log("ready — shape a pose on the axes, then Evaluate to hear what blind judges read");
+
+  return {
+    destroy() {
+      destroyed = true;
+      robotPending = null;
+      for (const unsub of unsubs) unsub();
+      unsubConn();
+      viz?.destroy();
+      root.remove();
+    },
+  };
+}

--- a/webapp/js/expression/main.js
+++ b/webapp/js/expression/main.js
@@ -16,9 +16,13 @@
 import {
   ACTUATORS,
   AXES,
+  NEUTRAL,
   PRESETS,
+  actuatorNumbers,
+  defaultBasis,
   exportPayload,
   parseImport,
+  sanitizeBasis,
   sanitizeOffsets,
   sanitizeWeights,
   synthesize,
@@ -35,6 +39,7 @@ const ARM_ACTION_TYPE = "brain_messages/action/ExecuteArmCommand";
 const STREAM_TOPIC = "/armsdk/stream_joints";
 const ARM_STATE_TOPIC = "/mars/arm/state";
 const LIBRARY_KEY = "innate.expression.library";
+const BASIS_KEY = "innate.expression.basis";
 const MAX_POSES = 60;
 
 /** @typedef {import("./model.js").Pose} Pose */
@@ -130,6 +135,20 @@ const CSS = `
 .exs-off-val { width: 56px; text-align: right; font-family: var(--mono, ui-monospace, monospace);
   font-size: 12px; color: var(--accent); }
 
+/* --- basis editor -------------------------------------------------------- */
+.exs-bx { border-top: 1px solid var(--hairline); padding: 7px 0 3px; }
+.exs-bx:first-child { border-top: none; }
+.exs-bx-head { display: flex; gap: 6px; align-items: center; }
+.exs-bx-head .spacer { flex: 1; }
+.exs-bx-head input { font-size: 12px; padding: 3px 6px; }
+.exs-bx-end { display: flex; gap: 6px; align-items: center; margin: 5px 0; }
+.exs-bx-end > b { width: 18px; font-size: 11px; color: var(--muted); font-weight: 500;
+  font-family: var(--mono, ui-monospace, monospace); }
+.exs-bx-end input { flex: 1; min-width: 0; font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11.5px; padding: 3px 7px; }
+.exs-bx-end input.bad { border-color: var(--danger); }
+.exs-bx-end button { white-space: nowrap; }
+
 /* --- judge -------------------------------------------------------------- */
 .exs-views { display: flex; gap: 8px; margin: 8px 0; }
 .exs-views figure { margin: 0; flex: 1; min-width: 0; }
@@ -218,6 +237,17 @@ const PAGE_HTML = `
         <div class="exs-row"><button class="exs-mini" data-el="clearOffsets">clear offsets</button></div>
         <div class="exs-hint">offsets add on top of the axes and export with the pose — use them to fix what the basis can't say, then fold recurring fixes back into the basis</div>
       </details>
+      <details>
+        <summary>Basis editor · redefine the axes</summary>
+        <div data-el="basisRows"></div>
+        <div class="exs-row">
+          <input type="text" data-el="newAxisName" placeholder="new axis name" size="12">
+          <button class="exs-mini" data-el="addAxis" title="Add an empty axis — then sculpt each extreme and capture it">+ add axis</button>
+          <span class="spacer"></span>
+          <button class="exs-mini exs-warn" data-el="resetBasis" title="Throw away every edit and restore the built-in basis">reset all</button>
+        </div>
+        <div class="exs-hint">the puppet workflow: sculpt an extreme with the axes + fine-tune, then <b>capture</b> it as that end of an axis (a delta from neutral — the slider then holds your pose at ±1). Edits persist in this browser and export with your poses; saved poses keep their exact look across basis changes.</div>
+      </details>
     </div>
   </div>
 
@@ -289,10 +319,21 @@ export function mount(stage) {
   let viz = null;
 
   // ---- pose state ---------------------------------------------------------
-  let weights = zeroWeights();
+  // The live basis: the built-ins, overridden by whatever this browser has
+  // sculpted in the basis editor.
+  /** @type {import("./model.js").Axis[]} */
+  let basis;
+  try {
+    basis = sanitizeBasis(JSON.parse(localStorage.getItem(BASIS_KEY) ?? "null"));
+  } catch {
+    basis = defaultBasis();
+  }
+  const persistBasis = () => localStorage.setItem(BASIS_KEY, JSON.stringify(basis));
+
+  let weights = zeroWeights(basis);
   /** @type {import("./model.js").PoseDelta} */
   let offsets = {};
-  const currentPose = () => synthesize(weights, offsets);
+  const currentPose = () => synthesize(weights, offsets, basis);
 
   /** @type {HTMLInputElement[]} */
   const axisSliders = [];
@@ -316,9 +357,9 @@ export function mount(stage) {
   }
 
   function refreshSliders() {
-    AXES.forEach((axis, i) => {
-      axisSliders[i].value = String(weights[axis.key]);
-      axisVals[i].textContent = weights[axis.key].toFixed(2);
+    basis.forEach((axis, i) => {
+      axisSliders[i].value = String(weights[axis.key] ?? 0);
+      axisVals[i].textContent = (weights[axis.key] ?? 0).toFixed(2);
     });
     ACTUATORS.forEach((a, i) => {
       offsetSliders[i].value = String(offsets[a.key] ?? 0);
@@ -332,52 +373,192 @@ export function mount(stage) {
       const preset = PRESETS[i];
       const active =
         Object.keys(offsets).length === 0 &&
-        AXES.every((axis) => Math.abs((preset.weights[axis.key] ?? 0) - weights[axis.key]) < 0.005);
+        basis.every((axis) => Math.abs((preset.weights[axis.key] ?? 0) - (weights[axis.key] ?? 0)) < 0.005);
       chip.classList.toggle("active", active);
     });
   }
 
   // ---- axes UI ------------------------------------------------------------
-  AXES.forEach((axis, i) => {
-    const row = document.createElement("div");
-    row.className = "exs-axis";
-    row.title = axis.doc;
-    row.innerHTML = `
-      <div class="exs-axis-top"><span class="exs-axis-name">${axis.label}</span>
-        <span class="exs-axis-val">0.00</span></div>
-      <div class="exs-axis-track"><span class="exs-axis-end">${axis.negLabel}</span>
-        <input type="range" min="-1" max="1" step="0.01" value="0">
-        <span class="exs-axis-end hi">${axis.posLabel}</span></div>`;
-    const slider = /** @type {HTMLInputElement} */ (row.querySelector("input"));
-    const val = /** @type {HTMLElement} */ (row.querySelector(".exs-axis-val"));
-    slider.addEventListener("input", () => {
-      weights[axis.key] = +slider.value;
-      val.textContent = (+slider.value).toFixed(2);
-      applyPose();
-    });
-    slider.addEventListener("dblclick", () => {
-      weights[axis.key] = 0;
-      slider.value = "0";
-      val.textContent = "0.00";
-      applyPose();
-    });
-    axisSliders.push(slider);
-    axisVals.push(val);
-    el("axes").appendChild(row);
-  });
+  // Rebuilt whenever the basis editor changes the axis roster or its labels.
+  function renderAxes() {
+    axisSliders.length = 0;
+    axisVals.length = 0;
+    el("axes").innerHTML = "";
+    for (const axis of basis) {
+      const row = document.createElement("div");
+      row.className = "exs-axis";
+      row.title = axis.doc;
+      row.innerHTML = `
+        <div class="exs-axis-top"><span class="exs-axis-name">${escapeHtml(axis.label)}</span>
+          <span class="exs-axis-val">0.00</span></div>
+        <div class="exs-axis-track"><span class="exs-axis-end">${escapeHtml(axis.negLabel)}</span>
+          <input type="range" min="-1" max="1" step="0.01" value="0">
+          <span class="exs-axis-end hi">${escapeHtml(axis.posLabel)}</span></div>`;
+      const slider = /** @type {HTMLInputElement} */ (row.querySelector("input"));
+      const val = /** @type {HTMLElement} */ (row.querySelector(".exs-axis-val"));
+      slider.addEventListener("input", () => {
+        weights[axis.key] = +slider.value;
+        val.textContent = (+slider.value).toFixed(2);
+        applyPose();
+      });
+      slider.addEventListener("dblclick", () => {
+        weights[axis.key] = 0;
+        slider.value = "0";
+        val.textContent = "0.00";
+        applyPose();
+      });
+      axisSliders.push(slider);
+      axisVals.push(val);
+      el("axes").appendChild(row);
+    }
+    refreshSliders();
+  }
 
   PRESETS.forEach((preset) => {
     const chip = document.createElement("button");
     chip.textContent = preset.label;
     chip.title = preset.doc;
     chip.addEventListener("click", () => {
-      weights = sanitizeWeights(preset.weights);
+      weights = sanitizeWeights(preset.weights, basis);
       offsets = {};
       refreshSliders();
       applyPose();
       input("poseName").value = preset.label;
     });
     el("presets").appendChild(chip);
+  });
+
+  // ---- basis editor -------------------------------------------------------
+  /** The current pose as a delta from neutral — what a captured extreme *is*.
+   * Values rounded to what the actuator meaningfully resolves. */
+  function deltaFromNeutral() {
+    const pose = currentPose();
+    /** @type {import("./model.js").PoseDelta} */
+    const delta = {};
+    for (const a of ACTUATORS) {
+      const d = pose[a.key] - NEUTRAL[a.key];
+      if (Math.abs(d) > (a.unit === "°" ? 0.5 : 0.005)) {
+        delta[a.key] = a.unit === "°" ? Math.round(d) : +d.toFixed(3);
+      }
+    }
+    return delta;
+  }
+
+  /** Re-render everything the basis feeds and persist it. */
+  function basisChanged() {
+    weights = sanitizeWeights(weights, basis);
+    persistBasis();
+    renderAxes();
+    renderBasisEditor();
+    applyPose();
+  }
+
+  function renderBasisEditor() {
+    el("basisRows").innerHTML = "";
+    basis.forEach((axis, index) => {
+      const row = document.createElement("div");
+      row.className = "exs-bx";
+      row.innerHTML = `
+        <div class="exs-bx-head">
+          <input type="text" value="${escapeHtml(axis.label)}" size="9" data-f="label" title="axis name">
+          <input type="text" value="${escapeHtml(axis.negLabel)}" size="8" data-f="negLabel" title="label of the −1 end">
+          <span class="exs-sub">⟷</span>
+          <input type="text" value="${escapeHtml(axis.posLabel)}" size="8" data-f="posLabel" title="label of the +1 end">
+          <span class="spacer"></span>
+          ${AXES.some((d) => d.key === axis.key) ? '<button class="exs-mini" data-f="restore" title="Restore this axis\'s built-in definition">↺</button>' : ""}
+          <button class="exs-mini exs-warn" data-f="del" title="Remove this axis from the basis">✕</button>
+        </div>
+        <div class="exs-bx-end"><b>−1</b>
+          <input type="text" spellcheck="false" data-end="neg" title='the −1 extreme as a delta from neutral, e.g. {"j2":-0.5,"head":-30}'>
+          <button class="exs-mini" data-cap="neg" title="Capture the CURRENT pose as this axis's −1 extreme; the slider then holds it at −1">⤓ capture</button>
+          <button class="exs-mini" data-view="neg" title="Preview this extreme (sets the slider to −1)">view</button>
+        </div>
+        <div class="exs-bx-end"><b>+1</b>
+          <input type="text" spellcheck="false" data-end="pos" title='the +1 extreme as a delta from neutral, e.g. {"j1":-0.7,"head":14}'>
+          <button class="exs-mini" data-cap="pos" title="Capture the CURRENT pose as this axis's +1 extreme; the slider then holds it at +1">⤓ capture</button>
+          <button class="exs-mini" data-view="pos" title="Preview this extreme (sets the slider to +1)">view</button>
+        </div>`;
+
+      for (const end of /** @type {const} */ (["neg", "pos"])) {
+        const field = /** @type {HTMLInputElement} */ (row.querySelector(`input[data-end="${end}"]`));
+        field.value = JSON.stringify(axis[end]);
+        field.addEventListener("change", () => {
+          try {
+            const delta = sanitizeOffsets(JSON.parse(field.value || "{}"));
+            field.classList.remove("bad");
+            axis[end] = delta;
+            field.value = JSON.stringify(delta);
+            persistBasis();
+            applyPose();
+          } catch {
+            field.classList.add("bad"); // left visible until a valid parse; not applied
+          }
+        });
+        /** @type {HTMLButtonElement} */ (row.querySelector(`[data-cap="${end}"]`)).addEventListener("click", () => {
+          axis[end] = deltaFromNeutral();
+          weights = zeroWeights(basis);
+          weights[axis.key] = end === "pos" ? 1 : -1;
+          offsets = {};
+          basisChanged();
+          log(`captured the pose as "${axis.label}" ${end === "pos" ? "+1" : "−1"} — the slider now owns it`, "ok");
+        });
+        /** @type {HTMLButtonElement} */ (row.querySelector(`[data-view="${end}"]`)).addEventListener("click", () => {
+          weights[axis.key] = end === "pos" ? 1 : -1;
+          refreshSliders();
+          applyPose();
+        });
+      }
+      for (const f of ["label", "negLabel", "posLabel"]) {
+        const field = /** @type {HTMLInputElement} */ (row.querySelector(`input[data-f="${f}"]`));
+        field.addEventListener("change", () => {
+          axis[/** @type {"label"|"negLabel"|"posLabel"} */ (f)] = field.value.trim() || axis.key;
+          persistBasis();
+          renderAxes();
+        });
+      }
+      row.querySelector('[data-f="restore"]')?.addEventListener("click", () => {
+        const builtin = defaultBasis().find((d) => d.key === axis.key);
+        if (!builtin) return;
+        basis[index] = builtin;
+        basisChanged();
+        log(`restored built-in "${builtin.label}"`);
+      });
+      /** @type {HTMLButtonElement} */ (row.querySelector('[data-f="del"]')).addEventListener("click", () => {
+        if (!window.confirm(`Remove the "${axis.label}" axis? Saved poses keep their look (they carry actuator vectors), but its slider disappears.`)) return;
+        basis.splice(index, 1);
+        basisChanged();
+        log(`removed axis "${axis.label}" — reset all restores the built-ins`);
+      });
+      el("basisRows").appendChild(row);
+    });
+  }
+
+  el("addAxis").addEventListener("click", () => {
+    const name = input("newAxisName").value.trim();
+    if (!name) {
+      input("newAxisName").focus();
+      return;
+    }
+    let key = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "axis";
+    while (basis.some((a) => a.key === key)) key += "2";
+    basis.push({
+      key,
+      label: name,
+      negLabel: "−",
+      posLabel: "+",
+      doc: "custom axis — sculpt each extreme with the sliders, then capture it",
+      neg: {},
+      pos: {},
+    });
+    input("newAxisName").value = "";
+    basisChanged();
+    log(`added axis "${name}" — capture its extremes to give it meaning`);
+  });
+  el("resetBasis").addEventListener("click", () => {
+    if (!window.confirm("Reset ALL axes to the built-in basis? Every edited or added axis is discarded.")) return;
+    basis = defaultBasis();
+    basisChanged();
+    log("basis reset to built-ins");
   });
 
   ACTUATORS.forEach((a, i) => {
@@ -402,7 +583,7 @@ export function mount(stage) {
   });
 
   el("resetAxes").addEventListener("click", () => {
-    weights = zeroWeights();
+    weights = zeroWeights(basis);
     offsets = {};
     refreshSliders();
     applyPose();
@@ -712,6 +893,32 @@ export function mount(stage) {
   }
   let library = loadLibrary();
 
+  /**
+   * Resolve a stored/imported pose against the LIVE basis. Weights are pruned
+   * to known axes; when the entry carries its exact actuator vector, the
+   * residual (from basis edits since it was authored) folds into offsets so
+   * the pose looks identical — the semantic weights survive where they still
+   * apply. Two passes: the second absorbs clamping interactions.
+   * @param {any} entryWeights @param {any} entryOffsets @param {import("./model.js").PoseDelta | null} actuators
+   */
+  function resolvePose(entryWeights, entryOffsets, actuators) {
+    const w = sanitizeWeights(entryWeights, basis);
+    let off = sanitizeOffsets(entryOffsets);
+    if (actuators) {
+      for (let pass = 0; pass < 2; pass++) {
+        const synth = synthesize(w, off, basis);
+        for (const a of ACTUATORS) {
+          const v = actuators[a.key];
+          if (typeof v === "number" && Math.abs(v - synth[a.key]) > 1e-4) {
+            off[a.key] = (off[a.key] ?? 0) + v - synth[a.key];
+          }
+        }
+      }
+      off = sanitizeOffsets(off);
+    }
+    return { weights: w, offsets: off };
+  }
+
   /** Thumbnail for an arbitrary pose: pose in, snapshot, current pose back
    * (the view eases home afterwards). @param {Pose} pose */
   function thumbFor(pose) {
@@ -733,8 +940,7 @@ export function mount(stage) {
           ${pose.judge ? `<div class="exs-lib-judge">${escapeHtml(pose.judge.target)} ${pose.judge.p.toFixed(2)}</div>` : ""}</span>
         <button class="exs-mini exs-warn" title="Delete this pose">✕</button>`;
       item.addEventListener("click", () => {
-        weights = sanitizeWeights(pose.weights);
-        offsets = sanitizeOffsets(pose.offsets);
+        ({ weights, offsets } = resolvePose(pose.weights, pose.offsets, actuatorNumbers(pose.actuators)));
         refreshSliders();
         applyPose();
         input("poseName").value = pose.name;
@@ -759,6 +965,7 @@ export function mount(stage) {
       offsets: { ...offsets },
       notes: "",
       thumb: thumbFor(currentPose()),
+      actuators: currentPose(),
       judge: lastVerdict,
     });
     library = library.slice(0, MAX_POSES);
@@ -768,7 +975,7 @@ export function mount(stage) {
   });
 
   el("exportBtn").addEventListener("click", () => {
-    const blob = new Blob([JSON.stringify(exportPayload(library), null, 2)], { type: "application/json" });
+    const blob = new Blob([JSON.stringify(exportPayload(library, basis), null, 2)], { type: "application/json" });
     const a = document.createElement("a");
     a.href = URL.createObjectURL(blob);
     a.download = "mars-expression-poses.json";
@@ -782,15 +989,24 @@ export function mount(stage) {
     input("importFile").value = "";
     if (!file) return;
     try {
-      const entries = parseImport(await file.text());
+      const { basis: fileBasis, poses: entries } = parseImport(await file.text());
+      if (fileBasis && JSON.stringify(fileBasis) !== JSON.stringify(basis)) {
+        if (window.confirm("This file carries its own axis basis. Adopt it (replaces your current axes)? The poses import correctly either way.")) {
+          basis = fileBasis;
+          basisChanged();
+          log("adopted the file's basis", "ok");
+        }
+      }
       for (const entry of entries) {
+        const resolved = resolvePose(entry.weights, entry.offsets, entry.actuators);
         library.unshift({
           id: crypto.randomUUID(),
           name: entry.name,
-          weights: entry.weights,
-          offsets: entry.offsets,
+          weights: resolved.weights,
+          offsets: resolved.offsets,
           notes: entry.notes,
-          thumb: thumbFor(synthesize(entry.weights, entry.offsets)),
+          thumb: thumbFor(synthesize(resolved.weights, resolved.offsets, basis)),
+          actuators: entry.actuators,
           judge: null,
         });
       }
@@ -808,7 +1024,8 @@ export function mount(stage) {
     return s.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
   }
 
-  refreshSliders();
+  renderAxes();
+  renderBasisEditor();
   applyPose();
   renderLibrary();
   log("ready — shape a pose on the axes, then Evaluate to hear what blind judges read");

--- a/webapp/js/expression/main.js
+++ b/webapp/js/expression/main.js
@@ -116,6 +116,9 @@ const CSS = `
 .exs-copy.copied { color: var(--ok); border-color: var(--ok); }
 
 /* --- axes --------------------------------------------------------------- */
+.exs-axgroup { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .09em;
+  font-weight: 600; margin: 12px 0 2px; padding-top: 8px; border-top: 1px solid var(--hairline); }
+.exs-axgroup:first-child { margin-top: 2px; padding-top: 0; border-top: none; }
 .exs-axis { margin: 9px 0; }
 .exs-axis-top { display: flex; align-items: baseline; gap: 8px; }
 .exs-axis-name { font-size: 12.5px; color: var(--text); width: 74px; }
@@ -379,12 +382,31 @@ export function mount(stage) {
   }
 
   // ---- axes UI ------------------------------------------------------------
+  const GROUP_LABELS = {
+    shape: "shape · the body's configuration",
+    stance: "stance · where it stands vs the person",
+  };
+
+  /** Append a group eyebrow to `parent` when `axis` starts a new group —
+   * suppressed while the whole basis lives in one group.
+   * @param {HTMLElement} parent @param {import("./model.js").Axis} axis @param {{ g: string }} state */
+  function groupEyebrow(parent, axis, state) {
+    if (axis.group === state.g || new Set(basis.map((a) => a.group)).size < 2) return;
+    state.g = axis.group;
+    const eyebrow = document.createElement("div");
+    eyebrow.className = "exs-axgroup";
+    eyebrow.textContent = GROUP_LABELS[axis.group] ?? axis.group;
+    parent.appendChild(eyebrow);
+  }
+
   // Rebuilt whenever the basis editor changes the axis roster or its labels.
   function renderAxes() {
     axisSliders.length = 0;
     axisVals.length = 0;
     el("axes").innerHTML = "";
+    const state = { g: "" };
     for (const axis of basis) {
+      groupEyebrow(el("axes"), axis, state);
       const row = document.createElement("div");
       row.className = "exs-axis";
       row.title = axis.doc;
@@ -455,7 +477,9 @@ export function mount(stage) {
 
   function renderBasisEditor() {
     el("basisRows").innerHTML = "";
+    const state = { g: "" };
     basis.forEach((axis, index) => {
+      groupEyebrow(el("basisRows"), axis, state);
       const row = document.createElement("div");
       row.className = "exs-bx";
       row.innerHTML = `
@@ -541,11 +565,13 @@ export function mount(stage) {
     }
     let key = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "axis";
     while (basis.some((a) => a.key === key)) key += "2";
-    basis.push({
+    // After the last shape axis, so the shape/stance grouping stays contiguous.
+    basis.splice(basis.map((a) => a.group).lastIndexOf("shape") + 1, 0, {
       key,
       label: name,
       negLabel: "−",
       posLabel: "+",
+      group: "shape",
       doc: "custom axis — sculpt each extreme with the sliders, then capture it",
       neg: {},
       pos: {},

--- a/webapp/js/expression/model.js
+++ b/webapp/js/expression/model.js
@@ -1,0 +1,299 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Expression model — the studio's representation of a pose, in two layers.
+//
+// Actuator layer: everything MARS can hold still — the 6 arm joints, the head
+// pitch servo, and where the base sits relative to its neutral spot (the robot
+// can drive anywhere, so base offset is a pose variable like any joint).
+//
+// Expression layer: a small basis of semantic axes. Each axis is a pair of
+// actuator-space deltas (the −1 and +1 extremes) chosen from what the axis
+// physically *means* — approach is literally distance to the person, expand is
+// literally silhouette area — not from how an emotion "should look". Emotions
+// are then just weight vectors over the basis (PRESETS), which is what makes
+// the vocabulary searchable by sliders, optimizers, and VLM judges alike.
+//
+// synthesize() is the whole runtime: neutral + Σ weight·delta + manual
+// offsets, clamped to actuator limits. Pure module — no DOM, no ROS.
+
+/**
+ * @typedef {"j1"|"j2"|"j3"|"j4"|"j5"|"j6"|"head"|"baseX"|"baseY"|"baseYaw"} ActuatorKey
+ * @typedef {Record<ActuatorKey, number>} Pose
+ * @typedef {Partial<Record<ActuatorKey, number>>} PoseDelta
+ * @typedef {{ key: string, label: string, negLabel: string, posLabel: string,
+ *             doc: string, neg: PoseDelta, pos: PoseDelta }} Axis
+ * @typedef {Record<string, number>} Weights axis key -> weight in [-1, 1]
+ * @typedef {{ key: string, label: string, doc: string, weights: Weights }} Preset
+ */
+
+// Arm ranges are the URDF joint limits (mars.urdf — what the arm can actually
+// hold); head is the servo's real range in degrees (HEAD_MIN/MAX_DEG, wider
+// than the URDF's stale ±20°); base offsets are studio bounds for "slightly"
+// — the runtime controller will own real driving.
+/** @type {{ key: ActuatorKey, label: string, min: number, max: number, unit: string, step: number }[]} */
+export const ACTUATORS = [
+  { key: "j1", label: "j1 · base yaw", min: -1.5708, max: 1.5708, unit: "rad", step: 0.01 },
+  { key: "j2", label: "j2 · shoulder", min: -1.5708, max: 1.22, unit: "rad", step: 0.01 },
+  { key: "j3", label: "j3 · elbow", min: -1.5708, max: 1.7453, unit: "rad", step: 0.01 },
+  { key: "j4", label: "j4 · wrist pitch", min: -1.9199, max: 1.7453, unit: "rad", step: 0.01 },
+  { key: "j5", label: "j5 · wrist roll", min: -1.5708, max: 1.5708, unit: "rad", step: 0.01 },
+  { key: "j6", label: "j6 · gripper", min: 0, max: 0.8727, unit: "rad", step: 0.01 },
+  { key: "head", label: "head pitch", min: -40, max: 70, unit: "°", step: 1 },
+  { key: "baseX", label: "base advance", min: -0.3, max: 0.3, unit: "m", step: 0.005 },
+  { key: "baseY", label: "base sidestep", min: -0.3, max: 0.3, unit: "m", step: 0.005 },
+  { key: "baseYaw", label: "base turn", min: -0.7854, max: 0.7854, unit: "rad", step: 0.01 },
+];
+
+// At-ease: arm loosely folded near the SDK rest pose but off the joint limits
+// (so every axis has room in both directions), head level on the person.
+/** @type {Pose} */
+export const NEUTRAL = {
+  j1: 0.9,
+  j2: -0.85,
+  j3: 1.35,
+  j4: -0.4,
+  j5: 0,
+  j6: 0.12,
+  head: 8,
+  baseX: 0,
+  baseY: 0,
+  baseYaw: 0,
+};
+
+// The person the robot is expressing *to* stands here (base frame, meters) —
+// shared by the renderer's observer figure and the judge's viewpoints, so
+// approach/turn/attend always read against the same target.
+export const PERSON = { x: 1.0, y: 0, height: 1.65 };
+
+// The basis. Deltas are what the +1 / −1 extreme adds to NEUTRAL; anything an
+// axis doesn't mention stays untouched, so axes compose additively.
+/** @type {Axis[]} */
+export const AXES = [
+  {
+    key: "approach",
+    label: "approach",
+    negLabel: "withdraw",
+    posLabel: "advance",
+    doc: "Distance to the person — the most primitive engagement signal. Advancing commits the body toward the stimulus; withdrawing moves the vulnerable whole away from it.",
+    neg: { baseX: -0.24 },
+    pos: { baseX: 0.17 },
+  },
+  {
+    key: "turn",
+    label: "turn",
+    negLabel: "away right",
+    posLabel: "away left",
+    doc: "Facing. 0 is square-on; either sign breaks the face-to-face axis. Body turned away with the head still on target reads very differently from full disengagement.",
+    neg: { baseYaw: -0.7 },
+    pos: { baseYaw: 0.7 },
+  },
+  {
+    key: "sidestep",
+    label: "sidestep",
+    negLabel: "right",
+    posLabel: "left",
+    doc: "Lateral offset from the person's axis — circling, peeking, giving way.",
+    neg: { baseY: -0.2 },
+    pos: { baseY: 0.2 },
+  },
+  {
+    key: "rise",
+    label: "rise",
+    negLabel: "shrink",
+    posLabel: "tower",
+    doc: "Silhouette height. The arm is most of what MARS can raise: mast-high arm plus lifted head maximizes apparent size; folding it low with the head dropped minimizes it.",
+    neg: { j2: -0.5, j3: 0.35, j4: -0.8, head: -30 },
+    pos: { j1: -0.7, j2: 0.75, j3: -2.75, j4: 0.3, head: 14 },
+  },
+  {
+    key: "expand",
+    label: "expand",
+    negLabel: "clench",
+    posLabel: "flare",
+    doc: "Silhouette width. Flaring swings the arm out of the body outline and opens the gripper; clenching folds everything inside the chassis footprint and shuts the claw.",
+    neg: { j1: 0.5, j3: 0.3, j4: -0.5, j6: -0.12 },
+    pos: { j1: -1.5, j3: -0.85, j4: 0.4, j6: 0.6 },
+  },
+  {
+    key: "reach",
+    label: "reach",
+    negLabel: "guard",
+    posLabel: "offer",
+    doc: "Arm extension along the robot→person line. Offering presents the effector to the person; guarding pulls it in against the chassis, protecting the protruding part.",
+    neg: { j2: -0.4, j3: 0.35, j4: -0.9, j6: -0.12 },
+    pos: { j1: -0.9, j2: 1.0, j3: -1.0, j4: -0.3, j6: 0.3 },
+  },
+  {
+    key: "attend",
+    label: "attend",
+    negLabel: "downcast",
+    posLabel: "raised",
+    doc: "Gaze height. The person's face is ~1.5 m above the robot's, so sensors-on-target means head pitched well up; head at the floor abandons the target entirely.",
+    neg: { head: -45 },
+    pos: { head: 55 },
+  },
+];
+
+// Emotions as weight vectors — derived from what the state *does* to a body,
+// not from acting them out. The interesting ones are combinations single axes
+// can't say: fear retreats and shrinks but keeps the sensors on the threat.
+/** @type {Preset[]} */
+export const PRESETS = [
+  {
+    key: "curious",
+    label: "curious",
+    doc: "Get the sensors closer to the thing without committing the body: advance a little, slight peek angle, head up and forward.",
+    weights: { approach: 0.45, sidestep: 0.25, rise: 0.15, reach: 0.35, attend: 0.7 },
+  },
+  {
+    key: "excited",
+    label: "excited",
+    doc: "Maximum energy: big, tall, open, pressing toward the person.",
+    weights: { approach: 0.5, rise: 0.65, expand: 0.7, reach: 0.2, attend: 0.8 },
+  },
+  {
+    key: "confident",
+    label: "confident",
+    doc: "Maximize apparent size and hold the ground: tall, open, square-on, no retreat.",
+    weights: { approach: 0.2, rise: 0.9, expand: 0.45, attend: 0.55 },
+  },
+  {
+    key: "affectionate",
+    label: "affectionate",
+    doc: "Close the distance and present the effector — contact-seeking, softly raised gaze.",
+    weights: { approach: 0.65, rise: -0.1, expand: 0.15, reach: 0.8, attend: 0.5 },
+  },
+  {
+    key: "fearful",
+    label: "fearful",
+    doc: "Retreat and shrink — but the head stays on the threat. Monitoring while withdrawing is what separates fear from mere disengagement.",
+    weights: { approach: -0.9, turn: 0.25, rise: -0.7, expand: -0.6, reach: -0.7, attend: 0.35 },
+  },
+  {
+    key: "sad",
+    label: "sad",
+    doc: "Low energy, no target focus: slumped small, gaze at the floor, slight drift away.",
+    weights: { approach: -0.3, rise: -0.6, expand: -0.3, reach: -0.3, attend: -0.9 },
+  },
+  {
+    key: "suspicious",
+    label: "suspicious",
+    doc: "Body turned off-axis and edged away while the head keeps watching — guarded observation.",
+    weights: { approach: -0.25, turn: 0.6, sidestep: -0.3, expand: -0.2, attend: 0.4 },
+  },
+  {
+    key: "relaxed",
+    label: "relaxed",
+    doc: "At ease near neutral: soft gaze on the person, nothing braced.",
+    weights: { attend: 0.2 },
+  },
+];
+
+/** Zero weight for every axis. @returns {Weights} */
+export function zeroWeights() {
+  return Object.fromEntries(AXES.map((a) => [a.key, 0]));
+}
+
+/** @param {number} v @param {number} lo @param {number} hi */
+const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+
+/** Clamp every actuator to its physical range. @param {Pose} pose @returns {Pose} */
+export function clampPose(pose) {
+  const out = /** @type {Pose} */ ({ ...pose });
+  for (const a of ACTUATORS) out[a.key] = clamp(out[a.key], a.min, a.max);
+  return out;
+}
+
+/**
+ * Fold the expression layers into one actuator pose:
+ * NEUTRAL + Σ axis contribution (weight toward the pos/neg extreme) + manual
+ * per-actuator offsets, clamped to limits.
+ * @param {Weights} weights @param {PoseDelta} [offsets] @returns {Pose}
+ */
+export function synthesize(weights, offsets = {}) {
+  const q = /** @type {Pose} */ ({ ...NEUTRAL });
+  for (const axis of AXES) {
+    const w = clamp(weights[axis.key] ?? 0, -1, 1);
+    if (w === 0) continue;
+    const delta = w > 0 ? axis.pos : axis.neg;
+    for (const [key, value] of Object.entries(delta)) {
+      q[/** @type {ActuatorKey} */ (key)] += Math.abs(w) * /** @type {number} */ (value);
+    }
+  }
+  for (const [key, value] of Object.entries(offsets)) {
+    q[/** @type {ActuatorKey} */ (key)] += /** @type {number} */ (value) || 0;
+  }
+  return clampPose(q);
+}
+
+/** @typedef {{ id: string, name: string, weights: Weights, offsets: PoseDelta,
+ *              notes: string, thumb: string | null,
+ *              judge: { target: string, p: number, stamp: number } | null }} SavedPose */
+
+/**
+ * The library's export payload — weights AND the synthesized actuator vector
+ * per pose, so downstream steps (PCA over collected poses, the runtime
+ * controller) can consume either layer without importing this module.
+ * @param {SavedPose[]} poses
+ */
+export function exportPayload(poses) {
+  return {
+    format: "innate-expression-poses",
+    version: 1,
+    robot: "mars",
+    neutral: NEUTRAL,
+    axes: AXES.map(({ key, neg, pos }) => ({ key, neg, pos })),
+    poses: poses.map((p) => ({
+      name: p.name,
+      notes: p.notes,
+      weights: p.weights,
+      offsets: p.offsets,
+      actuators: synthesize(p.weights, p.offsets),
+      judge: p.judge,
+    })),
+  };
+}
+
+/**
+ * Parse an exported payload back into library entries (thumbnails are not
+ * exported; they re-render on load). Throws on anything that isn't ours.
+ * @param {string} text @returns {{ name: string, weights: Weights, offsets: PoseDelta, notes: string }[]}
+ */
+export function parseImport(text) {
+  const data = JSON.parse(text);
+  if (data?.format !== "innate-expression-poses" || !Array.isArray(data.poses)) {
+    throw new Error("not an expression-poses export");
+  }
+  return data.poses.map((/** @type {any} */ p) => ({
+    name: String(p.name || "pose"),
+    weights: sanitizeWeights(p.weights),
+    offsets: sanitizeOffsets(p.offsets),
+    notes: String(p.notes || ""),
+  }));
+}
+
+/** Keep only known axis keys, as finite numbers in [-1, 1]. @param {any} raw @returns {Weights} */
+export function sanitizeWeights(raw) {
+  const w = zeroWeights();
+  if (raw && typeof raw === "object") {
+    for (const axis of AXES) {
+      const v = Number(raw[axis.key]);
+      if (Number.isFinite(v)) w[axis.key] = clamp(v, -1, 1);
+    }
+  }
+  return w;
+}
+
+/** Keep only known actuator keys with finite values. @param {any} raw @returns {PoseDelta} */
+export function sanitizeOffsets(raw) {
+  /** @type {PoseDelta} */
+  const out = {};
+  if (raw && typeof raw === "object") {
+    for (const a of ACTUATORS) {
+      const v = Number(raw[a.key]);
+      if (Number.isFinite(v) && v !== 0) out[a.key] = v;
+    }
+  }
+  return out;
+}

--- a/webapp/js/expression/model.js
+++ b/webapp/js/expression/model.js
@@ -66,8 +66,11 @@ export const NEUTRAL = {
 // approach/turn/attend always read against the same target.
 export const PERSON = { x: 1.0, y: 0, height: 1.65 };
 
-// The basis. Deltas are what the +1 / −1 extreme adds to NEUTRAL; anything an
-// axis doesn't mention stays untouched, so axes compose additively.
+// The built-in basis — a starting point, not a commitment. The studio edits a
+// live copy (defaultBasis/sanitizeBasis below): endpoints are re-captured from
+// sculpted poses, axes added or dropped, and the result persists and exports
+// with the pose library. Deltas are what the +1 / −1 extreme adds to NEUTRAL;
+// anything an axis doesn't mention stays untouched, so axes compose additively.
 /** @type {Axis[]} */
 export const AXES = [
   {
@@ -190,9 +193,40 @@ export const PRESETS = [
   },
 ];
 
-/** Zero weight for every axis. @returns {Weights} */
-export function zeroWeights() {
-  return Object.fromEntries(AXES.map((a) => [a.key, 0]));
+/** Zero weight for every axis. @param {Axis[]} [axes] @returns {Weights} */
+export function zeroWeights(axes = AXES) {
+  return Object.fromEntries(axes.map((a) => [a.key, 0]));
+}
+
+/** Deep copy of the built-in basis — the starting point for editing. @returns {Axis[]} */
+export function defaultBasis() {
+  return AXES.map((a) => ({ ...a, neg: { ...a.neg }, pos: { ...a.pos } }));
+}
+
+/**
+ * Validate a stored/imported basis back into Axis[]. Keys must be unique and
+ * non-empty; missing labels/docs fall back to the built-in axis of the same
+ * key (older exports carried only key+deltas). Throws on anything else.
+ * @param {any} raw @returns {Axis[]}
+ */
+export function sanitizeBasis(raw) {
+  if (!Array.isArray(raw) || raw.length === 0) throw new Error("not an axis basis");
+  const seen = new Set();
+  return raw.map((a) => {
+    const key = String(a?.key ?? "").trim();
+    if (!key || seen.has(key)) throw new Error("axis keys must be unique and non-empty");
+    seen.add(key);
+    const builtin = AXES.find((d) => d.key === key);
+    return {
+      key,
+      label: String(a.label || builtin?.label || key),
+      negLabel: String(a.negLabel || builtin?.negLabel || "−"),
+      posLabel: String(a.posLabel || builtin?.posLabel || "+"),
+      doc: String(a.doc || builtin?.doc || "custom axis"),
+      neg: sanitizeOffsets(a.neg),
+      pos: sanitizeOffsets(a.pos),
+    };
+  });
 }
 
 /** @param {number} v @param {number} lo @param {number} hi */
@@ -209,11 +243,11 @@ export function clampPose(pose) {
  * Fold the expression layers into one actuator pose:
  * NEUTRAL + Σ axis contribution (weight toward the pos/neg extreme) + manual
  * per-actuator offsets, clamped to limits.
- * @param {Weights} weights @param {PoseDelta} [offsets] @returns {Pose}
+ * @param {Weights} weights @param {PoseDelta} [offsets] @param {Axis[]} [axes] @returns {Pose}
  */
-export function synthesize(weights, offsets = {}) {
+export function synthesize(weights, offsets = {}, axes = AXES) {
   const q = /** @type {Pose} */ ({ ...NEUTRAL });
-  for (const axis of AXES) {
+  for (const axis of axes) {
     const w = clamp(weights[axis.key] ?? 0, -1, 1);
     if (w === 0) continue;
     const delta = w > 0 ? axis.pos : axis.neg;
@@ -228,56 +262,85 @@ export function synthesize(weights, offsets = {}) {
 }
 
 /** @typedef {{ id: string, name: string, weights: Weights, offsets: PoseDelta,
- *              notes: string, thumb: string | null,
+ *              notes: string, thumb: string | null, actuators?: PoseDelta | null,
  *              judge: { target: string, p: number, stamp: number } | null }} SavedPose */
 
 /**
- * The library's export payload — weights AND the synthesized actuator vector
- * per pose, so downstream steps (PCA over collected poses, the runtime
- * controller) can consume either layer without importing this module.
- * @param {SavedPose[]} poses
+ * The library's export payload — the live basis, plus weights AND the exact
+ * actuator vector per pose, so downstream steps (PCA over collected poses,
+ * the runtime controller) can consume either layer without importing this
+ * module — and so a pose survives later edits to the basis it was authored on.
+ * @param {SavedPose[]} poses @param {Axis[]} [axes]
  */
-export function exportPayload(poses) {
+export function exportPayload(poses, axes = AXES) {
   return {
     format: "innate-expression-poses",
     version: 1,
     robot: "mars",
     neutral: NEUTRAL,
-    axes: AXES.map(({ key, neg, pos }) => ({ key, neg, pos })),
+    axes,
     poses: poses.map((p) => ({
       name: p.name,
       notes: p.notes,
       weights: p.weights,
       offsets: p.offsets,
-      actuators: synthesize(p.weights, p.offsets),
+      actuators: actuatorNumbers(p.actuators) ?? synthesize(sanitizeWeights(p.weights, axes), p.offsets, axes),
       judge: p.judge,
     })),
   };
 }
 
+/** Finite actuator values from a raw object (zeros kept — 0 is a real value
+ * here, unlike in a delta), or null when nothing usable. @param {any} raw @returns {PoseDelta | null} */
+export function actuatorNumbers(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  /** @type {PoseDelta} */
+  const out = {};
+  for (const a of ACTUATORS) {
+    const v = Number(raw[a.key]);
+    if (Number.isFinite(v)) out[a.key] = v;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
 /**
- * Parse an exported payload back into library entries (thumbnails are not
- * exported; they re-render on load). Throws on anything that isn't ours.
- * @param {string} text @returns {{ name: string, weights: Weights, offsets: PoseDelta, notes: string }[]}
+ * Parse an exported payload back into library entries plus the basis the file
+ * was authored on (null when absent/invalid — older exports carried only
+ * key+deltas, which sanitizeBasis relabels from the built-ins). Thumbnails
+ * are not exported; they re-render on load. Throws on anything not ours.
+ * @param {string} text
+ * @returns {{ basis: Axis[] | null,
+ *             poses: { name: string, weights: Weights, offsets: PoseDelta, notes: string, actuators: PoseDelta | null }[] }}
  */
 export function parseImport(text) {
   const data = JSON.parse(text);
   if (data?.format !== "innate-expression-poses" || !Array.isArray(data.poses)) {
     throw new Error("not an expression-poses export");
   }
-  return data.poses.map((/** @type {any} */ p) => ({
-    name: String(p.name || "pose"),
-    weights: sanitizeWeights(p.weights),
-    offsets: sanitizeOffsets(p.offsets),
-    notes: String(p.notes || ""),
-  }));
+  /** @type {Axis[] | null} */
+  let basis = null;
+  try {
+    basis = sanitizeBasis(data.axes);
+  } catch {
+    basis = null;
+  }
+  return {
+    basis,
+    poses: data.poses.map((/** @type {any} */ p) => ({
+      name: String(p.name || "pose"),
+      weights: sanitizeWeights(p.weights, basis ?? AXES),
+      offsets: sanitizeOffsets(p.offsets),
+      notes: String(p.notes || ""),
+      actuators: actuatorNumbers(p.actuators),
+    })),
+  };
 }
 
-/** Keep only known axis keys, as finite numbers in [-1, 1]. @param {any} raw @returns {Weights} */
-export function sanitizeWeights(raw) {
-  const w = zeroWeights();
+/** Keep only known axis keys, as finite numbers in [-1, 1]. @param {any} raw @param {Axis[]} [axes] @returns {Weights} */
+export function sanitizeWeights(raw, axes = AXES) {
+  const w = zeroWeights(axes);
   if (raw && typeof raw === "object") {
-    for (const axis of AXES) {
+    for (const axis of axes) {
       const v = Number(raw[axis.key]);
       if (Number.isFinite(v)) w[axis.key] = clamp(v, -1, 1);
     }

--- a/webapp/js/expression/model.js
+++ b/webapp/js/expression/model.js
@@ -22,7 +22,7 @@
  * @typedef {Record<ActuatorKey, number>} Pose
  * @typedef {Partial<Record<ActuatorKey, number>>} PoseDelta
  * @typedef {{ key: string, label: string, negLabel: string, posLabel: string,
- *             doc: string, neg: PoseDelta, pos: PoseDelta }} Axis
+ *             group: "shape" | "stance", doc: string, neg: PoseDelta, pos: PoseDelta }} Axis
  * @typedef {Record<string, number>} Weights axis key -> weight in [-1, 1]
  * @typedef {{ key: string, label: string, doc: string, weights: Weights }} Preset
  */
@@ -42,11 +42,13 @@ export const ACTUATORS = [
   { key: "head", label: "head pitch", min: -40, max: 70, unit: "°", step: 1 },
   { key: "baseX", label: "base advance", min: -0.3, max: 0.3, unit: "m", step: 0.005 },
   { key: "baseY", label: "base sidestep", min: -0.3, max: 0.3, unit: "m", step: 0.005 },
-  { key: "baseYaw", label: "base turn", min: -0.7854, max: 0.7854, unit: "rad", step: 0.01 },
+  { key: "baseYaw", label: "base turn", min: -1.6, max: 1.6, unit: "rad", step: 0.01 },
 ];
 
 // At-ease: arm loosely folded near the SDK rest pose but off the joint limits
-// (so every axis has room in both directions), head level on the person.
+// (so every axis has room in both directions), head level on the person, and
+// the base standing slightly OBLIQUE — a relaxed body doesn't square up, so
+// squaring on becomes an engagement signal the orient axis can spend.
 /** @type {Pose} */
 export const NEUTRAL = {
   j1: 0.9,
@@ -58,7 +60,7 @@ export const NEUTRAL = {
   head: 8,
   baseX: 0,
   baseY: 0,
-  baseYaw: 0,
+  baseYaw: 0.26,
 };
 
 // The person the robot is expressing *to* stands here (base frame, meters) —
@@ -71,70 +73,95 @@ export const PERSON = { x: 1.0, y: 0, height: 1.65 };
 // sculpted poses, axes added or dropped, and the result persists and exports
 // with the pose library. Deltas are what the +1 / −1 extreme adds to NEUTRAL;
 // anything an axis doesn't mention stays untouched, so axes compose additively.
+// Shape axes describe the BODY's configuration (arm + head — Laban's Shape);
+// stance axes describe where the base stands relative to the person, which
+// the runtime driving layer will own at execution time. This is the
+// conversation's core vocabulary — orient, approach, expand, rise, tilt,
+// asymmetry — translated to MARS's morphology: "lean" is the arm+head mass
+// shifting (the chassis can't tilt), and "head tilt / asymmetry" becomes the
+// askew axis (the head can only pitch, so the wrist roll + arm cant carry
+// the cocked-head quality).
 /** @type {Axis[]} */
 export const AXES = [
   {
     key: "approach",
     label: "approach",
-    negLabel: "withdraw",
-    posLabel: "advance",
-    doc: "Distance to the person — the most primitive engagement signal. Advancing commits the body toward the stimulus; withdrawing moves the vulnerable whole away from it.",
-    neg: { baseX: -0.24 },
-    pos: { baseX: 0.17 },
-  },
-  {
-    key: "turn",
-    label: "turn",
-    negLabel: "away right",
-    posLabel: "away left",
-    doc: "Facing. 0 is square-on; either sign breaks the face-to-face axis. Body turned away with the head still on target reads very differently from full disengagement.",
-    neg: { baseYaw: -0.7 },
-    pos: { baseYaw: 0.7 },
-  },
-  {
-    key: "sidestep",
-    label: "sidestep",
-    negLabel: "right",
-    posLabel: "left",
-    doc: "Lateral offset from the person's axis — circling, peeking, giving way.",
-    neg: { baseY: -0.2 },
-    pos: { baseY: 0.2 },
-  },
-  {
-    key: "rise",
-    label: "rise",
-    negLabel: "shrink",
-    posLabel: "tower",
-    doc: "Silhouette height. The arm is most of what MARS can raise: mast-high arm plus lifted head maximizes apparent size; folding it low with the head dropped minimizes it.",
-    neg: { j2: -0.5, j3: 0.35, j4: -0.8, head: -30 },
-    pos: { j1: -0.7, j2: 0.75, j3: -2.75, j4: 0.3, head: 14 },
+    negLabel: "retract",
+    posLabel: "lean in",
+    group: "shape",
+    doc: "Body lean without moving the feet: the arm-and-head mass reaches toward the person (effector presented, gaze committed) or pulls back against the chassis, protecting the protruding parts. Distance itself is the advance axis.",
+    neg: { j2: -0.4, j3: 0.35, j4: -0.9, j6: -0.12, head: -4 },
+    pos: { j1: -0.9, j2: 1.0, j3: -1.0, j4: -0.3, j6: 0.3, head: 4 },
   },
   {
     key: "expand",
     label: "expand",
-    negLabel: "clench",
-    posLabel: "flare",
-    doc: "Silhouette width. Flaring swings the arm out of the body outline and opens the gripper; clenching folds everything inside the chassis footprint and shuts the claw.",
+    negLabel: "contract",
+    posLabel: "expand",
+    group: "shape",
+    doc: "Silhouette width. Expanding swings the arm out of the body outline and opens the gripper; contracting folds everything inside the chassis footprint and shuts the claw.",
     neg: { j1: 0.5, j3: 0.3, j4: -0.5, j6: -0.12 },
     pos: { j1: -1.5, j3: -0.85, j4: 0.4, j6: 0.6 },
   },
   {
-    key: "reach",
-    label: "reach",
-    negLabel: "guard",
-    posLabel: "offer",
-    doc: "Arm extension along the robot→person line. Offering presents the effector to the person; guarding pulls it in against the chassis, protecting the protruding part.",
-    neg: { j2: -0.4, j3: 0.35, j4: -0.9, j6: -0.12 },
-    pos: { j1: -0.9, j2: 1.0, j3: -1.0, j4: -0.3, j6: 0.3 },
+    key: "rise",
+    label: "rise",
+    negLabel: "low",
+    posLabel: "tall",
+    group: "shape",
+    doc: "Silhouette height. The arm is the only mass MARS can raise: mast-high maximizes apparent size, folded low minimizes it. Gaze height is attend's job, so the two can disagree (tall but downcast, small but watching).",
+    neg: { j2: -0.5, j3: 0.35, j4: -0.8 },
+    pos: { j1: -0.7, j2: 0.75, j3: -2.75, j4: 0.3 },
   },
   {
     key: "attend",
     label: "attend",
     negLabel: "downcast",
     posLabel: "raised",
+    group: "shape",
     doc: "Gaze height. The person's face is ~1.5 m above the robot's, so sensors-on-target means head pitched well up; head at the floor abandons the target entirely.",
     neg: { head: -45 },
     pos: { head: 55 },
+  },
+  {
+    key: "askew",
+    label: "askew",
+    negLabel: "canted in",
+    posLabel: "canted out",
+    group: "shape",
+    doc: "Asymmetry — the cocked-head quality. MARS's head can't roll, so the wrist roll and the arm canting across (in) or wide of (out) the body carry it; 0 is the composed, regular posture.",
+    neg: { j1: 0.55, j4: -0.4, j5: -1.3 },
+    pos: { j1: -0.5, j3: -0.3, j5: 1.3 },
+  },
+  {
+    key: "advance",
+    label: "advance",
+    negLabel: "withdraw",
+    posLabel: "advance",
+    group: "stance",
+    doc: "Distance to the person — the most primitive engagement signal. Advancing commits the whole body toward the stimulus; withdrawing moves it away.",
+    neg: { baseX: -0.24 },
+    pos: { baseX: 0.17 },
+  },
+  {
+    key: "orient",
+    label: "orient",
+    negLabel: "turned away",
+    posLabel: "squared on",
+    group: "stance",
+    doc: "Facing, away ↔ toward. Neutral stands casually oblique; +1 squares the body onto the person (full engagement), −1 turns it ~85° away. Turned away with the head still on target (attend up) reads guarded, not disengaged.",
+    neg: { baseYaw: 1.2 },
+    pos: { baseYaw: -0.26 },
+  },
+  {
+    key: "sidestep",
+    label: "sidestep",
+    negLabel: "right",
+    posLabel: "left",
+    group: "stance",
+    doc: "Lateral offset from the person's axis — circling, peeking, giving way.",
+    neg: { baseY: -0.2 },
+    pos: { baseY: 0.2 },
   },
 ];
 
@@ -146,49 +173,49 @@ export const PRESETS = [
   {
     key: "curious",
     label: "curious",
-    doc: "Get the sensors closer to the thing without committing the body: advance a little, slight peek angle, head up and forward.",
-    weights: { approach: 0.45, sidestep: 0.25, rise: 0.15, reach: 0.35, attend: 0.7 },
+    doc: "Get the sensors closer without committing the body: a small advance, a lean in, the cocked-head cant, gaze up on the person.",
+    weights: { approach: 0.5, askew: 0.4, advance: 0.4, orient: 0.3, rise: 0.1, attend: 0.7 },
   },
   {
     key: "excited",
     label: "excited",
-    doc: "Maximum energy: big, tall, open, pressing toward the person.",
-    weights: { approach: 0.5, rise: 0.65, expand: 0.7, reach: 0.2, attend: 0.8 },
+    doc: "Maximum energy: squared on, big, tall, open, pressing toward the person.",
+    weights: { advance: 0.5, orient: 1, rise: 0.7, expand: 0.7, attend: 0.8 },
   },
   {
     key: "confident",
     label: "confident",
-    doc: "Maximize apparent size and hold the ground: tall, open, square-on, no retreat.",
-    weights: { approach: 0.2, rise: 0.9, expand: 0.45, attend: 0.55 },
+    doc: "Maximize apparent size, square on, hold the ground: tall, open, composed (no cant), no retreat.",
+    weights: { advance: 0.2, orient: 1, rise: 0.9, expand: 0.45, attend: 0.55 },
   },
   {
     key: "affectionate",
     label: "affectionate",
-    doc: "Close the distance and present the effector — contact-seeking, softly raised gaze.",
-    weights: { approach: 0.65, rise: -0.1, expand: 0.15, reach: 0.8, attend: 0.5 },
+    doc: "Close the distance and lean in, effector offered — contact-seeking, softly raised gaze.",
+    weights: { advance: 0.65, orient: 0.6, approach: 0.85, expand: 0.15, attend: 0.5 },
   },
   {
     key: "fearful",
     label: "fearful",
-    doc: "Retreat and shrink — but the head stays on the threat. Monitoring while withdrawing is what separates fear from mere disengagement.",
-    weights: { approach: -0.9, turn: 0.25, rise: -0.7, expand: -0.6, reach: -0.7, attend: 0.35 },
+    doc: "Retreat, shrink, pull the body in — but the head stays on the threat. Monitoring while withdrawing is what separates fear from mere disengagement.",
+    weights: { advance: -0.9, orient: -0.25, approach: -0.7, rise: -0.7, expand: -0.6, attend: 0.35 },
   },
   {
     key: "sad",
     label: "sad",
-    doc: "Low energy, no target focus: slumped small, gaze at the floor, slight drift away.",
-    weights: { approach: -0.3, rise: -0.6, expand: -0.3, reach: -0.3, attend: -0.9 },
+    doc: "Low energy, no target focus: slumped small, gaze at the floor, slight drift away and off-axis.",
+    weights: { advance: -0.3, orient: -0.2, approach: -0.3, rise: -0.6, expand: -0.3, attend: -0.9 },
   },
   {
     key: "suspicious",
     label: "suspicious",
-    doc: "Body turned off-axis and edged away while the head keeps watching — guarded observation.",
-    weights: { approach: -0.25, turn: 0.6, sidestep: -0.3, expand: -0.2, attend: 0.4 },
+    doc: "Body turned off-axis and edged away while the head keeps watching, a wary cant — guarded observation.",
+    weights: { advance: -0.25, orient: -0.55, sidestep: -0.3, expand: -0.2, askew: 0.3, attend: 0.4 },
   },
   {
     key: "relaxed",
     label: "relaxed",
-    doc: "At ease near neutral: soft gaze on the person, nothing braced.",
+    doc: "At ease: the casually oblique neutral stance, soft gaze on the person, nothing braced.",
     weights: { attend: 0.2 },
   },
 ];
@@ -222,6 +249,7 @@ export function sanitizeBasis(raw) {
       label: String(a.label || builtin?.label || key),
       negLabel: String(a.negLabel || builtin?.negLabel || "−"),
       posLabel: String(a.posLabel || builtin?.posLabel || "+"),
+      group: a.group === "stance" || a.group === "shape" ? a.group : (builtin?.group ?? "shape"),
       doc: String(a.doc || builtin?.doc || "custom axis"),
       neg: sanitizeOffsets(a.neg),
       pos: sanitizeOffsets(a.pos),

--- a/webapp/js/expression/viz.js
+++ b/webapp/js/expression/viz.js
@@ -1,0 +1,339 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Whole-robot 3D view for the Expression Studio. Same URDF + meshes as the
+// Arm SDK page (served at /armsdk/model/), same ~100-line parser — but the
+// entire robot rides a movable root (base advance/sidestep/turn are pose
+// variables here), the head joint animates, and a person-scale observer
+// figure stands where the expression is aimed, so approach/turn/attend read
+// in the frame. Also renders the blind judge's fixed viewpoints offscreen.
+//
+// three.js is vendored (pinned r160) under /public/vendor/ — no CDN.
+
+import * as THREE from "../../public/vendor/three.module.min.js";
+import { OrbitControls } from "../../public/vendor/OrbitControls.js";
+import { STLLoader } from "../../public/vendor/STLLoader.js";
+import { PERSON } from "./model.js";
+
+const MODEL = "/armsdk/model";
+const ACCENT_LINKS = new Set(["link61", "link62"]);
+
+// The judge's cameras, fixed in the world frame — the robot moving inside a
+// static frame is how base offset becomes visible in a still image, so every
+// view must cover the full ±0.3 m the base can roam. The person view is
+// literally the observer's eyes (their own ghost body hidden); the profile
+// view holds both bodies full-height so distance reads directly.
+export const SNAPSHOT_VIEWS = [
+  { key: "person", label: "person's eyes", pos: [PERSON.x - 0.06, PERSON.y + 0.03, PERSON.height - 0.13], look: [-0.02, 0, 0.15], fov: 26, hidePerson: true },
+  { key: "quarter", label: "three-quarter", pos: [0.95, -1.15, 0.65], look: [0.02, 0, 0.2], fov: 42, hidePerson: false },
+  { key: "profile", label: "profile", pos: [0.35, -2.3, 0.85], look: [0.35, 0, 0.7], fov: 48, hidePerson: false },
+];
+
+/** URDF rpy is fixed-axis XYZ = Rz(y)·Ry(p)·Rx(r) = three's 'ZYX' Euler.
+ * @param {string | null} s */
+function rpyQuat(s) {
+  const [r, p, y] = (s || "0 0 0").trim().split(/\s+/).map(Number);
+  return new THREE.Quaternion().setFromEuler(new THREE.Euler(r, p, y, "ZYX"));
+}
+
+/** @param {string | null} s */
+function vec3(s) {
+  const [x, y, z] = (s || "0 0 0").trim().split(/\s+/).map(Number);
+  return new THREE.Vector3(x, y, z);
+}
+
+/**
+ * @param {HTMLElement} container
+ * @returns {Promise<{
+ *   setPose: (pose: import("./model.js").Pose) => void,
+ *   snapshot: (size?: number, viewKeys?: string[]) => { key: string, label: string, dataUrl: string }[],
+ *   destroy: () => void }>}
+ */
+export async function createExpressionViz(container) {
+  // Fetch + parse before any GPU resources exist — the fetch is the likely
+  // failure and failing here leaks nothing.
+  const urdfText = await fetch(`${MODEL}/urdf/mars.urdf`).then((r) => {
+    if (!r.ok) throw new Error(`URDF fetch failed (${r.status})`);
+    return r.text();
+  });
+  const doc = new DOMParser().parseFromString(urdfText, "text/xml");
+  if (doc.querySelector("parsererror")) throw new Error("URDF parse failed");
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.domElement.style.display = "block";
+  container.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+
+  // Z-up world, matching base_link.
+  const camera = new THREE.PerspectiveCamera(38, 1, 0.01, 30);
+  camera.up.set(0, 0, 1);
+  camera.position.set(0.9, -1.1, 0.7);
+
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.target.set(0.35, 0, 0.25);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+  controls.minDistance = 0.2;
+  controls.maxDistance = 6;
+
+  scene.add(new THREE.HemisphereLight(0xdde4ee, 0x1a1a20, 0.85));
+  const key = new THREE.DirectionalLight(0xffffff, 1.6);
+  key.position.set(0.8, -0.9, 1.1);
+  scene.add(key);
+  const fill = new THREE.DirectionalLight(0xa9b6cc, 0.5);
+  fill.position.set(-0.9, 0.7, 0.4);
+  scene.add(fill);
+
+  // Floor grid in the XY plane (GridHelper natively lies in XZ).
+  const grid = new THREE.GridHelper(3.2, 32, 0x3a3d45, 0x24262c);
+  grid.rotation.x = Math.PI / 2;
+  scene.add(grid);
+
+  const matLink = new THREE.MeshStandardMaterial({ color: 0x565b66, metalness: 0.35, roughness: 0.45 });
+  const matBase = new THREE.MeshStandardMaterial({ color: 0x33363e, metalness: 0.3, roughness: 0.6 });
+  const matAccent = new THREE.MeshStandardMaterial({ color: 0xe8a33d, metalness: 0.4, roughness: 0.35 });
+
+  // ---- kinematic tree from the URDF ---------------------------------------
+  /** @type {Map<string, THREE.Group>} */
+  const links = new Map();
+  doc.querySelectorAll("robot > link").forEach((el) => {
+    const group = new THREE.Group();
+    group.name = el.getAttribute("name") || "";
+    links.set(group.name, group);
+  });
+
+  /** @type {Map<string, { group: THREE.Group, originQuat: THREE.Quaternion, axis: THREE.Vector3, mimicOf: string | null, mimicMul: number, angle: number }>} */
+  const byName = new Map();
+  const childLinks = new Set();
+
+  doc.querySelectorAll("robot > joint").forEach((el) => {
+    const parent = links.get(el.querySelector("parent")?.getAttribute("link") || "");
+    const child = links.get(el.querySelector("child")?.getAttribute("link") || "");
+    if (!parent || !child) return;
+    const origin = el.querySelector("origin");
+    const frame = new THREE.Group();
+    frame.position.copy(vec3(origin?.getAttribute("xyz") ?? null));
+    const originQuat = rpyQuat(origin?.getAttribute("rpy") ?? null);
+    frame.quaternion.copy(originQuat);
+    parent.add(frame);
+    frame.add(child);
+    childLinks.add(child.name);
+
+    if (el.getAttribute("type") === "revolute" || el.getAttribute("type") === "continuous") {
+      const mimic = el.querySelector("mimic");
+      byName.set(el.getAttribute("name") || "", {
+        group: frame,
+        originQuat,
+        axis: vec3(el.querySelector("axis")?.getAttribute("xyz") ?? "0 0 1").normalize(),
+        mimicOf: mimic?.getAttribute("joint") ?? null,
+        mimicMul: mimic ? Number(mimic.getAttribute("multiplier") ?? 1) : 1,
+        angle: 0,
+      });
+    }
+  });
+
+  // The whole robot rides one movable root: base offset/turn animate here,
+  // exactly like a joint — the URDF tree hangs underneath untouched.
+  const robotRoot = new THREE.Group();
+  scene.add(robotRoot);
+  const urdfRoot = [...links.values()].find((l) => !childLinks.has(l.name));
+  if (urdfRoot) robotRoot.add(urdfRoot);
+
+  // Home ring — where the neutral base sits, so displacement reads against it.
+  const matRing = new THREE.MeshBasicMaterial({ color: 0xe8a33d, transparent: true, opacity: 0.55, side: THREE.DoubleSide });
+  const homeRing = new THREE.Mesh(new THREE.RingGeometry(0.1, 0.108, 48), matRing);
+  homeRing.position.z = 0.002; // just above the grid, no z-fighting
+  scene.add(homeRing);
+
+  // ---- observer figure ----------------------------------------------------
+  // A ghosted person at real scale: the ~1.4 m face-height gap is the reason
+  // "attend" runs to +70°, and the judge needs the same referent in frame.
+  const matPerson = new THREE.MeshStandardMaterial({
+    color: 0x6b93d6,
+    transparent: true,
+    opacity: 0.4,
+    roughness: 0.8,
+    depthWrite: false,
+  });
+  const person = new THREE.Group();
+  /** @type {THREE.BufferGeometry[]} */
+  const personGeos = [];
+  /** @param {THREE.BufferGeometry} geo @param {number} x @param {number} y @param {number} z @param {boolean} [upright] */
+  const addPart = (geo, x, y, z, upright = true) => {
+    personGeos.push(geo);
+    const mesh = new THREE.Mesh(geo, matPerson);
+    if (upright) mesh.rotation.x = Math.PI / 2; // three's capsules/cylinders extend along y; our up is z
+    mesh.position.set(x, y, z);
+    person.add(mesh);
+  };
+  addPart(new THREE.CapsuleGeometry(0.045, 0.68, 4, 10), 0, 0.075, 0.42); // legs
+  addPart(new THREE.CapsuleGeometry(0.045, 0.68, 4, 10), 0, -0.075, 0.42);
+  addPart(new THREE.CapsuleGeometry(0.1, 0.42, 4, 14), 0, 0, 1.06); // torso
+  addPart(new THREE.CapsuleGeometry(0.035, 0.52, 4, 8), 0, 0.155, 1.0); // arms
+  addPart(new THREE.CapsuleGeometry(0.035, 0.52, 4, 8), 0, -0.155, 1.0);
+  addPart(new THREE.SphereGeometry(0.096, 18, 14), 0, 0, PERSON.height - 0.09, false); // head
+  addPart(new THREE.SphereGeometry(0.026, 10, 8), -0.09, 0, PERSON.height - 0.1, false); // gaze marker, toward the robot
+  person.position.set(PERSON.x, PERSON.y, 0);
+  scene.add(person);
+
+  // ---- meshes -------------------------------------------------------------
+  const loader = new STLLoader();
+  /** @type {THREE.BufferGeometry[]} */
+  const geometries = [];
+  const meshJobs = [];
+  for (const el of doc.querySelectorAll("robot > link")) {
+    const linkName = el.getAttribute("name") || "";
+    for (const visual of el.querySelectorAll("visual")) {
+      const file = visual.querySelector("geometry > mesh")?.getAttribute("filename");
+      if (!file) continue;
+      const url = file.replace("package://mars_sim", MODEL);
+      const origin = visual.querySelector("origin");
+      meshJobs.push(
+        loader.loadAsync(url).then((geometry) => {
+          geometries.push(geometry);
+          const material = ACCENT_LINKS.has(linkName) ? matAccent : linkName === "base_link" ? matBase : matLink;
+          const mesh = new THREE.Mesh(geometry, material);
+          mesh.position.copy(vec3(origin?.getAttribute("xyz") ?? null));
+          mesh.quaternion.copy(rpyQuat(origin?.getAttribute("rpy") ?? null));
+          links.get(linkName)?.add(mesh);
+        }),
+      );
+    }
+  }
+  try {
+    await Promise.all(meshJobs);
+  } catch (err) {
+    // A mesh failed — free the GPU context instead of stranding it (repeated
+    // failed mounts would otherwise hit the browser's WebGL cap).
+    controls.dispose();
+    geometries.forEach((g) => g.dispose());
+    personGeos.forEach((g) => g.dispose());
+    renderer.dispose();
+    renderer.domElement.remove();
+    throw err;
+  }
+
+  // ---- animation ----------------------------------------------------------
+  const JOINT_ORDER = ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint_head"];
+  /** @type {Map<string, number>} */
+  const jointTargets = new Map(JOINT_ORDER.map((n) => [n, 0]));
+  const baseTarget = { x: 0, y: 0, yaw: 0 };
+
+  const tmpQuat = new THREE.Quaternion();
+  let disposed = false;
+  let raf = 0;
+  let last = performance.now();
+
+  /** Advance every eased value by dt; shared by the live loop and snapshots. @param {number} ease */
+  function stepTargets(ease) {
+    for (const [name, joint] of byName) {
+      const target = joint.mimicOf
+        ? (byName.get(joint.mimicOf)?.angle ?? 0) * joint.mimicMul
+        : (jointTargets.get(name) ?? joint.angle);
+      joint.angle += (target - joint.angle) * ease;
+      tmpQuat.setFromAxisAngle(joint.axis, joint.angle);
+      joint.group.quaternion.copy(joint.originQuat).multiply(tmpQuat);
+    }
+    robotRoot.position.x += (baseTarget.x - robotRoot.position.x) * ease;
+    robotRoot.position.y += (baseTarget.y - robotRoot.position.y) * ease;
+    robotRoot.rotation.z += (baseTarget.yaw - robotRoot.rotation.z) * ease;
+  }
+
+  function frame(/** @type {number} */ now) {
+    if (disposed) return;
+    raf = requestAnimationFrame(frame);
+    const dt = Math.min((now - last) / 1000, 0.1);
+    last = now;
+    stepTargets(1 - Math.exp(-10 * dt));
+    controls.update();
+    renderer.render(scene, camera);
+  }
+
+  function resize() {
+    const w = container.clientWidth;
+    const h = container.clientHeight;
+    if (!w || !h) return;
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
+  }
+  const observer = new ResizeObserver(resize);
+  observer.observe(container);
+  resize();
+  raf = requestAnimationFrame(frame);
+
+  // ---- snapshots ----------------------------------------------------------
+  // Offscreen renderer for the judge views, created on the first snapshot and
+  // kept for the page's life (a WebGL context is too costly to churn per shot).
+  /** @type {THREE.WebGLRenderer | null} */
+  let snapRenderer = null;
+  const snapCamera = new THREE.PerspectiveCamera(38, 1, 0.01, 30);
+  snapCamera.up.set(0, 0, 1);
+  const snapBackground = new THREE.Color(0xdfe3e8);
+
+  /**
+   * Render the judge's viewpoints to JPEG data URLs at the pose's *settled*
+   * targets (easing snapped forward, restored after) on an opaque neutral
+   * backdrop, home ring hidden — the judge sees a robot, not studio chrome.
+   * @param {number} [size] @param {string[]} [viewKeys]
+   */
+  function snapshot(size = 640, viewKeys) {
+    if (!snapRenderer) {
+      snapRenderer = new THREE.WebGLRenderer({ antialias: true, preserveDrawingBuffer: true });
+      snapRenderer.outputColorSpace = THREE.SRGBColorSpace;
+    }
+    snapRenderer.setSize(size, size, false);
+    const views = SNAPSHOT_VIEWS.filter((v) => !viewKeys || viewKeys.includes(v.key));
+    scene.background = snapBackground;
+    homeRing.visible = false;
+    stepTargets(1); // settle
+    const shots = views.map((view) => {
+      snapCamera.fov = view.fov;
+      snapCamera.aspect = 1;
+      snapCamera.position.set(view.pos[0], view.pos[1], view.pos[2]);
+      snapCamera.lookAt(view.look[0], view.look[1], view.look[2]);
+      snapCamera.updateProjectionMatrix();
+      person.visible = !view.hidePerson; // the observer's own body stays out of their eye view
+      /** @type {THREE.WebGLRenderer} */ (snapRenderer).render(scene, snapCamera);
+      return { key: view.key, label: view.label, dataUrl: /** @type {THREE.WebGLRenderer} */ (snapRenderer).domElement.toDataURL("image/jpeg", 0.85) };
+    });
+    scene.background = null;
+    homeRing.visible = true;
+    person.visible = true;
+    return shots;
+  }
+
+  return {
+    /** @param {import("./model.js").Pose} pose */
+    setPose(pose) {
+      jointTargets.set("joint1", pose.j1);
+      jointTargets.set("joint2", pose.j2);
+      jointTargets.set("joint3", pose.j3);
+      jointTargets.set("joint4", pose.j4);
+      jointTargets.set("joint5", pose.j5);
+      jointTargets.set("joint6", pose.j6);
+      jointTargets.set("joint_head", (pose.head * Math.PI) / 180);
+      baseTarget.x = pose.baseX;
+      baseTarget.y = pose.baseY;
+      baseTarget.yaw = pose.baseYaw;
+    },
+    snapshot,
+    destroy() {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+      controls.dispose();
+      geometries.forEach((g) => g.dispose());
+      personGeos.forEach((g) => g.dispose());
+      grid.dispose();
+      homeRing.geometry.dispose();
+      [matLink, matBase, matAccent, matRing, matPerson].forEach((m) => m.dispose());
+      snapRenderer?.dispose();
+      renderer.dispose();
+      renderer.domElement.remove();
+    },
+  };
+}

--- a/webapp/js/railLayout.js
+++ b/webapp/js/railLayout.js
@@ -16,7 +16,7 @@
 // runs the same IK node and answers the goto services, so the page exercises
 // the real Manipulation SDK against the simulated arm. The router gates its
 // routes on this set too (route keys are section keys).
-export const SIM_SECTIONS = new Set(["teleop", "agent", "nav", "logging", "armsdk", "settings"]);
+export const SIM_SECTIONS = new Set(["teleop", "agent", "nav", "logging", "expression", "armsdk", "settings"]);
 
 // The rail is grouped: standalone pages ride alone; multi-page workflows carry
 // an eyebrow label (visible while the rail is hover-expanded; collapsed, a
@@ -64,6 +64,17 @@ export const GROUPS = [
         key: "logging",
         label: "Logging",
         icon: '<polyline points="4.5,7 10,12 4.5,17"/><line x1="12.5" y1="17" x2="19.5" y2="17"/>',
+      },
+    ],
+  },
+  {
+    label: null,
+    sections: [
+      {
+        key: "expression",
+        label: "Expression",
+        // Face motif: two eyes and a smile, for the body-language studio.
+        icon: '<circle cx="12" cy="12" r="8.5"/><circle cx="9.2" cy="10.2" r="1.3" fill="currentColor" stroke="none"/><circle cx="14.8" cy="10.2" r="1.3" fill="currentColor" stroke="none"/><path d="M8.8 14.6c1.6 1.9 4.8 1.9 6.4 0"/>',
       },
     ],
   },

--- a/webapp/js/router.js
+++ b/webapp/js/router.js
@@ -38,6 +38,7 @@ const ROUTES = [
   { path: "/teleop", key: "teleop", load: () => import("./teleop/main.js") },
   { path: "/nav", key: "nav", load: () => import("./nav/main.js") },
   { path: "/logging", key: "logging", load: () => import("./logging/main.js") },
+  { path: "/expression", key: "expression", load: () => import("./expression/main.js") },
   { path: "/datasets", key: "datasets", load: () => import("./datasets/main.js") },
   { path: "/collect", key: "collect", load: () => import("./collect/main.js") },
   { path: "/training", key: "training", load: () => import("./training/main.js") },

--- a/webapp/tests/railLayout.test.js
+++ b/webapp/tests/railLayout.test.js
@@ -24,14 +24,14 @@ function fingerprint(rows) {
 test("full roster: labeled groups bracketed, standalone pages cluster", () => {
   assert.equal(
     fingerprint(railRows(GROUPS, null)),
-    "teleop agent nav logging |AI Lab collect datasets training profiling |Maintenance armsdk calibration",
+    "teleop agent nav logging expression |AI Lab collect datasets training profiling |Maintenance armsdk calibration",
   );
 });
 
 test("sim roster: AI Lab vanishes with its label, Maintenance keeps Arm SDK", () => {
   assert.equal(
     fingerprint(railRows(GROUPS, SIM_SECTIONS)),
-    "teleop agent nav logging |Maintenance armsdk",
+    "teleop agent nav logging expression |Maintenance armsdk",
   );
 });
 


### PR DESCRIPTION
## Summary

- New **`/expression` page (Expression Studio)** — the first-step tooling for giving the MARS agent emotional body language: a representation of "all the values", a live 3D preview, and blind VLM evaluation.
- **Two-layer pose representation** (`expression/model.js`, pure + dependency-free): an actuator vector (6 arm joints, head pitch in servo degrees, base advance/sidestep/turn) and a semantic basis matching the source design's core vocabulary, split into **shape** (the body's configuration) and **stance** (base placement vs the person, the runtime driving layer's future domain):
  - shape: `approach` (retract ↔ lean in — arm+head mass, feet planted), `expand` (contract ↔ expand), `rise` (low ↔ tall; gaze belongs to `attend`, so tall-but-downcast is expressible), `attend` (downcast ↔ raised), `askew` (the asymmetry axis — MARS's head can't roll, so wrist roll + arm cant carry the cocked-head quality)
  - stance: `advance` (withdraw ↔ advance), `orient` (turned away ↔ squared on — neutral stands casually oblique at 15°, so squaring on is an engagement signal), `sidestep`
  - A pose is `neutral + Σ weight·delta + manual offsets`, clamped to actuator limits. Emotions ship as preset weight vectors — e.g. fearful retreats and shrinks *while the head stays on the threat*; curious carries the head-cock cant.
- **Editable basis**: the axes are data, not code. A basis editor panel (grouped under shape/stance eyebrows) renames axes/end labels, edits endpoint deltas as JSON, previews extremes, and adds/removes/restores axes — plus the puppet workflow: sculpt an extreme with the sliders + fine-tune, then **capture** it as that axis's −1/+1 endpoint (the slider takes over holding the pose at ±1). Edits persist per browser and export with the library; saved/imported poses carry their exact actuator vectors so they keep their look across basis changes, and importing a file authored on a different basis offers to adopt it.
- **Full-robot 3D preview** (`expression/viz.js`): same URDF/meshes and parser as the Arm SDK page, but the whole robot rides a movable root (base offset/turn ease like joints), the head joint animates, and a ghosted person-scale observer figure stands where the expression is aimed — the ~1.4 m face-height gap is why `attend` runs to +70°.
- **Blind VLM judges** (`expression/judge.js`): renders three fixed world-frame viewpoints (person's eyes / three-quarter / profile) offscreen and asks a Gemini judge panel — never told the target — to distribute probability over a fixed 10-label vocabulary, plus cues and an impression. Pairwise **A/B vs a pinned pose** names the target but randomizes presentation order per judge. Uses the brain's dev path (`generativelanguage.googleapis.com` + API key, kept in localStorage).
- **Studio page** (`expression/main.js`): axis sliders with preset chips, per-actuator fine-tune offsets, a pose library with thumbnails + JSON export/import (weights **and** exact actuator vectors, ready for the later PCA / runtime-controller steps), score bars + judge log, and **apply-to-robot** over the existing Arm SDK stream topic + `/mars/head/set_position` (base offset stays preview-only; real driving belongs to the runtime controller).
- Rail/router registration (also visible in sim — preview and judging are fully local), README entry, rail-fingerprint test updated.

## Validation

- [x] I ran the relevant local validation, or explained why it was skipped.
  - `node tests/railLayout.test.js` (updated fingerprints) and the rest of the webapp node tests pass.
  - Headless Playwright against a local static server: page mounts and keeps working with no robot connection; every preset renders a distinct, readable pose in all three judge views (with the realigned basis: the oblique neutral, curious's cant, suspicious/fearful's turned-away-while-watching all verified visually); axis→chip sync, fine-tune offsets, library save/load/thumbnail, export payload shape, and the judge + A/B flows verified against a stubbed Gemini endpoint.
  - Basis editor verified the same way: capture holds the sculpted pose exactly and lands the slider at ±1 (with group eyebrows present); endpoint JSON validation; custom axes insert inside the shape group; persistence across reload; a saved pose loads back visually identical after an axis is redefined; export → import into a fresh profile adopts the file's basis and reproduces the pose; `orient +1` squares the base to exactly 0°.
  - `tsc` adds no errors in `model.js` / `judge.js` / `main.js`; `expression/viz.js` carries only the same untyped-vendored-three.js error classes as the existing `armsdk/viz.js` (the check is documented as optional and the repo baseline is not clean).
  - Python/ROS untouched, so the brain_client ruff/pytest/basedpyright gates don't apply.
- [ ] If I changed simulator behavior, config, or assets, I checked that the simulator starts with `./innate-sim up`. — n/a: no sim behavior, config, or asset changes (webapp-only).
- [ ] If I changed simulator asset files or asset references, I published the asset pack and committed the updated `sim/assets.lock.json`. — n/a.

https://claude.ai/code/session_012Cgr5b4y2dDztAEf6PAWKS