### PR TITLE
feat(nav): add autonomous mapping agent

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -21,6 +21,7 @@ class BrainConfig:
     # --- Topics ---
     image_topic: str
     cmd_vel_topic: str
+    motion_observation_topic: str
     arm_camera_image_topic: str
     odom_topic: str
     current_nav_mode_topic: str
@@ -83,7 +84,11 @@ class BrainConfig:
 _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     # --- Topics ---
     "image_topic": "/mars/main_camera/left/image_raw/compressed",
-    "cmd_vel_topic": "/cmd_vel",
+    # Brain/code-skill motion enters the skills-priority mux input.  Camera
+    # ego-motion suppression separately observes the final command sent to the
+    # base, which also includes teleop and Nav2.
+    "cmd_vel_topic": "/cmd_vel_skills",
+    "motion_observation_topic": "/cmd_vel",
     "arm_camera_image_topic": "/mars/arm/image_raw/compressed",
     "odom_topic": "/odom",
     "current_nav_mode_topic": "/nav/current_mode",

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -79,6 +79,7 @@ _GRID_FRESH_SEC = 5.0
 # and an old one must not adopt a newer stage into its foreign frame.
 _SAVE_ANNOUNCEMENT_FRESH_SEC = 30.0
 _MIN_HEAD_PITCH_DEG = -25.0  # looking further down films the floor, not the room
+_MAPPING_MODES = frozenset({"mapping", "autonomous_mapping"})
 
 
 @dataclass(frozen=True)
@@ -167,7 +168,7 @@ class MemoryRecorder:
             self._candidate = _Candidate(time.monotonic(), *pose, sharpness, jpeg)
 
     def _recordable_moment(self) -> bool:
-        if self._nav_mode == "mapping":
+        if self._nav_mode in _MAPPING_MODES:
             return self._mapping_started is not None and self._slam_alive()
         return self._nav_mode == "navigation" and bool(self._map_name) and self._confident()
 
@@ -243,7 +244,7 @@ class MemoryRecorder:
     # --- the 1 Hz tick ---
     def tick(self) -> None:
         try:
-            if self._nav_mode == "mapping":
+            if self._nav_mode in _MAPPING_MODES:
                 # Entering the stage needs the session's identity: before the
                 # latched /nav/mapping_session replay arrives, touching it
                 # could wipe a half-tour this very session staged.

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -75,7 +75,7 @@ class SkillsActionServer(Node):
 
         self._camera_node = CameraProvider()
 
-        self.declare_parameter("cmd_vel_topic", "/cmd_vel")
+        self.declare_parameter("cmd_vel_topic", "/cmd_vel_skills")
         self.cmd_vel_topic = str(self.get_parameter("cmd_vel_topic").value)
         self.declare_parameter("head_position_topic", "/mars/head/set_position")
         self.head_position_topic = str(self.get_parameter("head_position_topic").value)

--- a/ros2_ws/src/brain/brain_client/brain_client/perception/camera.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/perception/camera.py
@@ -134,7 +134,9 @@ class CameraCapture:
         self._head_sub = self._node.create_subscription(String, "/mars/head/current_position", self._on_head, 10)
         # The base being driven (joystick teleop, nav) is ego-motion the
         # primitive_running check can't see — a manual drive runs no skill.
-        self._cmd_vel_sub = self._node.create_subscription(Twist, self._config.cmd_vel_topic, self._on_cmd_vel, 10)
+        self._cmd_vel_sub = self._node.create_subscription(
+            Twist, self._config.motion_observation_topic, self._on_cmd_vel, 10
+        )
 
     def stop(self) -> None:
         # Destroying here is safe only because brain_client_node is spun

--- a/ros2_ws/src/brain/brain_client/brain_client/perception/gaze.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/perception/gaze.py
@@ -172,7 +172,8 @@ class ROSPersonTracker:
 
         # Hardware interfaces
         self._head = Head(node, node.get_logger())
-        self._mobility = Mobility(node, node.get_logger(), "/cmd_vel")
+        cmd_vel_topic = str(node.get_parameter("cmd_vel_topic").value)
+        self._mobility = Mobility(node, node.get_logger(), cmd_vel_topic)
 
         # Gaze controller
         self._gaze = GazeController(

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/mobility.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/mobility.py
@@ -5,7 +5,7 @@
 Mobility - Provides base movement (wheels) control capabilities to skills.
 
 This interface allows skills to:
-1. Send velocity commands on the common cmd_vel topic
+1. Send velocity commands through the skills-priority cmd_vel mux input
 2. Schedule automatic stop after a specified duration
 3. Precise blocking rotation via Nav2
 """
@@ -27,10 +27,10 @@ class Mobility:
 
     Injected as ``self.mobility`` when a skill declares ``mobility: Mobility``;
     the framework constructs it. Skills should use this instead of directly
-    publishing to cmd_vel.
+    publishing directly to the base command topic.
     """
 
-    def __init__(self, node: Node, logger, cmd_vel_topic: str = "/cmd_vel"):
+    def __init__(self, node: Node, logger, cmd_vel_topic: str = "/cmd_vel_skills"):
         self.node = node
         self.logger = UniversalLogger(enabled=True, wrapped_logger=logger)
         self.cmd_vel_topic = cmd_vel_topic

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/robot_state.py
@@ -34,11 +34,19 @@ from brain_client.state.image import DepthMap, MainImage, WristImage
 from brain_client.state.joint_states import JointStates
 from brain_client.state.lidar import Lidar
 from brain_client.state.map import Map
+from brain_client.state.nav_mode import NavMode
 from brain_client.state.odometry import Odometry
 from brain_client.state.pose import Pose
 
 if TYPE_CHECKING:
     from brain_client.robot.spatial_memory import SpatialMemory
+
+
+NAV_MODE_QOS = QoSProfile(
+    depth=1,
+    reliability=QoSReliabilityPolicy.RELIABLE,
+    durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+)
 
 
 class RobotStateProvider:
@@ -69,12 +77,18 @@ class RobotStateProvider:
         self.last_joint_states = None
         self.last_battery = None
         self.last_amcl_pose = None
+        self.last_mapping_pose = None
+        self.last_nav_mode = None
         self.last_scan = None
         self._lidar_cache = None  # (msg, Lidar) of the last converted scan
         # ((map msg, keepout msg), Map) of the last converted map — a fresh Map per 50 Hz tick
         # would discard Map.grid's cached_property and re-decode the whole
         # grid on every skill read
         self._map_cache = None
+        # (msg, Pose) from the active map authority. Stable identity lets a
+        # safety-critical skill distinguish a new localization sample from
+        # the 50 Hz reinjection tick.
+        self._pose_cache = None
         # (jpeg, Image) of the last converted frame per camera — the b64
         # encode is far too expensive to redo at 50 Hz for a ~15 Hz camera
         self._main_image_cache = None
@@ -87,6 +101,8 @@ class RobotStateProvider:
         self._joint_states_sub = None
         self._battery_sub = None
         self._amcl_pose_sub = None
+        self._mapping_pose_sub = None
+        self._nav_mode_sub = None
         self._scan_sub = None
         # Gate feeds with this flag, never by destroying subscriptions:
         # destroying one the executor already selected as "ready" crashes the
@@ -116,6 +132,7 @@ class RobotStateProvider:
             RobotStateType.LAST_BATTERY: self.current_battery,
             RobotStateType.LAST_HEAD_POSITION: self.current_head_position,
             RobotStateType.LAST_POSE: self.current_pose,
+            RobotStateType.LAST_NAV_MODE: self.current_nav_mode,
             RobotStateType.LAST_LIDAR: self.current_lidar,
             RobotStateType.LAST_ARM: self.current_arm,
         }
@@ -168,6 +185,8 @@ class RobotStateProvider:
         self._amcl_pose_sub = feed_node.create_subscription(
             PoseWithCovarianceStamped, "/amcl_pose", self._on_amcl_pose, latched_qos
         )
+        self._mapping_pose_sub = feed_node.create_subscription(OdometryMsg, "/mapping_pose", self._on_mapping_pose, 10)
+        self._nav_mode_sub = feed_node.create_subscription(String, "/nav/current_mode", self._on_nav_mode, NAV_MODE_QOS)
         # the lidar driver publishes with sensor-data QoS (best effort); a
         # reliable subscription would never match it
         self._scan_sub = feed_node.create_subscription(LaserScan, "/scan", self._on_scan, qos_profile_sensor_data)
@@ -213,6 +232,19 @@ class RobotStateProvider:
 
     def _on_amcl_pose(self, msg: PoseWithCovarianceStamped) -> None:
         self.last_amcl_pose = msg
+
+    def _on_mapping_pose(self, msg: OdometryMsg) -> None:
+        self.last_mapping_pose = msg
+
+    def _on_nav_mode(self, msg: String) -> None:
+        mode = msg.data.strip().lower()
+        if mode != self.last_nav_mode:
+            # A pose from the previous authority must never leak through a
+            # lifecycle transition. New samples repopulate the matching feed.
+            self.last_mapping_pose = None
+            self.last_amcl_pose = None
+            self._pose_cache = None
+        self.last_nav_mode = mode
 
     def _on_scan(self, msg: LaserScan) -> None:
         if self._active:
@@ -428,17 +460,33 @@ class RobotStateProvider:
         )
 
     def current_pose(self) -> Pose | None:
-        msg = self.last_amcl_pose
+        if self.last_nav_mode in {"mapping", "autonomous_mapping"}:
+            msg = self.last_mapping_pose
+        elif self.last_nav_mode == "navigation":
+            msg = self.last_amcl_pose
+        else:
+            msg = None
         if msg is None:
             return None
+        if msg.header.frame_id != "map":
+            self._warn_missing("map-frame pose")
+            return None
+        cached = self._pose_cache
+        if cached is not None and cached[0] is msg:
+            return cached[1]
         pose = msg.pose.pose
-        return Pose(
+        converted = Pose(
             x=pose.position.x,
             y=pose.position.y,
             theta=quaternion_to_yaw(pose.orientation),
             stamp=msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9,
             frame_id=msg.header.frame_id,
         )
+        self._pose_cache = (msg, converted)
+        return converted
+
+    def current_nav_mode(self) -> NavMode | None:
+        return NavMode(self.last_nav_mode) if self.last_nav_mode else None
 
     def current_lidar(self) -> Lidar | None:
         msg = self.last_scan
@@ -488,6 +536,11 @@ class RobotStateProvider:
             value = getter()
             if value is not None:
                 to_inject[state_type.value] = value
+            elif state_type is RobotStateType.LAST_POSE:
+                # Pose authority changes must invalidate an already-injected
+                # value; omitting None leaves the old AMCL/SLAM pose in place.
+                to_inject[state_type.value] = None
+                self._warn_missing(state_type.name)
             else:
                 self._warn_missing(state_type.name)
         if to_inject:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -178,6 +178,7 @@ class RobotStateType(Enum):
     LAST_JOINT_STATES = "last_joint_states"
     LAST_BATTERY = "last_battery"
     LAST_POSE = "last_pose"
+    LAST_NAV_MODE = "last_nav_mode"
     LAST_LIDAR = "last_lidar"
     LAST_ARM = "last_arm"
 
@@ -516,6 +517,7 @@ def _feed_specs() -> "tuple[_FeedSpec, ...]":
     from brain_client.state.joint_states import JointStates
     from brain_client.state.lidar import Lidar
     from brain_client.state.map import Map
+    from brain_client.state.nav_mode import NavMode
     from brain_client.state.odometry import Odometry
     from brain_client.state.pose import Pose
 
@@ -540,6 +542,14 @@ def _feed_specs() -> "tuple[_FeedSpec, ...]":
         ),
         _FeedSpec(Odometry, RobotState, RobotStateType.LAST_ODOM, "Odometry", ("odom",), "odometry"),
         _FeedSpec(Pose, RobotState, RobotStateType.LAST_POSE, "Pose", ("pose",), "map pose"),
+        _FeedSpec(
+            NavMode,
+            RobotState,
+            RobotStateType.LAST_NAV_MODE,
+            "NavMode",
+            ("nav_mode",),
+            "navigation mode",
+        ),
         # battery publishes at ~0.2 Hz — the default grace would always miss it
         _FeedSpec(Battery, RobotState, RobotStateType.LAST_BATTERY, "Battery", ("battery",), "battery", grace_s=6.0),
         _FeedSpec(Lidar, RobotState, RobotStateType.LAST_LIDAR, "Lidar", ("lidar",), "lidar"),

--- a/ros2_ws/src/brain/brain_client/brain_client/state/nav_mode.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/state/nav_mode.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Skill-facing navigation lifecycle mode. ROS-free on purpose."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NavMode:
+    """Current navigation lifecycle mode, read via ``self.nav_mode``."""
+
+    value: str
+
+    @property
+    def is_mapping(self) -> bool:
+        return self.value in {"mapping", "autonomous_mapping"}
+
+    @property
+    def is_autonomous_mapping(self) -> bool:
+        return self.value == "autonomous_mapping"
+
+    @property
+    def supports_map_navigation(self) -> bool:
+        return self.value in {"navigation", "autonomous_mapping"}

--- a/ros2_ws/src/brain/brain_client/brain_client/state/pose.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/state/pose.py
@@ -11,9 +11,10 @@ class Pose:
     """The robot's pose on the map, read via ``self.pose`` in skills.
 
     Unlike ``self.odom`` (odom frame: smooth but drifts and resets every
-    boot), this is the localizer's estimate in the persistent map frame —
-    the coordinates ``navigate_to_position`` targets live in. ``self.pose``
-    reads None until the robot is localized.
+    boot), this is the active map authority's estimate: AMCL in navigation or
+    slam_toolbox's TF-derived ``/mapping_pose`` in either mapping mode. These
+    are the coordinates ``navigate_to_position`` targets. ``self.pose`` reads
+    None until the active authority has produced a map-frame sample.
     """
 
     x: float

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -24,7 +24,7 @@ a bare type annotation — the type identifies the feed.
 and arm joints by name.
 
 One rule covers interfaces, cameras and robot state: annotate what you read.
-``battery: Battery``, ``odom: Odometry``, ``pose: Pose``, ``lidar: Lidar``,
+``battery: Battery``, ``odom: Odometry``, ``pose: Pose``, ``nav_mode: NavMode``, ``lidar: Lidar``,
 ``arm: Arm``, ``map: Map``, ``joint_states: JointStates``,
 ``head_position: HeadState``, ``image: MainImage`` / ``WristImage`` /
 ``DepthMap``, ``mobility: Mobility``, ``head: Head``,
@@ -82,6 +82,7 @@ from brain_client.state.image import DepthMap, Image, MainImage, WristImage
 from brain_client.state.joint_states import JointStates
 from brain_client.state.lidar import Lidar
 from brain_client.state.map import Map
+from brain_client.state.nav_mode import NavMode
 from brain_client.state.odometry import Odometry
 from brain_client.state.pose import Pose
 
