### PR TITLE
feat(brain): fold the arm to rest when an agent starts

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/core/lifecycle.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/lifecycle.py
@@ -27,6 +27,7 @@ class BrainLifecycle:
         runner,
         gaze,
         chat,
+        rest_pose,
         active_inputs_pub,
         stop_robot,
         publish_status,
@@ -40,6 +41,7 @@ class BrainLifecycle:
         self._runner = runner
         self._gaze = gaze
         self._chat = chat
+        self._rest_pose = rest_pose
         self._active_inputs_pub = active_inputs_pub
         self._stop_robot = stop_robot
         self._publish_status = publish_status
@@ -66,6 +68,7 @@ class BrainLifecycle:
             self._publish_status()
             return
         self.activate_directive_inputs()
+        self._rest_pose.fold()
         self._publish_status()
         # Announce in the shared chat so EVERY client sees it, not just the
         # device whose button was pressed (clients don't echo locally).

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -43,6 +43,7 @@ from brain_client.perception.gaze_control import GazeController
 from brain_client.perception.pose_tracking import PoseTracker
 from brain_client.perception.scan_health import ScanHealthMonitor
 from brain_client.robot.arm_recovery import ArmRecovery
+from brain_client.robot.rest_pose import ArmRestPose
 from brain_client.skills.hot_reload import ReloadCoordinator
 from brain_client.skills.roster import SkillRoster
 from brain_client.skills.runner import PrimitiveRunner
@@ -231,6 +232,7 @@ class BrainClientNode(Node):
         self.camera.motion_suppressed = lambda: self.state.primitive_running is not None or self.camera.recently_driven
         self.camera.on_motion = self._on_camera_motion
         self.arm_recovery = ArmRecovery(self, state, runner=self.runner, chat=self.chat, brain=self.brain)
