### PR TITLE
fix(control): keep the drive smoother running when system helpers hang

### DIFF
--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -111,7 +111,6 @@ std::string exec_command(const std::string& cmd) {
         const auto left =
             std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
         if (left <= std::chrono::milliseconds::zero()) {
-            killpg(pid, SIGKILL);
             break;
         }
         pollfd pfd{fds[0], POLLIN, 0};
@@ -120,7 +119,6 @@ std::string exec_command(const std::string& cmd) {
             continue;
         }
         if (ready <= 0) {
-            killpg(pid, SIGKILL);
             break;
         }
         char buffer[256];
@@ -134,7 +132,16 @@ std::string exec_command(const std::string& cmd) {
         result.append(buffer, static_cast<size_t>(n));
     }
     close(fds[0]);
-    waitpid(pid, nullptr, 0);
+    // EOF only proves the last pipeline stage closed stdout; an earlier stage may
+    // still be hung, so the reap honours the same deadline before killing the group.
+    while (waitpid(pid, nullptr, WNOHANG) == 0) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            killpg(pid, SIGKILL);
+            waitpid(pid, nullptr, 0);
+            break;
+        }
+        poll(nullptr, 0, 10);
+    }
 
     // Trim trailing newline
     while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -38,6 +38,7 @@
 #include <memory>
 #include <regex>
 #include <sstream>
+#include <thread>
 #include <cerrno>
 #include <poll.h>
 #include <signal.h>
@@ -75,24 +76,33 @@ bool is_running_in_docker() {
 }
 
 /**
- * Execute a shell command and return its output (trimmed), giving up after
- * EXEC_COMMAND_TIMEOUT. popen() has no deadline, and a hung helper must cost the
- * caller seconds, not forever — a wedged avahi-daemon once blocked `avahi-resolve`
- * indefinitely. The child gets its own process group so the timeout kills the
- * whole pipeline, not just the shell.
+ * Execute a shell command and return its output (trimmed) plus exit code, giving
+ * up after `timeout`. popen()/system() have no deadline, and a hung helper must
+ * cost the caller seconds, not forever — a wedged avahi-daemon once blocked
+ * `avahi-resolve` indefinitely. The child gets its own process group so the
+ * timeout kills the whole pipeline, not just the shell.
+ *
+ * The default is ~100× the healthy latency of the local helpers, keeping the
+ * worst-case slow-facts refresh to a few seconds; callers of genuinely slow
+ * commands (network git, systemctl) pass their own budget.
  */
-constexpr std::chrono::seconds EXEC_COMMAND_TIMEOUT{10};
+constexpr std::chrono::seconds EXEC_COMMAND_TIMEOUT{2};
 
