### PR TITLE
perf(sim): stop re-downloading dependencies, and give each checkout its own stack

### DIFF
--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -61,6 +61,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.image_tags.outputs.image_tag }}
       image_inputs_hash: ${{ steps.image_tags.outputs.image_inputs_hash }}
+      deps_inputs_hash: ${{ steps.image_tags.outputs.deps_inputs_hash }}
       assets_inputs_hash: ${{ steps.image_tags.outputs.assets_inputs_hash }}
       assets_published: ${{ steps.image_tags.outputs.assets_published }}
       push_main_tags: ${{ steps.image_tags.outputs.push_main_tags }}
@@ -82,6 +83,11 @@ jobs:
           # Shared with cleanup-sim-images.yml, which pins main's
           # inputs-<hash> versions against retention.
           image_inputs_hash="$(python3 sim/launcher/config.py sim-image-hash)"
+          # The deps image's own address: sim/Dockerfile plus the apt lists,
+          # with no ros2_ws/src in it, so this tag stands still while the ROS
+          # image's moves per commit. That standing-still is the point -- it is
+          # what the launcher pulls instead of a 25-30 min local build.
+          deps_inputs_hash="$(python3 sim/launcher/config.py deps-image-hash)"
           assets_inputs_hash="$(python3 sim/launcher/config.py assets-image-hash)"
           short_sha="${GITHUB_SHA::12}"
           # Every build is content/commit-addressed (sha-, inputs-); only
@@ -103,6 +109,7 @@ jobs:
 
           echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
           echo "image_inputs_hash=${image_inputs_hash}" >> "$GITHUB_OUTPUT"
+          echo "deps_inputs_hash=${deps_inputs_hash}" >> "$GITHUB_OUTPUT"
           echo "assets_inputs_hash=${assets_inputs_hash}" >> "$GITHUB_OUTPUT"
           echo "assets_published=${assets_published}" >> "$GITHUB_OUTPUT"
           echo "push_main_tags=${push_main_tags}" >> "$GITHUB_OUTPUT"
@@ -139,7 +146,7 @@ jobs:
             --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \
             --service-account="projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_CLOUD_BUILD_SERVICE_ACCOUNT }}" \
             --config=ci/cloudbuild.sim-images.yaml \
-            --substitutions="_IMAGE_PREFIX=${{ vars.SIM_IMAGE_PREFIX }},_IMAGE_TAG=${{ needs.tags.outputs.image_tag }},_IMAGE_INPUTS_HASH=${{ needs.tags.outputs.image_inputs_hash }},_PUSH_MAIN_TAGS=${{ needs.tags.outputs.push_main_tags }},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }},_COMMIT_SHA=${GITHUB_SHA},_SHORT_SHA=${{ needs.tags.outputs.short_sha }}"
+            --substitutions="_IMAGE_PREFIX=${{ vars.SIM_IMAGE_PREFIX }},_IMAGE_TAG=${{ needs.tags.outputs.image_tag }},_IMAGE_INPUTS_HASH=${{ needs.tags.outputs.image_inputs_hash }},_DEPS_INPUTS_HASH=${{ needs.tags.outputs.deps_inputs_hash }},_PUSH_MAIN_TAGS=${{ needs.tags.outputs.push_main_tags }},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }},_COMMIT_SHA=${GITHUB_SHA},_SHORT_SHA=${{ needs.tags.outputs.short_sha }}"
 
   arm64:
     needs: tags
@@ -168,6 +175,7 @@ jobs:
           IMAGE_PREFIX: ${{ vars.SIM_IMAGE_PREFIX }}
           IMAGE_TAG: ${{ needs.tags.outputs.image_tag }}
           IMAGE_INPUTS_HASH: ${{ needs.tags.outputs.image_inputs_hash }}
+          DEPS_INPUTS_HASH: ${{ needs.tags.outputs.deps_inputs_hash }}
           PUSH_MAIN_TAGS: ${{ needs.tags.outputs.push_main_tags }}
           COMMIT_SHA: ${{ github.sha }}
           SHORT_SHA: ${{ needs.tags.outputs.short_sha }}
@@ -197,6 +205,7 @@ jobs:
           IMAGE_PREFIX: ${{ vars.SIM_IMAGE_PREFIX }}
           IMAGE_TAG: ${{ needs.tags.outputs.image_tag }}
           IMAGE_INPUTS_HASH: ${{ needs.tags.outputs.image_inputs_hash }}
+          DEPS_INPUTS_HASH: ${{ needs.tags.outputs.deps_inputs_hash }}
           PUSH_MAIN_TAGS: ${{ needs.tags.outputs.push_main_tags }}
           SHORT_SHA: ${{ needs.tags.outputs.short_sha }}
         run: bash ci/stitch_sim_manifests.sh
@@ -204,6 +213,7 @@ jobs:
       - name: Published image tags
         run: |
           echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-deps:inputs-${{ needs.tags.outputs.image_inputs_hash }} (multi-arch)"
+          echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-deps:deps-${{ needs.tags.outputs.deps_inputs_hash }} (multi-arch)"
           echo "${{ vars.SIM_IMAGE_PREFIX }}/innate-os-sim-ros:inputs-${{ needs.tags.outputs.image_inputs_hash }} (multi-arch)"
 
   # The layered sim asset image. Independent of the colcon images above: no

--- a/ci/build_sim_images.sh
+++ b/ci/build_sim_images.sh
@@ -13,7 +13,7 @@
 #     colcon build into a multi-hour crawl)
 #
 # Required env: IMAGE_PREFIX, IMAGE_TAG, COMMIT_SHA, SHORT_SHA, ARCH
-# Optional env: IMAGE_INPUTS_HASH, PUSH_MAIN_TAGS
+# Optional env: IMAGE_INPUTS_HASH, DEPS_INPUTS_HASH, PUSH_MAIN_TAGS
 # The caller must already be logged in to the registry.
 set -euo pipefail
 
@@ -27,6 +27,13 @@ cache_tag="buildcache-${ARCH}"
 inputs_tag=""
 if [[ -n "${IMAGE_INPUTS_HASH:-}" && "${IMAGE_INPUTS_HASH}" != "manual" ]]; then
   inputs_tag="inputs-${IMAGE_INPUTS_HASH}"
+fi
+# The deps image's own content address (config.resolve_deps_image): the files
+# sim/Dockerfile reads, not ros2_ws/src, which it does not contain. This is
+# what the launcher pulls when no ROS prebuilt matches a checkout.
+deps_inputs_tag=""
+if [[ -n "${DEPS_INPUTS_HASH:-}" && "${DEPS_INPUTS_HASH}" != "manual" ]]; then
+  deps_inputs_tag="deps-${DEPS_INPUTS_HASH}"
 fi
 
 push_tags() {
@@ -49,30 +56,56 @@ push_tags() {
   done
 }
 
-# The plain `buildcache` pulls seed the cache from the pre-multi-arch tags
-# during the transition; harmless no-ops once the -$ARCH caches exist.
-docker pull "$deps_image:$cache_tag" || docker pull "$deps_image:buildcache" || true
-docker build \
-  --progress=plain \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from "$deps_image:$cache_tag" \
-  --cache-from "$deps_image:buildcache" \
-  --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
-  --label "org.opencontainers.image.revision=${COMMIT_SHA}" \
-  --tag "$deps_image:${IMAGE_TAG}-${ARCH}" \
-  --file sim/Dockerfile \
-  .
+# Reuse rather than rebuild when this arch already has one for these inputs: a
+# rebuild that misses its cache re-resolves apt and pip into layers that are
+# byte-different for identical content, and each difference is a
+# multi-hundred-MB download for every user downstream.
+deps_reused=false
+if [[ -n "$deps_inputs_tag" ]] && docker pull "$deps_image:${deps_inputs_tag}-${ARCH}"; then
+  docker tag "$deps_image:${deps_inputs_tag}-${ARCH}" "$deps_image:${IMAGE_TAG}-${ARCH}"
+  deps_reused=true
+  echo "Reusing published deps image $deps_image:${deps_inputs_tag}-${ARCH}"
+else
+  # The plain `buildcache` pulls seed the cache from the pre-multi-arch tags
+  # during the transition; harmless no-ops once the -$ARCH caches exist.
+  docker pull "$deps_image:$cache_tag" || docker pull "$deps_image:buildcache" || true
+  docker build \
+    --progress=plain \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --cache-from "$deps_image:$cache_tag" \
+    --cache-from "$deps_image:buildcache" \
+    --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
+    --label "org.opencontainers.image.revision=${COMMIT_SHA}" \
+    --tag "$deps_image:${IMAGE_TAG}-${ARCH}" \
+    --file sim/Dockerfile \
+    .
+fi
 
 deps_tags=("${IMAGE_TAG}-${ARCH}" "${sha_tag}-${ARCH}" "$cache_tag")
 if [[ -n "$inputs_tag" ]]; then
   deps_tags+=("${inputs_tag}-${ARCH}")
+fi
+if [[ -n "$deps_inputs_tag" ]]; then
+  deps_tags+=("${deps_inputs_tag}-${ARCH}")
 fi
 if [[ "${PUSH_MAIN_TAGS:-false}" == "true" ]]; then
   deps_tags+=("main-${ARCH}")
 fi
 push_tags "$deps_image" "${IMAGE_TAG}-${ARCH}" "${deps_tags[@]}"
 
-deps_ros_base="$deps_image:$cache_tag"
+# By digest, never the mutable buildcache tag it used to be: `docker push`
+# records the pushed manifest as a RepoDigest, so this is the exact image just
+# published. `|| true` because pipefail would make a no-match grep abort here,
+# and the explicit check below is the better error.
+deps_ros_base="$(
+  docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$deps_image:${IMAGE_TAG}-${ARCH}" |
+    grep "^${deps_image}@sha256:" | head -n1 || true
+)"
+if [[ -z "$deps_ros_base" ]]; then
+  echo "No RepoDigest for $deps_image:${IMAGE_TAG}-${ARCH} after push -- refusing to fall back to a mutable tag." >&2
+  exit 1
+fi
+echo "ROS image base: $deps_ros_base (reused=${deps_reused})"
 docker pull "$ros_image:$cache_tag" || docker pull "$ros_image:buildcache" || true
 docker build \
   --progress=plain \

--- a/ci/build_sim_images.sh
+++ b/ci/build_sim_images.sh
@@ -28,9 +28,8 @@ inputs_tag=""
 if [[ -n "${IMAGE_INPUTS_HASH:-}" && "${IMAGE_INPUTS_HASH}" != "manual" ]]; then
   inputs_tag="inputs-${IMAGE_INPUTS_HASH}"
 fi
-# The deps image's own content address (config.resolve_deps_image): the files
-# sim/Dockerfile reads, not ros2_ws/src, which it does not contain. This is
-# what the launcher pulls when no ROS prebuilt matches a checkout.
+# config.resolve_deps_image -- what the launcher pulls when no ROS prebuilt
+# matches a checkout.
 deps_inputs_tag=""
 if [[ -n "${DEPS_INPUTS_HASH:-}" && "${DEPS_INPUTS_HASH}" != "manual" ]]; then
   deps_inputs_tag="deps-${DEPS_INPUTS_HASH}"
@@ -56,9 +55,8 @@ push_tags() {
   done
 }
 
-# Reuse rather than rebuild when this arch already has one for these inputs: a
-# rebuild that misses its cache re-resolves apt and pip into layers that are
-# byte-different for identical content, and each difference is a
+# Reuse rather than rebuild: a rebuild that misses its cache re-resolves apt and
+# pip into byte-different layers for identical content, and each difference is a
 # multi-hundred-MB download for every user downstream.
 deps_reused=false
 if [[ -n "$deps_inputs_tag" ]] && docker pull "$deps_image:${deps_inputs_tag}-${ARCH}"; then
