### PR TITLE
Let coverage dominate Household Orders sweep scoring

### DIFF
--- a/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
+++ b/ros2_ws/src/brain/brain_client/test/test_household_resident_roster.py
@@ -2509,11 +2509,11 @@ def test_choose_view_penalizes_a_winding_route(monkeypatch):
     assert (view.row, view.col) == same_side
 
 
-def test_sweep_information_utility_prefers_efficient_gain_over_long_detour():
+def test_sweep_information_utility_lets_extra_coverage_outweigh_a_detour():
     nearby = search_module._coverage_travel_utility(40, 2.0, sweeping=True)
     distant = search_module._coverage_travel_utility(50, 8.0, sweeping=True)
 
-    assert nearby > distant
+    assert distant > nearby
     assert search_module._coverage_travel_utility(50, 0.0, sweeping=True) == 50
 
 

--- a/workspace/innate_skills/find_next_person.py
+++ b/workspace/innate_skills/find_next_person.py
@@ -44,9 +44,8 @@ HEADING_COUNT = 8
 MAX_VIEWPOINTS = 240
 MIN_NEW_CELLS = 6
 INITIAL_TRAVEL_COST_CELLS_PER_M = 12.0
-SWEEP_INFORMATION_DECAY_PER_M = 0.35
-SWEEP_NOVELTY_BONUS_CELLS_PER_M = 2.0
-SWEEP_NOVELTY_BONUS_MAX_M = 2.0
+SWEEP_TRAVEL_COST_CELLS_PER_M = 1.0
+SWEEP_NOVELTY_BONUS_CELLS_PER_M = 10.0
 SWEEP_BACKTRACK_PENALTY_CELLS = 12.0
 HANDLED_PERSON_ESTIMATED_DISTANCE_M = 1.5
 HANDLED_PERSON_VIEW_PENALTY_CELLS = 220.0
@@ -395,10 +394,9 @@ def _distance_from_observations(x: float, y: float, observations: list[dict]) ->
 
 
 def _coverage_travel_utility(gain: int, route_distance_m: float, *, sweeping: bool) -> float:
-    """Score information against actual route cost without rewarding long trips."""
-    if not sweeping:
-        return gain - INITIAL_TRAVEL_COST_CELLS_PER_M * route_distance_m
-    return gain / (1.0 + SWEEP_INFORMATION_DECAY_PER_M * route_distance_m)
+    """Keep the first view local, then let coverage gain dominate route length."""
+    travel_cost = SWEEP_TRAVEL_COST_CELLS_PER_M if sweeping else INITIAL_TRAVEL_COST_CELLS_PER_M
+    return gain - travel_cost * route_distance_m
 
 
 def _backtrack_penalty(x: float, y: float, observations: list[dict]) -> float:
@@ -534,7 +532,7 @@ def _choose_view(
                     )
                 score = (
                     _coverage_travel_utility(gain, evaluation_distance, sweeping=bool(observations))
-                    + SWEEP_NOVELTY_BONUS_CELLS_PER_M * min(novelty, SWEEP_NOVELTY_BONUS_MAX_M)
+                    + SWEEP_NOVELTY_BONUS_CELLS_PER_M * novelty
                     - _backtrack_penalty(evaluation_x, evaluation_y, observations)
                     - 0.5 * _angular_distance(theta, pose.theta)
                     - person_view_penalty


### PR DESCRIPTION
## Summary
- replace sweep distance-decay utility with the ablation-proven linear coverage utility
- raise uncapped novelty reward so the search spreads through unexplored space
- retain the conservative first-view travel cost and all reliability guards

## Why
The independent 40-run ablation improved successful median from 354.6s to 288.2s and successful max from 664.2s to 517.3s, with no observed behavior-valid reliability loss (37/40 control vs 35/37 after excluding three infrastructure failures). This PR applies only that component change.

## Validation
- `python3 -m py_compile workspace/innate_skills/find_next_person.py`
- targeted ROS-image test: 5 passed, 87 deselected
- fresh-source confirmation: 40/40 Batch jobs succeeded and 40/40 behavioral trials passed
- confirmation latency: min 230.7s, median 310.3s, P95 559.4s, max 590.5s
- confirmation infrastructure estimate: $2.60

The confirmation ran commit `95a493880b797e9281afe2af92d7b674c1cc44a0` on one fresh VM per trial, zero retries, with first-person evidence recording.