### PR TITLE
feat(brain): give the agent the wall clock, settable per robot

### DIFF
--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -210,6 +210,7 @@
 #     send_arm_camera_image: true   # also send the arm wrist camera image to the model
 #     log_everything: true          # log every turn's full input
 #     gemini_model: "gemini-3.6-flash"
+#     timezone: ""                  # IANA zone for the clock the agent sees; "" = the robot OS's own
 #     idle_turn_interval: 3.0       # seconds between looks when no skill is running
 #     supervision_turn_interval: 5.0  # seconds between looks while a skill runs
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -26,6 +26,7 @@ import json
 import math
 import time
 import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from brain_client.brain import grounding
@@ -44,6 +45,7 @@ from brain_client.brain.utils import (
     in_image,
     observation_text,
     parse_view_point,
+    resolve_timezone,
 )
 from brain_client.perception.scan_health import ScanHealthReporter
 from brain_client.transport.chat import Sender
@@ -107,6 +109,11 @@ class BrainAgent:
         self._lidar = ScanHealthReporter(
             scan_health, pose_tracker, chat, self._logger, enabled=not config.simulator_mode
         )
+        # Boot tolerates a bad zone (warn + host local); a Settings write does
+        # not — set_timezone rejects it so the operator sees the typo.
+        self._timezone = resolve_timezone(config.timezone)
+        if config.timezone.strip() and self._timezone is None:
+            self._logger.warn(f"[Brain] Unknown timezone '{config.timezone}' — using the host's local zone")
 
         transport, self.backend = pick_transport(proxy)
         self._context = (
@@ -145,6 +152,14 @@ class BrainAgent:
 
         if self._context is not None:
             self._context.on_request = self._trace_request  # the monitor renders the exact request body
+
+    def set_timezone(self, name: str) -> bool:
+        """Point the status-line clock at an IANA zone ("" = the host's own); False if unknown."""
+        zone = resolve_timezone(name)
+        if name.strip() and zone is None:
+            return False
+        self._timezone = zone
+        return True
 
     @property
     def available(self) -> bool:
@@ -415,6 +430,7 @@ class BrainAgent:
 
         running = self._state.primitive_running
         text = observation_text(
+            now=self._now(),
             uptime_s=int(time.monotonic() - self._activated_at),
             pose=self._pose_at_capture,
             battery=self._battery.current if self._battery is not None else None,
@@ -424,6 +440,10 @@ class BrainAgent:
             has_wrist_frame=arm_jpeg is not None,
         )
         return text, frames
+
+    def _now(self) -> datetime:
+        """Wall clock as an aware datetime, so the status line can name the zone."""
+        return datetime.now(self._timezone) if self._timezone is not None else datetime.now().astimezone()
 
     def _running_guidance(self, running: RunningSkill | None) -> str:
         if running is None:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -109,8 +109,7 @@ class BrainAgent:
         self._lidar = ScanHealthReporter(
             scan_health, pose_tracker, chat, self._logger, enabled=not config.simulator_mode
         )
-        # Boot tolerates a bad zone (warn + host local); a Settings write does
-        # not — set_timezone rejects it so the operator sees the typo.
+        # Boot tolerates a bad zone; set_timezone rejects one, so a Settings typo surfaces.
         self._timezone = resolve_timezone(config.timezone)
         if config.timezone.strip() and self._timezone is None:
             self._logger.warn(f"[Brain] Unknown timezone '{config.timezone}' — using the host's local zone")

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
@@ -32,6 +32,10 @@ you have failed to complete the action and think trying again might succeed.
 capability you don't have, briefly say you can't. Never write tool-call syntax in your text \
 (e.g. "Calling tool ...") — text is only ever speech.
 - Distances are meters, angles are degrees. The robot's forward axis is +x; +y is to its left.
+- Each update's status line carries the current local date and time. It is context for judging \
+what is appropriate right now — never announce it unless the user asks or it bears on what you \
+are doing. When the line shows no clock, the robot's clock is unset: say you don't know the time \
+rather than guessing.
 - Your battery percentage reads lower than the real charge: anything above 5% is a healthy \
 battery and not worth mentioning. Only below 5% are you actually running out of power.
 - You keep receiving updates while idle. Stay quiet and idle unless something relevant changes \

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
@@ -32,10 +32,8 @@ you have failed to complete the action and think trying again might succeed.
 capability you don't have, briefly say you can't. Never write tool-call syntax in your text \
 (e.g. "Calling tool ...") — text is only ever speech.
 - Distances are meters, angles are degrees. The robot's forward axis is +x; +y is to its left.
-- Each update's status line carries the current local date and time. It is context for judging \
-what is appropriate right now — never announce it unless the user asks or it bears on what you \
-are doing. When the line shows no clock, the robot's clock is unset: say you don't know the time \
-rather than guessing.
+- The status line's date and time are context for judging what is appropriate right now, not \
+news — never announce them unless the user asks or they bear on what you are doing.
 - Your battery percentage reads lower than the real charge: anything above 5% is a healthy \
 battery and not worth mentioning. Only below 5% are you actually running out of power.
 - You keep receiving updates while idle. Stay quiet and idle unless something relevant changes \

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from datetime import datetime, tzinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from brain_client.common.enums import StrEnum
 from brain_client.perception import pose as pose_math
@@ -57,8 +59,42 @@ class TraceEvent(StrEnum):
     SNAPSHOT = "snapshot"
 
 
+# An unsynced clock (no RTC battery, no network yet at boot) reads 1970, and a
+# confidently wrong time misleads the agent worse than no time at all.
+_CLOCK_VALID_FROM_YEAR = 2025
+
+
+def resolve_timezone(name: str) -> tzinfo | None:
+    """A named IANA zone, or None for the system's local zone.
+
+    An unknown name or missing tzdata falls back to local — a misconfigured
+    zone must not take the brain down with it. Local stays None rather than
+    resolving to a tzinfo here: a snapshot of the host's current offset would
+    freeze the brain on one side of a DST change.
+    """
+    if not name.strip():
+        return None
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+
+
+def clock_text(now: datetime) -> str:
+    """The wall clock as the status line shows it, or "" when it can't be trusted.
+
+    Minute precision: at a 3 s turn interval, seconds are noise that reads as
+    something to act on. The zone abbreviation is what makes a robot left on
+    UTC visible in the transcript instead of silently wrong.
+    """
+    if now.year < _CLOCK_VALID_FROM_YEAR:
+        return ""
+    return f"{now:%a %Y-%m-%d %H:%M %Z}".strip()
+
+
 def observation_text(
     *,
+    now: datetime,
     uptime_s: int,
     pose: Pose | None,
     battery: Battery | None,
@@ -68,7 +104,8 @@ def observation_text(
     has_wrist_frame: bool,
 ) -> str:
     """The text half of a turn input: robot status, guidance, and new events."""
-    status = f"[t+{uptime_s}s]"
+    clock = clock_text(now)
+    status = f"[{clock} | t+{uptime_s}s]" if clock else f"[t+{uptime_s}s]"
     if pose is not None:
         status += f" pose: x={pose[0]:.2f}m y={pose[1]:.2f}m heading={math.degrees(pose[2]):.0f}°"
     if battery is not None:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/utils.py
@@ -59,19 +59,14 @@ class TraceEvent(StrEnum):
     SNAPSHOT = "snapshot"
 
 
-# An unsynced clock (no RTC battery, no network yet at boot) reads 1970, and a
-# confidently wrong time misleads the agent worse than no time at all.
+# Cold boot before NTP, on a robot whose RTC lost the time: the clock reads 1970.
 _CLOCK_VALID_FROM_YEAR = 2025
+_CLOCK_UNSET = "time not known"
 
 
 def resolve_timezone(name: str) -> tzinfo | None:
-    """A named IANA zone, or None for the system's local zone.
-
-    An unknown name or missing tzdata falls back to local — a misconfigured
-    zone must not take the brain down with it. Local stays None rather than
-    resolving to a tzinfo here: a snapshot of the host's current offset would
-    freeze the brain on one side of a DST change.
-    """
+    """An IANA zone by name, or None for the host's own — left unresolved so a
+    DST change is picked up rather than frozen at boot."""
     if not name.strip():
         return None
     try:
@@ -81,14 +76,10 @@ def resolve_timezone(name: str) -> tzinfo | None:
 
 
 def clock_text(now: datetime) -> str:
-    """The wall clock as the status line shows it, or "" when it can't be trusted.
-
-    Minute precision: at a 3 s turn interval, seconds are noise that reads as
-    something to act on. The zone abbreviation is what makes a robot left on
-    UTC visible in the transcript instead of silently wrong.
-    """
+    """The wall clock for the status line, or a marker the agent can act on:
+    a confidently wrong time misleads it worse than a stated unknown does."""
     if now.year < _CLOCK_VALID_FROM_YEAR:
-        return ""
+        return _CLOCK_UNSET
     return f"{now:%a %Y-%m-%d %H:%M %Z}".strip()
 
 
@@ -104,8 +95,7 @@ def observation_text(
     has_wrist_frame: bool,
 ) -> str:
     """The text half of a turn input: robot status, guidance, and new events."""
-    clock = clock_text(now)
-    status = f"[{clock} | t+{uptime_s}s]" if clock else f"[t+{uptime_s}s]"
+    status = f"[{clock_text(now)} | t+{uptime_s}s]"
     if pose is not None:
         status += f" pose: x={pose[0]:.2f}m y={pose[1]:.2f}m heading={math.degrees(pose[2]):.0f}°"
     if battery is not None:

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -50,6 +50,7 @@ class BrainConfig:
 
     # --- Timing ---
     scan_stale_after_sec: float
+    timezone: str  # IANA name for the agent's wall clock; "" = the host's local zone
 
     # --- Proxy service config (credentials come from env, not params) ---
     cartesia_voice_id: str
@@ -115,6 +116,9 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "history_max_image_turns": 3,
     # --- Timing ---
     "scan_stale_after_sec": 10.0,
+    # The host's own zone by default. Set this when the robot's OS is left on
+    # UTC — the agent states the time out loud, so a wrong zone is user-visible.
+    "timezone": "",
     # --- Proxy service config ---
     "cartesia_voice_id": "9fdaae0b-f885-4813-b589-3c07cf9d5fea",
 }

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -91,7 +91,6 @@ class BrainClientNode(Node):
 
         self._proxy = self._init_proxy()
         self._tts_handler = self._init_tts()
-        self.add_on_set_parameters_callback(self._on_parameter_change)
 
         # --- helper node for synchronous service calls (not spun by the executor) ---
         self._service_call_node = rclpy.create_node("brain_client_service_caller")
@@ -99,6 +98,8 @@ class BrainClientNode(Node):
         self._reload_skills_client = self._service_call_node.create_client(ReloadSkillsAgents, "/brain/reload_skills")
 
         self._build_collaborators()
+        # Registered only once every collaborator a live write reaches exists.
+        self.add_on_set_parameters_callback(self._on_parameter_change)
         self._create_always_on_subscriptions()
         self._create_services()
         self._startup()
@@ -141,12 +142,18 @@ class BrainClientNode(Node):
     def _on_parameter_change(self, params: list[Parameter]) -> SetParametersResult:
         """Apply the parameters that take effect without a restart.
 
-        Only the TTS voice does: every other field was copied into a collaborator at
-        construction, so accepting a write would leave the robot running the old value.
-        Those are stored for the next boot, which is what the Settings page's `live`
-        flag says about them.
+        Only the TTS voice and the agent's timezone do: every other field was copied
+        into a collaborator at construction, so accepting a write would leave the robot
+        running the old value. Those are stored for the next boot, which is what the
+        Settings page's `live` flag says about them.
         """
         for param in params:
+            if param.name == "timezone":
+                if self.brain.set_timezone(str(param.value)):
+                    continue
+                return SetParametersResult(
+                    successful=False, reason=f"unknown timezone '{param.value}' (expected an IANA name, e.g. UTC)"
+                )
             if param.name != "cartesia_voice_id":
                 continue
             voice_id = str(param.value).strip()

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -473,6 +473,7 @@ def agent_factory(monkeypatch):
             idle_turn_interval=3.0,
             supervision_turn_interval=5.0,
             simulator_mode=False,
+            timezone="",
         )
         state = BrainState()
         state.is_brain_active = True

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -98,6 +98,22 @@ const STT_BACKEND_OPTIONS = [
   { value: "openai", label: "OpenAI Realtime" },
 ];
 