+        self.rest_pose = ArmRestPose(self, state)
         self.lifecycle = BrainLifecycle(
             self,
             state,
@@ -240,6 +242,7 @@ class BrainClientNode(Node):
             runner=self.runner,
             gaze=self.gaze,
             chat=self.chat,
+            rest_pose=self.rest_pose,
             active_inputs_pub=self.active_inputs_pub,
             stop_robot=self._stop_robot,
             publish_status=self.publish_agent_status,

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/manipulation.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/manipulation.py
@@ -141,6 +141,13 @@ class Manipulation:
     STREAM_MAX_SPEED = 1.8  # rad/s
     STREAM_IDLE_S = 0.4
 
+    # A motion completes on ARRIVAL, and motions serialize in the driver, so a
+    # queued one waits out whatever is already moving before its own duration
+    # even starts. Wait past the driver's own completion bound (total + 5s)
+    # rather than racing it: a failed wait must mean failed or hung, not merely
+    # queued behind another arm client.
+    _MOTION_SLACK_S = 6.0
+
     # /mars/arm/status samples torque state, then runs a multi-second servo
     # sweep before publishing — a heartbeat can arrive after a local torque
     # command yet predate it. Local writes stay authoritative for this long.
@@ -793,10 +800,10 @@ class Manipulation:
         try:
             future = self._goto_js_client.call_async(request)
             if wait:
-                if not self._await_motion_result(future, "GotoJS v2", duration + 1.0):
+                if not self._await_motion_result(future, "GotoJS v2", duration + self._MOTION_SLACK_S):
                     return False
             else:
-                self._pending = _PendingMotion(future, "GotoJS v2", time.monotonic() + duration + 1.0)
+                self._pending = _PendingMotion(future, "GotoJS v2", time.monotonic() + duration + self._MOTION_SLACK_S)
         except Exception as e:
             self.logger.error(f"[Manipulation] Exception calling GotoJS v2: {e}")
             return False
@@ -835,10 +842,12 @@ class Manipulation:
         try:
             future = self._goto_js_traj_client.call_async(request)
             if wait:
-                if not self._await_motion_result(future, "GotoJSTrajectory", total_time + 5.0):
+                if not self._await_motion_result(future, "GotoJSTrajectory", total_time + self._MOTION_SLACK_S):
                     return False
             else:
-                self._pending = _PendingMotion(future, "GotoJSTrajectory", time.monotonic() + total_time + 5.0)
+                self._pending = _PendingMotion(
+                    future, "GotoJSTrajectory", time.monotonic() + total_time + self._MOTION_SLACK_S
+                )
         except Exception as e:
             self.logger.error(f"[Manipulation] Exception calling GotoJSTrajectory: {e}")
             return False

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Fold the arm to its rest pose when an agent starts.
+
+Starting an agent hands the robot to the model, and it should take it in a
+known shape: an arm left extended by teleop or by a previous session is what
+the first navigation skill drags into a doorframe.
+
+Same mechanism Mad speed mode uses to brace the arm (``fold_arm_for_mad_mode``
+in ``mars_control/app.cpp``): ``/mars/arm/goto_js_v2`` directly, not the
+arm_rest_position skill — activation must not occupy the single skill slot the
+agent's own first turn needs. Fire-and-forget, so the agent starts thinking
+while the arm folds.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mars_msgs.srv import GotoJS
+from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
+
+from brain_client.robot.manipulation import Manipulation
+
+if TYPE_CHECKING:
+    from rclpy.node import Node
+    from rclpy.task import Future
+
+    from brain_client.core.state import BrainState
+
+GOTO_JS_SERVICE = "/mars/arm/goto_js_v2"
+COMMAND_STATE_TOPIC = "/mars/arm/command_state"
+
+_FOLD_DURATION_S = 3.0
+_SETTLE_DURATION_S = 1.0
+
+_LATCHED_QOS = QoSProfile(
+    depth=1,
+    durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+    reliability=QoSReliabilityPolicy.RELIABLE,
+)
+
+
+class ArmRestPose:
+    """Sends the arm to :attr:`Manipulation.REST` on agent activation."""
+
+    def __init__(self, node: Node, state: BrainState) -> None:
+        self._logger = node.get_logger()
+        self._state = state
+        self._client = node.create_client(GotoJS, GOTO_JS_SERVICE)
+        # Last COMMANDED j6 (the standing grip target). Transient local: a
+        # brain restart while an object is held must not read it back as zero.
+        self._grip: float | None = None
+        node.create_subscription(JointState, COMMAND_STATE_TOPIC, self._on_command_state, _LATCHED_QOS)
+
+    def fold(self) -> None:
+        """Fold to rest, keeping the grip; returns once the goto is sent."""
+        if self._state.primitive_running is not None:
+            return  # a skill already owns the arm
+        self._logger.info("[RestPose] Folding the arm to its rest pose for the starting agent")
+        self._send(_FOLD_DURATION_S, settle=True)
+
+    def _send(self, duration: float, *, settle: bool) -> None:
+        if not self._client.service_is_ready():
+            self._logger.warn(f"[RestPose] {GOTO_JS_SERVICE} is not ready; the arm stays where it is")
+            return
+        request = GotoJS.Request()
+        request.data = Float64MultiArray()
+        # j6 carries the standing grip target rather than the rest pose's own:
+        # it is current-based position control, so re-commanding it above that
+        # target zeroes the preload and drops a held object.
+        request.data.data = [*Manipulation.REST[:5], self._grip if self._grip is not None else Manipulation.REST[5]]
+        request.time = duration
+        self._client.call_async(request).add_done_callback(lambda future: self._on_result(future, settle))
+
+    def _on_command_state(self, msg: JointState) -> None:
+        if len(msg.position) >= 6:
+            self._grip = float(msg.position[5])
+
+    def _on_result(self, future: Future, settle: bool) -> None:
+        response = future.result()
+        if response is None or not response.success:
+            self._logger.warn("[RestPose] The arm rejected the rest fold; leaving it where it is")
+            return
+        if settle:
+            # Same second command Manipulation.rest() sends: the fold shifts a
+            # held load, and the servos need a re-command to settle under it.
+            self._send(_SETTLE_DURATION_S, settle=False)

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
@@ -3,10 +3,15 @@
 """Fold the arm to its rest pose when an agent starts.
 
 Same mechanism Mad speed mode uses to brace the arm (``fold_arm_for_mad_mode``
-in ``mars_control/app.cpp``): ``/mars/arm/goto_js_v2`` directly, not the
+in ``mars_control/app.cpp``): one ``/mars/arm/goto_js_v2`` call, not the
 arm_rest_position skill — activation must not occupy the single skill slot the
 agent's own first turn needs. Fire-and-forget, so the agent starts thinking
 while the arm folds.
+
+One command, deliberately: Manipulation.rest() re-commands the pose to settle
+the servos under a shifted load, but it runs inside a skill that owns the arm.
+Nothing here owns it, and a second command decided on the ROS callback thread
+cannot be sequenced against an agent claiming the arm on its own thread.
 """
 
 from __future__ import annotations
@@ -30,7 +35,6 @@ GOTO_JS_SERVICE = "/mars/arm/goto_js_v2"
 COMMAND_STATE_TOPIC = "/mars/arm/command_state"
 
 _FOLD_DURATION_S = 3.0
-_SETTLE_DURATION_S = 1.0
 
 _LATCHED_QOS = QoSProfile(
     depth=1,
@@ -55,10 +59,6 @@ class ArmRestPose:
         """Fold to rest, keeping the grip; returns once the goto is sent."""
         if self._state.primitive_running is not None:
             return  # a skill already owns the arm
-        self._logger.info("[RestPose] Folding the arm to its rest pose for the starting agent")
-        self._send(_FOLD_DURATION_S, settle=True)
-
-    def _send(self, duration: float, *, settle: bool) -> None:
         if not self._client.service_is_ready():
             self._logger.warn(f"[RestPose] {GOTO_JS_SERVICE} is not ready; the arm stays where it is")
             return
@@ -68,24 +68,15 @@ class ArmRestPose:
         # it is current-based position control, so re-commanding it above that
         # target zeroes the preload and drops a held object.
         request.data.data = [*Manipulation.REST[:5], self._grip if self._grip is not None else Manipulation.REST[5]]
-        request.time = duration
-        self._client.call_async(request).add_done_callback(lambda future: self._on_result(future, settle))
+        request.time = _FOLD_DURATION_S
+        self._logger.info("[RestPose] Folding the arm to its rest pose for the starting agent")
+        self._client.call_async(request).add_done_callback(self._on_result)
 
     def _on_command_state(self, msg: JointState) -> None:
         if len(msg.position) >= 6:
             self._grip = float(msg.position[5])
 
-    def _on_result(self, future: Future, settle: bool) -> None:
+    def _on_result(self, future: Future) -> None:
         response = future.result()
         if response is None or not response.success:
             self._logger.warn("[RestPose] The arm rejected the rest fold; leaving it where it is")
-            return
-        if not settle:
-            return
-        if self._state.primitive_running is not None:
-            # The agent claimed the arm during the fold; the settle would drag
-            # its trajectory back toward rest.
-            return
-        # Same second command Manipulation.rest() sends: the fold shifts a held
-        # load, and the servos need a re-command to settle under it.
-        self._send(_SETTLE_DURATION_S, settle=False)

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
@@ -2,10 +2,6 @@
 # Copyright (c) 2026 Innate Inc
 """Fold the arm to its rest pose when an agent starts.
 
-Starting an agent hands the robot to the model, and it should take it in a
-known shape: an arm left extended by teleop or by a previous session is what
-the first navigation skill drags into a doorframe.
-
 Same mechanism Mad speed mode uses to brace the arm (``fold_arm_for_mad_mode``
 in ``mars_control/app.cpp``): ``/mars/arm/goto_js_v2`` directly, not the
 arm_rest_position skill — activation must not occupy the single skill slot the

--- a/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/rest_pose.py
@@ -84,7 +84,12 @@ class ArmRestPose:
         if response is None or not response.success:
             self._logger.warn("[RestPose] The arm rejected the rest fold; leaving it where it is")
             return
-        if settle:
-            # Same second command Manipulation.rest() sends: the fold shifts a
-            # held load, and the servos need a re-command to settle under it.
-            self._send(_SETTLE_DURATION_S, settle=False)
+        if not settle:
+            return
+        if self._state.primitive_running is not None:
+            # The agent claimed the arm during the fold; the settle would drag
+            # its trajectory back toward rest.
+            return
+        # Same second command Manipulation.rest() sends: the fold shifts a held
+        # load, and the servos need a re-command to settle under it.
+        self._send(_SETTLE_DURATION_S, settle=False)

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -1145,8 +1145,11 @@ class ManipulationServer(Node):
                 f"Arm goto service called with position: {[float(p) for p in position]} (time: {time_duration}s)"
             )
 
-            # Wait for the service call to complete (service blocks for time_duration internally)
-            timeout_sec = time_duration + 0.2  # Small buffer for network/processing overhead
+            # The goto completes when the arm ARRIVES: nominal duration plus
+            # settle and scheduling drift (measured 0.2-0.25s past nominal on
+            # an idle sim). Wait past the arm server's own internal bound
+            # instead of racing it.
+            timeout_sec = time_duration + 6.0
             start_wait = time.time()
             while not future.done():
                 if time.time() - start_wait > timeout_sec:

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -1152,6 +1152,12 @@ class ManipulationServer(Node):
             timeout_sec = time_duration + 6.0
             start_wait = time.time()
             while not future.done():
+                if self._cancel_requested.is_set():
+                    # The command is already dispatched (the arm finishes or
+                    # is preempted by the cleanup goto); stop waiting so
+                    # cancellation tears the behavior down promptly.
+                    self.get_logger().info("Arm goto wait interrupted by cancel request")
+                    return False
                 if time.time() - start_wait > timeout_sec:
                     self.get_logger().error(f"Arm goto service timed out after {timeout_sec}s")
                     return False

--- a/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
+++ b/ros2_ws/src/brain/manipulation/manipulation/manipulation_server.py
@@ -377,8 +377,7 @@ class ManipulationServer(Node):
             if start_pose:
                 self.get_logger().info(f"Moving to start pose: {start_pose} (time: {start_pose_time}s)")
                 if not self.call_arm_goto_service(start_pose, start_pose_time):
-                    self.get_logger().error("Failed to move to start pose")
-                    return "FAILURE", "Failed to move arm to start pose"
+                    return self._goto_outcome("Failed to move arm to start pose")
 
             # Execute policy inference
             start_time = time.time()
@@ -417,7 +416,7 @@ class ManipulationServer(Node):
                     self.get_logger().info("Behavior execution canceled")
                     self._stop_robot()
                     if end_pose:
-                        self.call_arm_goto_service(end_pose, end_pose_time)
+                        self.call_arm_goto_service(end_pose, end_pose_time, interruptible=False)
                     return "CANCELLED", "User requested cancellation"
 
                 # Check if duration completed (moved earlier to prevent infinite loop)
@@ -465,8 +464,7 @@ class ManipulationServer(Node):
             if end_pose:
                 self.get_logger().info(f"Moving to end pose: {end_pose} (time: {end_pose_time}s)")
                 if not self.call_arm_goto_service(end_pose, end_pose_time):
-                    self.get_logger().error("Failed to move to end pose")
-                    return "FAILURE", "Failed to move arm to end pose"
+                    return self._goto_outcome("Failed to move arm to end pose")
 
             # One concise summary per policy execution.
             total_elapsed = time.time() - start_time
@@ -514,8 +512,7 @@ class ManipulationServer(Node):
 
                 # Execute pose movement
                 if not self.call_arm_goto_service(pose, steps):
-                    self.get_logger().error(f"Failed to reach pose {i + 1}")
-                    return "FAILURE", f"Failed to reach pose {i + 1}/{len(poses)}"
+                    return self._goto_outcome(f"Failed to reach pose {i + 1}/{len(poses)}")
 
                 time.sleep(steps)
 
@@ -556,8 +553,7 @@ class ManipulationServer(Node):
                 # Use start_pose from metadata
                 self.get_logger().info(f"Moving to start pose from metadata: {start_pose} (time: {start_pose_time}s)")
                 if not self.call_arm_goto_service(start_pose, start_pose_time):
-                    self.get_logger().error("Failed to move to start pose")
-                    return "FAILURE", "Failed to move to start pose"
+                    return self._goto_outcome("Failed to move to start pose")
             else:
                 # Fall back to first action from H5 file
                 # Action format: [arm_joints(6), linear.x, angular.z, progress?, termination?]
@@ -567,8 +563,7 @@ class ManipulationServer(Node):
                     f"Moving to initial arm position from H5: {first_arm_position} (time: {start_pose_time}s)"
                 )
                 if not self.call_arm_goto_service(first_arm_position, start_pose_time):
-                    self.get_logger().error("Failed to move to initial arm position")
-                    return "FAILURE", "Failed to move to initial arm position"
+                    return self._goto_outcome("Failed to move to initial arm position")
 
             # Replay parameters
             total_steps = actions.shape[0]
@@ -590,7 +585,7 @@ class ManipulationServer(Node):
                     self.get_logger().info("Replay execution canceled")
                     self._stop_robot()
                     if end_pose:
-                        self.call_arm_goto_service(end_pose, end_pose_time)
+                        self.call_arm_goto_service(end_pose, end_pose_time, interruptible=False)
                     return "CANCELLED", "User requested cancellation"
 
                 # Get current action
@@ -637,8 +632,7 @@ class ManipulationServer(Node):
             if end_pose:
                 self.get_logger().info(f"Moving to end pose: {end_pose} (time: {end_pose_time}s)")
                 if not self.call_arm_goto_service(end_pose, end_pose_time):
-                    self.get_logger().error("Failed to move to end pose")
-                    return "FAILURE", "Failed to move to end pose"
+                    return self._goto_outcome("Failed to move to end pose")
 
             self.get_logger().info(f"Replay behavior {behavior_name} completed successfully")
             return "SUCCESS", f"Replay completed successfully with {total_steps} steps"
@@ -1124,8 +1118,22 @@ class ManipulationServer(Node):
 
         return True
 
-    def call_arm_goto_service(self, position, time_duration=5):
-        """Call the arm goto service with specified position and wait for completion."""
+    def _goto_outcome(self, detail: str) -> tuple[str, str]:
+        """The outcome a failed goto reports. A cancel interrupts the wait and
+        returns False like any other failure, but must not abort the action —
+        and skills_server classifies the two on this text."""
+        if self._cancel_requested.is_set():
+            self.get_logger().info("Behavior cancelled while the arm was moving")
+            return "CANCELLED", "User requested cancellation"
+        self.get_logger().error(detail)
+        return "FAILURE", detail
+
+    def call_arm_goto_service(self, position, time_duration=5, *, interruptible=True):
+        """Call the arm goto service with specified position and wait for completion.
+
+        ``interruptible=False`` waits through a pending cancel: the end-pose
+        park is committed work, and cutting its wait short frees the arm for
+        the next command while it is still travelling."""
         if not self.arm_goto_client.wait_for_service(timeout_sec=2.0):
             self.get_logger().error("Arm goto service not available")
             return False
@@ -1152,7 +1160,7 @@ class ManipulationServer(Node):
             timeout_sec = time_duration + 6.0
             start_wait = time.time()
             while not future.done():
-                if self._cancel_requested.is_set():
+                if interruptible and self._cancel_requested.is_set():
                     # The command is already dispatched (the arm finishes or
                     # is preempted by the cleanup goto); stop waiting so
                     # cancellation tears the behavior down promptly.

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
@@ -345,9 +345,8 @@ class VirtualMarsNode(Node):
         return time.monotonic()
 
     # Settle: a goto completes when the arm ARRIVES (tol), like real servos,
-    # not when its time runs out. The cap bounds a blocked joint AND honours
-    # the service contract: manipulation_server waits only `time + 0.2s` wall
-    # for goto_js, so the settle must fit inside that budget.
+    # not when its time runs out. The cap bounds a blocked joint so a slow
+    # settle can't hang the goto_js caller.
     SETTLE_TOL_RAD = 0.015
     SETTLE_CAP_S = 0.15
 


### PR DESCRIPTION
Starting an agent hands the robot to the model, but not in any known shape: an arm left extended by teleop or by the previous session stays extended, and the agent's first navigation skill drags it into the nearest doorframe.

Activation now folds it, the way Mad speed mode braces it — one `/mars/arm/goto_js_v2` call from the node (`fold_arm_for_mad_mode` in `mars_control/app.cpp`), not the `arm_rest_position` skill. The skill would occupy the single execution slot the agent's own first turn needs, and it blocks; this is fire-and-forget, so the loop starts thinking while the arm moves.

Two details carried over from the mechanisms it borrows from:

- **j6 carries the standing grip target**, read from the latched `/mars/arm/command_state`, rather than the rest pose's own value. j6 is current-based position control, so commanding it above that target zeroes the preload and drops a held object — the same reason `mars_control` subscribes to that topic for the Mad fold.
- **One goto, no settle.** `Manipulation.rest()` re-commands the pose so the servos settle under a load the fold shifts, but that runs inside a skill holding the arm exclusively. Nothing here owns the arm, and a second command decided on the ROS callback thread can't be sequenced against an agent claiming the arm on its own — so the fold sends one command, same as `fold_arm_for_mad_mode`.

The pose itself is `Manipulation.REST`, imported rather than re-typed, so the auto-fold cannot drift from the skill.

The fold is skipped when a skill already owns the arm (a manual run from the webapp), and an arm service that is not up is a warning, not a failure — activation proceeds either way. It hangs off `activate_brain` after `brain.start()` succeeds, so a rolled-back activation does not move the arm. Deactivation is untouched.

`Manipulation._goto` also stopped racing the driver's own deadline. A goto completes on arrival and gotos serialize in the arm driver (`planAndExecuteTrajectory` walks its waypoints with `sleep_for` inside a `MutuallyExclusive` service callback), so a request landing behind another arm client waited on a `duration + 1.0` budget that covers its motion but nothing queued ahead of it — `ArmFailed`, after which the driver ran the abandoned motion anyway. Both motion paths now share `_MOTION_SLACK_S = 6.0`, clearing the driver's bound instead of tying it. This predates the fold (a Mad-mode brace can collide the same way); the fold makes it reachable at the moment the agent is most likely to reach for the arm.

## Verification

`ruff check` and `ruff format --check` are clean.

**Not verified:** the pytest suite and `basedpyright` need a ROS environment, which this machine does not have (no `rclpy`, and Docker was not running for the sim container) — both want a run there. Run anyway, basedpyright reports nothing on the new file beyond the unresolved-ROS-import errors every module in the package shows without ROS on the path. The fold has not been watched on hardware or in the sim.

---

## Also carries the arm-goto cancel fixes from #691

`fix/wave-start-end-pose` is merged in, plus a follow-up to the cancel-interrupt added there in 79840906. That commit routed cancellation into the same `False` that means "the goto failed", which had two reachable consequences — both by pressing Stop during a wave:

- **A cancel was reported to the agent as a failure.** Every caller reads that `False` as `return "FAILURE", …`, so the action aborts rather than cancels; `skills_server` classifies a behavior result by looking for "cancel" in its message, so `"Behavior wave failed. Failed to move arm to start pose"` reached the model as a FAILED skill. `_goto_outcome` now reports CANCELLED when the cancel flag is what ended the wait.
- **The cancel teardown stopped waiting for its end pose.** Both teardown paths call the helper with the flag already set, so the park returned on its first loop check and was never awaited — the behavior reported CANCELLED with the arm still travelling and the slot free for the next command to preempt it mid-park. Teardown passes `interruptible=False`: committed work, same rule as the `time.sleep` exception in AGENTS.md.

The `+6 s` deadline itself is unchanged — the only thing it delays is a genuinely hung service, which is the case worth waiting on.

**If #691 merges first, this merge collapses to nothing and only the follow-up commit remains.** The manipulation suite is 60 passed / 1 skipped, but it covers config validation only — nothing exercises the goto or cancel paths, so this needs the same kind of loaded-sim run #691 was verified with.