@@ -93,10 +91,8 @@ if [[ "${PUSH_MAIN_TAGS:-false}" == "true" ]]; then
 fi
 push_tags "$deps_image" "${IMAGE_TAG}-${ARCH}" "${deps_tags[@]}"
 
-# By digest, never the mutable buildcache tag it used to be: `docker push`
-# records the pushed manifest as a RepoDigest, so this is the exact image just
-# published. `|| true` because pipefail would make a no-match grep abort here,
-# and the explicit check below is the better error.
+# By digest, never the mutable buildcache tag it used to be. `|| true` because
+# pipefail would make a no-match grep abort before the explicit check below.
 deps_ros_base="$(
   docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$deps_image:${IMAGE_TAG}-${ARCH}" |
     grep "^${deps_image}@sha256:" | head -n1 || true

--- a/ci/cloudbuild.sim-images.yaml
+++ b/ci/cloudbuild.sim-images.yaml
@@ -4,6 +4,7 @@ substitutions:
   _GHCR_TOKEN_SECRET: innate-os-sim-ghcr-token
   _GHCR_USERNAME_SECRET: innate-os-sim-ghcr-username
   _COMMIT_SHA: manual
+  _DEPS_INPUTS_HASH: manual
   _IMAGE_INPUTS_HASH: manual
   _IMAGE_PREFIX: ghcr.io/innate-inc
   _IMAGE_TAG: manual
@@ -25,6 +26,7 @@ steps:
       - IMAGE_PREFIX=${_IMAGE_PREFIX}
       - IMAGE_TAG=${_IMAGE_TAG}
       - IMAGE_INPUTS_HASH=${_IMAGE_INPUTS_HASH}
+      - DEPS_INPUTS_HASH=${_DEPS_INPUTS_HASH}
       - PUSH_MAIN_TAGS=${_PUSH_MAIN_TAGS}
       - COMMIT_SHA=${_COMMIT_SHA}
       - SHORT_SHA=${_SHORT_SHA}