-std::string exec_command(const std::string& cmd) {
+struct ExecResult {
+    std::string output;
+    int exit_code;  // -1: spawn failure or killed at the deadline
+};
+
+ExecResult exec_command_status(const std::string& cmd, const std::chrono::seconds timeout = EXEC_COMMAND_TIMEOUT) {
     int fds[2];
     if (pipe(fds) != 0) {
-        return "";
+        return {"", -1};
     }
     const pid_t pid = fork();
     if (pid < 0) {
         close(fds[0]);
         close(fds[1]);
-        return "";
+        return {"", -1};
     }
     if (pid == 0) {
         setpgid(0, 0);
@@ -106,7 +116,7 @@ std::string exec_command(const std::string& cmd) {
     close(fds[1]);
 
     std::string result;
-    const auto deadline = std::chrono::steady_clock::now() + EXEC_COMMAND_TIMEOUT;
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
     for (;;) {
         const auto left =
             std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
@@ -134,7 +144,17 @@ std::string exec_command(const std::string& cmd) {
     close(fds[0]);
     // EOF only proves the last pipeline stage closed stdout; an earlier stage may
     // still be hung, so the reap honours the same deadline before killing the group.
-    while (waitpid(pid, nullptr, WNOHANG) == 0) {
+    int exit_code = -1;
+    int status = 0;
+    for (;;) {
+        const pid_t reaped = waitpid(pid, &status, WNOHANG);
+        if (reaped == pid) {
+            exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+            break;
+        }
+        if (reaped < 0) {
+            break;
+        }
         if (std::chrono::steady_clock::now() >= deadline) {
             killpg(pid, SIGKILL);
             waitpid(pid, nullptr, 0);
@@ -147,7 +167,11 @@ std::string exec_command(const std::string& cmd) {
     while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {
         result.pop_back();
     }
-    return result;
+    return {std::move(result), exit_code};
+}
+
+std::string exec_command(const std::string& cmd, const std::chrono::seconds timeout = EXEC_COMMAND_TIMEOUT) {
+    return exec_command_status(cmd, timeout).output;
 }
 
 /**
@@ -225,39 +249,26 @@ std::string get_latest_release_tag(const std::string& mars_root) {
 }
 
 /**
- * Get the latest tag by version. Returns empty string if the repo has no tags.
+ * Get the subject (first line) of `latest_tag`'s annotation message.
+ * Returns empty string if the tag is empty or has no message.
  */
-std::string get_latest_tag(const std::string& mars_root) {
-    return get_latest_release_tag(mars_root);
-}
-
-/**
- * Get the subject (first line) of the latest tag's annotation message.
- * Returns empty string if no tags or tag has no message.
- */
-std::string get_tag_subject(const std::string& mars_root) {
-    std::string latest_tag = get_latest_tag(mars_root);
+std::string get_tag_subject(const std::string& mars_root, const std::string& latest_tag) {
     if (latest_tag.empty()) {
         return "";
     }
-
-    // Get the tag message subject (first line only)
     std::string subject_cmd =
         "cd \"" + mars_root + "\" && git tag -l --format='%(contents:subject)' \"" + latest_tag + "\" 2>/dev/null";
     return exec_command(subject_cmd);
 }
 
 /**
- * Get the body (everything after first line) of the latest tag's annotation message.
- * Returns empty string if no tags or tag has no body.
+ * Get the body (everything after first line) of `latest_tag`'s annotation message.
+ * Returns empty string if the tag is empty or has no body.
  */
-std::string get_tag_body(const std::string& mars_root) {
-    std::string latest_tag = get_latest_tag(mars_root);
+std::string get_tag_body(const std::string& mars_root, const std::string& latest_tag) {
     if (latest_tag.empty()) {
         return "";
     }
-
-    // Get the tag message body (everything after subject line)
     std::string body_cmd =
         "cd \"" + mars_root + "\" && git tag -l --format='%(contents:body)' \"" + latest_tag + "\" 2>/dev/null";
     return exec_command(body_cmd);
@@ -271,7 +282,7 @@ std::string get_tag_body(const std::string& mars_root) {
  *   source without .git), returns "0.0.0-dev". A real robot is always checked
  *   out on a tag, so this fallback only applies in development.
  */
-std::string get_robot_version(const std::string& mars_root) {
+std::string get_robot_version(const std::string& mars_root, const std::string& latest_tag) {
     // Check if we're exactly on a tag (works for both branch and detached HEAD)
     std::string exact_cmd = "cd \"" + mars_root + "\" && git describe --exact-match --tags HEAD 2>/dev/null";
     std::string exact_tag = exec_command(exact_cmd);
@@ -285,8 +296,6 @@ std::string get_robot_version(const std::string& mars_root) {
     // Detached HEAD not exactly on a release tag (e.g. interrupted update, manual
     // checkout, or a feature branch) is treated like development: fall back to
     // the latest release tag + "-dev" instead of failing the version check.
-
-    std::string latest_tag = get_latest_release_tag(mars_root);
 
     // No release tags, or not a git checkout at all (the sim container mounts the
     // source without .git, so git errors and 2>/dev/null leaves this empty). Report a
@@ -373,16 +382,16 @@ bool set_system_hostname(const std::string& sanitized_hostname, std::string& err
 
     // Use sudo hostnamectl to set the hostname
     std::string cmd = "sudo hostnamectl hostname --static \"" + sanitized_hostname + "\" 2>&1";
-
-    // Execute the command
-    int exit_code = std::system(cmd.c_str());
-    if (WEXITSTATUS(exit_code) != 0) {
+    // Bounded, not system(): hostnamectl talks to systemd and can block on a sick
+    // daemon, and this runs on the slow executor thread every 30 s.
+    if (exec_command_status(cmd, std::chrono::seconds(10)).exit_code != 0) {
         error_msg = "Failed to set hostname via hostnamectl";
         return false;
     }
 
-    // Restart avahi-daemon to apply hostname changes to mDNS
-    std::system("sudo systemctl restart avahi-daemon.service 2>/dev/null");
+    // Restart avahi-daemon to apply hostname changes to mDNS. Best-effort, but
+    // bounded: restarting a wedged avahi unit can hang until systemd's job timeout.
+    exec_command_status("sudo systemctl restart avahi-daemon.service 2>/dev/null", std::chrono::seconds(10));
 
     return true;
 }
@@ -392,10 +401,11 @@ bool set_system_hostname(const std::string& sanitized_hostname, std::string& err
  * Returns true if updates are available, false otherwise.
  */
 bool check_update_available(const std::string& mars_root) {
-    // innate-update --quick-check returns 0 if up-to-date, 1 if updates available
+    // innate-update --quick-check returns 0 if up-to-date, 1 if updates available.
+    // 30 s budget: on a cache miss it does a network `git fetch`, which has no
+    // timeout of its own and must not pin the slow thread on a dead network.
     std::string cmd = mars_root + "/scripts/update/innate-update quick-check >/dev/null 2>&1";
-    int result = std::system(cmd.c_str());
-    return (WEXITSTATUS(result) != 0);
+    return exec_command_status(cmd, std::chrono::seconds(30)).exit_code > 0;
 }
 
 /**
@@ -435,11 +445,13 @@ class AppControl : public rclcpp::Node {
         _load_app_config();
 
         // Everything that shells out (robot info, hostname sync, the admin services)
-        // runs in this group, serviced by the executor's second thread: a hung external
-        // helper must never starve the drive smoother — a wedged avahi-daemon once
-        // blocked avahi-resolve for seconds per call and drove the 50 Hz timer to
+        // runs in this group, spun by its own executor thread (see main): a hung
+        // external helper must never starve the drive smoother — a wedged avahi-daemon
+        // once blocked avahi-resolve for seconds per call and drove the 50 Hz timer to
         // ~0.2 Hz. Mutually exclusive, so robot_info.json access stays serialised.
-        slow_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+        // Not auto-added with the node — main assigns it to the slow executor.
+        slow_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive,
+                                                  /*automatically_add_to_executor_with_node=*/false);
 
         // Declare parameters
         std::string mars_root = get_mars_root();
@@ -618,6 +630,10 @@ class AppControl : public rclcpp::Node {
         RCLCPP_INFO(this->get_logger(), "AppControl node started. [C++]");
     }
 
+    rclcpp::CallbackGroup::SharedPtr slow_group() const {
+        return slow_group_;
+    }
+
    private:
     std::string get_mars_root() {
         const char* env_root = std::getenv("INNATE_OS_ROOT");
@@ -765,8 +781,6 @@ class AppControl : public rclcpp::Node {
         if (last_slow_facts_time_ != 0.0 && (current_time - last_slow_facts_time_) < SLOW_FACTS_INTERVAL_S) {
             return slow_facts_;
         }
-        last_slow_facts_time_ = current_time;
-
         std::string new_ssid = nmcli_get_active_wifi_ssid();
         if (new_ssid != slow_facts_.wifi_ssid) {
             if (!new_ssid.empty()) {
@@ -783,9 +797,18 @@ class AppControl : public rclcpp::Node {
             slow_facts_.bluetooth_id = get_bluetooth_device_id();
         }
         const std::string mars_root = get_mars_root();
-        slow_facts_.version = get_robot_version(mars_root);
-        slow_facts_.tag_subject = get_tag_subject(mars_root);
-        slow_facts_.tag_body = get_tag_body(mars_root);
+        // One `git tag --list` shared by the version and both annotation reads.
+        const std::string latest_tag = get_latest_release_tag(mars_root);
+        slow_facts_.version = get_robot_version(mars_root, latest_tag);
+        slow_facts_.tag_subject = get_tag_subject(mars_root, latest_tag);
+        slow_facts_.tag_body = get_tag_body(mars_root, latest_tag);
+
+        // Stamped after the gather, not before: when the helpers hang, a refresh eats
+        // the whole interval, and stamping up front would make the just-skipped 1 Hz
+        // timer start the next refresh immediately — the slow thread would do nothing
+        // but shell out, and the admin services would queue behind it forever.
+        last_slow_facts_time_ =
+            std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch()).count();
         return slow_facts_;
     }
 
@@ -1264,22 +1287,27 @@ class AppControl : public rclcpp::Node {
                 data_to_publish_dict["minimum_app_version"] = app_config_["minimum_app_version"];
             }
 
-            const SlowFacts& facts = cached_slow_facts();
-            if (!facts.wifi_ssid.empty()) {
-                data_to_publish_dict["wifi_ssid"] = facts.wifi_ssid;
-            }
-            data_to_publish_dict["version"] = facts.version;
-            if (!facts.tag_subject.empty()) {
-                data_to_publish_dict["tag_subject"] = facts.tag_subject;
-            }
-            if (!facts.tag_body.empty()) {
-                data_to_publish_dict["tag_body"] = facts.tag_body;
-            }
-            if (!facts.bluetooth_id.empty()) {
-                data_to_publish_dict["device_id"] = facts.bluetooth_id;
-            }
-            if (!facts.hostname.empty()) {
-                data_to_publish_dict["hostname"] = facts.hostname;
+            // Inner boundary: a failed fact-gather drops these fields, not the payload.
+            try {
+                const SlowFacts& facts = cached_slow_facts();
+                if (!facts.wifi_ssid.empty()) {
+                    data_to_publish_dict["wifi_ssid"] = facts.wifi_ssid;
+                }
+                data_to_publish_dict["version"] = facts.version;
+                if (!facts.tag_subject.empty()) {
+                    data_to_publish_dict["tag_subject"] = facts.tag_subject;
+                }
+                if (!facts.tag_body.empty()) {
+                    data_to_publish_dict["tag_body"] = facts.tag_body;
+                }
+                if (!facts.bluetooth_id.empty()) {
+                    data_to_publish_dict["device_id"] = facts.bluetooth_id;
+                }
+                if (!facts.hostname.empty()) {
+                    data_to_publish_dict["hostname"] = facts.hostname;
+                }
+            } catch (const std::exception& e) {
+                RCLCPP_ERROR(this->get_logger(), "Failed to gather system facts: %s", e.what());
             }
 
             // Include update availability status
@@ -1571,8 +1599,8 @@ class AppControl : public rclcpp::Node {
     rclcpp::TimerBase::SharedPtr mad_mode_timer_;
 
     // Drive smoother state. Only touched from joystick_callback and drive_smoother_callback,
-    // both in the default mutually-exclusive callback group, which serialises them even
-    // under the two-thread executor, so no locking is needed.
+    // both in the default mutually-exclusive callback group, which only the single-threaded
+    // drive executor services (see main), so no locking is needed.
     double target_linear_ = 0.0;
     double target_angular_ = 0.0;
     drive::DriveSmoother smoother_;
@@ -1608,15 +1636,29 @@ class AppControl : public rclcpp::Node {
 int main(int argc, char** argv) {
     rclcpp::init(argc, argv);
     auto node = std::make_shared<mars_control::AppControl>();
-    // Two threads: the second exists so the slow group's shell-outs can block without
-    // ever starving the drive smoother (see slow_group_ in the constructor).
-    rclcpp::executors::MultiThreadedExecutor executor(rclcpp::ExecutorOptions(), 2);
-    executor.add_node(node);
+    // Two single-threaded executors rather than one multi-threaded one: the slow
+    // group's shell-outs can block without ever starving the drive smoother, the
+    // drive path keeps a dedicated thread, and each thread owns its own exception
+    // boundary — a throw on a MultiThreadedExecutor worker thread would bypass any
+    // try in main and land in std::terminate.
+    rclcpp::executors::SingleThreadedExecutor drive_executor;
+    rclcpp::executors::SingleThreadedExecutor slow_executor;
+    drive_executor.add_node(node);
+    slow_executor.add_callback_group(node->slow_group(), node->get_node_base_interface());
+    std::thread slow_thread([&slow_executor, &node]() {
+        try {
+            slow_executor.spin();
+        } catch (const std::exception& e) {
+            RCLCPP_ERROR(node->get_logger(), "Unhandled exception in app node (slow group): %s", e.what());
+        }
+        rclcpp::shutdown();  // one side dying must take the whole node down, not half of it
+    });
     try {
-        executor.spin();
+        drive_executor.spin();
     } catch (const std::exception& e) {
         RCLCPP_ERROR(node->get_logger(), "Unhandled exception in app node: %s", e.what());
     }
     rclcpp::shutdown();
+    slow_thread.join();
     return 0;
 }

--- a/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
+++ b/ros2_ws/src/mars_bot/mars_control/mars_control/app.cpp
@@ -38,7 +38,11 @@
 #include <memory>
 #include <regex>
 #include <sstream>
+#include <cerrno>
+#include <poll.h>
 #include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 using json = nlohmann::json;
 using namespace std::chrono_literals;
@@ -71,18 +75,67 @@ bool is_running_in_docker() {
 }
 
 /**
- * Execute a shell command and return its output (trimmed).
+ * Execute a shell command and return its output (trimmed), giving up after
+ * EXEC_COMMAND_TIMEOUT. popen() has no deadline, and a hung helper must cost the
+ * caller seconds, not forever — a wedged avahi-daemon once blocked `avahi-resolve`
+ * indefinitely. The child gets its own process group so the timeout kills the
+ * whole pipeline, not just the shell.
  */
+constexpr std::chrono::seconds EXEC_COMMAND_TIMEOUT{10};
+
 std::string exec_command(const std::string& cmd) {
-    std::array<char, 256> buffer;
-    std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
-    if (!pipe) {
+    int fds[2];
+    if (pipe(fds) != 0) {
         return "";
     }
-    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-        result += buffer.data();
+    const pid_t pid = fork();
+    if (pid < 0) {
+        close(fds[0]);
+        close(fds[1]);
+        return "";
     }
+    if (pid == 0) {
+        setpgid(0, 0);
+        dup2(fds[1], STDOUT_FILENO);
+        close(fds[0]);
+        close(fds[1]);
+        execl("/bin/sh", "sh", "-c", cmd.c_str(), static_cast<char*>(nullptr));
+        _exit(127);
+    }
+    setpgid(pid, pid);  // both sides set it — killpg must not race the child's exec
+    close(fds[1]);
+
+    std::string result;
+    const auto deadline = std::chrono::steady_clock::now() + EXEC_COMMAND_TIMEOUT;
+    for (;;) {
+        const auto left =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+        if (left <= std::chrono::milliseconds::zero()) {
+            killpg(pid, SIGKILL);
+            break;
+        }
+        pollfd pfd{fds[0], POLLIN, 0};
+        const int ready = poll(&pfd, 1, static_cast<int>(left.count()));
+        if (ready < 0 && errno == EINTR) {
+            continue;
+        }
+        if (ready <= 0) {
+            killpg(pid, SIGKILL);
+            break;
+        }
+        char buffer[256];
+        const ssize_t n = read(fds[0], buffer, sizeof(buffer));
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        if (n <= 0) {
+            break;
+        }
+        result.append(buffer, static_cast<size_t>(n));
+    }
+    close(fds[0]);
+    waitpid(pid, nullptr, 0);
+
     // Trim trailing newline
     while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {
         result.pop_back();
@@ -374,15 +427,12 @@ class AppControl : public rclcpp::Node {
         // Load app configuration
         _load_app_config();
 
-        // Cache for WiFi SSID to avoid frequent subprocess calls
-        _cached_wifi_ssid = "";
-        _last_wifi_check_time = 0.0;
-        _wifi_check_interval = 10.0;  // Check WiFi every 10 seconds instead of every 1 second
-
-        // Cache for update check to avoid frequent subprocess calls
-        _cached_update_available = false;
-        _last_update_check_time = 0.0;
-        _update_check_interval = 300.0;  // Check for updates every 5 minutes
+        // Everything that shells out (robot info, hostname sync, the admin services)
+        // runs in this group, serviced by the executor's second thread: a hung external
+        // helper must never starve the drive smoother — a wedged avahi-daemon once
+        // blocked avahi-resolve for seconds per call and drove the 50 Hz timer to
+        // ~0.2 Hz. Mutually exclusive, so robot_info.json access stays serialised.
+        slow_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
         // Declare parameters
         std::string mars_root = get_mars_root();
@@ -507,34 +557,41 @@ class AppControl : public rclcpp::Node {
         mad_mode_timer_ = this->create_wall_timer(100ms, std::bind(&AppControl::watch_mad_mode, this));
 
         // Timer for publishing robot info
-        robot_info_timer_ = this->create_wall_timer(1000ms, std::bind(&AppControl::publish_robot_info_callback, this));
+        robot_info_timer_ =
+            this->create_wall_timer(1000ms, std::bind(&AppControl::publish_robot_info_callback, this), slow_group_);
 
         // Timer for syncing system hostname to robot name
-        hostname_sync_timer_ = this->create_wall_timer(30000ms, std::bind(&AppControl::sync_hostname_callback, this));
+        hostname_sync_timer_ =
+            this->create_wall_timer(30000ms, std::bind(&AppControl::sync_hostname_callback, this), slow_group_);
 
         // Service for setting robot name
         set_robot_name_srv_ = this->create_service<mars_msgs::srv::SetRobotName>(
             "/set_robot_name",
-            std::bind(&AppControl::set_robot_name_callback, this, std::placeholders::_1, std::placeholders::_2));
+            std::bind(&AppControl::set_robot_name_callback, this, std::placeholders::_1, std::placeholders::_2),
+            rmw_qos_profile_services_default, slow_group_);
 
         // Service for triggering system update
         trigger_update_srv_ = this->create_service<mars_msgs::srv::TriggerUpdate>(
             "/trigger_update",
-            std::bind(&AppControl::trigger_update_callback, this, std::placeholders::_1, std::placeholders::_2));
+            std::bind(&AppControl::trigger_update_callback, this, std::placeholders::_1, std::placeholders::_2),
+            rmw_qos_profile_services_default, slow_group_);
 
         // Service for system shutdown
         shutdown_srv_ = this->create_service<mars_msgs::srv::Shutdown>(
-            "/shutdown", std::bind(&AppControl::shutdown_callback, this, std::placeholders::_1, std::placeholders::_2));
+            "/shutdown", std::bind(&AppControl::shutdown_callback, this, std::placeholders::_1, std::placeholders::_2),
+            rmw_qos_profile_services_default, slow_group_);
 
         // Service for setting system volume
         set_volume_srv_ = this->create_service<mars_msgs::srv::SetVolume>(
             "/set_volume",
-            std::bind(&AppControl::set_volume_callback, this, std::placeholders::_1, std::placeholders::_2));
+            std::bind(&AppControl::set_volume_callback, this, std::placeholders::_1, std::placeholders::_2),
+            rmw_qos_profile_services_default, slow_group_);
 
         // Service for enabling/disabling the robot microphone
         set_microphone_srv_ = this->create_service<std_srvs::srv::SetBool>(
             "/set_microphone",
-            std::bind(&AppControl::set_microphone_callback, this, std::placeholders::_1, std::placeholders::_2));
+            std::bind(&AppControl::set_microphone_callback, this, std::placeholders::_1, std::placeholders::_2),
+            rmw_qos_profile_services_default, slow_group_);
 
         // Latched publisher for microphone state
         mic_enabled_pub_ =
@@ -682,32 +739,47 @@ class AppControl : public rclcpp::Node {
     }
 
     /**
-     * Get WiFi SSID with caching to avoid frequent subprocess calls.
-     * Only checks for new SSID if the configured interval has passed.
+     * Facts gathered by shelling out, refreshed together at most every SLOW_FACTS_INTERVAL_S.
+     * They change rarely (the BT MAC never, version/tags only on update), so re-running
+     * seven subprocesses on every 1 Hz info tick was pure load on the Jetson.
      */
-    std::string get_cached_wifi_ssid() {
-        double current_time =
+    struct SlowFacts {
+        std::string wifi_ssid;
+        std::string hostname;
+        std::string bluetooth_id;
+        std::string version;
+        std::string tag_subject;
+        std::string tag_body;
+    };
+
+    const SlowFacts& cached_slow_facts() {
+        const double current_time =
             std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch()).count();
+        if (last_slow_facts_time_ != 0.0 && (current_time - last_slow_facts_time_) < SLOW_FACTS_INTERVAL_S) {
+            return slow_facts_;
+        }
+        last_slow_facts_time_ = current_time;
 
-        // If we haven't checked recently or don't have a cached value, check now
-        if (_cached_wifi_ssid.empty() || (current_time - _last_wifi_check_time) > _wifi_check_interval) {
-            std::string new_ssid = nmcli_get_active_wifi_ssid();
-
-            // Only log if the SSID actually changed or this is the first check
-            if (new_ssid != _cached_wifi_ssid) {
-                if (!new_ssid.empty()) {
-                    RCLCPP_INFO(this->get_logger(), "WiFi SSID updated: %s -> %s", _cached_wifi_ssid.c_str(),
-                                new_ssid.c_str());
-                } else {
-                    RCLCPP_WARN(this->get_logger(), "Could not retrieve WiFi SSID");
-                }
-
-                _cached_wifi_ssid = new_ssid;
+        std::string new_ssid = nmcli_get_active_wifi_ssid();
+        if (new_ssid != slow_facts_.wifi_ssid) {
+            if (!new_ssid.empty()) {
+                RCLCPP_INFO(this->get_logger(), "WiFi SSID updated: %s -> %s", slow_facts_.wifi_ssid.c_str(),
+                            new_ssid.c_str());
+            } else {
+                RCLCPP_WARN(this->get_logger(), "Could not retrieve WiFi SSID");
             }
-            _last_wifi_check_time = current_time;
+            slow_facts_.wifi_ssid = std::move(new_ssid);
         }
 
-        return _cached_wifi_ssid;
+        slow_facts_.hostname = get_hostname();
+        if (slow_facts_.bluetooth_id.empty()) {
+            slow_facts_.bluetooth_id = get_bluetooth_device_id();
+        }
+        const std::string mars_root = get_mars_root();
+        slow_facts_.version = get_robot_version(mars_root);
+        slow_facts_.tag_subject = get_tag_subject(mars_root);
+        slow_facts_.tag_body = get_tag_body(mars_root);
+        return slow_facts_;
     }
 
     /**
@@ -1185,42 +1257,22 @@ class AppControl : public rclcpp::Node {
                 data_to_publish_dict["minimum_app_version"] = app_config_["minimum_app_version"];
             }
 
-            // Include WiFi SSID
-            std::string wifi_ssid = get_cached_wifi_ssid();
-            if (!wifi_ssid.empty()) {
-                data_to_publish_dict["wifi_ssid"] = wifi_ssid;
+            const SlowFacts& facts = cached_slow_facts();
+            if (!facts.wifi_ssid.empty()) {
+                data_to_publish_dict["wifi_ssid"] = facts.wifi_ssid;
             }
-
-            // Include robot version and tag info
-            try {
-                std::string mars_root = get_mars_root();
-                std::string robot_version = get_robot_version(mars_root);
-                data_to_publish_dict["version"] = robot_version;
-
-                // Include tag subject and body for the latest version
-                std::string tag_subject = get_tag_subject(mars_root);
-                if (!tag_subject.empty()) {
-                    data_to_publish_dict["tag_subject"] = tag_subject;
-                }
-
-                std::string tag_body = get_tag_body(mars_root);
-                if (!tag_body.empty()) {
-                    data_to_publish_dict["tag_body"] = tag_body;
-                }
-            } catch (const std::exception& e) {
-                RCLCPP_ERROR(this->get_logger(), "Failed to get robot version: %s", e.what());
+            data_to_publish_dict["version"] = facts.version;
+            if (!facts.tag_subject.empty()) {
+                data_to_publish_dict["tag_subject"] = facts.tag_subject;
             }
-
-            // Include Bluetooth device ID
-            std::string device_id = get_bluetooth_device_id();
-            if (!device_id.empty()) {
-                data_to_publish_dict["device_id"] = device_id;
+            if (!facts.tag_body.empty()) {
+                data_to_publish_dict["tag_body"] = facts.tag_body;
             }
-
-            // Include system hostname
-            std::string hostname = get_hostname();
-            if (!hostname.empty()) {
-                data_to_publish_dict["hostname"] = hostname;
+            if (!facts.bluetooth_id.empty()) {
+                data_to_publish_dict["device_id"] = facts.bluetooth_id;
+            }
+            if (!facts.hostname.empty()) {
+                data_to_publish_dict["hostname"] = facts.hostname;
             }
 
             // Include update availability status
@@ -1474,15 +1526,18 @@ class AppControl : public rclcpp::Node {
     // Member variables
     json app_config_;
 
-    // Cache for WiFi SSID to avoid frequent subprocess calls
-    std::string _cached_wifi_ssid;
-    double _last_wifi_check_time;
-    double _wifi_check_interval;
+    // Shelled-out facts cache (see cached_slow_facts). Only touched from the slow group.
+    static constexpr double SLOW_FACTS_INTERVAL_S = 10.0;
+    SlowFacts slow_facts_;
+    double last_slow_facts_time_ = 0.0;
 
     // Cache for update check to avoid frequent subprocess calls
-    bool _cached_update_available;
-    double _last_update_check_time;
-    double _update_check_interval;
+    bool _cached_update_available = false;
+    double _last_update_check_time = 0.0;
+    double _update_check_interval = 300.0;  // Check for updates every 5 minutes
+
+    // See the constructor: the group every shell-out callback lives in.
+    rclcpp::CallbackGroup::SharedPtr slow_group_;
 
     // Subscribers
     rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr joystick_sub_;
@@ -1509,7 +1564,8 @@ class AppControl : public rclcpp::Node {
     rclcpp::TimerBase::SharedPtr mad_mode_timer_;
 
     // Drive smoother state. Only touched from joystick_callback and drive_smoother_callback,
-    // which the single-threaded executor serialises, so no locking is needed.
+    // both in the default mutually-exclusive callback group, which serialises them even
+    // under the two-thread executor, so no locking is needed.
     double target_linear_ = 0.0;
     double target_angular_ = 0.0;
     drive::DriveSmoother smoother_;
@@ -1545,8 +1601,12 @@ class AppControl : public rclcpp::Node {
 int main(int argc, char** argv) {
     rclcpp::init(argc, argv);
     auto node = std::make_shared<mars_control::AppControl>();
+    // Two threads: the second exists so the slow group's shell-outs can block without
+    // ever starving the drive smoother (see slow_group_ in the constructor).
+    rclcpp::executors::MultiThreadedExecutor executor(rclcpp::ExecutorOptions(), 2);
+    executor.add_node(node);
     try {
-        rclcpp::spin(node);
+        executor.spin();
     } catch (const std::exception& e) {
         RCLCPP_ERROR(node->get_logger(), "Unhandled exception in app node: %s", e.what());
     }


### PR DESCRIPTION
## Problem

Teleop wheel commands lagged by tens of seconds on mars-the-47th — even from the local network — while skills responded instantly.

Root cause: `publish_robot_info_callback` (1 s timer) shells out to `avahi-resolve`, `nmcli dev wifi`, `bluetoothctl`, and git (~7 subprocess spawns/sec) on the **same single-threaded executor** as the 50 Hz `drive_smoother_timer_`. When `avahi-daemon` wedged (it had been spinning at ~94% CPU for days), every `avahi-resolve` blocked indefinitely, the executor spent nearly all wall time inside `popen`, and the smoother ticked at ~0.2 Hz. Each tick advances the acceleration ramp by one fixed 20 ms step, so the robot accelerated ~250× slower than designed — turning was effectively dead. Skills publish `cmd_vel` from other nodes and were unaffected.

Measured on the robot: 10 s of continuous `/joystick` input produced **2** `/cmd_vel_teleop` messages; after restarting avahi, **119 at 50 Hz**.

## Fix (three layers)

1. **Isolation** — the two shell-out timers plus all admin services (`/set_robot_name`, `/set_volume`, `/set_microphone`, `/shutdown`, `/trigger_update`) move into a mutually-exclusive `slow_group_` serviced by a second `MultiThreadedExecutor` thread. The drive path never waits on a subprocess again. The default group stays mutually exclusive, so the drive-state no-locking invariant is preserved; the slow group being mutually exclusive keeps `robot_info.json` access serialised as before.
2. **Bounded exec** — `exec_command` now `fork`/`exec`s the shell in its own process group with a hard 10 s deadline (`poll` + `killpg`), so even on the slow thread a hung helper costs bounded staleness, never a wedged callback.
3. **Stop the subprocess churn** — hostname, BT MAC, version/tags, and SSID change rarely; they're now cached together and refreshed every 10 s instead of re-spawned every second (the update check keeps its 300 s cache).

## Verification

In the CI image (`innate-os-test:fullbuild`), with `nmcli` and `bluetoothctl` replaced by `sleep 600` stubs on PATH and `/joystick` published at 7 Hz:

- `/cmd_vel_teleop` holds **~49.7 Hz** (old code: sub-1 Hz in this scenario, ~0.2 Hz observed on the robot)
- `/robot/info` still publishes; the hung helpers' fields are simply absent until they recover
- clang-format via pre-commit: clean; Release build: clean (the one `-Wunused-result` warning is pre-existing untouched code)

## Notes

The wedged avahi-daemon itself was restarted on mars-the-47th during debugging (symptom gone), but this node must tolerate a sick system daemon — that's what this PR makes structural.