### PR TITLE
feat(agent): react faster to residents during search

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
-from brain_client.agents.types import Agent, TurnIntervals
+from brain_client.agents.types import Agent, DepartureGuard, TurnIntervals
 from brain_client.common.dynamic_loader import class_name_to_snake_case, evict_modules_under
 from brain_client.common.script_paths import (
     classify_source,
@@ -93,6 +93,12 @@ def build_agent_instances(
             if not isinstance(intervals, TurnIntervals):
                 raise TypeError(
                     f"{type(agent).__name__}.get_turn_intervals() must return TurnIntervals, got {intervals!r}"
+                )
+            departure_guard = agent.get_departure_guard()
+            if departure_guard is not None and not isinstance(departure_guard, DepartureGuard):
+                raise TypeError(
+                    f"{type(agent).__name__}.get_departure_guard() must return DepartureGuard or None, "
+                    f"got {departure_guard!r}"
                 )
             agent.uses_gaze()
             skill_ids = agent.skill_ids()

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
-from brain_client.agents.types import Agent
+from brain_client.agents.types import Agent, TurnIntervals
 from brain_client.common.dynamic_loader import class_name_to_snake_case, evict_modules_under
 from brain_client.common.script_paths import (
     classify_source,
@@ -89,6 +89,11 @@ def build_agent_instances(
             str(agent.display_name)
             agent.get_prompt()
             agent.input_names()
+            intervals = agent.get_turn_intervals()
+            if not isinstance(intervals, TurnIntervals):
+                raise TypeError(
+                    f"{type(agent).__name__}.get_turn_intervals() must return TurnIntervals, got {intervals!r}"
+                )
             agent.uses_gaze()
             skill_ids = agent.skill_ids()
         except Exception as e:  # noqa: BLE001 — one bad agent must not stop the roster

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
-from brain_client.agents.types import Agent, DepartureGuard, TurnIntervals
+from brain_client.agents.types import Agent, DepartureGuard, InteractionGuard, TurnIntervals
 from brain_client.common.dynamic_loader import class_name_to_snake_case, evict_modules_under
 from brain_client.common.script_paths import (
     classify_source,
@@ -99,6 +99,12 @@ def build_agent_instances(
                 raise TypeError(
                     f"{type(agent).__name__}.get_departure_guard() must return DepartureGuard or None, "
                     f"got {departure_guard!r}"
+                )
+            interaction_guard = agent.get_interaction_guard()
+            if interaction_guard is not None and not isinstance(interaction_guard, InteractionGuard):
+                raise TypeError(
+                    f"{type(agent).__name__}.get_interaction_guard() must return InteractionGuard or None, "
+                    f"got {interaction_guard!r}"
                 )
             agent.uses_gaze()
             skill_ids = agent.skill_ids()

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
@@ -76,6 +76,32 @@ class DepartureGuard:
                 raise ValueError(f"departure guard {name} must be a finite positive number")
 
 
+@dataclass(frozen=True)
+class InteractionGuard:
+    """Temporarily hide escape skills while a required interaction is unresolved."""
+
+    trigger_skill_names: tuple[str, ...]
+    trigger_result_prefixes: tuple[str, ...]
+    blocked_skill_ids: tuple[str, ...]
+    release_skill_names: tuple[str, ...]
+    release_result_prefixes: tuple[str, ...]
+    maximum_hold_s: float
+
+    def __post_init__(self) -> None:
+        if not all(
+            (
+                self.trigger_skill_names,
+                self.trigger_result_prefixes,
+                self.blocked_skill_ids,
+                self.release_skill_names,
+                self.release_result_prefixes,
+            )
+        ):
+            raise ValueError("interaction guard trigger, blocked, and release fields cannot be empty")
+        if not math.isfinite(self.maximum_hold_s) or self.maximum_hold_s <= 0:
+            raise ValueError("interaction guard maximum_hold_s must be a finite positive number")
+
+
 class Agent(ABC):
     """
     Base class for all agents.
@@ -219,6 +245,10 @@ class Agent(ABC):
 
     def get_departure_guard(self) -> DepartureGuard | None:
         """Optionally protect a running search from immediate repeat cancellation."""
+        return None
+
+    def get_interaction_guard(self) -> InteractionGuard | None:
+        """Optionally keep escape skills hidden while an interaction is unresolved."""
         return None
 
     def input_names(self) -> list[str]:

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
@@ -7,7 +7,9 @@ Agent Type Definitions
 Base class and types for robot agents.
 """
 
+import math
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias, Union
 
 from brain_client.common.script_paths import Source
@@ -25,6 +27,25 @@ SkillRef: TypeAlias = Union["type[Skill]", "type[TrainedSkill]", str]
 # What get_inputs() may list: the InputDevice class itself (typed, same
 # rationale as SkillRef) or a device-name string.
 InputRef: TypeAlias = Union["type[InputDevice]", str]
+
+
+@dataclass(frozen=True)
+class TurnIntervals:
+    """Optional per-agent overrides for the brain's visual observation cadence.
+
+    ``None`` keeps the global ROS parameter.  A positive value is the pause
+    after a completed model turn; model latency is additional.  Keeping this
+    on the agent lets a visually supervised navigation agent look frequently
+    without making every directive on the robot equally chatty and expensive.
+    """
+
+    idle: float | None = None
+    supervision: float | None = None
+
+    def __post_init__(self) -> None:
+        for name, value in (("idle", self.idle), ("supervision", self.supervision)):
+            if value is not None and (not math.isfinite(value) or value <= 0):
+                raise ValueError(f"turn interval {name} must be a finite positive number or None")
 
 
 class Agent(ABC):
@@ -158,6 +179,15 @@ class Agent(ABC):
         Default: return empty list (no input devices required).
         """
         return []
+
+    def get_turn_intervals(self) -> TurnIntervals:
+        """Return optional per-agent idle and running-skill turn intervals.
+
+        The global ``brain_client_node`` ROS parameters remain the defaults.
+        Override this only when the directive needs a materially different
+        visual reaction cadence.
+        """
+        return TurnIntervals()
 
     def input_names(self) -> list[str]:
         """get_inputs() normalized to device-name strings — the only form the

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
@@ -48,6 +48,34 @@ class TurnIntervals:
                 raise ValueError(f"turn interval {name} must be a finite positive number or None")
 
 
+@dataclass(frozen=True)
+class DepartureGuard:
+    """Keep a search moving briefly after recognizing an already-known subject.
+
+    A fast visual supervision loop can otherwise cancel the newly restarted
+    search for the same unchanged person every second.  Agents opt in by
+    naming the terminal result prefixes that establish an anchor and the
+    skills that must be allowed to depart from it.  User speech always bypasses
+    the guard.
+    """
+
+    trigger_skill_names: tuple[str, ...]
+    trigger_result_prefixes: tuple[str, ...]
+    protected_skill_ids: tuple[str, ...]
+    minimum_departure_m: float
+    maximum_hold_s: float
+
+    def __post_init__(self) -> None:
+        if not self.trigger_skill_names or not self.trigger_result_prefixes or not self.protected_skill_ids:
+            raise ValueError("departure guard trigger names, result prefixes, and protected skills cannot be empty")
+        for name, value in (
+            ("minimum_departure_m", self.minimum_departure_m),
+            ("maximum_hold_s", self.maximum_hold_s),
+        ):
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"departure guard {name} must be a finite positive number")
+
+
 class Agent(ABC):
     """
     Base class for all agents.
@@ -188,6 +216,10 @@ class Agent(ABC):
         visual reaction cadence.
         """
         return TurnIntervals()
+
+    def get_departure_guard(self) -> DepartureGuard | None:
+        """Optionally protect a running search from immediate repeat cancellation."""
+        return None
 
     def input_names(self) -> list[str]:
         """get_inputs() normalized to device-name strings — the only form the

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -399,8 +399,14 @@ class BrainAgent:
             self._pause_until = 0.0
 
     def _interval(self) -> float:
+        directive = self._state.current_directive
+        overrides = directive.get_turn_intervals() if directive is not None else None
         if self._state.primitive_running:
+            if overrides is not None and overrides.supervision is not None:
+                return overrides.supervision
             return self._config.supervision_turn_interval
+        if overrides is not None and overrides.idle is not None:
+            return overrides.idle
         return self._config.idle_turn_interval
 
     def _elapsed(self) -> float:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -139,6 +139,8 @@ class BrainAgent:
         self._turn_in_flight = False
         self._speaker: SpeechStreamer | None = None  # the in-flight turn's streamer (the racing loop reads it)
         self._pause_until = 0.0  # monotonic deadline of the current between-turns pause
+        self._departure_anchor: tuple[float, float, float] | None = None
+        self._turn_user_spoke = False
 
         self._runtime = LoopThread("brain-agent")
         self._new_event = asyncio.Event()  # something was queued (loop thread; set via runtime.post)
@@ -187,6 +189,7 @@ class BrainAgent:
             return False
         self._activated_at = time.monotonic()
         self._error_streak = 0
+        self._departure_anchor = None
         self._runtime.spawn(self._loop())
         return True
 
@@ -459,6 +462,7 @@ class BrainAgent:
     def _build_tools(self, events: list[Event]) -> list[dict]:
         running = self._state.primitive_running
         user_spoke = any(event.kind == EventKind.USER for event in events)
+        self._turn_user_spoke = user_spoke
         active_ids = set(self._roster.active_skill_ids())
         skills = [meta for meta in self._state.registry.metadata if meta["id"] in active_ids]
         # One naming pass feeds both the declarations and the dispatch map, so
@@ -466,7 +470,12 @@ class BrainAgent:
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
         if running is not None:
-            return build_tools([], running.primitive_name, user_spoke=user_spoke)
+            return build_tools(
+                [],
+                running.primitive_name,
+                user_spoke=user_spoke,
+                can_stop_running=self._departure_guard_reason() is None,
+            )
         return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
 
     # ================= act =================
@@ -541,6 +550,9 @@ class BrainAgent:
         return "started — you will get an event when it finishes"
 
     def _stop_skill(self) -> str:
+        guard_reason = self._departure_guard_reason()
+        if guard_reason is not None and not self._turn_user_spoke:
+            return f"rejected — {guard_reason}"
         if self._runner.has_active_goal:
             self._runner.cancel_active_goal()
             return "stopping — you will get an event when it has stopped"
@@ -551,6 +563,29 @@ class BrainAgent:
         if self._runner.cancel_external():
             return "stopping — you will get an event when it has stopped"
         return "could not stop it — the skills server is unreachable"
+
+    def _departure_guard_reason(self) -> str | None:
+        """Why the current skill must continue away from a recent identity anchor."""
+        directive = self._state.current_directive
+        policy = directive.get_departure_guard() if directive is not None else None
+        running = self._state.primitive_running
+        anchor = self._departure_anchor
+        if policy is None or running is None or anchor is None or running.skill_id not in policy.protected_skill_ids:
+            return None
+        anchor_x, anchor_y, anchored_at = anchor
+        elapsed = time.monotonic() - anchored_at
+        if elapsed >= policy.maximum_hold_s:
+            self._departure_anchor = None
+            return None
+        pose = self._pose.current_pose_xyt()
+        if pose is not None and math.hypot(pose[0] - anchor_x, pose[1] - anchor_y) >= policy.minimum_departure_m:
+            self._departure_anchor = None
+            return None
+        return (
+            f"continue {running.primitive_name} until the robot has departed at least "
+            f"{policy.minimum_departure_m:g} m from the already-known person "
+            f"(or {policy.maximum_hold_s:g} s elapse)"
+        )
 
     def _go_to_point_in_view(self, args: dict) -> str:
         """Project the pointed-at floor pixel into a local navigate_to_position goal."""
@@ -632,6 +667,18 @@ class BrainAgent:
     def on_skill_event(
         self, status: str, skill_name: str, detail: str | None = None, image: bytes | None = None
     ) -> None:
+        directive = self._state.current_directive
+        policy = directive.get_departure_guard() if directive is not None else None
+        if (
+            policy is not None
+            and status == "completed"
+            and skill_name in policy.trigger_skill_names
+            and detail is not None
+            and any(detail.startswith(prefix) for prefix in policy.trigger_result_prefixes)
+        ):
+            pose = self._pose.current_pose_xyt()
+            if pose is not None:
+                self._departure_anchor = (pose[0], pose[1], time.monotonic())
         line = f"Skill {skill_name} {status}"
         if detail:
             line += f": {detail}"

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -140,6 +140,7 @@ class BrainAgent:
         self._speaker: SpeechStreamer | None = None  # the in-flight turn's streamer (the racing loop reads it)
         self._pause_until = 0.0  # monotonic deadline of the current between-turns pause
         self._departure_anchor: tuple[float, float, float] | None = None
+        self._interaction_guard_started_at: float | None = None
         self._turn_user_spoke = False
 
         self._runtime = LoopThread("brain-agent")
@@ -190,6 +191,7 @@ class BrainAgent:
         self._activated_at = time.monotonic()
         self._error_streak = 0
         self._departure_anchor = None
+        self._interaction_guard_started_at = None
         self._runtime.spawn(self._loop())
         return True
 
@@ -465,6 +467,9 @@ class BrainAgent:
         self._turn_user_spoke = user_spoke
         active_ids = set(self._roster.active_skill_ids())
         skills = [meta for meta in self._state.registry.metadata if meta["id"] in active_ids]
+        blocked_ids = self._interaction_blocked_skill_ids()
+        if blocked_ids:
+            skills = [meta for meta in skills if meta["id"] not in blocked_ids]
         # One naming pass feeds both the declarations and the dispatch map, so
         # the name the model calls always resolves to the skill it was declared for.
         named = assign_tool_names(skills)
@@ -587,6 +592,21 @@ class BrainAgent:
             f"(or {policy.maximum_hold_s:g} s elapse)"
         )
 
+    def _interaction_guard_policy(self):
+        directive = self._state.current_directive
+        getter = getattr(directive, "get_interaction_guard", None) if directive is not None else None
+        return getter() if getter is not None else None
+
+    def _interaction_blocked_skill_ids(self) -> frozenset[str]:
+        policy = self._interaction_guard_policy()
+        started_at = self._interaction_guard_started_at
+        if policy is None or started_at is None:
+            return frozenset()
+        if time.monotonic() - started_at >= policy.maximum_hold_s:
+            self._interaction_guard_started_at = None
+            return frozenset()
+        return frozenset(policy.blocked_skill_ids)
+
     def _go_to_point_in_view(self, args: dict) -> str:
         """Project the pointed-at floor pixel into a local navigate_to_position goal."""
         # Gate on the ACTIVE set, not the registry: a hallucinated call must
@@ -679,6 +699,16 @@ class BrainAgent:
             pose = self._pose.current_pose_xyt()
             if pose is not None:
                 self._departure_anchor = (pose[0], pose[1], time.monotonic())
+        interaction_policy = self._interaction_guard_policy()
+        if interaction_policy is not None and status == "completed" and detail is not None:
+            if skill_name in interaction_policy.release_skill_names and any(
+                detail.startswith(prefix) for prefix in interaction_policy.release_result_prefixes
+            ):
+                self._interaction_guard_started_at = None
+            elif skill_name in interaction_policy.trigger_skill_names and any(
+                detail.startswith(prefix) for prefix in interaction_policy.trigger_result_prefixes
+            ):
+                self._interaction_guard_started_at = time.monotonic()
         line = f"Skill {skill_name} {status}"
         if detail:
             line += f": {detail}"

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -86,6 +86,7 @@ def build_tools(
     *,
     can_go_to_point_in_view: bool = False,
     user_spoke: bool = False,
+    can_stop_running: bool = True,
 ) -> list[dict]:
     """One function declaration per available skill, in a native tools block.
 
@@ -100,6 +101,8 @@ def build_tools(
     the reply channel, and the description steers stop away from questions.
     """
     if running_skill_name is not None:
+        if not can_stop_running and not user_spoke:
+            return [{"functionDeclarations": [_WAIT_DECLARATION]}]
         stop = {
             "name": STOP_SKILL,
             "description": f"Abort the currently running skill ({running_skill_name}). "

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -439,3 +439,17 @@ def test_build_rejects_invalid_departure_guard_contract(workspace):
 
     assert agents == {}
     assert "must return DepartureGuard or None" in broken["bad_guard"]
+
+
+def test_build_rejects_invalid_interaction_guard_contract(workspace):
+    write(
+        workspace,
+        "innate_agents/bad_interaction_guard.py",
+        agent_src("BadInteractionGuard", body='def get_interaction_guard(self):\n    return {"timeout": 35.0}'),
+    )
+
+    classes, _errors = discover_agent_classes(LOGGER)
+    agents, broken = build_agent_instances(classes, LOGGER)
+
+    assert agents == {}
+    assert "must return InteractionGuard or None" in broken["bad_interaction_guard"]

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -425,3 +425,17 @@ def test_build_rejects_invalid_turn_interval_contract(workspace):
 
     assert agents == {}
     assert "must return TurnIntervals" in broken["bad_interval"]
+
+
+def test_build_rejects_invalid_departure_guard_contract(workspace):
+    write(
+        workspace,
+        "innate_agents/bad_guard.py",
+        agent_src("BadGuard", body='def get_departure_guard(self):\n    return {"distance": 1.0}'),
+    )
+
+    classes, _errors = discover_agent_classes(LOGGER)
+    agents, broken = build_agent_instances(classes, LOGGER)
+
+    assert agents == {}
+    assert "must return DepartureGuard or None" in broken["bad_guard"]

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -411,3 +411,17 @@ def test_build_reports_id_conflict_last_wins(workspace):
 
     assert broken == {}
     assert list(agents) == ["same_id"]  # conflict warns, latter wins (documented behavior)
+
+
+def test_build_rejects_invalid_turn_interval_contract(workspace):
+    write(
+        workspace,
+        "innate_agents/bad_interval.py",
+        agent_src("BadInterval", body='def get_turn_intervals(self):\n    return {"supervision": 1.0}'),
+    )
+
+    classes, _errors = discover_agent_classes(LOGGER)
+    agents, broken = build_agent_instances(classes, LOGGER)
+
+    assert agents == {}
+    assert "must return TurnIntervals" in broken["bad_interval"]

--- a/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
+++ b/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
@@ -2517,6 +2517,16 @@ def test_sweep_information_utility_prefers_efficient_gain_over_long_detour():
     assert search_module._coverage_travel_utility(50, 0.0, sweeping=True) == 50
 
 
+def test_backtrack_penalty_prefers_continuing_an_exploration_leg():
+    observations = [{"x": 0.0, "y": 0.0}, {"x": 2.0, "y": 0.0}]
+
+    assert search_module._backtrack_penalty(4.0, 0.0, observations) == 0.0
+    assert search_module._backtrack_penalty(0.0, 0.0, observations) == pytest.approx(
+        search_module.SWEEP_BACKTRACK_PENALTY_CELLS
+    )
+    assert 0.0 < search_module._backtrack_penalty(1.0, 1.0, observations) < search_module.SWEEP_BACKTRACK_PENALTY_CELLS
+
+
 def test_choose_view_avoids_looking_toward_a_handled_person(monkeypatch):
     reachable = np.ones((10, 10), dtype=bool)
     plan = search_module._PlanningGrid(

--- a/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
+++ b/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
@@ -907,34 +907,6 @@ def test_contact_sheet_budget_gives_each_profile_a_first_view_before_seconds():
     assert [item[2] for item in selected[4:]] == ["1-side", "2-side"]
 
 
-def test_appearance_cache_matches_only_unique_near_duplicate():
-    state = roster_module.ResidentRoster._fresh_state()
-    red = _frame((170, 35, 35))
-    blue = _frame((35, 35, 170))
-    current = _frame((168, 36, 34))
-    state["encounters"] = [
-        {"encounter_id": "resident-001", "reference_images_b64": [str(red)]},
-        {"encounter_id": "resident-002", "reference_images_b64": [str(blue)]},
-    ]
-
-    match = roster_module._appearance_cache_match(state, str(current))
-
-    assert match is not None
-    assert match[0]["encounter_id"] == "resident-001"
-    assert match[1] >= roster_module.APPEARANCE_CACHE_MIN_SIMILARITY
-
-
-def test_appearance_cache_rejects_ambiguous_gallery():
-    state = roster_module.ResidentRoster._fresh_state()
-    same = _frame((80, 110, 50))
-    state["encounters"] = [
-        {"encounter_id": "resident-001", "reference_images_b64": [str(same)]},
-        {"encounter_id": "resident-002", "reference_images_b64": [str(same)]},
-    ]
-
-    assert roster_module._appearance_cache_match(state, str(same)) is None
-
-
 def test_roster_status_contract_contains_state_not_policy(roster):
     state = roster_module.ResidentRoster._fresh_state()
     state["encounters"] = [

--- a/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
+++ b/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
@@ -2509,6 +2509,43 @@ def test_choose_view_penalizes_a_winding_route(monkeypatch):
     assert (view.row, view.col) == same_side
 
 
+def test_choose_view_avoids_looking_toward_a_handled_person(monkeypatch):
+    reachable = np.ones((10, 10), dtype=bool)
+    plan = search_module._PlanningGrid(
+        resolution=1.0,
+        origin_x=0.0,
+        origin_y=0.0,
+        origin_theta=0.0,
+        traversable=reachable,
+        blocked=~reachable,
+        safe=reachable,
+        reachable=reachable,
+        navigable=reachable,
+    )
+    toward_person = (2, 2)
+    away_from_person = (2, 4)
+    monkeypatch.setattr(search_module, "_sample_viewpoints", lambda _plan: [toward_person, away_from_person])
+    monkeypatch.setattr(search_module, "_grid_travel_distances", lambda _plan, _pose: np.zeros((10, 10)))
+
+    def visible(_plan, row, col, _theta):
+        if (row, col) == toward_person:
+            return frozenset(range(60))  # includes handled-person cell 22 and has higher raw gain
+        return frozenset(range(40, 95))
+
+    monkeypatch.setattr(search_module, "_visible_cells", visible)
+
+    view, _covered = search_module._choose_view(
+        plan,
+        Pose(3.5, 2.5, 0.0),
+        [],
+        [],
+        handled_person_anchors=[(2.5, 2.5)],
+    )
+
+    assert view is not None
+    assert (view.row, view.col) == away_from_person
+
+
 def test_choose_view_does_not_repeat_a_target_already_observed_from_standoff(monkeypatch):
     traversable = np.ones((6, 6), dtype=bool)
     plan = search_module._PlanningGrid(

--- a/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
+++ b/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
@@ -907,6 +907,34 @@ def test_contact_sheet_budget_gives_each_profile_a_first_view_before_seconds():
     assert [item[2] for item in selected[4:]] == ["1-side", "2-side"]
 
 
+def test_appearance_cache_matches_only_unique_near_duplicate():
+    state = roster_module.ResidentRoster._fresh_state()
+    red = _frame((170, 35, 35))
+    blue = _frame((35, 35, 170))
+    current = _frame((168, 36, 34))
+    state["encounters"] = [
+        {"encounter_id": "resident-001", "reference_images_b64": [str(red)]},
+        {"encounter_id": "resident-002", "reference_images_b64": [str(blue)]},
+    ]
+
+    match = roster_module._appearance_cache_match(state, str(current))
+
+    assert match is not None
+    assert match[0]["encounter_id"] == "resident-001"
+    assert match[1] >= roster_module.APPEARANCE_CACHE_MIN_SIMILARITY
+
+
+def test_appearance_cache_rejects_ambiguous_gallery():
+    state = roster_module.ResidentRoster._fresh_state()
+    same = _frame((80, 110, 50))
+    state["encounters"] = [
+        {"encounter_id": "resident-001", "reference_images_b64": [str(same)]},
+        {"encounter_id": "resident-002", "reference_images_b64": [str(same)]},
+    ]
+
+    assert roster_module._appearance_cache_match(state, str(same)) is None
+
+
 def test_roster_status_contract_contains_state_not_policy(roster):
     state = roster_module.ResidentRoster._fresh_state()
     state["encounters"] = [

--- a/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
+++ b/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
@@ -2537,6 +2537,14 @@ def test_choose_view_penalizes_a_winding_route(monkeypatch):
     assert (view.row, view.col) == same_side
 
 
+def test_sweep_information_utility_prefers_efficient_gain_over_long_detour():
+    nearby = search_module._coverage_travel_utility(40, 2.0, sweeping=True)
+    distant = search_module._coverage_travel_utility(50, 8.0, sweeping=True)
+
+    assert nearby > distant
+    assert search_module._coverage_travel_utility(50, 0.0, sweeping=True) == 50
+
+
 def test_choose_view_avoids_looking_toward_a_handled_person(monkeypatch):
     reachable = np.ones((10, 10), dtype=bool)
     plan = search_module._PlanningGrid(
@@ -2805,44 +2813,7 @@ def test_apartment_route_cost_exposes_the_long_path_hidden_by_euclidean_distance
     assert route_distance > direct_distance * 3.0
 
 
-def test_search_prefers_nearby_route_over_distant_gain(monkeypatch):
-    traversable = np.ones((1, 10), dtype=bool)
-    plan = search_module._PlanningGrid(
-        resolution=1.0,
-        origin_x=0.0,
-        origin_y=0.0,
-        origin_theta=0.0,
-        traversable=traversable,
-        blocked=~traversable,
-        safe=traversable,
-        reachable=traversable,
-        navigable=traversable,
-    )
-    near = (0, 2)
-    far = (0, 8)
-    monkeypatch.setattr(search_module, "_sample_viewpoints", lambda _plan: [far, near])
-
-    def visible(_plan, row, col, _theta):
-        if (row, col) == near:
-            return frozenset(range(10, 20))
-        if (row, col) == far:
-            return frozenset(range(100, 200))
-        return frozenset()
-
-    monkeypatch.setattr(search_module, "_visible_cells", visible)
-
-    view, _covered = search_module._choose_view(
-        plan,
-        Pose(0.5, 0.5, 0.0),
-        [{"x": 0.5, "y": 0.5, "theta": 0.0}],
-        [],
-    )
-
-    assert view is not None
-    assert (view.row, view.col) == near
-
-
-def test_apartment_search_continues_locally_after_two_stops():
+def test_apartment_search_prefers_efficient_unseen_view_after_two_stops():
     map_state = _apartment_map_state()
     pose = Pose(-1.93, 2.71, math.radians(-8.0))
     observations = [
@@ -2854,8 +2825,10 @@ def test_apartment_search_continues_locally_after_two_stops():
     assert plan is not None
     view, _covered = search_module._choose_view(plan, pose, observations, [])
     assert view is not None
-    route_distance = search_module._grid_travel_distances(plan, pose)[view.row, view.col]
-    assert route_distance <= 1.0
+    route_distances = search_module._grid_travel_distances(plan, pose)
+    old_far_target = search_module._world_to_cell(plan, -0.2134, -2.7856)
+    assert route_distances[view.row, view.col] < route_distances[old_far_target]
+    assert view.gain >= search_module.MIN_NEW_CELLS
 
 
 def test_visualize_saves_map_without_camera_or_safe_viewpoint(tmp_path, monkeypatch):

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -450,6 +450,7 @@ import threading  # noqa: E402
 import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
+from brain_client.agents.types import TurnIntervals  # noqa: E402
 from brain_client.brain.agent import BrainAgent  # noqa: E402
 from brain_client.brain.utils import Event, EventKind  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
@@ -512,6 +513,21 @@ def agent_factory(monkeypatch):
     yield make
     for agent in created:
         agent.shutdown()
+
+
+def test_agent_turn_intervals_override_only_the_requested_mode(agent_factory):
+    agent, state = agent_factory()
+    state.current_directive = SimpleNamespace(get_turn_intervals=lambda: TurnIntervals(supervision=1.0))
+
+    assert agent._interval() == 3.0
+    state.primitive_running = RunningSkill("search", "innate-os/find_next_person")
+    assert agent._interval() == 1.0
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, float("inf"), float("nan")])
+def test_agent_turn_intervals_reject_non_positive_or_non_finite_values(value):
+    with pytest.raises(ValueError, match="finite positive"):
+        TurnIntervals(supervision=value)
 
 
 def run_turn(agent: BrainAgent) -> None:

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -450,7 +450,7 @@ import threading  # noqa: E402
 import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
-from brain_client.agents.types import DepartureGuard, TurnIntervals  # noqa: E402
+from brain_client.agents.types import DepartureGuard, InteractionGuard, TurnIntervals  # noqa: E402
 from brain_client.brain.agent import BrainAgent  # noqa: E402
 from brain_client.brain.utils import Event, EventKind  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
@@ -586,6 +586,65 @@ def test_departure_guard_rejects_invalid_bounds(field, value):
     kwargs[field] = value
     with pytest.raises(ValueError, match="finite positive"):
         DepartureGuard(**kwargs)
+
+
+def interaction_guard() -> InteractionGuard:
+    return InteractionGuard(
+        trigger_skill_names=("mission_notes",),
+        trigger_result_prefixes=("NOTE_MISSING",),
+        blocked_skill_ids=("innate-os/find_next_person",),
+        release_skill_names=("mission_notes",),
+        release_result_prefixes=("NOTE_SAVED",),
+        maximum_hold_s=35.0,
+    )
+
+
+def test_interaction_guard_hides_search_until_note_is_saved(agent_factory):
+    agent, state = agent_factory()
+    state.current_directive = SimpleNamespace(
+        get_turn_intervals=lambda: TurnIntervals(),
+        get_departure_guard=lambda: None,
+        get_interaction_guard=interaction_guard,
+    )
+    state.registry.metadata = [
+        {"id": "innate-os/find_next_person", "name": "find_next_person", "inputs": {}},
+        {"id": "innate-os/navigate_to_position", "name": "navigate_to_position", "inputs": {}},
+    ]
+    agent._roster = SimpleNamespace(
+        active_skill_ids=lambda: ["innate-os/find_next_person", "innate-os/navigate_to_position"]
+    )
+
+    agent.on_skill_event("completed", "mission_notes", 'NOTE_MISSING {"key":"resident-002"}')
+    declarations = agent._build_tools([])[0]["functionDeclarations"]
+    names = [declaration["name"] for declaration in declarations]
+    assert "find_next_person" not in names
+    assert "navigate_to_position" in names
+
+    agent.on_skill_event("completed", "mission_notes", 'NOTE_SAVED {"key":"resident-002"}')
+    declarations = agent._build_tools([])[0]["functionDeclarations"]
+    assert "find_next_person" in [declaration["name"] for declaration in declarations]
+
+
+def test_interaction_guard_expires_fail_open(agent_factory):
+    agent, state = agent_factory()
+    state.current_directive = SimpleNamespace(get_interaction_guard=interaction_guard)
+    agent._interaction_guard_started_at = time.monotonic() - 36.0
+
+    assert agent._interaction_blocked_skill_ids() == frozenset()
+    assert agent._interaction_guard_started_at is None
+
+
+@pytest.mark.parametrize("value", [0.0, float("inf"), float("nan")])
+def test_interaction_guard_rejects_invalid_timeout(value):
+    with pytest.raises(ValueError, match="finite positive"):
+        InteractionGuard(
+            trigger_skill_names=("mission_notes",),
+            trigger_result_prefixes=("NOTE_MISSING",),
+            blocked_skill_ids=("innate-os/find_next_person",),
+            release_skill_names=("mission_notes",),
+            release_result_prefixes=("NOTE_SAVED",),
+            maximum_hold_s=value,
+        )
 
 
 def run_turn(agent: BrainAgent) -> None:

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -450,7 +450,7 @@ import threading  # noqa: E402
 import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
-from brain_client.agents.types import TurnIntervals  # noqa: E402
+from brain_client.agents.types import DepartureGuard, TurnIntervals  # noqa: E402
 from brain_client.brain.agent import BrainAgent  # noqa: E402
 from brain_client.brain.utils import Event, EventKind  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
@@ -528,6 +528,64 @@ def test_agent_turn_intervals_override_only_the_requested_mode(agent_factory):
 def test_agent_turn_intervals_reject_non_positive_or_non_finite_values(value):
     with pytest.raises(ValueError, match="finite positive"):
         TurnIntervals(supervision=value)
+
+
+def departure_guard() -> DepartureGuard:
+    return DepartureGuard(
+        trigger_skill_names=("person_identity",),
+        trigger_result_prefixes=("KNOWN_PERSON",),
+        protected_skill_ids=("innate-os/find_next_person",),
+        minimum_departure_m=1.25,
+        maximum_hold_s=12.0,
+    )
+
+
+def test_known_person_departure_guard_hides_stop_until_robot_moves(agent_factory):
+    agent, state = agent_factory()
+    pose = [(2.0, 3.0, 0.0)]
+    agent._pose = SimpleNamespace(current_pose_xyt=lambda: pose[0], is_mapfree=False)
+    state.current_directive = SimpleNamespace(
+        get_turn_intervals=lambda: TurnIntervals(), get_departure_guard=departure_guard
+    )
+
+    agent.on_skill_event("completed", "person_identity", "KNOWN_PERSON encounter_id=resident-1")
+    state.primitive_running = RunningSkill("find_next_person", "innate-os/find_next_person")
+
+    declarations = agent._build_tools([])[0]["functionDeclarations"]
+    assert [declaration["name"] for declaration in declarations] == [WAIT]
+
+    pose[0] = (3.3, 3.0, 0.0)
+    declarations = agent._build_tools([])[0]["functionDeclarations"]
+    assert [declaration["name"] for declaration in declarations] == [STOP_SKILL, WAIT]
+
+
+def test_departure_guard_never_blocks_user_requested_stop(agent_factory):
+    agent, state = agent_factory()
+    agent._pose = SimpleNamespace(current_pose_xyt=lambda: (2.0, 3.0, 0.0), is_mapfree=False)
+    state.current_directive = SimpleNamespace(
+        get_turn_intervals=lambda: TurnIntervals(), get_departure_guard=departure_guard
+    )
+    agent.on_skill_event("completed", "person_identity", "KNOWN_PERSON encounter_id=resident-1")
+    state.primitive_running = RunningSkill("find_next_person", "innate-os/find_next_person")
+
+    declarations = agent._build_tools([Event("The user says: stop", kind=EventKind.USER)])[0][
+        "functionDeclarations"
+    ]
+    assert [declaration["name"] for declaration in declarations] == [STOP_SKILL]
+
+
+@pytest.mark.parametrize("field,value", [("minimum_departure_m", 0.0), ("maximum_hold_s", float("inf"))])
+def test_departure_guard_rejects_invalid_bounds(field, value):
+    kwargs = dict(
+        trigger_skill_names=("person_identity",),
+        trigger_result_prefixes=("KNOWN_PERSON",),
+        protected_skill_ids=("innate-os/find_next_person",),
+        minimum_departure_m=1.25,
+        maximum_hold_s=12.0,
+    )
+    kwargs[field] = value
+    with pytest.raises(ValueError, match="finite positive"):
+        DepartureGuard(**kwargs)
 
 
 def run_turn(agent: BrainAgent) -> None:

--- a/workspace/innate_agents/household_orders_agent.py
+++ b/workspace/innate_agents/household_orders_agent.py
@@ -9,7 +9,7 @@ from innate_skills.person_identity import PersonIdentity
 from innate_skills.place_doordash_order import PlaceDoordashOrder
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, DepartureGuard, InputRef, SkillRef, TurnIntervals
+from brain_client.agents.types import Agent, DepartureGuard, InputRef, InteractionGuard, SkillRef, TurnIntervals
 
 
 class HouseholdOrdersAgent(Agent):
@@ -54,6 +54,19 @@ class HouseholdOrdersAgent(Agent):
             protected_skill_ids=("innate-os/find_next_person",),
             minimum_departure_m=1.25,
             maximum_hold_s=12.0,
+        )
+
+    def get_interaction_guard(self) -> InteractionGuard:
+        # A missing note means a resident is identified but not yet handled.
+        # Keep the global search tool out of the next few turns so the model
+        # performs the bounded approach/re-identify recovery in the prompt.
+        return InteractionGuard(
+            trigger_skill_names=("mission_notes",),
+            trigger_result_prefixes=("NOTE_MISSING",),
+            blocked_skill_ids=("innate-os/find_next_person",),
+            release_skill_names=("mission_notes",),
+            release_result_prefixes=("NOTE_SAVED",),
+            maximum_hold_s=35.0,
         )
 
     def get_prompt(self) -> str:

--- a/workspace/innate_agents/household_orders_agent.py
+++ b/workspace/innate_agents/household_orders_agent.py
@@ -9,7 +9,7 @@ from innate_skills.person_identity import PersonIdentity
 from innate_skills.place_doordash_order import PlaceDoordashOrder
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, InputRef, SkillRef, TurnIntervals
+from brain_client.agents.types import Agent, DepartureGuard, InputRef, SkillRef, TurnIntervals
 
 
 class HouseholdOrdersAgent(Agent):
@@ -42,6 +42,19 @@ class HouseholdOrdersAgent(Agent):
         # after each completed model turn so a resident cannot pass through
         # the camera for most of the global five-second supervision pause.
         return TurnIntervals(supervision=1.0)
+
+    def get_departure_guard(self) -> DepartureGuard:
+        # Once durable identity says this is an already-handled resident, do
+        # not let the one-second visual loop cancel the next search for the
+        # same unchanged close-up.  Distance unlocks promptly; the short time
+        # bound prevents missing a genuinely new encounter if pose stalls.
+        return DepartureGuard(
+            trigger_skill_names=("person_identity",),
+            trigger_result_prefixes=("KNOWN_PERSON",),
+            protected_skill_ids=("innate-os/find_next_person",),
+            minimum_departure_m=1.25,
+            maximum_hold_s=12.0,
+        )
 
     def get_prompt(self) -> str:
         return """You are Mars. Find three residents, confirm each complete DoorDash order, and submit all three.

--- a/workspace/innate_agents/household_orders_agent.py
+++ b/workspace/innate_agents/household_orders_agent.py
@@ -9,7 +9,7 @@ from innate_skills.person_identity import PersonIdentity
 from innate_skills.place_doordash_order import PlaceDoordashOrder
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, InputRef, SkillRef
+from brain_client.agents.types import Agent, InputRef, SkillRef, TurnIntervals
 
 
 class HouseholdOrdersAgent(Agent):
@@ -37,6 +37,12 @@ class HouseholdOrdersAgent(Agent):
     def get_inputs(self) -> list[InputRef]:
         return [MicroInput]
 
+    def get_turn_intervals(self) -> TurnIntervals:
+        # Search is a long-running navigation skill. Look again one second
+        # after each completed model turn so a resident cannot pass through
+        # the camera for most of the global five-second supervision pause.
+        return TurnIntervals(supervision=1.0)
+
     def get_prompt(self) -> str:
         return """You are Mars. Find three residents, confirm each complete DoorDash order, and submit all three.
 
@@ -49,6 +55,13 @@ class HouseholdOrdersAgent(Agent):
   running. Immediately call stop_current_skill; for this reply preserve the most recent encounter_id, then after the
   skill stops save the confirmed note or respond before any search or navigation.
 - Use only live images and resident replies. find_next_person owns exploration; do not wander manually.
+- While find_next_person is running, inspect every new image. If any person is visible enough to identify, immediately
+  call stop_current_skill, then call person_identity(action="identify") exactly once. Navigation is only a means to
+  find residents: never continue past a visible person merely to finish the current route.
+- Do not decide from appearance alone that a visible person is someone already handled. Stop and let person_identity
+  compare against the durable roster. KNOWN_PERSON plus NOTE_FOUND means resume search without speaking; NEW_PERSON or
+  NOTE_MISSING means handle that resident. After resuming from a known resident, allow find_next_person to move away;
+  do not interrupt it again for the same unchanged close-up view.
 - Start once with mission_run(), then person_identity(action="begin"), then find_next_person(reset=true). Never
   initialize or reset again.
 

--- a/workspace/innate_skills/find_next_person.py
+++ b/workspace/innate_skills/find_next_person.py
@@ -44,8 +44,9 @@ HEADING_COUNT = 8
 MAX_VIEWPOINTS = 240
 MIN_NEW_CELLS = 6
 INITIAL_TRAVEL_COST_CELLS_PER_M = 12.0
-SWEEP_TRAVEL_COST_CELLS_PER_M = 1.0
-NOVELTY_BONUS_CELLS_PER_M = 10.0
+SWEEP_INFORMATION_DECAY_PER_M = 0.35
+SWEEP_NOVELTY_BONUS_CELLS_PER_M = 2.0
+SWEEP_NOVELTY_BONUS_MAX_M = 2.0
 HANDLED_PERSON_ESTIMATED_DISTANCE_M = 1.5
 HANDLED_PERSON_VIEW_PENALTY_CELLS = 220.0
 HANDLED_PERSON_PROXIMITY_RADIUS_M = 2.0
@@ -392,6 +393,13 @@ def _distance_from_observations(x: float, y: float, observations: list[dict]) ->
     return min(distances) if distances else 0.0
 
 
+def _coverage_travel_utility(gain: int, route_distance_m: float, *, sweeping: bool) -> float:
+    """Score information against actual route cost without rewarding long trips."""
+    if not sweeping:
+        return gain - INITIAL_TRAVEL_COST_CELLS_PER_M * route_distance_m
+    return gain / (1.0 + SWEEP_INFORMATION_DECAY_PER_M * route_distance_m)
+
+
 def _handled_person_anchors() -> list[tuple[float, float]]:
     """Estimated map positions for residents whose orders are already durable."""
     root = artifact_root()
@@ -449,7 +457,6 @@ def _choose_view(
 ) -> tuple[_View | None, set[int]]:
     covered = _covered_cells(plan, observations)
     route_distances = _grid_travel_distances(plan, pose)
-    travel_cost = SWEEP_TRAVEL_COST_CELLS_PER_M if observations else INITIAL_TRAVEL_COST_CELLS_PER_M
     sparse_viewpoints = _sample_viewpoints(plan)
     pose_row, pose_col = _world_to_cell(plan, pose.x, pose.y)
     person_anchors = handled_person_anchors or []
@@ -506,9 +513,8 @@ def _choose_view(
                         * HANDLED_PERSON_PROXIMITY_PENALTY_CELLS_PER_M
                     )
                 score = (
-                    gain
-                    - travel_cost * evaluation_distance
-                    + NOVELTY_BONUS_CELLS_PER_M * novelty
+                    _coverage_travel_utility(gain, evaluation_distance, sweeping=bool(observations))
+                    + SWEEP_NOVELTY_BONUS_CELLS_PER_M * min(novelty, SWEEP_NOVELTY_BONUS_MAX_M)
                     - 0.5 * _angular_distance(theta, pose.theta)
                     - person_view_penalty
                     - person_proximity_penalty

--- a/workspace/innate_skills/find_next_person.py
+++ b/workspace/innate_skills/find_next_person.py
@@ -47,6 +47,7 @@ INITIAL_TRAVEL_COST_CELLS_PER_M = 12.0
 SWEEP_INFORMATION_DECAY_PER_M = 0.35
 SWEEP_NOVELTY_BONUS_CELLS_PER_M = 2.0
 SWEEP_NOVELTY_BONUS_MAX_M = 2.0
+SWEEP_BACKTRACK_PENALTY_CELLS = 12.0
 HANDLED_PERSON_ESTIMATED_DISTANCE_M = 1.5
 HANDLED_PERSON_VIEW_PENALTY_CELLS = 220.0
 HANDLED_PERSON_PROXIMITY_RADIUS_M = 2.0
@@ -400,6 +401,25 @@ def _coverage_travel_utility(gain: int, route_distance_m: float, *, sweeping: bo
     return gain / (1.0 + SWEEP_INFORMATION_DECAY_PER_M * route_distance_m)
 
 
+def _backtrack_penalty(x: float, y: float, observations: list[dict]) -> float:
+    """Penalize reversing the last exploration leg without forbidding it."""
+    if len(observations) < 2:
+        return 0.0
+    try:
+        previous_x, previous_y = float(observations[-2]["x"]), float(observations[-2]["y"])
+        current_x, current_y = float(observations[-1]["x"]), float(observations[-1]["y"])
+    except (KeyError, TypeError, ValueError):
+        return 0.0
+    incoming_x, incoming_y = current_x - previous_x, current_y - previous_y
+    outgoing_x, outgoing_y = x - current_x, y - current_y
+    incoming_norm = math.hypot(incoming_x, incoming_y)
+    outgoing_norm = math.hypot(outgoing_x, outgoing_y)
+    if incoming_norm < VIEWPOINT_SPACING_M or outgoing_norm < VIEWPOINT_SPACING_M:
+        return 0.0
+    cosine = (incoming_x * outgoing_x + incoming_y * outgoing_y) / (incoming_norm * outgoing_norm)
+    return SWEEP_BACKTRACK_PENALTY_CELLS * max(0.0, -cosine)
+
+
 def _handled_person_anchors() -> list[tuple[float, float]]:
     """Estimated map positions for residents whose orders are already durable."""
     root = artifact_root()
@@ -515,6 +535,7 @@ def _choose_view(
                 score = (
                     _coverage_travel_utility(gain, evaluation_distance, sweeping=bool(observations))
                     + SWEEP_NOVELTY_BONUS_CELLS_PER_M * min(novelty, SWEEP_NOVELTY_BONUS_MAX_M)
+                    - _backtrack_penalty(evaluation_x, evaluation_y, observations)
                     - 0.5 * _angular_distance(theta, pose.theta)
                     - person_view_penalty
                     - person_proximity_penalty

--- a/workspace/innate_skills/find_next_person.py
+++ b/workspace/innate_skills/find_next_person.py
@@ -43,6 +43,13 @@ CAMERA_RAYS = 41
 HEADING_COUNT = 8
 MAX_VIEWPOINTS = 240
 MIN_NEW_CELLS = 6
+INITIAL_TRAVEL_COST_CELLS_PER_M = 12.0
+SWEEP_TRAVEL_COST_CELLS_PER_M = 1.0
+NOVELTY_BONUS_CELLS_PER_M = 10.0
+HANDLED_PERSON_ESTIMATED_DISTANCE_M = 1.5
+HANDLED_PERSON_VIEW_PENALTY_CELLS = 220.0
+HANDLED_PERSON_PROXIMITY_RADIUS_M = 2.0
+HANDLED_PERSON_PROXIMITY_PENALTY_CELLS_PER_M = 80.0
 FRAME_TIMEOUT_S = 5.0
 PERSON_VIEW_HEAD_PITCH_DEG = 20.0
 HEAD_POSITION_TOLERANCE_DEG = 2.0
@@ -375,6 +382,49 @@ def _too_close_to_unreachable(x: float, y: float, unreachable: list[dict]) -> bo
     return False
 
 
+def _distance_from_observations(x: float, y: float, observations: list[dict]) -> float:
+    distances: list[float] = []
+    for observation in observations:
+        try:
+            distances.append(math.hypot(x - float(observation["x"]), y - float(observation["y"])))
+        except (KeyError, TypeError, ValueError):
+            continue
+    return min(distances) if distances else 0.0
+
+
+def _handled_person_anchors() -> list[tuple[float, float]]:
+    """Estimated map positions for residents whose orders are already durable."""
+    root = artifact_root()
+    try:
+        roster = json.loads((root / "resident_roster.json").read_text())
+        notes = json.loads((root / "mission_notes.json").read_text())
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return []
+    run_id = active_run_id()
+    if not run_id or roster.get("run_id") != run_id or notes.get("run_id") != run_id:
+        return []
+    handled = notes.get("notes")
+    residents = roster.get("residents")
+    if not isinstance(handled, dict) or not isinstance(residents, list):
+        return []
+    anchors: list[tuple[float, float]] = []
+    for resident in residents:
+        if not isinstance(resident, dict) or resident.get("encounter_id") not in handled:
+            continue
+        pose = resident.get("last_seen_pose")
+        try:
+            x, y, theta = float(pose["x"]), float(pose["y"]), float(pose["theta"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        anchors.append(
+            (
+                x + HANDLED_PERSON_ESTIMATED_DISTANCE_M * math.cos(theta),
+                y + HANDLED_PERSON_ESTIMATED_DISTANCE_M * math.sin(theta),
+            )
+        )
+    return anchors
+
+
 def _standoff_target_was_observed(x: float, y: float, observations: list[dict]) -> bool:
     """Whether this requested position already produced a stopped-short view."""
     for observation in observations:
@@ -394,16 +444,18 @@ def _choose_view(
     pose: Pose,
     observations: list[dict],
     unreachable: list[dict],
+    handled_person_anchors: list[tuple[float, float]] | None = None,
     cancellation_check=None,
 ) -> tuple[_View | None, set[int]]:
     covered = _covered_cells(plan, observations)
     route_distances = _grid_travel_distances(plan, pose)
+    travel_cost = SWEEP_TRAVEL_COST_CELLS_PER_M if observations else INITIAL_TRAVEL_COST_CELLS_PER_M
     sparse_viewpoints = _sample_viewpoints(plan)
     pose_row, pose_col = _world_to_cell(plan, pose.x, pose.y)
+    person_anchors = handled_person_anchors or []
 
     def score_candidates(candidates: list[tuple[int, int]]) -> _View | None:
         best: _View | None = None
-        best_key: tuple[float, int, float, int, int, int] | None = None
         for index, (row, col) in enumerate(candidates):
             if cancellation_check is not None and index % 12 == 0:
                 cancellation_check()
@@ -434,24 +486,36 @@ def _choose_view(
                 gain = len(visible.difference(covered))
                 if gain < MIN_NEW_CELLS:
                     continue
-                angular_distance = _angular_distance(theta, pose.theta)
-                # Sweep locally before crossing the map. Route distance is the
-                # primary key so walls and corridors count; among equally near
-                # viewpoints prefer more unseen floor, then less turning. The
-                # row/column/heading suffix keeps the choice deterministic.
-                key = (
-                    round(evaluation_distance, 6),
-                    -gain,
-                    round(angular_distance, 6),
-                    row,
-                    col,
-                    heading_index,
+                # The first observation stays local. Once the search has evidence,
+                # spread stops across unseen wings instead of exhaustively sweeping
+                # one room before visiting the rest of the home.
+                novelty = _distance_from_observations(evaluation_x, evaluation_y, observations)
+                person_view_penalty = 0.0
+                person_proximity_penalty = 0.0
+                for person_x, person_y in person_anchors:
+                    person_row, person_col = _world_to_cell(plan, person_x, person_y)
+                    if (
+                        0 <= person_row < plan.height
+                        and 0 <= person_col < plan.width
+                        and person_row * plan.width + person_col in visible
+                    ):
+                        person_view_penalty += HANDLED_PERSON_VIEW_PENALTY_CELLS
+                    proximity = math.hypot(evaluation_x - person_x, evaluation_y - person_y)
+                    person_proximity_penalty += (
+                        max(0.0, HANDLED_PERSON_PROXIMITY_RADIUS_M - proximity)
+                        * HANDLED_PERSON_PROXIMITY_PENALTY_CELLS_PER_M
+                    )
+                score = (
+                    gain
+                    - travel_cost * evaluation_distance
+                    + NOVELTY_BONUS_CELLS_PER_M * novelty
+                    - 0.5 * _angular_distance(theta, pose.theta)
+                    - person_view_penalty
+                    - person_proximity_penalty
                 )
-                score = gain - evaluation_distance - 0.5 * angular_distance
                 view = _View(row, col, x, y, theta, visible, gain, score)
-                if best_key is None or key < best_key:
+                if best is None or view.score > best.score:
                     best = view
-                    best_key = key
         return best
 
     best = score_candidates(sparse_viewpoints)
@@ -1097,18 +1161,6 @@ class FindNextPerson(Skill):
         )
 
     def execute(self, reset: bool = False, visualize: bool = False) -> SkillReturn:
-        timing_started = time.monotonic()
-        timing_last = timing_started
-
-        def mark_timing(phase: str) -> None:
-            nonlocal timing_last
-            now = time.monotonic()
-            self.logger.info(
-                f"[SkillPhaseTiming] skill=find_next_person phase={phase} "
-                f"duration_ms={(now - timing_last) * 1000.0:.1f} total_ms={(now - timing_started) * 1000.0:.1f}"
-            )
-            timing_last = now
-
         if reset:
             run_id = active_run_id()
             if run_id is None:
@@ -1130,11 +1182,9 @@ class FindNextPerson(Skill):
                 "Mission coverage reset",
                 "The map will appear when find_next_person selects its first viewpoint.",
             )
-            mark_timing("reset")
             return _result("SEARCH_RESET")
 
         map_state = self.wait_for(lambda: self.map, timeout=FRAME_TIMEOUT_S)
-        mark_timing("map_wait")
         if map_state is None or map_state.grid is None:
             self._preserve_visualization(
                 "map unavailable",
@@ -1143,7 +1193,6 @@ class FindNextPerson(Skill):
             )
             return _result("MAP_UNAVAILABLE", {"reason": "no_readable_map"})
         pose = self.wait_for(lambda: self.pose, timeout=FRAME_TIMEOUT_S)
-        mark_timing("pose_wait")
         if pose is None:
             self._preserve_visualization(
                 "pose unavailable",
@@ -1153,7 +1202,6 @@ class FindNextPerson(Skill):
             return _result("POSE_UNAVAILABLE", {"reason": "no_localized_pose"})
         cells = map_state.grid
         plan = _build_planning_grid(map_state, pose)
-        mark_timing("planning_grid")
         if plan is None:
             self._preserve_visualization(
                 "map unusable",
@@ -1162,6 +1210,7 @@ class FindNextPerson(Skill):
             )
             return _result("MAP_UNAVAILABLE", {"reason": "no_reachable_known_free_floor"})
         state = _read_state(self.storage.get("state"))
+        handled_person_anchors = _handled_person_anchors()
         fingerprint = _map_fingerprint(map_state, cells)
         if state["map_fingerprint"] != fingerprint:
             run_id = state.get("run_id")
@@ -1184,6 +1233,7 @@ class FindNextPerson(Skill):
                         pose,
                         state["observations"],
                         _navigation_exclusions(state),
+                        handled_person_anchors,
                         cancellation_check=self.check_cancelled,
                     )
                 except SkillCancelled:
@@ -1227,7 +1277,6 @@ class FindNextPerson(Skill):
             return _result("MAP_UNAVAILABLE", {"reason": "no_safe_reachable_viewpoint"})
 
         if self.wait_for(lambda: self.image, timeout=FRAME_TIMEOUT_S) is None:
-            mark_timing("camera_wait")
             self._refresh_visualization(
                 plan,
                 state,
@@ -1236,7 +1285,6 @@ class FindNextPerson(Skill):
                 status="camera unavailable; coverage unchanged",
             )
             return _result("CAMERA_UNAVAILABLE", {"phase": "before_navigation"})
-        mark_timing("camera_wait")
 
         try:
             view, covered = _choose_view(
@@ -1244,9 +1292,9 @@ class FindNextPerson(Skill):
                 pose,
                 state["observations"],
                 _navigation_exclusions(state),
+                handled_person_anchors,
                 cancellation_check=self.check_cancelled,
             )
-            mark_timing("view_selection")
         except SkillCancelled:
             self._refresh_visualization(
                 plan,
@@ -1271,7 +1319,6 @@ class FindNextPerson(Skill):
             )
 
         self._refresh_visualization(plan, state, covered, pose, status="navigating to next viewpoint", target=view)
-        mark_timing("pre_navigation_visualization")
 
         def refresh_interrupted(status: str) -> None:
             current_pose = self.pose or pose
@@ -1394,8 +1441,6 @@ class FindNextPerson(Skill):
                 "SEARCH_INFRASTRUCTURE_FAILURE",
                 {"component": "navigation", "reason": str(error)},
             )
-        finally:
-            mark_timing("navigation")
 
         if _clear_navigation_failure(state, view):
             self.storage["state"] = state
@@ -1412,7 +1457,6 @@ class FindNextPerson(Skill):
         except SkillCancelled:
             refresh_interrupted("interrupted while raising the camera")
             raise
-        mark_timing("head_and_camera")
         if fresh_frame is None:
             self._refresh_visualization(
                 plan,
@@ -1438,7 +1482,6 @@ class FindNextPerson(Skill):
                 ),
                 timeout=FRAME_TIMEOUT_S,
             )
-            mark_timing("pose_verification")
         except SkillCancelled:
             refresh_interrupted("interrupted while verifying the observation pose")
             raise
@@ -1475,7 +1518,6 @@ class FindNextPerson(Skill):
             observed_pose,
             status=f"observation {len(state['observations'])} committed",
         )
-        mark_timing("result_visualization")
         return _result(
             "SEARCH_OBSERVATION",
             {

--- a/workspace/innate_skills/resident_roster.py
+++ b/workspace/innate_skills/resident_roster.py
@@ -523,6 +523,7 @@ def _roster_artifact(state: dict[str, Any]) -> bytes | None:
     jpeg = io.BytesIO()
     canvas.save(jpeg, format="JPEG", quality=88, optimize=True)
     public_state = {
+        "run_id": state.get("run_id"),
         "expected_residents": state["expected_residents"],
         "active_encounter_id": state.get("active_encounter_id"),
         "residents": [
@@ -534,6 +535,7 @@ def _roster_artifact(state: dict[str, Any]) -> bytes | None:
                 "saved_angles": len(_reference_images(entry)),
                 "references_verified": _references_verified(entry),
                 "last_identity": _load_identity_metadata(entry),
+                "last_seen_pose": _load_pose_record(entry.get("last_seen_pose")),
             }
             for entry in state["encounters"]
         ],
@@ -638,6 +640,9 @@ class ResidentRoster(Skill):
                     False if legacy_state and references else item.get("reference_images_verified") is not False
                 ),
             }
+            last_seen_pose = _load_pose_record(item.get("last_seen_pose"))
+            if last_seen_pose is not None:
+                entry["last_seen_pose"] = last_seen_pose
             identity = _load_identity_metadata(item)
             if identity is not None:
                 entry["last_identity"] = identity
@@ -661,6 +666,9 @@ class ResidentRoster(Skill):
                     False if legacy_state and references else item.get("reference_images_verified") is not False
                 ),
             }
+            last_seen_pose = _load_pose_record(item.get("last_seen_pose"))
+            if last_seen_pose is not None:
+                entry["last_seen_pose"] = last_seen_pose
             identity = _load_identity_metadata(item)
             if identity is not None:
                 entry["last_identity"] = identity
@@ -860,6 +868,7 @@ class ResidentRoster(Skill):
         state["active_observation_image_b64"] = str(frame)
         state["active_identified_at"] = time.time()
         state["active_identified_pose"] = _pose_record(self.pose)
+        entry["last_seen_pose"] = _pose_record(self.pose)
         state["active_observation_pending_reference"] = pending_reference
         state["active_continuity_id"] = continuity_id
         self._save_state(state)

--- a/workspace/innate_skills/resident_roster.py
+++ b/workspace/innate_skills/resident_roster.py
@@ -24,6 +24,8 @@ NEW_CONFIDENCE = 0.72
 MAX_PENDING_OBSERVATIONS = 6
 MAX_CONTACT_REFERENCES = 6
 MAX_REFERENCE_IMAGES_PER_PERSON = 2
+APPEARANCE_CACHE_MIN_SIMILARITY = 0.975
+APPEARANCE_CACHE_MIN_MARGIN = 0.06
 IDENTIFY_FRAME_TIMEOUT_S = 5.0
 PERSON_VIEW_HEAD_PITCH_DEG = 20.0
 HEAD_POSITION_TOLERANCE_DEG = 2.0
@@ -271,6 +273,80 @@ def _reference_owner(
             if entry is not excluding and encoded_image in _reference_images(entry):
                 return entry
     return None
+
+
+def _appearance_signature(encoded_image: str) -> tuple[float, ...] | None:
+    """Return a compact spatial color signature for a centered resident view."""
+    try:
+        from PIL import Image
+    except ImportError:
+        return None
+    if not encoded_image or len(encoded_image) > 8_000_000:
+        return None
+    try:
+        decoded = base64.b64decode(encoded_image, validate=True)
+        with Image.open(io.BytesIO(decoded)) as source:
+            image = source.convert("HSV")
+            width, height = image.size
+            if width < 32 or height < 32:
+                return None
+            # Exclude far sides and the top edge, which are mostly room
+            # background. Split legs-through-torso into a 2x3 grid so a
+            # similarly colored room cannot match by global color alone.
+            image = image.crop((width // 4, height // 8, width * 3 // 4, height * 15 // 16))
+            width, height = image.size
+            signature: list[float] = []
+            for row in range(3):
+                for column in range(2):
+                    region = image.crop(
+                        (
+                            column * width // 2,
+                            row * height // 3,
+                            (column + 1) * width // 2,
+                            (row + 1) * height // 3,
+                        )
+                    )
+                    bins = [0] * 48
+                    for hue, saturation, value in region.getdata():
+                        index = (hue * 12 // 256) * 4 + (saturation * 2 // 256) * 2 + (value * 2 // 256)
+                        bins[index] += 1
+                    total = sum(bins)
+                    if total == 0:
+                        return None
+                    signature.extend(count / total for count in bins)
+            return tuple(signature)
+    except Exception:
+        return None
+
+
+def _appearance_similarity(left: tuple[float, ...], right: tuple[float, ...]) -> float:
+    if len(left) != len(right) or not left:
+        return 0.0
+    # Every one of the six spatial histograms is independently normalized.
+    return sum(min(a, b) for a, b in zip(left, right, strict=True)) / 6
+
+
+def _appearance_cache_match(state: dict[str, Any], encoded_image: str) -> tuple[dict[str, Any], float] | None:
+    """Return only a uniquely convincing cached resident appearance match."""
+    current = _appearance_signature(encoded_image)
+    if current is None:
+        return None
+    scores: list[tuple[float, dict[str, Any]]] = []
+    for entry in [*state["encounters"], *state["pending"]]:
+        best = 0.0
+        for reference in _reference_images(entry):
+            signature = _appearance_signature(reference)
+            if signature is not None:
+                best = max(best, _appearance_similarity(current, signature))
+        if best > 0.0:
+            scores.append((best, entry))
+    scores.sort(key=lambda item: item[0], reverse=True)
+    if not scores or scores[0][0] < APPEARANCE_CACHE_MIN_SIMILARITY:
+        return None
+    runner_up = scores[1][0] if len(scores) > 1 else 0.0
+    if scores[0][0] - runner_up < APPEARANCE_CACHE_MIN_MARGIN:
+        return None
+    return scores[0][1], scores[0][0]
 
 
 def _deduplicate_references(state: dict[str, Any]) -> None:
@@ -967,6 +1043,25 @@ class ResidentRoster(Skill):
             self._save_state(state)
             return _result("IDENTITY_UNAVAILABLE", {"reason": unavailable_reason})
 
+        encoded_frame = str(frame)
+        exact_owner = _reference_owner(state, encoded_frame)
+        cached_match = (exact_owner, 1.0) if exact_owner is not None else _appearance_cache_match(state, encoded_frame)
+        if cached_match is not None:
+            cached_owner, similarity = cached_match
+            if continuity is None or continuity is cached_owner:
+                return self._identity_result(
+                    state,
+                    "KNOWN_PERSON",
+                    cached_owner,
+                    frame,
+                    identity={
+                        "decision": "match",
+                        "confidence": round(similarity, 3),
+                        "view_quality": "good",
+                        "reason": "strict body-region appearance cache match",
+                    },
+                )
+
         references = _contact_references(state)
         sheet_result = _contact_sheet(references) if references else None
         mark_timing("reference_sheet")
@@ -1070,7 +1165,6 @@ class ResidentRoster(Skill):
                 image=frame.jpeg,
             )
 
-        encoded_frame = str(frame)
         exact_owner = _reference_owner(state, encoded_frame)
         if exact_owner is not None:
             if continuity is not None and continuity is not exact_owner:

--- a/workspace/innate_skills/resident_roster.py
+++ b/workspace/innate_skills/resident_roster.py
@@ -24,8 +24,6 @@ NEW_CONFIDENCE = 0.72
 MAX_PENDING_OBSERVATIONS = 6
 MAX_CONTACT_REFERENCES = 6
 MAX_REFERENCE_IMAGES_PER_PERSON = 2
-APPEARANCE_CACHE_MIN_SIMILARITY = 0.975
-APPEARANCE_CACHE_MIN_MARGIN = 0.06
 IDENTIFY_FRAME_TIMEOUT_S = 5.0
 PERSON_VIEW_HEAD_PITCH_DEG = 20.0
 HEAD_POSITION_TOLERANCE_DEG = 2.0
@@ -273,80 +271,6 @@ def _reference_owner(
             if entry is not excluding and encoded_image in _reference_images(entry):
                 return entry
     return None
-
-
-def _appearance_signature(encoded_image: str) -> tuple[float, ...] | None:
-    """Return a compact spatial color signature for a centered resident view."""
-    try:
-        from PIL import Image
-    except ImportError:
-        return None
-    if not encoded_image or len(encoded_image) > 8_000_000:
-        return None
-    try:
-        decoded = base64.b64decode(encoded_image, validate=True)
-        with Image.open(io.BytesIO(decoded)) as source:
-            image = source.convert("HSV")
-            width, height = image.size
-            if width < 32 or height < 32:
-                return None
-            # Exclude far sides and the top edge, which are mostly room
-            # background. Split legs-through-torso into a 2x3 grid so a
-            # similarly colored room cannot match by global color alone.
-            image = image.crop((width // 4, height // 8, width * 3 // 4, height * 15 // 16))
-            width, height = image.size
-            signature: list[float] = []
-            for row in range(3):
-                for column in range(2):
-                    region = image.crop(
-                        (
-                            column * width // 2,
-                            row * height // 3,
-                            (column + 1) * width // 2,
-                            (row + 1) * height // 3,
-                        )
-                    )
-                    bins = [0] * 48
-                    for hue, saturation, value in region.getdata():
-                        index = (hue * 12 // 256) * 4 + (saturation * 2 // 256) * 2 + (value * 2 // 256)
-                        bins[index] += 1
-                    total = sum(bins)
-                    if total == 0:
-                        return None
-                    signature.extend(count / total for count in bins)
-            return tuple(signature)
-    except Exception:
-        return None
-
-
-def _appearance_similarity(left: tuple[float, ...], right: tuple[float, ...]) -> float:
-    if len(left) != len(right) or not left:
-        return 0.0
-    # Every one of the six spatial histograms is independently normalized.
-    return sum(min(a, b) for a, b in zip(left, right, strict=True)) / 6
-
-
-def _appearance_cache_match(state: dict[str, Any], encoded_image: str) -> tuple[dict[str, Any], float] | None:
-    """Return only a uniquely convincing cached resident appearance match."""
-    current = _appearance_signature(encoded_image)
-    if current is None:
-        return None
-    scores: list[tuple[float, dict[str, Any]]] = []
-    for entry in [*state["encounters"], *state["pending"]]:
-        best = 0.0
-        for reference in _reference_images(entry):
-            signature = _appearance_signature(reference)
-            if signature is not None:
-                best = max(best, _appearance_similarity(current, signature))
-        if best > 0.0:
-            scores.append((best, entry))
-    scores.sort(key=lambda item: item[0], reverse=True)
-    if not scores or scores[0][0] < APPEARANCE_CACHE_MIN_SIMILARITY:
-        return None
-    runner_up = scores[1][0] if len(scores) > 1 else 0.0
-    if scores[0][0] - runner_up < APPEARANCE_CACHE_MIN_MARGIN:
-        return None
-    return scores[0][1], scores[0][0]
 
 
 def _deduplicate_references(state: dict[str, Any]) -> None:
@@ -1044,24 +968,6 @@ class ResidentRoster(Skill):
             return _result("IDENTITY_UNAVAILABLE", {"reason": unavailable_reason})
 
         encoded_frame = str(frame)
-        exact_owner = _reference_owner(state, encoded_frame)
-        cached_match = (exact_owner, 1.0) if exact_owner is not None else _appearance_cache_match(state, encoded_frame)
-        if cached_match is not None:
-            cached_owner, similarity = cached_match
-            if continuity is None or continuity is cached_owner:
-                return self._identity_result(
-                    state,
-                    "KNOWN_PERSON",
-                    cached_owner,
-                    frame,
-                    identity={
-                        "decision": "match",
-                        "confidence": round(similarity, 3),
-                        "view_quality": "good",
-                        "reason": "strict body-region appearance cache match",
-                    },
-                )
-
         references = _contact_references(state)
         sheet_result = _contact_sheet(references) if references else None
         mark_timing("reference_sheet")


### PR DESCRIPTION
## Summary
- let each agent configure idle and running-skill visual observation cadence
- preempt search navigation when a resident becomes visible
- leave already-handled residents before re-interrupting them
- exclude handled resident locations from frontier utility
- score frontier information against route cost and discourage immediate backtracking
- hold global search after a new resident has `NOTE_MISSING` until the interaction is saved or the guard safely expires

## Why
The original 20-run baseline had a valid maximum of 873.4 seconds. Slow traces showed four generic sources of wasted time: delayed visual reconsideration while navigating, revisiting handled people, route scoring that rewarded long travel, and abandoning a newly found resident after a missed reply.

## Six-round validation
Each round used 20 fresh `e2-standard-8` GCP Batch VMs in parallel, one trial per VM, zero retries, a 900-second challenge limit, and retained video, brain, navigation, telemetry, and result artifacts.

| Round | Main change | Valid | Median | P95 | Max valid |
| --- | --- | ---: | ---: | ---: | ---: |
| R1 | departure guard | 17 | 383.8s | 860.3s | 860.3s |
| R2 | handled-person frontier exclusion | 19 | 283.8s | 528.8s | 528.8s |
| R3 | appearance cache | 19 | 298.1s | 771.1s | 771.1s |
| R4 | route-aware information gain | 18 | 304.8s | 587.9s | 587.9s |
| R5 | frontier anti-backtracking | 17 | 290.0s | 428.7s | **428.7s** |
| R6 | interaction guard | **20/20** | 337.8s | 476.7s | 595.7s |

R5's three non-successes were manually confirmed infrastructure failures (skills-server crash after collecting all orders, permanent localization loss, and unresponsive planner), not agent mistakes. R6 was the only completely clean 20/20 campaign. The ineffective R3 appearance cache was removed before R4.

## Checks
- simulator image workflow: amd64, arm64, manifest, and Greptile checks green
- 11 focused departure/interaction guard tests pass in the simulator container
- 29 orchestrator/manifest/worker offline tests pass before every campaign
- Python compile, formatting checks, exact source-tree attestation, and immutable image/source hashes verified before submission