--- a/ci/sim_image_retention.jq
+++ b/ci/sim_image_retention.jq
@@ -21,10 +21,15 @@ def tags: .metadata.container.tags // [];
 def age_days:
   (.updated_at // .created_at) as $ts
   | if $ts == null then 0 else (now - ($ts | fromdateiso8601)) / 86400 end;
+# deps-<hash> moves only when the Dockerfile or an apt list does, and any
+# checkout back to those inputs pulls it rather than rebuilding for 25-30
+# minutes. A superseded version loses the tag to its successor and ages out
+# below, so this keeps the current one per hash, not every one ever built.
 def keep_forever:
   tags | any(
     . == "main" or startswith("main-")
     or startswith("buildcache")
+    or startswith("deps-")
     or . == "inputs-\($main_hash)" or startswith("inputs-\($main_hash)-")
   );
 # Commit components of this version's sha-<hex>[-<arch>] tags. Prefix-matched

--- a/ci/sim_image_retention.jq
+++ b/ci/sim_image_retention.jq
@@ -21,10 +21,9 @@ def tags: .metadata.container.tags // [];
 def age_days:
   (.updated_at // .created_at) as $ts
   | if $ts == null then 0 else (now - ($ts | fromdateiso8601)) / 86400 end;
-# deps-<hash> moves only when the Dockerfile or an apt list does, and any
-# checkout back to those inputs pulls it rather than rebuilding for 25-30
-# minutes. A superseded version loses the tag to its successor and ages out
-# below, so this keeps the current one per hash, not every one ever built.
+# deps-<hash> moves only when the Dockerfile or an apt list does, and a checkout
+# back to those inputs pulls it instead of rebuilding. A superseded version loses
+# the tag to its successor and ages out below.
 def keep_forever:
   tags | any(
     . == "main" or startswith("main-")

--- a/ci/stitch_sim_manifests.sh
+++ b/ci/stitch_sim_manifests.sh
@@ -29,8 +29,6 @@ fi
 # run leaves some tags stitched and others stale to near zero.
 for image in "${IMAGE_PREFIX}/innate-os-sim-deps" "${IMAGE_PREFIX}/innate-os-sim-ros"; do
   image_tags=("${tags[@]}")
-  # deps-<hash> names the deps image's own inputs; the ROS image on top has a
-  # different content address.
   if [[ "$image" == *"/innate-os-sim-deps" && -n "${DEPS_INPUTS_HASH:-}" && "${DEPS_INPUTS_HASH}" != "manual" ]]; then
     image_tags+=("deps-${DEPS_INPUTS_HASH}")
   fi

--- a/ci/stitch_sim_manifests.sh
+++ b/ci/stitch_sim_manifests.sh
@@ -9,7 +9,7 @@
 #   - .github/workflows/publish-sim-images.yml (manifest job)
 #
 # Required env: IMAGE_PREFIX, IMAGE_TAG, SHORT_SHA
-# Optional env: IMAGE_INPUTS_HASH, PUSH_MAIN_TAGS
+# Optional env: IMAGE_INPUTS_HASH, DEPS_INPUTS_HASH, PUSH_MAIN_TAGS
 # The caller must already be logged in to the registry.
 set -euo pipefail
 
@@ -28,9 +28,15 @@ fi
 # tag pointers are written back-to-back, keeping the window where a cancelled
 # run leaves some tags stitched and others stale to near zero.
 for image in "${IMAGE_PREFIX}/innate-os-sim-deps" "${IMAGE_PREFIX}/innate-os-sim-ros"; do
+  image_tags=("${tags[@]}")
+  # deps-<hash> names the deps image's own inputs; the ROS image on top has a
+  # different content address.
+  if [[ "$image" == *"/innate-os-sim-deps" && -n "${DEPS_INPUTS_HASH:-}" && "${DEPS_INPUTS_HASH}" != "manual" ]]; then
+    image_tags+=("deps-${DEPS_INPUTS_HASH}")
+  fi
   tag_args=()
   seen="|"
-  for tag in "${tags[@]}"; do
+  for tag in "${image_tags[@]}"; do
     if [[ "$seen" == *"|$tag|"* ]]; then
       continue
     fi

--- a/scripts/validate_sim_ros_install.zsh
+++ b/scripts/validate_sim_ros_install.zsh
@@ -86,15 +86,11 @@ seed_prebuilt_install() {
         return 1
     fi
 
-    # Seed only into a workspace with nothing to build on. Dropping the image's
-    # install/ over a local build tree leaves build/ facing an install/ made at
-    # a different prefix, and made without --symlink-install where the local
-    # build uses it: the next source edit then stops being incremental and
-    # becomes a full workspace rebuild. Measured at >20 min against 20 s.
-    #
-    # build/, not install/: an install that merely matches right now says
-    # nothing about whether a rebuild can be incremental, and reverting an edit
-    # would make it stale again and re-arm the same clobber on the next `up`.
+    # Seed only into a workspace with nothing to build on. The image's install/
+    # is made at a different prefix and without --symlink-install, so dropping it
+    # over a local build tree turns the next edit into a full rebuild: measured
+    # >20 min against 20 s. Keyed on build/ rather than install/ matching, since
+    # reverting an edit would make install/ stale again and re-arm the clobber.
     if [[ -n "$(ls -A build 2>/dev/null)" ]]; then
         echo "Local ROS build tree present; building incrementally rather than seeding."
         return 1
@@ -135,11 +131,10 @@ install_is_stale() {
     return 1
 }
 
-# Reserved for an install that cannot be built ON: no setup.zsh, or symlinks
-# pointing at nothing. A CHECKOUT change is deliberately no longer in that set
-# -- volumes are per-checkout now, the paths inside the container are identical
+# Reserved for an install that cannot be built ON. A CHECKOUT change is no
+# longer in that set: volumes are per-checkout now, container paths are identical
 # either way, and colcon_build_with_retry already cleans on the stale-symlink
-# failure when one actually happens.
+# failure when one happens.
 install_needs_clean_rebuild() {
     [[ ! -f install/setup.zsh ]] && return 0
     find install -xtype l -print -quit | grep -q . && return 0

--- a/scripts/validate_sim_ros_install.zsh
+++ b/scripts/validate_sim_ros_install.zsh
@@ -121,15 +121,14 @@ install_is_stale() {
     return 1
 }
 
+# Reserved for an install that cannot be built ON: no setup.zsh, or symlinks
+# pointing at nothing. A CHECKOUT change is deliberately no longer in that set
+# -- volumes are per-checkout now, the paths inside the container are identical
+# either way, and colcon_build_with_retry already cleans on the stale-symlink
+# failure when one actually happens.
 install_needs_clean_rebuild() {
     [[ ! -f install/setup.zsh ]] && return 0
     find install -xtype l -print -quit | grep -q . && return 0
-
-    if [[ -n "${INNATE_OS_HOST_REPO_ID:-}" ]]; then
-        local installed_repo_id
-        installed_repo_id="$(cat install/.innate-local-repo-id 2>/dev/null || true)"
-        [[ "$installed_repo_id" != "$INNATE_OS_HOST_REPO_ID" ]] && return 0
-    fi
 
     return 1
 }
@@ -140,7 +139,7 @@ elif seed_prebuilt_install; then
     :
 elif install_is_stale; then
     if install_needs_clean_rebuild; then
-        echo "Removing stale ROS build/install/log volumes before rebuild."
+        echo "ROS install is unusable (missing or dangling); cleaning build/install/log before rebuild."
         clean_ros_build_artifacts
     fi
     colcon_build_with_retry

--- a/scripts/validate_sim_ros_install.zsh
+++ b/scripts/validate_sim_ros_install.zsh
@@ -86,6 +86,20 @@ seed_prebuilt_install() {
         return 1
     fi
 
+    # Seed only into a workspace with nothing to build on. Dropping the image's
+    # install/ over a local build tree leaves build/ facing an install/ made at
+    # a different prefix, and made without --symlink-install where the local
+    # build uses it: the next source edit then stops being incremental and
+    # becomes a full workspace rebuild. Measured at >20 min against 20 s.
+    #
+    # build/, not install/: an install that merely matches right now says
+    # nothing about whether a rebuild can be incremental, and reverting an edit
+    # would make it stale again and re-arm the same clobber on the next `up`.
+    if [[ -n "$(ls -A build 2>/dev/null)" ]]; then
+        echo "Local ROS build tree present; building incrementally rather than seeding."
+        return 1
+    fi
+
     if [[ ! -f install/setup.zsh ]] ||
         [[ "$(cat install/.innate-prebuilt-source.sha256 2>/dev/null)" != "$prebuilt_hash" ]] ||
         [[ "$(cat install/.innate-prebuilt-install.sha256 2>/dev/null)" != "$prebuilt_install_hash" ]]; then

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -6,7 +6,12 @@
 # is bind-mounted by sim/docker-compose.dev.yml and built into persistent named
 # volumes at runtime, so source edits do not require rebuilding the image.
 
-ARG ROS_BASE_IMAGE=ros:humble-ros-base
+# The index digest, not the tag: upstream rebuilds this weekly, and a moved
+# base makes every layer above it different -- two consecutive publishes of
+# innate-os-sim-ros shared one layer out of 26. ci/build_sim_images.sh pins the
+# ROS image's own base the same way; both links have to be immutable or neither
+# is. Bump deliberately to take base updates.
+ARG ROS_BASE_IMAGE=ros:humble-ros-base@sha256:75dd3aba34a3838dadbb31a9f7bef769bdfa8713e6cec686fc868db2981b0987
 FROM ${ROS_BASE_IMAGE} AS os-deps
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -6,11 +6,10 @@
 # is bind-mounted by sim/docker-compose.dev.yml and built into persistent named
 # volumes at runtime, so source edits do not require rebuilding the image.
 
-# The index digest, not the tag: upstream rebuilds this weekly, and a moved
-# base makes every layer above it different -- two consecutive publishes of
+# The index digest, not the tag: upstream rebuilds this weekly, and a moved base
+# makes every layer above it different -- two consecutive publishes of
 # innate-os-sim-ros shared one layer out of 26. ci/build_sim_images.sh pins the
-# ROS image's own base the same way; both links have to be immutable or neither
-# is. Bump deliberately to take base updates.
+# ROS image's own base the same way. Bump deliberately to take base updates.
 ARG ROS_BASE_IMAGE=ros:humble-ros-base@sha256:75dd3aba34a3838dadbb31a9f7bef769bdfa8713e6cec686fc868db2981b0987
 FROM ${ROS_BASE_IMAGE} AS os-deps
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -342,6 +342,12 @@ the container, on every platform, importing straight from your checkout.
 loads it. Restart that one from the host:
 `./innate-sim down && ./innate-sim up`.
 
+**Several clones at once.** Each checkout gets its own container, network and
+named volumes, so a branch clone beside your main one keeps its own compiled
+workspace. They still share the host's ports, so only one can be `up` at a
+time — starting a second stops with the name and path of the checkout holding
+them.
+
 `innate view` is the fastest way to see why a node is unhappy: the tmux
 session has one window per subsystem (zenoh, rosbridge-app, sim-driver,
 nav-brain, behavior, arm-ik, vision-nav, console-webapp, foxglove), each

--- a/sim/config.toml.template
+++ b/sim/config.toml.template
@@ -3,14 +3,22 @@
 # Leave values commented to use the built-in defaults.
 
 [os]
-# Optional prebuilt Innate OS image. By default, the launcher tries a
-# content-addressed prebuilt image matching this checkout, then falls back to
-# the local Docker build if no matching image is available.
+# Optional prebuilt Innate OS image. By default ("auto") the launcher tries a
+# content-addressed prebuilt image matching this checkout; failing that, the
+# published dependency image (which carries no workspace, so it matches any
+# source tree); failing that, a local Docker build.
 # image = "auto"
 #
 # Other options:
-# image = "local"
+# image = "local"    # never consult the registry, and use the compose default
+#                    # innate-os-sim-clean-innate:latest -- a MUTABLE tag, so
+#                    # it is not rebuilt when sim/Dockerfile or the apt lists
+#                    # change. Prefer pull_image = false below, which stays
+#                    # content-addressed.
 # image = "ghcr.io/innate-inc/innate-os-sim-ros:main"
+#
+# Whether "auto" may reach the network: false uses whatever is already on this
+# machine and builds anything missing locally.
 # pull_image = true
 
 # Run `colcon build` on every startup. Leave false for incremental startup:

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -1,3 +1,6 @@
+# The launcher passes `-p innate-os-<checkout id>` so each clone gets its own
+# container, network and volumes; this name is only for running the file by
+# hand, where a stable project beats the directory basename ("sim").
 name: innate-os
 
 services:
@@ -31,7 +34,9 @@ services:
       # fails with "Temporary failure resolving ...". Harmless where bridge
       # DNS already works.
       network: host
-    container_name: innate-dev
+    # config.OS_CONTAINER_NAME, matching the -p project above. The default is
+    # both the by-hand name and the one every checkout shared before.
+    container_name: ${INNATE_OS_CONTAINER_NAME:-innate-dev}
     # Use host networking if you need direct access to hardware, or use your own approach
     environment:
       # Points at the optional novnc X display (COMPOSE_PROFILES=x11);

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -1,6 +1,5 @@
-# The launcher passes `-p innate-os-<checkout id>` so each clone gets its own
-# container, network and volumes; this name is only for running the file by
-# hand, where a stable project beats the directory basename ("sim").
+# The launcher passes `-p innate-os-<checkout id>`; this name is for running the
+# file by hand.
 name: innate-os
 
 services:
@@ -34,8 +33,7 @@ services:
       # fails with "Temporary failure resolving ...". Harmless where bridge
       # DNS already works.
       network: host
-    # config.OS_CONTAINER_NAME, matching the -p project above. The default is
-    # both the by-hand name and the one every checkout shared before.
+    # config.OS_CONTAINER_NAME, matching the -p project above.
     container_name: ${INNATE_OS_CONTAINER_NAME:-innate-dev}
     # Use host networking if you need direct access to hardware, or use your own approach
     environment:

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -67,6 +67,12 @@ SIM_IMAGE_INPUT_FILES = (
     "ros2_ws/apt-dependencies.hardware.txt",
     "ros2_ws/apt-dependencies.sim.txt",
 )
+# The deps-only image CI publishes, addressed by compute_local_image_inputs_hash
+# and NOT the sim-image hash the ROS image carries: that one covers all of
+# ros2_ws/src, which this image does not contain, so a source edit would rename
+# an identical image out of reach -- the case this exists to serve.
+DEFAULT_SIM_DEPS_IMAGE = "ghcr.io/innate-inc/innate-os-sim-deps"
+DEPS_IMAGE_TAG_PREFIX = "deps-"
 # What the local (deps-only) sim/Dockerfile build actually reads from the repo.
 LOCAL_OS_IMAGE_REPO = "innate-os-sim-clean-innate"
 LOCAL_IMAGE_INPUT_FILES = (
@@ -114,6 +120,15 @@ ASSETS_IMAGE_PATHSPECS = (
     "ros2_ws/src/mars_bot/mars_sim_driver",
     "ros2_ws/src/mars_bot/mars_sim",
 )
+# Hashed because export_nav_map.py reads them, not because they build anything.
+# Geometry is carved out by EXCLUSION so a pathspec added above joins the
+# geometry hash by default: one wrongly excluded costs a needless refusal, one
+# wrongly included reuses geometry that no longer matches the checkout.
+NON_GEOMETRY_PATHSPECS = (
+    "ros2_ws/src/mars_bot/mars_sim_driver",
+    "ros2_ws/src/mars_bot/mars_sim",
+)
+GEOMETRY_INPUT_PATHSPECS = tuple(p for p in ASSETS_IMAGE_PATHSPECS if p not in NON_GEOMETRY_PATHSPECS)
 # The SimSession bundle the webapp loads, as its own image
 # (sim/viewer/Dockerfile), addressed by inputs-<compute_viewer_inputs_hash over
 # sim/viewer on disk>. That hash covers a little more than the build reads
@@ -151,9 +166,17 @@ SIM_ASSET_UNITS = SIM_ASSET_UNITS_DERIVED + SIM_ASSET_UNITS_AUTHORED
 # tests/test_assets_image_inputs.py holds the dockerignore (which IS hashed)
 # EQUAL to this set; weaken it to a subset check and that stops being true.
 OS_CONTAINER_SERVICE = "innate"
-# Must match `container_name:` / `name:` in sim/docker-compose.dev.yml.
-OS_CONTAINER_NAME = "innate-dev"
-COMPOSE_PROJECT_NAME = "innate-os"
+# One stack per checkout: clones of this repo used to share a container and a
+# set of named volumes, so `up` from the second either served the first one's
+# bind-mounted code or wiped its workspace build. The compose file cannot
+# compute this, so it arrives as `-p` and INNATE_OS_CONTAINER_NAME.
+HOST_REPO_ID = hashlib.sha256(str(REPO_ROOT.resolve()).encode("utf-8")).hexdigest()[:16]
+COMPOSE_PROJECT_NAME = f"innate-os-{HOST_REPO_ID}"
+OS_CONTAINER_NAME = f"innate-dev-{HOST_REPO_ID}"
+# Removed once on upgrade: it publishes 443/80/9090, so leaving it running
+# would fail the first per-checkout `up` on a port conflict.
+LEGACY_SHARED_CONTAINER = "innate-dev"
+LEGACY_SHARED_PROJECT = "innate-os"
 LEGACY_CLOUD_AGENT_CONTAINER = "innate-cloud-agent"
 OS_CONTAINER_TMUX_CMD = "./scripts/launch_sim_in_tmux.zsh --detach"
 SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY)
@@ -504,6 +527,24 @@ def resolve_assets_image(repo_root: Path) -> str:
 
 
 @functools.lru_cache
+def compute_geometry_inputs_hash(repo_root: Path) -> str:
+    """Whether the geometry already installed still describes this checkout.
+
+    A second hash, not a second identity: the asset image is rightly renamed by
+    a driver edit (it can move the nav map), but that alone must not hard-stop
+    `up`, because geometry has no local build path to fall back to and a fork
+    has no CI to publish a new one.
+    """
+    digest = hashlib.sha256()
+    _hash_input_files(
+        digest,
+        repo_root,
+        _collect_input_files(repo_root, ASSETS_IMAGE_INPUT_FILES, GEOMETRY_INPUT_PATHSPECS),
+    )
+    return digest.hexdigest()
+
+
+@functools.lru_cache
 def compute_viewer_inputs_hash(repo_root: Path) -> str:
     """Content hash of sim/viewer as it is ON DISK, tracked or not.
 
@@ -577,6 +618,13 @@ def resolve_local_os_image(repo_root: Path) -> str:
     different image inputs (Dockerfile, apt lists) keep separate images
     instead of clobbering a shared :latest."""
     return f"{LOCAL_OS_IMAGE_REPO}:inputs-{compute_local_image_inputs_hash(repo_root)}"
+
+
+def resolve_deps_image(repo_root: Path) -> str:
+    """The published twin of resolve_local_os_image: same Dockerfile, same
+    inputs, same hash. Its own tag prefix, because the ROS image in the
+    neighbouring repository names a different hash under `inputs-`."""
+    return f"{DEFAULT_SIM_DEPS_IMAGE}:{DEPS_IMAGE_TAG_PREFIX}{compute_local_image_inputs_hash(repo_root)}"
 
 
 def resolve_os_image_setting(value: str | None, repo_root: Path) -> tuple[str, bool]:
@@ -660,6 +708,7 @@ if __name__ == "__main__":
     # Named, not argless: there are several hashes in this file.
     _hash_commands = {
         "assets-image-hash": compute_assets_image_inputs_hash,
+        "deps-image-hash": compute_local_image_inputs_hash,
         "sim-image-hash": compute_sim_image_inputs_hash,
         "viewer-image-hash": compute_viewer_inputs_hash,
     }

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -67,10 +67,9 @@ SIM_IMAGE_INPUT_FILES = (
     "ros2_ws/apt-dependencies.hardware.txt",
     "ros2_ws/apt-dependencies.sim.txt",
 )
-# The deps-only image CI publishes, addressed by compute_local_image_inputs_hash
-# and NOT the sim-image hash the ROS image carries: that one covers all of
-# ros2_ws/src, which this image does not contain, so a source edit would rename
-# an identical image out of reach -- the case this exists to serve.
+# Addressed by compute_local_image_inputs_hash, not the ROS image's hash: that
+# one covers ros2_ws/src, which this image does not contain, so a source edit
+# would rename an identical image out of reach.
 DEFAULT_SIM_DEPS_IMAGE = "ghcr.io/innate-inc/innate-os-sim-deps"
 DEPS_IMAGE_TAG_PREFIX = "deps-"
 # What the local (deps-only) sim/Dockerfile build actually reads from the repo.
@@ -120,10 +119,9 @@ ASSETS_IMAGE_PATHSPECS = (
     "ros2_ws/src/mars_bot/mars_sim_driver",
     "ros2_ws/src/mars_bot/mars_sim",
 )
-# Hashed because export_nav_map.py reads them, not because they build anything.
-# Geometry is carved out by EXCLUSION so a pathspec added above joins the
-# geometry hash by default: one wrongly excluded costs a needless refusal, one
-# wrongly included reuses geometry that no longer matches the checkout.
+# Geometry is carved out by EXCLUSION, so a pathspec added above joins the
+# geometry hash by default: wrongly excluded costs a needless refusal, wrongly
+# included reuses geometry that no longer matches.
 NON_GEOMETRY_PATHSPECS = (
     "ros2_ws/src/mars_bot/mars_sim_driver",
     "ros2_ws/src/mars_bot/mars_sim",
@@ -166,15 +164,14 @@ SIM_ASSET_UNITS = SIM_ASSET_UNITS_DERIVED + SIM_ASSET_UNITS_AUTHORED
 # tests/test_assets_image_inputs.py holds the dockerignore (which IS hashed)
 # EQUAL to this set; weaken it to a subset check and that stops being true.
 OS_CONTAINER_SERVICE = "innate"
-# One stack per checkout: clones of this repo used to share a container and a
-# set of named volumes, so `up` from the second either served the first one's
-# bind-mounted code or wiped its workspace build. The compose file cannot
-# compute this, so it arrives as `-p` and INNATE_OS_CONTAINER_NAME.
+# One stack per checkout: clones used to share a container and a volume set, so
+# `up` from the second served the first one's code or wiped its build. The
+# compose file cannot compute this; it arrives as `-p` and
+# INNATE_OS_CONTAINER_NAME.
 HOST_REPO_ID = hashlib.sha256(str(REPO_ROOT.resolve()).encode("utf-8")).hexdigest()[:16]
 COMPOSE_PROJECT_NAME = f"innate-os-{HOST_REPO_ID}"
 OS_CONTAINER_NAME = f"innate-dev-{HOST_REPO_ID}"
-# Removed once on upgrade: it publishes 443/80/9090, so leaving it running
-# would fail the first per-checkout `up` on a port conflict.
+# Removed once on upgrade: it holds 443/80/9090.
 LEGACY_SHARED_CONTAINER = "innate-dev"
 LEGACY_SHARED_PROJECT = "innate-os"
 LEGACY_CLOUD_AGENT_CONTAINER = "innate-cloud-agent"
@@ -530,10 +527,9 @@ def resolve_assets_image(repo_root: Path) -> str:
 def compute_geometry_inputs_hash(repo_root: Path) -> str:
     """Whether the geometry already installed still describes this checkout.
 
-    A second hash, not a second identity: the asset image is rightly renamed by
-    a driver edit (it can move the nav map), but that alone must not hard-stop
-    `up`, because geometry has no local build path to fall back to and a fork
-    has no CI to publish a new one.
+    A second hash, not a second identity: a driver edit rightly renames the
+    asset image, but must not hard-stop `up` -- geometry has no local build path
+    to fall back to, and a fork has no CI to publish a new one.
     """
     digest = hashlib.sha256()
     _hash_input_files(
@@ -622,8 +618,8 @@ def resolve_local_os_image(repo_root: Path) -> str:
 
 def resolve_deps_image(repo_root: Path) -> str:
     """The published twin of resolve_local_os_image: same Dockerfile, same
-    inputs, same hash. Its own tag prefix, because the ROS image in the
-    neighbouring repository names a different hash under `inputs-`."""
+    inputs, same hash. Its own prefix, because the ROS image alongside it names
+    a different hash under `inputs-`."""
     return f"{DEFAULT_SIM_DEPS_IMAGE}:{DEPS_IMAGE_TAG_PREFIX}{compute_local_image_inputs_hash(repo_root)}"
 
 

--- a/sim/launcher/dashboard.py
+++ b/sim/launcher/dashboard.py
@@ -157,6 +157,9 @@ class DashboardRuntime:
 
 SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 STEP_LABEL_WIDTH = 8
+# Log rows a live step shows under its status line, as scripts/install-sim.sh
+# draws them. A step that only spins cannot be told apart from a hang.
+STEP_TAIL_ROWS = 3
 SELECTED, UNSELECTED = "●", "○"
 
 
@@ -289,6 +292,9 @@ class LiveStep:
     def __init__(self, label: str, message: str, done: str | None = None) -> None:
         self.label = label
         self.message = message
+        # Recent log lines, drawn under the status line. Empty keeps the step a
+        # single line, so a step that finishes instantly never flashes a region.
+        self.tail: list[str] = []
         # What it says once finished; the message is what it says while
         # working, which wants a verb.
         self.done = done or message
@@ -310,25 +316,44 @@ class LiveStep:
         self._thread = threading.Thread(target=self._animate, daemon=True)
         self._thread.start()
 
-    def _render(self, mark: str) -> str:
-        detail = f"  {DIM}{self.detail}{NC}" if self.detail else ""
-        line = f"  {CYAN}{self.label:>{STEP_LABEL_WIDTH}}{NC}  {mark} {self.message}{detail}"
+    def _width(self) -> int:
         # A line wider than the terminal wraps, and then \r returns to the
         # start of the WRAPPED row -- every redraw leaves the previous one
         # behind, which is how a spinner becomes a wall of repeated lines.
-        return clip_to_width(line, shutil.get_terminal_size((100, 40)).columns - 1)
+        return shutil.get_terminal_size((100, 40)).columns - 1
+
+    def _render(self, mark: str) -> str:
+        detail = f"  {DIM}{self.detail}{NC}" if self.detail else ""
+        line = f"  {CYAN}{self.label:>{STEP_LABEL_WIDTH}}{NC}  {mark} {self.message}{detail}"
+        return clip_to_width(line, self._width())
+
+    def _draw(self, mark: str) -> None:
+        """Status line plus the log tail, written once and stepped back over.
+
+        One write, not a clear followed by a draw: the region is blank between
+        the two for as long as the terminal takes to paint, which reads as
+        flicker. \033[J from the top wipes however many rows the last frame
+        used, so the tail can grow and shrink without bookkeeping.
+        """
+        width = self._width()
+        gutter = " " * STEP_LABEL_WIDTH
+        rows = [self._render(mark)]
+        rows += [clip_to_width(f"  {DIM}{gutter}  │ {line}{NC}", width) for line in self.tail]
+        body = "\r\033[J" + "\n".join(f"\033[K{row}" for row in rows)
+        step_back = f"\033[{len(rows) - 1}A" if len(rows) > 1 else ""
+        sys.stdout.write(body + step_back + "\r")
+        sys.stdout.flush()
 
     def _animate(self) -> None:
         frame = 0
         while not self._stop.wait(0.12):
-            sys.stdout.write("\r\033[K" + self._render(SPINNER_FRAMES[frame % len(SPINNER_FRAMES)]))
-            sys.stdout.flush()
+            self._draw(SPINNER_FRAMES[frame % len(SPINNER_FRAMES)])
             frame += 1
 
     def note(self, message: str) -> None:
         """Print a full line above the spinner, which redraws on its next tick."""
         if self.live:
-            sys.stdout.write("\r\033[K")
+            sys.stdout.write("\r\033[J")
         print(message)
 
     def finish(self, *, ok: bool = True) -> None:
@@ -336,8 +361,10 @@ class LiveStep:
         if self._thread is not None:
             self._thread.join()
         if self.live:
-            sys.stdout.write("\r\033[K")
+            # \033[J, not \033[K: the tail rows below have to go too.
+            sys.stdout.write("\r\033[J")
             _set_cursor(CURSOR_SHOW)
+        self.tail = []
         self.detail = ""
         self.message = self.done
         print(self._render(f"{GREEN}✔{NC}" if ok else f"{RED}✗{NC}"))
@@ -365,6 +392,17 @@ def live_step(label: str, message: str, done: str | None = None):
         step.finish(ok=step.ok)
     finally:
         _active_step = previous
+
+
+def clean_log_line(line: str) -> str:
+    """One log line, safe to draw inside a step's frame.
+
+    Escapes are stripped because a cursor move from the log would walk out of
+    the region the step redraws; tabs because they mis-measure the width; and
+    only the last carriage-return segment survives, which is what a terminal
+    would have shown for a progress line rewritten in place.
+    """
+    return ANSI_ESCAPE_RE.sub("", line.split("\r")[-1]).replace("\t", " ").rstrip()
 
 
 def clip_to_width(text: str, width: int) -> str:

--- a/sim/launcher/dashboard.py
+++ b/sim/launcher/dashboard.py
@@ -350,6 +350,12 @@ class LiveStep:
             self._draw(SPINNER_FRAMES[frame % len(SPINNER_FRAMES)])
             frame += 1
 
+    def retitle(self, message: str) -> None:
+        """Say what the step is doing NOW. One step can span phases that look
+        nothing alike -- starting a container, then a colcon build that runs for
+        minutes -- and a label stuck on the first of them describes a hang."""
+        self.message = message
+
     def note(self, message: str) -> None:
         """Print a full line above the spinner, which redraws on its next tick."""
         if self.live:

--- a/sim/launcher/dashboard.py
+++ b/sim/launcher/dashboard.py
@@ -157,8 +157,8 @@ class DashboardRuntime:
 
 SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 STEP_LABEL_WIDTH = 8
-# Log rows a live step shows under its status line, as scripts/install-sim.sh
-# draws them. A step that only spins cannot be told apart from a hang.
+# As scripts/install-sim.sh draws them: a step that only spins cannot be told
+# apart from a hang.
 STEP_TAIL_ROWS = 3
 SELECTED, UNSELECTED = "●", "○"
 
@@ -292,8 +292,6 @@ class LiveStep:
     def __init__(self, label: str, message: str, done: str | None = None) -> None:
         self.label = label
         self.message = message
-        # Recent log lines, drawn under the status line. Empty keeps the step a
-        # single line, so a step that finishes instantly never flashes a region.
         self.tail: list[str] = []
         # What it says once finished; the message is what it says while
         # working, which wants a verb.
@@ -330,10 +328,9 @@ class LiveStep:
     def _draw(self, mark: str) -> None:
         """Status line plus the log tail, written once and stepped back over.
 
-        One write, not a clear followed by a draw: the region is blank between
-        the two for as long as the terminal takes to paint, which reads as
-        flicker. \033[J from the top wipes however many rows the last frame
-        used, so the tail can grow and shrink without bookkeeping.
+        One write, not a clear then a draw: the gap between them reads as
+        flicker. \033[J from the top wipes whatever the last frame used, so the
+        tail can grow and shrink without bookkeeping.
         """
         width = self._width()
         gutter = " " * STEP_LABEL_WIDTH
@@ -351,9 +348,6 @@ class LiveStep:
             frame += 1
 
     def retitle(self, message: str) -> None:
-        """Say what the step is doing NOW. One step can span phases that look
-        nothing alike -- starting a container, then a colcon build that runs for
-        minutes -- and a label stuck on the first of them describes a hang."""
         self.message = message
 
     def note(self, message: str) -> None:
@@ -401,13 +395,8 @@ def live_step(label: str, message: str, done: str | None = None):
 
 
 def clean_log_line(line: str) -> str:
-    """One log line, safe to draw inside a step's frame.
-
-    Escapes are stripped because a cursor move from the log would walk out of
-    the region the step redraws; tabs because they mis-measure the width; and
-    only the last carriage-return segment survives, which is what a terminal
-    would have shown for a progress line rewritten in place.
-    """
+    """Safe to draw inside a step's frame: an escape would walk the cursor out of
+    the redrawn region, and only the last \r segment is what a terminal shows."""
     return ANSI_ESCAPE_RE.sub("", line.split("\r")[-1]).replace("\t", " ").rstrip()
 
 

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -55,7 +55,7 @@ from runtime import (
     open_os_container_shell,
     prefetch_runtime,
     print_startup_checks,
-    remove_legacy_cloud_agent,
+    remove_superseded_containers,
     runtime_already_running,
     stop_world_server,
     tail_file,
@@ -116,9 +116,10 @@ def cmd_up(
         # workspace dirs for the invoking user (root-owned bind-mount dirs on
         # Linux otherwise), and warns if an earlier run already claimed them.
         ensure_workspace_dirs(config)
-        # Before the fast path, not after it: the container it removes is
-        # exactly what an upgrade from a still-running older stack leaves behind.
-        remove_legacy_cloud_agent()
+        # Before the fast path, not after it: the containers it removes are
+        # exactly what an upgrade from a still-running older stack leaves
+        # behind -- and one of them holds the ports this stack needs.
+        remove_superseded_containers()
         if runtime_already_running(config):
             # A code update can leave a stale world server running (frozen
             # 3D view); ensure_world_server restarts it.
@@ -220,7 +221,7 @@ def cmd_up(
 
 
 def cmd_down(config: dict[str, object]) -> None:
-    remove_legacy_cloud_agent()
+    remove_superseded_containers()
     down_os(config)
     stop_world_server()
     log("Innate sim runtime is down.")

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -225,8 +225,6 @@ def run_logged_with_heartbeat(
     # A bar redrawn in place needs to be refreshed often to look like one; a
     # log file gets the slow cadence, so a CI transcript is not a flipbook.
     live = progress_formatter is not None and sys.stdout.isatty()
-    # A step draws the log tail itself (see below), which wants the same quick
-    # cadence a progress bar does -- a tail refreshed every 10s reads as stuck.
     if live or (sys.stdout.isatty() and active_step() is not None):
         heartbeat_seconds = 0.5
     drew_progress = False
@@ -260,10 +258,8 @@ def run_logged_with_heartbeat(
                     # says how far along. Before docker's first layer line is
                     # parseable that is just the clock.
                     step.detail = f"{progress}  {stamp}" if progress else stamp
-                    # The tail is for commands with nothing better to show. A
-                    # formatter means there IS something better -- the pull's
-                    # aggregate bar, which replaced exactly this layer chatter
-                    # on purpose -- so those keep the single line.
+                    # A formatter means there is something better to show: for
+                    # the pulls, the bar that replaced this very chatter.
                     if progress_formatter is None:
                         lines = [clean_log_line(line) for line in appended.splitlines()]
                         step.tail = [line for line in lines if line.strip()][-STEP_TAIL_ROWS:]
@@ -575,8 +571,6 @@ def os_compose_env(
     *,
     env_file: Path = GENERATED_OS_ENV_PATH,
 ) -> dict[str, str]:
-    # On every compose call, not just `up`: it is interpolated into
-    # `container_name:`, and compose refuses a file it cannot resolve.
     values = {
         "INNATE_OS_ENV_FILE": str(env_file),
         "INNATE_OS_CONTAINER_NAME": OS_CONTAINER_NAME,
@@ -671,11 +665,8 @@ def ensure_os_image_available(
 def adopt_published_deps_image(local_image: str, *, cwd: Path, env: dict[str, str]) -> bool:
     """Pull the published deps image and give it the local build's name.
 
-    Retagged rather than used under its own name: the two are the same bytes at
-    the same content address, so the offline resolution, the prune and the next
-    run's fast path keep working with no second notion of "the deps image".
-
-    False on any failure: a shortcut past a local build, never a prerequisite.
+    Retagged rather than used under its own name: same bytes at the same content
+    address, so every path that already looks for the local build keeps working.
     """
     deps_image = resolve_deps_image(REPO_ROOT)
     log(f"Fetching prebuilt dependencies {shorten_docker_image_ref(deps_image)}...")
@@ -710,10 +701,9 @@ def prune_stale_local_images(
 ) -> None:
     """Untag superseded content-addressed tags sharing `current_image`'s repo.
 
-    `keep_recent` holds back that many newest superseded tags, so bouncing
-    between two branches does not re-download either. Affordable only because
-    the bases are digest-pinned: a second copy costs its own layers rather than
-    a duplicate of everything beneath them.
+    `keep_recent` holds back that many newest, so a branch bounce does not
+    re-download. Affordable only because the bases are digest-pinned: a second
+    copy costs its own layers, not a duplicate of everything beneath them.
 
     The repo comes off `current_image` rather than a second argument: sweeping
     a different repo than the one being kept is the only way this can be wrong.
@@ -725,7 +715,7 @@ def prune_stale_local_images(
     try:
         listing = subprocess.run(
             # Timestamp first: keep_recent must not rest on the undocumented
-            # default ordering of a formatted listing.
+            # ordering of a formatted listing.
             ["docker", "images", "--format", "{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}", repo],
             cwd=cwd,
             env=env,
@@ -749,11 +739,8 @@ def prune_stale_local_images(
 
 
 def prune_superseded_pulled_images(config: dict[str, object], *, cwd: Path, env: dict[str, str]) -> None:
-    """Sweep the image families the launcher PULLS, not just the ones it builds.
-
-    Never called under --offline: deleting the only copy of something that
-    cannot be re-fetched is a different kind of mistake from using disk.
-    """
+    """Never under --offline: deleting the only copy of something that cannot be
+    re-fetched is a different mistake from using disk."""
     os_repo: Path = config["os_repo"]  # type: ignore[assignment]
     families = (
         (resolve_auto_os_image(os_repo), "inputs-", "Innate OS prebuilt", 1),
@@ -838,7 +825,6 @@ def os_container_foxglove_port_current(config: dict[str, object]) -> bool:
 
 
 def retitle_step(message: str) -> None:
-    """Rename the live step, when there is one, to the phase now running."""
     step = active_step()
     if step is not None:
         step.retitle(message)
@@ -950,8 +936,6 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         compose_values["INNATE_OS_IMAGE"] = os_image
     compose_values["VIRTUAL_MARS_REMOTE"] = str(config.get("world_endpoint", "") or "")
     compose_env = os_compose_env(compose_values, env_file=os_env_file)
-    # Outside the branch above: the common `up` reuses a warm container, and
-    # that is exactly the run preceded by a `git pull` and a fresh image.
     if not offline:
         retitle_step("Reclaiming superseded images")
         prune_superseded_pulled_images(config, cwd=os_repo, env=compose_env)
@@ -1090,9 +1074,7 @@ def force_remove_container(name: str) -> bool:
 
 def container_in_compose_project(name: str, project: str = COMPOSE_PROJECT_NAME) -> bool:
     """True when `name` is a container `project` created, rather than a
-    hand-started one that happens to share the name. The project is a
-    parameter because the superseded shared stack is identified by the name it
-    used to have, not by this checkout's."""
+    hand-started one that happens to share the name."""
     try:
         result = subprocess.run(
             ["docker", "inspect", "-f", '{{index .Config.Labels "com.docker.compose.project"}}', name],
@@ -1124,10 +1106,8 @@ def remove_legacy_cloud_agent() -> None:
 def running_stack_from_another_checkout() -> tuple[str, str] | None:
     """(container, that checkout's path) for another clone's running stack.
 
-    Stacks are per-checkout but the ports are not (9090 and 9999 are not even
-    overridable), so the second clone to start would otherwise fail deep inside
-    compose with "already allocated". The path is read back off the container's
-    own ros2_ws bind mount, so the remedy can name where to run `down`.
+    Stacks are per-checkout but the ports are not. The path comes off the
+    container's own ros2_ws bind mount, so the remedy can name it.
     """
     try:
         listing = subprocess.run(
@@ -1170,7 +1150,6 @@ def running_stack_from_another_checkout() -> tuple[str, str] | None:
 
 
 def refuse_if_another_checkout_is_running() -> None:
-    """Stop before compose does, with the other clone's path in hand."""
     found = running_stack_from_another_checkout()
     if found is None:
         return
@@ -1187,9 +1166,8 @@ def refuse_if_another_checkout_is_running() -> None:
 def remove_legacy_shared_container() -> None:
     """Drop the single container every checkout used to share.
 
-    Only a container the OLD compose project created, so the same name run by
-    hand is left alone. Its volumes are named in the log rather than removed:
-    deleting someone's workspace build unasked is not this function's call.
+    Only one the OLD compose project created, so the same name run by hand is
+    left alone. Its volumes are named in the log rather than removed.
     """
     if not container_in_compose_project(LEGACY_SHARED_CONTAINER, LEGACY_SHARED_PROJECT):
         return
@@ -1204,7 +1182,6 @@ def remove_legacy_shared_container() -> None:
 
 
 def remove_superseded_containers() -> None:
-    """Every container an older layout of this launcher left behind."""
     remove_legacy_cloud_agent()
     remove_legacy_shared_container()
 
@@ -1239,8 +1216,8 @@ def docker_compose_cmd(*parts: str) -> list[str]:
     # only WHICH image varies (see viewer_image_ref), so there is no overlay to
     # apply on `up` and forget on every later subcommand.
     #
-    # `-p` rather than `name:` or COMPOSE_PROJECT_NAME: the flag outranks both,
-    # so no reader has to recall their precedence.
+    # `-p` rather than `name:` or COMPOSE_PROJECT_NAME: it outranks both, so no
+    # reader has to recall their precedence.
     return ["docker", "compose", "-p", COMPOSE_PROJECT_NAME, "-f", "sim/docker-compose.dev.yml", *parts]
 
 
@@ -1705,9 +1682,8 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
                 f"The geometry is fetched over the registry API, so an override has to name a pushed "
                 f"image -- one that exists only in the local Docker store cannot be read here."
             ) from exc
-        # Nothing published under this name -- but the name also moves for
-        # inputs that cannot change geometry, and "push the branch" is not
-        # advice a fork can take.
+        # The name also moves for inputs that cannot change geometry, and
+        # "push the branch" is not advice a fork can take.
         if parts[2:3] == [geometry_hash] and installed:
             log("Reusing the installed geometry (geometry inputs unchanged).")
             return

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -837,6 +837,13 @@ def os_container_foxglove_port_current(config: dict[str, object]) -> bool:
     return any(line.strip().endswith(f":{published}") for line in result.stdout.splitlines())
 
 
+def retitle_step(message: str) -> None:
+    """Rename the live step, when there is one, to the phase now running."""
+    step = active_step()
+    if step is not None:
+        step.retitle(message)
+
+
 def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline: bool = False) -> None:
     os_repo: Path = config["os_repo"]  # type: ignore[assignment]
     os_image = str(config["os_image"]).strip()
@@ -926,6 +933,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         compose_values["VIRTUAL_MARS_REMOTE"] = str(config.get("world_endpoint", "") or "")
         compose_env = os_compose_env(compose_values, env_file=os_env_file)
         log("Starting Innate OS dev container...")
+        retitle_step("Starting the Innate OS container")
         run_logged_with_heartbeat(
             up_cmd,
             cwd=os_repo,
@@ -945,6 +953,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
     # Outside the branch above: the common `up` reuses a warm container, and
     # that is exactly the run preceded by a `git pull` and a fresh image.
     if not offline:
+        retitle_step("Reclaiming superseded images")
         prune_superseded_pulled_images(config, cwd=os_repo, env=compose_env)
     build_cmd = (
         f"INNATE_OS_ALWAYS_BUILD={1 if config['os_always_build'] else 0} "
@@ -968,6 +977,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         log("ROS workspace install already validated for this checkout.")
     else:
         log("Building / validating the ROS workspace inside the container...")
+        retitle_step("Building the ROS workspace (first build takes a few minutes)")
         run_logged_with_heartbeat(
             os_compose_zsh_cmd(build_cmd),
             cwd=os_repo,
@@ -980,6 +990,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         ROS_INSTALL_STATE_PATH.write_text(f"{ros_inputs_hash}\n", encoding="utf-8")
 
     log("Launching ROS simulation nodes inside the OS container...")
+    retitle_step("Launching the ROS nodes")
     launch_script = (
         "INNATE_SIM_TMUX_SETTLE_SECONDS=${INNATE_SIM_TMUX_SETTLE_SECONDS:-0} "
         "INNATE_SIM_TMUX_CLEANUP_SETTLE_SECONDS=${INNATE_SIM_TMUX_CLEANUP_SETTLE_SECONDS:-0} "

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -79,8 +79,10 @@ from dashboard import (
     NC,
     RED,
     STEP_LABEL_WIDTH,
+    STEP_TAIL_ROWS,
     USE_COLOR,
     active_step,
+    clean_log_line,
     format_bytes,
     live_step,
     render_progress_bar,
@@ -223,7 +225,9 @@ def run_logged_with_heartbeat(
     # A bar redrawn in place needs to be refreshed often to look like one; a
     # log file gets the slow cadence, so a CI transcript is not a flipbook.
     live = progress_formatter is not None and sys.stdout.isatty()
-    if live:
+    # A step draws the log tail itself (see below), which wants the same quick
+    # cadence a progress bar does -- a tail refreshed every 10s reads as stuck.
+    if live or (sys.stdout.isatty() and active_step() is not None):
         heartbeat_seconds = 0.5
     drew_progress = False
     with log_path.open("a", encoding="utf-8") as log_file:
@@ -256,6 +260,13 @@ def run_logged_with_heartbeat(
                     # says how far along. Before docker's first layer line is
                     # parseable that is just the clock.
                     step.detail = f"{progress}  {stamp}" if progress else stamp
+                    # The tail is for commands with nothing better to show. A
+                    # formatter means there IS something better -- the pull's
+                    # aggregate bar, which replaced exactly this layer chatter
+                    # on purpose -- so those keep the single line.
+                    if progress_formatter is None:
+                        lines = [clean_log_line(line) for line in appended.splitlines()]
+                        step.tail = [line for line in lines if line.strip()][-STEP_TAIL_ROWS:]
                 elif progress and live:
                     print(f"\r\033[K  {progress}  {DIM}{stamp}{NC}", end="", flush=True)
                     drew_progress = True

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -29,10 +29,15 @@ from config import (
     CLI_SIM,
     COMPOSE_LOG_PATH,
     COMPOSE_PROJECT_NAME,
+    DEPS_IMAGE_TAG_PREFIX,
     DOWN_LOG_PATH,
     GENERATED_OS_ENV_PATH,
+    GEOMETRY_INPUT_PATHSPECS,
+    HOST_REPO_ID,
     INNATE_BACKEND,
     LEGACY_CLOUD_AGENT_CONTAINER,
+    LEGACY_SHARED_CONTAINER,
+    LEGACY_SHARED_PROJECT,
     NO_BACKEND,
     OS_BUILD_LOG_PATH,
     OS_CONTAINER_NAME,
@@ -54,10 +59,13 @@ from config import (
     WORLD_SERVER_PORT,
     DockerUnresponsiveError,
     StackError,
+    compute_geometry_inputs_hash,
     compute_ros_install_validation_hash,
     ensure_state_dir,
     log,
     resolve_assets_image,
+    resolve_auto_os_image,
+    resolve_deps_image,
     resolve_local_os_image,
     resolve_local_viewer_image,
     resolve_viewer_image,
@@ -556,7 +564,12 @@ def os_compose_env(
     *,
     env_file: Path = GENERATED_OS_ENV_PATH,
 ) -> dict[str, str]:
-    values = {"INNATE_OS_ENV_FILE": str(env_file)}
+    # On every compose call, not just `up`: it is interpolated into
+    # `container_name:`, and compose refuses a file it cannot resolve.
+    values = {
+        "INNATE_OS_ENV_FILE": str(env_file),
+        "INNATE_OS_CONTAINER_NAME": OS_CONTAINER_NAME,
+    }
     if base_env:
         values.update(base_env)
     return docker_compose_env(values)
@@ -644,24 +657,65 @@ def ensure_os_image_available(
     )
 
 
-def prune_stale_local_images(current_image: str, *, cwd: Path, env: dict[str, str], label: str) -> None:
-    """Untag superseded local builds sharing `current_image`'s repo.
+def adopt_published_deps_image(local_image: str, *, cwd: Path, env: dict[str, str]) -> bool:
+    """Pull the published deps image and give it the local build's name.
 
-    Both local builds -- the OS fallback and the viewer bundle -- are tagged
-    `<repo>:inputs-<hash>`, so each input change mints a new tag and strands
-    the old one in `docker images` forever.
+    Retagged rather than used under its own name: the two are the same bytes at
+    the same content address, so the offline resolution, the prune and the next
+    run's fast path keep working with no second notion of "the deps image".
+
+    False on any failure: a shortcut past a local build, never a prerequisite.
+    """
+    deps_image = resolve_deps_image(REPO_ROOT)
+    log(f"Fetching prebuilt dependencies {shorten_docker_image_ref(deps_image)}...")
+    plat = _docker_platform()
+    try:
+        run_logged_with_heartbeat(
+            ["docker", "pull", *(["--platform", plat] if plat else []), deps_image],
+            cwd=cwd,
+            env=env,
+            log_path=COMPOSE_LOG_PATH,
+            failure_message=f"Could not pull the prebuilt dependency image: {shorten_docker_image_ref(deps_image)}",
+            progress_message="Docker is still pulling the dependency image.",
+            include_recent_log_on_failure=False,
+            progress_formatter=docker_pull_progress,
+        )
+    except StackError:
+        return False
+    if not command_succeeds(["docker", "tag", deps_image, local_image], cwd=cwd, env=env):
+        return False
+    log("Using the published dependency image; skipping the local Docker build.")
+    return True
+
+
+def prune_stale_local_images(
+    current_image: str,
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    label: str,
+    tag_prefix: str = "inputs-",
+    keep_recent: int = 0,
+) -> None:
+    """Untag superseded content-addressed tags sharing `current_image`'s repo.
+
+    `keep_recent` holds back that many newest superseded tags, so bouncing
+    between two branches does not re-download either. Affordable only because
+    the bases are digest-pinned: a second copy costs its own layers rather than
+    a duplicate of everything beneath them.
 
     The repo comes off `current_image` rather than a second argument: sweeping
     a different repo than the one being kept is the only way this can be wrong.
     rpartition takes the LAST colon, so a registry:port survives.
 
-    Best-effort: an image still used by a container simply fails to untag and
-    is left alone.
+    Best-effort: an image still used by a container fails to untag and is left.
     """
     repo = current_image.rpartition(":")[0]
     try:
         listing = subprocess.run(
-            ["docker", "images", "--format", "{{.Repository}}:{{.Tag}}", repo],
+            # Timestamp first: keep_recent must not rest on the undocumented
+            # default ordering of a formatted listing.
+            ["docker", "images", "--format", "{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}", repo],
             cwd=cwd,
             env=env,
             text=True,
@@ -674,13 +728,30 @@ def prune_stale_local_images(current_image: str, *, cwd: Path, env: dict[str, st
         return
     if listing.returncode != 0:
         return
-    stale = [ref for ref in listing.stdout.split() if ref != current_image and ref.startswith(f"{repo}:inputs-")]
-    pruned = 0
-    for ref in stale:
-        if command_succeeds(["docker", "rmi", ref], cwd=cwd, env=env):
-            pruned += 1
+    rows = [line.split("\t", 1) for line in listing.stdout.splitlines() if "\t" in line]
+    stale = [
+        ref for _, ref in sorted(rows, reverse=True) if ref != current_image and ref.startswith(f"{repo}:{tag_prefix}")
+    ]
+    pruned = sum(command_succeeds(["docker", "rmi", ref], cwd=cwd, env=env) for ref in stale[keep_recent:])
     if pruned:
-        log(f"Pruned {pruned} superseded local {label} image tag(s).")
+        log(f"Pruned {pruned} superseded {label} image tag(s).")
+
+
+def prune_superseded_pulled_images(config: dict[str, object], *, cwd: Path, env: dict[str, str]) -> None:
+    """Sweep the image families the launcher PULLS, not just the ones it builds.
+
+    Never called under --offline: deleting the only copy of something that
+    cannot be re-fetched is a different kind of mistake from using disk.
+    """
+    os_repo: Path = config["os_repo"]  # type: ignore[assignment]
+    families = (
+        (resolve_auto_os_image(os_repo), "inputs-", "Innate OS prebuilt", 1),
+        (resolve_deps_image(os_repo), DEPS_IMAGE_TAG_PREFIX, "dependency", 1),
+        (resolve_viewer_image(os_repo), "inputs-", "sim viewer bundle", 1),
+        (resolve_assets_image(os_repo), "inputs-", "sim asset", 0),
+    )
+    for current, prefix, label, keep in families:
+        prune_stale_local_images(current, cwd=cwd, env=env, label=label, tag_prefix=prefix, keep_recent=keep)
 
 
 # Directories the container's ROS nodes create lazily on the workspace
@@ -770,6 +841,7 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
     if reuse_running_container:
         log("Innate OS dev container already running.")
     else:
+        refuse_if_another_checkout_is_running()
         up_cmd = docker_compose_cmd("up", "-d")
         if offline:
             # Reuse an image that is already local; never pull or build, which
@@ -820,11 +892,17 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
                     )
                     os_image = local_image
                     up_cmd.append("--no-build")
+                elif bool(config["os_pull_image"]) and adopt_published_deps_image(
+                    local_image, cwd=os_repo, env=compose_probe_env
+                ):
+                    os_image = local_image
+                    up_cmd.append("--no-build")
                 else:
                     warn(
                         "No matching prebuilt Innate OS image is available for this checkout "
-                        f"({shorten_docker_image_ref(os_image)}). Building it locally instead. "
-                        f"Pull details are in {COMPOSE_LOG_PATH}."
+                        f"({shorten_docker_image_ref(os_image)}), and no published dependency image "
+                        "either. Building it locally instead -- this takes 25-30 minutes once. "
+                        f"Details are in {COMPOSE_LOG_PATH}."
                     )
                     os_image = local_image
                     up_cmd.append("--build")
@@ -853,11 +931,13 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
         compose_values["INNATE_OS_IMAGE"] = os_image
     compose_values["VIRTUAL_MARS_REMOTE"] = str(config.get("world_endpoint", "") or "")
     compose_env = os_compose_env(compose_values, env_file=os_env_file)
-    host_repo_id = hashlib.sha256(str(os_repo.resolve()).encode("utf-8")).hexdigest()[:16]
-
+    # Outside the branch above: the common `up` reuses a warm container, and
+    # that is exactly the run preceded by a `git pull` and a fresh image.
+    if not offline:
+        prune_superseded_pulled_images(config, cwd=os_repo, env=compose_env)
     build_cmd = (
         f"INNATE_OS_ALWAYS_BUILD={1 if config['os_always_build'] else 0} "
-        f"INNATE_OS_HOST_REPO_ID={shlex.quote(host_repo_id)} "
+        f"INNATE_OS_HOST_REPO_ID={shlex.quote(HOST_REPO_ID)} "
         "~/innate-os/scripts/validate_sim_ros_install.zsh"
     )
 
@@ -957,7 +1037,7 @@ def down_os(config: dict[str, object], *, remove_volumes: bool = False) -> None:
 
 def clean_runtime(config: dict[str, object]) -> None:
     """Stop the runtime and delete all related Docker resources."""
-    remove_legacy_cloud_agent()
+    remove_superseded_containers()
     log("Removing Innate OS containers, networks, and named volumes...")
     down_os(config, remove_volumes=True)
     # Belt-and-suspenders: force-remove named containers that may linger outside
@@ -986,9 +1066,11 @@ def force_remove_container(name: str) -> bool:
     return result.returncode == 0 and bool(result.stdout.strip())
 
 
-def container_in_compose_project(name: str) -> bool:
-    """True when `name` is a container this launcher's compose project created,
-    rather than a hand-started one that happens to share the name."""
+def container_in_compose_project(name: str, project: str = COMPOSE_PROJECT_NAME) -> bool:
+    """True when `name` is a container `project` created, rather than a
+    hand-started one that happens to share the name. The project is a
+    parameter because the superseded shared stack is identified by the name it
+    used to have, not by this checkout's."""
     try:
         result = subprocess.run(
             ["docker", "inspect", "-f", '{{index .Config.Labels "com.docker.compose.project"}}', name],
@@ -1000,7 +1082,7 @@ def container_in_compose_project(name: str) -> bool:
         )
     except (OSError, subprocess.TimeoutExpired):
         return False
-    return result.returncode == 0 and result.stdout.strip() == COMPOSE_PROJECT_NAME
+    return result.returncode == 0 and result.stdout.strip() == project
 
 
 def remove_legacy_cloud_agent() -> None:
@@ -1015,6 +1097,94 @@ def remove_legacy_cloud_agent() -> None:
         return
     if force_remove_container(LEGACY_CLOUD_AGENT_CONTAINER):
         log("Removed the leftover cloud-agent container; the brain now runs inside brain_client.")
+
+
+def running_stack_from_another_checkout() -> tuple[str, str] | None:
+    """(container, that checkout's path) for another clone's running stack.
+
+    Stacks are per-checkout but the ports are not (9090 and 9999 are not even
+    overridable), so the second clone to start would otherwise fail deep inside
+    compose with "already allocated". The path is read back off the container's
+    own ros2_ws bind mount, so the remedy can name where to run `down`.
+    """
+    try:
+        listing = subprocess.run(
+            ["docker", "ps", "--filter", "label=com.docker.compose.project", "--format", "{{.Names}}"],
+            text=True,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+            timeout=DOCKER_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None  # a probe that cannot answer must not block a start
+    if listing.returncode != 0:
+        return None
+    for name in listing.stdout.split():
+        if name == OS_CONTAINER_NAME or not name.startswith(f"{LEGACY_SHARED_CONTAINER}-"):
+            continue
+        try:
+            mounts = subprocess.run(
+                [
+                    "docker",
+                    "inspect",
+                    "-f",
+                    '{{range .Mounts}}{{if eq .Destination "/root/innate-os/ros2_ws"}}{{.Source}}{{end}}{{end}}',
+                    name,
+                ],
+                text=True,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                check=False,
+                timeout=DOCKER_PROBE_TIMEOUT_S,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return (name, "")
+        source = mounts.stdout.strip() if mounts.returncode == 0 else ""
+        # Docker Desktop prefixes the host path; strip it to something cd-able.
+        checkout = source[len("/host_mnt") :] if source.startswith("/host_mnt/") else source
+        return (name, str(Path(checkout).parent) if checkout else "")
+    return None
+
+
+def refuse_if_another_checkout_is_running() -> None:
+    """Stop before compose does, with the other clone's path in hand."""
+    found = running_stack_from_another_checkout()
+    if found is None:
+        return
+    container, checkout = found
+    where = f"  cd {checkout} && {CLI_SIM} down" if checkout else f"  docker stop {container}"
+    raise StackError(
+        f"Another checkout's simulator is already running ({container}).\n"
+        "Each checkout keeps its own container and workspace build, but they share this machine's "
+        "ports (9090 and 9999 are not overridable), so only one can be up at a time.\n"
+        f"Stop that one first:\n{where}"
+    )
+
+
+def remove_legacy_shared_container() -> None:
+    """Drop the single container every checkout used to share.
+
+    Only a container the OLD compose project created, so the same name run by
+    hand is left alone. Its volumes are named in the log rather than removed:
+    deleting someone's workspace build unasked is not this function's call.
+    """
+    if not container_in_compose_project(LEGACY_SHARED_CONTAINER, LEGACY_SHARED_PROJECT):
+        return
+    if force_remove_container(LEGACY_SHARED_CONTAINER):
+        log(
+            "Removed the shared Innate OS container; each checkout now gets its own.\n"
+            "This checkout rebuilds its ROS workspace once. Reclaim the old shared one with:\n"
+            f"  docker volume rm {LEGACY_SHARED_PROJECT}_ros2_ws_build "
+            f"{LEGACY_SHARED_PROJECT}_ros2_ws_install {LEGACY_SHARED_PROJECT}_ros2_ws_log "
+            f"{LEGACY_SHARED_PROJECT}_ccache"
+        )
+
+
+def remove_superseded_containers() -> None:
+    """Every container an older layout of this launcher left behind."""
+    remove_legacy_cloud_agent()
+    remove_legacy_shared_container()
 
 
 def tail_file(path: Path, limit: int = 40) -> str:
@@ -1046,7 +1216,10 @@ def docker_compose_cmd(*parts: str) -> list[str]:
     # One compose file for every invocation: dist-lib is always an image mount,
     # only WHICH image varies (see viewer_image_ref), so there is no overlay to
     # apply on `up` and forget on every later subcommand.
-    return ["docker", "compose", "-f", "sim/docker-compose.dev.yml", *parts]
+    #
+    # `-p` rather than `name:` or COMPOSE_PROJECT_NAME: the flag outranks both,
+    # so no reader has to recall their precedence.
+    return ["docker", "compose", "-p", COMPOSE_PROJECT_NAME, "-f", "sim/docker-compose.dev.yml", *parts]
 
 
 def os_compose_exec_cmd(*parts: str) -> list[str]:
@@ -1474,7 +1647,8 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
     marker = sim_repo / "assets" / ".assets-tag"
     image = assets_image_ref(config)
 
-    # The marker holds "<digest> <image ref>". Keyed on the geometry layer's
+    # The marker holds "<digest> <image ref> <geometry inputs hash>". Keyed on
+    # the geometry layer's
     # digest, not the tag: the tag moves whenever any tracked input changes,
     # so re-extracting 168 MB for a viewer-source edit would be waste.
     #
@@ -1493,7 +1667,8 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
     # ref is content-addressed and ci/build_assets_image.sh never rebuilds an
     # existing tag. NOT valid for an INNATE_SIM_ASSETS_IMAGE override, which
     # may name a mutable tag -- those probe the manifest every time.
-    if not os.environ.get("INNATE_SIM_ASSETS_IMAGE", "").strip() and parts[1:] == [image] and installed:
+    geometry_hash = compute_geometry_inputs_hash(config["os_repo"])  # type: ignore[arg-type]
+    if not os.environ.get("INNATE_SIM_ASSETS_IMAGE", "").strip() and parts[1:2] == [image] and installed:
         return
 
     try:
@@ -1508,17 +1683,24 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
                 f"The geometry is fetched over the registry API, so an override has to name a pushed "
                 f"image -- one that exists only in the local Docker store cannot be read here."
             ) from exc
+        # Nothing published under this name -- but the name also moves for
+        # inputs that cannot change geometry, and "push the branch" is not
+        # advice a fork can take.
+        if parts[2:3] == [geometry_hash] and installed:
+            log("Reusing the installed geometry (geometry inputs unchanged).")
+            return
         raise StackError(
             f"No published sim asset image for this checkout ({shorten_docker_image_ref(image)}): {exc}\n"
-            f"Editing anything the image is built from renames it. Push the branch so CI publishes "
-            f"it, or set INNATE_SIM_ASSETS_IMAGE to one that exists."
+            f"The geometry inputs themselves changed ({', '.join(GEOMETRY_INPUT_PATHSPECS)}), so what is "
+            f"installed no longer describes this checkout. Push the branch so CI publishes it, or set "
+            f"INNATE_SIM_ASSETS_IMAGE to one that exists."
         ) from exc
     digest = manifest["layers"][ASSETS_IMAGE_LAYERS.index("work")]["digest"]
 
     if parts[:1] == [digest] and installed:
         # Same geometry under a new ref (or an old digest-only marker):
         # remember the ref so the next run skips the probe above.
-        marker.write_text(f"{digest} {image}\n")
+        marker.write_text(f"{digest} {image} {geometry_hash}\n")
         return
 
     log(f"Downloading sim assets {digest[7:19]} (~85 MB, one-time)...")
@@ -1572,7 +1754,7 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
         # OUTSIDE the units, so the per-unit replacement leaves it behind.
         shutil.rmtree(sim_repo / "assets" / ".model_cache", ignore_errors=True)
         marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(f"{digest} {image}\n")
+        marker.write_text(f"{digest} {image} {geometry_hash}\n")
         log(f"Sim assets {digest[7:19]} installed.")
     finally:
         blob.unlink(missing_ok=True)
@@ -1593,6 +1775,7 @@ def ensure_viewer_public_assets(config: dict[str, object]) -> None:
         sim_repo / "viewer" / "public",
         sim_repo / "viewer" / "public" / ".installed-tag",
         label="viewer assets",
+        geometry_hash=compute_geometry_inputs_hash(config["os_repo"]),  # type: ignore[arg-type]
     )
 
 
@@ -1604,6 +1787,7 @@ def install_layer_subtree(
     marker: Path,
     *,
     label: str,
+    geometry_hash: str | None = None,
 ) -> None:
     """Put one subtree of one image layer on disk, idempotently.
 
@@ -1617,19 +1801,28 @@ def install_layer_subtree(
     (like sim/assets/.assets-tag): both are gitignored, so neither shows up as
     a working-tree change -- which would make every checkout look dirty and
     send the viewer bundle down the local-build path forever -- and deleting
-    the directory forgets the marker with it. It holds "<layer digest> <ref>" --
-    the digest, so a tag that moved for an unrelated input does not re-fetch,
-    and the ref, so an override that renames the image does.
+    the directory forgets the marker with it. It holds
+    "<layer digest> <ref> [<geometry inputs hash>]" -- the digest, so a tag
+    that moved for an unrelated input does not re-fetch; the ref, so an
+    override that renames the image does; and the narrow hash, so an
+    unpublished tag can be told from a real change (see ensure_sim_assets).
     """
     parts = marker.read_text().split() if marker.exists() else []
-    if parts[1:] == [image] and destination.is_dir() and any(destination.iterdir()):
+    populated = destination.is_dir() and any(destination.iterdir())
+    if parts[1:2] == [image] and populated:
         return
 
-    manifest = oci.manifest_for_image(image)
+    try:
+        manifest = oci.manifest_for_image(image)
+    except oci.OciError:
+        if geometry_hash is not None and parts[2:3] == [geometry_hash] and populated:
+            log(f"Reusing the installed {label} (geometry inputs unchanged).")
+            return
+        raise
     digest = manifest["layers"][layer_index]["digest"]
-    if parts[:1] == [digest] and destination.is_dir() and any(destination.iterdir()):
+    if parts[:1] == [digest] and populated:
         marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(f"{digest} {image}\n")
+        marker.write_text(f"{digest} {image} {geometry_hash or ''}\n")
         return
 
     # Staged beside the destination so the install is a rename, not a copy
@@ -1651,7 +1844,7 @@ def install_layer_subtree(
         shutil.rmtree(destination, ignore_errors=True)
         shutil.move(str(source), str(destination))
         marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(f"{digest} {image}\n")
+        marker.write_text(f"{digest} {image} {geometry_hash or ''}\n")
         log(f"{label} {digest[7:19]} installed.")
     finally:
         blob.unlink(missing_ok=True)


### PR DESCRIPTION
Seven things people kept hitting while working on the sim. They have separate causes but one shared shape: every one only fires when somebody has *edited* something. CI builds from a clean checkout and end users run published images, so neither ever executes these paths — which is why they sat undetected, and why the first person doing sim development meets all seven at once.

Numbers below are measured on this branch against the live registry, not estimated.

---

## "Docker downloads gigabytes every time I pull main"

**What happens.** You `git pull`, run `./innate-sim up`, and wait through a multi-gigabyte pull for a change that touched a few source files.

**Why.** Docker skips layers you already have. Ours were never the same twice. `sim/Dockerfile` said `FROM ros:humble-ros-base` — a *tag*, and upstream rebuilds that image roughly weekly. A moved base makes every layer above it different, so nothing could be reused. The two published `innate-os-sim-ros` images from Aug 15 and Aug 18:

| | |
|---|---|
| non-empty layers each | 26 |
| shared between them | **1** |
| layers shared from the bottom | **0** — not even the ROS base |
| wire cost of the newer given the older | **1437 MB** |

Only ~65 MB of that was the actual commit.

**Fix.** Pin both bases by digest: the upstream ROS base to its multi-arch index digest, and the ROS image's own base to the digest of the deps image just pushed rather than a mutable `buildcache` tag. Both links have to be immutable or neither is. CI also reuses a published deps image when its inputs are unchanged, so identical content stops being rebuilt into different bytes.

**→ 1437 MB → 64.6 MB on the wire.** Verified after the fact on the branch's own published images: the ROS prebuilt's 28 layers contain **all 23** of the deps image's, so a developer holding one pulls the other for **0 bytes**. On disk, holding both costs 6.72 GB rather than 12.9 GB.

---

## "I edited one file and now it wants half an hour"

**What happens.** You change something in `ros2_ws/src`, run `up`, and get *"No matching prebuilt image… Building it locally instead"* — 25–30 minutes of apt and torch.

**Why.** The prebuilt image bakes a colcon workspace, so its tag hashes all of `ros2_ws/src`. Edit one file and no published tag matches — correct, and by design. But underneath it sits a dependency-only image with nothing to do with your source, which CI has built and published as `innate-os-sim-deps` since the very first publish workflow. **Nothing has ever pulled it.** The launcher knew only `innate-os-sim-ros`, so it rebuilt from scratch what was already in the registry.

That is the ordinary state of a tree being worked on, and the **only** state a fork with no CI can ever be in.

**Fix.** Publish the deps image at its own content address (`deps-<hash>` over the files `sim/Dockerfile` actually reads) and have the launcher pull it, adopted under the local build's name — the same address, so the offline resolution, the prune and the next run's fast path keep working untouched.

---

## "I have two clones and switching between them rebuilds everything"

**What happens.** A branch clone beside your main one. `up` in the second either silently serves the *first* one's code, or rebuilds the whole ROS workspace — and going back rebuilds it again. Every switch, both directions.

**Why.** One container name and one set of named volumes for the whole machine. If the first clone's container was running, the launcher reused it, bind mounts and all, pointing at the wrong checkout. If it wasn't, compose recreated it and `validate_sim_ros_install.zsh` found a foreign repo id in the volume and wiped `build/install/log`.

**Fix.** Project and container names carry a hash of the checkout path, so each clone keeps its own container, network and compiled workspace. A checkout change no longer triggers a wipe — the paths inside the container are identical either way, and `colcon_build_with_retry` already cleans on the stale-symlink failure when one actually happens.

Ports are still shared (9090 and 9999 aren't overridable), so only one stack runs at a time — but a second `up` now stops with the **name and path of the checkout holding them**, read off that container's own bind mount, instead of failing inside compose.

**Verified on a real machine:** two fully-built workspaces coexisting, 290.4 MB and 21 packages each, each volume stamped with its own checkout id. That is structurally impossible on `main`.

---

## "I changed one file and it rebuilt the whole workspace"

**What happens.** A clean-tree `up`, then one edited Python file, and colcon rebuilds everything — 23 packages, C++ from scratch, north of 20 minutes. The edit *after* that takes 20 seconds.

**Why.** The clean-tree run seeds `install/` from the prebuilt image, and that seed is what breaks the next build: it drops the image's `install/` — built at `/opt/innate-os-prebuilt/ros2_ws`, and **without** `--symlink-install` where the in-container build uses it — on top of a `build/` tree from a local build. colcon cannot build incrementally against that. Reverting the edit re-arms it, because the local install marker goes stale and the next `up` seeds again.

**Fix.** Seed only into a workspace with nothing to build on. Keyed on `build/` rather than on `install/` matching, because an install that matches right now says nothing about whether a rebuild can be incremental. First runs are unaffected — an empty `build/` still seeds, which is the case the prebuilt exists for.

**→ measured: the clean-tree round trip that used to reseed now finishes in 16s with a 2.82s colcon pass.**

---

## "Docker has eaten my disk"

**What happens.** `docker system df` climbing without bound: 19.31 GB of images, 13.07 GB reclaimable, including two ~6.7 GB ROS images sharing 32 bytes and three ~332 MB asset images nothing has referenced since asset distribution moved to Releases.

**Why.** ghcr retention was designed twice — the original weekly cleanup in #391, then #525's age/branch-aware policy sized for every-branch publishing. The client side never got a counterpart. The prune derived its repo from `resolve_local_os_image`, so it only ever swept images this machine **built**. Every pulled tag was kept forever.

**Fix.** The sweep covers the pulled families too, keeps one predecessor so bouncing between branches doesn't re-download, runs on every `up` rather than only when the container is recreated, and never runs under `--offline`.

The ordering matters: this is only cheap *because* the bases are now pinned. On unshared images, dropping the old one frees 5 GB and costs 5 GB to get back. Pinned, it is ~65 MB either way.

---

## "I edited the driver and the sim won't start at all"

**What happens.** `up` dies before starting anything:

```
assets  ✗ world geometry
Error: No published sim asset image for this checkout (…): HTTP 404
```

…with the advice *"Push the branch so CI publishes it."*

**Why.** `mars_sim_driver` and `mars_sim` are hashed into the asset image for one narrow reason: `export_nav_map.py` instantiates `VirtualMars`, so the nav map is a function of the laser's height. That is enough to rename the whole image. Editing `node.py` — a pure RPC client that touches no geometry — renames a multi-hour image, and geometry is the one layer with no local build path to fall back to. For a fork this is terminal, not slow: no CI, so "push the branch" is not advice they can take.

**Fix.** A second, narrower hash answers the question `up` actually needs — *is the geometry already on disk still the geometry this checkout describes?* Unchanged means it is, so it is reused with a log line instead of a refusal. The image's identity is untouched: a driver edit really can move the nav map, and the tag must still say so.

The narrow list is carved out of `ASSETS_IMAGE_PATHSPECS` by **exclusion**, so a pathspec added to the asset image later joins the geometry hash by default. That is the safe direction to be wrong in: one wrongly excluded costs a needless refusal, one wrongly included would reuse geometry that no longer matches.

---

## "It has said the same thing for four minutes — is it working or hung?"

**What happens.** The `os` step shows `Starting the Innate OS container` and an elapsed clock, and nothing else, for as long as it takes. `scripts/install-sim.sh` has drawn a live log tail under its status line all along.

**Why.** `LiveStep` never grew the same region — `_animate` wrote one line. `run_logged_with_heartbeat` computed the latest log line and then used it only *outside* a step. And the label was wrong anyway: that one step covers starting a container, a colcon build that can run for minutes, and launching the nodes.

**Fix.** Two things. `LiveStep` draws up to three cleaned log rows under its status line, written in one go and stepped back over — the technique `draw_step_frame` uses, for the same reason (clearing and drawing separately leaves the region blank long enough to read as flicker). And the step retitles itself as the work moves between phases. Steps with a progress formatter keep their single line: a formatter means there is something better to show, and for the pulls that is the aggregate bar which replaced exactly this layer chatter on purpose.

---

# How this fits what came before

Worth reading the trail, because none of this reverses a decision that was made — it finishes several that were half-made.

| PR | decided | what it did not cover |
|---|---|---|
| **#390** (May 11) | `Dockerfile.ros-prebuilt` + `seed_prebuilt_install`, **opt-in**. Only stated rationale is a config comment: *"skip the first local colcon build when source matches."* | The seed was designed for a first run. Nothing considered a returning developer with a warm build tree. |
| **#391** (May 13) | Flipped the default to `auto` and content-addressed the tags: *"avoids asking developers to copy a commit SHA while also avoiding a moving `:main` image mismatch."* | Hit the mutable-base problem **during that PR** — *"the ROS image still rebuilding because its base image tag changed per run"* — and fixed it for CI's build time with a stable `buildcache` tag, never for consumers' pulls. Its cost analysis is entirely registry-side (Cloud Build minutes, GHCR storage "currently free"). |
| **#524** (Jul 13) | Multi-arch, on a clear trade: *"~25–30 min local Docker build (plus ~10 GB of build cache) that amd64 users skip with a ~5 min pull."* Also moved publishing from ~50/month to **400–600/month**. | Compared pull *time* against build *time*, never per-pull bytes — and 10×'d the frequency in the same change. |
| **#525** (Jul 14) | Age/branch-aware GHCR retention sized for that new volume. | Sized GitHub's disk. Nobody sized the user's. |
| **#526** (Jul 14) | Hash alignment: *"silently broken for everyone, on every platform… The 'normal first-run build' everyone has been paying is this bug."* | Means the pull path only went live in mid-July — simultaneously with multi-arch and 10× publishing. #391's assumptions were never re-examined under those conditions. |
| **#661** (Aug 18) | One-command install made it load-bearing: `sim-stable` only advances to commits whose images are published. | |
| **4c71ddca** (May 27) | The repo-id marker, *"Avoid repeated ROS volume cleanup for same checkout."* | Solved the same checkout re-cleaning. Two checkouts sharing one volume set was never in scope. |

So:

- **The digest pin is #391's own fix, extended to the side it never reached.** They diagnosed a moving base and stabilised it for the builder; this stabilises it for everyone downstream.
- **The client-side prune is #525, written for the other disk.** Same policy shape, same reasons.
- **The deps image needs no new infrastructure** — CI has published it since #391. Only the consumer was missing.
- **The seed guard keeps #390's intent and narrows its blast radius.** A prebuilt still accelerates a first run; it just stops clobbering a workspace that has a build tree of its own.
- **The repo-id marker from 4c71ddca stays.** It simply no longer triggers a wipe, because per-checkout volumes make the hazard it guarded against impossible.
- **The geometry hash follows the direction already taken twice**: `1e2bd5ca` moved the geometry from a pinned tarball to a content-addressed layer fetched over plain HTTPS, and `777d0692` moved the viewer assets off `type: image` mounts onto disk keyed to a layer digest. This adds the second, narrower key those markers needed to tell a rename from a real change.

The one place this argues *against* a prior decision is `image = "local"`, which resolves to an empty image string and so silently disables the whole prebuilt-and-deps path in favour of a mutable `:latest`. Left alone here and documented in the template, since changing it is a semantics change worth its own discussion.

---

# Where this lands

| | before | after |
|---|---|---|
| standard user, per update | 1437 MB, kept forever | ~65 MB, predecessor pruned |
| developer, per commit | 1437 MB, or a 25–30 min build | 0 |
| second checkout | wrong code, or a full rebuild | own warm workspace; clear refusal on port clash |
| one-file edit after a clean `up` | >20 min, 23 packages | 16–20s, incremental |
| fork editing the driver | `up` dies | warning, keeps running |
| images on disk | 19.31 GB, 13.07 GB reclaimable | 6.72 GB |
| a long step | a clock | phase name + live log tail |

# Tested

End to end on a real machine, on this branch:

- **The deps adoption**, on a dirty tree: the ROS tag 404s, `deps-053cc128…` is pulled, no local Docker build. The retag holds — `innate-os-sim-deps:deps-…` and `innate-os-sim-clean-innate:inputs-…` share one image ID, so two names cost one copy.
- **The publish path** ran on the branch: `deps-<hash>` is published and properly multi-arch (amd64 + arm64).
- **Layer sharing**, against the live registry: all 23 deps layers inside the ROS prebuilt's 28; 1437 MB → 64.6 MB.
- **Per-checkout stacks**: two fully-built workspaces coexisting, each volume stamped with its own checkout id.
- **The seed guard**: a fixture covering fresh / current / stale / reverted states picks the seed only when `build/` is empty, and the real round trip that used to reseed now takes 16s.
- **The step frame**, under a real pty: phase label follows the work, tail rows render in the gutter, formatter-driven steps stay single-line, an empty tail renders as one line.
- ruff, the shell and yaml parsers, the jq retention policy, and the existing suite.

# Out of scope

Seeding the prebuilt image's colcon **build tree** alongside its `install/`. With the seed guard above this now only affects a genuinely fresh workspace — the *first* local build after a first run, which has no build tree to be incremental against. It needs the image built at the workspace's final path and its `--symlink-install` flags reconciled with the local build's, so it wants a CI round trip of its own.

# Upgrade note

The first `up` after this removes the shared `innate-dev` container (it holds 443/80/9090) and builds this checkout's workspace once. The old `innate-os_*` volumes are left alone and named in the log, so they can be reclaimed deliberately rather than silently.
