### PR TITLE
feat(brain): change the robot's voice without restarting it

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -43,7 +43,10 @@
 #     inflation_layer:              # costmap obstacle inflation (every costmap)
 #       inflation_radius: 0.3       # metres of inflation around obstacles
 #       cost_scaling_factor: 10.0   # higher = cost decays faster with distance
-#     # TTS voice for BOTH speech paths (brain chat-TTS + realtime voice loop)
+#     # TTS voice for BOTH speech paths (brain chat-TTS + realtime voice loop).
+#     # The Settings page applies it live; over SSH the same is
+#     #   ros2 param set /brain_client_node cartesia_voice_id <id>
+#     # and setting it here only changes what the robot boots into.
 #     cartesia_voice_id: "9fdaae0b-f885-4813-b589-3c07cf9d5fea"
 
 # ── Teleop: joystick ──────────────────────────────────────────────────

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -18,7 +18,9 @@ import time
 import rclpy
 from brain_messages.srv import ForgetMemory, GetAvailableDirectives, GetChatHistory, ReloadSkillsAgents, ResetBrain
 from geometry_msgs.msg import Twist
+from rcl_interfaces.msg import SetParametersResult
 from rclpy.node import Node
+from rclpy.parameter import Parameter
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
 from std_msgs.msg import String
 from std_srvs.srv import SetBool, Trigger
@@ -89,6 +91,7 @@ class BrainClientNode(Node):
 
         self._proxy = self._init_proxy()
         self._tts_handler = self._init_tts()
+        self.add_on_set_parameters_callback(self._on_parameter_change)
 
         # --- helper node for synchronous service calls (not spun by the executor) ---
         self._service_call_node = rclpy.create_node("brain_client_service_caller")
@@ -134,6 +137,25 @@ class BrainClientNode(Node):
         else:
             self.get_logger().warning("⚠️ TTS handler created but Cartesia client unavailable")
         return handler
+
+    def _on_parameter_change(self, params: list[Parameter]) -> SetParametersResult:
+        """Apply the parameters that take effect without a restart.
+
+        Only the TTS voice does: every other field was copied into a collaborator at
+        construction, so accepting a write would leave the robot running the old value.
+        Those are stored for the next boot, which is what the Settings page's `live`
+        flag says about them.
+        """
+        for param in params:
+            if param.name != "cartesia_voice_id":
+                continue
+            voice_id = str(param.value).strip()
+            if not voice_id:
+                return SetParametersResult(successful=False, reason="cartesia_voice_id must not be empty")
+            if self._tts_handler is None:
+                return SetParametersResult(successful=False, reason="TTS is unavailable (no proxy)")
+            self._tts_handler.set_voice(voice_id)
+        return SetParametersResult(successful=True)
 
     def _build_collaborators(self) -> None:
         cfg, state = self.config, self.state

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/tts.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/tts.py
@@ -24,7 +24,8 @@ class TTSHandler:
     Handles text-to-speech conversion using Cartesia API and audio playback via aplay.
 
     Requires a ProxyClient instance for accessing Cartesia services.
