### PR TITLE
fix(teleop): make the robot-mic toggle find, and share, the microphone

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -160,6 +160,7 @@ class WebRTCStreamer : public rclcpp::Node {
     // ---- Shared audio (mic) — encoded once like the cameras, fanned out, gated for privacy ----
     bool build_audio_pipeline();  // alsasrc -> opusenc -> rtpopuspay -> appsink (built once, kept NULL)
     void reconcile_audio();       // PLAYING when some peer has audio active, NULL otherwise (mic off)
+    void fail_audio_pipeline();   // NULL + arm the retry backoff; the one landing for every mic failure
     static GstFlowReturn on_audio_sample(GstElement* appsink, gpointer user_data);
     void fan_out_audio(GstElement* appsink);
 

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -230,6 +230,7 @@ class WebRTCStreamer : public rclcpp::Node {
     // ---- Shared audio (mic) pipeline: encoded once, fanned out to peers, gated for mic privacy ----
     GstElement* audio_pipeline_ = nullptr;   // built once if enable_audio_; alsasrc..rtpopuspay..appsink
     GstElement* audio_sink_ = nullptr;       // ref'd appsink (the fan-out tap)
+    GstElement* audio_src_ = nullptr;        // ref'd mic source (device re-resolved before each open)
     std::atomic<int> want_audio_{0};         // # peers with audio active; >0 => mic open (pipeline PLAYING)
     std::atomic<uint64_t> audio_frames_{0};  // for status: is audio actually flowing
     // audio_playing_ and mic_retry_ns_ are unlocked on purpose: every writer is a ROS callback on this

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -232,6 +232,7 @@ class WebRTCStreamer : public rclcpp::Node {
     std::atomic<int> want_audio_{0};         // # peers with audio active; >0 => mic open (pipeline PLAYING)
     std::atomic<uint64_t> audio_frames_{0};  // for status: is audio actually flowing
     bool audio_playing_ = false;             // current audio pipeline state (gated by want_audio_)
+    int64_t mic_retry_ns_ = 0;               // earliest retry after a failed open (the poll runs at 5 Hz)
 
     // ---- Peers ----
     std::map<std::string, std::unique_ptr<Peer>> peers_;

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -232,8 +232,11 @@ class WebRTCStreamer : public rclcpp::Node {
     GstElement* audio_sink_ = nullptr;       // ref'd appsink (the fan-out tap)
     std::atomic<int> want_audio_{0};         // # peers with audio active; >0 => mic open (pipeline PLAYING)
     std::atomic<uint64_t> audio_frames_{0};  // for status: is audio actually flowing
-    bool audio_playing_ = false;             // current audio pipeline state (gated by want_audio_)
-    int64_t mic_retry_ns_ = 0;               // earliest retry after a failed open (the poll runs at 5 Hz)
+    // audio_playing_ and mic_retry_ns_ are unlocked on purpose: every writer is a ROS callback on this
+    // node, and all callbacks share the default mutually exclusive group, so the executor serializes
+    // them even in a multithreaded container. Moving any callback to a reentrant group revisits this.
+    bool audio_playing_ = false;  // current audio pipeline state (gated by want_audio_)
+    int64_t mic_retry_ns_ = 0;    // earliest retry after a failed open (the poll runs at 5 Hz)
 
     // ---- Peers ----
     std::map<std::string, std::unique_ptr<Peer>> peers_;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -9,7 +9,7 @@
 #include <cctype>  // std::isalnum (audio element/device validation)
 #include <cmath>
 #include <cstdlib>
-#include <cstring>  // memcpy (push_frame)
+#include <cstring>     // memcpy (push_frame)
 #include <filesystem>  // /proc/asound (mic lookup)
 #include <fstream>
 #include <memory>

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -45,12 +45,12 @@ bool looks_like_camera(std::string name) {
     return name.find("camera") != std::string::npos || name.find("webcam") != std::string::npos;
 }
 
-// A dedicated mic beats a camera's built-in one, and both beat the Tegra I2S card, whose capture nodes are
-// XBAR links with nothing on the far end. Mirrors the ladder workspace/inputs/micro_input.py walks, so the
-// agent and the teleop stream land on the same microphone.
+// A dedicated mic beats a camera's built-in one. The Tegra I2S card is never a fallback (rank 0): its
+// capture nodes are XBAR links with nothing on the far end, so it opens cleanly and records silence.
+// Approximates the name-based ladder in workspace/inputs/micro_input.py; the two are separate copies.
 int capture_rank(const std::string& driver, const std::string& long_name) {
     if (driver != "USB-Audio") {
-        return 1;
+        return 0;
     }
     return looks_like_camera(long_name) ? 2 : 3;
 }
@@ -314,7 +314,7 @@ bool WebRTCStreamer::build_audio_pipeline() {
                      audio_source_element_.c_str());
         return false;
     }
-    std::string src = audio_source_element_;
+    std::string src = audio_source_element_ + " name=src_audio";
     if (!audio_capture_device_.empty()) {
         const bool valid_device =
             std::all_of(audio_capture_device_.begin(), audio_capture_device_.end(), [](unsigned char c) {
@@ -325,12 +325,6 @@ bool WebRTCStreamer::build_audio_pipeline() {
             RCLCPP_ERROR(this->get_logger(), "audio_capture_device '%s' has unexpected chars",
                          audio_capture_device_.c_str());
             return false;
-        }
-        const std::string resolved = resolve_capture_device(audio_capture_device_);
-        if (resolved != audio_capture_device_) {
-            RCLCPP_WARN(this->get_logger(), "audio_capture_device '%s' is not present; using '%s' instead",
-                        audio_capture_device_.c_str(), resolved.c_str());
-            audio_capture_device_ = resolved;
         }
         src += " device=\"" + audio_capture_device_ + "\"";
     }
@@ -355,8 +349,9 @@ bool WebRTCStreamer::build_audio_pipeline() {
         return false;
     }
     audio_sink_ = gst_bin_get_by_name(GST_BIN(audio_pipeline_), "sink_audio");
-    if (!audio_sink_) {
-        RCLCPP_ERROR(this->get_logger(), "Audio pipeline missing appsink");
+    audio_src_ = gst_bin_get_by_name(GST_BIN(audio_pipeline_), "src_audio");
+    if (!audio_sink_ || !audio_src_) {
+        RCLCPP_ERROR(this->get_logger(), "Audio pipeline missing appsink or source");
         return false;
     }
     g_signal_connect(audio_sink_, "new-sample", G_CALLBACK(on_audio_sample), this);
@@ -386,6 +381,9 @@ void WebRTCStreamer::reconcile_audio() {
         return;
     }
     const bool want = want_audio_.load(std::memory_order_relaxed) > 0;
+    if (!want) {
+        mic_retry_ns_ = 0;  // dropping the request clears the backoff even when nothing was open
+    }
     if (want == audio_playing_) {
         return;
     }
@@ -396,6 +394,16 @@ void WebRTCStreamer::reconcile_audio() {
         if (now_ns < mic_retry_ns_) {
             return;
         }
+        std::string device = audio_capture_device_;
+        if (!device.empty() && audio_src_) {
+            // Re-resolved on every attempt: the configured card can (re)appear after boot.
+            device = resolve_capture_device(device);
+            if (device != audio_capture_device_) {
+                RCLCPP_WARN(this->get_logger(), "audio_capture_device '%s' is not present; using '%s' instead",
+                            audio_capture_device_.c_str(), device.c_str());
+            }
+            g_object_set(audio_src_, "device", device.c_str(), nullptr);
+        }
         if (gst_element_set_state(audio_pipeline_, GST_STATE_PLAYING) != GST_STATE_CHANGE_FAILURE) {
             audio_playing_ = true;
             mic_retry_ns_ = 0;
@@ -403,13 +411,12 @@ void WebRTCStreamer::reconcile_audio() {
         } else {
             fail_audio_pipeline();
             RCLCPP_WARN(this->get_logger(), "Mic '%s' failed to open; retrying in %lld s",
-                        audio_capture_device_.empty() ? "(default)" : audio_capture_device_.c_str(),
+                        device.empty() ? "(default)" : device.c_str(),
                         static_cast<long long>(kMicRetryBackoffNs / 1000000000));
         }
     } else {
         gst_element_set_state(audio_pipeline_, GST_STATE_NULL);  // closes the device; joins the fan-out thread
         audio_playing_ = false;
-        mic_retry_ns_ = 0;  // the next request tries immediately, whatever the last one cost
         RCLCPP_INFO(this->get_logger(), "Mic closed (no peer wants audio)");
     }
 }

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -390,9 +390,8 @@ void WebRTCStreamer::reconcile_audio() {
         return;
     }
     if (want) {
-        // A mic that cannot open (unplugged, or held exclusively by another process) fails on every poll,
-        // so back the retry off — at 5 Hz it buries the log under its own GStreamer errors for as long as
-        // the operator leaves the toggle on.
+        // A mic that cannot open fails identically on every poll; without the backoff the 5 Hz retry
+        // buries the log under its own GStreamer errors for as long as the toggle stays on.
         const int64_t now_ns = std::chrono::steady_clock::now().time_since_epoch().count();
         if (now_ns < mic_retry_ns_) {
             return;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -366,6 +366,15 @@ bool WebRTCStreamer::build_audio_pipeline() {
     return true;
 }
 
+// Every mic failure lands here — a synchronous set_state refusal or an error the bus reports later —
+// so the retry backoff cannot be sidestepped: an open that "succeeds" ASYNC and then fails on the bus
+// would otherwise be reopened by every 5 Hz poll. Same locking contract as closing in reconcile_audio.
+void WebRTCStreamer::fail_audio_pipeline() {
+    gst_element_set_state(audio_pipeline_, GST_STATE_NULL);
+    audio_playing_ = false;
+    mic_retry_ns_ = std::chrono::steady_clock::now().time_since_epoch().count() + kMicRetryBackoffNs;
+}
+
 void WebRTCStreamer::reconcile_audio() {
     // Mic-privacy gate: the mic pipeline is PLAYING only while some peer has audio ACTIVE, NULL otherwise
     // (the device is genuinely closed). Opening (NULL->PLAYING) starts threads and never blocks, so it is
@@ -393,8 +402,7 @@ void WebRTCStreamer::reconcile_audio() {
             mic_retry_ns_ = 0;
             RCLCPP_INFO(this->get_logger(), "Mic opened (a peer activated audio)");
         } else {
-            gst_element_set_state(audio_pipeline_, GST_STATE_NULL);
-            mic_retry_ns_ = now_ns + kMicRetryBackoffNs;
+            fail_audio_pipeline();
             RCLCPP_WARN(this->get_logger(), "Mic '%s' failed to open; retrying in %lld s",
                         audio_capture_device_.empty() ? "(default)" : audio_capture_device_.c_str(),
                         static_cast<long long>(kMicRetryBackoffNs / 1000000000));

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -10,17 +10,98 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>  // memcpy (push_frame)
+#include <filesystem>  // /proc/asound (mic lookup)
+#include <fstream>
 #include <memory>
 #include <sstream>
 
 namespace mars_cam {
 
 namespace {
+
+// Backoff between attempts to reopen a mic that just refused to open.
+constexpr int64_t kMicRetryBackoffNs = 10LL * 1000000000LL;
+
 struct FanOutTarget {
     std::string client_id;
     std::string stream;
     GstElement* src = nullptr;
 };
+
+// A card can capture iff it exposes a pcm*c node.
+bool card_can_capture(const std::filesystem::path& dir) {
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+        const std::string node = entry.path().filename().string();
+        if (node.rfind("pcm", 0) == 0 && node.back() == 'c') {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool looks_like_camera(std::string name) {
+    std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return std::tolower(c); });
+    return name.find("camera") != std::string::npos || name.find("webcam") != std::string::npos;
+}
+
+// A dedicated mic beats a camera's built-in one, and both beat the Tegra I2S card, whose capture nodes are
+// XBAR links with nothing on the far end. Mirrors the ladder workspace/inputs/micro_input.py walks, so the
+// agent and the teleop stream land on the same microphone.
+int capture_rank(const std::string& driver, const std::string& long_name) {
+    if (driver != "USB-Audio") {
+        return 1;
+    }
+    return looks_like_camera(long_name) ? 2 : 3;
+}
+
+// Parses lines of /proc/asound/cards: " 0 [Camera         ]: USB-Audio - Arducam USB Camera".
+// Each card's second (continuation) line has no brackets and is skipped.
+std::string best_capture_card() {
+    std::ifstream cards("/proc/asound/cards");
+    std::string line;
+    std::string best;
+    int best_rank = 0;
+    while (std::getline(cards, line)) {
+        const std::size_t open = line.find('[');
+        const std::size_t close = line.find("]: ");
+        const std::size_t dash = line.find(" - ", close == std::string::npos ? 0 : close);
+        if (open == std::string::npos || close == std::string::npos || dash == std::string::npos) {
+            continue;
+        }
+        std::string id = line.substr(open + 1, close - open - 1);
+        id.erase(id.find_last_not_of(' ') + 1);
+        const std::string driver = line.substr(close + 3, dash - close - 3);
+        const std::string long_name = line.substr(dash + 3);
+        std::error_code ec;
+        const std::filesystem::path dir = "/proc/asound/" + id;
+        if (!std::filesystem::exists(dir, ec) || !card_can_capture(dir)) {
+            continue;
+        }
+        const int rank = capture_rank(driver, long_name);
+        if (rank > best_rank) {
+            best_rank = rank;
+            best = id;
+        }
+    }
+    return best;
+}
+
+// The mic's ALSA card name is not the same on every MARS build, so a configured name that is absent here
+// would open nothing and the operator would hear silence with no clue why. Anything not in CARD= form (an
+// explicit hw:0,0) is a deliberate choice and is left alone.
+std::string resolve_capture_device(const std::string& configured) {
+    const std::size_t card = configured.find("CARD=");
+    if (card == std::string::npos) {
+        return configured;
+    }
+    std::error_code ec;
+    if (std::filesystem::exists("/proc/asound/" + configured.substr(card + 5), ec)) {
+        return configured;
+    }
+    const std::string best = best_capture_card();
+    return best.empty() ? configured : configured.substr(0, card + 5) + best;
+}
 }  // namespace
 
 // =============================================================================
@@ -245,6 +326,12 @@ bool WebRTCStreamer::build_audio_pipeline() {
                          audio_capture_device_.c_str());
             return false;
         }
+        const std::string resolved = resolve_capture_device(audio_capture_device_);
+        if (resolved != audio_capture_device_) {
+            RCLCPP_WARN(this->get_logger(), "audio_capture_device '%s' is not present; using '%s' instead",
+                        audio_capture_device_.c_str(), resolved.c_str());
+            audio_capture_device_ = resolved;
+        }
         src += " device=\"" + audio_capture_device_ + "\"";
     }
     // mic -> opus -> rtp -> appsink (the fan-out tap). Encoded once for all peers; matches the RTP caps
@@ -294,15 +381,28 @@ void WebRTCStreamer::reconcile_audio() {
         return;
     }
     if (want) {
+        // A mic that cannot open (unplugged, or held exclusively by another process) fails on every poll,
+        // so back the retry off — at 5 Hz it buries the log under its own GStreamer errors for as long as
+        // the operator leaves the toggle on.
+        const int64_t now_ns = std::chrono::steady_clock::now().time_since_epoch().count();
+        if (now_ns < mic_retry_ns_) {
+            return;
+        }
         if (gst_element_set_state(audio_pipeline_, GST_STATE_PLAYING) != GST_STATE_CHANGE_FAILURE) {
             audio_playing_ = true;
+            mic_retry_ns_ = 0;
             RCLCPP_INFO(this->get_logger(), "Mic opened (a peer activated audio)");
         } else {
-            RCLCPP_WARN(this->get_logger(), "Mic failed to open");
+            gst_element_set_state(audio_pipeline_, GST_STATE_NULL);
+            mic_retry_ns_ = now_ns + kMicRetryBackoffNs;
+            RCLCPP_WARN(this->get_logger(), "Mic '%s' failed to open; retrying in %lld s",
+                        audio_capture_device_.empty() ? "(default)" : audio_capture_device_.c_str(),
+                        static_cast<long long>(kMicRetryBackoffNs / 1000000000));
         }
     } else {
         gst_element_set_state(audio_pipeline_, GST_STATE_NULL);  // closes the device; joins the fan-out thread
         audio_playing_ = false;
+        mic_retry_ns_ = 0;  // the next request tries immediately, whatever the last one cost
         RCLCPP_INFO(this->get_logger(), "Mic closed (no peer wants audio)");
     }
 }

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -244,6 +244,8 @@ WebRTCStreamer::~WebRTCStreamer() {
     }
     if (audio_sink_)
         gst_object_unref(audio_sink_);
+    if (audio_src_)
+        gst_object_unref(audio_src_);
     if (audio_pipeline_) {
         gst_element_set_state(audio_pipeline_, GST_STATE_NULL);
         gst_object_unref(audio_pipeline_);

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -348,7 +348,14 @@ void WebRTCStreamer::poll_pipeline_health() {
     };
 
     drain_bus(encode_pipeline_, "encode", /*expected_teardown=*/false);
-    drain_bus(audio_pipeline_, "audio", /*expected_teardown=*/false);
+    // A runtime mic error (device unplugged, fatal xrun) otherwise leaves audio_playing_ true with a dead
+    // pipeline, and reconcile_audio() no-ops on it forever. Reset so the reconcile below reopens — once if
+    // the fault was transient, onto the failed-open backoff if the device is gone. Safe here: the lock is
+    // not yet held, so NULL-ing (which joins the fan-out thread) cannot deadlock.
+    if (drain_bus(audio_pipeline_, "audio", /*expected_teardown=*/false) && audio_playing_) {
+        gst_element_set_state(audio_pipeline_, GST_STATE_NULL);
+        audio_playing_ = false;
+    }
 
     std::unique_lock<std::mutex> lock(peers_mutex_);
     if (peers_.empty()) {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -349,12 +349,11 @@ void WebRTCStreamer::poll_pipeline_health() {
 
     drain_bus(encode_pipeline_, "encode", /*expected_teardown=*/false);
     // A runtime mic error (device unplugged, fatal xrun) otherwise leaves audio_playing_ true with a dead
-    // pipeline, and reconcile_audio() no-ops on it forever. Reset so the reconcile below reopens — once if
-    // the fault was transient, onto the failed-open backoff if the device is gone. Safe here: the lock is
-    // not yet held, so NULL-ing (which joins the fan-out thread) cannot deadlock.
+    // pipeline, and reconcile_audio() no-ops on it forever. Fail it onto the backoff, and the reconcile
+    // retries once that expires. Safe here: the lock is not yet held, so NULL-ing (which joins the
+    // fan-out thread) cannot deadlock.
     if (drain_bus(audio_pipeline_, "audio", /*expected_teardown=*/false) && audio_playing_) {
-        gst_element_set_state(audio_pipeline_, GST_STATE_NULL);
-        audio_playing_ = false;
+        fail_audio_pipeline();
     }
 
     std::unique_lock<std::mutex> lock(peers_mutex_);

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -604,12 +604,15 @@ class MicroInput(InputDevice):
         try:
             result = subprocess.run(["arecord", "-l"], capture_output=True, text=True, timeout=5)
             if result.returncode == 0:
-                pattern = r"card (\d+):.*?\[([^\]]+)\].*?device (\d+):"
+                pattern = r"card (\d+): (\S+) \[([^\]]+)\].*?device (\d+):"
                 for match in re.finditer(pattern, result.stdout):
                     card_num = match.group(1)
-                    card_name = match.group(2)
-                    device_num = match.group(3)
-                    device_id = f"plughw:{card_num},{device_num}"
+                    card_id = match.group(2)
+                    card_name = match.group(3)
+                    device_num = match.group(4)
+                    # sysdefault, not plughw: it goes through dsnoop, so the teleop WebRTC stream can open
+                    # the same mic at the same time. plughw takes the card exclusively and locks teleop out.
+                    device_id = f"sysdefault:CARD={card_id}"
                     devices.append({"card": card_num, "device": device_num, "name": card_name, "id": device_id})
         except Exception:
             pass

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -612,7 +612,9 @@ class MicroInput(InputDevice):
                     device_num = match.group(4)
                     # sysdefault, not plughw: it goes through dsnoop, so the teleop WebRTC stream can open
                     # the same mic at the same time. plughw takes the card exclusively and locks teleop out.
-                    device_id = f"sysdefault:CARD={card_id}"
+                    # sysdefault only addresses the card's device 0; the rare card capturing on another
+                    # device keeps the exact (exclusive) address rather than failing to open at all.
+                    device_id = f"sysdefault:CARD={card_id}" if device_num == "0" else f"plughw:{card_num},{device_num}"
                     devices.append({"card": card_num, "device": device_num, "name": card_name, "id": device_id})
         except Exception:
             pass

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -610,10 +610,9 @@ class MicroInput(InputDevice):
                     card_id = match.group(2)
                     card_name = match.group(3)
                     device_num = match.group(4)
-                    # sysdefault, not plughw: it goes through dsnoop, so the teleop WebRTC stream can open
-                    # the same mic at the same time. plughw takes the card exclusively and locks teleop out.
-                    # sysdefault only addresses the card's device 0; the rare card capturing on another
-                    # device keeps the exact (exclusive) address rather than failing to open at all.
+                    # sysdefault goes through dsnoop, so the teleop WebRTC stream can open the same mic
+                    # concurrently (plughw is exclusive and would lock it out) — but it only addresses
+                    # device 0, so a card capturing on another device keeps its exact, exclusive address.
                     device_id = f"sysdefault:CARD={card_id}" if device_num == "0" else f"plughw:{card_num},{device_num}"
                     devices.append({"card": card_num, "device": device_num, "name": card_name, "id": device_id})
         except Exception:


### PR DESCRIPTION
## The bug

The teleop **"Robot mic on — click to mute"** toggle does nothing on some robots. The UI flips, the START goes out, and the operator hears silence.

The WebRTC streamer's capture device is hardcoded to `sysdefault:CARD=Light`. On a robot whose mic enumerates under any other ALSA card name, that opens nothing:

```
[ERROR] [webrtc_streamer]: GStreamer audio error from alsasrc0: Could not open audio device for recording.
[WARN]  [webrtc_streamer]: Mic failed to open
```

…repeating ten lines a second, because the health poll retries the failed open at 5 Hz for as long as the toggle is left on.

The agent's mic keeps working throughout, which is what makes this confusing to diagnose. It's a completely separate capture path (`workspace/inputs/micro_input.py`, `arecord`) that *discovers* its device from `arecord -l` instead of trusting a configured name.

## Two faults, both fixed

**1. The card name isn't portable.** An absent name now falls back to whatever card can actually capture, ranked the way micro_input's ladder ranks — dedicated USB mic first, a camera's built-in mic next, the Tegra I2S card only as a last resort (its capture nodes are XBAR links with nothing on the far end). A configured name that *is* present still wins, and an explicit `hw:0,0` is left alone as a deliberate choice.

**2. The two mic paths locked each other out.** This one bites even with the name correct. The agent opened `plughw:{card},{device}`, which takes the card exclusively — so the toggle failed with the identical error for as long as the agent was listening, which is precisely when an operator wants to listen in. Addressing it as `sysdefault:CARD=` routes through dsnoop and the two capture the same mic side by side.

Measured, on card 0:

| First holder | Second opener | Result |
|---|---|---|
| `plughw:0,0` (agent, before) | `sysdefault:CARD=Camera` | ❌ `Device or resource busy` |
| `sysdefault:CARD=Camera` (agent, after) | `sysdefault:CARD=Camera` | ✅ both capture |

A failed open now also backs off 10 s instead of hammering at 5 Hz, and names the device it failed on.

## Why not just share the agent's code

`micro_input.py` is workspace user code — editable and hot-reloaded — so having a C++ ROS node depend on it inverts the dependency. The two also have genuinely different needs: the streamer's mic pipeline must stay `NULL` until a peer opts in, for the privacy gate. What's worth sharing is the **device convention** (`sysdefault:CARD=`, never `plughw:`), not the implementation; the ranking is ~20 lines on each side.

Routing the streamer's audio off the agent's `/mic/audio` topic instead was considered and rejected: it adds a base64-over-ROS hop and its latency to the one path where latency is the product, and it would make teleop audio depend on the agent being active.

## Testing

- Agent params (24 kHz stereo) and the streamer's exact GStreamer chain (48 kHz mono → opus) capture the same card **concurrently**, clean on both sides.
- Resolver exercised against the live `/proc/asound` and synthetic card trees: mic-beats-camera (ranks above a lower-numbered camera), non-USB last resort, playback-only cards ignored, no-capture-card leaves the configured value untouched.
- `mars_cam` builds clean, no new warnings; `ruff check` / `format` pass on the Python change.

**Not verified:** no audio has been driven end to end through a browser. This clears the two faults that stop the mic from opening at all; anything downstream in the fan-out is untested.
