### PR TITLE
feat(onboarding): fade-in intro tour, driven from the web

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -210,6 +210,10 @@ class WorldServer:
             with self.lock:
                 self.sim.remove_all_props()
             ok = True
+        elif op == "reset":  # onboarding starts every tour from the spawn pose
+            with self.lock:
+                self.sim.reset()
+            ok = True
         elif op == "start_challenge":  # sets its own scene up; see challenges.py
             self.challenges.start(str(cmd.get("id", "")))
             self.publish_state()

--- a/sim/viewer/src/physics/worldStateController.ts
+++ b/sim/viewer/src/physics/worldStateController.ts
@@ -105,6 +105,11 @@ export class WorldStateController {
     await this.#open;
   }
 
+  /** True while the observer socket is open and send() will actually send. */
+  get ready(): boolean {
+    return this.#ws.readyState === WebSocket.OPEN;
+  }
+
   /** Send a stage command (e.g. place_group) back up the observer socket.
    * Dropped silently while the socket is (re)connecting -- it is a button
    * press, not something worth queueing. */

--- a/sim/viewer/src/props.ts
+++ b/sim/viewer/src/props.ts
@@ -180,6 +180,7 @@ export class PropLibrary {
   private hulls: THREE.Mesh[] = [];
   private hullsVisible = false;
   private placementPreview?: PlacementPreview;
+  private group = new THREE.Group();
 
   constructor(
     private scene: THREE.Scene,
@@ -190,6 +191,7 @@ export class PropLibrary {
     onModelReady: (model: THREE.Group) => void = () => {},
   ) {
     this.models = new PropModels(onModelReady);
+    this.scene.add(this.group);
   }
 
   /** Adopt the server's roster. Props that vanish from it lose their bodies. */
@@ -200,7 +202,7 @@ export class PropLibrary {
     }
     for (const [name, root] of this.roots) {
       if (!this.info.has(name)) {
-        this.scene.remove(root);
+        this.group.remove(root);
         const label = nameLabelOf(root);
         if (label) {
           label.material.map?.dispose();
@@ -253,6 +255,10 @@ export class PropLibrary {
     for (const hull of this.hulls) hull.visible = visible;
   }
 
+  setSceneVisible(visible: boolean): void {
+    this.group.visible = visible;
+  }
+
   showPlacementPreview(name: string, x: number, y: number, yaw: number): void {
     if (name !== this.placementPreview?.name) {
       this.clearPlacementPreview();
@@ -265,7 +271,7 @@ export class PropLibrary {
 
   clearPlacementPreview(): void {
     if (!this.placementPreview) return;
-    this.scene.remove(this.placementPreview.root);
+    this.group.remove(this.placementPreview.root);
     for (const material of this.placementPreview.materials) material.dispose();
     for (const geometry of this.placementPreview.geometries) geometry.dispose();
     this.placementPreview = undefined;
@@ -306,7 +312,7 @@ export class PropLibrary {
     root.add(visual);
     root.updateMatrixWorld(true);
     visual.position.z -= new THREE.Box3().setFromObject(root).min.z;
-    this.scene.add(root);
+    this.group.add(root);
     return { name, root, materials: ownedMaterials, geometries };
   }
 
@@ -325,7 +331,7 @@ export class PropLibrary {
 
     const root = new THREE.Group();
     this.roots.set(name, root);
-    this.scene.add(root);
+    this.group.add(root);
     if (info.viewer.hulls) void this.loadHullSoup(info, root);
 
     const model = this.models.get(name);

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -34,7 +34,6 @@ interface ManifestRoom {
   bytes: number;
   bbox: { min: number[]; max: number[] };
 }
-
 /** The apartment's wireframe skeleton: parent group (already in the scene,
  * carrying the Y-up -> Z-up rotation) plus one placeholder box per room, drawn
  * from the manifest alone. streamApartment() then swaps boxes for real glbs. */
@@ -109,7 +108,7 @@ const SHADOW_MARGIN_M = 0.5; // the robot's own extent plus the throw of its sha
 const SHADOW_MAP_PX = 2048;
 
 // Initial orbit framing used when a pose is snapped in (see spawnAt below).
-const INITIAL_ORBIT_POSITION = { forward: 0.61, left: 0.02, height: 0.25 };
+const INITIAL_ORBIT_POSITION = { forward: 0.75, left: 0.02, height: 0.28 };
 const INITIAL_ORBIT_TARGET = { forward: -0.01, left: 0, height: 0.13 };
 
 // How the orbit camera behaves. Orthogonal to CameraView, which picks WHICH
@@ -140,6 +139,17 @@ const TOP_FALLBACK_HEIGHT_M = 12;
 // Robot-mounted camera views: frames, axis conventions, FOV and near plane
 // match the driver's cameras (mars_sim_driver.core's CAMERAS).
 export type CameraView = "orbit" | "main" | "arm";
+// The tour steps between the greeting and the handoff all behave alike here:
+// everything but "complete" keeps the world hidden, so the robot stays on the
+// blank onboarding background while the UI panels appear one by one.
+export type OnboardingStep =
+  | "await_hello"
+  | "welcome"
+  | "await_go"
+  | "tour_cameras"
+  | "tour_telemetry"
+  | "tour_chat"
+  | "complete";
 // Track mars_sim_driver/constants.py: per-camera FOVs matching what the
 // driver renders (the head and wrist are different physical lenses), so the
 // operator's preview frames what the robot consumes. main is the head's real
@@ -183,6 +193,8 @@ export class SimScene {
   private lidarPoints?: THREE.Points;
   private keyLight?: THREE.DirectionalLight;
   private shadowCatcher?: THREE.Mesh;
+  private groundGrid?: THREE.GridHelper;
+  private apartmentRoot?: THREE.Group;
   private shadowBoxM = SHADOW_BOX_MIN_M;
   private robotXY: [number, number] = [0, 0];
   private hullsGroup?: THREE.Group;
@@ -206,6 +218,11 @@ export class SimScene {
   // While true a placement drag owns the pointer and orbit stays off.
   private placementMode = false;
   private cameraMode: CameraMode = "free";
+  private lidarVisible = false;
+  private onboardingStep: OnboardingStep = "complete";
+  private readonly worldBackground = new THREE.Color(0x14161a);
+  private readonly worldFog = new THREE.FogExp2(0x14161a, 0.035);
+  private readonly onboardingBackground = new THREE.Color(0x000000);
   /** Notified on every mode change, including one the user caused by grabbing
    * the camera out of chase -- so a mode switch in the UI can reflect it. */
   onCameraModeChange?: (mode: CameraMode) => void;
@@ -243,8 +260,8 @@ export class SimScene {
     this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
     this.renderer.toneMappingExposure = 1.5;
 
-    this.scene.background = new THREE.Color(0x14161a);
-    this.scene.fog = new THREE.FogExp2(0x14161a, 0.035);
+    this.scene.background = this.worldBackground;
+    this.scene.fog = this.worldFog;
 
     // Props share the apartment's hull wireframe material, so one "collisions"
     // toggle covers both. A prop entering the world refits the shadow box.
@@ -399,6 +416,7 @@ export class SimScene {
     const grid = new THREE.GridHelper(40, 80, 0x2a2d33, 0x1c1e22);
     grid.rotation.x = Math.PI / 2;
     grid.position.z = -0.02;
+    this.groundGrid = grid;
     this.scene.add(grid);
   }
 
@@ -416,7 +434,29 @@ export class SimScene {
   }
 
   setLidarVisible(visible: boolean): void {
-    if (this.lidarPoints) this.lidarPoints.visible = visible;
+    this.lidarVisible = visible;
+    if (this.lidarPoints) this.lidarPoints.visible = visible && this.onboardingStep === "complete";
+  }
+
+  setOnboardingStep(step: OnboardingStep): void {
+    if (step === this.onboardingStep) return;
+    this.onboardingStep = step;
+    this.followCamera = step === "complete";
+    this.setWorldVisible(step === "complete");
+  }
+
+  private setWorldVisible(visible: boolean): void {
+    this.scene.background = visible ? this.worldBackground : this.onboardingBackground;
+    this.scene.fog = visible ? this.worldFog : null;
+    if (this.groundGrid) this.groundGrid.visible = visible;
+    if (this.apartmentRoot) this.apartmentRoot.visible = visible;
+    if (this.shadowCatcher) this.shadowCatcher.visible = visible;
+    if (this.lidarPoints) this.lidarPoints.visible = visible && this.lidarVisible;
+    this.props.setSceneVisible(visible);
+    this.props.setHullsVisible(visible && this.hullsVisible);
+    if (this.hullsGroup) this.hullsGroup.visible = visible && this.hullsVisible;
+    for (const collider of this.robotColliders) collider.visible = visible && this.hullsVisible;
+    if (this.robotBox) this.robotBox.visible = visible;
   }
 
   /**
@@ -429,7 +469,7 @@ export class SimScene {
    */
   setCollisionHullsVisible(visible: boolean): void {
     this.hullsVisible = visible;
-    this.props.setHullsVisible(visible);
+    this.props.setHullsVisible(visible && this.onboardingStep === "complete");
     if (visible && !this.hullsPromise) {
       // ~1300 OBJ fetches; takes seconds on first show. A failure resets the
       // promise so toggling again retries instead of staying dead forever.
@@ -438,8 +478,9 @@ export class SimScene {
         this.hullsPromise = undefined;
       });
     }
-    if (this.hullsGroup) this.hullsGroup.visible = visible;
-    for (const collider of this.robotColliders) collider.visible = visible;
+    const shown = visible && this.onboardingStep === "complete";
+    if (this.hullsGroup) this.hullsGroup.visible = shown;
+    for (const collider of this.robotColliders) collider.visible = shown;
   }
 
   private async loadCollisionHulls(): Promise<void> {
@@ -470,7 +511,7 @@ export class SimScene {
         }),
       );
     }
-    group.visible = this.hullsVisible; // honor toggles made while loading
+    group.visible = this.hullsVisible && this.onboardingStep === "complete";
     this.hullsGroup = group;
     this.scene.add(group);
   }
@@ -486,6 +527,8 @@ export class SimScene {
     // so it's applied once; placeholder boxes and rooms attach underneath.
     const group = new THREE.Group();
     group.rotation.x = Math.PI / 2;
+    group.visible = this.onboardingStep === "complete";
+    this.apartmentRoot = group;
     this.scene.add(group);
 
     let manifest: ApartmentManifest | null = null;

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -217,6 +217,7 @@ export class SimSession {
         this.#playT = null;
       }
       this.#live = true;
+      this.#flushReset(); // a state frame proves the socket is open both ways
       if (s.challenge) this.#publishChallenge(s.challenge);
       if (!this.#gotPose) {
         this.#gotPose = true;
@@ -339,6 +340,30 @@ export class SimSession {
       active: block.active,
     };
     for (const cb of this.#challengeListeners) cb(this.#challenge);
+  }
+
+  /**
+   * Put the world back to its starting state: robot at the spawn pose, arm
+   * home, props parked. Goes over the stage channel rather than the sim's
+   * /virtual_mars/reset topic — that topic carries std_msgs/Empty, which the
+   * bridge cannot serialize, and the malformed message kills the sim node.
+   *
+   * send() drops silently while the socket is still connecting, and onboarding
+   * asks for this within moments of the page mounting, so an unsent reset is
+   * remembered and flushed by the first state frame. Resetting is idempotent —
+   * a flush racing a fresh request is two teleports to the same pose.
+   */
+  resetWorld(): void {
+    this.#pendingReset = true;
+    this.#flushReset();
+  }
+
+  #pendingReset = false;
+
+  #flushReset(): void {
+    if (!this.#pendingReset || !this.#controller?.ready) return;
+    this.#pendingReset = false;
+    this.#controller.send({ op: "reset" });
   }
 
   /** Start a challenge by id (resets the world and drops its props). */

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -10,7 +10,7 @@
 // which walked a phone into the OS memory killer.
 
 import * as THREE from "three";
-import { SimScene, type CameraMode, type CameraView } from "./scene";
+import { SimScene, type CameraMode, type CameraView, type OnboardingStep } from "./scene";
 import type { PropInfo } from "./props";
 import { LoadQueue } from "./loadQueue";
 import { THUMB_H, THUMB_W, type SimSession } from "./simSession";
@@ -73,6 +73,7 @@ export function createSimStage(
   setSafeInsets: (insets: { right?: number }) => void;
   attach: (parent: HTMLElement) => void;
   detach: () => void;
+  setOnboardingStep: (step: OnboardingStep) => void;
   destroy: () => void;
 } {
   const wrap = document.createElement("div");
@@ -409,6 +410,38 @@ export function createSimStage(
 
   const scene = new SimScene(canvas, { fixedSize: { width: parent.clientWidth || 1280, height: parent.clientHeight || 720 } });
   scene.followCamera = true;
+  let onboardingStep: OnboardingStep = "complete";
+  let backgroundFade: HTMLCanvasElement | null = null;
+  const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const removeBackgroundFade = (snapshot: HTMLCanvasElement) => {
+    snapshot.remove();
+    if (backgroundFade === snapshot) backgroundFade = null;
+  };
+  const setOnboardingStep = (step: OnboardingStep) => {
+    if (step === onboardingStep) return;
+    // Any step of the tour, not just the welcome: the world fades in once,
+    // when onboarding hands over.
+    const revealBackground = onboardingStep !== "complete" && step === "complete";
+    backgroundFade?.remove();
+    backgroundFade = null;
+
+    if (revealBackground && !reduceMotion) {
+      const snapshot = document.createElement("canvas");
+      snapshot.className = "sim-onboarding-background-fade";
+      snapshot.width = canvas.width;
+      snapshot.height = canvas.height;
+      snapshot.getContext("2d")?.drawImage(canvas, 0, 0);
+      wrap.appendChild(snapshot);
+      backgroundFade = snapshot;
+      void snapshot.offsetWidth;
+      snapshot.classList.add("is-fading");
+      snapshot.addEventListener("transitionend", () => removeBackgroundFade(snapshot), { once: true });
+      setTimeout(() => removeBackgroundFade(snapshot), 5500);
+    }
+
+    onboardingStep = step;
+    scene.setOnboardingStep(step);
+  };
   // The scene takes chase off when the camera is dragged, so the switch has to
   // follow the scene rather than be the only thing that knows the mode.
   scene.onCameraModeChange = (mode) => {
@@ -638,6 +671,7 @@ export function createSimStage(
       clearPlacementSelection(); // an armed prop must not follow the pointer either
       wrap.remove();
     },
+    setOnboardingStep,
     destroy() {
       disposed = true;
       queue.cancel(); // stop pulling new downloads for a stage that's gone
@@ -650,6 +684,7 @@ export function createSimStage(
       window.removeEventListener("pointercancel", cancelDrop);
       document.removeEventListener(PANEL_OPEN_EVENT, onPanelOpen);
       document.removeEventListener("pointerdown", onOutsidePointer, true);
+      backgroundFade?.remove();
       scene.dispose();
       wrap.remove();
     },

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -231,6 +231,15 @@ select.skill-input {
   color: var(--text);
 }
 
+.rail-action {
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
 .rail-link.active {
   color: var(--text);
 }
@@ -7135,6 +7144,180 @@ select.skill-input {
   background: transparent;
 }
 
+/* The onboarding hide/reveal pair is a specificity balance: this blanket rule
+   scores three classes (a :not() list counts once, as its most specific
+   argument), and every reveal below scores four, so reveals win on specificity
+   rather than on source order. Adding a chained :not() here would outscore them
+   and blank the page. */
+.agent-cockpit.agent-onboarding-enabled
+  > :not(.agent-mic-control, .agent-onboarding-nudge, .agent-onboarding-skip) {
+  transition:
+    opacity 220ms cubic-bezier(0.215, 0.61, 0.355, 1),
+    visibility 0s;
+}
+
+.agent-cockpit.agent-onboarding-active
+  > :not(.agent-mic-control, .agent-onboarding-nudge, .agent-onboarding-skip) {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 180ms cubic-bezier(0.215, 0.61, 0.355, 1),
+    visibility 0s linear 180ms;
+}
+
+.agent-onboarding-nudge {
+  position: absolute;
+  left: 50%;
+  bottom: 242px;
+  z-index: 9;
+  margin: 0;
+  color: rgb(231 231 234 / 58%);
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 6px);
+  transition:
+    opacity 180ms cubic-bezier(0.215, 0.61, 0.355, 1),
+    transform 200ms cubic-bezier(0.215, 0.61, 0.355, 1),
+    visibility 0s linear 200ms;
+}
+
+.agent-onboarding-nudge strong {
+  color: rgb(255 255 255 / 92%);
+  font-weight: 600;
+}
+
+.agent-cockpit.agent-onboarding-awaiting > .agent-onboarding-nudge {
+  visibility: visible;
+  opacity: 1;
+  transform: translate(-50%, 0);
+  transition:
+    opacity 180ms cubic-bezier(0.215, 0.61, 0.355, 1),
+    transform 200ms cubic-bezier(0.215, 0.61, 0.355, 1),
+    visibility 0s;
+}
+
+.agent-cockpit.agent-onboarding-active.agent-onboarding-staged > .agent-feed-frame {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.agent-cockpit.agent-onboarding-active .video-stage > canvas {
+  opacity: 0;
+  transition: opacity 2000ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  will-change: opacity;
+}
+
+.agent-cockpit.agent-onboarding-active.agent-onboarding-staged
+  > .agent-feed-frame
+  > .video-stage
+  > canvas {
+  opacity: 1;
+}
+
+.sim-onboarding-background-fade {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  opacity: 1;
+  pointer-events: none;
+  transition: opacity 5000ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  will-change: opacity;
+}
+
+.sim-onboarding-background-fade.is-fading {
+  opacity: 0;
+}
+
+.agent-cockpit.agent-onboarding-active .video-stage > :not(canvas) {
+  display: none;
+}
+
+/* The current Agent composer owns the mic after onboarding. While the tour is
+   active, main.js temporarily moves that same control to the cockpit root so
+   it remains the centered, full-size first interaction from PR #690. */
+.agent-cockpit.agent-onboarding-active > .agent-mic-control {
+  position: absolute;
+  left: 50%;
+  bottom: 14px;
+  z-index: 8;
+  width: 184px;
+  height: 184px;
+  transform: translateX(-50%);
+}
+
+.agent-cockpit.agent-onboarding-active > .agent-mic-control .agent-mic-button {
+  --agent-mic-inner-wave-scale: 2.62;
+  width: 184px;
+  height: 184px;
+}
+
+.agent-cockpit.agent-onboarding-active > .agent-mic-control .agent-mic-button::before {
+  width: 68px;
+  height: 68px;
+  border-width: 1.5px;
+}
+
+/* Tour reveals: each step un-hides one panel and it stays up for the rest of
+   the tour, so the page assembles itself a piece at a time. The blanket hide
+   above is what these override. */
+.agent-cockpit.agent-onboarding-active.agent-onboarding-show-cameras
+  > .overlay-stack-top-left,
+.agent-cockpit.agent-onboarding-active.agent-onboarding-show-telemetry
+  > .agent-telemetry-overlay,
+.agent-cockpit.agent-onboarding-active.agent-onboarding-show-chat > .agent-panel {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  animation: agent-onboarding-reveal 260ms cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+
+@keyframes agent-onboarding-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Offered only when the greeting goes unheard — the robot-level mic toggle can
+   veto the mic device, and the first step has no other way forward. */
+.agent-onboarding-skip {
+  position: absolute;
+  left: 50%;
+  bottom: 214px;
+  z-index: 9;
+  padding: 6px 14px;
+  border: 1px solid rgb(255 255 255 / 14%);
+  border-radius: 999px;
+  background: rgb(255 255 255 / 6%);
+  color: rgb(231 231 234 / 72%);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transform: translateX(-50%);
+  transition: color 160ms ease, background-color 160ms ease;
+}
+
+.agent-onboarding-skip:hover {
+  background: rgb(255 255 255 / 10%);
+  color: rgb(255 255 255 / 92%);
+}
+
 .agent-cockpit .cam-strip {
   position: relative;
   top: auto;
@@ -7207,6 +7390,23 @@ select.skill-input {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .agent-cockpit.agent-onboarding-enabled
+    > :not(.agent-mic-control, .agent-onboarding-nudge, .agent-onboarding-skip),
+  .agent-cockpit.agent-onboarding-active .video-stage > canvas,
+  .sim-onboarding-background-fade,
+  .agent-onboarding-nudge {
+    transition: none;
+  }
+
+  .agent-cockpit.agent-onboarding-active.agent-onboarding-show-cameras
+    > .overlay-stack-top-left,
+  .agent-cockpit.agent-onboarding-active.agent-onboarding-show-telemetry
+    > .agent-telemetry-overlay,
+  .agent-cockpit.agent-onboarding-active.agent-onboarding-show-chat
+    > .agent-panel {
+    animation: none;
+  }
+
   .telemetry-value-duplicate {
     display: none;
   }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -32,6 +32,7 @@
     <link rel="modulepreload" href="/js/micAudioState.js" />
     <link rel="modulepreload" href="/js/agent/main.js" />
     <link rel="modulepreload" href="/js/agent/agentPanel.js" />
+    <link rel="modulepreload" href="/js/agent/agentSheet.js" />
     <link rel="modulepreload" href="/js/agent/chatStream.js" />
     <link rel="modulepreload" href="/js/agent/directiveControls.js" />
     <link rel="modulepreload" href="/js/agent/skillFormat.js" />
@@ -39,7 +40,10 @@
     <link rel="modulepreload" href="/js/agent/challengeIntro.js" />
     <link rel="modulepreload" href="/js/agent/micStream.js" />
     <link rel="modulepreload" href="/js/agent/agentMicControl.js" />
+    <link rel="modulepreload" href="/js/agent/onboarding.js" />
+    <link rel="modulepreload" href="/js/agent/onboardingWelcome.js" />
     <link rel="modulepreload" href="/js/pageMount.js" />
+    <link rel="modulepreload" href="/js/keyboardInset.js" />
     <link rel="modulepreload" href="/js/robotSession.js" />
     <link rel="modulepreload" href="/js/sharedVideoSession.js" />
     <link rel="modulepreload" href="/js/webrtcSession.js" />

--- a/webapp/js/agent/agentMicControl.js
+++ b/webapp/js/agent/agentMicControl.js
@@ -305,6 +305,7 @@ export function createAgentMicControl(root, callbacks) {
   document.addEventListener("pointerdown", dismissMicMessages, listenerOptions);
 
   return {
+    el: control,
     setEnabled(enabled) {
       if (isMicEnabled === enabled) return;
       isMicEnabled = enabled;

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -40,10 +40,13 @@ const CHAT_EXAMPLES = [
  * @param {ReturnType<typeof import("../teleop/agentState.js").sharedAgentState>} agentState
  * @param {{
  *   enableMic?: boolean,
- *   onMicState?: (state: {on: boolean, busy: boolean, level: number, waveform: number[], error: string | null}) => void
+ *   onMicState?: (state: {on: boolean, busy: boolean, level: number, waveform: number[], error: string | null}) => void,
+ *   ensureListening?: () => Promise<boolean>,
  * }} opts
  *   enableMic connects the browser microphone in sim, where the robot has no
  *   physical microphone (see micStream.js).
+ *   ensureListening, when it returns true, opens listening without starting an
+ *   agent during onboarding.
  * @returns {{
  *   destroy: () => void,
  *   startMic: () => Promise<void>,
@@ -188,8 +191,13 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   });
 
   // ---- composer -----------------------------------------------------------
-  async function startMic() {
+  async function ensureAgentOrOnboarding() {
+    if (opts.ensureListening && (await opts.ensureListening())) return;
     await directives.ensureRunning();
+  }
+
+  async function startMic() {
+    await ensureAgentOrOnboarding();
     await mic?.start();
   }
 
@@ -204,7 +212,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     input.value = "";
     input.style.height = "auto";
     syncComposerAction();
-    await directives.ensureRunning();
+    await ensureAgentOrOnboarding();
     rosClient.publish(CHAT_IN_TOPIC, {
       data: JSON.stringify({ text, sender: "user", timestamp: Date.now() / 1000, origin: selfOrigin }),
     });
@@ -336,4 +344,3 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     },
   };
 }
-

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -29,6 +29,8 @@ import { sharedAgentState } from "../teleop/agentState.js";
 import { createAgentPanel } from "./agentPanel.js";
 import { createChallengePanel } from "./challengePanel.js";
 import { createAgentMicControl } from "./agentMicControl.js";
+import { createAgentOnboarding } from "./onboarding.js";
+import { createScriptedActionRunner } from "./onboardingWelcome.js";
 
 // Runtime feature flags (config.json, served static), same as teleop. simControls
 // marks a sim deployment — used here to drop the (absent) battery readout. Fetched
@@ -60,6 +62,35 @@ export function mount(stage) {
  */
 function buildAgentView(root) {
   const session = createSession();
+  const agentState = sharedAgentState();
+  const scriptedActions = config.simControls
+    ? createScriptedActionRunner(ros)
+    : null;
+  const onboarding =
+    config.simControls && scriptedActions
+      ? createAgentOnboarding(root, ros, {
+          runner: scriptedActions,
+          onHandoff: async () => {
+            const { agents, currentDirective } = agentState.get();
+            const preferred =
+              agents.find((agent) => agent.id === "intro_agent")?.id ||
+              currentDirective ||
+              agents[0]?.id ||
+              "";
+            if (preferred) await agentState.setDirective(preferred);
+          },
+          onResetWorld: () => {
+            const sim = /** @type {any} */ (session);
+            if (typeof sim.resetWorld !== "function") {
+              console.warn(
+                "[onboarding] stage has no resetWorld — rebuild sim/viewer (npm run build:lib)",
+              );
+              return;
+            }
+            sim.resetWorld();
+          },
+        })
+      : null;
 
   const feedFrame = document.createElement("div");
   feedFrame.className = "agent-feed-frame";
@@ -70,13 +101,18 @@ function buildAgentView(root) {
   const videoStage =
     realVideo ??
     /** @type {NonNullable<typeof createStage>} */ (createStage)(feedFrame, session);
+  const setOnboardingStep =
+    "setOnboardingStep" in videoStage ? videoStage.setOnboardingStep : null;
+  const stopOnboardingStageSync =
+    onboarding && setOnboardingStep
+      ? onboarding.onStep(setOnboardingStep)
+      : null;
   const sceneSetup = feedFrame.querySelector(".sim-debug-stack");
   if (sceneSetup) root.append(sceneSetup);
 
   const cornerStack = document.createElement("div");
   cornerStack.className = "overlay-stack-top-left";
   root.append(cornerStack);
-  const agentState = sharedAgentState();
 
   const cameraSwitch = createCameraSwitch(root, session, ros, {
     storeKey: "innate.cameras.agent",
@@ -86,11 +122,9 @@ function buildAgentView(root) {
     // Real robots have no orbit camera, so their saved choice is untouched.
     primaryOnMount: config.simControls ? "orbit" : undefined,
   });
-  const telemetryOverlay = config.simControls ? null : document.createElement("div");
-  if (telemetryOverlay) {
-    telemetryOverlay.className = "overlay telemetry-overlay agent-telemetry-overlay";
-    root.append(telemetryOverlay);
-  }
+  const telemetryOverlay = document.createElement("div");
+  telemetryOverlay.className = "overlay telemetry-overlay agent-telemetry-overlay";
+  root.append(telemetryOverlay);
 
   // The Brain monitor's layer sits between the camera overlays and the panel
   // (DOM order + z-index): opening it covers the stage but never the controls.
@@ -160,6 +194,10 @@ function buildAgentView(root) {
   let micControl = null;
   const panel = createAgentPanel(root, ros, agentState, {
     enableMic: Boolean(config.simControls),
+    ensureListening: async () => {
+      if (!onboarding || onboarding.isComplete()) return false;
+      return onboarding.ensureListening();
+    },
     onMicState: (state) => {
       micControl?.setCaptureState(state);
       micControl?.setAudioFeedback({
@@ -179,13 +217,28 @@ function buildAgentView(root) {
     challengePanel?.dismiss();
   };
   root.addEventListener("pointerdown", onScenePointerDown);
-  const telemetry = telemetryOverlay ? createTelemetry(telemetryOverlay, ros) : null;
+  const telemetry = createTelemetry(telemetryOverlay, ros, {
+    showBattery: !config.simControls,
+  });
   if (config.simControls) {
     micControl = createAgentMicControl(panel.micMount, {
-      startListening: panel.startMic,
-      stopListening: panel.stopMic,
+      startListening: () => {
+        onboarding?.noteMicDown();
+        return panel.startMic();
+      },
+      stopListening: () => {
+        onboarding?.noteMicUp();
+        panel.stopMic();
+      },
     });
   }
+  const stopOnboardingMicSync =
+    onboarding && micControl
+      ? onboarding.onStep((step) => {
+          const parent = step === "complete" ? panel.micMount : root;
+          if (micControl?.el.parentElement !== parent) parent.append(micControl.el);
+        })
+      : null;
 
   const compactLayout = window.matchMedia(COMPACT_LAYOUT_QUERY);
   const monitorTooNarrow = window.matchMedia(BRAIN_MONITOR_QUERY);
@@ -223,6 +276,10 @@ function buildAgentView(root) {
   applyLayout();
 
   const parts = [
+    ...(stopOnboardingStageSync ? [{ destroy: stopOnboardingStageSync }] : []),
+    ...(stopOnboardingMicSync ? [{ destroy: stopOnboardingMicSync }] : []),
+    ...(onboarding ? [onboarding] : []),
+    ...(scriptedActions ? [scriptedActions] : []),
     videoStage,
     {
       destroy: () => {
@@ -232,7 +289,7 @@ function buildAgentView(root) {
       },
     },
     ...(challengePanel ? [challengePanel] : []),
-    ...(telemetry ? [telemetry] : []),
+    telemetry,
     // Square, always-live camera tiles (own prefs key so teleop's defaults stay put).
     cameraSwitch,
     ...(micControl ? [micControl] : []),
@@ -274,4 +331,3 @@ function buildAgentView(root) {
     },
   };
 }
-

--- a/webapp/js/agent/onboarding.js
+++ b/webapp/js/agent/onboarding.js
@@ -1,0 +1,468 @@
+// @ts-check
+// Versioned declarative onboarding engine. Steps own fixed dialogue, completion
+// events, entry actions, and next links. Progress is {version, stepId} only.
+//
+// The tour runs entirely from the browser and never listens to what the user
+// says: a step that waits on the user completes when they hold the mic, however
+// long they talk and whatever words they use. That keeps the brain out of it —
+// no agent, no STT, no transcript to match — so the only robot-side traffic is
+// speech and skills, plus one custom-input event at the handoff that tells the
+// agent it is joining a conversation already in progress.
+
+import { CUSTOM_INPUT_TOPIC } from "../constants.js";
+
+const ONBOARDING_VERSION = 3;
+const STORAGE_KEY = "innate.agentOnboarding";
+const LEGACY_STEP_KEY = "innate.agentOnboardingStep";
+const LEGACY_COMPLETE_KEY = "innate.agentOnboardingComplete";
+const RESET_EVENT = "innate:agent-onboarding-reset";
+// A hold this long reads as "the user said something". Comfortably above the
+// mic control's 350ms short-click threshold, so a stray click cannot advance
+// the tour, and short enough that holding never feels like a wait.
+const MIN_HOLD_MS = 600;
+// How long a prompt may go unanswered before offering a way past it. Denied
+// microphone permission never produces a hold at all, and a tour that cannot be
+// skipped would strand the page on its first step.
+const SKIP_OFFER_MS = 25000;
+// Where the arm reaches to point at a panel, in base_link metres: x forward,
+// y left, z up. The onboarding camera sits almost directly in front of the
+// robot (eye at -3.5,-3.5 looking at a spawn of -4.34,-0.17 facing -Y), so the
+// view is mirrored — reaching to the robot's left shows up on the viewer's
+// right. SIDE_LEFT/SIDE_RIGHT are named for where the panel is on screen, and
+// carry the flip so the call sites do not have to think about it.
+const POINT_REACH = { x: 0.25, z: 0.3, duration: 2 };
+const SIDE_LEFT = -0.2;
+const SIDE_RIGHT = 0.2;
+
+// Spoken as two utterances, not one: synthesis time scales with the text, so a
+// short opener is heard far sooner, and the longer line is generated while it
+// plays. Same reason the agent's own replies stream a sentence at a time.
+const WELCOME_LINES = [
+  "Welcome to the simulator!",
+  "I'll be here to show you some of the main things we can do together!",
+];
+
+export const WELCOME_DIALOGUE = WELCOME_LINES.join(" ");
+
+/**
+ * Completion event kinds reserved for later lessons:
+ * - hold: the user held the mic (content ignored)
+ * - action: entry scripted runner finished
+ * - skill_success / sim_event / user_action: extension points (unused yet)
+ * - complete: terminal handoff step
+ *
+ * @typedef {"await_hello" | "welcome" | "await_go" | "tour_cameras" | "tour_telemetry" | "tour_chat" | "complete"} OnboardingStepId
+ * @typedef {"hold" | "action" | "skill_success" | "sim_event" | "user_action" | "complete"} CompletionKind
+ * @typedef {{
+ *   id: OnboardingStepId,
+ *   instruction?: string,
+ *   dialogue?: string,
+ *   completeOn: CompletionKind,
+ *   reveal?: string,
+ *   recap?: string,
+ *   actions?: (reveal: () => void) => import("./onboardingWelcome.js").ScriptedAction[],
+ *   next: OnboardingStepId | null,
+ * }} OnboardingStepDef
+ */
+
+/** @type {Record<OnboardingStepId, OnboardingStepDef>} */
+const STEPS = {
+  await_hello: {
+    id: "await_hello",
+    // The words are a suggestion, not a condition — holding the mic is the gate.
+    instruction: 'Hold the mic and say <strong>“Hello MARS”</strong>',
+    completeOn: "hold",
+    next: "welcome",
+  },
+  welcome: {
+    id: "welcome",
+    dialogue: WELCOME_DIALOGUE,
+    completeOn: "action",
+    recap: "greeted them and waved",
+    // No approach step: the 0.2m nudge this used to open with cost seven to
+    // sixteen seconds of silence before the first word, and it displaced the
+    // robot a little further every run until it wedged against something and
+    // started failing outright. Appearing and speaking is the moment; creeping
+    // forward first was never part of it.
+    actions: () => [
+      { type: "speak", text: WELCOME_LINES[0] },
+      // Queued the moment the opener starts playing, so its synthesis overlaps
+      // the opener instead of landing in the pause after it.
+      { type: "speak", text: WELCOME_LINES[1], queue: true },
+      { type: "skill", name: "head_emotion", inputs: { emotion: "excited", repeat: 5 }, afterSpeechStart: true },
+      { type: "skill", name: "wave", inputs: {} },
+    ],
+    next: "await_go",
+  },
+  await_go: {
+    id: "await_go",
+    instruction: 'Hold the mic and say <strong>“Let’s go”</strong>',
+    completeOn: "hold",
+    next: "tour_cameras",
+  },
+  tour_cameras: {
+    id: "tour_cameras",
+    dialogue: "Up here are my cameras. That's how I see the room — and what I look at when you ask me about something.",
+    completeOn: "action",
+    reveal: "cameras",
+    recap: "showed them the camera views",
+    actions: (reveal) => pointOut(SIDE_LEFT, reveal, STEPS.tour_cameras.dialogue ?? "", "happy"),
+    next: "tour_telemetry",
+  },
+  tour_telemetry: {
+    id: "tour_telemetry",
+    dialogue: "This panel is how I'm doing — where I am, how I'm moving, how much battery I have left.",
+    completeOn: "action",
+    reveal: "telemetry",
+    recap: "showed them the telemetry panel",
+    actions: (reveal) => pointOut(SIDE_RIGHT, reveal, STEPS.tour_telemetry.dialogue ?? "", "agreeing"),
+    next: "tour_chat",
+  },
+  tour_chat: {
+    id: "tour_chat",
+    dialogue: "And this is where we talk. Hold the microphone, or type — either way, I'm listening.",
+    completeOn: "action",
+    reveal: "chat",
+    recap: "showed them the chat panel",
+    actions: (reveal) => pointOut(SIDE_RIGHT, reveal, STEPS.tour_chat.dialogue ?? "", "very_happy"),
+    next: "complete",
+  },
+  complete: {
+    id: "complete",
+    completeOn: "complete",
+    next: null,
+  },
+};
+
+/** Step order, which is also reveal order: resuming re-applies every earlier reveal. */
+/** @type {OnboardingStepId[]} */
+const STEP_ORDER = [
+  "await_hello",
+  "welcome",
+  "await_go",
+  "tour_cameras",
+  "tour_telemetry",
+  "tour_chat",
+  "complete",
+];
+
+/** @type {string[]} */
+const REVEAL_TARGETS = ["cameras", "telemetry", "chat"];
+
+/**
+ * One tour beat: reach toward the panel, reveal it, say the line, react, lower
+ * the arm. Pointing is the arm, not the base — turning the whole robot reads as
+ * "it spun round", and it leaves the robot facing somewhere new for the step
+ * after it.
+ *
+ * @param {number} sideY signed base_link y: SIDE_LEFT or SIDE_RIGHT
+ * @param {() => void} reveal
+ * @param {string} text
+ * @param {string} emotion
+ * @returns {import("./onboardingWelcome.js").ScriptedAction[]}
+ */
+function pointOut(sideY, reveal, text, emotion) {
+  return [
+    { type: "skill", name: "arm_move_to_xyz", inputs: { ...POINT_REACH, y: sideY } },
+    { type: "ui", apply: reveal },
+    { type: "speak", text },
+    { type: "skill", name: "head_emotion", inputs: { emotion }, afterSpeechStart: true },
+    { type: "skill", name: "arm_rest_position", inputs: {} },
+  ];
+}
+
+/**
+ * @param {HTMLElement} root
+ * @param {import("../rosClient.js").RosClient} rosClient
+ * @param {{
+ *   runner: {
+ *     run: (actions: import("./onboardingWelcome.js").ScriptedAction[]) => Promise<void>,
+ *     cancel: () => void,
+ *   },
+ *   onHandoff?: () => Promise<void> | void,
+ *   onResetWorld?: () => void,
+ * }} options
+ */
+export function createAgentOnboarding(root, rosClient, options) {
+  const { runner, onHandoff, onResetWorld } = options;
+  /** @type {OnboardingStepId} */
+  let stepId = loadStepId();
+  /** @type {Set<(step: OnboardingStepId) => void>} */
+  const stepListeners = new Set();
+  let entryToken = 0;
+  let destroyed = false;
+  /** @type {Set<string>} */
+  const revealed = new Set();
+  /** @type {ReturnType<typeof setTimeout> | null} */
+  let skipTimer = null;
+  /** When the current mic hold started, 0 when the mic is not held. */
+  let micDownAt = 0;
+  root.classList.add("agent-onboarding-enabled");
+
+  // Advertised up front, not at first use: an unadvertised topic resolves its
+  // type from an existing publisher, and the first message can be dropped
+  // before rosbridge finishes wiring it up.
+  const unadvertiseCustom = rosClient.advertise(CUSTOM_INPUT_TOPIC, "std_msgs/msg/String");
+
+  const nudge = document.createElement("p");
+  nudge.className = "agent-onboarding-nudge";
+  root.append(nudge);
+
+  const skip = document.createElement("button");
+  skip.type = "button";
+  skip.className = "agent-onboarding-skip";
+  skip.textContent = "Skip intro";
+  skip.hidden = true;
+  skip.addEventListener("click", () => {
+    void enter("complete");
+  });
+  root.append(skip);
+
+  /** @param {OnboardingStepId} id */
+  function waitsForHold(id) {
+    return STEPS[id]?.completeOn === "hold";
+  }
+
+  function render() {
+    const active = stepId !== "complete";
+    const awaiting = waitsForHold(stepId);
+    root.classList.toggle("agent-onboarding-active", active);
+    // Distinct from the per-step classes: the robot appears at the welcome and
+    // stays on screen for the whole tour, so the stage cannot key off one step.
+    root.classList.toggle("agent-onboarding-staged", stepId !== "await_hello");
+    root.classList.toggle("agent-onboarding-awaiting", awaiting);
+    for (const id of STEP_ORDER) {
+      root.classList.toggle(`agent-onboarding-${id}`, stepId === id);
+    }
+    for (const target of REVEAL_TARGETS) {
+      root.classList.toggle(`agent-onboarding-show-${target}`, revealed.has(target));
+    }
+    nudge.innerHTML = STEPS[stepId]?.instruction ?? "";
+    nudge.setAttribute("aria-hidden", String(!awaiting));
+    for (const listener of stepListeners) listener(stepId);
+  }
+
+  /** Reveals every panel introduced at or before `upTo`, so a resumed step keeps its predecessors. */
+  /** @param {OnboardingStepId} upTo */
+  function syncRevealsThrough(upTo) {
+    const limit = STEP_ORDER.indexOf(upTo);
+    for (const id of STEP_ORDER.slice(0, limit)) {
+      const target = STEPS[id].reveal;
+      if (target) revealed.add(target);
+    }
+  }
+
+  function persist() {
+    storageSet(STORAGE_KEY, JSON.stringify({ version: ONBOARDING_VERSION, stepId }));
+  }
+
+  function armSkipOffer() {
+    if (skipTimer !== null) clearTimeout(skipTimer);
+    const armedFor = stepId;
+    skipTimer = setTimeout(() => {
+      skipTimer = null;
+      if (destroyed || stepId !== armedFor) return;
+      skip.hidden = false;
+    }, SKIP_OFFER_MS);
+  }
+
+  /** @param {OnboardingStepId} nextId */
+  async function enter(nextId) {
+    if (destroyed) return;
+    const crossingIntoComplete = nextId === "complete" && stepId !== "complete";
+    stepId = nextId;
+    micDownAt = 0;
+    syncRevealsThrough(nextId);
+    persist();
+    render();
+    const token = ++entryToken;
+    if (skipTimer !== null) {
+      clearTimeout(skipTimer);
+      skipTimer = null;
+    }
+    skip.hidden = true;
+    if (nextId === "complete") {
+      runner.cancel();
+      if (crossingIntoComplete) {
+        await onHandoff?.();
+        if (token !== entryToken || destroyed) return;
+        publishHandoffContext(rosClient);
+      }
+      return;
+    }
+    if (waitsForHold(nextId)) {
+      // A fresh tour starts from spawn. This is what makes the rail's Reset
+      // onboarding work from any page: the button clears storage and navigates
+      // here, and the newly mounted engine enters await_hello and asks for the
+      // world reset itself — the engine that heard the click is already gone.
+      if (nextId === "await_hello") onResetWorld?.();
+      armSkipOffer();
+      return;
+    }
+    if (nextId === "welcome") {
+      // The robot becomes visible here, so this is where it has to be standing
+      // at spawn — and it is late enough that the stage channel is connected,
+      // which it is not when the page first builds.
+      onResetWorld?.();
+    }
+    const step = STEPS[nextId];
+    if (step.completeOn !== "action" || !step.actions) return;
+    await runner.run(step.actions(() => {
+      if (step.reveal) revealed.add(step.reveal);
+      render();
+    }));
+    if (token !== entryToken || destroyed || stepId !== nextId) return;
+    await advance();
+  }
+
+  async function advance() {
+    const step = STEPS[stepId];
+    if (!step?.next) return;
+    await enter(step.next);
+  }
+
+  async function reset() {
+    runner.cancel();
+    entryToken++;
+    revealed.clear();
+    skip.hidden = true;
+    storageRemove(STORAGE_KEY);
+    storageRemove(LEGACY_STEP_KEY);
+    storageRemove(LEGACY_COMPLETE_KEY);
+    await enter("await_hello");
+  }
+
+  const onReset = () => {
+    void reset();
+  };
+  window.addEventListener(RESET_EVENT, onReset);
+
+  void enter(stepId);
+
+  return {
+    getStep() {
+      return stepId;
+    },
+    isComplete() {
+      return stepId === "complete";
+    },
+    /**
+     * True while the tour still owns the mic button, which is what keeps
+     * holding it from starting the agent underneath the tour.
+     */
+    async ensureListening() {
+      return stepId !== "complete";
+    },
+    /** The mic button went down: start timing the hold. */
+    noteMicDown() {
+      micDownAt = Date.now();
+    },
+    /** The mic button came up: a long enough hold answers a waiting step. */
+    noteMicUp() {
+      const heldFor = micDownAt ? Date.now() - micDownAt : 0;
+      micDownAt = 0;
+      if (heldFor < MIN_HOLD_MS || !waitsForHold(stepId)) return;
+      void advance();
+    },
+    /** @param {(step: OnboardingStepId) => void} listener */
+    onStep(listener) {
+      stepListeners.add(listener);
+      listener(stepId);
+      return () => stepListeners.delete(listener);
+    },
+    destroy() {
+      destroyed = true;
+      entryToken++;
+      runner.cancel();
+      window.removeEventListener(RESET_EVENT, onReset);
+      if (skipTimer !== null) clearTimeout(skipTimer);
+      stepListeners.clear();
+      nudge.remove();
+      skip.remove();
+      root.classList.remove(
+        "agent-onboarding-enabled",
+        "agent-onboarding-active",
+        "agent-onboarding-staged",
+        "agent-onboarding-awaiting",
+        ...STEP_ORDER.map((id) => `agent-onboarding-${id}`),
+        ...REVEAL_TARGETS.map((target) => `agent-onboarding-show-${target}`),
+      );
+      unadvertiseCustom();
+    },
+  };
+}
+
+export function resetAgentOnboarding() {
+  storageRemove(STORAGE_KEY);
+  storageRemove(LEGACY_STEP_KEY);
+  storageRemove(LEGACY_COMPLETE_KEY);
+  window.dispatchEvent(new Event(RESET_EVENT));
+}
+
+/** @returns {OnboardingStepId} */
+function loadStepId() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed?.version === ONBOARDING_VERSION && isStepId(parsed?.stepId)) {
+        return parsed.stepId;
+      }
+      // A finished older tour stays finished; an unfinished one restarts, since
+      // its step ids no longer describe this version's lesson order.
+      if (parsed?.stepId === "complete") return "complete";
+    }
+    const legacy = localStorage.getItem(LEGACY_STEP_KEY);
+    if (legacy === "greeted") return "welcome";
+    if (legacy === "complete") return "complete";
+    if (legacy === "hello") return "await_hello";
+    if (localStorage.getItem(LEGACY_COMPLETE_KEY)) return "complete";
+  } catch {
+    // Fall through to the first lesson.
+  }
+  return "await_hello";
+}
+
+/** @param {unknown} value @returns {value is OnboardingStepId} */
+function isStepId(value) {
+  return typeof value === "string" && Object.prototype.hasOwnProperty.call(STEPS, value);
+}
+
+/**
+ * Tell the agent what it just did, so it continues the conversation instead of
+ * opening a new one. Only meaningful once the brain is active — custom input is
+ * dropped while it is not — so this runs after the directive has been set.
+ *
+ * @param {import("../rosClient.js").RosClient} rosClient
+ */
+function publishHandoffContext(rosClient) {
+  const recap = STEP_ORDER.map((id) => STEPS[id].recap).filter(Boolean).join(", ");
+  rosClient.publish(CUSTOM_INPUT_TOPIC, {
+    data: JSON.stringify({
+      input_device: "onboarding",
+      event: "onboarding_complete",
+      summary:
+        `You have just finished welcoming this user to the simulator. You ${recap}. ` +
+        "They are still here and the conversation is already under way — carry on from " +
+        "that point, and do not greet them or introduce yourself again.",
+    }),
+  });
+}
+
+/** @param {string} key @param {string} value */
+function storageSet(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // In-memory step still advances for this page view.
+  }
+}
+
+/** @param {string} key */
+function storageRemove(key) {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // Reset still applies through the event for the current page.
+  }
+}

--- a/webapp/js/agent/onboardingWelcome.js
+++ b/webapp/js/agent/onboardingWelcome.js
@@ -1,0 +1,207 @@
+// @ts-check
+// Deterministic scripted actions for onboarding: exact /brain/tts lines and
+// sequential /execute_skill goals. Motion gated on browser TTS playback start.
+// A "ui" action carries its own effect, which is how a tour step reveals the
+// panel it is pointing at without this runner knowing anything about the page.
+
+import {
+  AVAILABLE_SKILLS_TOPIC,
+  CANCEL_SKILL_SERVICE,
+  EXECUTE_SKILL_ACTION,
+  EXECUTE_SKILL_ACTION_TYPE,
+  TTS_TOPIC,
+} from "../constants.js";
+import { onTtsPlaybackStart } from "../ttsAudio.js";
+
+// Matches the panel reveal transition in app.css.
+const UI_SETTLE_MS = 260;
+// A spoken line normally starts playing within ~2s (synthesis plus transfer).
+// Past this the script stops waiting and carries on: playback start is a
+// convenience for syncing gestures, and several ordinary situations never
+// deliver it at all -- another tab holds the shared speaker lock, autoplay is
+// blocked, a clip fails to decode. None of those should strand the tour.
+const SPEECH_START_TIMEOUT_MS = 6000;
+
+/**
+ * @typedef {{
+ *   type: "speak",
+ *   text: string,
+ *   queue?: boolean,
+ * } | {
+ *   type: "skill",
+ *   name: string,
+ *   inputs?: Record<string, unknown>,
+ *   afterSpeechStart?: boolean,
+ * } | {
+ *   type: "ui",
+ *   apply: () => void,
+ * }} ScriptedAction
+ */
+
+/** @param {import("../rosClient.js").RosClient} rosClient */
+export function createScriptedActionRunner(rosClient) {
+  /** @type {any[]} */
+  let skills = [];
+  /** @type {(() => void) | null} */
+  let cancelActive = null;
+  /** @type {(() => void) | null} */
+  let resolveSpeechStart = null;
+  let generation = 0;
+
+  const unsubSkills = rosClient.subscribe(
+    AVAILABLE_SKILLS_TOPIC,
+    (message) => {
+      skills = Array.isArray(message?.skills) ? message.skills : [];
+    },
+    undefined,
+    "brain_messages/msg/AvailableSkills",
+  );
+
+  const stopPlaybackListener = onTtsPlaybackStart(() => {
+    const resolve = resolveSpeechStart;
+    resolveSpeechStart = null;
+    resolve?.();
+  });
+
+  /** @param {number} id */
+  function waitForSpeechStart(id) {
+    return new Promise((/** @type {(value?: void) => void} */ resolve) => {
+      if (id !== generation) {
+        resolve();
+        return;
+      }
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (resolveSpeechStart === finish) resolveSpeechStart = null;
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        console.warn("[onboarding] no speech playback heard — continuing without it");
+        finish();
+      }, SPEECH_START_TIMEOUT_MS);
+      resolveSpeechStart = finish;
+    });
+  }
+
+  /** @param {string} name @param {Record<string, unknown>} inputs @param {number} id */
+  async function runSkill(name, inputs, id) {
+    if (id !== generation) return;
+    const skillId = await waitForSkillId(name, id);
+    if (!skillId || id !== generation) return;
+    const action = rosClient.sendActionGoal(
+      EXECUTE_SKILL_ACTION,
+      EXECUTE_SKILL_ACTION_TYPE,
+      { skill_type: skillId, inputs: JSON.stringify(inputs) },
+    );
+    cancelActive = action.cancel;
+    try {
+      await action.promise;
+    } catch (error) {
+      if (id === generation) console.warn(`[onboarding] '${name}' failed`, error);
+    } finally {
+      if (cancelActive === action.cancel) cancelActive = null;
+    }
+  }
+
+  /** @param {string} name @param {number} id */
+  async function waitForSkillId(name, id) {
+    const existing = findSkillId(skills, name);
+    if (existing) return existing;
+    const deadline = Date.now() + 8000;
+    while (id === generation && Date.now() < deadline) {
+      await sleep(100);
+      const found = findSkillId(skills, name);
+      if (found) return found;
+    }
+    if (id === generation) console.warn(`[onboarding] '${name}' is unavailable`);
+    return "";
+  }
+
+  /**
+   * @param {ScriptedAction[]} actions
+   * @returns {Promise<void>}
+   */
+  async function run(actions) {
+    cancel();
+    const id = ++generation;
+    let heardSpeech = false;
+
+    for (const action of actions) {
+      if (id !== generation) return;
+      if (action.type === "speak") {
+        // Utterances queue on the robot and play in order, so a queued line is
+        // synthesizing while the previous one is still being heard. Waiting on
+        // every line instead would put the whole synthesis delay in the gap
+        // between them.
+        if (action.queue) {
+          rosClient.publish(TTS_TOPIC, { data: action.text });
+          continue;
+        }
+        const speechStarted = waitForSpeechStart(id);
+        rosClient.publish(TTS_TOPIC, { data: action.text });
+        await speechStarted;
+        heardSpeech = id === generation;
+        continue;
+      }
+      if (action.type === "ui") {
+        action.apply();
+        // Let the reveal's CSS transition start before the next line lands, so
+        // the panel is on screen while the robot talks about it.
+        await sleep(UI_SETTLE_MS);
+        continue;
+      }
+      if (action.type === "skill") {
+        if (action.afterSpeechStart && !heardSpeech) {
+          await waitForSpeechStart(id);
+          heardSpeech = id === generation;
+        }
+        await runSkill(action.name, action.inputs ?? {}, id);
+      }
+    }
+  }
+
+  function cancel() {
+    generation++;
+    const resolve = resolveSpeechStart;
+    resolveSpeechStart = null;
+    resolve?.();
+    cancelActive?.();
+    cancelActive = null;
+    void rosClient.callService(CANCEL_SKILL_SERVICE, {}).catch(() => {});
+  }
+
+  return {
+    run,
+    cancel,
+    destroy() {
+      cancel();
+      stopPlaybackListener();
+      unsubSkills();
+    },
+  };
+}
+
+/** @deprecated Use createScriptedActionRunner */
+export const createOnboardingWelcome = createScriptedActionRunner;
+
+/** @param {any[]} skills @param {string} name */
+function findSkillId(skills, name) {
+  const expected = normalize(name);
+  const match = skills.find((skill) =>
+    [skill?.id, skill?.name].some((value) => normalize(String(value ?? "").split("/").at(-1) ?? "") === expected),
+  );
+  return typeof match?.id === "string" ? match.id : "";
+}
+
+/** @param {string} value */
+function normalize(value) {
+  return value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+/** @param {number} ms */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -61,6 +61,10 @@ export const GET_CHAT_HISTORY_SERVICE = "/brain/get_chat_history";
 export const GET_AVAILABLE_DIRECTIVES_SERVICE = "/brain/get_available_directives";
 export const SET_DIRECTIVE_TOPIC = "/brain/set_directive";
 export const SET_BRAIN_ACTIVE_SERVICE = "/brain/set_brain_active";
+// A free-form event into the running agent's context (std_msgs/String JSON;
+// `input_device` names the source). Dropped while the brain is inactive, so
+// publish only after activation.
+export const CUSTOM_INPUT_TOPIC = "/input_manager/custom";
 // Set which skills the current directive may use (std_msgs/String JSON:
 // {agent_id, skills:[id,...]} — the full active set, not a delta).
 export const SET_ACTIVE_SKILLS_TOPIC = "/brain/set_active_skills";

--- a/webapp/js/robotSession.js
+++ b/webapp/js/robotSession.js
@@ -35,7 +35,16 @@ let simHolders = 0;
 /** @type {number | null} */ let simLinger = null;
 
 /**
- * @returns {Promise<{ createSession: () => WebRtcSession, releaseSession: (session: WebRtcSession) => void, createStage: ((root: HTMLElement, session: WebRtcSession) => { audioEl: HTMLAudioElement | null, destroy: () => void }) | null }>}
+ * @typedef {{
+ *   audioEl: HTMLAudioElement | null,
+ *   destroy: () => void,
+ *   setOnboardingStep?: (step: "await_hello" | "welcome" | "await_go"
+ *     | "tour_cameras" | "tour_telemetry" | "tour_chat" | "complete") => void
+ * }} RobotStage
+ */
+
+/**
+ * @returns {Promise<{ createSession: () => WebRtcSession, releaseSession: (session: WebRtcSession) => void, createStage: ((root: HTMLElement, session: WebRtcSession) => RobotStage) | null }>}
  * createStage is null for real robots (pages use createVideoStage); in sim it
  * mounts the live Three.js canvas (full resolution, drag-to-orbit).
  */

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -13,6 +13,7 @@ import { createArmAlert } from "./armAlert.js";
 import { maybeShowAppPromo } from "./appPromo.js";
 import { installPressActivate } from "./pressActivate.js";
 import { FOOTER_SECTIONS, GROUPS, SECTIONS, SIM_SECTIONS, railRows } from "./railLayout.js";
+import { resetAgentOnboarding } from "./agent/onboarding.js";
 
 /** @typedef {import("./railLayout.js").Section} Section */
 
@@ -85,7 +86,12 @@ export function initShell(navigate) {
   function renderNav(visible) {
     nav.innerHTML = "";
     for (const row of railRows(GROUPS, visible)) {
-      nav.appendChild(row.kind === "divider" ? buildDivider(row.label) : buildLink(row.section));
+      if (row.kind === "divider") {
+        nav.appendChild(buildDivider(row.label));
+        continue;
+      }
+      nav.appendChild(buildLink(row.section));
+      if (row.section.key === "armsdk") nav.appendChild(buildOnboardingReset());
     }
     footNav.innerHTML = "";
     for (const section of FOOTER_SECTIONS) {
@@ -112,6 +118,22 @@ export function initShell(navigate) {
       `<span class="rail-label">${section.label}</span>` +
       (shortcut ? `<span class="rail-key" aria-hidden="true">${shortcut}</span>` : "");
     return a;
+  }
+
+  function buildOnboardingReset() {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "rail-link rail-action";
+    button.title = "Reset Agent onboarding";
+    button.setAttribute("aria-label", "Reset Agent onboarding");
+    button.innerHTML =
+      '<span class="rail-ico"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4v6h6"/><path d="M5.6 16.5A8 8 0 1 0 6 7.2L4 10"/></svg></span>' +
+      '<span class="rail-label">Reset onboarding</span>';
+    button.addEventListener("click", () => {
+      resetAgentOnboarding();
+      navigate("/");
+    });
+    return button;
   }
 
   /** @param {string | null} label */

--- a/webapp/js/teleop/telemetry.js
+++ b/webapp/js/teleop/telemetry.js
@@ -10,9 +10,11 @@ import { BATTERY_STATE_TOPIC, ROBOT_INFO_TOPIC, WEBSOCKET_STATUS_TOPIC } from ".
 /**
  * @param {HTMLElement} parent
  * @param {import("../rosClient.js").RosClient} rosClient
+ * @param {{ showBattery?: boolean }} [opts] The sim has no battery, so it opts out.
  * @returns {{ destroy: () => void }}
  */
-export function createTelemetry(parent, rosClient) {
+export function createTelemetry(parent, rosClient, opts = {}) {
+  const showBattery = opts.showBattery !== false;
   const wrap = document.createElement("div");
   wrap.className = "telemetry";
 
@@ -25,6 +27,8 @@ export function createTelemetry(parent, rosClient) {
   const items = [name, battery, link, agent];
   /** @type {number | null} */
   let measureFrame = null;
+  battery.el.hidden = !showBattery;
+  wrap.classList.toggle("with-battery", showBattery);
 
   /**
    * @param {TelemetryKey} key
@@ -158,20 +162,22 @@ export function createTelemetry(parent, rosClient) {
     ),
   ];
 
-  unsubs.push(
-    rosClient.subscribe(
-      BATTERY_STATE_TOPIC,
-      (/** @type {BatteryStateMsg} */ msg) => {
-        const p = msg?.percentage;
-        if (typeof p !== "number" || Number.isNaN(p)) return;
-        // The robot publishes 0–100; tolerate a spec-compliant 0–1 source.
-        const pct = p <= 1 ? p * 100 : p;
-        update(battery, `${Math.round(pct)}%`, pct <= 15 ? "warn" : "");
-      },
-      1000,
-      "sensor_msgs/msg/BatteryState",
-    ),
-  );
+  if (showBattery) {
+    unsubs.push(
+      rosClient.subscribe(
+        BATTERY_STATE_TOPIC,
+        (/** @type {BatteryStateMsg} */ msg) => {
+          const p = msg?.percentage;
+          if (typeof p !== "number" || Number.isNaN(p)) return;
+          // The robot publishes 0–100; tolerate a spec-compliant 0–1 source.
+          const pct = p <= 1 ? p * 100 : p;
+          update(battery, `${Math.round(pct)}%`, pct <= 15 ? "warn" : "");
+        },
+        1000,
+        "sensor_msgs/msg/BatteryState",
+      ),
+    );
+  }
 
   return {
     destroy() {

--- a/webapp/js/ttsAudio.js
+++ b/webapp/js/ttsAudio.js
@@ -14,6 +14,14 @@ import { isMicAudioActive, setTtsPlaying } from "./micAudioState.js";
 const TTS_AUDIO_TOPIC = "/tts/audio";
 
 let started = false;
+/** @type {Set<() => void>} */
+const playbackStartListeners = new Set();
+
+/** @param {() => void} listener */
+export function onTtsPlaybackStart(listener) {
+  playbackStartListeners.add(listener);
+  return () => playbackStartListeners.delete(listener);
+}
 
 // One speaker across tabs: rosbridge fans /tts/audio out to every client, so
 // N open tabs played N overlapping copies. A held Web Lock elects exactly one
@@ -95,6 +103,9 @@ function play(b64) {
   };
   audio.addEventListener("ended", done, { once: true });
   audio.addEventListener("error", done, { once: true });
+  audio.addEventListener("playing", () => {
+    for (const listener of playbackStartListeners) listener();
+  }, { once: true });
   audio.play().catch((err) => {
     // Browser autoplay policies block playback until the user has interacted
     // with the page; after any click/keypress this succeeds.

--- a/workspace/innate_agents/intro_agent.py
+++ b/workspace/innate_agents/intro_agent.py
@@ -36,7 +36,23 @@ class IntroAgent(Agent):
 
     def get_prompt(self) -> str:
         """Return the prompt that defines the robot's personality and behavior"""
-        return """You are Mars, a friendly robot assistant. Keep responses concise and conversational. You can see through a camera and use tools to wave, move, and interact. You have a long-term memory of what you've seen on this map — consult it via your skills before saying no. Greet people warmly when you see them! Whenever you say something, also use a head emotion, one of "happy", "very_happy", "sad", "excited", "angry", "agreeing", prefer "very_happy" for 12 syllables or more sentence. Navigate only when prompted to. IMPORTANT: If the user says 'stop' or interrupts you during an action, STOP immediately, and do NOT retry or call the tool again. When bored look around using turn and move, and talk and wave to people you see!"""
+        return """
+You are Mars, a friendly robot assistant. Keep responses concise and conversational.
+You can see through a camera and use tools to wave, move, and interact. You have a
+long-term memory of what you have seen on this map, so consult it before saying no.
+
+For responses, use a fitting head emotion: "happy", "very_happy", "sad",
+"excited", "angry", or "agreeing". Prefer "very_happy" for sentences of twelve
+syllables or more. Navigate only when prompted.
+
+The web app may run a scripted welcome before you start, and tells you so with
+an onboarding_complete input. When that has happened you are already mid
+conversation: do not greet the user or introduce yourself again, just carry on.
+
+If the user says "stop" or interrupts you during an action, stop immediately.
+Do not retry or call the tool again. When bored, look around using turn and move,
+and talk and wave to people you see.
+""".strip()
 
     def uses_gaze(self) -> bool:
         """Enable person-tracking gaze during conversation."""


### PR DESCRIPTION
Takes over the `fade-vomit` branch (renamed, rebased on `main`) and finishes the onboarding tour.

## What this does

Say "Hello MARS" -> the robot appears, greets you and waves -> the UI assembles itself a panel at a time while he turns toward each one -> the intro agent takes over mid-conversation, without starting the introduction over.

## Why brain_client is untouched

The branch added a `/brain/set_onboarding_input` service to open MicroInput for STT while `BrainAgent` stayed stopped, plus an `is_onboarding_input` flag making `_on_chat_in` drop scripted transcripts.

That second half was redundant: `_on_chat_in` already returns early when the brain is inactive, so the agent was never going to consume the greeting. And the first half did not need the brain at all. `/input_manager/active_inputs` is owned by the **input_manager** node and applies with no reference to brain state, so publishing `{"inputs": ["micro"]}` from the page runs the robot's own VAD and STT directly. The transcript still arrives on `/brain/chat_in`, which is what the step table matches on.

Activation republishes the directive's required inputs, so the brain reclaims the mic on handoff with no explicit teardown.

Net: all three `brain_client` files revert to `main`. This also works on a real robot, where MicroInput just listens to the real mic.

## Handing context to the intro agent

Crossing into `complete` activates the directive, then posts one `/input_manager/custom` event naming what already happened. Paired with a line in the intro agent's prompt, that is what stops Mars greeting someone he has just spent a minute talking to. Ordering matters: custom input is dropped while the brain is inactive, so it goes out only after `set_brain_active` resolves.

## The tour

Three steps added between the welcome and the handoff, each revealing one panel: cameras, telemetry, chat. Every step turns toward its panel and turns back by the same amount, so it starts and ends centred and can resume standalone from `localStorage`. The scripted runner gained a `ui` action that carries its own effect, so it reveals panels without knowing anything about the page.

Progress version bumped to 2: a finished v1 tour stays finished, an unfinished one restarts, since the old step ids no longer describe this lesson order.

## Notes for review

- **Skip affordance.** The robot-level mic toggle can veto the mic device, which would strand the page on "Say Hello MARS" with no way forward. A "Skip intro" button appears after 25s unanswered.
- **`turn_in_place` is new to the script.** The other skills were already exercised on the branch. A missing skill costs an 8s stall in `waitForSkillId` before it is skipped, so it is worth confirming it resolves in the sim.
- **Worth a look on screen.** The tour timing (`UI_SETTLE_MS`, turn angles, dialogue pacing) is the kind of thing that reads differently running than in a diff.

## Verified

- `sim/viewer`: `npm run typecheck` clean.
- `webapp`: `npx tsc --noEmit` clean for every file this touches (the pre-existing `armsdk/` and vendored `three` errors are unrelated).
- `brain_client` is byte-identical to `main`, so its ruff/pytest/basedpyright gates are unaffected. Note `ruff` is not installed on my machine, so I checked identity rather than re-running them.
- Not yet run end-to-end in the sim.
