### PR TITLE
feat(brain): fold the arm to rest when an agent starts

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/core/lifecycle.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/lifecycle.py
@@ -27,6 +27,7 @@ class BrainLifecycle:
         runner,
         gaze,
         chat,
+        rest_pose,
         active_inputs_pub,
         stop_robot,
         publish_status,
@@ -40,6 +41,7 @@ class BrainLifecycle:
         self._runner = runner
         self._gaze = gaze
         self._chat = chat
+        self._rest_pose = rest_pose
         self._active_inputs_pub = active_inputs_pub
         self._stop_robot = stop_robot
         self._publish_status = publish_status
@@ -66,6 +68,7 @@ class BrainLifecycle:
             self._publish_status()
             return
         self.activate_directive_inputs()
+        self._rest_pose.fold()
         self._publish_status()
         # Announce in the shared chat so EVERY client sees it, not just the
         # device whose button was pressed (clients don't echo locally).

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -43,6 +43,7 @@ from brain_client.perception.gaze_control import GazeController
 from brain_client.perception.pose_tracking import PoseTracker
 from brain_client.perception.scan_health import ScanHealthMonitor
 from brain_client.robot.arm_recovery import ArmRecovery
+from brain_client.robot.rest_pose import ArmRestPose
 from brain_client.skills.hot_reload import ReloadCoordinator
 from brain_client.skills.roster import SkillRoster
 from brain_client.skills.runner import PrimitiveRunner
@@ -231,6 +232,7 @@ class BrainClientNode(Node):
         self.camera.motion_suppressed = lambda: self.state.primitive_running is not None or self.camera.recently_driven
         self.camera.on_motion = self._on_camera_motion
         self.arm_recovery = ArmRecovery(self, state, runner=self.runner, chat=self.chat, brain=self.brain)
+        self.rest_pose = ArmRestPose(self, state)
         self.lifecycle = BrainLifecycle(
             self,
             state,
@@ -240,6 +242,7 @@ class BrainClientNode(Node):
             runner=self.runner,
             gaze=self.gaze,
             chat=self.chat,
+            rest_pose=self.rest_pose,
             active_inputs_pub=self.active_inputs_pub,
             stop_robot=self._stop_robot,
             publish_status=self.publish_agent_status,

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Fold the arm to its rest pose when an agent starts.
+
+Starting an agent hands the robot to the model, and it should take it in a
+known shape: an arm left extended by teleop or by a previous session is what
+the first navigation skill drags into a doorframe.
+
+Same mechanism Mad speed mode uses to brace the arm (``fold_arm_for_mad_mode``
+in ``mars_control/app.cpp``): ``/mars/arm/goto_js_v2`` directly, not the
+arm_rest_position skill — activation must not occupy the single skill slot the
+agent's own first turn needs. Fire-and-forget, so the agent starts thinking
+while the arm folds.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mars_msgs.srv import GotoJS
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
+
+from brain_client.robot.manipulation import Manipulation
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
+    from rclpy.task import Future
+
+    from brain_client.core.state import BrainState
+
+GOTO_JS_SERVICE = "/mars/arm/goto_js_v2"
+COMMAND_STATE_TOPIC = "/mars/arm/command_state"
+
+_FOLD_DURATION_S = 3.0
+_SETTLE_DURATION_S = 1.0
+
+_LATCHED_QOS = QoSProfile(
+    depth=1,
+    durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+    reliability=QoSReliabilityPolicy.RELIABLE,
+)
+
+
+class ArmRestPose:
+    """Sends the arm to :attr:`Manipulation.REST` on agent activation."""
+
+    def __init__(self, node: Node, state: BrainState) -> None:
+        self._logger = node.get_logger()
+        self._state = state
+        self._client = node.create_client(GotoJS, GOTO_JS_SERVICE)
+        # Last COMMANDED j6 (the standing grip target). Transient local: a
+        # brain restart while an object is held must not read it back as zero.
+        self._grip: float | None = None
+        node.create_subscription(JointState, COMMAND_STATE_TOPIC, self._on_command_state, _LATCHED_QOS)
+
+    def fold(self) -> None:
+        """Fold to rest, keeping the grip; returns once the goto is sent."""
+        if self._state.primitive_running is not None:
+            return  # a skill already owns the arm
+        self._logger.info("[RestPose] Folding the arm to its rest pose for the starting agent")
+        self._send(_FOLD_DURATION_S, settle=True)
+
+    def _send(self, duration: float, *, settle: bool) -> None:
+        if not self._client.service_is_ready():
+            self._logger.warn(f"[RestPose] {GOTO_JS_SERVICE} is not ready; the arm stays where it is")
+            return
+        request = GotoJS.Request()
+        request.data = Float64MultiArray()
+        # j6 carries the standing grip target rather than the rest pose's own:
+        # it is current-based position control, so re-commanding it above that
+        # target zeroes the preload and drops a held object.
+        request.data.data = [*Manipulation.REST[:5], self._grip if self._grip is not None else Manipulation.REST[5]]
+        request.time = duration
+        self._client.call_async(request).add_done_callback(lambda future: self._on_result(future, settle))
+
+    def _on_command_state(self, msg: JointState) -> None:
+        if len(msg.position) >= 6:
+            self._grip = float(msg.position[5])
+
+    def _on_result(self, future: Future, settle: bool) -> None:
+        response = future.result()
+        if response is None or not response.success:
+            self._logger.warn("[RestPose] The arm rejected the rest fold; leaving it where it is")
+            return
+        if settle:
+            # Same second command Manipulation.rest() sends: the fold shifts a
+            # held load, and the servos need a re-command to settle under it.
+            self._send(_SETTLE_DURATION_S, settle=False)


### PR DESCRIPTION
Starting an agent hands the robot to the model, but not in any known shape: an arm left extended by teleop or by the previous session stays extended, and the agent's first navigation skill drags it into the nearest doorframe.

Activation now folds it, the way Mad speed mode braces it — one `/mars/arm/goto_js_v2` call from the node (`fold_arm_for_mad_mode` in `mars_control/app.cpp`), not the `arm_rest_position` skill. The skill would occupy the single execution slot the agent's own first turn needs, and it blocks; this is fire-and-forget, so the loop starts thinking while the arm moves.

Two details carried over from the mechanisms it borrows from:

- **j6 carries the standing grip target**, read from the latched `/mars/arm/command_state`, rather than the rest pose's own value. j6 is current-based position control, so commanding it above that target zeroes the preload and drops a held object — the same reason `mars_control` subscribes to that topic for the Mad fold.
- **The goto is re-commanded once on completion**, as `Manipulation.rest()` does: the fold shifts a held load, and the servos need the second command to settle under it.

The pose itself is `Manipulation.REST`, imported rather than re-typed, so the auto-fold cannot drift from the skill.

The fold is skipped when a skill already owns the arm (a manual run from the webapp), and an arm service that is not up is a warning, not a failure — activation proceeds either way. It hangs off `activate_brain` after `brain.start()` succeeds, so a rolled-back activation does not move the arm. Deactivation is untouched.

## Verification

`ruff check` and `ruff format --check` are clean.

**Not verified:** the pytest suite and `basedpyright` need a ROS environment, which this machine does not have (no `rclpy`, and Docker was not running for the sim container) — both want a run there. Run anyway, basedpyright reports nothing on the new file beyond the unresolved-ROS-import errors every module in the package shows without ROS on the path. The fold has not been watched on hardware or in the sim.