-    Voice ID is read from proxy.config["cartesia_voice_id"].
+    Voice ID starts at proxy.config["cartesia_voice_id"] and is swappable at
+    runtime through set_voice; every utterance reads the current one.
     """
 
     # Default voice ID (Alfred)
@@ -98,6 +99,17 @@ class TTSHandler:
     def is_available(self) -> bool:
         """Check if TTS is available and configured."""
         return self._cartesia_client is not None
+
+    def set_voice(self, voice_id: str) -> None:
+        """Speak in a different voice from the next utterance on.
+
+        A clip already streaming keeps the voice it started with — Cartesia picks
+        the voice per request, so there is nothing to swap mid-stream.
+        """
+        if voice_id == self.voice_id:
+            return
+        self.voice_id = voice_id
+        self.logger.info(f"🗣️ TTS voice changed to {voice_id}")
 
     def _publish_tts_status(self, status: str):
         """Publish TTS playback status to /tts/is_playing topic."""

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -49,10 +49,12 @@
  *   derived from the values, so the robot decides what exists and nothing here drifts.
  * @property {string} [customPlaceholder]  Placeholder for the "Custom…" free-text field.
  * @property {string} [live]  Node to push this knob to with set_parameters after saving,
- *   so it applies without a restart. Set ONLY where the running node re-reads the
- *   parameter (mars_app reads its drive knobs every tick). Nodes that copy a parameter
- *   into a field at construction — bringup's safety clamp, the camera driver, nav2's
- *   launch-time remap — must be left off, or the UI would claim an effect it did not have.
+ *   so it applies without a restart. Set ONLY where the running node acts on the write —
+ *   by re-reading the parameter every tick (mars_app's drive knobs) or by applying it in
+ *   an on_set_parameters callback (motor_sound's synth, brain_client_node's TTS voice).
+ *   Nodes that copy a parameter into a field at construction — bringup's safety clamp,
+ *   the camera driver, nav2's launch-time remap — must be left off, or the UI would
+ *   claim an effect it did not have.
  * @property {string} [subsection]  Optional label grouping related knobs inside a
  *   section card (e.g. "Linear" / "Angular"). Consecutive knobs with the same
  *   subsection render under one subhead.
@@ -119,9 +121,11 @@ export const SETTINGS_PAGES = [
       },
       {
         title: "Robot voice",
-        note: "The TTS voice drives both chat-TTS and realtime voice.",
+        note: "Saving swaps the voice on the next thing the robot says — a clip already playing finishes in the old one.",
         knobs: [
-          { path: ["/**", P, "cartesia_voice_id"], label: "TTS voice", default: "9fdaae0b-f885-4813-b589-3c07cf9d5fea", type: "string", doc: "Cartesia TTS voice (drives both chat-TTS and realtime-voice). Pick a stock voice, or paste any voice ID from Cartesia's library of hundreds.", docHref: "https://play.cartesia.ai/voices", docLinkText: "Browse Cartesia voices\u00A0↗", options: VOICE_OPTIONS },
+          // `/**` in the file so a restart reaches every node that declares it, but the
+          // live push goes to brain_client_node alone — it owns the only TTS that speaks.
+          { path: ["/**", P, "cartesia_voice_id"], label: "TTS voice", default: "9fdaae0b-f885-4813-b589-3c07cf9d5fea", type: "string", doc: "Cartesia voice for everything the robot speaks. Pick a stock voice, or paste any voice ID from Cartesia's library of hundreds.", docHref: "https://play.cartesia.ai/voices", docLinkText: "Browse Cartesia voices\u00A0↗", options: VOICE_OPTIONS, live: "/brain_client_node" },
         ],
       },
     ],

--- a/webapp/js/settings/main.js
+++ b/webapp/js/settings/main.js
@@ -452,7 +452,7 @@ function buildSettingsPage() {
     textEl(
       "p",
       "settings-note",
-      "Changes save to config/settings.yaml; restart the robot to apply.",
+      "Changes save to config/settings.yaml. Saving applies what it can immediately and says so; the rest take effect on the next restart.",
     ),
     search,
     accordion,


### PR DESCRIPTION
Picking a voice in **Settings → Sound → Robot voice** wrote it to `config/settings.yaml` and stopped there — the robot kept speaking in the old voice until `innate restart`.

Two reasons, both fixed here:

- `TTSHandler` read `cartesia_voice_id` off the proxy config **once** at construction.
- The knob was not marked `live`, so the Settings page never pushed the new id at the running node (it only pushes knobs whose node actually acts on the write).

## What changed

- `brain_client_node` registers an `on_set_parameters` callback and hands a new `cartesia_voice_id` to `TTSHandler.set_voice`. The voice dict is built per utterance from `self.voice_id`, so the change lands on the next thing the robot says. A clip already streaming finishes in the old voice — Cartesia picks the voice per request, so there is nothing to swap mid-stream.
- The catalog knob gets `live: "/brain_client_node"`. It stays a `/**` entry in the file so a restart still reaches every node that declares it, but the live push goes to the brain alone: it owns the only TTS that speaks. `input_manager_node`'s copy just rides along in the proxy config that user input devices read (`self.proxy.config`), so pushing there would claim an effect it does not have.
- Empty ids are refused, as is a write arriving with no TTS handler (no proxy). The Settings page already reports "N could not be applied live", which beats claiming an effect that did not happen.
- `settings.yaml.template` and the `live` JSDoc say what is now true; the section note tells the operator the swap is immediate.

Over SSH the same thing is:

```bash
ros2 param set /brain_client_node cartesia_voice_id d46abd1d-2d02-43e8-819f-51fb652c1c61
```

## Verified

Driven over a **real `set_parameters` service call** against a throwaway node running this branch's `_on_parameter_change` and `TTSHandler.set_voice`, inside the running sim container (the live sim session was left untouched):

```
1) set Newsman  -> Set parameter successful | handler.voice_id = d46abd1d-…
   [INFO] 🗣️ TTS voice changed to d46abd1d-…
2) set empty    -> Setting parameter failed: cartesia_voice_id must not be empty
3) no TTS       -> Setting parameter failed: TTS is unavailable (no proxy)
```

Gates:

- `pre-commit run --all-files -c .config/pre-commit-config.yaml` — all 6 hooks pass (ruff, ruff-format, clang-format, nav2 remap, settings double-keys, launcher/image tests).
- `tsc --noEmit` on `webapp/` — no new diagnostics; `js/settings/catalog.js` is clean.
- No tests added: nothing here is a behaviour the existing suite covers, and per CLAUDE.md new test files ship only when asked. The `test_node_boot` launch test in CI covers the node still booting with the new callback.

## Follow-up, not in this PR

A "Preview voice" button on the Settings page — publish a short line on `/brain/tts` so the operator hears the voice before saving. Worth doing, but it is a new control rather than the missing half of this one.