+// The robot's OS ships on Etc/UTC, so the agent's clock has to be told where the
+// robot physically stands — not where an operator is teleoperating from. A shortlist
+// plus Custom: the full IANA set is ~600 names, unusable as a dropdown.
+const TIMEZONE_OPTIONS = [
+  { value: "", label: "Robot system setting" },
+  { value: "America/Los_Angeles", label: "Los Angeles (US Pacific)" },
+  { value: "America/Denver", label: "Denver (US Mountain)" },
+  { value: "America/Chicago", label: "Chicago (US Central)" },
+  { value: "America/New_York", label: "New York (US Eastern)" },
+  { value: "Europe/London", label: "London" },
+  { value: "Europe/Berlin", label: "Berlin" },
+  { value: "Europe/Prague", label: "Prague" },
+  { value: "Asia/Tokyo", label: "Tokyo" },
+  { value: "UTC", label: "UTC" },
+];
+
 const VAD_ENGINE_OPTIONS = [
   { value: "silero", label: "Silero (neural)" },
   { value: "energy", label: "Energy threshold" },
@@ -299,6 +315,13 @@ export const SETTINGS_PAGES = [
           { path: ["brain_client_node", P, "height_cam"], label: "Camera height", default: 0.19663, type: "float", unit: "m", doc: "Camera height above the floor" },
           { path: ["brain_client_node", P, "scan_stale_after_sec"], label: "Scan stale after", default: 10, type: "float", unit: "s", doc: "Seconds without a lidar scan before flagging stale" },
           { path: ["brain_client_node", P, "send_arm_camera_image"], label: "Send arm-camera image", default: true, type: "bool", doc: "Also send the arm wrist camera image to the model" },
+        ],
+      },
+      {
+        title: "Clock",
+        note: "The agent reads the local date and time on every turn, so it can tell morning from midnight and answer when asked. Set where the ROBOT is — not where you are, which differs when you teleoperate.",
+        knobs: [
+          { path: ["brain_client_node", P, "timezone"], label: "Time zone", default: "", type: "string", doc: "IANA time zone for the clock the agent sees. \"Robot system setting\" follows the robot's OS, which ships on UTC — pick a zone here unless you have set one over SSH. Any other IANA name works in Custom.", options: TIMEZONE_OPTIONS, customPlaceholder: "e.g. Australia/Sydney", live: "/brain_client_node" },
         ],
       },
       {


### PR DESCRIPTION
## Why

The agent's only temporal signal was uptime since activation:

```
[t+123s] pose: x=1.20m y=0.30m heading=45° | battery: 87%
```

So it can't tell morning from midnight, can't answer "what time is it", and can't situate the **absolute** timestamps memory search already hands it — `_frame_label` prints `recorded 2026-08-24 14:30` and verdicts say `recorded 3h ago`, with no "now" to compare against.

## What

The status line now leads with the local date and time:

```
[Mon 2026-08-24 14:32 PDT | t+123s] pose: x=1.20m y=0.30m heading=45° | battery: 87%
```

Plus a `timezone` parameter, exposed in **Settings → Brain client → Clock**, applied **live** (no restart).

## Design notes

**Ambient, not a `get_current_time` skill.** While a skill runs, `build_tools` collapses the tool list to `stop_current_skill` alone — a clock skill would be uncallable during navigation, exactly when elapsed time matters. It would also cost a full turn round-trip, against ~10 tokens on a line that already changes every turn (`t+Ns`), so there is no prompt-cache cost either.

**Uptime stays.** It is what separates "just woke" from "been on all day", and it is the cheap relative delta across history turns.

**Minute precision.** At a 3 s idle interval, seconds churn every turn and read as something to act on. The weekday is there so a directive can say "weekday mornings".

**An unsynced clock prints nothing.** Year < 2025 (no RTC battery, no network yet at boot) drops the clock and falls back to plain `[t+5s]`; the prompt tells the model to say it does not know the time rather than reading 1970 aloud. One more prompt rule keeps it from narrating the time every turn, mirroring the existing battery rule.

**Timezone is set per robot, not derived from the browser.** The robot OS ships on `Etc/UTC`:

```
Time zone: Etc/UTC (UTC, +0000)
System clock synchronized: yes
```

The clock is accurate, only the zone is wrong — so the agent has to be told where the robot physically stands. Deliberately *not* taken from `Intl.DateTimeFormat()`: that reports the **operator's** zone, which is wrong the moment someone teleoperates from another continent. The Settings dropdown is a shortlist plus the existing "Custom…" free-text field (the full IANA set is ~600 names). Default stays `""` = follow the host, so a fleet that provisions `/etc/localtime` properly needs no override.

**Boot and Settings treat a bad zone differently.** Construction warns and falls back to host-local — refusing to boot over a typo'd zone is worse than showing the wrong clock. A Settings write is *rejected* with `unknown timezone 'Foo/Bar'`, so the UI reports it instead of silently doing nothing.

**One structural change:** `add_on_set_parameters_callback` moved to after `_build_collaborators()`. It was registered before, fine when the only live knob touched `_tts_handler` (assigned just above), but the timezone branch touches `self.brain`, which did not exist yet. No collaborator calls `declare_parameter`, so nothing is skipped by moving it.

## Verification

- `ruff check` + `ruff format --check`: clean, 96 files
- pytest: **274 passed**. The `agent_factory` fixture's fake config needed the new field — an existing test the change legitimately invalidated, not a new one.
- basedpyright: 14 errors, all pre-existing, **none in touched files**
- webapp `tsc --noEmit`: **5177 errors with and without this change** (verified by stashing the catalog edit and re-running); the two in `settings/main.js` are pre-existing
- Settings YAML round-trip: set → `timezone: America/Los_Angeles`, set-empty → `timezone: ''`, clear → template line re-commented, overrides empty
- Live switch on a real `BrainAgent`: `set_timezone("America/Los_Angeles")` → `Mon 2026-08-24 14:26 PDT`; a rejected write leaves the previous zone intact; `""` returns to host-local

## Follow-up

This is the prerequisite for agent-settable alarms — without a clock in context the agent cannot do "7:30" at all, only relative delays. That work is scoped but not started; it needs a process-lifetime owner with disk persistence, since an alarm has to outlive the turn, the skill, a directive switch, brain deactivation, and a reboot.
