### PR TITLE
feat(teleop): add relocate shortcut

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1633,6 +1633,13 @@ select.skill-input {
   top: 72px;
 }
 
+/* The hardware telemetry card is taller than the simulator's camera strip.
+   Clear its bottom edge so Relocate cannot be covered while Go To remains
+   visible below it. */
+.cockpit.teleop-hardware .cam-map-host.big .map-controls {
+  top: 123px;
+}
+
 /* Map promoted to the big stage: full-bleed under the control overlays. Inserted as the stage's first
    child, so DOM order keeps the overlays (and the strip) painting on top; the video stage hides. */
 .cam-map-host.big {
@@ -9389,7 +9396,8 @@ select.skill-input {
   /* The camera strip spans the whole top on phones -- start below the tiles
      (the .big selector outranks the desktop cockpit offset). */
   .map-controls,
-  .cam-map-host.big .map-controls {
+  .cam-map-host.big .map-controls,
+  .cockpit.teleop-hardware .cam-map-host.big .map-controls {
     top: calc(26px + min(120px, 24vw));
     left: 14px;
   }

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -2397,6 +2397,26 @@ select.skill-input {
   color: var(--ctl-accent);
 }
 
+/* ---- relocate shortcut ---------------------------------------------------- */
+
+.relocate-control {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.relocate-label {
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--ctl-text);
+}
+
+.relocate-button:focus-visible {
+  outline: 2px solid var(--ctl-accent);
+  outline-offset: 2px;
+}
+
 /* ---- head tilt ------------------------------------------------------------ */
 
 .head-tilt {

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -2397,26 +2397,6 @@ select.skill-input {
   color: var(--ctl-accent);
 }
 
-/* ---- relocate shortcut ---------------------------------------------------- */
-
-.relocate-control {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-
-.relocate-label {
-  font-size: 9px;
-  letter-spacing: 0.08em;
-  color: var(--ctl-text);
-}
-
-.relocate-button:focus-visible {
-  outline: 2px solid var(--ctl-accent);
-  outline-offset: 2px;
-}
-
 /* ---- head tilt ------------------------------------------------------------ */
 
 .head-tilt {

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -191,7 +191,7 @@ function rasterizeGrid(msg, canvas, ctx, paint) {
  *   small); enables scroll-to-zoom. Omit to fit the whole grid (the standalone page). onZoomChange
  *   fires after each wheel-zoom. layers turns on optional overlays (Nav page): live lidar scan,
  *   global/local costmaps, odometry trail — each adds its subscription only while enabled.
- * @returns {{ destroy: () => void, refresh: () => void, openLocate: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void, highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void, robotNowS: () => number }}
+ * @returns {{ destroy: () => void, refresh: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void, highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void, robotNowS: () => number }}
  */
 export function createMap(root, opts = {}) {
   let zoomMeters = opts.zoom;
@@ -232,7 +232,7 @@ export function createMap(root, opts = {}) {
   const backBtn = makeButton(ICONS.back, "");
   backBtn.classList.add("map-btn-compact");
   backBtn.title = "Back";
-  const locateBtn = makeButton(ICONS.locate, "Locate", "auto or manual");
+  const locateBtn = makeButton(ICONS.locate, "Relocate", "auto or manual");
   locateBtn.title = `${LOCALIZE_SERVICE} · ${SET_INITIAL_POSE_SERVICE}`;
   const autoBtn = makeButton(ICONS.auto, "Auto", "match lidar to the map");
   autoBtn.title = LOCALIZE_SERVICE;
@@ -1849,13 +1849,6 @@ export function createMap(root, opts = {}) {
      *  resized against the box it actually landed in. */
     refresh() {
       fit();
-    },
-    /** Open the shared Auto / Manual localization controls. Teleop uses this
-     * after promoting its map, so relocation is reachable without first
-     * navigating to the dedicated Nav page. */
-    openLocate() {
-      if (mappingMode) return;
-      setUi("locate");
     },
     /** Swap to a saved zoom (e.g. when this widget reparents between thumbnail and full stage). */
     setZoom(meters) {

--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -191,7 +191,7 @@ function rasterizeGrid(msg, canvas, ctx, paint) {
  *   small); enables scroll-to-zoom. Omit to fit the whole grid (the standalone page). onZoomChange
  *   fires after each wheel-zoom. layers turns on optional overlays (Nav page): live lidar scan,
  *   global/local costmaps, odometry trail — each adds its subscription only while enabled.
- * @returns {{ destroy: () => void, refresh: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void, highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void, robotNowS: () => number }}
+ * @returns {{ destroy: () => void, refresh: () => void, openLocate: () => void, setZoom: (meters: number) => void, setLayer: (name: LayerName, on: boolean) => void, setMappingMode: (on: boolean) => void, clearTrail: () => void, mapChanged: () => void, highlightMemory: (id: number | null) => void, focusMemory: (id: number) => void, robotNowS: () => number }}
  */
 export function createMap(root, opts = {}) {
   let zoomMeters = opts.zoom;
@@ -1849,6 +1849,13 @@ export function createMap(root, opts = {}) {
      *  resized against the box it actually landed in. */
     refresh() {
       fit();
+    },
+    /** Open the shared Auto / Manual localization controls. Teleop uses this
+     * after promoting its map, so relocation is reachable without first
+     * navigating to the dedicated Nav page. */
+    openLocate() {
+      if (mappingMode) return;
+      setUi("locate");
     },
     /** Swap to a saved zoom (e.g. when this widget reparents between thumbnail and full stage). */
     setZoom(meters) {

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -48,7 +48,7 @@ const MAP_ZOOM_DEFAULT = { small: 6, big: 16 }; // tighter as a thumbnail, wider
  *   primary. Switching views still works and still persists — the next mount
  *   just starts here again. Falls back to the usual default if the view is not
  *   in the roster.
- * @returns {{ destroy: () => void }}
+ * @returns {{ destroy: () => void, openRelocate: () => void }}
  */
 export function createCameraSwitch(parent, session, ros, opts = {}) {
   const storeKey = opts.storeKey || STORE_KEY;
@@ -72,9 +72,10 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   // synchronously so the tiles have something to reparent, and the widget drops into it once the import
   // lands. It is persistent and reparents between a strip tile (small) and the stage (big) — never rebuilt.
   /** @type {HTMLElement | null} */ let mapHost = null;
-  /** @type {{ destroy: () => void, setZoom: (m: number) => void, refresh: () => void } | null} */ let mapWidget = null;
+  /** @type {{ destroy: () => void, setZoom: (m: number) => void, refresh: () => void, openLocate: () => void } | null} */ let mapWidget = null;
   /** @type {"small" | "big"} which saved zoom is live: thumbnail vs full stage */ let mapMode = "small";
   let mapZoom = { ...MAP_ZOOM_DEFAULT };
+  let locateOnMapReady = false;
 
   loadPrefs();
 
@@ -204,6 +205,10 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
             // robot's spatial memory, and this is where you watch it happen.
             layers: { memories: true },
           });
+          if (locateOnMapReady) {
+            locateOnMapReady = false;
+            mapWidget.openLocate();
+          }
         })
         .catch(() => {
           // A dropped fetch must not blank the map for the session: with the
@@ -388,7 +393,16 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   }, undefined, "std_msgs/msg/String");
 
   return {
+    /** Promote the map and open its existing Auto / Manual localization menu.
+     * If the lazily-loaded widget is still arriving, remember the intent and
+     * open the menu as soon as it mounts. */
+    openRelocate() {
+      if (primary !== MAP_ID) promote(MAP_ID);
+      if (mapWidget) mapWidget.openLocate();
+      else locateOnMapReady = true;
+    },
     destroy() {
+      locateOnMapReady = false;
       unsub?.();
       unsubSession();
       mapWidget?.destroy();

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -48,7 +48,7 @@ const MAP_ZOOM_DEFAULT = { small: 6, big: 16 }; // tighter as a thumbnail, wider
  *   primary. Switching views still works and still persists — the next mount
  *   just starts here again. Falls back to the usual default if the view is not
  *   in the roster.
- * @returns {{ destroy: () => void, openRelocate: () => void }}
+ * @returns {{ destroy: () => void }}
  */
 export function createCameraSwitch(parent, session, ros, opts = {}) {
   const storeKey = opts.storeKey || STORE_KEY;
@@ -72,10 +72,9 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   // synchronously so the tiles have something to reparent, and the widget drops into it once the import
   // lands. It is persistent and reparents between a strip tile (small) and the stage (big) — never rebuilt.
   /** @type {HTMLElement | null} */ let mapHost = null;
-  /** @type {{ destroy: () => void, setZoom: (m: number) => void, refresh: () => void, openLocate: () => void } | null} */ let mapWidget = null;
+  /** @type {{ destroy: () => void, setZoom: (m: number) => void, refresh: () => void } | null} */ let mapWidget = null;
   /** @type {"small" | "big"} which saved zoom is live: thumbnail vs full stage */ let mapMode = "small";
   let mapZoom = { ...MAP_ZOOM_DEFAULT };
-  let locateOnMapReady = false;
 
   loadPrefs();
 
@@ -205,10 +204,6 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
             // robot's spatial memory, and this is where you watch it happen.
             layers: { memories: true },
           });
-          if (locateOnMapReady) {
-            locateOnMapReady = false;
-            mapWidget.openLocate();
-          }
         })
         .catch(() => {
           // A dropped fetch must not blank the map for the session: with the
@@ -393,16 +388,7 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   }, undefined, "std_msgs/msg/String");
 
   return {
-    /** Promote the map and open its existing Auto / Manual localization menu.
-     * If the lazily-loaded widget is still arriving, remember the intent and
-     * open the menu as soon as it mounts. */
-    openRelocate() {
-      if (primary !== MAP_ID) promote(MAP_ID);
-      if (mapWidget) mapWidget.openLocate();
-      else locateOnMapReady = true;
-    },
     destroy() {
-      locateOnMapReady = false;
       unsub?.();
       unsubSession();
       mapWidget?.destroy();

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -55,6 +55,10 @@ export function mount(stage) {
  * @returns {{ destroy: () => void }}
  */
 function buildCockpit(root) {
+  // Hardware shows the telemetry card in the map's top-left corner; expose the
+  // mode to CSS so map controls can clear it without moving the sim layout.
+  root.classList.toggle("teleop-hardware", !config.simControls);
+
   const session = createSession();
   dbg.session = session;
 

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -84,8 +84,10 @@ function buildCockpit(root) {
   if (!config.simControls && videoStage.audioEl) {
     parts.push(createAudioToggle(rightRail, session, videoStage.audioEl));
   }
+  const cameraSwitch = createCameraSwitch(root, session, ros);
   parts.push(
     createSpeedModes(rightRail, ros),
+    createRelocateButton(rightRail, cameraSwitch.openRelocate),
     createHeadTilt(rightRail, ros),
     createWasdChips(chipsOverlay, keyboard),
     createJoystick(stickOverlay, drive),
@@ -94,7 +96,7 @@ function buildCockpit(root) {
     createSkillsMenu(ttsOverlay, ros),
     createArmPanel(armOverlay, ros, { hideServices: !!config.simControls }),
     ...(config.simControls ? [] : [createProfilingPanel(root, session)]),
-    createCameraSwitch(root, session, ros),
+    cameraSwitch,
     keyboard,
   );
 
@@ -109,6 +111,42 @@ function buildCockpit(root) {
       for (const part of parts) part.destroy();
       session.destroy();
       root.innerHTML = "";
+    },
+  };
+}
+
+/**
+ * Keep relocation one click away while driving: the map switcher promotes the
+ * live map and opens the exact Auto / Manual controls used by Navigation.
+ * @param {HTMLElement} parent
+ * @param {() => void} openRelocate
+ * @returns {{ destroy: () => void }}
+ */
+function createRelocateButton(parent, openRelocate) {
+  const wrap = document.createElement("div");
+  wrap.className = "relocate-control";
+
+  const label = document.createElement("span");
+  label.className = "relocate-label";
+  label.textContent = "RELOCATE";
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "icon-toggle relocate-button";
+  button.title = "Relocate robot on the map (auto or manual)";
+  button.setAttribute("aria-label", "Relocate robot");
+  button.innerHTML =
+    '<svg viewBox="0 0 16 16" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" aria-hidden="true">' +
+    '<circle cx="8" cy="8" r="4.5"/><path d="M8 .8v2.4M8 12.8v2.4M.8 8h2.4M12.8 8h2.4"/>' +
+    "</svg>";
+  button.addEventListener("click", openRelocate);
+
+  wrap.append(label, button);
+  parent.appendChild(wrap);
+  return {
+    destroy() {
+      button.removeEventListener("click", openRelocate);
+      wrap.remove();
     },
   };
 }

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -84,10 +84,8 @@ function buildCockpit(root) {
   if (!config.simControls && videoStage.audioEl) {
     parts.push(createAudioToggle(rightRail, session, videoStage.audioEl));
   }
-  const cameraSwitch = createCameraSwitch(root, session, ros);
   parts.push(
     createSpeedModes(rightRail, ros),
-    createRelocateButton(rightRail, cameraSwitch.openRelocate),
     createHeadTilt(rightRail, ros),
     createWasdChips(chipsOverlay, keyboard),
     createJoystick(stickOverlay, drive),
@@ -96,7 +94,7 @@ function buildCockpit(root) {
     createSkillsMenu(ttsOverlay, ros),
     createArmPanel(armOverlay, ros, { hideServices: !!config.simControls }),
     ...(config.simControls ? [] : [createProfilingPanel(root, session)]),
-    cameraSwitch,
+    createCameraSwitch(root, session, ros),
     keyboard,
   );
 
@@ -111,42 +109,6 @@ function buildCockpit(root) {
       for (const part of parts) part.destroy();
       session.destroy();
       root.innerHTML = "";
-    },
-  };
-}
-
-/**
- * Keep relocation one click away while driving: the map switcher promotes the
- * live map and opens the exact Auto / Manual controls used by Navigation.
- * @param {HTMLElement} parent
- * @param {() => void} openRelocate
- * @returns {{ destroy: () => void }}
- */
-function createRelocateButton(parent, openRelocate) {
-  const wrap = document.createElement("div");
-  wrap.className = "relocate-control";
-
-  const label = document.createElement("span");
-  label.className = "relocate-label";
-  label.textContent = "RELOCATE";
-
-  const button = document.createElement("button");
-  button.type = "button";
-  button.className = "icon-toggle relocate-button";
-  button.title = "Relocate robot on the map (auto or manual)";
-  button.setAttribute("aria-label", "Relocate robot");
-  button.innerHTML =
-    '<svg viewBox="0 0 16 16" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" aria-hidden="true">' +
-    '<circle cx="8" cy="8" r="4.5"/><path d="M8 .8v2.4M8 12.8v2.4M.8 8h2.4M12.8 8h2.4"/>' +
-    "</svg>";
-  button.addEventListener("click", openRelocate);
-
-  wrap.append(label, button);
-  parent.appendChild(wrap);
-  return {
-    destroy() {
-      button.removeEventListener("click", openRelocate);
-      wrap.remove();
     },
   };
 }


### PR DESCRIPTION
## Summary

- add a labeled Relocate shortcut to the Teleop right rail
- promote the live map and open the existing Auto / Manual localization controls in one click
- preserve the action when the map widget is still loading lazily

## Validation

- `node --test webapp/tests/*.test.js` (8 test files pass)
- `node --check` on all three modified JavaScript files
- changed-file TypeScript diagnostics: none
- `git diff --check`

The repository-wide TypeScript check still reports the existing unrelated vendor, Arm SDK, and other baseline diagnostics.