@@ -107,6 +108,7 @@ __all__ = [
     "Manipulation",
     "Map",
     "Mobility",
+    "NavMode",
     "Odometry",
     "Pose",
     "RecallVerdict",

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     current_nav_mode_topic_arg = DeclareLaunchArgument(
         "current_nav_mode_topic",
         default_value="/nav/current_mode",
-        description="Topic for current navigation mode (mapfree, mapping, navigation)",
+        description="Topic for current navigation mode (mapfree, mapping, autonomous_mapping, navigation)",
     )
     log_everything_arg = DeclareLaunchArgument(
         "log_everything",

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
@@ -23,7 +23,9 @@ def generate_launch_description():
         description="Image topic",
     )
     cmd_vel_topic_arg = DeclareLaunchArgument(
-        "cmd_vel_topic", default_value="/cmd_vel", description="Command velocity topic"
+        "cmd_vel_topic",
+        default_value="/cmd_vel_skills",
+        description="Command velocity topic — skills-priority input of the cmd_vel mux",
     )
     map_topic_arg = DeclareLaunchArgument("map_topic", default_value="/map", description="Map topic (skills server)")
     send_arm_camera_image_arg = DeclareLaunchArgument(
@@ -39,7 +41,7 @@ def generate_launch_description():
     current_nav_mode_topic_arg = DeclareLaunchArgument(
         "current_nav_mode_topic",
         default_value="/nav/current_mode",
-        description="Topic for current navigation mode (mapfree, mapping, navigation)",
+        description="Topic for current navigation mode (mapfree, mapping, autonomous_mapping, navigation)",
     )
     log_everything_arg = DeclareLaunchArgument(
         "log_everything",
@@ -95,6 +97,7 @@ def generate_launch_description():
                     {
                         "image_topic": LaunchConfiguration("image_topic"),
                         "map_topic": LaunchConfiguration("map_topic"),
+                        "cmd_vel_topic": LaunchConfiguration("cmd_vel_topic"),
                     }
                 ],
             ),

--- a/ros2_ws/src/brain/brain_client/package.xml
+++ b/ros2_ws/src/brain/brain_client/package.xml
@@ -22,6 +22,9 @@
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>action_msgs</depend>
+  <depend>nav2_msgs</depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>nav2_simple_commander</exec_depend>
 
   <!-- TF dependencies -->
   <depend>tf2_ros</depend>

--- a/ros2_ws/src/brain/brain_client/test/ros_skill_test_stubs.py
+++ b/ros2_ws/src/brain/brain_client/test/ros_skill_test_stubs.py
@@ -52,6 +52,7 @@ def install_if_ros_is_missing() -> None:
     geometry_msgs_msg = module("geometry_msgs.msg")
     nav_msgs_msg = module("nav_msgs.msg")
     sensor_msgs_msg = module("sensor_msgs.msg")
+    std_srvs_srv = module("std_srvs.srv")
     brain_messages_srv = module("brain_messages.srv")
     nav2_msgs_action = module("nav2_msgs.action")
     navigator_module = module("nav2_simple_commander.robot_navigator")
@@ -102,6 +103,10 @@ def install_if_ros_is_missing() -> None:
             def __init__(self):
                 self.mode = ""
 
+    class Trigger:
+        class Request:
+            pass
+
     class NavigateToPose:
         class Goal:
             def __init__(self):
@@ -142,6 +147,7 @@ def install_if_ros_is_missing() -> None:
     sensor_msgs_msg.CompressedImage = type("CompressedImage", (), {})
     sensor_msgs_msg.JointState = type("JointState", (), {})
     sensor_msgs_msg.LaserScan = type("LaserScan", (), {})
+    std_srvs_srv.Trigger = Trigger
     brain_messages_srv.ChangeNavigationMode = ChangeNavigationMode
     nav2_msgs_action.NavigateToPose = NavigateToPose
     navigator_module.BasicNavigator = type("BasicNavigator", (), {})

--- a/ros2_ws/src/brain/brain_client/test/ros_skill_test_stubs.py
+++ b/ros2_ws/src/brain/brain_client/test/ros_skill_test_stubs.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Minimal ROS module shims for host-side workspace-skill unit tests.
+
+The integration image has the real packages. macOS host tests do not, and the
+orchestration under test is duck-typed, so install only the import surface the
+skill modules need when ROS is absent.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+def install_if_ros_is_missing() -> None:
+    try:
+        from action_msgs.msg import GoalStatus  # noqa: F401
+        from brain_messages.srv import ChangeNavigationMode  # noqa: F401
+        from geometry_msgs.msg import PoseStamped  # noqa: F401
+        from nav2_msgs.action import NavigateToPose  # noqa: F401
+        from rclpy.action import ActionClient  # noqa: F401
+        from rclpy.node import Node  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+
+    # Preserve the real local brain_client package path before registering
+    # placeholder child modules below.
+    __import__("brain_client.robot")
+
+    def module(name: str, *, package: bool = False) -> ModuleType:
+        existing = sys.modules.get(name)
+        if existing is not None:
+            return existing
+        created = ModuleType(name)
+        if package:
+            created.__path__ = []
+        sys.modules[name] = created
+        if "." in name:
+            parent_name, _, child_name = name.rpartition(".")
+            parent = module(parent_name, package=True)
+            setattr(parent, child_name, created)
+        return created
+
+    rclpy_node = module("rclpy.node")
+    rclpy_action = module("rclpy.action")
+    rclpy_qos = module("rclpy.qos")
+    action_msgs_msg = module("action_msgs.msg")
+    std_msgs_msg = module("std_msgs.msg")
+    geometry_msgs_msg = module("geometry_msgs.msg")
+    nav_msgs_msg = module("nav_msgs.msg")
+    sensor_msgs_msg = module("sensor_msgs.msg")
+    brain_messages_srv = module("brain_messages.srv")
+    nav2_msgs_action = module("nav2_msgs.action")
+    navigator_module = module("nav2_simple_commander.robot_navigator")
+    # Skill annotation materialization imports every robot interface to build
+    # its type table. The tests exercise only state feeds, so placeholders are
+    # sufficient and avoid pulling their larger ROS message surfaces.
+    robot_head = module("brain_client.robot.head")
+    robot_manipulation = module("brain_client.robot.manipulation")
+    robot_mobility = module("brain_client.robot.mobility")
+    robot_memory = module("brain_client.robot.spatial_memory")
+
+    class QoSProfile:
+        def __init__(self, *, depth, durability=None, history=None, reliability=None):
+            self.depth = depth
+            self.durability = durability
+            self.history = history
+            self.reliability = reliability
+
+    class DurabilityPolicy:
+        TRANSIENT_LOCAL = "transient_local"
+
+    class ReliabilityPolicy:
+        BEST_EFFORT = "best_effort"
+        RELIABLE = "reliable"
+
+    class HistoryPolicy:
+        KEEP_LAST = "keep_last"
+
+    class PoseStamped:
+        def __init__(self):
+            self.header = SimpleNamespace(frame_id="", stamp=None)
+            self.pose = SimpleNamespace(
+                position=SimpleNamespace(x=0.0, y=0.0, z=0.0),
+                orientation=SimpleNamespace(x=0.0, y=0.0, z=0.0, w=1.0),
+            )
+
+    class Twist:
+        def __init__(self):
+            self.linear = SimpleNamespace(x=0.0, y=0.0, z=0.0)
+            self.angular = SimpleNamespace(x=0.0, y=0.0, z=0.0)
+
+    class String:
+        def __init__(self, *, data=""):
+            self.data = data
+
+    class ChangeNavigationMode:
+        class Request:
+            def __init__(self):
+                self.mode = ""
+
+    class NavigateToPose:
+        class Goal:
+            def __init__(self):
+                self.pose = None
+                self.behavior_tree = ""
+
+    class GoalStatus:
+        STATUS_UNKNOWN = 0
+        STATUS_ACCEPTED = 1
+        STATUS_EXECUTING = 2
+        STATUS_CANCELING = 3
+        STATUS_SUCCEEDED = 4
+        STATUS_CANCELED = 5
+        STATUS_ABORTED = 6
+
+    class TaskResult:
+        SUCCEEDED = "succeeded"
+
+    class BatteryState:
+        POWER_SUPPLY_STATUS_CHARGING = 1
+
+    rclpy_node.Node = object
+    rclpy_action.ActionClient = type("ActionClient", (), {})
+    rclpy_qos.DurabilityPolicy = DurabilityPolicy
+    rclpy_qos.QoSDurabilityPolicy = DurabilityPolicy
+    rclpy_qos.QoSHistoryPolicy = HistoryPolicy
+    rclpy_qos.QoSReliabilityPolicy = ReliabilityPolicy
+    rclpy_qos.QoSProfile = QoSProfile
+    rclpy_qos.qos_profile_sensor_data = object()
+    action_msgs_msg.GoalStatus = GoalStatus
+    std_msgs_msg.String = String
+    geometry_msgs_msg.PoseStamped = PoseStamped
+    geometry_msgs_msg.PoseWithCovarianceStamped = type("PoseWithCovarianceStamped", (), {})
+    geometry_msgs_msg.Twist = Twist
+    nav_msgs_msg.OccupancyGrid = type("OccupancyGrid", (), {})
+    nav_msgs_msg.Odometry = type("Odometry", (), {})
+    sensor_msgs_msg.BatteryState = BatteryState
+    sensor_msgs_msg.CompressedImage = type("CompressedImage", (), {})
+    sensor_msgs_msg.JointState = type("JointState", (), {})
+    sensor_msgs_msg.LaserScan = type("LaserScan", (), {})
+    brain_messages_srv.ChangeNavigationMode = ChangeNavigationMode
+    nav2_msgs_action.NavigateToPose = NavigateToPose
+    navigator_module.BasicNavigator = type("BasicNavigator", (), {})
+    navigator_module.TaskResult = TaskResult
+    robot_head.Head = type("Head", (), {})
+    robot_manipulation.Manipulation = type("Manipulation", (), {})
+    robot_mobility.Mobility = type("Mobility", (), {})
+    robot_memory.SpatialMemory = type("SpatialMemory", (), {})

--- a/ros2_ws/src/brain/brain_client/test/test_explore_map.py
+++ b/ros2_ws/src/brain/brain_client/test/test_explore_map.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Orchestration tests for the autonomous mapping skill.
+
+The geometry algorithm has its own ROS-free suite. These tests pin the skill's
+mode handoff, Nav2 call contract, bounded failure policy, and human takeover.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+sys.path.insert(0, str(_REPO_ROOT / "workspace"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from ros_skill_test_stubs import install_if_ros_is_missing  # noqa: E402
+
+install_if_ros_is_missing()
+
+from geometry_msgs.msg import Twist  # noqa: E402
+from innate_skills import explore_map as explore_module  # noqa: E402
+from innate_skills._frontier_planner import FrontierGoal  # noqa: E402
+from innate_skills.explore_map import AUTONOMOUS_MAPPING_MODE, ExploreMap, _TeleopTakeover  # noqa: E402
+
+from innate import NavMode, Pose, SkillCancelled, SkillFailed  # noqa: E402
+
+
+def _map_state(grid: np.ndarray | None = None):
+    if grid is None:
+        grid = np.zeros((20, 20), dtype=np.int8)
+    return SimpleNamespace(
+        grid=grid,
+        resolution=0.1,
+        origin_x=0.0,
+        origin_y=0.0,
+        origin_theta=0.0,
+        frame_id="map",
+    )
+
+
+def _goal(index: int = 0) -> FrontierGoal:
+    x = 1.0 + 2.0 * index
+    return FrontierGoal(
+        row=10,
+        col=10 + index,
+        x=x,
+        y=1.0,
+        yaw=0.25,
+        frontier_cells=10,
+        route_distance_m=1.5,
+        score=0.5,
+        cluster_anchor=(5, 5 + index),
+    )
+
+
+class _Teleop:
+    armed = False
+    taken_over = False
+
+
+class _Navigator:
+    def __init__(self, failure: str | None = None):
+        self.failure = failure
+        self.calls = []
+
+    def go_to_position(self, x, y, yaw, local_frame, *, timeout_s, safety_check):
+        self.calls.append((x, y, yaw, local_frame, timeout_s, safety_check))
+        safety_check()
+        if self.failure:
+            raise SkillFailed(self.failure)
+
+
+class _ModeController:
+    def __init__(self, skill: ExploreMap, new_map=None, new_pose=None):
+        self.skill = skill
+        self.new_map = new_map
+        self.new_pose = new_pose
+        self.calls = 0
+
+    def switch_to_autonomous_mapping(self):
+        self.calls += 1
+        self.skill.nav_mode = NavMode(AUTONOMOUS_MAPPING_MODE)
+        if self.new_map is not None:
+            self.skill.map = self.new_map
+        if self.new_pose is not None:
+            self.skill.pose = self.new_pose
+
+
+def _skill(*, mode: str = AUTONOMOUS_MAPPING_MODE, map_state=None) -> ExploreMap:
+    skill = ExploreMap(logging.getLogger("test_explore_map"))
+    skill.nav_mode = NavMode(mode)
+    skill.map = map_state or _map_state()
+    skill.pose = Pose(x=0.55, y=0.55, theta=0.0)
+    skill.lidar = SimpleNamespace(frame_id="laser")
+    skill.__dict__["teleop"] = _Teleop()
+    skill.__dict__["navigator"] = _Navigator()
+    skill.__dict__["mode_controller"] = _ModeController(skill)
+    skill.feedback = lambda _message: None
+    skill.sleep = lambda _seconds: skill.check_cancelled()
+    return skill
+
+
+def test_switches_from_manual_mapping_then_sends_exact_map_frame_goal(monkeypatch):
+    previous_map = _map_state()
+    fresh_map = _map_state()
+    skill = _skill(mode="mapping", map_state=previous_map)
+    fresh_pose = Pose(x=0.6, y=0.6, theta=0.0, stamp=2.0)
+    controller = _ModeController(skill, fresh_map, fresh_pose)
+    navigator = _Navigator()
+    skill.__dict__["mode_controller"] = controller
+    skill.__dict__["navigator"] = navigator
+    monkeypatch.setattr(explore_module, "find_frontier_goals", lambda *args, **kwargs: [_goal()])
+
+    result = skill.execute(max_frontiers=1)
+
+    assert controller.calls == 1
+    assert len(navigator.calls) == 1
+    x, y, yaw, local_frame, timeout_s, safety_check = navigator.calls[0]
+    assert (x, y, yaw, local_frame) == (1.0, 1.0, 0.25, False)
+    assert 89.0 <= timeout_s <= 90.0
+    assert callable(safety_check)
+    assert result.data["reached_frontiers"] == 1
+    assert result.data["mode"] == AUTONOMOUS_MAPPING_MODE
+
+
+def test_mode_switch_requires_a_genuinely_new_mapping_pose():
+    skill = _skill(mode="mapping")
+    previous_map = skill.map
+    previous_pose = skill.pose
+    skill.nav_mode = NavMode(AUTONOMOUS_MAPPING_MODE)
+    skill.map = _map_state()
+    # Make wait_for deterministic: the stale pose predicate returns None.
+    skill.wait_for = lambda read, timeout: read()
+
+    with pytest.raises(SkillFailed, match="fresh map-frame mapping pose"):
+        skill._wait_for_mapping_state(previous_map, previous_pose, require_new_state=True)
+
+
+def test_unchanged_mapping_pose_trips_freshness_guard(monkeypatch):
+    now = [0.0]
+    monkeypatch.setattr(explore_module.time, "monotonic", lambda: now[0])
+    skill = _skill()
+    skill._arm_safety(skill.map, skill.pose, skill.lidar)
+
+    now[0] = explore_module.POSE_STALE_TIMEOUT_S + 0.01
+    with pytest.raises(SkillCancelled, match="pose stopped updating"):
+        skill._safety_check()
+
+
+def test_new_pose_wrappers_with_a_frozen_tf_stamp_are_still_stale(monkeypatch):
+    now = [0.0]
+    monkeypatch.setattr(explore_module.time, "monotonic", lambda: now[0])
+    skill = _skill()
+    skill.pose = Pose(x=0.55, y=0.55, theta=0.0, stamp=42.0)
+    skill._arm_safety(skill.map, skill.pose, skill.lidar)
+
+    # mode_manager may publish a new Odometry wrapper on every wheel-odom
+    # sample. It must not refresh safety unless the underlying TF stamp moved.
+    skill.pose = Pose(x=0.55, y=0.55, theta=0.0, stamp=42.0)
+    now[0] = explore_module.POSE_STALE_TIMEOUT_S + 0.01
+    with pytest.raises(SkillCancelled, match="pose stopped updating"):
+        skill._safety_check()
+
+
+def test_teleop_takeover_monitors_mux_input_and_latches_only_when_armed():
+    subscriptions = []
+
+    class Node:
+        def create_subscription(self, message_type, topic, callback, qos):
+            subscription = SimpleNamespace(message_type=message_type, topic=topic, callback=callback, qos=qos)
+            subscriptions.append(subscription)
+            return subscription
+
+        def destroy_subscription(self, _subscription):
+            pass
+
+    cancel_calls = []
+    monitor = _TeleopTakeover(SimpleNamespace(node=Node(), cancel=lambda: cancel_calls.append(True)))
+    assert subscriptions[0].topic == "/cmd_vel_teleop"
+
+    moving = Twist()
+    moving.linear.x = 0.2
+    subscriptions[0].callback(moving)
+    assert monitor.taken_over is False
+    assert cancel_calls == []
+    monitor.armed = True
+    subscriptions[0].callback(moving)
+    assert monitor.taken_over is True
+    assert cancel_calls == [True]
+    subscriptions[0].callback(moving)
+    assert cancel_calls == [True]
+
+
+def test_human_takeover_during_planning_cancels_before_navigation(monkeypatch):
+    skill = _skill()
+    navigator = _Navigator()
+    skill.__dict__["navigator"] = navigator
+
+    def planner(*args, check_cancelled, **kwargs):
+        skill.teleop.taken_over = True
+        check_cancelled()
+        return [_goal()]
+
+    monkeypatch.setattr(explore_module, "find_frontier_goals", planner)
+
+    with pytest.raises(SkillCancelled, match="joystick takeover"):
+        skill.execute(max_frontiers=1)
+    assert navigator.calls == []
+
+
+def test_three_navigation_failures_end_the_run(monkeypatch):
+    skill = _skill()
+    navigator = _Navigator(failure="route blocked")
+    skill.__dict__["navigator"] = navigator
+
+    def planner(*args, excluded_world, **kwargs):
+        return [_goal(len(excluded_world))]
+
+    monkeypatch.setattr(explore_module, "find_frontier_goals", planner)
+
+    with pytest.raises(SkillFailed, match="3 navigation failures"):
+        skill.execute(max_frontiers=10)
+    assert len(navigator.calls) == 3
+
+
+def test_no_frontier_completes_only_after_two_fresh_map_updates(monkeypatch):
+    skill = _skill()
+    navigator = _Navigator()
+    skill.__dict__["navigator"] = navigator
+    map_reads = []
+
+    def planner(*args, **kwargs):
+        map_reads.append(skill.map)
+        return []
+
+    def advance_map(_seconds):
+        skill.map = _map_state()
+        skill.check_cancelled()
+
+    skill.sleep = advance_map
+    monkeypatch.setattr(explore_module, "find_frontier_goals", planner)
+
+    result = skill.execute(max_frontiers=10)
+
+    assert len(map_reads) == 2
+    assert navigator.calls == []
+    assert result.data["stop_reason"] == "map coverage complete"
+
+
+def test_mode_change_cancels_before_any_goal_is_sent(monkeypatch):
+    skill = _skill()
+    navigator = _Navigator()
+    skill.__dict__["navigator"] = navigator
+
+    def planner(*args, check_cancelled, **kwargs):
+        skill.nav_mode = NavMode("mapping")
+        check_cancelled()
+        return [_goal()]
+
+    monkeypatch.setattr(explore_module, "find_frontier_goals", planner)
+
+    with pytest.raises(SkillCancelled, match="mode changed"):
+        skill.execute(max_frontiers=1)
+    assert navigator.calls == []

--- a/ros2_ws/src/brain/brain_client/test/test_explore_map.py
+++ b/ros2_ws/src/brain/brain_client/test/test_explore_map.py
@@ -28,6 +28,7 @@ from geometry_msgs.msg import Twist  # noqa: E402
 from innate_skills import explore_map as explore_module  # noqa: E402
 from innate_skills._frontier_planner import FrontierGoal  # noqa: E402
 from innate_skills.explore_map import AUTONOMOUS_MAPPING_MODE, ExploreMap, _TeleopTakeover  # noqa: E402
+from innate_skills.navigate_to_position import NavigationBlocked  # noqa: E402
 
 from innate import NavMode, Pose, SkillCancelled, SkillFailed  # noqa: E402
 
@@ -74,7 +75,17 @@ class _Navigator:
         self.calls.append((x, y, yaw, local_frame, timeout_s, safety_check))
         safety_check()
         if self.failure:
+            if isinstance(self.failure, SkillFailed):
+                raise self.failure
             raise SkillFailed(self.failure)
+
+
+class _RecoveryHint:
+    def __init__(self):
+        self.hints = 0
+
+    def mark_front_obstacle(self):
+        self.hints += 1
 
 
 class _ModeController:
@@ -101,6 +112,7 @@ def _skill(*, mode: str = AUTONOMOUS_MAPPING_MODE, map_state=None) -> ExploreMap
     skill.lidar = SimpleNamespace(frame_id="laser")
     skill.__dict__["teleop"] = _Teleop()
     skill.__dict__["navigator"] = _Navigator()
+    skill.__dict__["recovery_hint"] = _RecoveryHint()
     skill.__dict__["mode_controller"] = _ModeController(skill)
     skill.feedback = lambda _message: None
     skill.sleep = lambda _seconds: skill.check_cancelled()
@@ -217,7 +229,7 @@ def test_human_takeover_during_planning_cancels_before_navigation(monkeypatch):
 
 def test_three_navigation_failures_end_the_run(monkeypatch):
     skill = _skill()
-    navigator = _Navigator(failure="route blocked")
+    navigator = _Navigator(failure=NavigationBlocked("route blocked"))
     skill.__dict__["navigator"] = navigator
 
     def planner(*args, excluded_world, **kwargs):
@@ -228,6 +240,7 @@ def test_three_navigation_failures_end_the_run(monkeypatch):
     with pytest.raises(SkillFailed, match="3 navigation failures"):
         skill.execute(max_frontiers=10)
     assert len(navigator.calls) == 3
+    assert skill.recovery_hint.hints == 2
 
 
 def test_no_frontier_completes_only_after_two_fresh_map_updates(monkeypatch):

--- a/ros2_ws/src/brain/brain_client/test/test_explore_map.py
+++ b/ros2_ws/src/brain/brain_client/test/test_explore_map.py
@@ -94,6 +94,14 @@ class _ModeController:
         self.new_map = new_map
         self.new_pose = new_pose
         self.calls = 0
+        self.reset_calls = 0
+
+    def reset_mapping(self):
+        self.reset_calls += 1
+        if self.new_map is not None:
+            self.skill.map = self.new_map
+        if self.new_pose is not None:
+            self.skill.pose = self.new_pose
 
     def switch_to_autonomous_mapping(self):
         self.calls += 1
@@ -140,6 +148,21 @@ def test_switches_from_manual_mapping_then_sends_exact_map_frame_goal(monkeypatc
     assert callable(safety_check)
     assert result.data["reached_frontiers"] == 1
     assert result.data["mode"] == AUTONOMOUS_MAPPING_MODE
+
+
+def test_reset_discards_current_session_before_restarting_exploration(monkeypatch):
+    skill = _skill()
+    fresh_map = _map_state()
+    fresh_pose = Pose(x=0.6, y=0.6, theta=0.0, stamp=2.0)
+    controller = _ModeController(skill, fresh_map, fresh_pose)
+    skill.__dict__["mode_controller"] = controller
+    monkeypatch.setattr(explore_module, "find_frontier_goals", lambda *args, **kwargs: [_goal()])
+
+    result = skill.execute(max_frontiers=1, reset_map=True)
+
+    assert controller.reset_calls == 1
+    assert controller.calls == 0
+    assert result.data["reached_frontiers"] == 1
 
 
 def test_mode_switch_requires_a_genuinely_new_mapping_pose():

--- a/ros2_ws/src/brain/brain_client/test/test_frontier_planner.py
+++ b/ros2_ws/src/brain/brain_client/test/test_frontier_planner.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Focused unit tests for the ROS-free autonomous-mapping planner."""
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+sys.path.insert(0, str(_REPO_ROOT / "workspace"))
+
+from innate_skills._frontier_planner import (  # noqa: E402
+    GridGeometry,
+    _nearest_reachable_cell,
+    find_frontier_goals,
+    known_area_m2,
+)
+
+
+def _world(geometry: GridGeometry, row: int, col: int) -> tuple[float, float]:
+    return geometry.cell_to_world(row, col)
+
+
+def _single_frontier_grid() -> np.ndarray:
+    grid = np.full((7, 8), 100, dtype=np.int16)
+    grid[3, 1] = 0
+    grid[3, 2:5] = 49
+    grid[3, 5] = -1
+    return grid
+
+
+def _rooms_joined_by_corridor(corridor_width_cells: int) -> np.ndarray:
+    """Return two rooms joined by a centered 5 cm/cell corridor."""
+    grid = np.full((40, 80), 100, dtype=np.int16)
+    grid[5:35, 5:26] = 0
+    grid[5:35, 45:71] = 0
+    first_row = 20 - corridor_width_cells // 2
+    grid[first_row : first_row + corridor_width_cells, 25:46] = 0
+    grid[10:30, 65:70] = -1
+    return grid
+
+
+def test_grid_geometry_round_trips_cell_centers_with_rotated_origin():
+    geometry = GridGeometry(resolution=0.5, origin_x=10.0, origin_y=-2.0, origin_yaw=math.pi / 2)
+
+    x, y = geometry.cell_to_world(1, 2)
+
+    assert x == pytest.approx(9.25)
+    assert y == pytest.approx(-0.75)
+    assert geometry.world_to_cell(x, y) == (1, 2)
+
+
+def test_known_free_values_below_threshold_are_traversable_and_threshold_is_occupied():
+    geometry = GridGeometry(resolution=1.0, origin_x=0.0, origin_y=0.0)
+    grid = _single_frontier_grid()
+    robot_x, robot_y = _world(geometry, 3, 1)
+
+    goals = find_frontier_goals(
+        grid,
+        geometry,
+        robot_x,
+        robot_y,
+        occupied_threshold=50,
+        obstacle_clearance_m=0.0,
+        min_frontier_length_m=0.1,
+    )
+
+    assert [(goal.row, goal.col) for goal in goals] == [(3, 4)]
+    assert grid[goals[0].row, goals[0].col] == 49
+
+    blocked = grid.copy()
+    blocked[3, 3] = 50
+    assert (
+        find_frontier_goals(
+            blocked,
+            geometry,
+            robot_x,
+            robot_y,
+            occupied_threshold=50,
+            obstacle_clearance_m=0.0,
+            min_frontier_length_m=0.1,
+        )
+        == []
+    )
+    assert known_area_m2(np.array([[-1, 0, 49, 50, 100]]), resolution=0.5) == pytest.approx(1.0)
+
+
+def test_unreachable_frontier_island_is_not_returned():
+    geometry = GridGeometry(resolution=1.0, origin_x=0.0, origin_y=0.0)
+    grid = np.full((9, 15), 100, dtype=np.int16)
+    grid[2:7, 1:6] = 0
+    grid[2:7, 6] = -1
+    grid[2:7, 9:14] = 0
+    grid[2:7, 8] = -1
+    robot_x, robot_y = _world(geometry, 4, 2)
+
+    goals = find_frontier_goals(
+        grid,
+        geometry,
+        robot_x,
+        robot_y,
+        obstacle_clearance_m=0.0,
+        min_frontier_length_m=1.0,
+    )
+
+    assert len(goals) == 1
+    assert goals[0].col == 5
+    assert grid[goals[0].row, goals[0].col] == 0
+
+
+def test_route_clearance_rejects_frontier_behind_30_cm_bottleneck():
+    geometry = GridGeometry(resolution=0.05, origin_x=0.0, origin_y=0.0)
+    grid = _rooms_joined_by_corridor(corridor_width_cells=6)
+    robot_x, robot_y = _world(geometry, 20, 10)
+
+    assert find_frontier_goals(
+        grid,
+        geometry,
+        robot_x,
+        robot_y,
+        route_clearance_m=0.0,
+        min_frontier_length_m=0.1,
+    )
+    goals = find_frontier_goals(grid, geometry, robot_x, robot_y, min_frontier_length_m=0.1)
+
+    assert goals == []
+
+
+def test_route_clearance_retains_frontier_behind_35_cm_doorway():
+    geometry = GridGeometry(resolution=0.05, origin_x=0.0, origin_y=0.0)
+    grid = _rooms_joined_by_corridor(corridor_width_cells=7)
+    robot_x, robot_y = _world(geometry, 20, 10)
+
+    goals = find_frontier_goals(grid, geometry, robot_x, robot_y, min_frontier_length_m=0.1)
+
+    assert goals
+    assert goals[0].col >= 64
+
+
+def test_route_seed_search_does_not_snap_across_occupied_wall():
+    traversable = np.ones((7, 7), dtype=bool)
+    traversable[:, 3] = False
+    target = np.zeros_like(traversable)
+    target[3, 4] = True  # Euclidean-nearest target, across the wall.
+    target[0, 0] = True  # Farther target, reachable on the robot's side.
+
+    route_start, distance = _nearest_reachable_cell(
+        target,
+        traversable,
+        start=(3, 2),
+        max_steps=10,
+        check_cancelled=None,
+    )
+
+    assert route_start == (0, 0)
+    assert distance == 5
+
+
+def test_goal_clearance_avoids_nearby_obstacle_with_deterministic_tie_break():
+    geometry = GridGeometry(resolution=1.0, origin_x=0.0, origin_y=0.0)
+    grid = np.full((15, 15), 100, dtype=np.int16)
+    grid[3:12, 2:10] = 0
+    grid[3:12, 10] = -1
+    grid[7, 8] = 100
+    robot_x, robot_y = _world(geometry, 7, 3)
+    kwargs = {
+        "obstacle_clearance_m": 1.1,
+        "min_frontier_length_m": 1.0,
+    }
+
+    first = find_frontier_goals(grid, geometry, robot_x, robot_y, **kwargs)
+    second = find_frontier_goals(grid, geometry, robot_x, robot_y, **kwargs)
+
+    assert first == second
+    assert [(goal.row, goal.col) for goal in first] == [(6, 9)]
+    assert math.hypot(first[0].row - 7, first[0].col - 8) > 1.1
+
+
+def test_goal_heading_uses_exact_unknown_cell_centroid():
+    geometry = GridGeometry(resolution=1.0, origin_x=2.0, origin_y=-3.0, origin_yaw=0.35)
+    grid = np.full((9, 9), 100, dtype=np.int16)
+    grid[4, 4] = 0
+    unknown_cells = [(3, 4), (4, 5)]
+    for cell in unknown_cells:
+        grid[cell] = -1
+    robot_x, robot_y = _world(geometry, 4, 4)
+
+    goals = find_frontier_goals(
+        grid,
+        geometry,
+        robot_x,
+        robot_y,
+        obstacle_clearance_m=0.0,
+        min_frontier_length_m=0.1,
+        min_goal_distance_m=0.0,
+    )
+
+    assert len(goals) == 1
+    unknown_world = [_world(geometry, row, col) for row, col in unknown_cells]
+    centroid_x = sum(x for x, _ in unknown_world) / len(unknown_world)
+    centroid_y = sum(y for _, y in unknown_world) / len(unknown_world)
+    expected_yaw = math.atan2(centroid_y - goals[0].y, centroid_x - goals[0].x)
+    assert goals[0].yaw == pytest.approx(expected_yaw)
+    assert goals[0].yaw != pytest.approx(geometry.origin_yaw - math.pi / 2)
+
+
+def test_world_exclusion_survives_grid_origin_expansion():
+    grid = _single_frontier_grid()
+    geometry = GridGeometry(resolution=1.0, origin_x=0.0, origin_y=0.0)
+    robot_x, robot_y = _world(geometry, 3, 1)
+    kwargs = {
+        "obstacle_clearance_m": 0.0,
+        "min_frontier_length_m": 0.1,
+    }
+    original = find_frontier_goals(grid, geometry, robot_x, robot_y, **kwargs)
+    assert len(original) == 1
+
+    expanded = np.full((grid.shape[0], grid.shape[1] + 1), 100, dtype=grid.dtype)
+    expanded[:, 1:] = grid
+    shifted_geometry = GridGeometry(resolution=1.0, origin_x=-1.0, origin_y=0.0)
+    shifted = find_frontier_goals(expanded, shifted_geometry, robot_x, robot_y, **kwargs)
+
+    assert len(shifted) == 1
+    assert shifted[0].x == pytest.approx(original[0].x)
+    assert shifted[0].y == pytest.approx(original[0].y)
+    assert (
+        find_frontier_goals(
+            expanded,
+            shifted_geometry,
+            robot_x,
+            robot_y,
+            excluded_world=[(original[0].x, original[0].y)],
+            exclusion_radius_m=0.1,
+            **kwargs,
+        )
+        == []
+    )
+
+
+def test_fully_known_reachable_map_has_no_frontiers():
+    geometry = GridGeometry(resolution=0.1, origin_x=0.0, origin_y=0.0)
+    grid = np.zeros((20, 20), dtype=np.int8)
+    grid[[0, -1], :] = 100
+    grid[:, [0, -1]] = 100
+    robot_x, robot_y = _world(geometry, 10, 10)
+
+    assert find_frontier_goals(grid, geometry, robot_x, robot_y) == []
+
+
+def test_cancellation_checkpoint_runs_before_goals_are_returned():
+    class CancelProbe(BaseException):
+        pass
+
+    geometry = GridGeometry(resolution=1.0, origin_x=0.0, origin_y=0.0)
+    grid = _single_frontier_grid()
+    robot_x, robot_y = _world(geometry, 3, 1)
+
+    def cancel():
+        raise CancelProbe
+
+    with pytest.raises(CancelProbe):
+        find_frontier_goals(
+            grid,
+            geometry,
+            robot_x,
+            robot_y,
+            obstacle_clearance_m=0.0,
+            min_frontier_length_m=0.1,
+            check_cancelled=cancel,
+        )

--- a/ros2_ws/src/brain/brain_client/test/test_mapping_pose_state.py
+++ b/ros2_ws/src/brain/brain_client/test/test_mapping_pose_state.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Tests for map-pose authority selection across navigation lifecycle modes."""
+
+import logging
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_PACKAGE_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from ros_skill_test_stubs import install_if_ros_is_missing  # noqa: E402
+
+install_if_ros_is_missing()
+
+from rclpy.qos import QoSDurabilityPolicy, QoSReliabilityPolicy  # noqa: E402
+
+from brain_client.skills.robot_state import NAV_MODE_QOS, RobotStateProvider  # noqa: E402
+from brain_client.skills.types import Skill  # noqa: E402
+from brain_client.state.nav_mode import NavMode  # noqa: E402
+from brain_client.state.pose import Pose  # noqa: E402
+
+
+class _PoseConsumer(Skill):
+    nav_mode: NavMode
+    pose: Pose | None = None
+
+    def execute(self):
+        pass
+
+
+class _Logger:
+    def __init__(self):
+        self.warnings: list[str] = []
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def error(self, _message: str) -> None:
+        pass
+
+
+class _FeedNode:
+    def __init__(self):
+        self.subscriptions: list[SimpleNamespace] = []
+
+    def create_subscription(self, message_type, topic, callback, qos):
+        subscription = SimpleNamespace(message_type=message_type, topic=topic, callback=callback, qos=qos)
+        self.subscriptions.append(subscription)
+        return subscription
+
+
+class _Manipulation:
+    def __init__(self):
+        self.node = _FeedNode()
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+
+def _provider() -> RobotStateProvider:
+    logger = _Logger()
+    owner = SimpleNamespace(get_logger=lambda: logger)
+    manipulation = _Manipulation()
+    provider = RobotStateProvider(
+        owner,
+        None,
+        manipulation=manipulation,
+        mobility=None,
+        head=None,
+        memory=None,
+        head_current_position_topic="/head/current_position",
+    )
+    provider._active = True
+    return provider
+
+
+def _mode(value: str) -> SimpleNamespace:
+    return SimpleNamespace(data=value)
+
+
+def _pose_message(x: float, y: float, yaw: float, *, frame_id: str = "map", stamp: float = 12.25):
+    sec = math.floor(stamp)
+    nanosec = round((stamp - sec) * 1e9)
+    pose = SimpleNamespace(
+        position=SimpleNamespace(x=x, y=y),
+        orientation=SimpleNamespace(x=0.0, y=0.0, z=math.sin(yaw / 2.0), w=math.cos(yaw / 2.0)),
+    )
+    return SimpleNamespace(
+        header=SimpleNamespace(frame_id=frame_id, stamp=SimpleNamespace(sec=sec, nanosec=nanosec)),
+        pose=SimpleNamespace(pose=pose),
+    )
+
+
+def test_current_pose_selects_amcl_in_navigation_and_mapping_pose_in_mapping():
+    provider = _provider()
+    amcl = _pose_message(1.0, 2.0, 0.25, stamp=3.5)
+    mapping = _pose_message(8.0, 9.0, -0.5, stamp=4.75)
+
+    provider._on_nav_mode(_mode(" Navigation "))
+    provider._on_amcl_pose(amcl)
+    provider._on_mapping_pose(mapping)
+    pose = provider.current_pose()
+    assert (pose.x, pose.y, pose.theta, pose.stamp) == pytest.approx((1.0, 2.0, 0.25, 3.5))
+    assert pose.frame_id == "map"
+
+    # Even if the inactive source received a message, changing authorities
+    # must wait for a new sample from the newly active source.
+    provider._on_nav_mode(_mode("autonomous_mapping"))
+    assert provider.current_pose() is None
+    assert provider.last_amcl_pose is None
+    assert provider.last_mapping_pose is None
+
+    provider._on_mapping_pose(mapping)
+    pose = provider.current_pose()
+    assert (pose.x, pose.y, pose.theta, pose.stamp) == pytest.approx((8.0, 9.0, -0.5, 4.75))
+    assert provider.current_nav_mode().value == "autonomous_mapping"
+    assert provider.current_nav_mode().is_mapping
+    assert provider.current_nav_mode().supports_map_navigation
+
+
+def test_pose_conversion_is_cached_per_sensor_sample():
+    provider = _provider()
+    provider._on_nav_mode(_mode("autonomous_mapping"))
+    first_message = _pose_message(1.0, 2.0, 0.25, stamp=3.5)
+    provider._on_mapping_pose(first_message)
+
+    first = provider.current_pose()
+    assert provider.current_pose() is first
+
+    provider._on_mapping_pose(_pose_message(1.1, 2.1, 0.3, stamp=3.6))
+    second = provider.current_pose()
+    assert second is not first
+    assert second.position == pytest.approx((1.1, 2.1))
+
+
+def test_mode_change_clears_already_injected_pose_until_new_authority_sample():
+    provider = _provider()
+    skill = _PoseConsumer(logging.getLogger("test_pose_consumer"))
+    provider._on_nav_mode(_mode("navigation"))
+    provider._on_amcl_pose(_pose_message(1.0, 2.0, 0.25, stamp=3.5))
+    provider.update_skill_robot_state(skill)
+    assert skill.pose.position == pytest.approx((1.0, 2.0))
+    assert skill.nav_mode.value == "navigation"
+
+    provider._on_nav_mode(_mode("autonomous_mapping"))
+    provider.update_skill_robot_state(skill)
+    assert skill.pose is None
+    assert skill.nav_mode.value == "autonomous_mapping"
+
+    provider._on_mapping_pose(_pose_message(8.0, 9.0, -0.5, stamp=4.75))
+    provider.update_skill_robot_state(skill)
+    assert skill.pose.position == pytest.approx((8.0, 9.0))
+
+
+def test_authority_transition_does_not_reuse_cached_inactive_pose_or_odom():
+    provider = _provider()
+    mapping = _pose_message(4.0, 5.0, 0.75)
+    cached_amcl = _pose_message(-10.0, -11.0, -0.25)
+
+    provider._on_nav_mode(_mode("mapping"))
+    provider._on_mapping_pose(mapping)
+    provider._on_amcl_pose(cached_amcl)
+    assert provider.current_pose().position == pytest.approx((4.0, 5.0))
+
+    provider._on_nav_mode(_mode("navigation"))
+    assert provider.current_pose() is None
+    provider._on_amcl_pose(_pose_message(6.0, 7.0, 1.0))
+    assert provider.current_pose().position == pytest.approx((6.0, 7.0))
+
+    provider.last_odom = _pose_message(99.0, 100.0, 0.0, frame_id="odom")
+    provider._on_nav_mode(_mode("mapfree"))
+    assert provider.current_pose() is None
+
+
+def test_current_pose_rejects_non_map_frame_from_active_authority():
+    provider = _provider()
+    provider._on_nav_mode(_mode("mapping"))
+    provider._on_mapping_pose(_pose_message(1.0, 2.0, 0.0, frame_id="odom"))
+
+    assert provider.current_pose() is None
+    assert provider._logger.warnings == [
+        "Skill requires map-frame pose but none available (yet); will inject when it arrives."
+    ]
+
+
+def test_nav_mode_subscription_requests_latched_reliable_status():
+    provider = _provider()
+    provider._active = False
+
+    provider.start_subscriptions()
+
+    subscription = next(sub for sub in provider._manipulation.node.subscriptions if sub.topic == "/nav/current_mode")
+    assert subscription.qos is NAV_MODE_QOS
+    assert subscription.qos.depth == 1
+    assert subscription.qos.reliability == QoSReliabilityPolicy.RELIABLE
+    assert subscription.qos.durability == QoSDurabilityPolicy.TRANSIENT_LOCAL

--- a/ros2_ws/src/brain/brain_client/test/test_navigate_to_position_timeout.py
+++ b/ros2_ws/src/brain/brain_client/test/test_navigate_to_position_timeout.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Pins the cancellable, terminal-safe Nav2 action controller."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+sys.path.insert(0, str(_REPO_ROOT / "workspace"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from ros_skill_test_stubs import install_if_ros_is_missing  # noqa: E402
+
+install_if_ros_is_missing()
+
+from action_msgs.msg import GoalStatus  # noqa: E402
+from geometry_msgs.msg import PoseStamped  # noqa: E402
+from innate_skills import navigate_to_position as navigate_module  # noqa: E402
+from innate_skills.navigate_to_position import Nav2Controller, NavigateToPosition  # noqa: E402
+
+from innate import SkillCancelled, SkillFailed  # noqa: E402
+
+
+class _Future:
+    def __init__(self, result=None, *, done: bool = False):
+        self._event = threading.Event()
+        self._result = result
+        self._callbacks = []
+        self._lock = threading.Lock()
+        if done:
+            self._event.set()
+
+    def done(self):
+        return self._event.is_set()
+
+    def result(self):
+        assert self.done(), "future result read before completion"
+        return self._result
+
+    def add_done_callback(self, callback):
+        with self._lock:
+            if self.done():
+                run_now = True
+            else:
+                self._callbacks.append(callback)
+                run_now = False
+        if run_now:
+            callback(self)
+
+    def set_result(self, result):
+        with self._lock:
+            self._result = result
+            self._event.set()
+            callbacks, self._callbacks = self._callbacks, []
+        for callback in callbacks:
+            callback(self)
+
+
+def _result(status):
+    return SimpleNamespace(status=status, result=SimpleNamespace())
+
+
+class _GoalHandle:
+    def __init__(self, *, accepted=True, result_future=None, terminal_on_cancel=False):
+        self.accepted = accepted
+        self.result_future = result_future or _Future()
+        self.terminal_on_cancel = terminal_on_cancel
+        self.cancel_calls = 0
+        self.cancel_called = threading.Event()
+
+    def get_result_async(self):
+        return self.result_future
+
+    def cancel_goal_async(self):
+        self.cancel_calls += 1
+        self.cancel_called.set()
+        if self.terminal_on_cancel and not self.result_future.done():
+            self.result_future.set_result(_result(GoalStatus.STATUS_CANCELED))
+        return _Future(SimpleNamespace(goals_canceling=[object()]), done=True)
+
+
+class _ActionClient:
+    def __init__(self, send_future, *, ready=True):
+        self.ready = ready
+        self.send_future = send_future
+        self.sent_goals = []
+        self.sent = threading.Event()
+
+    def server_is_ready(self):
+        return self.ready
+
+    def send_goal_async(self, goal, feedback_callback=None):
+        self.sent_goals.append((goal, feedback_callback))
+        self.sent.set()
+        return self.send_future
+
+
+class _Clock:
+    def __init__(self):
+        self.value = 0.0
+        self._lock = threading.Lock()
+
+    def now(self):
+        with self._lock:
+            return self.value
+
+    def advance(self, seconds):
+        with self._lock:
+            self.value += seconds
+
+
+class _Node:
+    def get_clock(self):
+        return SimpleNamespace(now=lambda: SimpleNamespace(to_msg=lambda: PoseStamped().header.stamp))
+
+
+class _SkillHarness:
+    def __init__(self, clock):
+        self.node = _Node()
+        self.odom = None
+        self._clock = clock
+        self._cancelled = threading.Event()
+        self._cancel_hooks = []
+        self.feedback_messages = []
+
+    def sleep(self, seconds):
+        self._clock.advance(seconds)
+        if self._cancelled.wait(0.001):
+            raise SkillCancelled("cancelled")
+
+    def check_cancelled(self):
+        if self._cancelled.is_set():
+            raise SkillCancelled("cancelled")
+
+    def on_cancel(self, callback):
+        self._cancel_hooks.append(callback)
+
+    def cancel(self):
+        self._cancelled.set()
+        for callback in list(self._cancel_hooks):
+            callback()
+
+    def feedback(self, message):
+        self.feedback_messages.append(message)
+
+
+class _Logger:
+    def __init__(self):
+        self.errors = []
+
+    def info(self, *_args):
+        pass
+
+    def warning(self, *_args):
+        pass
+
+    def error(self, message):
+        self.errors.append(message)
+
+
+def _controller(client, clock):
+    skill = _SkillHarness(clock)
+    controller = Nav2Controller.__new__(Nav2Controller)
+    controller.skill = skill
+    controller.logger = _Logger()
+    controller._client = client
+    controller._commanded_goal_pub = SimpleNamespace(messages=[], publish=lambda msg: None)
+    controller._goal_lock = threading.Lock()
+    controller._active_goal_handle = None
+    controller._active_result_future = None
+    controller._cancel_future = None
+    controller._latest_feedback = None
+    skill.on_cancel(controller._request_active_cancel)
+    return controller, skill
+
+
+def _run_in_thread(call):
+    outcome = []
+
+    def target():
+        try:
+            outcome.append(call())
+        except BaseException as exc:  # SkillCancelled deliberately extends BaseException.
+            outcome.append(exc)
+
+    worker = threading.Thread(target=target, daemon=True)
+    worker.start()
+    return worker, outcome
+
+
+def test_timeout_cancels_and_waits_for_terminal_result(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    goal_handle = _GoalHandle(terminal_on_cancel=True)
+    client = _ActionClient(_Future(goal_handle, done=True))
+    controller, _skill = _controller(client, clock)
+
+    with pytest.raises(SkillFailed, match="timed out"):
+        controller.go_to_position(1.0, 2.0, 0.0, False, timeout_s=0.25)
+
+    assert goal_handle.cancel_calls == 1
+    assert goal_handle.result_future.done()
+
+
+def test_cancel_ack_is_not_mistaken_for_terminal_result(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    goal_handle = _GoalHandle()
+    client = _ActionClient(_Future(goal_handle, done=True))
+    controller, skill = _controller(client, clock)
+
+    worker, outcome = _run_in_thread(lambda: controller.go_to_position(1.0, 2.0, 0.0, False))
+    assert client.sent.wait(1.0)
+    skill.cancel()
+    assert goal_handle.cancel_called.wait(1.0)
+
+    # cancel_goal_async already returned an acknowledgement, but the outer
+    # result remains pending until the router confirms internal Nav2 terminal.
+    worker.join(0.05)
+    assert worker.is_alive()
+    goal_handle.result_future.set_result(_result(GoalStatus.STATUS_CANCELED))
+    worker.join(1.0)
+
+    assert not worker.is_alive()
+    assert len(outcome) == 1 and isinstance(outcome[0], SkillCancelled)
+    assert goal_handle.cancel_calls == 1
+
+
+def test_cancel_during_pending_dispatch_settles_then_cancels(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    send_future = _Future()
+    goal_handle = _GoalHandle()
+    client = _ActionClient(send_future)
+    controller, skill = _controller(client, clock)
+
+    worker, outcome = _run_in_thread(lambda: controller.go_to_position(1.0, 2.0, 0.0, False))
+    assert client.sent.wait(1.0)
+    skill.cancel()
+    worker.join(0.05)
+    assert worker.is_alive(), "controller returned before the pending goal response settled"
+
+    send_future.set_result(goal_handle)
+    assert goal_handle.cancel_called.wait(1.0)
+    worker.join(0.05)
+    assert worker.is_alive(), "controller returned after cancel acknowledgement but before terminal result"
+
+    goal_handle.result_future.set_result(_result(GoalStatus.STATUS_CANCELED))
+    worker.join(1.0)
+    assert not worker.is_alive()
+    assert len(outcome) == 1 and isinstance(outcome[0], SkillCancelled)
+    assert goal_handle.cancel_calls == 1
+
+
+def test_rejected_goal_fails_without_consulting_prior_result(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    rejected = _GoalHandle(accepted=False, result_future=_Future(_result(GoalStatus.STATUS_SUCCEEDED), done=True))
+    client = _ActionClient(_Future(rejected, done=True))
+    controller, _skill = _controller(client, clock)
+
+    with pytest.raises(SkillFailed, match="rejected"):
+        controller.go_to_position(1.0, 2.0, 0.0, False)
+
+    assert rejected.cancel_calls == 0
+
+
+def test_safety_change_before_dispatch_sends_no_goal(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    client = _ActionClient(_Future())
+    controller, _skill = _controller(client, clock)
+
+    def unsafe():
+        raise SkillCancelled("mode changed")
+
+    with pytest.raises(SkillCancelled, match="mode changed"):
+        controller.go_to_position(1.0, 2.0, 0.0, False, safety_check=unsafe)
+
+    assert client.sent_goals == []
+
+
+def test_safety_change_after_dispatch_cancels_and_waits_terminal(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    goal_handle = _GoalHandle(terminal_on_cancel=True)
+    client = _ActionClient(_Future(goal_handle, done=True))
+    controller, _skill = _controller(client, clock)
+    checks = 0
+
+    def unsafe_after_dispatch():
+        nonlocal checks
+        checks += 1
+        if checks >= 5:
+            raise SkillCancelled("joystick takeover")
+
+    with pytest.raises(SkillCancelled, match="joystick takeover"):
+        controller.go_to_position(1.0, 2.0, 0.0, False, safety_check=unsafe_after_dispatch)
+
+    assert client.sent_goals
+    assert goal_handle.cancel_calls == 1
+    assert goal_handle.result_future.done()
+
+
+def test_waiting_for_action_server_remains_cancellable(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    client = _ActionClient(_Future(), ready=False)
+    controller, skill = _controller(client, clock)
+
+    worker, outcome = _run_in_thread(lambda: controller.go_to_position(1.0, 2.0, 0.0, False))
+    skill.cancel()
+    worker.join(1.0)
+
+    assert not worker.is_alive()
+    assert len(outcome) == 1 and isinstance(outcome[0], SkillCancelled)
+    assert client.sent_goals == []
+
+
+def test_success_uses_map_selector_and_returns(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    goal_handle = _GoalHandle(result_future=_Future(_result(GoalStatus.STATUS_SUCCEEDED), done=True))
+    client = _ActionClient(_Future(goal_handle, done=True))
+    controller, _skill = _controller(client, clock)
+
+    controller.go_to_position(1.0, 2.0, 0.25, False)
+
+    assert len(client.sent_goals) == 1
+    goal, _feedback_callback = client.sent_goals[0]
+    assert goal.behavior_tree == "navigation"
+    assert goal.pose.header.frame_id == "map"
+    assert goal_handle.cancel_calls == 0
+
+
+def test_external_navigation_cancel_stops_skill_instead_of_retrying(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    goal_handle = _GoalHandle(result_future=_Future(_result(GoalStatus.STATUS_CANCELED), done=True))
+    client = _ActionClient(_Future(goal_handle, done=True))
+    controller, _skill = _controller(client, clock)
+
+    with pytest.raises(SkillCancelled, match="navigation was canceled"):
+        controller.go_to_position(1.0, 2.0, 0.25, False)
+
+    assert goal_handle.cancel_calls == 0
+
+
+def test_public_skill_schema_no_longer_exposes_timeout_string_union():
+    assert "timeout_s" not in inspect.signature(NavigateToPosition.execute).parameters

--- a/ros2_ws/src/brain/brain_client/test/test_navigate_to_position_timeout.py
+++ b/ros2_ws/src/brain/brain_client/test/test_navigate_to_position_timeout.py
@@ -23,7 +23,7 @@ install_if_ros_is_missing()
 from action_msgs.msg import GoalStatus  # noqa: E402
 from geometry_msgs.msg import PoseStamped  # noqa: E402
 from innate_skills import navigate_to_position as navigate_module  # noqa: E402
-from innate_skills.navigate_to_position import Nav2Controller, NavigateToPosition  # noqa: E402
+from innate_skills.navigate_to_position import Nav2Controller, NavigateToPosition, NavigationBlocked  # noqa: E402
 
 from innate import SkillCancelled, SkillFailed  # noqa: E402
 
@@ -351,6 +351,17 @@ def test_external_navigation_cancel_stops_skill_instead_of_retrying(monkeypatch)
         controller.go_to_position(1.0, 2.0, 0.25, False)
 
     assert goal_handle.cancel_calls == 0
+
+
+def test_aborted_navigation_is_a_recoverable_blocked_route(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(navigate_module.time, "monotonic", clock.now)
+    goal_handle = _GoalHandle(result_future=_Future(_result(GoalStatus.STATUS_ABORTED), done=True))
+    client = _ActionClient(_Future(goal_handle, done=True))
+    controller, _skill = _controller(client, clock)
+
+    with pytest.raises(NavigationBlocked, match="route may be blocked"):
+        controller.go_to_position(1.0, 2.0, 0.25, False)
 
 
 def test_public_skill_schema_no_longer_exposes_timeout_string_union():

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -1066,11 +1066,11 @@ def test_bad_frames_never_overwrite_a_view(data_dir, clock):
 # ================= recording while mapping =================
 
 
-def see_mapping_world(recorder, started: float = 1000.0):
+def see_mapping_world(recorder, started: float = 1000.0, mode: str = "mapping"):
     """Feed the recorder everything a mapping-mode record needs: SLAM's live
     grid stands in for AMCL confidence, mode_manager's latched session stamp
     names the frame."""
-    recorder._on_nav_mode(SimpleNamespace(data="mapping"))
+    recorder._on_nav_mode(SimpleNamespace(data=mode))
     recorder._on_mapping_session(SimpleNamespace(data=json.dumps({"started": started})))
     recorder._on_map(grid_msg(open_room(40)))
     recorder._on_head(SimpleNamespace(data=json.dumps({"current_position": -10.0})))
@@ -1101,6 +1101,15 @@ def test_mapping_records_into_the_session_stage(data_dir, clock):
     see_mapping_world(recorder)
     recorder.tick()  # starts the hold
     assert store.snapshot().memories == ()
+    mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    snapshot = store.snapshot()
+    assert snapshot.map_name == MAPPING_SESSION and len(snapshot.memories) == 1
+
+
+def test_autonomous_mapping_records_into_the_same_session_stage(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_mapping_world(recorder, mode="autonomous_mapping")
+    recorder.tick()
     mapping_observe(recorder, clock, GOOD_JPEG, advance=3.1)
     snapshot = store.snapshot()
     assert snapshot.map_name == MAPPING_SESSION and len(snapshot.memories) == 1

--- a/ros2_ws/src/cloud/innate_uninavid/PROTOCOL.md
+++ b/ros2_ws/src/cloud/innate_uninavid/PROTOCOL.md
@@ -16,13 +16,13 @@ goal completes, is cancelled, or an error occurs.
 ros2 launch innate_uninavid uninavid.launch.py
 # Override the config file:
 ros2 launch innate_uninavid uninavid.launch.py params_file:=/path/to/custom.yaml
-# In simulator mode, publish directly to /cmd_vel:
-ros2 launch innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel
+# The simulator runs the same velocity smoother and final mux as hardware, so
+# the default command path is correct there too.
 ```
 
 By default, the launch file applies a `/cmd_vel` → `/cmd_vel_scaled`
-remapping.  The simulator overrides this to `/cmd_vel` because its bridge
-subscribes directly to that topic.
+remapping.  The velocity smoother then feeds `/cmd_vel_nav`, where the final
+mux arbitrates and applies mode-specific limits before publishing `/cmd_vel`.
 
 ### ROS parameters
 

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -518,11 +518,18 @@ class AppControl : public rclcpp::Node {
 
         // The mode as the robot actually entered it, not as a client asked for it:
         // mode_manager redirects to mapping whenever there is no current map, and
-        // auto-starts there on a mapless boot, so no client can be trusted to know
-        // a mapping run began. Republished at 1 Hz; the policy ignores repeats.
+        // auto-starts there on a mapless boot, so no client can be trusted to know a
+        // mapping run began. Use the latched status so a late-starting app applies the
+        // policy immediately.
+        // Keep the mapping policy through `switching`, which is published before active
+        // navigation is cancelled; the final stable mode releases it after teardown.
         nav_mode_sub_ = this->create_subscription<std_msgs::msg::String>(
-            "/nav/current_mode", 10, [this](const std_msgs::msg::String::SharedPtr msg) {
-                mapping_ = (msg->data == "mapping");
+            "/nav/current_mode", rclcpp::QoS(1).reliable().transient_local(),
+            [this](const std_msgs::msg::String::SharedPtr msg) {
+                if (msg->data == "switching") {
+                    return;
+                }
+                mapping_ = (msg->data == "mapping" || msg->data == "autonomous_mapping");
                 apply_speed_policy();
             });
 
@@ -1013,6 +1020,18 @@ class AppControl : public rclcpp::Node {
                 if (value < 0.05 || value > drive::max_speed_scale()) {
                     result.successful = false;
                     result.reason = "motion_control.speed_scale must be within the published preset range";
+                    return result;
+                }
+                // Mapping is a hard Slow activity, not merely a one-shot preset.
+                // Reject another client's Fast/Mad write so /robot/info, the
+                // teleop smoother, and the Mad arm policy cannot disagree with
+                // the final cmd_vel mapping envelope.  apply_speed_policy()
+                // restores the pre-mapping selection after the stable exit mode
+                // arrives; holding through `switching` prevents an early release.
+                const double mapping_scale = drive::scale_for_mode(drive::MAPPING_SCALE_ID);
+                if (mapping_ && std::abs(value - mapping_scale) > 1e-9) {
+                    result.successful = false;
+                    result.reason = "Mapping locks motion_control.speed_scale to the Slow preset";
                     return result;
                 }
                 // The Mad-mode arm fold reacts to the APPLIED value (watch_mad_mode).

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/joystick.py
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/joystick.py
@@ -11,6 +11,8 @@ from geometry_msgs.msg import Twist
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 
+from mars_control.teleop_publish_gate import TeleopPublishGate
+
 
 class JoystickAxis:
     def __init__(
@@ -88,8 +90,11 @@ class JoystickController(Node):
             slow_mode_factor=self.joystick_control["slow_mode_factor"],
         )
 
-        # Publisher for velocity commands
-        self.twist_pub = self.create_publisher(Twist, "/cmd_vel", 10)
+        # Route human commands through the priority mux. Publishing directly
+        # to /cmd_vel would compete with Nav2 and bypass autonomous-skill
+        # takeover monitoring.
+        self.twist_pub = self.create_publisher(Twist, "/cmd_vel_teleop", 10)
+        self._publish_gate = TeleopPublishGate()
 
         # Create timer for reading joystick input (use dt from parameters)
         self.create_timer(self.motion_control["dt"], self.timer_callback)
@@ -166,11 +171,17 @@ class JoystickController(Node):
             self.fig.canvas.draw()
             self.fig.canvas.flush_events()
 
-        # Create and publish Twist message only if publishing is enabled
-        if self.publishing_enabled:
+        # Teleop is the mux's top-priority input. Stream only while moving,
+        # followed by one exact zero, so a connected neutral joystick cannot
+        # starve Nav2 indefinitely.
+        command = self._publish_gate.next_command(
+            linear_speed,
+            angular_speed,
+            enabled=self.publishing_enabled,
+        )
+        if command is not None:
             msg = Twist()
-            msg.linear.x = linear_speed
-            msg.angular.z = angular_speed
+            msg.linear.x, msg.angular.z = command
             self.twist_pub.publish(msg)
 
     def _load_parameters(self):

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/keyboard.py
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/keyboard.py
@@ -9,6 +9,8 @@ from pynput import keyboard
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 
+from mars_control.teleop_publish_gate import TeleopPublishGate
+
 
 class KeyboardController(Node):
     def __init__(self):
@@ -26,8 +28,11 @@ class KeyboardController(Node):
         self.max_speed = self.get_parameter("motion_control.max_speed").value
         self.max_turn = self.get_parameter("motion_control.max_angular_speed").value
 
-        # Publisher for velocity commands
-        self.twist_pub = self.create_publisher(Twist, "/cmd_vel", 10)
+        # Route human commands through the priority mux. Publishing directly
+        # to /cmd_vel would compete with Nav2 and bypass autonomous-skill
+        # takeover monitoring.
+        self.twist_pub = self.create_publisher(Twist, "/cmd_vel_teleop", 10)
+        self._publish_gate = TeleopPublishGate()
 
         # Create timer for publishing commands
         self.create_timer(0.1, self.timer_callback)
@@ -73,10 +78,13 @@ Control Instructions:
         return True
 
     def timer_callback(self):
-        # Create and publish Twist message
+        # Teleop is the mux's top-priority input. After an explicit stop,
+        # publish one zero and go silent so Nav2 can regain ownership.
+        command = self._publish_gate.next_command(self.current_speed, self.current_turn)
+        if command is None:
+            return
         msg = Twist()
-        msg.linear.x = self.current_speed
-        msg.angular.z = self.current_turn
+        msg.linear.x, msg.angular.z = command
         self.twist_pub.publish(msg)
 
 

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/teleop_publish_gate.py
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/teleop_publish_gate.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Publish-until-stopped policy for top-priority teleop velocity sources."""
+
+
+class TeleopPublishGate:
+    """Stream motion, emit one settling zero, then release the velocity mux."""
+
+    def __init__(self, epsilon: float = 1e-3):
+        if epsilon < 0.0:
+            raise ValueError("epsilon must be non-negative")
+        self._epsilon = epsilon
+        self._active = False
+
+    def next_command(self, linear: float, angular: float, *, enabled: bool = True) -> tuple[float, float] | None:
+        moving = enabled and (abs(linear) > self._epsilon or abs(angular) > self._epsilon)
+        if moving:
+            self._active = True
+            return linear, angular
+        if self._active:
+            self._active = False
+            return 0.0, 0.0
+        return None

--- a/ros2_ws/src/mars_bot/mars_nav/config/costmap.yaml
+++ b/ros2_ws/src/mars_bot/mars_nav/config/costmap.yaml
@@ -21,7 +21,7 @@ navigation:
         obstacle_layer:
           plugin: "nav2_costmap_2d::ObstacleLayer"
           enabled: True
-          observation_sources: scan
+          observation_sources: scan mapping_recovery
           scan:
             topic: /scan
             max_obstacle_height: 2.0
@@ -32,6 +32,14 @@ navigation:
             raytrace_min_range: 0.2
             obstacle_max_range: 2.5
             obstacle_min_range: 0.2
+          mapping_recovery:
+            topic: /mapping/recovery_scan
+            clearing: False
+            marking: True
+            data_type: "LaserScan"
+            obstacle_max_range: 1.0
+            obstacle_min_range: 0.05
+            observation_persistence: 8.0
         inflation_layer:
           plugin: "nav2_costmap_2d::InflationLayer"
           cost_scaling_factor: 10.0
@@ -74,7 +82,7 @@ local_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
-        observation_sources: scan
+        observation_sources: scan mapping_recovery
         scan:
           topic: /scan
           max_obstacle_height: 2.0
@@ -85,6 +93,14 @@ local_costmap:
           raytrace_min_range: 0.2
           obstacle_max_range: 2.5
           obstacle_min_range: 0.2
+        mapping_recovery:
+          topic: /mapping/recovery_scan
+          clearing: False
+          marking: True
+          data_type: "LaserScan"
+          obstacle_max_range: 1.0
+          obstacle_min_range: 0.05
+          observation_persistence: 8.0
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 10.0

--- a/ros2_ws/src/mars_bot/mars_nav/launch/mapping.launch.py
+++ b/ros2_ws/src/mars_bot/mars_nav/launch/mapping.launch.py
@@ -18,7 +18,9 @@ def generate_launch_description():
 
     # Declare launch arguments.
     declare_use_sim_time_argument = DeclareLaunchArgument(
-        "use_sim_time", default_value="true", description="Use simulation/Gazebo clock"
+        "use_sim_time",
+        default_value="false",
+        description="Use simulation clock (the native simulator and hardware both use wall time by default)",
     )
 
     # Configure the asynchronous slam_toolbox node using the parameter file.

--- a/ros2_ws/src/mars_bot/mars_nav/launch/mode_manager.launch.py
+++ b/ros2_ws/src/mars_bot/mars_nav/launch/mode_manager.launch.py
@@ -9,7 +9,7 @@ from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
-from mars_bringup.config_loader import load_motion_limit_overrides, load_yaml_param_defaults
+from mars_bringup.config_loader import load_motion_limit_overrides, load_yaml_param_defaults, settings_params
 
 
 def expand_action_remappings(action_remappings):
@@ -114,6 +114,10 @@ def generate_launch_description():
         executable="cmd_vel_mux.py",
         name="cmd_vel_mux",
         output="screen",
+        # The mapping Slow envelope derives from the lower manual/Nav2 caps.
+        # settings.yaml is layered last so both motion_control and nav
+        # overrides remain authoritative.
+        parameters=[*settings_params()],
     )
 
     # Shared BT navigator node

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/cmd_vel_mux.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/cmd_vel_mux.py
@@ -9,7 +9,9 @@ its freshness window:
     /cmd_vel_teleop > /cmd_vel_skills > /cmd_vel_nav  ->  /cmd_vel
 
 Event-driven (no re-timing). One zero twist is published when every source
-goes stale so the base stops deterministically.
+goes stale so the base stops deterministically.  Mapping modes apply the
+robot's Slow envelope at this final common path, so Fast/Mad teleop settings,
+skills, Nav2, and recovery behaviors cannot bypass it.
 """
 
 import time
@@ -18,6 +20,20 @@ from functools import partial
 import rclpy
 from geometry_msgs.msg import Twist
 from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+from std_msgs.msg import String
+from std_srvs.srv import SetBool
+
+from mars_nav.navigation_policy import (
+    DEFAULT_MANUAL_MAX_ANGULAR_RPS,
+    DEFAULT_MANUAL_MAX_LINEAR_MPS,
+    DEFAULT_NAV_MAX_ANGULAR_RPS,
+    DEFAULT_NAV_MAX_LINEAR_MPS,
+    MAPPING_SPEED_LIMIT_SERVICE,
+    mapping_slow_limits,
+    mapping_speed_factor,
+    mapping_speed_limit_active,
+)
 
 # (name, topic, freshness window s) — highest priority first. Windows exceed
 # each source's publish interval so an active source never flickers stale.
@@ -31,9 +47,36 @@ SOURCES = [
 class CmdVelMux(Node):
     def __init__(self):
         super().__init__("cmd_vel_mux")
+        self.declare_parameter("motion_control.max_speed", DEFAULT_MANUAL_MAX_LINEAR_MPS)
+        self.declare_parameter("motion_control.max_angular_speed", DEFAULT_MANUAL_MAX_ANGULAR_RPS)
+        self.declare_parameter("nav.max_speed", DEFAULT_NAV_MAX_LINEAR_MPS)
+        self.declare_parameter("nav.max_angular_speed", DEFAULT_NAV_MAX_ANGULAR_RPS)
+        self._mapping_max_linear, self._mapping_max_angular = mapping_slow_limits(
+            float(self.get_parameter("motion_control.max_speed").value),
+            float(self.get_parameter("motion_control.max_angular_speed").value),
+            float(self.get_parameter("nav.max_speed").value),
+            float(self.get_parameter("nav.max_angular_speed").value),
+        )
+
+        # Fail slow until mode_manager synchronously establishes an
+        # authoritative state. The mode topic remains a compatibility fallback
+        # only until the first acknowledged SetBool request.
+        self._mapping_limit_enabled = True
+        self._has_authoritative_limit_source = False
         self._pub = self.create_publisher(Twist, "/cmd_vel", 10)
         self._last_rx = {name: 0.0 for name, _topic, _window in SOURCES}
         self._forwarding = False  # motion since the last all-stale zero-stop
+        mode_qos = QoSProfile(
+            depth=1,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        self._mode_sub = self.create_subscription(String, "/nav/current_mode", self._on_mode, mode_qos)
+        self._mapping_limit_service = self.create_service(
+            SetBool,
+            MAPPING_SPEED_LIMIT_SERVICE,
+            self._set_mapping_speed_limit,
+        )
         for priority, (name, topic, _window) in enumerate(SOURCES):
             self.create_subscription(Twist, topic, partial(self._on_twist, priority, name), 10)
         self.create_timer(0.1, self._stop_when_all_stale)
@@ -46,8 +89,61 @@ class CmdVelMux(Node):
         if override:
             self.get_logger().info(f"'{override}' overriding '{name}' on /cmd_vel", throttle_duration_sec=2.0)
             return
-        self._pub.publish(msg)
+        self._pub.publish(self._apply_mapping_speed_limit(msg))
         self._forwarding = True
+
+    def _on_mode(self, msg):
+        if self._has_authoritative_limit_source:
+            self.get_logger().debug(f"Ignoring fallback mapping envelope update from /nav/current_mode ({msg.data!r})")
+            return
+
+        enabled = mapping_speed_limit_active(msg.data)
+        was_enabled = self._mapping_limit_enabled
+        self._mapping_limit_enabled = enabled
+        if enabled and not was_enabled:
+            # A legacy mode manager has entered switching/mapping. Replace any
+            # previously forwarded unrestricted command before accepting more.
+            self._publish_zero_stop()
+
+    def _set_mapping_speed_limit(self, request, response):
+        """Synchronously establish the authoritative final-drive envelope."""
+
+        self._has_authoritative_limit_source = True
+        self._mapping_limit_enabled = bool(request.data)
+        if self._mapping_limit_enabled:
+            # publish() runs before this callback returns, so a successful
+            # service acknowledgement can never precede the replacing zero.
+            self._publish_zero_stop()
+        response.success = True
+        response.message = (
+            "Mapping Slow envelope enabled" if self._mapping_limit_enabled else "Mapping Slow envelope disabled"
+        )
+        return response
+
+    def _publish_zero_stop(self):
+        self._forwarding = False
+        self._pub.publish(Twist())
+
+    def _apply_mapping_speed_limit(self, msg):
+        if not self._mapping_limit_enabled:
+            return msg
+
+        factor = mapping_speed_factor(
+            True,
+            float(msg.linear.x),
+            float(msg.angular.z),
+            self._mapping_max_linear,
+            self._mapping_max_angular,
+        )
+        # MARS is differential drive. While the envelope is active, explicitly
+        # zero every unsupported Twist axis so a source cannot bypass the cap
+        # through linear.y/z or angular.x/y.
+        limited = Twist()
+        if factor <= 0.0:
+            return limited
+        limited.linear.x = msg.linear.x * factor
+        limited.angular.z = msg.angular.z * factor
+        return limited
 
     def _fresh_source_above(self, priority, now):
         """Name of a higher-priority source still inside its freshness window."""

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -48,6 +48,13 @@ map_server_node = "navigation_map_server"
 bt_node = "bt_navigator"
 
 NAV_CANCEL_SERVICE = "/internal_navigate_to_pose/_action/cancel_goal"
+MAPPING_AUTHORITY_CONFLICTS = frozenset(
+    {
+        "navigation_map_server",
+        "navigation_amcl",
+        "null_map_node",
+    }
+)
 
 
 class ModeManager(Node):
@@ -697,6 +704,7 @@ class ModeManager(Node):
                 return False, msg
 
             node_names = nodes
+            authority_failures = []
 
             for node_name in all_nodes_except_target:
                 # Check if this node should skip cleanup (only deactivate to INACTIVE)
@@ -715,6 +723,15 @@ class ModeManager(Node):
 
                 if not success:
                     self.get_logger().warning(f"Failed to shutdown non-target node {node_name} (continuing)")
+                    if mode.value in MAPPING_MODES and node_name in MAPPING_AUTHORITY_CONFLICTS:
+                        authority_failures.append(node_name)
+
+            if authority_failures:
+                message = (
+                    f"Refusing to start mapping while competing map/TF authorities remain active: {authority_failures}"
+                )
+                self.get_logger().error(message)
+                return False, message
 
             # Get nodes that should only be configured (not activated) for this mode
             configure_only = configure_only_nodes.get(mode.value, set())

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -9,7 +9,6 @@ import subprocess
 import threading
 import time
 import traceback
-from enum import Enum
 
 import rclpy
 
@@ -30,8 +29,18 @@ from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy, qos_profile_sensor_data
 from sensor_msgs.msg import PointCloud2
 from std_msgs.msg import String
-from std_srvs.srv import Trigger
+from std_srvs.srv import SetBool, Trigger
 
+from mars_nav.navigation_policy import (
+    MAPPING_MODES,
+    MAPPING_SPEED_LIMIT_SERVICE,
+    VALID_NAVIGATION_MODES,
+    NavigationMode,
+    configure_only_nodes,
+    modes_nodes,
+    skip_cleanup_nodes,
+    starts_new_mapping_session,
+)
 from mars_nav.service_utils import call_service, get_node_state, transition_node
 
 # TODO: move this into launch file?
@@ -39,50 +48,6 @@ map_server_node = "navigation_map_server"
 bt_node = "bt_navigator"
 
 NAV_CANCEL_SERVICE = "/internal_navigate_to_pose/_action/cancel_goal"
-
-# Nodes that should only be configured (not activated) in specific modes
-configure_only_nodes = {
-    "mapfree": {"navigation/planner_server"},
-}
-
-# Nodes that should only be deactivated (not cleaned up/unconfigured) to avoid RMW bugs
-# These nodes stay in INACTIVE state rather than being fully unconfigured
-skip_cleanup_nodes = {
-    "controller_server",  # Zenoh RMW crashes during TF unsubscription in cleanup
-    "mapfree/planner_server",  # Segfaults during costmap cleanup (SIGSEGV exit code -11)
-    "navigation/planner_server",  # Same binary, same risk
-}
-
-modes_nodes = {
-    "mapping": ["slam_toolbox"],
-    "mapfree": [
-        "null_map_node",
-        "navigation/planner_server",  # unnecsessary but needed for BT, TODO, find a way to remove
-        "mapfree/planner_server",  # TBD DO WE WANT TO CLEAR COSTMAPS OR NAH # def has to be unconfigured to reload static map (unless we want to do update topics and stuff. which might be worth doing in iter 2) - do MAP_UPDATES
-        "controller_server",  # doesn't have to be deactivated, theoretically action should be cancelled by bt before it dies, and this won't receive a new path to follow - BUT IT HAS COSTMAP!!!
-        "bt_navigator",  # could stay on but underlying actions r gonna fail and be in a weird state;
-        "behavior_server",  # i guess this can just be deactivated - WHY??
-        "velocity_smoother",  # might be able to leave it running throughout any changes
-    ],
-    "navigation": [  # on map switch
-        "navigation_map_server",  # load_map topic
-        "navigation_grid_localizer",  # localize Trigger service - USE THE TRIGGER SERVICE AND RELOAD MAP SERVICE
-        "navigation_amcl",  # either restart or make sure its not first_map_only and send /map and /initialpose
-        "mapfree/planner_server",
-        "navigation/planner_server",  # TBD DO WE WANT TO CLEAR COSTMAPS OR NAH # def has to be unconfigured to reload static map (unless we want to do update topics and stuff. which might be worth doing in iter 2) - do MAP_UPDATES
-        "controller_server",  # doesn't have to be deactivated, theoretically action should be cancelled by bt before it dies, and this won't receive a new path to follow - BUT IT HAS COSTMAP!!!
-        "bt_navigator",  # could stay on but underlying actions r gonna fail and be in a weird state;
-        "behavior_server",  # i guess this can just be deactivated - WHY??
-        "velocity_smoother",  # might be able to leave it running throughout any changes
-        # TODO: kill any running BTs or behaviors on switch
-    ],
-}
-
-
-class NavigationMode(Enum):
-    NAV = "navigation"
-    MAPPING = "mapping"
-    MAPFREE = "mapfree"
 
 
 class ModeManager(Node):
@@ -99,6 +64,12 @@ class ModeManager(Node):
 
         # Will be set in main() after adding this node to an executor.
         self._executor = None
+
+        # main() binds this to the in-process NavigateToPoseRouter.  DDS remains
+        # the public status transport, while this sink closes admission before
+        # a lifecycle teardown can race topic delivery.
+        self._navigation_mode_sink = None
+        self._navigation_pending_goals_getter = None
 
         # Lock to prevent concurrent mode changes
 
@@ -121,6 +92,11 @@ class ModeManager(Node):
         self._nav_active_goals = 0
         self._service_clients[NAV_CANCEL_SERVICE] = self.create_client(
             CancelGoal, NAV_CANCEL_SERVICE, callback_group=self._calls_going_outside_group
+        )
+        self._service_clients[MAPPING_SPEED_LIMIT_SERVICE] = self.create_client(
+            SetBool,
+            MAPPING_SPEED_LIMIT_SERVICE,
+            callback_group=self._calls_going_outside_group,
         )
         self._nav_status_sub = self.create_subscription(
             GoalStatusArray,
@@ -159,8 +135,15 @@ class ModeManager(Node):
             DeleteMap, "/nav/delete_map", self.delete_map_callback, callback_group=self._internal_callbacks_group
         )
 
-        # Publisher to announce current mode
-        self.mode_publisher = self.create_publisher(String, "/nav/current_mode", 10)
+        # Publisher to announce current mode.  The router and late-starting
+        # skills need the current value immediately; a volatile publisher is
+        # incompatible with their transient-local subscriptions.
+        mode_qos = QoSProfile(
+            depth=1,
+            reliability=QoSReliabilityPolicy.RELIABLE,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        self.mode_publisher = self.create_publisher(String, "/nav/current_mode", mode_qos)
 
         # Publisher to announce available maps
         self.maps_publisher = self.create_publisher(String, "/nav/available_maps", 10)
@@ -282,7 +265,10 @@ class ModeManager(Node):
         )
 
         self.get_logger().info("Mode Manager starting with map management capabilities.")
-        self.get_logger().info('- Call /nav/change_mode service to switch modes ("navigation" or "mapping")')
+        self.get_logger().info(
+            '- Call /nav/change_mode service to switch modes ("navigation", "mapping", '
+            '"autonomous_mapping", or "mapfree")'
+        )
         self.get_logger().info(
             "- Call /nav/change_navigation_map service to change map (restarts navigation if running)"
         )
@@ -311,15 +297,18 @@ class ModeManager(Node):
         )
 
     def odom_callback(self, msg):
-        # Only publish mapping_pose in mapping mode
-        if getattr(self, "current_mode", None) != "mapping":
+        # Both mapping modes use slam_toolbox as the map->odom authority.
+        if getattr(self, "current_mode", None) not in MAPPING_MODES:
             return
         try:
             tf_time = rclpy.time.Time()
             tf: TransformStamped = self.tf_buffer.lookup_transform("map", "base_link", tf_time)
             self._last_mapping_pose = (tf, time.monotonic())
             odom_msg = Odometry()
-            odom_msg.header.stamp = msg.header.stamp
+            # Stamp the pose with the TF sample it actually represents. Using
+            # the incoming odometry time would make a frozen SLAM transform
+            # look fresh as long as wheel odometry kept arriving.
+            odom_msg.header.stamp = tf.header.stamp
             odom_msg.header.frame_id = "map"
             odom_msg.child_frame_id = "base_link"
             odom_msg.pose.pose.position.x = tf.transform.translation.x
@@ -365,7 +354,7 @@ class ModeManager(Node):
             if os.path.exists(self.mode_file):
                 with open(self.mode_file) as f:
                     saved_mode = f.read().strip()
-                    if saved_mode in ["navigation", "mapping", "mapfree"]:
+                    if saved_mode in VALID_NAVIGATION_MODES:
                         self.get_logger().info(f"Loaded last mode: {saved_mode}")
                         return saved_mode
             # Default to navigation mode
@@ -447,15 +436,9 @@ class ModeManager(Node):
             self.get_logger().info("Create a map first, then switch to navigation mode")
             self.current_mode = "mapping"
 
-        if self.current_mode in ["navigation", "mapping"]:
+        if self.current_mode in VALID_NAVIGATION_MODES:
             self.get_logger().info(f"Auto-starting in {self.current_mode} mode...")
             # Simulate a service request
-            request = ChangeNavigationMode.Request()
-            request.mode = self.current_mode
-            response = ChangeNavigationMode.Response()
-            self.change_mode_callback(request, response, first_start=True)
-        elif self.current_mode == "mapfree":
-            self.get_logger().info("Auto-starting in mapfree mode (local Nav2)")
             request = ChangeNavigationMode.Request()
             request.mode = self.current_mode
             response = ChangeNavigationMode.Response()
@@ -466,7 +449,16 @@ class ModeManager(Node):
         # self.log_num += 1
         # if not (self.log_num % 10):
         # self.get_logger().info("Publishing status every second....", throttle_duration_sec = 10)
-        # Publish current mode
+        # Update the co-located router synchronously before the DDS publish.
+        # In particular, `switching` must close admission before cancellation
+        # checks and lifecycle teardown begin.
+        if self._navigation_mode_sink is not None:
+            try:
+                self._navigation_mode_sink(self.current_mode)
+            except Exception as e:
+                self.get_logger().error(f"Failed to synchronize navigation admission: {e}")
+
+        # Publish current mode for all other consumers and late subscribers.
         mode_msg = String()
         mode_msg.data = self.current_mode
         self.mode_publisher.publish(mode_msg)
@@ -480,6 +472,23 @@ class ModeManager(Node):
         current_map_msg = String()
         current_map_msg.data = self.current_map if self.current_map is not None else ""
         self.current_map_publisher.publish(current_map_msg)
+
+    def set_navigation_mode_sink(self, sink):
+        """Bind the co-located router's synchronous mode update hook."""
+        self._navigation_mode_sink = sink
+
+    def set_navigation_pending_goals_getter(self, getter):
+        """Bind the co-located router's accepted-goal reservation count."""
+        self._navigation_pending_goals_getter = getter
+
+    def _navigation_pending_goals(self):
+        if self._navigation_pending_goals_getter is None:
+            return 0
+        try:
+            return max(0, int(self._navigation_pending_goals_getter()))
+        except Exception as e:
+            self.get_logger().error(f"Failed to read router goal reservations: {e}")
+            return None
 
     def _init_service_clients(self):
         """Pre-create all service clients needed for lifecycle management."""
@@ -559,7 +568,7 @@ class ModeManager(Node):
         Request startup of navigation nodes for the given mode.
         First configures all nodes in forward order, then activates them one by one.
         Args:
-            mode: The mode type - must be NavigationMode.NAV, NavigationMode.MAPPING, or NavigationMode.MAPFREE
+            mode: One of the NavigationMode values.
         Returns: (success: bool, message: str)
         """
 
@@ -883,6 +892,15 @@ class ModeManager(Node):
             if not self._mode_change_lock.acquire(blocking=False):
                 return
             try:
+                # The unlocked probes above can overlap an entire mode change.
+                # Never resurrect nodes from the captured stack after that
+                # transition has finished (e.g. slam_toolbox beside AMCL).
+                if self.current_mode != mode:
+                    self.get_logger().info(
+                        f"Navigation mode changed from {mode} to {self.current_mode} during watchdog probes; "
+                        "discarding stale repairs"
+                    )
+                    return
                 for node_name in needs_restore:
                     # Re-check under the lock: a mode operation may have just moved it.
                     wrong, target = restore_target(node_name)
@@ -1045,6 +1063,7 @@ class ModeManager(Node):
         Service callback to change the map for navigation mode
         request.map_name should contain the map filename (e.g., "home.yaml")
         """
+        release_warning = ""
         try:
             requested_map = request.map_name.strip()
 
@@ -1071,13 +1090,43 @@ class ModeManager(Node):
             self._switch_generation += 1
             my_generation = self._switch_generation
             previous_map = self.current_map
+            previous_mode = self.current_mode
+            admission_closed = False
+            speed_limit_armed = False
             try:
+                # A map replacement tears bt_navigator down just like a mode
+                # switch. Close the co-located router synchronously and wait
+                # for both handed-off and reserved goals to terminate before
+                # touching current_map or any lifecycle node. The web client's
+                # skill cancel is only a request acknowledgement and cannot be
+                # this server-side safety barrier.
+                if previous_mode == "navigation":
+                    limit_ok, limit_message = self._set_mapping_speed_limit(True)
+                    if not limit_ok:
+                        response.success = False
+                        response.message = f"Map switch aborted before transition: {limit_message}"
+                        self.get_logger().error(response.message)
+                        return response
+                    speed_limit_armed = True
+                    self.current_mode = "switching"
+                    admission_closed = True
+                    self.publish_status()
+                    cancelled_ok, cancel_message = self._cancel_active_navigation()
+                    if not cancelled_ok:
+                        response.success = False
+                        response.message = f"Map switch aborted: could not stop active navigation ({cancel_message})"
+                        self.current_mode = previous_mode
+                        self.publish_status()
+                        admission_closed = False
+                        self.get_logger().error(response.message)
+                        return response
+
                 # _efficient_map_switch loads self.current_map, so set it for
                 # the attempt but only persist (and keep) it on success.
                 self.current_map = requested_map
 
                 # If we're in navigation mode, use efficient map switch
-                if self.current_mode == "navigation":
+                if previous_mode == "navigation":
                     self.get_logger().info(f"Efficiently switching to new map: {requested_map}")
 
                     success, message = self._efficient_map_switch()
@@ -1105,7 +1154,22 @@ class ModeManager(Node):
                 self.current_map = previous_map
                 raise
             finally:
-                self._mode_change_lock.release()
+                try:
+                    if admission_closed:
+                        self.current_mode = previous_mode
+                        self.publish_status()
+                    if (
+                        speed_limit_armed
+                        and self.current_mode == previous_mode
+                        and previous_mode in {NavigationMode.NAV.value, NavigationMode.MAPFREE.value}
+                    ):
+                        limit_ok, limit_message = self._release_mapping_speed_limit_after_stable_mode()
+                        if not limit_ok:
+                            release_warning = f"; Slow drive envelope remains active ({limit_message})"
+                            if getattr(response, "message", ""):
+                                response.message += release_warning
+                finally:
+                    self._mode_change_lock.release()
 
             # Outside the lock: relocalization waits up to ~12 s on the grid
             # localizer and must not block concurrent mode/map service calls —
@@ -1114,8 +1178,12 @@ class ModeManager(Node):
                 self._trigger_relocalization(since=switch_started, generation=my_generation)
 
         except Exception as e:
-            response.success = False
-            response.message = f"Error changing map: {str(e)}"
+            if getattr(response, "success", None) is False and getattr(response, "message", ""):
+                response.message += f"; additional error while changing map: {str(e)}"
+            else:
+                response.success = False
+                response.message = f"Error changing map: {str(e)}"
+            response.message += release_warning
             self.get_logger().error(response.message)
 
         return response
@@ -1215,17 +1283,55 @@ class ModeManager(Node):
     def save_map_callback(self, request, response):
         """
         Service callback to save the current map with a new name
-        Only works when in mapping mode
+        Autonomous mapping is first quiesced into manual mapping so the saved
+        occupancy grid is not taken while exploration is still driving.
         request.map_name should contain the new map name (e.g., "my_new_map")
         request.overwrite: if true, allows overwriting existing maps
         """
+        # Reject malformed requests before stopping an autonomous run.
+        map_name = request.map_name.strip()
+        if not map_name or not map_name.replace("_", "").replace("-", "").isalnum():
+            response.success = False
+            response.message = (
+                f"Invalid map name '{map_name}'. Use alphanumeric characters, underscores, and hyphens only."
+            )
+            self.get_logger().error(response.message)
+            return response
+
+        # Do not hold _mode_change_lock while entering the existing mode-change
+        # path: it owns that lock itself and provides the full admission-close,
+        # goal-cancel, terminal-wait, and lifecycle transition barrier. A
+        # standalone save intentionally leaves the robot in manual mapping.
+        if self.current_mode == NavigationMode.AUTONOMOUS_MAPPING.value:
+            mode_request = ChangeNavigationMode.Request()
+            mode_request.mode = NavigationMode.MAPPING.value
+            mode_response = self.change_mode_callback(mode_request, ChangeNavigationMode.Response())
+            if not mode_response.success:
+                response.success = False
+                response.message = f"Cannot save map - failed to stop autonomous exploration: {mode_response.message}"
+                self.get_logger().error(response.message)
+                return response
+
+        # Saving reads current_mode/current_map and mutates the maps directory.
+        # Serialize it with mode switches and map changes so slam_toolbox cannot
+        # be torn down halfway through map_saver_cli or an overwrite cannot race
+        # another map operation. Keep the acquire non-blocking so executor
+        # threads never queue behind a long map save.
+        if not self._mode_change_lock.acquire(blocking=False):
+            response.success = False
+            response.message = "A mode or map operation is already in progress; try again"
+            self.get_logger().warning(response.message)
+            return response
         try:
             map_name = request.map_name.strip()
 
-            # Validate we're in mapping mode
-            if self.current_mode != "mapping":
+            # Revalidate under the lock. Autonomous mapping may have restarted
+            # after the optimistic quiesce returned but before this acquire;
+            # never delete or write map files unless manual mapping still owns
+            # the lifecycle stack.
+            if self.current_mode != NavigationMode.MAPPING.value:
                 response.success = False
-                response.message = f"Cannot save map - not in mapping mode. Current mode: {self.current_mode}"
+                response.message = f"Cannot save map - manual mapping is not active. Current mode: {self.current_mode}"
                 self.get_logger().error(response.message)
                 return response
 
@@ -1332,6 +1438,8 @@ class ModeManager(Node):
             response.success = False
             response.message = f"Error saving map: {str(e)}"
             self.get_logger().error(response.message)
+        finally:
+            self._mode_change_lock.release()
 
         return response
 
@@ -1356,7 +1464,7 @@ class ModeManager(Node):
     def _nav_status_callback(self, msg):
         self._nav_active_goals = sum(1 for s in msg.status_list if s.status in self._NAV_ACTIVE_STATUSES)
 
-    def _cancel_active_navigation(self, timeout_sec=5.0):
+    def _cancel_active_navigation(self, rpc_timeout_sec=5.0, terminal_timeout_sec=5.0):
         """Cancel all active NavigateToPose goals and wait for them to reach a
         terminal state. Returns (success, message).
 
@@ -1366,20 +1474,39 @@ class ModeManager(Node):
         or skill waiting forever. Never reports success while a goal is still
         live: skipping the cancel would strand it once Nav2 is torn down.
         """
-        if self._nav_active_goals == 0:
+        pending_goals = self._navigation_pending_goals()
+        if pending_goals is None:
+            return False, "Could not verify router goal reservations"
+        if self._nav_active_goals == 0 and pending_goals == 0:
             return True, "No active navigation goals"
 
-        deadline = time.time() + timeout_sec
         response = call_service(
-            self._service_clients, self.get_logger(), NAV_CANCEL_SERVICE, CancelGoal.Request(), timeout_sec
+            self._service_clients, self.get_logger(), NAV_CANCEL_SERVICE, CancelGoal.Request(), rpc_timeout_sec
         )
         if response is None:
             return False, "Navigation is active but its cancel service did not respond"
 
-        while self._nav_active_goals > 0 and time.time() < deadline:
+        # The cancel RPC has its own availability/response budget.  Start a
+        # fresh terminal-settle budget only after its acknowledgement arrives;
+        # otherwise a slow-but-successful RPC could consume the entire deadline
+        # and force lifecycle rollback before goals have a chance to terminate.
+        terminal_deadline = time.monotonic() + terminal_timeout_sec
+        while time.monotonic() < terminal_deadline:
+            pending_goals = self._navigation_pending_goals()
+            if pending_goals is None:
+                return False, "Could not verify router goal reservations"
+            if self._nav_active_goals == 0 and pending_goals == 0:
+                break
             time.sleep(0.05)
-        if self._nav_active_goals > 0:
-            return False, "Cancelled goals did not reach a terminal state in time"
+        pending_goals = self._navigation_pending_goals()
+        if pending_goals is None:
+            return False, "Could not verify router goal reservations"
+        if self._nav_active_goals > 0 or pending_goals > 0:
+            return (
+                False,
+                "Cancelled goals did not reach a terminal state in time "
+                f"(internal={self._nav_active_goals}, router={pending_goals})",
+            )
         return True, f"Cancelled {len(response.goals_canceling)} navigation goal(s)"
 
     def cancel_navigation_callback(self, request, response):
@@ -1387,6 +1514,47 @@ class ModeManager(Node):
         response.success, response.message = self._cancel_active_navigation()
         self.get_logger().info(f"/nav/cancel_navigation: {response.message}")
         return response
+
+    def _set_mapping_speed_limit(self, enabled: bool) -> tuple[bool, str]:
+        """Synchronously set the mux's authoritative final-drive envelope."""
+
+        state = "enable" if enabled else "disable"
+        try:
+            request = SetBool.Request()
+            request.data = enabled
+            result = call_service(
+                self._service_clients,
+                self.get_logger(),
+                MAPPING_SPEED_LIMIT_SERVICE,
+                request,
+                timeout_sec=2.0,
+            )
+        except Exception as e:
+            message = f"Could not {state} the mapping Slow envelope: {e}"
+            self.get_logger().error(message)
+            return False, message
+        if result is None:
+            message = f"Could not {state} the mapping Slow envelope: cmd_vel_mux did not acknowledge"
+            self.get_logger().error(message)
+            return False, message
+        if not result.success:
+            message = f"Could not {state} the mapping Slow envelope: {result.message}"
+            self.get_logger().error(message)
+            return False, message
+        return True, result.message
+
+    def _release_mapping_speed_limit_after_stable_mode(self) -> tuple[bool, str]:
+        """Release Slow only after navigation admission has a stable mode."""
+
+        stable_nonmapping_modes = {
+            NavigationMode.NAV.value,
+            NavigationMode.MAPFREE.value,
+        }
+        if self.current_mode not in stable_nonmapping_modes:
+            message = f"Refusing to release mapping Slow envelope while mode is '{self.current_mode}'"
+            self.get_logger().error(message)
+            return False, message
+        return self._set_mapping_speed_limit(False)
 
     def change_mode_callback(self, request, response, first_start=False):
         """
@@ -1407,15 +1575,17 @@ class ModeManager(Node):
 
         try:
             target_mode = request.mode.strip().lower()
-            if self.current_map is None:
-                target_mode = "mapping"
-
             # Validate mode
-            if target_mode not in ["navigation", "mapping", "mapfree"]:
+            if target_mode not in VALID_NAVIGATION_MODES:
                 response.success = False
-                response.message = f"Invalid mode '{target_mode}'. Use 'navigation', 'mapping', or 'mapfree'"
+                response.message = (
+                    f"Invalid mode '{target_mode}'. Use 'navigation', 'mapping', 'autonomous_mapping', or 'mapfree'"
+                )
                 self.get_logger().error(response.message)
                 return response
+
+            if self.current_map is None and target_mode not in MAPPING_MODES:
+                target_mode = "mapping"
 
             # Check if trying to switch to navigation but no maps are available
             if target_mode == "navigation" and not self.available_maps:
@@ -1428,8 +1598,18 @@ class ModeManager(Node):
 
             # Don't restart if already in the requested mode
             if self.current_mode == target_mode and not first_start:
-                response.success = True
-                response.message = f"Already in {target_mode} mode"
+                if target_mode in MAPPING_MODES:
+                    limit_ok, limit_message = self._set_mapping_speed_limit(True)
+                    response.success = limit_ok
+                    response.message = (
+                        f"Already in {target_mode} mode" if limit_ok else f"Mapping mode is not safe: {limit_message}"
+                    )
+                else:
+                    limit_ok, limit_message = self._release_mapping_speed_limit_after_stable_mode()
+                    response.success = True
+                    response.message = f"Already in {target_mode} mode"
+                    if not limit_ok:
+                        response.message += f"; Slow drive envelope remains active ({limit_message})"
                 self.get_logger().info(response.message)
                 return response
 
@@ -1443,21 +1623,42 @@ class ModeManager(Node):
                 self.current_map = fallback
                 self.save_last_map(fallback)
 
+            # Close router admission before checking/cancelling active goals. If
+            # cancellation ran first, a new goal could be admitted in the gap
+            # between its final status check and lifecycle teardown.
+            previous_mode = self.current_mode
+            limit_ok, limit_message = self._set_mapping_speed_limit(True)
+            if not limit_ok:
+                response.success = False
+                response.message = f"Mode switch aborted before transition: {limit_message}"
+                if first_start:
+                    # auto_start_mode already tore every lifecycle stack down.
+                    # Keep the persisted desired mode untouched, but publish
+                    # truthful runtime state so a later request does not take
+                    # the same-mode fast path without starting its stack.
+                    self.current_mode = "none"
+                    self.publish_status()
+                self.get_logger().error(response.message)
+                return response
+            self.current_mode = "switching"
+            self.publish_status()
+
             # Cancel active nav goals before tearing down their lifecycle nodes.
             # If cancellation can't be confirmed (service unreachable, or goals
-            # not terminal in time), abort rather than tear Nav2 down under a
-            # pending goal — that would strand the router/skill forever. Nav is
-            # left running; the caller can Stop explicitly and retry.
+            # not terminal in time), restore the still-running previous mode so
+            # callers can Stop explicitly and retry.
             cancelled_ok, cancel_message = self._cancel_active_navigation()
             if not cancelled_ok:
                 response.success = False
                 response.message = f"Mode switch aborted: could not stop active navigation ({cancel_message})"
+                self.current_mode = previous_mode
+                self.publish_status()
+                if previous_mode in {NavigationMode.NAV.value, NavigationMode.MAPFREE.value}:
+                    limit_ok, limit_message = self._release_mapping_speed_limit_after_stable_mode()
+                    if not limit_ok:
+                        response.message += f"; Slow drive envelope remains active ({limit_message})"
                 self.get_logger().error(response.message)
                 return response
-
-            # Set mode to switching
-            self.current_mode = "switching"
-            self.publish_status()  # Immediately publish the change
 
             # For mapfree, launch local-only Nav2 (planner, controller, costmaps) without map/AMCL
             if target_mode == "mapfree":
@@ -1474,6 +1675,11 @@ class ModeManager(Node):
                     response.message = f"Failed to start mapfree local navigation: {message}"
                     self.current_mode = "none"
 
+                self.publish_status()
+                if success:
+                    limit_ok, limit_message = self._release_mapping_speed_limit_after_stable_mode()
+                    if not limit_ok:
+                        response.message += f"; Slow drive envelope remains active ({limit_message})"
                 self.get_logger().info(response.message)
                 return response
 
@@ -1481,6 +1687,7 @@ class ModeManager(Node):
             mode_enum_map = {
                 "navigation": NavigationMode.NAV,
                 "mapping": NavigationMode.MAPPING,
+                "autonomous_mapping": NavigationMode.AUTONOMOUS_MAPPING,
             }
             target_mode_enum = mode_enum_map.get(target_mode)
 
@@ -1499,21 +1706,43 @@ class ModeManager(Node):
                         self.get_logger().info("BasicNavigator initialized for navigation mode")
                     except Exception as e:
                         self.get_logger().warning(f"Could not initialize BasicNavigator: {e}")
-                elif target_mode == "mapping":
-                    # Every slam_toolbox activation is a new coordinate frame;
-                    # stamp it before the mode flips so no subscriber pairs
-                    # mode "mapping" with a previous session's stamp.
+                elif starts_new_mapping_session(previous_mode, target_mode, first_start=first_start):
+                    # Every slam_toolbox activation is a new coordinate frame.
+                    # Manual <-> autonomous mapping keeps the same live SLAM
+                    # node, so that handoff must retain the session identity
+                    # and its staged spatial memories through save/finalize.
                     self._mapping_session_started = time.time()
                     self.mapping_session_publisher.publish(
                         String(data=json.dumps({"started": self._mapping_session_started}))
                     )
                 self.current_mode = target_mode
                 self.save_last_mode(target_mode)
+                self.publish_status()
+                if target_mode == NavigationMode.NAV.value:
+                    limit_ok, limit_message = self._release_mapping_speed_limit_after_stable_mode()
+                    if not limit_ok:
+                        response.message += f"; Slow drive envelope remains active ({limit_message})"
                 self.get_logger().info(response.message)
             else:
                 response.success = False
                 response.message = f"Failed to start {target_mode} mode: {message}"
-                self.current_mode = "none"
+                if not first_start and previous_mode in MAPPING_MODES and target_mode in MAPPING_MODES:
+                    # Both mapping stacks share slam_toolbox. A partial
+                    # expansion or contraction can fail after changing only
+                    # the autonomous Nav2 nodes while SLAM remains in the same
+                    # coordinate frame. Restore the previous stack and retain
+                    # that frame's session identity so a retry cannot wipe
+                    # staged memories.
+                    rollback_ok, rollback_message = self.request_mode_startup(NavigationMode(previous_mode))
+                    if rollback_ok:
+                        self.current_mode = previous_mode
+                        response.message += f"; restored {previous_mode} mode"
+                    else:
+                        self.current_mode = "none"
+                        response.message += f"; failed to restore {previous_mode} mode: {rollback_message}"
+                else:
+                    self.current_mode = "none"
+                self.publish_status()
                 self.get_logger().error(response.message)
 
         except Exception as e:
@@ -1521,6 +1750,7 @@ class ModeManager(Node):
             response.message = f"Error switching modes: {str(e)}"
             self.get_logger().error(response.message)
             self.current_mode = "none"
+            self.publish_status()
         finally:
             self._mode_change_lock.release()
 
@@ -1546,6 +1776,8 @@ def main(args=None):
     from mars_nav.navigate_to_pose_router import NavigateToPoseRouter
 
     navigate_to_pose_router = NavigateToPoseRouter()
+    mode_manager.set_navigation_mode_sink(navigate_to_pose_router.set_current_mode)
+    mode_manager.set_navigation_pending_goals_getter(navigate_to_pose_router.get_pending_goal_count)
 
     try:
         executor = MultiThreadedExecutor(num_threads=4)

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -113,6 +113,12 @@ class ModeManager(Node):
             self.cancel_navigation_callback,
             callback_group=self._internal_callbacks_group,
         )
+        self.reset_mapping_service = self.create_service(
+            Trigger,
+            "/nav/reset_mapping",
+            self.reset_mapping_callback,
+            callback_group=self._internal_callbacks_group,
+        )
 
         # Service to change maps in navigation mode. Same reentrant group as
         # the mode service: both drive lifecycle transitions on the same nodes
@@ -562,6 +568,82 @@ class ModeManager(Node):
 
             except Exception as e:
                 self.get_logger().debug(f"Error shutting down {node_name}: {e}")
+
+    def reset_mapping_callback(self, _request, response):
+        """Discard the unsaved SLAM graph and restart the current mapping stack."""
+
+        if not self._mode_change_lock.acquire(blocking=False):
+            response.success = False
+            response.message = "Navigation mode change already in progress"
+            return response
+
+        previous_mode = self.current_mode
+        try:
+            if previous_mode not in MAPPING_MODES:
+                response.success = False
+                response.message = "A map can only be reset while mapping is active"
+                return response
+
+            limit_ok, limit_message = self._set_mapping_speed_limit(True)
+            if not limit_ok:
+                response.success = False
+                response.message = f"Map reset aborted before transition: {limit_message}"
+                return response
+
+            self.current_mode = "switching"
+            self.publish_status()
+            cancelled_ok, cancel_message = self._cancel_active_navigation()
+            if not cancelled_ok:
+                self.current_mode = previous_mode
+                self.publish_status()
+                response.success = False
+                response.message = f"Map reset aborted: could not stop active navigation ({cancel_message})"
+                return response
+
+            # A same-mode startup deliberately preserves slam_toolbox.  Reset
+            # instead tears the complete mapping stack down, with SLAM last,
+            # so its next configure creates a genuinely empty pose graph.
+            for node_name in reversed(modes_nodes[previous_mode]):
+                target_state = (
+                    State.PRIMARY_STATE_INACTIVE
+                    if node_name in skip_cleanup_nodes
+                    else State.PRIMARY_STATE_UNCONFIGURED
+                )
+                if not transition_node(self._service_clients, self.get_logger(), node_name, target_state):
+                    rollback_ok, rollback_message = self.request_mode_startup(NavigationMode(previous_mode))
+                    self.current_mode = previous_mode if rollback_ok else "none"
+                    self.publish_status()
+                    response.success = False
+                    response.message = f"Map reset failed while stopping {node_name}"
+                    if not rollback_ok:
+                        response.message += f"; failed to restore mapping: {rollback_message}"
+                    return response
+
+            success, message = self.request_mode_startup(NavigationMode(previous_mode))
+            if not success:
+                self.current_mode = "none"
+                self.publish_status()
+                response.success = False
+                response.message = f"Map reset failed while restarting mapping: {message}"
+                return response
+
+            self._mapping_session_started = time.time()
+            self.mapping_session_publisher.publish(String(data=json.dumps({"started": self._mapping_session_started})))
+            self.current_mode = previous_mode
+            self.save_last_mode(previous_mode)
+            self.publish_status()
+            response.success = True
+            response.message = "Discarded the old map and started a fresh SLAM session"
+            return response
+        except Exception as exc:
+            self.current_mode = "none"
+            self.publish_status()
+            response.success = False
+            response.message = f"Error resetting map: {exc}"
+            self.get_logger().error(response.message)
+            return response
+        finally:
+            self._mode_change_lock.release()
 
     def request_mode_startup(self, mode: NavigationMode) -> tuple[bool, str]:
         """

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/navigate_to_pose_router.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/navigate_to_pose_router.py
@@ -9,12 +9,16 @@ It listens on /navigate_to_pose and forwards all requests to /internal_navigate_
 This allows for interception, logging, or future middleware functionality.
 """
 
+import threading
+
 from nav2_msgs.action import NavigateToPose
 from rclpy.action import ActionClient, ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
 from std_msgs.msg import String
+
+from mars_nav.navigation_policy import resolve_navigation_route
 
 
 class NavigateToPoseRouter(Node):
@@ -29,7 +33,18 @@ class NavigateToPoseRouter(Node):
         self._goal_handle_map = {}  # Maps server goal_id (bytes) to client goal handle
 
         # Track current navigation mode
-        self._current_mode = "mapfree"  # Default mode
+        # Fail closed until mode_manager's transient-local status arrives.
+        self._current_mode = None
+        # Once the co-located ModeManager supplies a synchronous update, it is
+        # the authoritative mode source.  Older DDS samples may already be
+        # queued and must never overwrite that update (especially `switching`,
+        # which closes admission before lifecycle teardown).
+        self._has_authoritative_mode_source = False
+        # Goal admission and mode closure must be one atomic decision.  An
+        # accepted goal holds a reservation until its outer execute callback
+        # reaches a terminal path, including the internal handoff window.
+        self._admission_lock = threading.Lock()
+        self._pending_goal_reservations = 0
 
         # QoS profile for persistent/latched topic
         latched_qos = QoSProfile(
@@ -44,17 +59,6 @@ class NavigateToPoseRouter(Node):
 
         # Publisher for current goal checker selection
         self._current_goal_checker_pub = self.create_publisher(String, "/nav/current_goal_checker", latched_qos)
-
-        # Publish initial values at startup (mapfree mode)
-        initial_planner = String()
-        initial_planner.data = "mapfree"
-        self._current_planner_pub.publish(initial_planner)
-
-        initial_goal_checker = String()
-        initial_goal_checker.data = "goal_checker_precise"
-        self._current_goal_checker_pub.publish(initial_goal_checker)
-
-        self.get_logger().info("Published initial planner: mapfree, goal_checker: goal_checker_precise")
 
         # Create action client to forward requests to internal action
         self._action_client = ActionClient(
@@ -77,13 +81,67 @@ class NavigateToPoseRouter(Node):
         self.get_logger().info("  Forwarding to: /internal_navigate_to_pose")
 
     def _mode_callback(self, msg):
-        """Track the current navigation mode."""
-        self._current_mode = msg.data
-        self.get_logger().debug(f"Current mode updated: {self._current_mode}")
+        """Track DDS mode status until the in-process manager takes over."""
+        self.set_current_mode(msg.data, authoritative=False)
+
+    def set_current_mode(self, mode, *, authoritative=True):
+        """Synchronously update admission state from the in-process manager.
+
+        The DDS subscription still serves late/cross-process updates, but mode
+        teardown must not wait for asynchronous topic delivery to close goal
+        admission.
+        """
+        next_mode = mode.strip().lower()
+        with self._admission_lock:
+            if not authoritative and self._has_authoritative_mode_source:
+                self.get_logger().debug(f"Ignoring DDS mode update {next_mode!r}; in-process source is authoritative")
+                return
+            if authoritative:
+                self._has_authoritative_mode_source = True
+            if next_mode == self._current_mode:
+                return
+            self._current_mode = next_mode
+            self.get_logger().debug(f"Current mode updated: {self._current_mode}")
+            route = resolve_navigation_route(self._current_mode)
+            if route is not None:
+                self._publish_route(route)
+
+    def get_pending_goal_count(self):
+        """Return accepted outer goals that have not reached a terminal path."""
+        with self._admission_lock:
+            return self._pending_goal_reservations
+
+    def _release_goal_reservation(self):
+        with self._admission_lock:
+            if self._pending_goal_reservations == 0:
+                self.get_logger().error("Router goal reservation underflow")
+                return
+            self._pending_goal_reservations -= 1
+
+    def _publish_route(self, route):
+        planner_msg = String()
+        planner_msg.data = route.planner
+        self._current_planner_pub.publish(planner_msg)
+
+        goal_checker_msg = String()
+        goal_checker_msg.data = route.goal_checker
+        self._current_goal_checker_pub.publish(goal_checker_msg)
+        self.get_logger().info(f"Published planner: {route.planner}, goal_checker: {route.goal_checker}")
 
     def _goal_callback(self, goal_request):
         """Accept or reject incoming goal requests."""
         self.get_logger().info("Received navigate_to_pose goal request")
+        with self._admission_lock:
+            admitted_mode = self._current_mode
+            route = resolve_navigation_route(admitted_mode, goal_request.behavior_tree)
+            if route is not None:
+                self._pending_goal_reservations += 1
+        if route is None:
+            requested = goal_request.behavior_tree or "<current mode>"
+            self.get_logger().warn(
+                f"Navigation goal rejected: selector {requested!r} is unavailable in mode {admitted_mode!r}"
+            )
+            return GoalResponse.REJECT
         return GoalResponse.ACCEPT
 
     def _cancel_callback(self, goal_handle):
@@ -120,9 +178,66 @@ class NavigateToPoseRouter(Node):
 
         client_goal_handle.cancel_goal_async().add_done_callback(_on_cancel_response)
 
+    async def _cancel_internal_and_wait_for_terminal(self, client_goal_handle):
+        """Cancel a handed-off goal and wait until it can no longer drive.
+
+        Register the result request before sending the cancel so lifecycle
+        teardown cannot make us miss a fast terminal transition.  Humble's
+        action futures do not expose a timeout argument, so this deliberately
+        treats the terminal result as a safety barrier instead of returning
+        while the internal goal may still be active.
+        """
+        result_future = client_goal_handle.get_result_async()
+        cancel_accepted = False
+
+        try:
+            cancel_response = await client_goal_handle.cancel_goal_async()
+            cancel_accepted = bool(cancel_response.goals_canceling)
+            if cancel_accepted:
+                self.get_logger().info("Internal action accepted the handoff cancel request")
+            else:
+                self.get_logger().error("Internal action rejected the handoff cancel request")
+        except Exception as e:
+            self.get_logger().error(f"Handoff cancel request failed: {e}")
+
+        try:
+            result_response = await result_future
+        except Exception as e:
+            self.get_logger().error(f"Failed waiting for the internal goal to terminate after handoff cancel: {e}")
+            return cancel_accepted, None
+
+        if result_response.status == 5:  # CANCELED
+            self.get_logger().info("Internal goal reached CANCELED after handoff cancel")
+        else:
+            self.get_logger().error(
+                f"Internal goal reached terminal status {result_response.status} instead of CANCELED "
+                "after handoff cancel"
+            )
+        return cancel_accepted, result_response
+
     async def _execute_callback(self, goal_handle):
+        """Execute one accepted goal while holding its admission reservation."""
+        try:
+            return await self._execute_reserved_goal(goal_handle)
+        finally:
+            self._release_goal_reservation()
+
+    async def _execute_reserved_goal(self, goal_handle):
         """Execute callback that forwards the goal to internal action."""
         self.get_logger().info("Executing navigate_to_pose goal...")
+
+        # Re-check after goal acceptance: a mode switch can race the action
+        # handoff, and invalid modes must fail before waiting on a server that is
+        # intentionally down.
+        admitted_mode = self._current_mode
+        admitted_route = resolve_navigation_route(admitted_mode, goal_handle.request.behavior_tree)
+        if admitted_route is None:
+            requested = goal_handle.request.behavior_tree or "<current mode>"
+            self.get_logger().warn(
+                f"Navigation rejected: selector {requested!r} is unavailable in mode {self._current_mode!r}"
+            )
+            goal_handle.abort()
+            return NavigateToPose.Result()
 
         # Wait for the internal action server to be available
         if not self._action_client.wait_for_server(timeout_sec=5.0):
@@ -136,38 +251,21 @@ class NavigateToPoseRouter(Node):
         goal_msg.pose = goal_handle.request.pose
         # Leave behavior_tree empty, publish frame to /nav/current_frame instead
 
-        # Determine the frame to use
-        requested_frame = goal_handle.request.behavior_tree
-        if not requested_frame:
-            # If no frame specified, use the current mode
-            requested_frame = self._current_mode
-
-        # If in mapping mode, reject the navigation request
-        if requested_frame == "mapping":
-            self.get_logger().warn("Navigation rejected: currently in mapping mode")
+        # Resolve the selector against the lifecycle mode. Unknown values and
+        # modes whose planner is inactive reject rather than silently falling
+        # through to mapfree.
+        # The lifecycle mode may have changed while wait_for_server blocked.
+        admitted_mode = self._current_mode
+        admitted_route = resolve_navigation_route(admitted_mode, goal_handle.request.behavior_tree)
+        if admitted_route is None:
+            requested = goal_handle.request.behavior_tree or "<current mode>"
+            self.get_logger().warn(
+                f"Navigation rejected: selector {requested!r} is unavailable in mode {self._current_mode!r}"
+            )
             goal_handle.abort()
             result = NavigateToPose.Result()
             return result
-
-        # Determine planner and goal checker based on frame
-        if requested_frame == "navigation":
-            planner = "navigation"
-            goal_checker = "goal_checker"
-        else:  # mapfree or any other
-            planner = "mapfree"
-            goal_checker = "goal_checker_precise"
-
-        # Publish the planner selection
-        planner_msg = String()
-        planner_msg.data = planner
-        self._current_planner_pub.publish(planner_msg)
-
-        # Publish the goal checker selection
-        goal_checker_msg = String()
-        goal_checker_msg.data = goal_checker
-        self._current_goal_checker_pub.publish(goal_checker_msg)
-
-        self.get_logger().info(f"Published planner: {planner}, goal_checker: {goal_checker}")
+        self._publish_route(admitted_route)
 
         self.get_logger().info(
             f"Forwarding goal to /nav/navigate_to_pose: "
@@ -191,6 +289,29 @@ class NavigateToPoseRouter(Node):
             return result
 
         self.get_logger().info("Internal goal accepted")
+
+        # A mode switch may have closed admission while the internal action
+        # request was in flight. Cancel that just-accepted goal immediately;
+        # otherwise it can start driving after mode_manager's cancel sweep and
+        # be stranded when the old lifecycle stack is torn down.
+        current_route = resolve_navigation_route(self._current_mode, goal_handle.request.behavior_tree)
+        if self._current_mode != admitted_mode or current_route != admitted_route:
+            self.get_logger().warn(
+                f"Navigation mode changed during goal handoff ({admitted_mode!r} -> {self._current_mode!r}); "
+                "canceling the internal goal"
+            )
+            cancel_accepted, result_response = await self._cancel_internal_and_wait_for_terminal(client_goal_handle)
+            internal_canceled = result_response is not None and result_response.status == 5
+            if not cancel_accepted:
+                self.get_logger().error("Handoff cancel was not acknowledged by the internal action server")
+            if not internal_canceled:
+                self.get_logger().error("Handoff failed to confirm that the internal goal was canceled")
+
+            if internal_canceled and goal_handle.is_cancel_requested:
+                goal_handle.canceled()
+            else:
+                goal_handle.abort()
+            return result_response.result if result_response is not None else NavigateToPose.Result()
 
         # Store mapping for cancel handling
         goal_id = bytes(goal_handle.goal_id.uuid)

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/navigation_policy.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/navigation_policy.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Pure navigation-mode policy shared by the lifecycle manager and router.
+
+Keep this module ROS-free.  Besides making the safety rules explicit in one
+place, that lets the host-only test job exercise mode routing without a ROS
+installation.
+"""
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+
+class NavigationMode(Enum):
+    NAV = "navigation"
+    MAPPING = "mapping"
+    AUTONOMOUS_MAPPING = "autonomous_mapping"
+    MAPFREE = "mapfree"
+
+
+VALID_NAVIGATION_MODES = frozenset(mode.value for mode in NavigationMode)
+MAPPING_MODES = frozenset(
+    {
+        NavigationMode.MAPPING.value,
+        NavigationMode.AUTONOMOUS_MAPPING.value,
+    }
+)
+
+# Mapping is intentionally a slow-driving activity.  The final envelope starts
+# from the lower of the robot's manual and Nav2 limits on each axis, then
+# applies the fixed Slow preset. Launch-time motion_control/nav overrides are
+# passed to cmd_vel_mux. Keep the ratio aligned with
+# mars_control::drive::SPEED_MODES.
+DEFAULT_MANUAL_MAX_LINEAR_MPS = 0.4
+DEFAULT_MANUAL_MAX_ANGULAR_RPS = 1.0
+DEFAULT_NAV_MAX_LINEAR_MPS = 0.45
+DEFAULT_NAV_MAX_ANGULAR_RPS = 0.6
+MAPPING_SLOW_SCALE = 0.35
+MAPPING_SPEED_LIMIT_SERVICE = "/nav/set_mapping_speed_limit"
+
+# ``switching`` is published before active navigation is cancelled.  It must
+# remain limited so a mode exit cannot briefly speed up a still-settling goal.
+# Unknown/startup state also fails slow until a stable non-mapping mode arrives.
+_UNLIMITED_DRIVE_MODES = frozenset(
+    {
+        NavigationMode.NAV.value,
+        NavigationMode.MAPFREE.value,
+    }
+)
+
+
+def mapping_speed_limit_active(current_mode: str | None) -> bool:
+    """Whether final base commands must remain inside the Slow envelope."""
+
+    mode = (current_mode or "").strip().lower()
+    return mode not in _UNLIMITED_DRIVE_MODES
+
+
+def starts_new_mapping_session(previous_mode: str | None, target_mode: str, *, first_start: bool = False) -> bool:
+    """Whether starting ``target_mode`` creates a new live SLAM frame.
+
+    Manual and autonomous mapping share the same active slam_toolbox when
+    handing off between each other. A cold start or entry from a non-mapping
+    mode activates SLAM and therefore starts a new coordinate-frame session.
+    """
+
+    return target_mode in MAPPING_MODES and (first_start or previous_mode not in MAPPING_MODES)
+
+
+def mapping_slow_limits(
+    manual_max_linear_mps: float,
+    manual_max_angular_rps: float,
+    nav_max_linear_mps: float,
+    nav_max_angular_rps: float,
+) -> tuple[float, float]:
+    """Final mapping limits shared by manual and autonomous drive sources."""
+
+    limits = (
+        manual_max_linear_mps,
+        manual_max_angular_rps,
+        nav_max_linear_mps,
+        nav_max_angular_rps,
+        MAPPING_SLOW_SCALE,
+    )
+    if not all(math.isfinite(value) and value > 0.0 for value in limits):
+        return 0.0, 0.0
+    return (
+        min(manual_max_linear_mps, nav_max_linear_mps) * MAPPING_SLOW_SCALE,
+        min(manual_max_angular_rps, nav_max_angular_rps) * MAPPING_SLOW_SCALE,
+    )
+
+
+def mapping_speed_factor(
+    speed_limit_active: bool,
+    linear_x: float,
+    angular_z: float,
+    max_linear_mps: float,
+    max_angular_rps: float,
+) -> float:
+    """Uniform Twist scale that fits the mapping Slow envelope.
+
+    Scaling both axes by one factor preserves curvature.  An absolute envelope
+    avoids applying Slow twice to teleop commands that mars_app already shaped
+    at the Slow preset, while still constraining Fast/Mad, skills, Nav2, and
+    recovery commands at the final mux.
+    """
+
+    if not speed_limit_active:
+        return 1.0
+    values = (linear_x, angular_z, max_linear_mps, max_angular_rps)
+    if not all(math.isfinite(value) for value in values) or max_linear_mps <= 0.0 or max_angular_rps <= 0.0:
+        return 0.0
+    return min(
+        1.0,
+        max_linear_mps / abs(linear_x) if linear_x else 1.0,
+        max_angular_rps / abs(angular_z) if angular_z else 1.0,
+    )
+
+
+# Nodes that should only be configured (not activated) in specific modes.
+# The shared BT constructs both planner action nodes even though its Switch
+# ticks only one.  A configured planner exposes the action endpoint without
+# running its costmap or accepting planning goals.
+configure_only_nodes = {
+    NavigationMode.AUTONOMOUS_MAPPING.value: {"mapfree/planner_server"},
+    NavigationMode.MAPFREE.value: {"navigation/planner_server"},
+}
+
+# Nodes that should only be deactivated (not cleaned up/unconfigured) to avoid
+# the observed Zenoh/Nav2 teardown crashes.
+skip_cleanup_nodes = {
+    "controller_server",
+    "mapfree/planner_server",
+    "navigation/planner_server",
+}
+
+# Ordered lifecycle targets. Autonomous mapping excludes the saved-map
+# localization stack and every competing /map or map->odom owner: map_server,
+# AMCL, grid_localizer and the mapfree null-map node. slam_toolbox is activated
+# first so its live map and transform exist before the navigation costmap comes
+# up; bt_navigator is last so all action servers it binds are already present.
+modes_nodes = {
+    NavigationMode.MAPPING.value: ["slam_toolbox"],
+    NavigationMode.AUTONOMOUS_MAPPING.value: [
+        "slam_toolbox",
+        "mapfree/planner_server",
+        "navigation/planner_server",
+        "controller_server",
+        "behavior_server",
+        "velocity_smoother",
+        "bt_navigator",
+    ],
+    NavigationMode.MAPFREE.value: [
+        "null_map_node",
+        "navigation/planner_server",
+        "mapfree/planner_server",
+        "controller_server",
+        "bt_navigator",
+        "behavior_server",
+        "velocity_smoother",
+    ],
+    NavigationMode.NAV.value: [
+        "navigation_map_server",
+        "navigation_grid_localizer",
+        "navigation_amcl",
+        "mapfree/planner_server",
+        "navigation/planner_server",
+        "controller_server",
+        "bt_navigator",
+        "behavior_server",
+        "velocity_smoother",
+    ],
+}
+
+
+@dataclass(frozen=True)
+class NavigationRoute:
+    planner: str
+    goal_checker: str
+
+
+_ROUTABLE_SELECTORS = {
+    NavigationMode.NAV.value: frozenset({"navigation", "mapfree"}),
+    NavigationMode.AUTONOMOUS_MAPPING.value: frozenset({"navigation", "autonomous_mapping"}),
+    NavigationMode.MAPFREE.value: frozenset({"mapfree"}),
+}
+
+
+def resolve_navigation_route(current_mode: str | None, requested_selector: str | None = None) -> NavigationRoute | None:
+    """Resolve a planner selector, failing closed when its server is inactive.
+
+    ``NavigateToPose.behavior_tree`` is currently used as a lightweight
+    planner selector by the root router.  Unknown strings (including a real BT
+    XML path), switching/none, and manual mapping all reject instead of falling
+    through to mapfree.
+    """
+
+    mode = (current_mode or "").strip().lower()
+    allowed = _ROUTABLE_SELECTORS.get(mode)
+    if allowed is None:
+        return None
+
+    selector = (requested_selector or "").strip().lower()
+    if not selector:
+        selector = mode
+    if selector not in allowed:
+        return None
+    if selector == NavigationMode.AUTONOMOUS_MAPPING.value:
+        selector = "navigation"
+
+    if selector == "navigation":
+        return NavigationRoute(planner="navigation", goal_checker="goal_checker")
+    return NavigationRoute(planner="mapfree", goal_checker="goal_checker_precise")

--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -121,7 +121,7 @@ echo "Started arm IK..."
 
 # === Window 6: Vision Navigation Inference Client ===
 tmux new-window -t "$SESSION_NAME" -n vision-nav
-tmux send-keys -t "${TMUX_TARGET_PREFIX}:vision-nav" "ros2 launch innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel" C-m
+tmux send-keys -t "${TMUX_TARGET_PREFIX}:vision-nav" "ros2 launch innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel_scaled" C-m
 echo "Started vision navigation inference client..."
 settle_after_launch
 

--- a/tests/test_manual_drive_routing.py
+++ b/tests/test_manual_drive_routing.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Host-safe contracts for manual base-command routing."""
+
+import ast
+import sys
+from pathlib import Path
+from types import MethodType, ModuleType, SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "ros2_ws/src/mars_bot/mars_control"))
+sys.path.insert(0, str(_REPO_ROOT / "ros2_ws/src/mars_bot/mars_nav"))
+sys.path.insert(0, str(_REPO_ROOT / "ros2_ws/src/brain/brain_client"))
+sys.path.insert(0, str(_REPO_ROOT / "ros2_ws/src/brain/brain_client/test"))
+
+from ros_skill_test_stubs import install_if_ros_is_missing  # noqa: E402
+
+install_if_ros_is_missing()
+
+# The shared host ROS shim predates cmd_vel_mux's authoritative SetBool safety
+# service. Keep this test importable in either order without changing the brain
+# test-support package from this mars_nav-focused change.
+try:
+    from std_srvs.srv import SetBool as _SetBool  # noqa: F401
+except (ImportError, ModuleNotFoundError):
+    std_srvs_module = sys.modules.setdefault("std_srvs", ModuleType("std_srvs"))
+    std_srvs_module.__path__ = []
+    std_srvs_srv_module = ModuleType("std_srvs.srv")
+
+    class _SetBool:
+        class Request:
+            def __init__(self):
+                self.data = False
+
+        class Response:
+            def __init__(self):
+                self.success = False
+                self.message = ""
+
+    class _Trigger:
+        class Request:
+            pass
+
+        class Response:
+            def __init__(self):
+                self.success = False
+                self.message = ""
+
+    std_srvs_srv_module.SetBool = _SetBool
+    std_srvs_srv_module.Trigger = _Trigger
+    std_srvs_module.srv = std_srvs_srv_module
+    sys.modules["std_srvs.srv"] = std_srvs_srv_module
+
+from geometry_msgs.msg import Twist  # noqa: E402
+
+from mars_control.teleop_publish_gate import TeleopPublishGate  # noqa: E402
+from mars_nav.cmd_vel_mux import SOURCES, CmdVelMux  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "ros2_ws/src/mars_bot/mars_control/mars_control/joystick.py",
+        "ros2_ws/src/mars_bot/mars_control/mars_control/keyboard.py",
+    ],
+)
+def test_manual_controller_twist_publishers_use_teleop_mux_input(relative_path):
+    tree = ast.parse((_REPO_ROOT / relative_path).read_text())
+    topics = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "create_publisher" or len(node.args) < 2:
+            continue
+        message_type, topic = node.args[:2]
+        if isinstance(message_type, ast.Name) and message_type.id == "Twist":
+            assert isinstance(topic, ast.Constant) and isinstance(topic.value, str)
+            topics.append(topic.value)
+
+    assert topics == ["/cmd_vel_teleop"]
+    assert "/cmd_vel" not in topics
+
+
+@pytest.mark.parametrize(
+    "launch_name",
+    ["brain_client.launch.py", "brain_client.sim.launch.py"],
+)
+def test_brain_and_code_skills_use_the_skills_priority_mux_input(launch_name):
+    source = (_REPO_ROOT / "ros2_ws/src/brain/brain_client/launch" / launch_name).read_text()
+
+    assert 'default_value="/cmd_vel_skills"' in source
+    # The one launch argument must feed both brain_client_node and the
+    # skills_action_server. A simulator-only direct /cmd_vel writer would
+    # bypass the mapping Slow envelope and priority arbitration.
+    assert source.count('"cmd_vel_topic": LaunchConfiguration("cmd_vel_topic")') == 2
+
+
+def test_brain_motion_defaults_and_gaze_cannot_bypass_the_mux():
+    brain_root = _REPO_ROOT / "ros2_ws/src/brain/brain_client/brain_client"
+    config_source = (brain_root / "core/config.py").read_text()
+    server_source = (brain_root / "nodes/skills_server.py").read_text()
+    mobility_source = (brain_root / "robot/mobility.py").read_text()
+    gaze_source = (brain_root / "perception/gaze.py").read_text()
+    camera_source = (brain_root / "perception/camera.py").read_text()
+
+    assert '"cmd_vel_topic": "/cmd_vel_skills"' in config_source
+    assert '"motion_observation_topic": "/cmd_vel"' in config_source
+    assert 'declare_parameter("cmd_vel_topic", "/cmd_vel_skills")' in server_source
+    assert 'cmd_vel_topic: str = "/cmd_vel_skills"' in mobility_source
+    assert 'get_parameter("cmd_vel_topic")' in gaze_source
+    assert 'Mobility(node, node.get_logger(), "/cmd_vel")' not in gaze_source
+    # This is deliberately not the publish topic: camera motion suppression
+    # must also see manual teleop and Nav2 at the final base output.
+    assert "_config.motion_observation_topic" in camera_source
+    assert "_config.cmd_vel_topic, self._on_cmd_vel" not in camera_source
+
+
+def test_sim_vision_navigation_enters_the_nav_mux_path():
+    script = (_REPO_ROOT / "scripts/launch_sim_in_tmux.zsh").read_text()
+    protocol = (_REPO_ROOT / "ros2_ws/src/cloud/innate_uninavid/PROTOCOL.md").read_text()
+
+    assert "innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel_scaled" in script
+    assert 'innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel"' not in script
+    assert "cmd_vel_topic:=/cmd_vel" not in protocol
+
+
+def test_teleop_source_streams_motion_then_publishes_one_settling_zero():
+    gate = TeleopPublishGate()
+
+    assert gate.next_command(0.0, 0.0) is None
+    assert gate.next_command(0.2, -0.1) == (0.2, -0.1)
+    assert gate.next_command(0.1, 0.0) == (0.1, 0.0)
+    assert gate.next_command(0.0, 0.0) == (0.0, 0.0)
+    assert gate.next_command(0.0, 0.0) is None
+
+
+def test_disabling_an_active_teleop_source_releases_the_mux_once():
+    gate = TeleopPublishGate()
+
+    assert gate.next_command(0.2, 0.0) == (0.2, 0.0)
+    assert gate.next_command(0.2, 0.0, enabled=False) == (0.0, 0.0)
+    assert gate.next_command(0.2, 0.0, enabled=False) is None
+
+
+@pytest.mark.parametrize(("priority", "source"), list(enumerate(name for name, _topic, _window in SOURCES)))
+def test_every_mux_source_is_capped_at_the_slow_envelope_while_mapping(priority, source):
+    published = []
+    mux = SimpleNamespace(
+        _mapping_limit_enabled=True,
+        _mapping_max_linear=0.14,
+        _mapping_max_angular=0.21,
+        _last_rx={name: 0.0 for name, _topic, _window in SOURCES},
+        _fresh_source_above=lambda _priority, _now: None,
+        _pub=SimpleNamespace(publish=published.append),
+        _forwarding=False,
+    )
+    mux._apply_mapping_speed_limit = MethodType(CmdVelMux._apply_mapping_speed_limit, mux)
+    command = Twist()
+    command.linear.x = -0.4
+    command.linear.y = 100.0
+    command.linear.z = -100.0
+    command.angular.x = 100.0
+    command.angular.y = -100.0
+    command.angular.z = 0.6
+
+    CmdVelMux._on_twist(mux, priority, source, command)
+
+    assert len(published) == 1
+    assert published[0].linear.x == pytest.approx(-0.14)
+    assert published[0].angular.z == pytest.approx(0.21)
+    assert (published[0].linear.y, published[0].linear.z) == (0.0, 0.0)
+    assert (published[0].angular.x, published[0].angular.y) == (0.0, 0.0)
+    assert mux._forwarding is True
+
+
+def test_mux_returns_the_original_command_only_when_the_envelope_is_disabled():
+    mux = SimpleNamespace(_mapping_limit_enabled=False, _mapping_max_linear=0.14, _mapping_max_angular=0.21)
+    command = Twist()
+    command.linear.x = 0.4
+    command.angular.z = 1.0
+
+    assert CmdVelMux._apply_mapping_speed_limit(mux, command) is command
+
+
+@pytest.mark.parametrize(("linear", "angular"), [(float("nan"), 0.0), (0.0, float("inf"))])
+def test_mux_replaces_non_finite_mapping_commands_with_a_finite_zero(linear, angular):
+    mux = SimpleNamespace(_mapping_limit_enabled=True, _mapping_max_linear=0.14, _mapping_max_angular=0.21)
+    command = Twist()
+    command.linear.x = linear
+    command.angular.z = angular
+
+    limited = CmdVelMux._apply_mapping_speed_limit(mux, command)
+
+    assert (limited.linear.x, limited.linear.y, limited.linear.z) == (0.0, 0.0, 0.0)
+    assert (limited.angular.x, limited.angular.y, limited.angular.z) == (0.0, 0.0, 0.0)
+
+
+def test_enabling_the_authoritative_envelope_publishes_zero_before_success_ack():
+    response = SimpleNamespace(success=False, message="")
+    events = []
+
+    def publish(msg):
+        assert response.success is False
+        events.append((msg.linear.x, msg.angular.z))
+
+    mux = SimpleNamespace(
+        _mapping_limit_enabled=False,
+        _has_authoritative_limit_source=False,
+        _forwarding=True,
+        _pub=SimpleNamespace(publish=publish),
+    )
+    mux._publish_zero_stop = MethodType(CmdVelMux._publish_zero_stop, mux)
+
+    returned = CmdVelMux._set_mapping_speed_limit(mux, SimpleNamespace(data=True), response)
+
+    assert returned is response
+    assert events == [(0.0, 0.0)]
+    assert response.success is True
+    assert mux._mapping_limit_enabled is True
+    assert mux._has_authoritative_limit_source is True
+    assert mux._forwarding is False
+
+
+def test_queued_mode_samples_are_fallback_only_after_an_authoritative_request():
+    published = []
+    mux = SimpleNamespace(
+        _mapping_limit_enabled=True,
+        _has_authoritative_limit_source=False,
+        _forwarding=False,
+        _pub=SimpleNamespace(publish=published.append),
+        get_logger=lambda: SimpleNamespace(debug=lambda _message: None),
+    )
+    mux._publish_zero_stop = MethodType(CmdVelMux._publish_zero_stop, mux)
+
+    CmdVelMux._set_mapping_speed_limit(
+        mux,
+        SimpleNamespace(data=False),
+        SimpleNamespace(success=False, message=""),
+    )
+    CmdVelMux._on_mode(mux, SimpleNamespace(data="mapping"))
+    assert mux._mapping_limit_enabled is False
+
+    CmdVelMux._set_mapping_speed_limit(
+        mux,
+        SimpleNamespace(data=True),
+        SimpleNamespace(success=False, message=""),
+    )
+    CmdVelMux._on_mode(mux, SimpleNamespace(data="navigation"))
+    assert mux._mapping_limit_enabled is True
+    assert len(published) == 1
+
+
+def test_mode_topic_fallback_enables_slow_and_zeros_motion_before_authority_exists():
+    published = []
+    mux = SimpleNamespace(
+        _mapping_limit_enabled=False,
+        _has_authoritative_limit_source=False,
+        _forwarding=True,
+        _pub=SimpleNamespace(publish=published.append),
+    )
+    mux._publish_zero_stop = MethodType(CmdVelMux._publish_zero_stop, mux)
+
+    CmdVelMux._on_mode(mux, SimpleNamespace(data="switching"))
+
+    assert mux._mapping_limit_enabled is True
+    assert mux._forwarding is False
+    assert len(published) == 1
+    assert published[0].linear.x == 0.0
+    assert published[0].angular.z == 0.0
+
+
+def test_mux_subscribes_to_the_latched_navigation_mode_and_loads_motion_overrides():
+    mux_source = (_REPO_ROOT / "ros2_ws/src/mars_bot/mars_nav/mars_nav/cmd_vel_mux.py").read_text()
+    launch_source = (_REPO_ROOT / "ros2_ws/src/mars_bot/mars_nav/launch/mode_manager.launch.py").read_text()
+
+    assert '"/nav/current_mode"' in mux_source
+    assert "QoSDurabilityPolicy.TRANSIENT_LOCAL" in mux_source
+    assert "QoSReliabilityPolicy.RELIABLE" in mux_source
+    assert 'declare_parameter("motion_control.max_speed"' in mux_source
+    assert 'declare_parameter("motion_control.max_angular_speed"' in mux_source
+    assert 'declare_parameter("nav.max_speed"' in mux_source
+    assert 'declare_parameter("nav.max_angular_speed"' in mux_source
+    assert "MAPPING_SPEED_LIMIT_SERVICE" in mux_source
+    assert "create_service(" in mux_source
+    assert "parameters=[*settings_params()]" in launch_source
+
+
+def test_mars_app_reports_slow_for_both_mapping_modes_and_holds_it_through_switching():
+    app_source = (_REPO_ROOT / "ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp").read_text()
+    speed_modes = (_REPO_ROOT / "ros2_ws/src/mars_bot/mars_control/mars_control/drive_smoother.hpp").read_text()
+
+    assert '"/nav/current_mode", rclcpp::QoS(1).reliable().transient_local()' in app_source
+    assert 'msg->data == "mapping" || msg->data == "autonomous_mapping"' in app_source
+    assert 'if (msg->data == "switching")' in app_source
+    assert 'MAPPING_SCALE_ID = "slow"' in speed_modes
+    assert "mapping_ && std::abs(value - mapping_scale) > 1e-9" in app_source
+    assert "Mapping locks motion_control.speed_scale to the Slow preset" in app_source

--- a/tests/test_navigation_policy.py
+++ b/tests/test_navigation_policy.py
@@ -1,0 +1,1557 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Host-only contracts for navigation modes and planner routing."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib.util
+import sys
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MARS_NAV_ROOT = REPO_ROOT / "ros2_ws" / "src" / "mars_bot" / "mars_nav"
+MODE_MANAGER = MARS_NAV_ROOT / "mars_nav" / "mode_manager.py"
+ROUTER = MARS_NAV_ROOT / "mars_nav" / "navigate_to_pose_router.py"
+sys.path.insert(0, str(MARS_NAV_ROOT))
+
+from mars_nav.navigation_policy import (  # noqa: E402
+    DEFAULT_MANUAL_MAX_ANGULAR_RPS,
+    DEFAULT_MANUAL_MAX_LINEAR_MPS,
+    DEFAULT_NAV_MAX_ANGULAR_RPS,
+    DEFAULT_NAV_MAX_LINEAR_MPS,
+    MAPPING_MODES,
+    VALID_NAVIGATION_MODES,
+    NavigationMode,
+    NavigationRoute,
+    configure_only_nodes,
+    mapping_slow_limits,
+    mapping_speed_factor,
+    mapping_speed_limit_active,
+    modes_nodes,
+    resolve_navigation_route,
+    skip_cleanup_nodes,
+    starts_new_mapping_session,
+)
+
+AUTONOMOUS_MAPPING = NavigationMode.AUTONOMOUS_MAPPING.value
+
+
+def test_mode_sets_match_the_lifecycle_table():
+    assert VALID_NAVIGATION_MODES == frozenset({"navigation", "mapping", AUTONOMOUS_MAPPING, "mapfree"})
+    assert MAPPING_MODES == frozenset({"mapping", AUTONOMOUS_MAPPING})
+    assert set(modes_nodes) == VALID_NAVIGATION_MODES
+
+
+@pytest.mark.parametrize("target", [NavigationMode.MAPPING.value, AUTONOMOUS_MAPPING])
+def test_mapping_session_starts_only_when_slam_frame_starts(target):
+    assert starts_new_mapping_session(NavigationMode.NAV.value, target)
+    assert starts_new_mapping_session(target, target, first_start=True)
+    assert not starts_new_mapping_session(NavigationMode.MAPPING.value, target)
+    assert not starts_new_mapping_session(AUTONOMOUS_MAPPING, target)
+
+
+def test_nonmapping_modes_never_start_mapping_sessions():
+    assert not starts_new_mapping_session(NavigationMode.MAPPING.value, NavigationMode.NAV.value)
+    assert not starts_new_mapping_session(None, NavigationMode.MAPFREE.value, first_start=True)
+
+
+def test_mapping_failure_rollback_requires_a_live_nonstartup_handoff():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_mode_callback"
+    )
+    assert "not first_start and previous_mode in MAPPING_MODES and (target_mode in MAPPING_MODES)" in ast.unparse(
+        method
+    )
+
+
+def test_autonomous_mapping_has_exact_lifecycle_contract():
+    assert modes_nodes[AUTONOMOUS_MAPPING] == [
+        "slam_toolbox",
+        "mapfree/planner_server",
+        "navigation/planner_server",
+        "controller_server",
+        "behavior_server",
+        "velocity_smoother",
+        "bt_navigator",
+    ]
+    assert configure_only_nodes == {
+        AUTONOMOUS_MAPPING: {"mapfree/planner_server"},
+        NavigationMode.MAPFREE.value: {"navigation/planner_server"},
+    }
+    assert skip_cleanup_nodes == {
+        "controller_server",
+        "mapfree/planner_server",
+        "navigation/planner_server",
+    }
+
+
+def test_autonomous_mapping_activates_only_live_map_navigation_nodes():
+    configured_only = configure_only_nodes[AUTONOMOUS_MAPPING]
+    active = [node for node in modes_nodes[AUTONOMOUS_MAPPING] if node not in configured_only]
+    assert active == [
+        "slam_toolbox",
+        "navigation/planner_server",
+        "controller_server",
+        "behavior_server",
+        "velocity_smoother",
+        "bt_navigator",
+    ]
+    assert {
+        "navigation_map_server",
+        "navigation_amcl",
+        "navigation_grid_localizer",
+        "null_map_node",
+    }.isdisjoint(modes_nodes[AUTONOMOUS_MAPPING])
+
+
+def test_autonomous_mapping_orders_every_bt_dependency_before_navigator():
+    nodes = modes_nodes[AUTONOMOUS_MAPPING]
+    assert nodes[0] == "slam_toolbox"
+    bt_index = nodes.index("bt_navigator")
+    for dependency in (
+        "mapfree/planner_server",
+        "navigation/planner_server",
+        "controller_server",
+        "behavior_server",
+        "velocity_smoother",
+    ):
+        assert nodes.index(dependency) < bt_index
+
+
+def test_manual_mapping_remains_slam_only():
+    assert modes_nodes[NavigationMode.MAPPING.value] == ["slam_toolbox"]
+    assert NavigationMode.MAPPING.value not in configure_only_nodes
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [None, "", "none", "unknown", "switching", "mapping", AUTONOMOUS_MAPPING],
+)
+def test_mapping_speed_limit_fails_slow_until_a_stable_non_mapping_mode(mode):
+    assert mapping_speed_limit_active(mode)
+
+
+@pytest.mark.parametrize("mode", ["navigation", "mapfree"])
+def test_mapping_speed_limit_releases_only_in_a_stable_non_mapping_mode(mode):
+    assert not mapping_speed_limit_active(mode)
+
+
+def test_mapping_speed_envelope_matches_the_canonical_slow_preset():
+    linear_cap, angular_cap = mapping_slow_limits(
+        DEFAULT_MANUAL_MAX_LINEAR_MPS,
+        DEFAULT_MANUAL_MAX_ANGULAR_RPS,
+        DEFAULT_NAV_MAX_LINEAR_MPS,
+        DEFAULT_NAV_MAX_ANGULAR_RPS,
+    )
+
+    assert linear_cap == pytest.approx(0.14)
+    assert angular_cap == pytest.approx(0.21)
+    assert mapping_speed_factor(True, 0.4, 0.0, linear_cap, angular_cap) == pytest.approx(0.35)
+    assert mapping_speed_factor(True, -0.4, 0.0, linear_cap, angular_cap) == pytest.approx(0.35)
+    assert mapping_speed_factor(True, 0.0, 1.0, linear_cap, angular_cap) == pytest.approx(0.21)
+
+
+def test_mapping_speed_envelope_uses_the_lower_manual_and_nav_cap_before_slow_scale():
+    assert mapping_slow_limits(0.2, 1.5, 0.45, 0.4) == pytest.approx((0.07, 0.14))
+    assert mapping_slow_limits(0.8, 0.3, 0.1, 0.6) == pytest.approx((0.035, 0.105))
+
+
+def test_mapping_speed_envelope_preserves_curvature_and_does_not_double_limit_slow_input():
+    linear_cap, angular_cap = mapping_slow_limits(
+        DEFAULT_MANUAL_MAX_LINEAR_MPS,
+        DEFAULT_MANUAL_MAX_ANGULAR_RPS,
+        DEFAULT_NAV_MAX_LINEAR_MPS,
+        DEFAULT_NAV_MAX_ANGULAR_RPS,
+    )
+
+    factor = mapping_speed_factor(True, 0.4, 0.8, linear_cap, angular_cap)
+    assert factor == pytest.approx(0.2625)
+    assert (0.4 * factor) / (0.8 * factor) == pytest.approx(0.4 / 0.8)
+    assert mapping_speed_factor(True, 0.1, 0.2, linear_cap, angular_cap) == 1.0
+    assert mapping_speed_factor(False, 4.0, 8.0, linear_cap, angular_cap) == 1.0
+
+
+@pytest.mark.parametrize(
+    ("linear", "angular", "linear_cap", "angular_cap"),
+    [
+        (float("nan"), 0.0, 0.14, 0.21),
+        (0.0, float("inf"), 0.14, 0.21),
+        (0.1, 0.1, 0.0, 0.21),
+        (0.1, 0.1, 0.14, -1.0),
+    ],
+)
+def test_mapping_speed_envelope_fails_to_zero_for_invalid_commands_or_caps(linear, angular, linear_cap, angular_cap):
+    assert mapping_speed_factor(True, linear, angular, linear_cap, angular_cap) == 0.0
+
+
+@pytest.mark.parametrize("invalid", [0.0, -1.0, float("nan"), float("inf")])
+def test_mapping_speed_limits_fail_closed_for_invalid_config(invalid):
+    assert mapping_slow_limits(invalid, 1.0, 0.45, 0.6) == (0.0, 0.0)
+
+
+def test_every_configure_only_node_belongs_to_its_mode():
+    for mode, configured_only in configure_only_nodes.items():
+        assert configured_only <= set(modes_nodes[mode])
+
+
+NAVIGATION_ROUTE = NavigationRoute(planner="navigation", goal_checker="goal_checker")
+MAPFREE_ROUTE = NavigationRoute(planner="mapfree", goal_checker="goal_checker_precise")
+
+
+@pytest.mark.parametrize(
+    ("mode", "selector", "expected"),
+    [
+        ("navigation", None, NAVIGATION_ROUTE),
+        ("navigation", "", NAVIGATION_ROUTE),
+        ("navigation", "navigation", NAVIGATION_ROUTE),
+        ("navigation", "mapfree", MAPFREE_ROUTE),
+        ("mapfree", None, MAPFREE_ROUTE),
+        ("mapfree", "mapfree", MAPFREE_ROUTE),
+        (AUTONOMOUS_MAPPING, None, NAVIGATION_ROUTE),
+        (AUTONOMOUS_MAPPING, "navigation", NAVIGATION_ROUTE),
+        (AUTONOMOUS_MAPPING, AUTONOMOUS_MAPPING, NAVIGATION_ROUTE),
+        ("  AUTONOMOUS_MAPPING  ", "  NAVIGATION ", NAVIGATION_ROUTE),
+    ],
+)
+def test_navigation_route_matrix(mode, selector, expected):
+    assert resolve_navigation_route(mode, selector) == expected
+
+
+@pytest.mark.parametrize(
+    ("mode", "selector"),
+    [
+        (None, None),
+        ("", None),
+        ("none", None),
+        ("switching", "navigation"),
+        ("unknown", None),
+        ("mapping", None),
+        ("mapping", "navigation"),
+        (AUTONOMOUS_MAPPING, "mapfree"),
+        ("mapfree", "navigation"),
+        ("navigation", "mapping"),
+        ("navigation", AUTONOMOUS_MAPPING),
+        ("navigation", "/tmp/custom_tree.xml"),
+    ],
+)
+def test_navigation_routes_fail_closed(mode, selector):
+    assert resolve_navigation_route(mode, selector) is None
+
+
+def _is_mode_lock_call(node: ast.AST, method_name: str) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == method_name
+        and ast.unparse(node.func.value) == "self._mode_change_lock"
+    )
+
+
+def test_save_map_serializes_with_mode_and_map_operations():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "save_map_callback"
+    )
+
+    acquire = next(node for node in ast.walk(method) if _is_mode_lock_call(node, "acquire"))
+    assert any(
+        keyword.arg == "blocking" and isinstance(keyword.value, ast.Constant) and keyword.value.value is False
+        for keyword in acquire.keywords
+    )
+
+    guarded_try = next(node for node in method.body if isinstance(node, ast.Try) and node.finalbody)
+    assert acquire.lineno < guarded_try.lineno
+    assert any(
+        _is_mode_lock_call(node, "release") for statement in guarded_try.finalbody for node in ast.walk(statement)
+    )
+
+
+def test_save_map_quiesces_before_lock_and_revalidates_before_file_mutation():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "save_map_callback"
+    )
+    calls = [node for node in ast.walk(method) if isinstance(node, ast.Call)]
+
+    quiesce = next(
+        node for node in calls if isinstance(node.func, ast.Attribute) and node.func.attr == "change_mode_callback"
+    )
+    acquire = next(node for node in calls if _is_mode_lock_call(node, "acquire"))
+    mode_revalidation = next(
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.If) and ast.unparse(node.test) == "self.current_mode != NavigationMode.MAPPING.value"
+    )
+    first_map_mutation = min(
+        node.lineno
+        for node in calls
+        if (isinstance(node.func, ast.Attribute) and node.func.attr in {"makedirs", "remove"})
+        or (isinstance(node.func, ast.Attribute) and ast.unparse(node.func) == "subprocess.run")
+    )
+    assert quiesce.lineno < acquire.lineno < mode_revalidation.lineno < first_map_mutation
+
+    autonomous_guard = next(
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == "self.current_mode == NavigationMode.AUTONOMOUS_MAPPING.value"
+    )
+    assert any(descendant is quiesce for descendant in ast.walk(autonomous_guard))
+    assert any(
+        isinstance(node, ast.If) and ast.unparse(node.test) == "not mode_response.success"
+        for node in ast.walk(autonomous_guard)
+    )
+
+
+def test_save_map_racing_autonomous_restart_fails_before_file_mutation():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "save_map_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+
+    events = []
+
+    class ChangeMode:
+        class Request:
+            mode = ""
+
+        class Response:
+            success = False
+            message = ""
+
+    class RacingLock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("save_lock")
+            manager.current_mode = AUTONOMOUS_MAPPING
+            return True
+
+        def release(self):
+            events.append("release")
+
+    class Logger:
+        def error(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+    def fail_file_mutation(*_args, **_kwargs):
+        events.append("file_mutation")
+        raise AssertionError("map files must not be touched after autonomous mapping restarts")
+
+    namespace = {
+        "ChangeNavigationMode": ChangeMode,
+        "NavigationMode": NavigationMode,
+        "MAPPING_MODES": MAPPING_MODES,
+        "os": types.SimpleNamespace(
+            makedirs=fail_file_mutation,
+            remove=fail_file_mutation,
+            path=types.SimpleNamespace(join=lambda *_parts: "unused", exists=lambda _path: False),
+        ),
+        "subprocess": types.SimpleNamespace(TimeoutExpired=TimeoutError, run=fail_file_mutation),
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    manager = types.SimpleNamespace(
+        current_mode=AUTONOMOUS_MAPPING,
+        _mode_change_lock=RacingLock(),
+        get_logger=lambda: Logger(),
+    )
+
+    def quiesce(request, mode_response, first_start=False):
+        assert request.mode == NavigationMode.MAPPING.value
+        assert first_start is False
+        events.append("quiesce")
+        manager.current_mode = NavigationMode.MAPPING.value
+        mode_response.success = True
+        mode_response.message = "manual mapping active"
+        return mode_response
+
+    manager.change_mode_callback = quiesce
+    request = types.SimpleNamespace(map_name="safe_name", overwrite=False)
+    response = types.SimpleNamespace(success=None, message="")
+
+    returned = namespace["save_map_callback"](manager, request, response)
+
+    assert returned is response
+    assert response.success is False
+    assert "manual mapping is not active" in response.message
+    assert events == ["quiesce", "save_lock", "release"]
+
+
+def test_router_fails_closed_before_waiting_for_internal_action_server():
+    tree = ast.parse(ROUTER.read_text())
+    methods = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in {"_goal_callback", "_execute_reserved_goal"}
+    }
+
+    goal_callback_source = ast.unparse(methods["_goal_callback"])
+    assert "resolve_navigation_route" in goal_callback_source
+    assert "GoalResponse.REJECT" in goal_callback_source
+
+    execute_calls = [node for node in ast.walk(methods["_execute_reserved_goal"]) if isinstance(node, ast.Call)]
+    first_resolve = min(
+        node.lineno
+        for node in execute_calls
+        if isinstance(node.func, ast.Name) and node.func.id == "resolve_navigation_route"
+    )
+    wait_for_server = min(
+        node.lineno
+        for node in execute_calls
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "wait_for_server"
+    )
+    assert first_resolve < wait_for_server
+
+
+def test_mode_switch_closes_admission_before_cancel_and_restores_on_failure():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_mode_callback"
+    )
+    source = ast.unparse(method)
+
+    capture_previous = source.index("previous_mode = self.current_mode")
+    arm_slow = source.index("self._set_mapping_speed_limit(True)", capture_previous)
+    publish_switching = source.index("self.current_mode = 'switching'")
+    cancel_navigation = source.index("self._cancel_active_navigation()")
+    assert capture_previous < arm_slow < publish_switching < cancel_navigation
+
+    cancellation_failure = next(
+        node for node in ast.walk(method) if isinstance(node, ast.If) and ast.unparse(node.test) == "not cancelled_ok"
+    )
+    failure_source = ast.unparse(cancellation_failure)
+    assert "self.current_mode = previous_mode" in failure_source
+    assert "self.publish_status()" in failure_source
+    restored_publish = failure_source.index("self.publish_status()")
+    release_slow = failure_source.index("self._release_mapping_speed_limit_after_stable_mode()")
+    assert restored_publish < release_slow
+
+
+def test_mode_switch_requires_slow_ack_before_admission_cancel_or_lifecycle_mutation():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_mode_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    namespace = {
+        "MAPPING_MODES": MAPPING_MODES,
+        "NavigationMode": NavigationMode,
+        "VALID_NAVIGATION_MODES": VALID_NAVIGATION_MODES,
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    events = []
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("release")
+
+    class Logger:
+        def info(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            events.append("error")
+
+        def debug(self, _message):
+            pass
+
+    manager = types.SimpleNamespace(
+        available_maps=["home.yaml"],
+        current_map="home.yaml",
+        current_mode=NavigationMode.NAV.value,
+        _mode_change_lock=Lock(),
+        _switch_generation=0,
+        get_logger=lambda: Logger(),
+    )
+    manager._set_mapping_speed_limit = lambda enabled: (
+        events.append(f"limit:{enabled}") or (False, "no acknowledgement")
+    )
+    manager.publish_status = lambda: (_ for _ in ()).throw(AssertionError("must not publish switching"))
+    manager._cancel_active_navigation = lambda: (_ for _ in ()).throw(AssertionError("must not cancel"))
+    manager.request_mode_startup = lambda _mode: (_ for _ in ()).throw(AssertionError("must not mutate lifecycle"))
+
+    response = types.SimpleNamespace(success=None, message="")
+    returned = namespace["change_mode_callback"](
+        manager,
+        types.SimpleNamespace(mode=NavigationMode.MAPPING.value),
+        response,
+    )
+
+    assert returned is response
+    assert response.success is False
+    assert "before transition" in response.message
+    assert manager.current_mode == NavigationMode.NAV.value
+    assert events == ["lock", "limit:True", "error", "release"]
+
+
+def test_first_start_slow_ack_failure_publishes_none_then_saved_mode_request_starts_lifecycle():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_mode_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    namespace = {
+        "MAPPING_MODES": MAPPING_MODES,
+        "NavigationMode": NavigationMode,
+        "VALID_NAVIGATION_MODES": VALID_NAVIGATION_MODES,
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    events = []
+    saved_modes = []
+    enable_attempts = 0
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("lock:release")
+
+    class Logger:
+        def info(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            events.append("error")
+
+        def debug(self, _message):
+            pass
+
+    manager = types.SimpleNamespace(
+        available_maps=["home.yaml"],
+        current_map="home.yaml",
+        current_mode=NavigationMode.MAPFREE.value,
+        _mode_change_lock=Lock(),
+        _switch_generation=0,
+        get_logger=lambda: Logger(),
+    )
+
+    def set_slow(enabled):
+        nonlocal enable_attempts
+        events.append(f"limit:{enabled}")
+        if enabled:
+            enable_attempts += 1
+            if enable_attempts == 1:
+                return False, "no acknowledgement"
+        return True, "ok"
+
+    manager._set_mapping_speed_limit = set_slow
+    manager.publish_status = lambda: events.append(f"publish:{manager.current_mode}")
+    manager._cancel_active_navigation = lambda: events.append("cancel") or (True, "stopped")
+    manager.request_mode_startup = lambda mode: events.append(f"lifecycle:{mode.value}") or (True, "started")
+    manager.save_last_mode = lambda mode: (saved_modes.append(mode), events.append(f"persist:{mode}"))
+    manager._release_mapping_speed_limit_after_stable_mode = lambda: (
+        events.append(f"release_slow:{manager.current_mode}") or (True, "released")
+    )
+    request = types.SimpleNamespace(mode=NavigationMode.MAPFREE.value)
+
+    first_response = namespace["change_mode_callback"](
+        manager,
+        request,
+        types.SimpleNamespace(success=None, message=""),
+        first_start=True,
+    )
+
+    assert first_response.success is False
+    assert manager.current_mode == "none"
+    assert saved_modes == []
+    assert "lifecycle:mapfree" not in events
+    assert events == ["lock", "limit:True", "publish:none", "error", "lock:release"]
+
+    second_response = namespace["change_mode_callback"](
+        manager,
+        request,
+        types.SimpleNamespace(success=None, message=""),
+    )
+
+    assert second_response.success is True
+    assert manager.current_mode == NavigationMode.MAPFREE.value
+    assert saved_modes == [NavigationMode.MAPFREE.value]
+    assert events[5:] == [
+        "lock",
+        "limit:True",
+        "publish:switching",
+        "cancel",
+        "lifecycle:mapfree",
+        "persist:mapfree",
+        "publish:mapfree",
+        "release_slow:mapfree",
+        "lock:release",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("previous_mode", "target_mode"),
+    [
+        (NavigationMode.MAPPING, NavigationMode.AUTONOMOUS_MAPPING),
+        (NavigationMode.AUTONOMOUS_MAPPING, NavigationMode.MAPPING),
+    ],
+)
+def test_failed_mapping_handoff_restores_previous_stack_and_retry_keeps_session(previous_mode, target_mode):
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_mode_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    namespace = {
+        "MAPPING_MODES": MAPPING_MODES,
+        "NavigationMode": NavigationMode,
+        "VALID_NAVIGATION_MODES": VALID_NAVIGATION_MODES,
+        "starts_new_mapping_session": starts_new_mapping_session,
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    events = []
+    target_attempts = 0
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("lock:release")
+
+    class Logger:
+        def info(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            events.append("error")
+
+        def debug(self, _message):
+            pass
+
+    manager = types.SimpleNamespace(
+        available_maps=["home.yaml"],
+        current_map="home.yaml",
+        current_mode=previous_mode.value,
+        _mapping_session_started=1234.5,
+        _mode_change_lock=Lock(),
+        _switch_generation=0,
+        get_logger=lambda: Logger(),
+    )
+    manager._set_mapping_speed_limit = lambda enabled: events.append(f"limit:{enabled}") or (True, "ok")
+    manager.publish_status = lambda: events.append(f"publish:{manager.current_mode}")
+    manager._cancel_active_navigation = lambda: events.append("cancel") or (True, "stopped")
+
+    def start(mode):
+        nonlocal target_attempts
+        events.append(f"lifecycle:{mode.value}")
+        if mode == target_mode:
+            target_attempts += 1
+            if target_attempts == 1:
+                return False, "controller failed"
+        return True, "started"
+
+    manager.request_mode_startup = start
+    manager.save_last_mode = lambda mode: events.append(f"persist:{mode}")
+    manager.mapping_session_publisher = types.SimpleNamespace(
+        publish=lambda _msg: (_ for _ in ()).throw(AssertionError("mapping handoff minted a new session"))
+    )
+    request = types.SimpleNamespace(mode=target_mode.value)
+
+    failed = namespace["change_mode_callback"](
+        manager,
+        request,
+        types.SimpleNamespace(success=None, message=""),
+    )
+    assert failed.success is False
+    assert f"restored {previous_mode.value} mode" in failed.message
+    assert manager.current_mode == previous_mode.value
+    assert manager._mapping_session_started == 1234.5
+
+    retried = namespace["change_mode_callback"](
+        manager,
+        request,
+        types.SimpleNamespace(success=None, message=""),
+    )
+    assert retried.success is True
+    assert manager.current_mode == target_mode.value
+    assert manager._mapping_session_started == 1234.5
+    assert events.count(f"lifecycle:{previous_mode.value}") == 1
+    assert events.count(f"lifecycle:{target_mode.value}") == 2
+
+
+def test_mode_cancel_failure_restores_stable_status_then_attempts_slow_release():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_mode_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    namespace = {
+        "MAPPING_MODES": MAPPING_MODES,
+        "NavigationMode": NavigationMode,
+        "VALID_NAVIGATION_MODES": VALID_NAVIGATION_MODES,
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    events = []
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("lock:release")
+
+    class Logger:
+        def info(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            events.append("error")
+
+        def debug(self, _message):
+            pass
+
+    manager = types.SimpleNamespace(
+        available_maps=["home.yaml"],
+        current_map="home.yaml",
+        current_mode=NavigationMode.NAV.value,
+        _mode_change_lock=Lock(),
+        _switch_generation=0,
+        get_logger=lambda: Logger(),
+    )
+    manager._set_mapping_speed_limit = lambda enabled: events.append(f"limit:{enabled}") or (True, "ok")
+    manager.publish_status = lambda: events.append(f"publish:{manager.current_mode}")
+    manager._cancel_active_navigation = lambda: events.append("cancel") or (False, "goal still active")
+    manager._release_mapping_speed_limit_after_stable_mode = lambda: (
+        events.append(f"release_slow:{manager.current_mode}") or (False, "release unavailable")
+    )
+    manager.request_mode_startup = lambda _mode: (_ for _ in ()).throw(AssertionError("must not mutate lifecycle"))
+
+    response = types.SimpleNamespace(success=None, message="")
+    returned = namespace["change_mode_callback"](
+        manager,
+        types.SimpleNamespace(mode=NavigationMode.MAPPING.value),
+        response,
+    )
+
+    assert returned is response
+    assert response.success is False
+    assert "could not stop active navigation (goal still active)" in response.message
+    assert "Slow drive envelope remains active (release unavailable)" in response.message
+    assert manager.current_mode == NavigationMode.NAV.value
+    assert events == [
+        "lock",
+        "limit:True",
+        "publish:switching",
+        "cancel",
+        "publish:navigation",
+        "release_slow:navigation",
+        "error",
+        "lock:release",
+    ]
+
+
+def test_successful_nonmapping_mode_releases_slow_only_after_stable_status_publish():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_mode_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    namespace = {
+        "MAPPING_MODES": MAPPING_MODES,
+        "NavigationMode": NavigationMode,
+        "VALID_NAVIGATION_MODES": VALID_NAVIGATION_MODES,
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    events = []
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("lock:release")
+
+    class Logger:
+        def info(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            pass
+
+        def debug(self, _message):
+            events.append("return")
+
+    manager = types.SimpleNamespace(
+        available_maps=["home.yaml"],
+        current_map="home.yaml",
+        current_mode=NavigationMode.MAPPING.value,
+        _mode_change_lock=Lock(),
+        _switch_generation=0,
+        get_logger=lambda: Logger(),
+    )
+    manager._set_mapping_speed_limit = lambda enabled: events.append(f"limit:{enabled}") or (True, "ok")
+    manager.publish_status = lambda: events.append(f"publish:{manager.current_mode}")
+    manager._cancel_active_navigation = lambda: events.append("cancel") or (True, "stopped")
+    manager.request_mode_startup = lambda mode: events.append(f"lifecycle:{mode.value}") or (True, "started")
+    manager.save_last_mode = lambda mode: events.append(f"persist:{mode}")
+
+    def release_after_stable():
+        events.append(f"release_slow:{manager.current_mode}")
+        assert manager.current_mode == NavigationMode.MAPFREE.value
+        return True, "released"
+
+    manager._release_mapping_speed_limit_after_stable_mode = release_after_stable
+    response = types.SimpleNamespace(success=None, message="")
+    returned = namespace["change_mode_callback"](
+        manager,
+        types.SimpleNamespace(mode=NavigationMode.MAPFREE.value),
+        response,
+    )
+
+    assert returned is response
+    assert response.success is True
+    assert events == [
+        "lock",
+        "limit:True",
+        "publish:switching",
+        "cancel",
+        "lifecycle:mapfree",
+        "persist:mapfree",
+        "publish:mapfree",
+        "release_slow:mapfree",
+        "lock:release",
+    ]
+
+
+def test_map_switch_closes_admission_and_cancels_before_map_or_lifecycle_mutation():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_map_callback"
+    )
+    source = ast.unparse(method)
+
+    capture_previous = source.index("previous_mode = self.current_mode")
+    arm_slow = source.index("self._set_mapping_speed_limit(True)", capture_previous)
+    publish_switching = source.index("self.current_mode = 'switching'")
+    cancel_navigation = source.index("self._cancel_active_navigation()")
+    set_requested_map = source.index("self.current_map = requested_map")
+    switch_lifecycle = source.index("self._efficient_map_switch()")
+    assert capture_previous < arm_slow < publish_switching < cancel_navigation < set_requested_map < switch_lifecycle
+
+
+def test_map_switch_cancel_failure_restores_mode_without_mutating_map_or_lifecycle():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_map_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    namespace = {
+        "NavigationMode": NavigationMode,
+        "time": types.SimpleNamespace(monotonic=lambda: 123.0),
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    events = []
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("release")
+
+    class Logger:
+        def info(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            events.append("error")
+
+    manager = types.SimpleNamespace(
+        available_maps=["old.yaml", "next.yaml"],
+        current_map="old.yaml",
+        current_mode="navigation",
+        _mode_change_lock=Lock(),
+        _switch_generation=7,
+        get_logger=lambda: Logger(),
+    )
+
+    def publish_status():
+        events.append(f"publish:{manager.current_mode}:{manager.current_map}")
+
+    def cancel_active_navigation():
+        events.append("cancel")
+        return False, "goal still active"
+
+    def fail_lifecycle():
+        events.append("lifecycle")
+        raise AssertionError("lifecycle must remain untouched after cancellation failure")
+
+    manager.publish_status = publish_status
+    manager._set_mapping_speed_limit = lambda enabled: events.append(f"limit:{enabled}") or (True, "ok")
+    manager._release_mapping_speed_limit_after_stable_mode = lambda: (
+        events.append("limit:release")
+        or (
+            False,
+            "release unavailable",
+        )
+    )
+    manager._cancel_active_navigation = cancel_active_navigation
+    manager._efficient_map_switch = fail_lifecycle
+    manager.save_last_map = lambda _name: events.append("persist")
+    manager._trigger_relocalization = lambda **_kwargs: events.append("relocalize")
+    request = types.SimpleNamespace(map_name="next.yaml")
+    response = types.SimpleNamespace(success=None, message="")
+
+    returned = namespace["change_map_callback"](manager, request, response)
+
+    assert returned is response
+    assert response.success is False
+    assert "could not stop active navigation" in response.message
+    assert "Slow drive envelope remains active (release unavailable)" in response.message
+    assert manager.current_mode == "navigation"
+    assert manager.current_map == "old.yaml"
+    assert manager._switch_generation == 8
+    assert events == [
+        "lock",
+        "limit:True",
+        "publish:switching:old.yaml",
+        "cancel",
+        "publish:navigation:old.yaml",
+        "error",
+        "limit:release",
+        "release",
+    ]
+
+
+def test_map_cancel_retries_restored_status_before_releasing_slow_if_first_publish_throws():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_map_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    namespace = {
+        "NavigationMode": NavigationMode,
+        "time": types.SimpleNamespace(monotonic=lambda: 123.0),
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    events = []
+    stable_publish_attempts = 0
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("lock:release")
+
+    class Logger:
+        def info(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            events.append("error")
+
+    manager = types.SimpleNamespace(
+        available_maps=["old.yaml", "next.yaml"],
+        current_map="old.yaml",
+        current_mode=NavigationMode.NAV.value,
+        _mode_change_lock=Lock(),
+        _switch_generation=7,
+        get_logger=lambda: Logger(),
+    )
+
+    def publish_status():
+        nonlocal stable_publish_attempts
+        events.append(f"publish:{manager.current_mode}:{manager.current_map}")
+        if manager.current_mode == NavigationMode.NAV.value:
+            stable_publish_attempts += 1
+            if stable_publish_attempts == 1:
+                raise RuntimeError("transient stable-status publish failure")
+
+    manager.publish_status = publish_status
+    manager._set_mapping_speed_limit = lambda enabled: events.append(f"limit:{enabled}") or (True, "ok")
+    manager._cancel_active_navigation = lambda: events.append("cancel") or (False, "goal still active")
+    manager._release_mapping_speed_limit_after_stable_mode = lambda: (
+        events.append("limit:release")
+        or (
+            True,
+            "released",
+        )
+    )
+    manager._efficient_map_switch = lambda: (_ for _ in ()).throw(AssertionError("must not mutate lifecycle"))
+    manager.save_last_map = lambda _name: events.append("persist")
+    manager._trigger_relocalization = lambda **_kwargs: events.append("relocalize")
+    response = types.SimpleNamespace(success=None, message="")
+
+    returned = namespace["change_map_callback"](
+        manager,
+        types.SimpleNamespace(map_name="next.yaml"),
+        response,
+    )
+
+    assert returned is response
+    assert response.success is False
+    assert "could not stop active navigation (goal still active)" in response.message
+    assert "additional error while changing map: transient stable-status publish failure" in response.message
+    assert stable_publish_attempts == 2
+    restored_publishes = [index for index, event in enumerate(events) if event == "publish:navigation:old.yaml"]
+    assert len(restored_publishes) == 2
+    assert restored_publishes[0] < restored_publishes[1] < events.index("limit:release")
+    assert events.index("limit:release") < events.index("lock:release")
+    assert "persist" not in events
+    assert "relocalize" not in events
+
+
+@pytest.mark.parametrize("failure_kind", ["lifecycle_result", "exception"])
+def test_map_switch_failures_restore_status_then_attempt_slow_release_without_masking_failure(failure_kind):
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "change_map_callback"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    namespace = {
+        "NavigationMode": NavigationMode,
+        "time": types.SimpleNamespace(monotonic=lambda: 123.0),
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    events = []
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("lock:release")
+
+    class Logger:
+        def info(self, _message):
+            pass
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            events.append("error")
+
+    manager = types.SimpleNamespace(
+        available_maps=["old.yaml", "next.yaml"],
+        current_map="old.yaml",
+        current_mode=NavigationMode.NAV.value,
+        _mode_change_lock=Lock(),
+        _switch_generation=7,
+        get_logger=lambda: Logger(),
+    )
+    manager.publish_status = lambda: events.append(f"publish:{manager.current_mode}:{manager.current_map}")
+    manager._set_mapping_speed_limit = lambda enabled: events.append(f"limit:{enabled}") or (True, "ok")
+    manager._cancel_active_navigation = lambda: events.append("cancel") or (True, "stopped")
+    manager._release_mapping_speed_limit_after_stable_mode = lambda: (
+        events.append("limit:release")
+        or (
+            False,
+            "release unavailable",
+        )
+    )
+
+    def fail_map_switch():
+        events.append("lifecycle")
+        if failure_kind == "exception":
+            raise RuntimeError("map lifecycle exploded")
+        return False, "lifecycle incomplete"
+
+    manager._efficient_map_switch = fail_map_switch
+    manager.save_last_map = lambda _name: events.append("persist")
+    manager._trigger_relocalization = lambda **_kwargs: events.append("relocalize")
+    response = types.SimpleNamespace(success=None, message="")
+
+    returned = namespace["change_map_callback"](
+        manager,
+        types.SimpleNamespace(map_name="next.yaml"),
+        response,
+    )
+
+    assert returned is response
+    assert response.success is False
+    if failure_kind == "exception":
+        assert "Error changing map: map lifecycle exploded" in response.message
+    else:
+        assert "Failed to switch to map 'next.yaml': lifecycle incomplete" in response.message
+    assert "Slow drive envelope remains active (release unavailable)" in response.message
+    assert manager.current_mode == NavigationMode.NAV.value
+    assert manager.current_map == "old.yaml"
+    restored_status = events.index("publish:navigation:old.yaml", events.index("publish:switching:old.yaml") + 1)
+    release_slow = events.index("limit:release")
+    lock_release = events.index("lock:release")
+    assert restored_status < release_slow < lock_release
+    assert "persist" not in events
+    assert "relocalize" not in events
+
+
+def test_mapping_pose_uses_the_tf_sample_stamp_not_wheel_odometry_time():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "odom_callback")
+    source = ast.unparse(method)
+
+    assert "odom_msg.header.stamp = tf.header.stamp" in source
+    assert "odom_msg.header.stamp = msg.header.stamp" not in source
+
+
+def test_watchdog_discards_old_stack_repairs_if_mode_changes_during_unlocked_probe():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_lifecycle_watchdog"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+
+    class State:
+        PRIMARY_STATE_UNCONFIGURED = 1
+        PRIMARY_STATE_INACTIVE = 2
+        PRIMARY_STATE_ACTIVE = 3
+
+    events = []
+
+    class Lock:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            events.append("lock")
+            return True
+
+        def release(self):
+            events.append("release")
+
+    class Logger:
+        def info(self, message):
+            events.append(f"info:{message}")
+
+        def warning(self, _message):
+            pass
+
+        def error(self, _message):
+            pass
+
+    manager = types.SimpleNamespace(
+        _lifecycle_watchdog_armed=True,
+        _watchdog_busy=False,
+        current_mode=NavigationMode.MAPPING.value,
+        _mode_change_lock=Lock(),
+        _service_clients={},
+        get_logger=lambda: Logger(),
+    )
+
+    def get_state(_clients, _logger, node_name, timeout_sec):
+        assert node_name == "slam_toolbox"
+        assert timeout_sec == 2.0
+        events.append("probe:mapping")
+        # Simulate a complete mapping -> navigation transition while the
+        # watchdog is outside the lifecycle lock.
+        manager.current_mode = NavigationMode.NAV.value
+        return State.PRIMARY_STATE_UNCONFIGURED
+
+    def fail_transition(*_args, **_kwargs):
+        events.append("restore")
+        raise AssertionError("watchdog must not restore nodes from the old mode")
+
+    namespace = {
+        "State": State,
+        "configure_only_nodes": configure_only_nodes,
+        "get_node_state": get_state,
+        "modes_nodes": modes_nodes,
+        "transition_node": fail_transition,
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    namespace["_lifecycle_watchdog"](manager)
+
+    assert manager.current_mode == NavigationMode.NAV.value
+    assert manager._watchdog_busy is False
+    assert events[0:2] == ["probe:mapping", "lock"]
+    assert "restore" not in events
+    assert events[-1] == "release"
+
+
+def test_mode_status_synchronously_updates_router_before_dds_publish():
+    mode_tree = ast.parse(MODE_MANAGER.read_text())
+    mode_methods = {
+        node.name: node for node in ast.walk(mode_tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    publish_source = ast.unparse(mode_methods["publish_status"])
+    sink_update = publish_source.index("self._navigation_mode_sink(self.current_mode)")
+    dds_publish = publish_source.index("self.mode_publisher.publish(mode_msg)")
+    assert sink_update < dds_publish
+
+    main_source = ast.unparse(mode_methods["main"])
+    sink_binding = main_source.index("mode_manager.set_navigation_mode_sink(navigate_to_pose_router.set_current_mode)")
+    pending_binding = main_source.index(
+        "mode_manager.set_navigation_pending_goals_getter(navigate_to_pose_router.get_pending_goal_count)"
+    )
+    executor_spin = main_source.index("executor.spin()")
+    assert sink_binding < pending_binding < executor_spin
+
+    router_tree = ast.parse(ROUTER.read_text())
+    set_mode = next(
+        node for node in ast.walk(router_tree) if isinstance(node, ast.FunctionDef) and node.name == "set_current_mode"
+    )
+    set_mode_source = ast.unparse(set_mode)
+    assert "self._current_mode = next_mode" in set_mode_source
+    assert "with self._admission_lock" in set_mode_source
+
+
+def test_mode_teardown_waits_for_internal_and_router_goals_with_a_deadline():
+    mode_tree = ast.parse(MODE_MANAGER.read_text())
+    cancel_method = next(
+        node
+        for node in ast.walk(mode_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_cancel_active_navigation"
+    )
+    source = ast.unparse(cancel_method)
+
+    assert "pending_goals = self._navigation_pending_goals()" in source
+    assert "self._nav_active_goals == 0 and pending_goals == 0" in source
+    cancel_rpc = source.index("response = call_service")
+    terminal_deadline = source.index("terminal_deadline = time.monotonic() + terminal_timeout_sec")
+    assert cancel_rpc < terminal_deadline
+    assert "CancelGoal.Request(), rpc_timeout_sec" in source
+    assert "while time.monotonic() < terminal_deadline" in source
+    assert "self._nav_active_goals > 0 or pending_goals > 0" in source
+    assert "router={pending_goals}" in source
+
+
+def test_router_admission_reservation_is_locked_and_always_released():
+    tree = ast.parse(ROUTER.read_text())
+    methods = {node.name: node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    goal_source = ast.unparse(methods["_goal_callback"])
+    execute_source = ast.unparse(methods["_execute_callback"])
+
+    assert "with self._admission_lock" in goal_source
+    assert "self._pending_goal_reservations += 1" in goal_source
+    assert "finally:\n        self._release_goal_reservation()" in execute_source
+
+
+def test_router_cancels_an_internal_goal_if_mode_changes_during_handoff():
+    tree = ast.parse(ROUTER.read_text())
+    methods = {node.name: node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef)}
+    execute_source = ast.unparse(methods["_execute_reserved_goal"])
+    cancel_source = ast.unparse(methods["_cancel_internal_and_wait_for_terminal"])
+
+    internal_acceptance = execute_source.index("client_goal_handle = await send_goal_future")
+    handoff_mode_check = execute_source.index("self._current_mode != admitted_mode")
+    handoff_cancel = execute_source.index("await self._cancel_internal_and_wait_for_terminal(client_goal_handle)")
+    terminal_check = execute_source.index("internal_canceled =", handoff_cancel)
+    outer_abort = execute_source.index("goal_handle.abort()", handoff_mode_check)
+    assert internal_acceptance < handoff_mode_check < handoff_cancel < terminal_check < outer_abort
+
+    result_registration = cancel_source.index("result_future = client_goal_handle.get_result_async()")
+    cancel_ack = cancel_source.index("await client_goal_handle.cancel_goal_async()")
+    terminal_result = cancel_source.index("result_response = await result_future")
+    assert result_registration < cancel_ack < terminal_result
+
+
+def _load_router_for_host_test(monkeypatch):
+    """Import the router with tiny ROS stubs so its async safety helper is testable."""
+
+    class Dummy:
+        pass
+
+    class DummyNavigateToPose:
+        class Result:
+            pass
+
+    nav2_msgs = types.ModuleType("nav2_msgs")
+    nav2_msgs_action = types.ModuleType("nav2_msgs.action")
+    nav2_msgs_action.NavigateToPose = DummyNavigateToPose
+    nav2_msgs.action = nav2_msgs_action
+
+    rclpy = types.ModuleType("rclpy")
+    rclpy_action = types.ModuleType("rclpy.action")
+    rclpy_action.ActionClient = Dummy
+    rclpy_action.ActionServer = Dummy
+    rclpy_action.CancelResponse = Dummy
+
+    class DummyGoalResponse:
+        ACCEPT = object()
+        REJECT = object()
+
+    rclpy_action.GoalResponse = DummyGoalResponse
+    rclpy_callback_groups = types.ModuleType("rclpy.callback_groups")
+    rclpy_callback_groups.MutuallyExclusiveCallbackGroup = Dummy
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = Dummy
+    rclpy_qos = types.ModuleType("rclpy.qos")
+    rclpy_qos.QoSDurabilityPolicy = Dummy
+    rclpy_qos.QoSProfile = Dummy
+    rclpy_qos.QoSReliabilityPolicy = Dummy
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.String = Dummy
+    std_msgs.msg = std_msgs_msg
+
+    for name, module in {
+        "nav2_msgs": nav2_msgs,
+        "nav2_msgs.action": nav2_msgs_action,
+        "rclpy": rclpy,
+        "rclpy.action": rclpy_action,
+        "rclpy.callback_groups": rclpy_callback_groups,
+        "rclpy.node": rclpy_node,
+        "rclpy.qos": rclpy_qos,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    spec = importlib.util.spec_from_file_location("navigate_to_pose_router_host_test", ROUTER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_in_process_mode_update_atomically_closes_admission_and_preserves_reservation(monkeypatch):
+    module = _load_router_for_host_test(monkeypatch)
+    logs = []
+
+    class Logger:
+        def info(self, message):
+            logs.append(("info", message))
+
+        def debug(self, message):
+            logs.append(("debug", message))
+
+        def warn(self, message):
+            logs.append(("warn", message))
+
+        def error(self, message):
+            logs.append(("error", message))
+
+    router = types.SimpleNamespace(
+        _admission_lock=threading.Lock(),
+        _current_mode="navigation",
+        _has_authoritative_mode_source=False,
+        _pending_goal_reservations=0,
+        get_logger=lambda: Logger(),
+    )
+    request = types.SimpleNamespace(behavior_tree="")
+    first_response = module.NavigateToPoseRouter._goal_callback(router, request)
+    module.NavigateToPoseRouter.set_current_mode(router, "switching")
+    second_response = module.NavigateToPoseRouter._goal_callback(router, request)
+
+    assert first_response is module.GoalResponse.ACCEPT
+    assert router._current_mode == "switching"
+    assert second_response is module.GoalResponse.REJECT
+    assert module.NavigateToPoseRouter.get_pending_goal_count(router) == 1
+    module.NavigateToPoseRouter._release_goal_reservation(router)
+    assert module.NavigateToPoseRouter.get_pending_goal_count(router) == 0
+    assert any("rejected" in message.lower() for level, message in logs if level == "warn")
+
+
+def test_queued_dds_mode_cannot_reopen_admission_after_authoritative_switching(monkeypatch):
+    module = _load_router_for_host_test(monkeypatch)
+    logs = []
+
+    class Logger:
+        def debug(self, message):
+            logs.append(message)
+
+        def info(self, _message):
+            pass
+
+        def warn(self, _message):
+            pass
+
+        def error(self, _message):
+            pass
+
+    router = module.NavigateToPoseRouter.__new__(module.NavigateToPoseRouter)
+    router._admission_lock = threading.Lock()
+    router._current_mode = "navigation"
+    router._has_authoritative_mode_source = False
+    router._pending_goal_reservations = 0
+    router.get_logger = lambda: Logger()
+
+    # The direct sink closes admission, then an older navigation sample that
+    # was already queued in DDS arrives.  It must not reopen the route.
+    router.set_current_mode("switching")
+    router._mode_callback(types.SimpleNamespace(data="navigation"))
+    response = router._goal_callback(types.SimpleNamespace(behavior_tree=""))
+
+    assert router._current_mode == "switching"
+    assert router._has_authoritative_mode_source is True
+    assert response is module.GoalResponse.REJECT
+    assert router.get_pending_goal_count() == 0
+    assert any("Ignoring DDS mode update" in message for message in logs)
+
+
+def test_cancel_terminal_budget_starts_after_slow_cancel_rpc_acknowledgement():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_cancel_active_navigation"
+    )
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+
+    class FakeClock:
+        now = 0.0
+
+        @classmethod
+        def monotonic(cls):
+            return cls.now
+
+        @classmethod
+        def sleep(cls, duration):
+            cls.now += duration
+            if cls.now >= 100.1:
+                manager._nav_active_goals = 0
+
+    class CancelGoal:
+        class Request:
+            pass
+
+    class Logger:
+        pass
+
+    manager = types.SimpleNamespace(
+        _nav_active_goals=1,
+        _service_clients={},
+        _navigation_pending_goals=lambda: 0,
+        get_logger=lambda: Logger(),
+    )
+
+    def slow_cancel_rpc(_clients, _logger, service_name, request, timeout_sec):
+        assert service_name == "/internal_navigate_to_pose/_action/cancel_goal"
+        assert isinstance(request, CancelGoal.Request)
+        assert timeout_sec == 2.0
+        # Consume far more than the terminal budget before acknowledging.  A
+        # deadline created before this call would already be expired.
+        FakeClock.now = 100.0
+        return types.SimpleNamespace(goals_canceling=[object()])
+
+    namespace = {
+        "CancelGoal": CancelGoal,
+        "NAV_CANCEL_SERVICE": "/internal_navigate_to_pose/_action/cancel_goal",
+        "call_service": slow_cancel_rpc,
+        "time": FakeClock,
+    }
+    exec(compile(method_module, str(MODE_MANAGER), "exec"), namespace)
+
+    success, message = namespace["_cancel_active_navigation"](manager, rpc_timeout_sec=2.0, terminal_timeout_sec=0.2)
+
+    assert success is True
+    assert "Cancelled 1 navigation goal" in message
+    assert FakeClock.now >= 100.1
+
+
+@pytest.mark.parametrize(
+    ("goals_canceling", "terminal_status", "cancel_accepted"),
+    [([object()], 5, True), ([], 4, False)],
+)
+def test_handoff_cancel_waits_for_ack_and_terminal_result(
+    monkeypatch, goals_canceling, terminal_status, cancel_accepted
+):
+    module = _load_router_for_host_test(monkeypatch)
+    events = []
+    logs = []
+    terminal_response = types.SimpleNamespace(status=terminal_status, result=object())
+
+    class Logger:
+        def info(self, message):
+            logs.append(("info", message))
+
+        def error(self, message):
+            logs.append(("error", message))
+
+    class RouterHarness:
+        def get_logger(self):
+            return Logger()
+
+    class ClientGoalHandle:
+        def get_result_async(self):
+            events.append("result_registered")
+
+            async def wait_for_terminal():
+                events.append("terminal_result")
+                return terminal_response
+
+            return wait_for_terminal()
+
+        def cancel_goal_async(self):
+            events.append("cancel_requested")
+
+            async def wait_for_ack():
+                events.append("cancel_ack")
+                return types.SimpleNamespace(goals_canceling=goals_canceling)
+
+            return wait_for_ack()
+
+    outcome = asyncio.run(
+        module.NavigateToPoseRouter._cancel_internal_and_wait_for_terminal(RouterHarness(), ClientGoalHandle())
+    )
+
+    assert events == ["result_registered", "cancel_requested", "cancel_ack", "terminal_result"]
+    assert outcome == (cancel_accepted, terminal_response)
+    if cancel_accepted:
+        assert not [message for level, message in logs if level == "error"]
+    else:
+        assert any("rejected" in message for level, message in logs if level == "error")

--- a/tests/test_navigation_policy.py
+++ b/tests/test_navigation_policy.py
@@ -111,6 +111,16 @@ def test_autonomous_mapping_activates_only_live_map_navigation_nodes():
     }.isdisjoint(modes_nodes[AUTONOMOUS_MAPPING])
 
 
+def test_mapping_startup_fails_closed_on_competing_map_or_tf_authority():
+    tree = ast.parse(MODE_MANAGER.read_text())
+    method = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "request_mode_startup"
+    )
+    source = ast.unparse(method)
+    assert "mode.value in MAPPING_MODES and node_name in MAPPING_AUTHORITY_CONFLICTS" in source
+    assert source.index("if authority_failures") < source.index("self._startup_pass")
+
+
 def test_autonomous_mapping_orders_every_bt_dependency_before_navigator():
     nodes = modes_nodes[AUTONOMOUS_MAPPING]
     assert nodes[0] == "slam_toolbox"

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -159,24 +159,36 @@ frame and would need a live `map->odom` transform to sit on the map canvas.
 
 **Mapping.** The Maps panel ports the mobile app's workflow: list/switch/
 delete maps (`/nav/available_maps`, `/nav/change_navigation_map`,
-`/nav/delete_map`), a map-free toggle, and **+ New map**, which flips the
-robot into mapping mode (`/nav/change_mode {mode: "mapping"}`). While
-mapping, a banner over the scene runs the record flow (Finish → name →
-Save, mirroring the mobile app's record/name screens); Save calls
+`/nav/delete_map`), a map-free toggle, and **+ New map**, which starts manual
+mapping (`/nav/change_mode {mode: "mapping"}`). When the optional **Explore
+Map** skill is present in the skill roster, the webapp pins it in the Skills
+launcher; running it uses `autonomous_mapping`. The two modes are one mapping
+session in the web UI. Both are robot-enforced Slow modes: `mars_app` reports
+the Slow preset, and the final command mux caps teleop, skills, Nav2, and
+recovery motion even if another client selects Fast or Mad. In either mode, a banner over the scene runs the record
+flow (Finish → name → Save, mirroring the manual record/name screens); Save calls
 `/nav/save_map` (name must be alphanumeric/`_`/`-`; `.yaml` appended
-server-side), then returns to navigation and activates the new map — the
-same sequence the mobile app runs. All nav state and every mode_manager
+server-side), then returns to navigation and activates the new map. In
+autonomous mode, Finish first settles Nav2 and leaves SLAM in manual mapping
+for naming. Before a
+save, map activation, or explicit mode change, the webapp best-effort calls
+`/brain/cancel_skill` so an explorer does not outlive the mapping session; old
+robot images without that service still proceed. All nav state and every mode_manager
 call live in `js/nav/navStore.js` (the webapp's port of the mobile app's
 MapDataContext); the panel, banner, and page are views of that store. The widget swaps its pose source to
-`/mapping_pose` (map-frame TF, published by mode_manager only while
-mapping) because raw `/odom` drifts against the growing SLAM map and any
+`/mapping_pose` (map-frame TF, published by mode_manager during either mapping
+mode) because raw `/odom` drifts against the growing SLAM map and any
 AMCL fix predates it. Mode follows the `/nav/current_mode` topic, so a
 mapping session started from the mobile app shows the same controls here.
-While mapping, the scene strips down to the growing map + live scan (the
+While either mapping mode is active, the scene strips down to the growing map + live scan (the
 costmap belongs to the previous map; layer chips lock), and the teleop
 drive kit mounts over it — main-camera PiP (WebRTC, or the sim viewer in
-sim), virtual joystick, WASD, and head tilt — because you drive the robot
-to build the map, exactly like the mobile app's record screen.
+sim), virtual joystick, WASD, and head tilt. In autonomous mapping, a nonzero
+joystick/WASD command follows the existing `/joystick` → `/cmd_vel_teleop`
+pipeline; Explore Map watches the latter and cancels itself so manual input
+takes over immediately. Releasing the controls still emits one zero and then
+goes silent. This is additive: robots whose available-skill roster does not
+include Explore Map keep the existing manual mapping workflow.
 
 **Measured velocity is derived, not read.** This robot never populates
 `Odometry.twist` — `mars_bringup`'s `_publish_odometry` copies pose out of the

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -124,6 +124,8 @@ export const NAV_CURRENT_MAP_TOPIC = "/nav/current_map";
 export const NAV_MAPPING_MODES = Object.freeze(["mapping", "autonomous_mapping"]);
 /** @param {unknown} mode */
 export const isMappingNavMode = (mode) => typeof mode === "string" && NAV_MAPPING_MODES.includes(mode);
+/** Keep the live-map view through a mapping-to-mapping transition. */
+export const mappingViewActive = (mode, wasMapping) => (mode === "switching" ? wasMapping : isMappingNavMode(mode));
 // std_msgs/String carrying JSON {"available_maps": ["home.yaml", ...]}.
 export const NAV_AVAILABLE_MAPS_TOPIC = "/nav/available_maps";
 // mode_manager services (brain_messages srvs, all → {success, message}):

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -116,25 +116,28 @@ export const GLOBAL_COSTMAP_TOPIC = "/navigation/global_costmap/costmap"; // nav
 export const LOCAL_COSTMAP_TOPIC = "/local_costmap/costmap";
 // Latched static transforms; carries base_link -> base_laser from the URDF.
 export const TF_STATIC_TOPIC = "/tf_static"; // tf2_msgs/TFMessage
-// mode_manager state (std_msgs/String each): navigation/mapfree/mapping, and
-// the active map's name.
+// mode_manager state (std_msgs/String each): navigation, mapfree, manual
+// mapping, or autonomous mapping, plus the active map's name. Both mapping
+// modes share the same map-session UI and map-frame pose source.
 export const NAV_CURRENT_MODE_TOPIC = "/nav/current_mode";
 export const NAV_CURRENT_MAP_TOPIC = "/nav/current_map";
+export const NAV_MAPPING_MODES = Object.freeze(["mapping", "autonomous_mapping"]);
+/** @param {unknown} mode */
+export const isMappingNavMode = (mode) => typeof mode === "string" && NAV_MAPPING_MODES.includes(mode);
 // std_msgs/String carrying JSON {"available_maps": ["home.yaml", ...]}.
 export const NAV_AVAILABLE_MAPS_TOPIC = "/nav/available_maps";
 // mode_manager services (brain_messages srvs, all → {success, message}):
-// change_mode {mode: "navigation"|"mapping"|"mapfree"} swaps the whole nav
-// lifecycle stack; save_map {map_name, overwrite} only works in mapping mode
-// (name must be alphanumeric/_/-; ".yaml" is appended server-side);
-// delete_map accepts base name or filename.
+// change_mode {mode: "navigation"|"mapping"|"autonomous_mapping"|"mapfree"}
+// swaps the whole nav lifecycle stack; save_map {map_name, overwrite} works in
+// either mapping mode (name must be alphanumeric/_/-; ".yaml" is appended
+// server-side); delete_map accepts base name or filename.
 export const NAV_CHANGE_MODE_SERVICE = "/nav/change_mode";
 export const NAV_CHANGE_MAP_SERVICE = "/nav/change_navigation_map";
 export const NAV_SAVE_MAP_SERVICE = "/nav/save_map";
 export const NAV_DELETE_MAP_SERVICE = "/nav/delete_map";
-// map-frame pose while mapping (nav_msgs/Odometry, TF map->base_link),
-// published by mode_manager only in mapping mode. The right pose source
-// during SLAM: raw /odom drifts against the growing map, and /amcl_pose is
-// stale from navigation mode.
+// map-frame pose during manual or autonomous mapping (nav_msgs/Odometry, TF
+// map->base_link). The right pose source during SLAM: raw /odom drifts against
+// the growing map, and /amcl_pose is stale from navigation mode.
 export const MAPPING_POSE_TOPIC = "/mapping_pose";
 
 // ---- Spatial memory ---------------------------------------------------------
@@ -225,7 +228,7 @@ export const ARM_STATUS_TOPIC = "/mars/arm/status";
 // the skill's display name (case-insensitive, last path segment, "_"→" ").
 // Skills not currently available are skipped, everything else keeps roster order.
 // Ported from the sim console's config.json `pinnedSkills`.
-export const PINNED_SKILLS = ["navigate with vision", "navigate with position", "wave"];
+export const PINNED_SKILLS = ["navigate with vision", "navigate with position", "explore map", "wave"];
 
 // Run one skill directly (brain_messages/action/ExecuteSkill). Goal is
 // {skill_type, inputs} where inputs is a JSON object string; feedback streams

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -338,7 +338,10 @@ export function createMap(root, opts = {}) {
   let unsubMappingPose = null;
 
   function composedPose() {
-    if (mappingMode) return mappingPose ?? odomPose;
+    // Raw odometry is in the odom frame and must never be placed directly on
+    // a map-frame grid. If the SLAM pose is temporarily unavailable, hiding
+    // the marker is more truthful than drawing it several metres away.
+    if (mappingMode) return mappingPose;
     if (!amclPose) return odomPose;
     if (!odomAtAmcl || !odomPose) return amclPose;
     // Motion since the fix in the base frame, re-applied at the AMCL fix.

--- a/webapp/js/nav/main.js
+++ b/webapp/js/nav/main.js
@@ -29,7 +29,7 @@ import {
   ODOM_TOPIC,
   PLAN_TOPICS,
   SCAN_TOPIC,
-  isMappingNavMode,
+  mappingViewActive,
 } from "../constants.js";
 import { createMap, MAP_COLORS } from "../map/mapWidget.js";
 import { createNavStore } from "./navStore.js";
@@ -242,7 +242,7 @@ function buildView(root) {
     const noMap = !s.currentMap || s.mode === "mapfree";
     mapPill.classList.toggle("is-empty", noMap);
     mapPillName.textContent = noMap ? "no map" : s.currentMap;
-    const mapping = isMappingNavMode(s.mode);
+    const mapping = mappingViewActive(s.mode, wasMapping);
     if (mapping !== wasMapping) {
       wasMapping = mapping;
       onMappingChange(mapping);

--- a/webapp/js/nav/main.js
+++ b/webapp/js/nav/main.js
@@ -29,6 +29,7 @@ import {
   ODOM_TOPIC,
   PLAN_TOPICS,
   SCAN_TOPIC,
+  isMappingNavMode,
 } from "../constants.js";
 import { createMap, MAP_COLORS } from "../map/mapWidget.js";
 import { createNavStore } from "./navStore.js";
@@ -189,10 +190,11 @@ function buildView(root) {
   }
 
   // ---- mapping reaction --------------------------------------------------------
-  // Mapping reshapes the page: the scene shows only the growing map + live
-  // scan (the costmap belongs to the previous map; chips lock so the view
-  // can't drift mid-recording), the widget swaps to /mapping_pose, and the
-  // teleop drive kit mounts — you drive the robot to build the map.
+  // Either mapping mode reshapes the page: the scene shows only the growing
+  // map + live scan (the costmap belongs to the previous map; chips lock so
+  // the view can't drift mid-recording), the widget swaps to /mapping_pose,
+  // and the teleop drive kit mounts. In autonomous mode, its first nonzero
+  // command follows the normal /joystick pipeline and takes over from Explore Map.
   /** @type {Record<string, boolean> | null} chip states to restore after mapping */
   let savedLayers = null;
   /** @type {{ destroy: () => void } | null} */
@@ -240,7 +242,7 @@ function buildView(root) {
     const noMap = !s.currentMap || s.mode === "mapfree";
     mapPill.classList.toggle("is-empty", noMap);
     mapPillName.textContent = noMap ? "no map" : s.currentMap;
-    const mapping = s.mode === "mapping";
+    const mapping = isMappingNavMode(s.mode);
     if (mapping !== wasMapping) {
       wasMapping = mapping;
       onMappingChange(mapping);

--- a/webapp/js/nav/mappingSession.js
+++ b/webapp/js/nav/mappingSession.js
@@ -9,11 +9,23 @@
 //   naming:     name field + inline validation    [Save]   [Back]
 //
 // Visibility follows the store's mode (topic-driven), so a session started
-// from the mobile app shows the same controls here; leaving mapping — by
-// whoever — resets the banner to the recording step for next time.
+// from the mobile app shows the same controls here; leaving either mapping
+// mode — by whoever — resets the banner to the recording step for next time.
 
+import { isMappingNavMode } from "../constants.js";
 import { confirmDialog } from "./confirm.js";
 import { MAP_NAME_RE } from "./navStore.js";
+
+/**
+ * Finish is a real motion boundary in autonomous mapping. Moving to manual
+ * mapping makes mode_manager close goal admission, cancel and settle Nav2,
+ * and leave slam_toolbox running for naming/saving.
+ * @param {ReturnType<typeof import("./navStore.js").createNavStore>} store
+ */
+export async function quiesceForMapNaming(store) {
+  if (store.state.mode !== "autonomous_mapping") return true;
+  return store.changeMode("mapping");
+}
 
 // The ⇧ glyph as an outline path rather than the unicode character: its
 // rendering varies wildly by platform font, and this matches the stroke
@@ -39,11 +51,14 @@ export function createMappingSession(scene, store) {
   banner.className = "mapping-banner";
   banner.hidden = true;
 
-  // Two prebuilt prose spans rather than one retitled on every render: the
+  // Prebuilt prose spans rather than retitling on every render: the manual
   // recording line carries a key cap, and render() runs on every store change.
   const recordingText = document.createElement("span");
   recordingText.className = "mapping-banner-text";
   recordingText.append("Recording map — cover the space, hold ", shiftKeyCap(), " to drive slowly");
+  const autonomousText = document.createElement("span");
+  autonomousText.className = "mapping-banner-text";
+  autonomousText.textContent = "Autonomous mapping — joystick or WASD takes over";
   const namingText = document.createElement("span");
   namingText.className = "mapping-banner-text";
   namingText.textContent = "Name this map";
@@ -61,11 +76,15 @@ export function createMappingSession(scene, store) {
   const secondaryBtn = document.createElement("button");
   secondaryBtn.type = "button";
   secondaryBtn.className = "mapping-btn danger";
-  banner.append(recordingText, namingText, nameInput, hint, primaryBtn, secondaryBtn);
+  banner.append(recordingText, autonomousText, namingText, nameInput, hint, primaryBtn, secondaryBtn);
   scene.appendChild(banner);
 
   /** @type {"recording" | "naming"} */
   let step = "recording";
+  // mode_manager publishes a transient `switching` mode before the service
+  // response and final `mapping` topic. Preserve Finish's naming intent across
+  // either delivery order; unrelated exits still reset the next session.
+  let namingTransitionPending = false;
 
   /** Inline validation while typing; returns the trimmed name if saveable. */
   function validName() {
@@ -84,16 +103,24 @@ export function createMappingSession(scene, store) {
 
   /** @param {import("./navStore.js").NavState} s */
   function render(s) {
-    const mapping = s.mode === "mapping";
+    const mapping = isMappingNavMode(s.mode);
     banner.hidden = !mapping;
     if (!mapping) {
-      step = "recording";
-      nameInput.value = "";
-      hint.textContent = "";
+      if (!namingTransitionPending) {
+        step = "recording";
+        nameInput.value = "";
+        hint.textContent = "";
+      }
       return;
     }
+    if (namingTransitionPending && s.mode === "mapping") {
+      step = "naming";
+      namingTransitionPending = false;
+    }
     const naming = step === "naming";
-    recordingText.hidden = naming;
+    const autonomous = s.mode === "autonomous_mapping";
+    recordingText.hidden = naming || autonomous;
+    autonomousText.hidden = naming || !autonomous;
     namingText.hidden = !naming;
     nameInput.hidden = !naming;
     hint.hidden = !naming;
@@ -109,7 +136,15 @@ export function createMappingSession(scene, store) {
 
   primaryBtn.addEventListener("click", async () => {
     if (step === "recording") {
+      const leavingAutonomous = store.state.mode === "autonomous_mapping";
+      namingTransitionPending = leavingAutonomous;
+      if (!(await quiesceForMapNaming(store))) {
+        namingTransitionPending = false;
+        render(store.state);
+        return;
+      }
       step = "naming";
+      if (store.state.mode === "mapping") namingTransitionPending = false;
       render(store.state);
       nameInput.focus();
       return;

--- a/webapp/js/nav/mapsPanel.js
+++ b/webapp/js/nav/mapsPanel.js
@@ -8,7 +8,7 @@
 // navigation). Any map can be deleted, including the one in use — the store
 // drops to map-free first. The roster locks while a recording is in progress.
 
-import { NAV_AVAILABLE_MAPS_TOPIC } from "../constants.js";
+import { NAV_AVAILABLE_MAPS_TOPIC, isMappingNavMode } from "../constants.js";
 import { confirmDialog } from "./confirm.js";
 
 /**
@@ -76,7 +76,7 @@ export function createMapsPanel(host, store) {
 
   /** @param {import("./navStore.js").NavState} s */
   function render(s) {
-    const mapping = s.mode === "mapping";
+    const mapping = isMappingNavMode(s.mode);
     newBtn.disabled = !!s.busy || mapping;
     mapfreeToggle.checked = s.mode === "mapfree";
     mapfreeToggle.disabled = !!s.busy || mapping || (s.mode !== "mapfree" && s.maps.length === 0);
@@ -91,7 +91,7 @@ export function createMapsPanel(host, store) {
     if (mapping) {
       const note = document.createElement("div");
       note.className = "maps-empty";
-      note.textContent = "Recording — finish or discard on the map.";
+      note.textContent = "Mapping in progress — finish or discard on the map.";
       list.appendChild(note);
       return;
     }

--- a/webapp/js/nav/navStore.js
+++ b/webapp/js/nav/navStore.js
@@ -18,6 +18,7 @@ import {
   NAV_AVAILABLE_MAPS_TOPIC,
   NAV_CHANGE_MAP_SERVICE,
   NAV_CHANGE_MODE_SERVICE,
+  CANCEL_SKILL_SERVICE,
   NAV_CURRENT_MAP_TOPIC,
   NAV_CURRENT_MODE_TOPIC,
   NAV_DELETE_MAP_SERVICE,
@@ -25,6 +26,9 @@ import {
 } from "../constants.js";
 
 const MODE_CHANGE_TIMEOUT_MS = 60_000;
+// Older robot images may not expose the cross-client skill-cancel service.
+// Keep this short and best-effort so a missing brain never blocks nav controls.
+const SKILL_CANCEL_TIMEOUT_MS = 2_000;
 // mode_manager's own save_map validation, mirrored for inline feedback: it
 // strips _ and - then requires isalnum(), so at least one alphanumeric is
 // needed — "___" is rejected server-side.
@@ -51,8 +55,9 @@ export const MAP_NAME_RE = /^[A-Za-z0-9_-]*[A-Za-z0-9][A-Za-z0-9_-]*$/;
  *   saveAndActivate: (name: string, overwrite: boolean) => Promise<boolean>,
  *   destroy: () => void,
  * }}
+ * @param {import("../rosClient.js").RosClient} [rosClient]
  */
-export function createNavStore() {
+export function createNavStore(rosClient = ros) {
   /** @type {NavState} */
   const state = { mode: "", maps: [], currentMap: "", busy: null, status: null };
   /** @type {Set<(state: NavState) => void>} */
@@ -69,20 +74,35 @@ export function createNavStore() {
     emit();
   }
 
+  async function cancelActiveSkillBestEffort() {
+    try {
+      // Trigger success=false simply means there was no active skill. Either
+      // way it is safe to continue with the requested nav operation.
+      await rosClient.callService(CANCEL_SKILL_SERVICE, {}, SKILL_CANCEL_TIMEOUT_MS);
+    } catch (err) {
+      console.warn("Could not cancel the active brain skill before nav change:", err);
+    }
+  }
+
   /**
    * One serialized service call: publishes its label via `busy`, its outcome
    * via `status` (failures keep mode_manager's message — e.g. "A mode or map
    * change is in progress").
-   * @param {string} service @param {object} args @param {string} doing
+   * @param {string} service
+   * @param {object} args
+   * @param {string} doing
+   * @param {{ cancelSkill?: boolean }} [options]
    * @returns {Promise<boolean>}
    */
-  async function call(service, args, doing) {
+  async function call(service, args, doing, { cancelSkill = false } = {}) {
     // destroyed: the page is gone, but a caller may still resolve later (a
     // confirm dialog orphaned by navigation) — never command the robot then.
     if (destroyed || state.busy) return false;
     set({ busy: doing, status: null });
     try {
-      const res = await ros.callService(service, args, MODE_CHANGE_TIMEOUT_MS);
+      if (cancelSkill) await cancelActiveSkillBestEffort();
+      if (destroyed) return false;
+      const res = await rosClient.callService(service, args, MODE_CHANGE_TIMEOUT_MS);
       if (destroyed) return false;
       const ok = !!res?.success;
       if (!ok) set({ status: { kind: "fail", text: res?.message || `${doing} failed` } });
@@ -98,7 +118,7 @@ export function createNavStore() {
   }
 
   const unsubs = [
-    ros.subscribe(NAV_AVAILABLE_MAPS_TOPIC, (msg) => {
+    rosClient.subscribe(NAV_AVAILABLE_MAPS_TOPIC, (msg) => {
       if (typeof msg?.data !== "string") return;
       try {
         const parsed = JSON.parse(msg.data);
@@ -113,10 +133,10 @@ export function createNavStore() {
         // torn payload — keep the last good roster
       }
     }, 0, "std_msgs/msg/String"),
-    ros.subscribe(NAV_CURRENT_MAP_TOPIC, (msg) => {
+    rosClient.subscribe(NAV_CURRENT_MAP_TOPIC, (msg) => {
       if (typeof msg?.data === "string" && msg.data !== state.currentMap) set({ currentMap: msg.data });
     }, 0, "std_msgs/msg/String"),
-    ros.subscribe(NAV_CURRENT_MODE_TOPIC, (msg) => {
+    rosClient.subscribe(NAV_CURRENT_MODE_TOPIC, (msg) => {
       if (typeof msg?.data === "string" && msg.data && msg.data !== state.mode) set({ mode: msg.data });
     }, 0, "std_msgs/msg/String"),
   ];
@@ -135,19 +155,28 @@ export function createNavStore() {
     // /nav/current_mode, so it covers the runs no client asked for (a mapless
     // boot, mode_manager redirecting a navigation request) and restores the
     // operator's preset on the way out.
-    async startMapping() {
-      return call(NAV_CHANGE_MODE_SERVICE, { mode: "mapping" }, "Starting mapping");
+    startMapping() {
+      return call(NAV_CHANGE_MODE_SERVICE, { mode: "mapping" }, "Starting mapping", {
+        cancelSkill: true,
+      });
     },
 
-    /** @param {string} mode "navigation" | "mapfree" */
+    /** @param {string} mode "navigation" | "mapping" | "autonomous_mapping" | "mapfree" */
     changeMode(mode) {
-      const doing = mode === "mapfree" ? "Switching to map-free" : "Returning to navigation";
-      return call(NAV_CHANGE_MODE_SERVICE, { mode }, doing);
+      const doing =
+        mode === "mapfree"
+          ? "Switching to map-free"
+          : mode === "mapping"
+            ? "Starting mapping"
+            : mode === "autonomous_mapping"
+              ? "Starting autonomous mapping"
+              : "Returning to navigation";
+      return call(NAV_CHANGE_MODE_SERVICE, { mode }, doing, { cancelSkill: true });
     },
 
     /** @param {string} name map filename, e.g. "home.yaml" */
     changeMap(name) {
-      return call(NAV_CHANGE_MAP_SERVICE, { map_name: name }, `Switching to ${name}`);
+      return call(NAV_CHANGE_MAP_SERVICE, { map_name: name }, `Switching to ${name}`, { cancelSkill: true });
     },
 
     /**
@@ -158,7 +187,9 @@ export function createNavStore() {
      */
     async deleteMap(name) {
       if (name === state.currentMap && state.mode === "navigation") {
-        if (!(await call(NAV_CHANGE_MODE_SERVICE, { mode: "mapfree" }, "Switching to map-free"))) return false;
+        if (!(await call(NAV_CHANGE_MODE_SERVICE, { mode: "mapfree" }, "Switching to map-free", { cancelSkill: true }))) {
+          return false;
+        }
       }
       return call(NAV_DELETE_MAP_SERVICE, { map_name: name }, `Deleting ${name}`);
     },
@@ -170,7 +201,9 @@ export function createNavStore() {
      * @param {string} name base name (no .yaml) @param {boolean} overwrite
      */
     async saveAndActivate(name, overwrite) {
-      if (!(await call(NAV_SAVE_MAP_SERVICE, { map_name: name, overwrite }, `Saving ${name}`))) return false;
+      if (!(await call(NAV_SAVE_MAP_SERVICE, { map_name: name, overwrite }, `Saving ${name}`, { cancelSkill: true }))) {
+        return false;
+      }
       if (!(await call(NAV_CHANGE_MODE_SERVICE, { mode: "navigation" }, "Returning to navigation"))) return false;
       if (!(await call(NAV_CHANGE_MAP_SERVICE, { map_name: `${name}.yaml` }, `Loading ${name}`))) return false;
       set({ status: { kind: "ok", text: `Saved ${name}.yaml — use Locate if the robot isn't where the map thinks` } });

--- a/webapp/tests/navMapping.test.js
+++ b/webapp/tests/navMapping.test.js
@@ -60,6 +60,7 @@ const {
   PINNED_SKILLS,
   NAV_SAVE_MAP_SERVICE,
   isMappingNavMode,
+  mappingViewActive,
 } = await import("../js/constants.js");
 const { createNavStore } = await import("../js/nav/navStore.js");
 const { createMappingSession, quiesceForMapNaming } = await import("../js/nav/mappingSession.js");
@@ -92,6 +93,13 @@ await test("manual and autonomous mapping share the mapping UI policy", () => {
   assert.equal(isMappingNavMode("navigation"), false);
   assert.equal(isMappingNavMode("mapfree"), false);
   assert.equal(isMappingNavMode(null), false);
+});
+
+await test("mapping view holds its map-frame pose source through switching", () => {
+  assert.equal(mappingViewActive("switching", true), true);
+  assert.equal(mappingViewActive("switching", false), false);
+  assert.equal(mappingViewActive("autonomous_mapping", false), true);
+  assert.equal(mappingViewActive("navigation", true), false);
 });
 
 await test("Explore Map is pinned and takeover preserves the robot teleop pipeline", () => {

--- a/webapp/tests/navMapping.test.js
+++ b/webapp/tests/navMapping.test.js
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Mapping-mode and disruptive-operation tests — zero dependencies, plain node:
+//   node tests/navMapping.test.js
+
+import assert from "node:assert/strict";
+
+// navStore imports the shared RosClient singleton. Its constructor only needs
+// these browser event surfaces; the store itself receives the fake client below.
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = tagName;
+    this.children = [];
+    this.listeners = new Map();
+    this.classList = { toggle() {} };
+    this.hidden = false;
+    this.disabled = false;
+    this.value = "";
+    this.textContent = "";
+  }
+
+  append(...children) {
+    this.children.push(...children);
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  addEventListener(type, callback) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(callback);
+    this.listeners.set(type, listeners);
+  }
+
+  async emit(type, event = {}) {
+    for (const callback of this.listeners.get(type) || []) await callback(event);
+  }
+
+  focus() {}
+  remove() {}
+}
+
+globalThis.window = { addEventListener() {} };
+globalThis.document = {
+  addEventListener() {},
+  createElement(tagName) {
+    return new FakeElement(tagName);
+  },
+  visibilityState: "visible",
+};
+globalThis.localStorage = { getItem() { return null; } };
+
+const {
+  CANCEL_SKILL_SERVICE,
+  JOYSTICK_TOPIC,
+  NAV_CHANGE_MAP_SERVICE,
+  NAV_CHANGE_MODE_SERVICE,
+  PINNED_SKILLS,
+  NAV_SAVE_MAP_SERVICE,
+  isMappingNavMode,
+} = await import("../js/constants.js");
+const { createNavStore } = await import("../js/nav/navStore.js");
+const { createMappingSession, quiesceForMapNaming } = await import("../js/nav/mappingSession.js");
+
+let passed = 0;
+/** @param {string} name @param {() => void | Promise<void>} fn */
+async function test(name, fn) {
+  await fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+function fakeRos() {
+  const calls = [];
+  return {
+    calls,
+    subscribe() {
+      return () => {};
+    },
+    async callService(service, args, timeoutMs) {
+      calls.push({ service, args, timeoutMs });
+      return { success: true, message: "ok" };
+    },
+  };
+}
+
+await test("manual and autonomous mapping share the mapping UI policy", () => {
+  assert.equal(isMappingNavMode("mapping"), true);
+  assert.equal(isMappingNavMode("autonomous_mapping"), true);
+  assert.equal(isMappingNavMode("navigation"), false);
+  assert.equal(isMappingNavMode("mapfree"), false);
+  assert.equal(isMappingNavMode(null), false);
+});
+
+await test("Explore Map is pinned and takeover preserves the robot teleop pipeline", () => {
+  assert.equal(PINNED_SKILLS.includes("explore map"), true);
+  assert.equal(JOYSTICK_TOPIC, "/joystick");
+});
+
+await test("Finish settles autonomous navigation before map naming", async () => {
+  const calls = [];
+  const store = {
+    state: { mode: "autonomous_mapping" },
+    async changeMode(mode) {
+      calls.push(mode);
+      return true;
+    },
+  };
+
+  assert.equal(await quiesceForMapNaming(/** @type {any} */ (store)), true);
+  assert.deepEqual(calls, ["mapping"]);
+
+  store.state.mode = "mapping";
+  assert.equal(await quiesceForMapNaming(/** @type {any} */ (store)), true);
+  assert.deepEqual(calls, ["mapping"]);
+});
+
+await test("Finish preserves naming across service-before-final-mode delivery", async () => {
+  const listeners = new Set();
+  const store = {
+    state: { mode: "autonomous_mapping", maps: [], currentMap: "", busy: null, status: null },
+    onChange(callback) {
+      listeners.add(callback);
+      callback(this.state);
+      return () => listeners.delete(callback);
+    },
+    async changeMode(mode) {
+      assert.equal(mode, "mapping");
+      this.state.mode = "switching";
+      for (const callback of [...listeners]) callback(this.state);
+      // The service can resolve before the final latched mode topic arrives.
+      return true;
+    },
+  };
+  const scene = new FakeElement("section");
+  const session = createMappingSession(/** @type {any} */ (scene), /** @type {any} */ (store));
+  const banner = scene.children[0];
+  const primary = banner.children.find((child) => child.tagName === "button" && child.textContent === "Finish");
+
+  await primary.emit("click");
+  assert.equal(banner.hidden, true);
+
+  store.state.mode = "mapping";
+  for (const callback of [...listeners]) callback(store.state);
+  assert.equal(banner.hidden, false);
+  assert.equal(primary.textContent, "Save");
+  session.destroy();
+});
+
+await test("explicit mode changes best-effort cancel the active skill first", async () => {
+  const client = fakeRos();
+  const store = createNavStore(/** @type {any} */ (client));
+
+  assert.equal(await store.changeMode("navigation"), true);
+  assert.deepEqual(client.calls.map((call) => call.service), [CANCEL_SKILL_SERVICE, NAV_CHANGE_MODE_SERVICE]);
+  store.destroy();
+});
+
+await test("starting manual mapping leaves the robot-side Slow policy to mars_app", async () => {
+  const client = fakeRos();
+  const store = createNavStore(/** @type {any} */ (client));
+
+  assert.equal(await store.startMapping(), true);
+  assert.deepEqual(client.calls.map((call) => call.service), [CANCEL_SKILL_SERVICE, NAV_CHANGE_MODE_SERVICE]);
+  store.destroy();
+});
+
+await test("a missing cancel service never blocks the requested mode change", async () => {
+  const client = fakeRos();
+  client.callService = async (service, args, timeoutMs) => {
+    client.calls.push({ service, args, timeoutMs });
+    if (service === CANCEL_SKILL_SERVICE) throw new Error("service unavailable");
+    return { success: true, message: "ok" };
+  };
+  const store = createNavStore(/** @type {any} */ (client));
+  const originalWarn = console.warn;
+  console.warn = () => {};
+
+  try {
+    assert.equal(await store.changeMode("mapfree"), true);
+    assert.deepEqual(client.calls.map((call) => call.service), [CANCEL_SKILL_SERVICE, NAV_CHANGE_MODE_SERVICE]);
+  } finally {
+    console.warn = originalWarn;
+    store.destroy();
+  }
+});
+
+await test("map activation cancels the active skill before switching maps", async () => {
+  const client = fakeRos();
+  const store = createNavStore(/** @type {any} */ (client));
+
+  assert.equal(await store.changeMap("home.yaml"), true);
+  assert.deepEqual(client.calls.map((call) => call.service), [CANCEL_SKILL_SERVICE, NAV_CHANGE_MAP_SERVICE]);
+  store.destroy();
+});
+
+await test("save-and-activate cancels before the sequence, then saves, changes mode, and loads", async () => {
+  const client = fakeRos();
+  const store = createNavStore(/** @type {any} */ (client));
+
+  assert.equal(await store.saveAndActivate("office", false), true);
+  assert.deepEqual(client.calls.map((call) => call.service), [
+    CANCEL_SKILL_SERVICE,
+    NAV_SAVE_MAP_SERVICE,
+    NAV_CHANGE_MODE_SERVICE,
+    NAV_CHANGE_MAP_SERVICE,
+  ]);
+  store.destroy();
+});
+
+console.log(`\n${passed} passed`);

--- a/workspace/innate_agents/basic_agent.py
+++ b/workspace/innate_agents/basic_agent.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
+from innate_skills.explore_map import ExploreMap
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.navigate_with_vision import NavigateWithVision
 from innate_skills.search_memory import SearchMemory
@@ -25,7 +26,7 @@ class BasicAgent(Agent):
     def get_skills(self) -> list[SkillRef]:
         """The skills this directive can use — classes for code skills;
         physical skills (no class) stay id strings like "local/pick_socks"."""
-        return [NavigateToPosition, NavigateWithVision, SearchMemory]
+        return [NavigateToPosition, NavigateWithVision, ExploreMap, SearchMemory]
 
     def get_inputs(self) -> list[InputRef]:
         """Enable microphone input to hear user"""

--- a/workspace/innate_agents/mapping_agent.py
+++ b/workspace/innate_agents/mapping_agent.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Agent dedicated to supervised, autonomous map building."""
+
+from innate_skills.explore_map import ExploreMap
+from inputs.micro_input import MicroInput
+
+from brain_client.agents.types import Agent, InputRef, SkillRef
+
+
+class MappingAgent(Agent):
+    @property
+    def id(self) -> str:
+        return "mapping_agent"
+
+    @property
+    def display_name(self) -> str:
+        return "Autonomous Mapping"
+
+    def get_skills(self) -> list[SkillRef]:
+        return [ExploreMap]
+
+    def get_inputs(self) -> list[InputRef]:
+        return [MicroInput]
+
+    def get_prompt(self) -> str:
+        return (
+            "You supervise autonomous mapping. Start ExploreMap only when the user explicitly asks the robot to "
+            "map or explore the space. While it runs, keep answering ordinary questions without stopping it. "
+            "If the user says stop, cancel immediately and do not restart. Manual joystick input also ends "
+            "autonomous driving. When mapping finishes, report the result and ask the user to inspect and save "
+            "the map; never save it or switch navigation modes without their request."
+        )

--- a/workspace/innate_agents/mapping_agent.py
+++ b/workspace/innate_agents/mapping_agent.py
@@ -28,6 +28,8 @@ class MappingAgent(Agent):
             "You supervise autonomous mapping. Start ExploreMap only when the user explicitly asks the robot to "
             "map or explore the space. While it runs, keep answering ordinary questions without stopping it. "
             "If the user says stop, cancel immediately and do not restart. Manual joystick input also ends "
-            "autonomous driving. When mapping finishes, report the result and ask the user to inspect and save "
-            "the map; never save it or switch navigation modes without their request."
+            "autonomous driving. If the user asks to reset or start over, stop the running skill first, then start "
+            "ExploreMap with reset_map=true. This discards the unsaved SLAM map. Never say a map was reset unless "
+            "that reset-enabled skill call succeeded. When mapping finishes, report the result and ask the user to "
+            "inspect and save the map; never save it or switch navigation modes without their request."
         )

--- a/workspace/innate_skills/_frontier_planner.py
+++ b/workspace/innate_skills/_frontier_planner.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Deterministic, ROS-free frontier planning on a live occupancy grid."""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+import numpy as np
+
+Cell = tuple[int, int]  # row, column
+
+
+class FrontierPlanningError(ValueError):
+    """The current grid/pose cannot safely produce exploration goals."""
+
+
+@dataclass(frozen=True)
+class GridGeometry:
+    resolution: float
+    origin_x: float
+    origin_y: float
+    origin_yaw: float = 0.0
+
+    def __post_init__(self):
+        if not math.isfinite(self.resolution) or self.resolution <= 0.0:
+            raise FrontierPlanningError("map resolution must be positive")
+        if not all(math.isfinite(v) for v in (self.origin_x, self.origin_y, self.origin_yaw)):
+            raise FrontierPlanningError("map origin must be finite")
+
+    def cell_to_world(self, row: int, col: int) -> tuple[float, float]:
+        """Return the map-frame center of ``(row, col)``."""
+        local_x = (col + 0.5) * self.resolution
+        local_y = (row + 0.5) * self.resolution
+        c = math.cos(self.origin_yaw)
+        s = math.sin(self.origin_yaw)
+        return (
+            self.origin_x + c * local_x - s * local_y,
+            self.origin_y + s * local_x + c * local_y,
+        )
+
+    def world_to_cell(self, x: float, y: float) -> Cell:
+        """Return the occupancy cell containing a map-frame point."""
+        dx = x - self.origin_x
+        dy = y - self.origin_y
+        c = math.cos(self.origin_yaw)
+        s = math.sin(self.origin_yaw)
+        local_x = c * dx + s * dy
+        local_y = -s * dx + c * dy
+        return (math.floor(local_y / self.resolution), math.floor(local_x / self.resolution))
+
+
+@dataclass(frozen=True)
+class FrontierGoal:
+    row: int
+    col: int
+    x: float
+    y: float
+    yaw: float
+    frontier_cells: int
+    route_distance_m: float
+    score: float
+    cluster_anchor: Cell
+
+
+_CARDINAL = ((-1, 0), (0, -1), (0, 1), (1, 0))
+_EIGHT_CONNECTED = tuple((dr, dc) for dr in (-1, 0, 1) for dc in (-1, 0, 1) if not (dr == 0 and dc == 0))
+
+
+def known_area_m2(grid: np.ndarray, resolution: float) -> float:
+    return float(np.count_nonzero(np.asarray(grid) >= 0)) * resolution * resolution
+
+
+def _adjacent_to(mask: np.ndarray, neighbors: Iterable[Cell] = _EIGHT_CONNECTED) -> np.ndarray:
+    height, width = mask.shape
+    padded = np.pad(mask.astype(bool, copy=False), 1, mode="constant", constant_values=False)
+    adjacent = np.zeros((height, width), dtype=bool)
+    for dr, dc in neighbors:
+        adjacent |= padded[1 + dr : 1 + dr + height, 1 + dc : 1 + dc + width]
+    return adjacent
+
+
+def _inflate_obstacles(occupied: np.ndarray, clearance_m: float, resolution: float) -> np.ndarray:
+    """Inflate occupied cells and the grid edge by a Euclidean radius."""
+    if clearance_m <= 0.0:
+        return occupied.astype(bool, copy=True)
+    radius = int(math.ceil(clearance_m / resolution))
+    height, width = occupied.shape
+    padded = np.pad(occupied.astype(bool, copy=False), radius, mode="constant", constant_values=True)
+    inflated = np.zeros((height, width), dtype=bool)
+    for dr in range(-radius, radius + 1):
+        for dc in range(-radius, radius + 1):
+            if math.hypot(dr, dc) * resolution > clearance_m + 1e-9:
+                continue
+            inflated |= padded[
+                radius + dr : radius + dr + height,
+                radius + dc : radius + dc + width,
+            ]
+    return inflated
+
+
+def _nearest_free_cell(free: np.ndarray, start: Cell, max_snap_cells: int) -> Cell:
+    height, width = free.shape
+    row, col = start
+    if 0 <= row < height and 0 <= col < width and free[row, col]:
+        return start
+    cells = np.argwhere(free)
+    if cells.size == 0:
+        raise FrontierPlanningError("map has no known-free cells")
+    distances_sq = (cells[:, 0] - row) ** 2 + (cells[:, 1] - col) ** 2
+    best_index = int(np.argmin(distances_sq))
+    if int(distances_sq[best_index]) > max_snap_cells * max_snap_cells:
+        raise FrontierPlanningError("map pose is not near known-free space")
+    return (int(cells[best_index, 0]), int(cells[best_index, 1]))
+
+
+def _nearest_reachable_cell(
+    target: np.ndarray,
+    traversable: np.ndarray,
+    start: Cell,
+    max_steps: int,
+    check_cancelled: Callable[[], None] | None,
+) -> tuple[Cell, int]:
+    """Find the nearest target through a bounded four-connected traversal.
+
+    This is intentionally not a Euclidean nearest-cell lookup: the latter can
+    move the route seed through an occupied wall when the robot starts inside
+    the route-clearance halo around an obstacle.
+    """
+    if target[start]:
+        return start, 0
+
+    height, width = traversable.shape
+    distances = np.full((height, width), -1, dtype=np.int32)
+    distances[start] = 0
+    queue = deque([start])
+    visited = 0
+    while queue:
+        row, col = queue.popleft()
+        distance = int(distances[row, col])
+        if distance >= max_steps:
+            continue
+        for dr, dc in _CARDINAL:
+            nr, nc = row + dr, col + dc
+            if not (0 <= nr < height and 0 <= nc < width):
+                continue
+            if not traversable[nr, nc] or distances[nr, nc] >= 0:
+                continue
+            next_distance = distance + 1
+            if target[nr, nc]:
+                return (nr, nc), next_distance
+            distances[nr, nc] = next_distance
+            queue.append((nr, nc))
+        visited += 1
+        if check_cancelled is not None and visited % 4096 == 0:
+            check_cancelled()
+
+    raise FrontierPlanningError("map pose is not near footprint-clear free space")
+
+
+def _route_distances(
+    free: np.ndarray,
+    start: Cell,
+    check_cancelled: Callable[[], None] | None,
+) -> np.ndarray:
+    """Four-connected BFS distance, preventing diagonal corner cutting."""
+    height, width = free.shape
+    distances = np.full((height, width), -1, dtype=np.int32)
+    distances[start] = 0
+    queue = deque([start])
+    visited = 0
+    while queue:
+        row, col = queue.popleft()
+        next_distance = int(distances[row, col]) + 1
+        for dr, dc in _CARDINAL:
+            nr, nc = row + dr, col + dc
+            if 0 <= nr < height and 0 <= nc < width and free[nr, nc] and distances[nr, nc] < 0:
+                distances[nr, nc] = next_distance
+                queue.append((nr, nc))
+        visited += 1
+        if check_cancelled is not None and visited % 4096 == 0:
+            check_cancelled()
+    return distances
+
+
+def _clusters(mask: np.ndarray, check_cancelled: Callable[[], None] | None) -> list[list[Cell]]:
+    height, width = mask.shape
+    unseen = mask.copy()
+    clusters: list[list[Cell]] = []
+    for seed_row, seed_col in np.argwhere(mask):
+        seed = (int(seed_row), int(seed_col))
+        if not unseen[seed]:
+            continue
+        unseen[seed] = False
+        queue = deque([seed])
+        cluster: list[Cell] = []
+        while queue:
+            row, col = queue.popleft()
+            cluster.append((row, col))
+            for dr, dc in _EIGHT_CONNECTED:
+                nr, nc = row + dr, col + dc
+                if 0 <= nr < height and 0 <= nc < width and unseen[nr, nc]:
+                    unseen[nr, nc] = False
+                    queue.append((nr, nc))
+            if check_cancelled is not None and len(cluster) % 2048 == 0:
+                check_cancelled()
+        cluster.sort()
+        clusters.append(cluster)
+    return clusters
+
+
+def _is_excluded(x: float, y: float, excluded: Iterable[tuple[float, float]], radius_m: float) -> bool:
+    radius_sq = radius_m * radius_m
+    return any((x - ex) ** 2 + (y - ey) ** 2 <= radius_sq for ex, ey in excluded)
+
+
+def find_frontier_goals(
+    grid: np.ndarray,
+    geometry: GridGeometry,
+    robot_x: float,
+    robot_y: float,
+    *,
+    occupied_threshold: int = 50,
+    route_clearance_m: float = 0.17,
+    obstacle_clearance_m: float = 0.30,
+    min_frontier_length_m: float = 0.35,
+    min_goal_distance_m: float = 0.25,
+    excluded_world: Iterable[tuple[float, float]] = (),
+    exclusion_radius_m: float = 0.60,
+    information_gain_weight: float = 1.0,
+    travel_cost_weight: float = 0.25,
+    check_cancelled: Callable[[], None] | None = None,
+) -> list[FrontierGoal]:
+    """Return ranked, reachable known-free cells beside unknown space.
+
+    The frontier itself is represented by *free* cells adjacent to unknown,
+    never by the unknown centroid. This matches Nav2's ``allow_unknown=false``
+    contract. Reachability uses a footprint-sized clearance that rejects
+    definitely impassable corridors while retaining valid narrow doorways.
+    Destination safety separately uses the larger obstacle clearance.
+    """
+
+    grid = np.asarray(grid)
+    if grid.ndim != 2 or grid.shape[0] == 0 or grid.shape[1] == 0:
+        raise FrontierPlanningError("occupancy grid must be a non-empty 2D array")
+    if not all(math.isfinite(v) for v in (robot_x, robot_y)):
+        raise FrontierPlanningError("map pose must be finite")
+    if (
+        route_clearance_m < 0.0
+        or obstacle_clearance_m < 0.0
+        or min_frontier_length_m <= 0.0
+        or exclusion_radius_m < 0.0
+    ):
+        raise FrontierPlanningError("frontier distances must be non-negative")
+
+    free = (grid >= 0) & (grid < occupied_threshold)
+    occupied = grid >= occupied_threshold
+    start = geometry.world_to_cell(robot_x, robot_y)
+    max_snap_cells = max(1, int(math.ceil(0.5 / geometry.resolution)))
+    start = _nearest_free_cell(free, start, max_snap_cells)
+    route_unsafe = _inflate_obstacles(occupied, route_clearance_m, geometry.resolution)
+    route_free = free & ~route_unsafe
+    max_route_seed_steps = int(math.ceil(route_clearance_m / geometry.resolution))
+    route_start, seed_distance = _nearest_reachable_cell(
+        route_free,
+        free,
+        start,
+        max_route_seed_steps,
+        check_cancelled,
+    )
+    distances = _route_distances(route_free, route_start, check_cancelled)
+    distances[distances >= 0] += seed_distance
+    reachable = distances >= 0
+
+    frontier_mask = free & reachable & _adjacent_to(grid < 0)
+    if not np.any(frontier_mask):
+        return []
+    unsafe = _inflate_obstacles(occupied, obstacle_clearance_m, geometry.resolution)
+    safe_destination = frontier_mask & ~unsafe
+    excluded = tuple(excluded_world)
+
+    goals: list[FrontierGoal] = []
+    for cluster in _clusters(frontier_mask, check_cancelled):
+        if len(cluster) * geometry.resolution + 1e-9 < min_frontier_length_m:
+            continue
+        cluster_anchor = cluster[0]
+        centroid_row = sum(cell[0] for cell in cluster) / len(cluster)
+        centroid_col = sum(cell[1] for cell in cluster) / len(cluster)
+
+        candidates = []
+        for row, col in cluster:
+            if not safe_destination[row, col]:
+                continue
+            route_distance_m = float(distances[row, col]) * geometry.resolution
+            if route_distance_m + 1e-9 < min_goal_distance_m:
+                continue
+            x, y = geometry.cell_to_world(row, col)
+            if _is_excluded(x, y, excluded, exclusion_radius_m):
+                continue
+            centroid_distance_sq = (row - centroid_row) ** 2 + (col - centroid_col) ** 2
+            candidates.append((centroid_distance_sq, route_distance_m, row, col, x, y))
+        if not candidates:
+            continue
+        _, route_distance_m, row, col, x, y = min(candidates)
+
+        unknown_neighbors: set[Cell] = set()
+        height, width = grid.shape
+        for frontier_row, frontier_col in cluster:
+            for dr, dc in _EIGHT_CONNECTED:
+                nr, nc = frontier_row + dr, frontier_col + dc
+                if 0 <= nr < height and 0 <= nc < width and grid[nr, nc] < 0:
+                    unknown_neighbors.add((nr, nc))
+        if not unknown_neighbors:
+            continue
+        # Average the exact map-frame cell centers. Flooring the mean grid
+        # coordinate biases the heading by as much as half a cell on each
+        # axis, especially for asymmetric frontier boundaries.
+        unknown_world = [geometry.cell_to_world(r, c) for r, c in unknown_neighbors]
+        unknown_x = sum(point[0] for point in unknown_world) / len(unknown_world)
+        unknown_y = sum(point[1] for point in unknown_world) / len(unknown_world)
+        yaw = math.atan2(unknown_y - y, unknown_x - x)
+        frontier_length_m = len(cluster) * geometry.resolution
+        score = information_gain_weight * frontier_length_m - travel_cost_weight * route_distance_m
+        goals.append(
+            FrontierGoal(
+                row=row,
+                col=col,
+                x=x,
+                y=y,
+                yaw=yaw,
+                frontier_cells=len(cluster),
+                route_distance_m=route_distance_m,
+                score=score,
+                cluster_anchor=cluster_anchor,
+            )
+        )
+        if check_cancelled is not None:
+            check_cancelled()
+
+    goals.sort(
+        key=lambda goal: (
+            -goal.score,
+            goal.route_distance_m,
+            goal.cluster_anchor[0],
+            goal.cluster_anchor[1],
+            goal.row,
+            goal.col,
+        )
+    )
+    return goals

--- a/workspace/innate_skills/explore_map.py
+++ b/workspace/innate_skills/explore_map.py
@@ -22,7 +22,8 @@ from innate_skills._frontier_planner import (
     find_frontier_goals,
     known_area_m2,
 )
-from innate_skills.navigate_to_position import Nav2Controller
+from innate_skills.navigate_to_position import Nav2Controller, NavigationBlocked
+from sensor_msgs.msg import LaserScan
 
 from innate import Lidar, Map, NavMode, Pose, Skill, SkillCancelled, SkillFailed, SkillOutput, SkillReturn, resource
 
@@ -34,6 +35,8 @@ POSE_STALE_TIMEOUT_S = 2.0
 LIDAR_STALE_TIMEOUT_S = 1.5
 MAX_CONSECUTIVE_FAILURES = 3
 STABLE_EMPTY_MAPS = 2
+RECOVERY_HINT_TOPIC = "/mapping/recovery_scan"
+RECOVERY_HINT_DISTANCE_M = 0.32
 
 
 def _sample_marker(sample: object) -> tuple[str, object]:
@@ -107,6 +110,29 @@ class _TeleopTakeover:
         self._node.destroy_subscription(self._sub)
 
 
+class _RecoveryHintPublisher:
+    """Mark one inferred contact in Nav2's costmaps, never in the SLAM map."""
+
+    def __init__(self, skill: ExploreMap):
+        self._node = skill.node
+        self._hint_pub = skill.node.create_publisher(LaserScan, RECOVERY_HINT_TOPIC, 10)
+
+    def mark_front_obstacle(self) -> None:
+        scan = LaserScan()
+        scan.header.stamp = self._node.get_clock().now().to_msg()
+        scan.header.frame_id = "base_link"
+        scan.angle_min = 0.0
+        scan.angle_max = 0.0
+        scan.angle_increment = 1.0
+        scan.range_min = 0.05
+        scan.range_max = 1.0
+        scan.ranges = [RECOVERY_HINT_DISTANCE_M]
+        self._hint_pub.publish(scan)
+
+    def destroy(self) -> None:
+        self._node.destroy_publisher(self._hint_pub)
+
+
 class ExploreMap(Skill):
     nav_mode: NavMode
     map: Map | None = None
@@ -130,6 +156,12 @@ class ExploreMap(Skill):
         controller = Nav2Controller(self)
         yield controller
         controller.destroy()
+
+    @resource
+    def recovery_hint(self) -> Iterator[_RecoveryHintPublisher]:
+        publisher = _RecoveryHintPublisher(self)
+        yield publisher
+        publisher.destroy()
 
     def guidelines(self) -> str:
         return (
@@ -365,6 +397,9 @@ class ExploreMap(Skill):
                 if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
                     stop_reason = "navigation failed repeatedly"
                     break
+                if isinstance(exc, NavigationBlocked):
+                    self.feedback("Nav2 exhausted its recoveries; adding a short-lived obstacle hint before replanning")
+                    self.recovery_hint.mark_front_obstacle()
                 self.sleep(0.5)
                 continue
 

--- a/workspace/innate_skills/explore_map.py
+++ b/workspace/innate_skills/explore_map.py
@@ -24,6 +24,7 @@ from innate_skills._frontier_planner import (
 )
 from innate_skills.navigate_to_position import Nav2Controller, NavigationBlocked
 from sensor_msgs.msg import LaserScan
+from std_srvs.srv import Trigger
 
 from innate import Lidar, Map, NavMode, Pose, Skill, SkillCancelled, SkillFailed, SkillOutput, SkillReturn, resource
 
@@ -56,35 +57,43 @@ class _MappingModeController:
     def __init__(self, skill: ExploreMap):
         self.skill = skill
         self.client = skill.node.create_client(ChangeNavigationMode, "/nav/change_mode")
+        self.reset_client = skill.node.create_client(Trigger, "/nav/reset_mapping")
 
-    def switch_to_autonomous_mapping(self) -> None:
+    def _call(self, client, request, action: str) -> None:
         deadline = time.monotonic() + MODE_CHANGE_TIMEOUT_S
-        while not self.client.service_is_ready():
+        while not client.service_is_ready():
             if time.monotonic() >= deadline:
-                raise SkillFailed("navigation mode service is unavailable")
+                raise SkillFailed(f"{action} service is unavailable")
             self.skill.sleep(0.1)
 
-        request = ChangeNavigationMode.Request()
-        request.mode = AUTONOMOUS_MAPPING_MODE
-        future = self.client.call_async(request)
+        future = client.call_async(request)
         try:
             while not future.done():
                 if time.monotonic() >= deadline:
                     future.cancel()
-                    raise SkillFailed("timed out starting autonomous mapping mode")
+                    raise SkillFailed(f"timed out {action}")
                 self.skill.sleep(0.1)
             response = future.result()
         except (SkillCancelled, SkillFailed):
             future.cancel()
             raise
         except Exception as exc:
-            raise SkillFailed(f"navigation mode service failed: {exc}") from exc
+            raise SkillFailed(f"{action} service failed: {exc}") from exc
         if response is None or not response.success:
             detail = response.message if response is not None else "no response"
-            raise SkillFailed(f"could not start autonomous mapping mode: {detail}")
+            raise SkillFailed(f"could not {action}: {detail}")
+
+    def reset_mapping(self) -> None:
+        self._call(self.reset_client, Trigger.Request(), "reset the map")
+
+    def switch_to_autonomous_mapping(self) -> None:
+        request = ChangeNavigationMode.Request()
+        request.mode = AUTONOMOUS_MAPPING_MODE
+        self._call(self.client, request, "start autonomous mapping mode")
 
     def destroy(self) -> None:
         self.skill.node.destroy_client(self.client)
+        self.skill.node.destroy_client(self.reset_client)
 
 
 class _TeleopTakeover:
@@ -268,6 +277,7 @@ class ExploreMap(Skill):
         max_duration_minutes: float = 10.0,
         max_frontiers: int = 30,
         goal_timeout_seconds: float = 90.0,
+        reset_map: bool = False,
     ) -> SkillReturn:
         if not 1.0 <= float(max_duration_minutes) <= 60.0:
             self.fail("max_duration_minutes must be between 1 and 60")
@@ -288,6 +298,13 @@ class ExploreMap(Skill):
         previous_pose = self.pose
         changed_mode = self.nav_mode.value != AUTONOMOUS_MAPPING_MODE
 
+        if reset_map and self.nav_mode.value in {"mapping", AUTONOMOUS_MAPPING_MODE}:
+            self.feedback("Discarding the current map and starting a fresh SLAM session")
+            try:
+                self.mode_controller.reset_mapping()
+            except SkillFailed as exc:
+                self.fail(str(exc))
+
         self.feedback("Starting SLAM and collision-aware navigation for autonomous mapping")
         if changed_mode:
             try:
@@ -299,7 +316,7 @@ class ExploreMap(Skill):
             initial_map, initial_pose, initial_lidar = self._wait_for_mapping_state(
                 previous_map,
                 previous_pose,
-                changed_mode,
+                changed_mode or reset_map,
             )
         except SkillFailed as exc:
             self.fail(str(exc))

--- a/workspace/innate_skills/explore_map.py
+++ b/workspace/innate_skills/explore_map.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Autonomously build a map by navigating to reachable exploration frontiers.
+
+Use when the user explicitly asks the robot to map or explore a space. The
+skill switches into autonomous mapping, then lets slam_toolbox own the growing
+map while Nav2 performs collision-aware motion. It never commands wheel
+velocities directly. Manual joystick input, Stop, a mode change, or stale map,
+pose, or lidar data ends exploration immediately.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+
+from brain_messages.srv import ChangeNavigationMode
+from geometry_msgs.msg import Twist
+from innate_skills._frontier_planner import (
+    FrontierPlanningError,
+    GridGeometry,
+    find_frontier_goals,
+    known_area_m2,
+)
+from innate_skills.navigate_to_position import Nav2Controller
+
+from innate import Lidar, Map, NavMode, Pose, Skill, SkillCancelled, SkillFailed, SkillOutput, SkillReturn, resource
+
+AUTONOMOUS_MAPPING_MODE = "autonomous_mapping"
+MODE_CHANGE_TIMEOUT_S = 60.0
+INITIAL_STATE_TIMEOUT_S = 12.0
+MAP_STALE_TIMEOUT_S = 4.0
+POSE_STALE_TIMEOUT_S = 2.0
+LIDAR_STALE_TIMEOUT_S = 1.5
+MAX_CONSECUTIVE_FAILURES = 3
+STABLE_EMPTY_MAPS = 2
+
+
+def _sample_marker(sample: object) -> tuple[str, object]:
+    """Track source time when available, identity only for unstamped fakes.
+
+    RobotState memoizes each ROS sample, but `/mapping_pose` itself is a
+    wrapper around TF. Its TF-derived stamp is the authority that proves SLAM
+    is still updating; merely receiving a newly allocated wrapper is not.
+    """
+    stamp = getattr(sample, "stamp", None)
+    if isinstance(stamp, (int, float)) and stamp > 0.0:
+        return ("stamp", float(stamp))
+    return ("identity", id(sample))
+
+
+class _MappingModeController:
+    def __init__(self, skill: ExploreMap):
+        self.skill = skill
+        self.client = skill.node.create_client(ChangeNavigationMode, "/nav/change_mode")
+
+    def switch_to_autonomous_mapping(self) -> None:
+        deadline = time.monotonic() + MODE_CHANGE_TIMEOUT_S
+        while not self.client.service_is_ready():
+            if time.monotonic() >= deadline:
+                raise SkillFailed("navigation mode service is unavailable")
+            self.skill.sleep(0.1)
+
+        request = ChangeNavigationMode.Request()
+        request.mode = AUTONOMOUS_MAPPING_MODE
+        future = self.client.call_async(request)
+        try:
+            while not future.done():
+                if time.monotonic() >= deadline:
+                    future.cancel()
+                    raise SkillFailed("timed out starting autonomous mapping mode")
+                self.skill.sleep(0.1)
+            response = future.result()
+        except (SkillCancelled, SkillFailed):
+            future.cancel()
+            raise
+        except Exception as exc:
+            raise SkillFailed(f"navigation mode service failed: {exc}") from exc
+        if response is None or not response.success:
+            detail = response.message if response is not None else "no response"
+            raise SkillFailed(f"could not start autonomous mapping mode: {detail}")
+
+    def destroy(self) -> None:
+        self.skill.node.destroy_client(self.client)
+
+
+class _TeleopTakeover:
+    """A non-zero human drive command cancels, rather than merely masks, Nav2."""
+
+    def __init__(self, skill: ExploreMap):
+        self.taken_over = False
+        self.armed = False
+        self._skill = skill
+        self._sub = skill.node.create_subscription(Twist, "/cmd_vel_teleop", self._on_command, 10)
+        self._node = skill.node
+
+    def _on_command(self, msg: Twist) -> None:
+        moving = abs(msg.linear.x) > 1e-3 or abs(msg.linear.y) > 1e-3 or abs(msg.angular.z) > 1e-3
+        if self.armed and moving and not self.taken_over:
+            self.taken_over = True
+            # Cancel from the subscription callback so takeover is immediate
+            # even during a mode-service or initial-state wait. This also fires
+            # Nav2Controller's external-action cancel hook when a goal is live.
+            self._skill.cancel()
+
+    def destroy(self) -> None:
+        self._node.destroy_subscription(self._sub)
+
+
+class ExploreMap(Skill):
+    nav_mode: NavMode
+    map: Map | None = None
+    pose: Pose | None = None
+    lidar: Lidar | None = None
+
+    @resource
+    def mode_controller(self) -> Iterator[_MappingModeController]:
+        controller = _MappingModeController(self)
+        yield controller
+        controller.destroy()
+
+    @resource
+    def teleop(self) -> Iterator[_TeleopTakeover]:
+        monitor = _TeleopTakeover(self)
+        yield monitor
+        monitor.destroy()
+
+    @resource
+    def navigator(self) -> Iterator[Nav2Controller]:
+        controller = Nav2Controller(self)
+        yield controller
+        controller.destroy()
+
+    def guidelines(self) -> str:
+        return (
+            "Autonomously explore a space to build its occupancy map. Use only after an explicit request to map. "
+            "The skill starts autonomous mapping itself; do not precede it with MoveStraight or raw driving. "
+            "The user can keep talking while it runs and can say Stop or use the joystick to take over."
+        )
+
+    def guidelines_when_running(self) -> str:
+        return (
+            "Mapping continues while you answer ordinary questions. Report progress conversationally without stopping it. "
+            "Stop only when the user explicitly asks, manually drives, or a safety condition ends the run."
+        )
+
+    def _wait_for_autonomous_mode(self) -> NavMode:
+        mode = self.wait_for(
+            lambda: self.nav_mode if self.nav_mode.value == AUTONOMOUS_MAPPING_MODE else None,
+            timeout=INITIAL_STATE_TIMEOUT_S,
+        )
+        if mode is None:
+            raise SkillFailed(f"mode manager did not enter {AUTONOMOUS_MAPPING_MODE}")
+        return mode
+
+    def _wait_for_mapping_state(
+        self,
+        previous_map: Map | None,
+        previous_pose: Pose | None,
+        require_new_state: bool,
+    ) -> tuple[Map, Pose, Lidar]:
+        map_state = self.wait_for(
+            lambda: (
+                self.map if self.map is not None and (not require_new_state or self.map is not previous_map) else None
+            ),
+            timeout=INITIAL_STATE_TIMEOUT_S,
+        )
+        pose = self.wait_for(
+            lambda: (
+                self.pose
+                if self.pose is not None and (not require_new_state or self.pose is not previous_pose)
+                else None
+            ),
+            timeout=INITIAL_STATE_TIMEOUT_S,
+        )
+        lidar = self.wait_for(lambda: self.lidar, timeout=INITIAL_STATE_TIMEOUT_S)
+        if map_state is None:
+            raise SkillFailed("no fresh live SLAM map arrived after the mode switch")
+        if pose is None:
+            detail = (
+                "no fresh map-frame mapping pose arrived after the mode switch"
+                if require_new_state
+                else ("no map-frame mapping pose is available")
+            )
+            raise SkillFailed(detail)
+        if lidar is None:
+            raise SkillFailed("no lidar scan is available for obstacle avoidance")
+        if map_state.frame_id != "map" or pose.frame_id != "map":
+            raise SkillFailed(
+                f"mapping frame mismatch: map={map_state.frame_id!r}, pose={pose.frame_id!r}; both must be 'map'"
+            )
+        return map_state, pose, lidar
+
+    def _arm_safety(self, map_state: Map, pose: Pose, lidar: Lidar) -> None:
+        now = time.monotonic()
+        self._last_map_marker = _sample_marker(map_state)
+        self._last_map_seen_at = now
+        self._last_pose_marker = _sample_marker(pose)
+        self._last_pose_seen_at = now
+        self._last_lidar_marker = _sample_marker(lidar)
+        self._last_lidar_seen_at = now
+        self.teleop.armed = True
+
+    def _safety_check(self) -> None:
+        self.check_cancelled()
+        if self.nav_mode.value != AUTONOMOUS_MAPPING_MODE:
+            raise SkillCancelled(f"mapping stopped because navigation mode changed to {self.nav_mode.value}")
+        if self.teleop.taken_over:
+            raise SkillCancelled("mapping stopped for manual joystick takeover")
+
+        now = time.monotonic()
+        current_map = self.map
+        current_pose = self.pose
+        current_lidar = self.lidar
+        map_marker = _sample_marker(current_map) if current_map is not None else None
+        pose_marker = _sample_marker(current_pose) if current_pose is not None else None
+        lidar_marker = _sample_marker(current_lidar) if current_lidar is not None else None
+        if map_marker is not None and map_marker != self._last_map_marker:
+            self._last_map_marker = map_marker
+            self._last_map_seen_at = now
+        if pose_marker is not None and pose_marker != self._last_pose_marker:
+            self._last_pose_marker = pose_marker
+            self._last_pose_seen_at = now
+        if lidar_marker is not None and lidar_marker != self._last_lidar_marker:
+            self._last_lidar_marker = lidar_marker
+            self._last_lidar_seen_at = now
+        if now - self._last_map_seen_at > MAP_STALE_TIMEOUT_S:
+            raise SkillCancelled("mapping stopped because the live SLAM map stopped updating")
+        if now - self._last_pose_seen_at > POSE_STALE_TIMEOUT_S:
+            raise SkillCancelled("mapping stopped because the map-frame pose stopped updating")
+        if now - self._last_lidar_seen_at > LIDAR_STALE_TIMEOUT_S:
+            raise SkillCancelled("mapping stopped because lidar scans stopped updating")
+
+    def execute(
+        self,
+        max_duration_minutes: float = 10.0,
+        max_frontiers: int = 30,
+        goal_timeout_seconds: float = 90.0,
+    ) -> SkillReturn:
+        if not 1.0 <= float(max_duration_minutes) <= 60.0:
+            self.fail("max_duration_minutes must be between 1 and 60")
+        if isinstance(max_frontiers, bool) or not 1 <= int(max_frontiers) <= 100:
+            self.fail("max_frontiers must be between 1 and 100")
+        if not 10.0 <= float(goal_timeout_seconds) <= 300.0:
+            self.fail("goal_timeout_seconds must be between 10 and 300")
+
+        max_duration_s = float(max_duration_minutes) * 60.0
+        max_frontiers = int(max_frontiers)
+        goal_timeout_seconds = float(goal_timeout_seconds)
+        # Construct and arm the subscription before the potentially long mode
+        # transition, so manual input during startup also owns the base.
+        self.teleop.armed = True
+        started_at = time.monotonic()
+        deadline = started_at + max_duration_s
+        previous_map = self.map
+        previous_pose = self.pose
+        changed_mode = self.nav_mode.value != AUTONOMOUS_MAPPING_MODE
+
+        self.feedback("Starting SLAM and collision-aware navigation for autonomous mapping")
+        if changed_mode:
+            try:
+                self.mode_controller.switch_to_autonomous_mapping()
+            except SkillFailed as exc:
+                self.fail(str(exc))
+        try:
+            self._wait_for_autonomous_mode()
+            initial_map, initial_pose, initial_lidar = self._wait_for_mapping_state(
+                previous_map,
+                previous_pose,
+                changed_mode,
+            )
+        except SkillFailed as exc:
+            self.fail(str(exc))
+        self._arm_safety(initial_map, initial_pose, initial_lidar)
+
+        start_grid = initial_map.grid
+        if start_grid is None:
+            self.fail("live SLAM map has no occupancy data")
+        start_area = known_area_m2(start_grid, initial_map.resolution)
+        excluded_goals: list[tuple[float, float]] = []
+        reached = 0
+        failures = 0
+        consecutive_failures = 0
+        stable_empty_maps = 0
+        last_empty_map = None
+        stop_reason = "frontier limit reached"
+        planning_error_since = None
+
+        while reached < max_frontiers:
+            self._safety_check()
+            if time.monotonic() >= deadline:
+                stop_reason = "time limit reached"
+                break
+
+            map_state = self.map
+            pose = self.pose
+            if map_state is None or pose is None or map_state.frame_id != "map" or pose.frame_id != "map":
+                raise SkillCancelled("mapping stopped because map-frame state became unavailable")
+            grid = map_state.grid
+            if grid is None:
+                raise SkillCancelled("mapping stopped because occupancy data became unavailable")
+            geometry = GridGeometry(
+                resolution=map_state.resolution,
+                origin_x=map_state.origin_x,
+                origin_y=map_state.origin_y,
+                origin_yaw=map_state.origin_theta,
+            )
+            try:
+                goals = find_frontier_goals(
+                    grid,
+                    geometry,
+                    pose.x,
+                    pose.y,
+                    excluded_world=excluded_goals,
+                    check_cancelled=self._safety_check,
+                )
+                planning_error_since = None
+            except FrontierPlanningError as exc:
+                if planning_error_since is None:
+                    planning_error_since = time.monotonic()
+                    self.feedback(f"Waiting for SLAM to settle: {exc}")
+                elif time.monotonic() - planning_error_since > INITIAL_STATE_TIMEOUT_S:
+                    self.fail(f"could not plan mapping frontiers: {exc}")
+                self.sleep(0.5)
+                continue
+
+            if not goals:
+                if map_state is not last_empty_map:
+                    stable_empty_maps += 1
+                    last_empty_map = map_state
+                if stable_empty_maps >= STABLE_EMPTY_MAPS:
+                    stop_reason = "no reachable frontiers remain" if failures else "map coverage complete"
+                    break
+                self.sleep(0.5)
+                continue
+            stable_empty_maps = 0
+            last_empty_map = None
+
+            goal = goals[0]
+            remaining_s = max(0.0, deadline - time.monotonic())
+            timeout_s = min(goal_timeout_seconds, remaining_s)
+            if timeout_s < 1.0:
+                stop_reason = "time limit reached"
+                break
+            self.feedback(
+                f"Exploring frontier {reached + 1}/{max_frontiers} at ({goal.x:.2f}, {goal.y:.2f}); "
+                f"route {goal.route_distance_m:.1f}m"
+            )
+            try:
+                self.navigator.go_to_position(
+                    goal.x,
+                    goal.y,
+                    goal.yaw,
+                    local_frame=False,
+                    timeout_s=timeout_s,
+                    safety_check=self._safety_check,
+                )
+            except SkillFailed as exc:
+                failures += 1
+                consecutive_failures += 1
+                excluded_goals.append((goal.x, goal.y))
+                self.feedback(
+                    f"Frontier was unreachable; replanning ({consecutive_failures}/{MAX_CONSECUTIVE_FAILURES}): {exc}"
+                )
+                if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                    stop_reason = "navigation failed repeatedly"
+                    break
+                self.sleep(0.5)
+                continue
+
+            reached += 1
+            consecutive_failures = 0
+            excluded_goals.append((goal.x, goal.y))
+            self.feedback(f"Reached frontier {reached}; updating the exploration plan")
+            self.sleep(0.5)
+
+        self._safety_check()
+        end_map = self.map or initial_map
+        end_grid = end_map.grid
+        end_area = known_area_m2(end_grid, end_map.resolution) if end_grid is not None else start_area
+        elapsed = time.monotonic() - started_at
+        if stop_reason == "navigation failed repeatedly" and reached == 0:
+            self.fail(f"Autonomous mapping could not reach a frontier after {failures} navigation failures")
+        return SkillOutput(
+            f"Autonomous mapping stopped: {stop_reason}. Reached {reached} frontiers and mapped "
+            f"{end_area:.1f} m² ({max(0.0, end_area - start_area):.1f} m² new).",
+            data={
+                "reached_frontiers": reached,
+                "navigation_failures": failures,
+                "start_known_area_m2": round(start_area, 3),
+                "end_known_area_m2": round(end_area, 3),
+                "duration_s": round(elapsed, 1),
+                "stop_reason": stop_reason,
+                "mode": AUTONOMOUS_MAPPING_MODE,
+            },
+        )

--- a/workspace/innate_skills/navigate_to_position.py
+++ b/workspace/innate_skills/navigate_to_position.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
 import math
+import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
+from action_msgs.msg import GoalStatus
 from geometry_msgs.msg import PoseStamped
-from nav2_simple_commander.robot_navigator import BasicNavigator, TaskResult
+from nav2_msgs.action import NavigateToPose
+from rclpy.action import ActionClient
 from rclpy.qos import DurabilityPolicy, QoSProfile
 
 from innate import Map, Odometry, Pose, Skill, SkillCancelled, SkillFailed, SkillReturn, resource
@@ -14,8 +17,14 @@ from innate import Map, Odometry, Pose, Skill, SkillCancelled, SkillFailed, Skil
 # Nav2. Must match the mapfree costmap's global_frame (mars_nav costmap.yaml)
 # and Odometry.frame_id, which is what resolves them.
 LOCAL_GOAL_FIXED_FRAME = "odom"
-APPROACH_SEARCH_STEPS = 5
-MIN_APPROACH_PROGRESS_M = 0.15
+_POLL_INTERVAL_S = 0.1
+_TERMINAL_STATUSES = frozenset(
+    {
+        GoalStatus.STATUS_SUCCEEDED,
+        GoalStatus.STATUS_CANCELED,
+        GoalStatus.STATUS_ABORTED,
+    }
+)
 
 
 def resolve_local_goal(base_x, base_y, base_yaw, x, y, theta):
@@ -61,9 +70,7 @@ def _has_keepouts(map_state: Map | None) -> bool:
 
 
 def _keepout_distance_ahead(map_state: Map | None, x0: float, y0: float, x1: float, y1: float) -> float | None:
-    """How far along the straight line to the target the first keepout cell
-    sits, or None if that line stays clear. A geometric fact about the direct
-    line, not a claim about the planner's own route."""
+    """Return the first keepout distance on the direct line to the target."""
     keepouts = map_state.keepout_grid if map_state is not None else None
     if keepouts is None:
         return None
@@ -83,14 +90,21 @@ class Nav2Controller:
     def __init__(self, skill):
         self.skill = skill
         self.logger = skill.logger
-        self.navigator = BasicNavigator(namespace="")
-        self.navigator_mapfree = BasicNavigator(namespace="mapfree")
-        self.navigator_navigation = BasicNavigator(namespace="navigation")
+        self._client = ActionClient(skill.node, NavigateToPose, "/navigate_to_pose")
 
         # The exact goal this skill commands, latched so UIs can render the
         # true target (the replanned path's endpoint wiggles).
         latched = QoSProfile(depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL)
-        self._commanded_goal_pub = self.navigator.create_publisher(PoseStamped, "/nav/commanded_goal", latched)
+        self._commanded_goal_pub = skill.node.create_publisher(PoseStamped, "/nav/commanded_goal", latched)
+        self._goal_lock = threading.Lock()
+        self._active_goal_handle = None
+        self._active_result_future = None
+        self._cancel_future = None
+        self._latest_feedback = None
+        # Stop must reach the external action immediately. The polling loop is
+        # still the authority that unwinds the skill, while its finally block
+        # waits for the outer action's terminal result before returning.
+        skill.on_cancel(self._request_active_cancel)
 
     def _resolve_goal(self, x, y, theta, local_frame):
         if not local_frame:
@@ -104,32 +118,13 @@ class Nav2Controller:
         self.logger.info(f"Resolved local goal ({x}, {y}, {theta}) to ({gx:.3f}, {gy:.3f}, {gyaw:.3f})")
         return gx, gy, gyaw, LOCAL_GOAL_FIXED_FRAME
 
-    def _pose_stamped(self, x: float, y: float, yaw: float, frame: str) -> PoseStamped:
-        pose = PoseStamped()
-        pose.header.frame_id = frame
-        pose.header.stamp = self.navigator.get_clock().now().to_msg()
-        pose.pose.position.x = x
-        pose.pose.position.y = y
-        pose.pose.orientation.z = math.sin(yaw / 2.0)
-        pose.pose.orientation.w = math.cos(yaw / 2.0)
-        return pose
-
     def _map_frame_goal(self, goal_x: float, goal_y: float, goal_frame: str) -> tuple[float, float] | None:
-        """The commanded goal as a point in the map frame, where the map and
-        keepout mask live.
-
-        Read at diagnosis time, never latched at goal time: `pose` is cleared
-        between skill runs, so at goal time it is routinely still None and a
-        latched map goal would be None for the whole run.
-        """
         if goal_frame != LOCAL_GOAL_FIXED_FRAME:
             return goal_x, goal_y
         pose = getattr(self.skill, "pose", None)
         odom = self.skill.odom
         if pose is None or odom is None:
             return None
-        # the odom goal is fixed, so composing it with the odom->map offset read
-        # now stays correct after the recoveries have moved the robot
         angle = pose.theta - odom.theta
         dx, dy = goal_x - odom.x, goal_y - odom.y
         return (
@@ -138,7 +133,7 @@ class Nav2Controller:
         )
 
     def _blocking_cause(self, goal_x: float, goal_y: float, goal_frame: str) -> str | None:
-        """A cause proven from the map and keepout grids, in the map frame."""
+        """Return only causes supported by the current map and keepout mask."""
         map_state = getattr(self.skill, "map", None)
         if map_state is None:
             return None
@@ -155,175 +150,253 @@ class Nav2Controller:
             return "active keepout zones may cut off the route"
         return None
 
-    def _start_xy(self, local_frame: bool) -> tuple[float, float] | None:
-        state = self.skill.odom if local_frame else getattr(self.skill, "pose", None)
-        if state is None:
-            return None
-        return float(state.x), float(state.y)
-
-    def _closest_reachable_approach(
+    def go_to_position(
         self,
-        path_navigator: BasicNavigator,
-        goal_x: float,
-        goal_y: float,
-        goal_yaw: float,
-        goal_frame: str,
+        x: float,
+        y: float,
+        theta: float,
         local_frame: bool,
-    ) -> tuple[float, float, float] | None:
-        """Find a reachable approach on the current-pose-to-goal line.
-
-        This is a bounded best-effort hint for the agent, not a command. Five
-        bisection probes cap the extra planner work while locating the approach
-        to roughly 1/32 of the original distance.
-        """
-        start = self._start_xy(local_frame)
-        if start is None:
-            return None
-        start_x, start_y = start
-        total_distance = math.hypot(goal_x - start_x, goal_y - start_y)
-        if total_distance < MIN_APPROACH_PROGRESS_M:
-            return None
-
-        reachable_fraction = 0.0
-        blocked_fraction = 1.0
-        for _ in range(APPROACH_SEARCH_STEPS):
-            self.skill.check_cancelled()
-            fraction = (reachable_fraction + blocked_fraction) / 2.0
-            candidate_x = start_x + fraction * (goal_x - start_x)
-            candidate_y = start_y + fraction * (goal_y - start_y)
-            candidate = self._pose_stamped(candidate_x, candidate_y, goal_yaw, goal_frame)
-            if path_navigator.getPath(candidate, candidate, use_start=False) is None:
-                blocked_fraction = fraction
-            else:
-                reachable_fraction = fraction
-
-        progressed = reachable_fraction * total_distance
-        if progressed < MIN_APPROACH_PROGRESS_M:
-            return None
-        approach_x = start_x + reachable_fraction * (goal_x - start_x)
-        approach_y = start_y + reachable_fraction * (goal_y - start_y)
-        return approach_x, approach_y, total_distance - progressed
-
-    def _no_path_detail(
-        self,
-        path_navigator: BasicNavigator,
-        goal_x: float,
-        goal_y: float,
-        goal_yaw: float,
-        goal_frame: str,
-        local_frame: bool,
-    ) -> str:
-        start = self._start_xy(local_frame)
-        reason = (
-            self._blocking_cause(goal_x, goal_y, goal_frame)
-            or "the route may be blocked or the target may be unreachable"
-        )
-        detail = f"the planner found no path because {reason}"
-        approach = self._closest_reachable_approach(path_navigator, goal_x, goal_y, goal_yaw, goal_frame, local_frame)
-        if approach is None:
-            if start is not None:
-                remaining = math.hypot(goal_x - start[0], goal_y - start[1])
-                detail += (
-                    f". The robot did not move and remains at ({start[0]:.2f}, {start[1]:.2f}), "
-                    f"{remaining:.2f}m from the target"
-                )
-            else:
-                detail += ". The robot did not move"
-        else:
-            approach_x, approach_y, remaining = approach
-            detail += (
-                f". A reachable approach on the direct line is ({approach_x:.2f}, {approach_y:.2f}) "
-                f"in the {goal_frame} frame, {remaining:.2f}m short of the target. "
-                "The robot did not move there; navigate to that pose explicitly if approaching is appropriate"
-            )
-        return detail
-
-    def go_to_position(self, x: float, y: float, theta: float, local_frame: bool) -> None:
+        *,
+        timeout_s: float | None = None,
+        safety_check: Callable[[], None] | None = None,
+    ) -> None:
         """Navigate to the goal, blocking until Nav2 finishes. Raises
         SkillFailed with a human-readable reason; a skill cancel unwinds as
         SkillCancelled with the Nav2 task cancelled."""
+        if timeout_s is not None and timeout_s <= 0.0:
+            raise SkillFailed("navigation timeout must be positive")
+        deadline = time.monotonic() + timeout_s if timeout_s is not None else None
         goal_x, goal_y, goal_yaw, goal_frame = self._resolve_goal(x, y, theta, local_frame)
+        self._check_operational(deadline, timeout_s, safety_check)
 
-        goal_pose = self._pose_stamped(goal_x, goal_y, goal_yaw, goal_frame)
+        goal_pose = PoseStamped()
+        goal_pose.header.frame_id = goal_frame
+        goal_pose.header.stamp = self.skill.node.get_clock().now().to_msg()
+        goal_pose.pose.position.x = goal_x
+        goal_pose.pose.position.y = goal_y
+        goal_pose.pose.orientation.z = math.sin(goal_yaw / 2.0)
+        goal_pose.pose.orientation.w = math.cos(goal_yaw / 2.0)
         self._commanded_goal_pub.publish(goal_pose)
 
-        path_navigator = self.navigator_mapfree if local_frame else self.navigator_navigation
-        if path_navigator.getPath(goal_pose, goal_pose, use_start=False) is None:
-            raise SkillFailed(self._no_path_detail(path_navigator, goal_x, goal_y, goal_yaw, goal_frame, local_frame))
+        goal = NavigateToPose.Goal()
+        goal.pose = goal_pose
+        # The root router treats this field as a planner selector.
+        goal.behavior_tree = "mapfree" if local_frame else "navigation"
 
-        self.navigator.goToPose(goal_pose, behavior_tree="mapfree" if local_frame else "navigation")
-
+        send_future = None
+        goal_handle = None
+        result_future = None
+        dispatched = False
+        terminal = False
         initial_distance = -1.0
         last_distance = -1.0
         last_recoveries = 0
+        last_pose = None
         last_progress_log = 0.0
         said_close_to_goal = False
-        last_pose = None
-        while not self.navigator.isTaskComplete():
+        try:
+            # Never use BasicNavigator's synchronous setup helpers here: their
+            # wait_for_server/spin calls have no cancellation or deadline path.
+            while not self._client.server_is_ready():
+                self._poll(deadline, timeout_s, safety_check)
+
+            self._check_operational(deadline, timeout_s, safety_check)
+            self._latest_feedback = None
+            send_future = self._client.send_goal_async(goal, feedback_callback=self._on_feedback)
+            dispatched = True
+            while not send_future.done():
+                self._poll(deadline, timeout_s, safety_check)
+            self._check_operational(deadline, timeout_s, safety_check)
+
+            goal_handle = send_future.result()
+            if goal_handle is None or not goal_handle.accepted:
+                terminal = True
+                raise SkillFailed("navigation goal was rejected")
+
+            result_future = goal_handle.get_result_async()
+            self._set_active_goal(goal_handle, result_future)
+            # Close the race where Stop landed just before _set_active_goal.
+            self._check_operational(deadline, timeout_s, safety_check)
+
+            while not result_future.done():
+                self._poll(deadline, timeout_s, safety_check)
+                feedback = self._latest_feedback
+                if feedback is None:
+                    continue
+                try:
+                    distance = float(feedback.distance_remaining)
+                    last_recoveries = int(feedback.number_of_recoveries)
+                except (AttributeError, TypeError, ValueError):
+                    continue
+                try:
+                    current = feedback.current_pose
+                    last_pose = (current.pose.position.x, current.pose.position.y, current.header.frame_id or "map")
+                except (AttributeError, TypeError, ValueError):
+                    pass
+                if distance > 0.0:
+                    last_distance = distance
+                    if initial_distance < 0.0:
+                        initial_distance = distance
+
+                now = time.monotonic()
+                if now - last_progress_log >= 1.0:
+                    last_progress_log = now
+                    completion = 100.0 * (1.0 - distance / initial_distance) if initial_distance > 0.0 else 0.0
+                    self.logger.info(
+                        f"Navigation progress: {max(0.0, min(100.0, completion)):.0f}% "
+                        f"({distance:.2f}m remaining, {last_recoveries} recoveries)"
+                    )
+
+                if 0.0 < distance < 0.2 and not said_close_to_goal:
+                    said_close_to_goal = True
+                    self.skill.feedback(
+                        "I'm almost done with this movement, if I think I should navigate again to pursue this task"
+                        ", I should stop the current primitive and start a new navigation movement."
+                    )
+
+            # Cancellation wins a same-tick race with a terminal result.
+            self._check_operational(deadline, timeout_s, safety_check)
+            result_response = result_future.result()
+            status = result_response.status
+            terminal = status in _TERMINAL_STATUSES
+            if status == GoalStatus.STATUS_SUCCEEDED:
+                return
+            if status == GoalStatus.STATUS_CANCELED:
+                raise SkillCancelled("navigation was canceled")
+            detail = f"Nav2 reported {self._status_name(status)}"
+            if last_distance >= 0.0:
+                detail += f" with {last_distance:.2f}m still to go"
+            if last_pose is not None:
+                detail += f"; the robot stopped at ({last_pose[0]:.2f}, {last_pose[1]:.2f}) in the {last_pose[2]} frame"
+            if last_recoveries > 0:
+                detail += f" after {last_recoveries} recovery attempt{'s' if last_recoveries != 1 else ''}"
+            cause = self._blocking_cause(goal_x, goal_y, goal_frame)
+            detail += f"; {cause}" if cause is not None else "; the route may be blocked or the robot may be stuck"
+            raise SkillFailed(detail + ". The target was not reached")
+        except (SkillCancelled, SkillFailed):
+            raise
+        except Exception as exc:
+            raise SkillFailed(f"navigation action failed: {exc}") from exc
+        finally:
+            if dispatched and not terminal:
+                self._cancel_dispatched_goal(send_future, goal_handle, result_future)
+            self._clear_active_goal(goal_handle)
+
+    def _check_operational(self, deadline, timeout_s, safety_check) -> None:
+        self.skill.check_cancelled()
+        if safety_check is not None:
+            safety_check()
+        if deadline is not None and time.monotonic() >= deadline:
+            raise SkillFailed(f"navigation timed out after {timeout_s:.0f}s")
+
+    def _poll(self, deadline, timeout_s, safety_check) -> None:
+        self._check_operational(deadline, timeout_s, safety_check)
+        self.skill.sleep(_POLL_INTERVAL_S)
+
+    def _on_feedback(self, feedback_message) -> None:
+        self._latest_feedback = getattr(feedback_message, "feedback", None)
+
+    def _set_active_goal(self, goal_handle, result_future) -> None:
+        with self._goal_lock:
+            if self._active_goal_handle is not goal_handle:
+                self._cancel_future = None
+            self._active_goal_handle = goal_handle
+            self._active_result_future = result_future
+
+    def _clear_active_goal(self, goal_handle) -> None:
+        with self._goal_lock:
+            if goal_handle is not None and self._active_goal_handle is not goal_handle:
+                return
+            self._active_goal_handle = None
+            self._active_result_future = None
+            self._cancel_future = None
+
+    def _request_active_cancel(self) -> None:
+        with self._goal_lock:
+            goal_handle = self._active_goal_handle
+            result_future = self._active_result_future
+            if goal_handle is None or result_future is None or result_future.done() or self._cancel_future is not None:
+                return
             try:
-                self.skill.sleep(0.1)
-            except SkillCancelled:
-                self.navigator.cancelTask()
-                raise
+                self._cancel_future = goal_handle.cancel_goal_async()
+            except Exception as exc:
+                self.logger.error(f"Failed to request navigation cancellation: {exc}")
 
-            feedback = self.navigator.getFeedback()
-            if not feedback:
-                continue
-            # Nav2's own distance_remaining: feedback.current_pose is in the
-            # navigator's global frame while our goal may be in another.
-            distance = feedback.distance_remaining
-            last_recoveries = feedback.number_of_recoveries
-            current = feedback.current_pose
-            last_pose = (current.pose.position.x, current.pose.position.y, current.header.frame_id or "map")
-            if distance > 0.0:
-                last_distance = distance
-                if initial_distance < 0.0:
-                    initial_distance = distance
+    @staticmethod
+    def _wait_committed(future) -> None:
+        """Wait without consulting the skill cancel latch.
 
-            now = time.monotonic()
-            if now - last_progress_log >= 1.0:
-                last_progress_log = now
-                completion = 100.0 * (1.0 - distance / initial_distance) if initial_distance > 0.0 else 0.0
-                self.logger.info(
-                    f"Navigation progress: {max(0.0, min(100.0, completion)):.0f}% "
-                    f"({distance:.2f}m remaining, {last_recoveries} recoveries)"
-                )
-
-            if 0.0 < distance < 0.2 and not said_close_to_goal:
-                said_close_to_goal = True
-                self.skill.feedback(
-                    "I'm almost done with this movement, if I think I should navigate again to pursue this task"
-                    ", I should stop the current primitive and start a new navigation movement."
-                )
-
-        result = self.navigator.getResult()
-        if result == TaskResult.SUCCEEDED:
+        Once a goal request has been sent, teardown is a committed safety
+        section: returning early could leave Nav2 driving. The run node remains
+        on the skills server's executor, so action futures continue progressing.
+        """
+        if future.done():
             return
-        detail = f"Nav2 reported {getattr(result, 'name', result)}"
-        if last_distance >= 0.0:
-            detail += f" with {last_distance:.2f}m still to go"
-        if last_pose is not None:
-            detail += f"; the robot stopped at ({last_pose[0]:.2f}, {last_pose[1]:.2f}) in the {last_pose[2]} frame"
-        if last_recoveries > 0:
-            detail += f" after {last_recoveries} recovery attempt{'s' if last_recoveries != 1 else ''}"
-        cause = self._blocking_cause(goal_x, goal_y, goal_frame)
-        detail += f"; {cause}" if cause is not None else "; the route may be blocked or the robot may be stuck"
-        raise SkillFailed(detail + ". The target was not reached")
+        done = threading.Event()
+        future.add_done_callback(lambda _future: done.set())
+        while not future.done():
+            done.wait(_POLL_INTERVAL_S)
+
+    def _cancel_dispatched_goal(self, send_future, goal_handle, result_future) -> None:
+        # A cancel can land before goal acceptance. Settle that response first;
+        # if it was accepted, cancel and wait for the OUTER result. The router
+        # keeps that result pending until its internal Nav2 goal is terminal.
+        if goal_handle is None:
+            self._wait_committed(send_future)
+            try:
+                goal_handle = send_future.result()
+            except Exception as exc:
+                self.logger.error(f"Navigation goal response failed during cancellation: {exc}")
+                return
+        if goal_handle is None or not goal_handle.accepted:
+            return
+        if result_future is not None and result_future.done():
+            try:
+                response = result_future.result()
+                if response.status in _TERMINAL_STATUSES:
+                    return
+            except Exception as exc:
+                self.logger.error(f"Navigation result failed during cancellation; requesting it again: {exc}")
+            result_future = None
+        if result_future is None:
+            result_future = goal_handle.get_result_async()
+        self._set_active_goal(goal_handle, result_future)
+        self._request_active_cancel()
+        self._wait_committed(result_future)
+
+        with self._goal_lock:
+            cancel_future = self._cancel_future
+        if cancel_future is not None and cancel_future.done():
+            try:
+                response = cancel_future.result()
+                if not getattr(response, "goals_canceling", []):
+                    self.logger.error("Navigation action rejected the cancel request; waited for terminal result")
+            except Exception as exc:
+                self.logger.error(f"Navigation cancel response failed: {exc}")
+
+    @staticmethod
+    def _status_name(status: int) -> str:
+        names = {
+            GoalStatus.STATUS_UNKNOWN: "UNKNOWN",
+            GoalStatus.STATUS_ACCEPTED: "ACCEPTED",
+            GoalStatus.STATUS_EXECUTING: "EXECUTING",
+            GoalStatus.STATUS_CANCELING: "CANCELING",
+            GoalStatus.STATUS_SUCCEEDED: "SUCCEEDED",
+            GoalStatus.STATUS_CANCELED: "CANCELED",
+            GoalStatus.STATUS_ABORTED: "ABORTED",
+        }
+        return names.get(status, str(status))
 
     def destroy(self):
-        """Destroy the navigator nodes so their graph entities disappear now,
-        not at some eventual GC pass."""
-        for navigator in (self.navigator, self.navigator_mapfree, self.navigator_navigation):
-            try:
-                # Humble's BasicNavigator.destroy_node() misses this client; its
-                # live handle would keep the rcl node and graph entities alive.
-                navigator.assisted_teleop_client.destroy()
-            except Exception as e:
-                self.logger.warning(f"Error destroying assisted_teleop client: {e}")
-            try:
-                navigator.destroy_node()
-            except Exception as e:
-                self.logger.warning(f"Error destroying navigator node: {e}")
+        """Destroy entities explicitly; the throwaway run node is destroyed next."""
+        try:
+            self._client.destroy()
+        except Exception as exc:
+            self.logger.warning(f"Error destroying navigation action client: {exc}")
+        try:
+            self.skill.node.destroy_publisher(self._commanded_goal_pub)
+        except Exception as exc:
+            self.logger.warning(f"Error destroying commanded-goal publisher: {exc}")
 
 
 class NavigateToPosition(Skill):
@@ -337,7 +410,7 @@ class NavigateToPosition(Skill):
     map: Map | None
     """Classifies planning failures, including keepout targets, in either frame."""
     pose: Pose | None
-    """Places local goals on the map for diagnosis; seeds closest-approach planning."""
+    """Places local goals on the map for diagnosis."""
 
     @resource
     def controller(self) -> Iterator[Nav2Controller]:
@@ -354,7 +427,12 @@ class NavigateToPosition(Skill):
         )
 
     def execute(
-        self, x: float, y: float, theta_degrees: float = 0.0, local_frame: bool = False, **legacy
+        self,
+        x: float,
+        y: float,
+        theta_degrees: float = 0.0,
+        local_frame: bool = False,
+        **legacy,
     ) -> SkillReturn:
         # The tool schema speaks theta_degrees, but the cloud agent and the
         # pose-adjustment pipeline speak `theta` in radians.

--- a/workspace/innate_skills/navigate_to_position.py
+++ b/workspace/innate_skills/navigate_to_position.py
@@ -27,6 +27,10 @@ _TERMINAL_STATUSES = frozenset(
 )
 
 
+class NavigationBlocked(SkillFailed):
+    """Nav2 exhausted its bounded planning and recovery attempts."""
+
+
 def resolve_local_goal(base_x, base_y, base_yaw, x, y, theta):
     """Compose a base_link-relative (x, y, theta) goal with the robot's pose in
     the fixed frame, returning (gx, gy, gyaw) expressed in that fixed frame."""
@@ -272,7 +276,7 @@ class Nav2Controller:
                 detail += f" after {last_recoveries} recovery attempt{'s' if last_recoveries != 1 else ''}"
             cause = self._blocking_cause(goal_x, goal_y, goal_frame)
             detail += f"; {cause}" if cause is not None else "; the route may be blocked or the robot may be stuck"
-            raise SkillFailed(detail + ". The target was not reached")
+            raise NavigationBlocked(detail + ". The target was not reached")
         except (SkillCancelled, SkillFailed):
             raise
         except Exception as exc:


### PR DESCRIPTION
## Summary

- add an `autonomous_mapping` lifecycle mode that runs live SLAM and the collision-aware Nav2 stack together
- add deterministic free-side frontier planning plus a cancellable `ExploreMap` skill and dedicated mapping agent
- expose the live SLAM map-frame pose to skills and keep the brain/agent process active while mapping runs
- stage #641 spatial memories in the same live SLAM session across manual/autonomous handoffs and promote them on save
- make manual and autonomous mapping robot-enforced Slow activities, including the final shared velocity path
- integrate autonomous mapping into the existing map UI while preserving manual mapping as the default workflow

Rebased onto current `main`, including #681 and #641.

## Safety and lifecycle behavior

- Stop, nonzero joystick/WASD input, a mode change, stale map/pose/lidar input, and navigation timeout all cancel exploration
- goal admission closes synchronously before mode or map lifecycle teardown; accepted/handoff goals are held until terminal
- saving from autonomous mapping first settles navigation and leaves SLAM in manual mapping before touching map files
- manual/autonomous mapping handoffs retain one SLAM-session identity; partial lifecycle failures roll back to the previous mapping stack without wiping staged memories
- map switching waits for active and in-flight navigation to terminate before changing lifecycle state
- frontier goals are reachable known-free cells beside unknown space, matching `allow_unknown: false`; raw odometry is never mixed with map coordinates
- route reachability applies the robot's 0.17 m inscribed clearance, rejecting 0.30 m bottlenecks while retaining 0.35 m doorways; Nav2 remains the final dynamic-footprint authority

### Slow drive invariant

- `mapping` and `autonomous_mapping` lock `mars_app` to the 0.35 Slow preset; Fast/Mad parameter writes are rejected until a stable non-mapping mode returns
- every managed base-command source (teleop, brain/code skills, Nav2/recovery, and simulator UniNavid) enters the priority mux; the final `/cmd_vel` writer applies the mapping envelope and zeros unsupported axes
- with package defaults, mapping is capped at 0.14 m/s linear and 0.21 rad/s angular: `0.35 × min(manual cap, Nav cap)` on each axis
- transitions synchronously arm the final envelope and publish zero before goal cancellation or lifecycle mutation; Slow releases only after stable `navigation`/`mapfree`
- startup, `none`, unknown, `switching`, mapping, failed transitions, and unacknowledged limit-service calls remain fail-slow

## Validation

- 322 host Python tests passed, including the complete spatial-memory suite and both mapping-handoff failure/retry directions
- all 9 webapp Node test files passed
- full simulator/ROS rebuild and boot passed
- all pre-commit hooks, Ruff check/format, clang-format, and `git diff --check` passed
- live policy probe in autonomous mapping rejected a 2.0 Fast/Mad write with `Mapping locks motion_control.speed_scale to the Slow preset`; the applied value remained 0.35
- three pre-rebase fresh bounded one-frontier runs succeeded after explicit manual-mapping resets on one accumulating live SLAM map:
  - run 1: 7.8 m² new, 10.2 m² total; 0.8 m route; 208 output samples; maxima 0.140 m/s and 0.210 rad/s
  - run 2: 17.1 m² new, 27.3 m² total; 5.0 m route; 2,044 output samples; maxima 0.140 m/s and 0.210 rad/s
  - run 3: 5.6 m² new, 32.8 m² total; 5.1 m route; 1,910 output samples; maxima 0.140 m/s and 0.210 rad/s
  - all unsupported linear/angular axes remained zero in every run
- earlier simulator safety runs confirmed Stop cancels active exploration and nonzero teleop input takes over and cancels it
- live lifecycle inspection confirmed one `/map` publisher (slam_toolbox), the intended hybrid node states, fresh map-frame `/mapping_pose`, and the brain plus both mapping-capable agent rosters running concurrently
- simulator shutdown was verified with no runtime container, launcher/world process, or relevant listener left active

The simulator image had no LLM key, so the live run verified brain/agent coexistence and skill availability but did not exercise a conversational model turn during motion. Physical MARS hardware has not yet been tested.
