### PR TITLE
fix(sim): setup prefetches the dependency image too

### DIFF
--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -2149,10 +2149,18 @@ def _prefetch_os_image(config: dict[str, object]) -> None:
     except StackError:
         if not config["os_image_auto"]:
             raise
-        # `up` handles this the same way, with the same fallback -- warn and
-        # let it, rather than failing a setup that has otherwise succeeded.
+        # Same fallback order as ensure_os_container, so setup downloads what
+        # `up` would and the first start is a start.
+        os_repo: Path = config["os_repo"]  # type: ignore[assignment]
+        local_image = resolve_local_os_image(os_repo)
+        env = os_compose_env()
+        if docker_image_present(local_image, cwd=os_repo, env=env):
+            return
+        if adopt_published_deps_image(local_image, cwd=os_repo, env=env):
+            return
         warn(
-            f"No prebuilt Innate OS image for this checkout ({shorten_docker_image_ref(os_image)}).\n"
+            f"No prebuilt Innate OS image for this checkout ({shorten_docker_image_ref(os_image)}), "
+            f"and no published dependency image either.\n"
             f"`{CLI_SIM} up` will build one locally instead, which takes considerably longer."
         )
 


### PR DESCRIPTION
Follow-up to #683, which landed the dependency-image fallback in `up` but not in `setup`.

## The gap

`_prefetch_os_image` stops at the ROS prebuilt. On a 404 it warns:

> `./innate-sim up` will build one locally instead, which takes considerably longer.

After #683 that is wrong on both counts. `up` no longer builds locally — it pulls `innate-os-sim-deps:deps-<hash>` and adopts it under the local build's name. So a checkout with no published ROS prebuilt (an edited tree, or a fork with no CI) downloads **nothing** during `setup` and then pays a ~4.9 GB pull on the first `up`.

That is exactly the split #661 introduced to avoid:

> `setup` now asks for the key first and then fetches everything `up` would otherwise fetch on its first run… The long download runs unattended instead of stopping on a prompt, and the first `up` starts in a minute or two rather than after a few GB.

## The fix

Give the prefetch the same fallback order `ensure_os_container` already uses: local image → published deps image → warn. The warning now says "and no published dependency image either", which is the only case where a local build still happens.

11 lines, one file.

## Not changed, deliberately

`scripts/install-sim.sh` carries measured disk figures (`OS image 6.73 GB unpacked (1.4 GB compressed over 28 layers)`, `DISK_GB_RUNTIME=8`). They stay correct: a *fresh* machine has nothing to share layers with, so a first install pays full freight either way — #683 only changed what subsequent pulls cost. If anything the budget gets more accurate, since the old fallback was a local Docker build carrying ~10 GB of build cache (per #524) rather than a bounded ~6.2 GB pull.

## Tested

`ruff`, formatting, the existing suite, and the resulting fallback order asserted directly against `_prefetch_os_image`.
