### PR TITLE
feat(teleop): echo-cancelled full-duplex talkback

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -175,11 +175,14 @@ class WebRTCStreamer : public rclcpp::Node {
     std::string speaker_pipeline_description() const;  // audiomixer -> volume -> [probe] -> speaker
     static std::string talk_decode_description();      // one peer's depay -> decode -> PCM appsink
     bool build_speaker_pipeline();                     // built + PLAYING at startup; peers mix into it
+    void teardown_speaker_pipeline();                  // only with no peers alive (they hold inputs inside it)
+    void restart_speaker_pipeline();                   // health poll: NULL->PLAYING after a bus error (throttled)
     // Give/take this peer its own appsrc + audiomixer pad. Both run on the executor thread with
     // peers_mutex_ held; detach is safe only after ~Peer has joined the thread that pushes.
     bool attach_speaker_input(Peer* peer);
     void detach_speaker_input(GstElement* src, GstPad* pad);
-    void set_peer_talk(Peer* peer, bool on);  // flip the gate; caller holds peers_mutex_
+    void set_peer_talk(Peer* peer, bool on);         // flip the gate; caller holds peers_mutex_
+    bool peer_audio_active(const Peer& peer) const;  // listen intent minus the talk duck (lifted by AEC)
     void reconcile_talk();  // publish /talkback/is_playing when the last talker stops (or the first starts)
 
     // ---- Shared audio (mic) — encoded once like the cameras, fanned out, gated for privacy ----
@@ -269,6 +272,7 @@ class WebRTCStreamer : public rclcpp::Node {
     GstElement* talk_mixer_ = nullptr;        // ref'd; peers request their input pads from it
     std::atomic<int> want_talk_{0};           // # peers holding the talk button; >0 => the robot is audibly speaking
     bool talk_playing_ = false;               // last published /talkback/is_playing state
+    int64_t last_speaker_restart_ns_ = 0;     // restart_speaker_pipeline backoff
 
     // ---- Peers ----
     std::map<std::string, std::unique_ptr<Peer>> peers_;

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -84,10 +84,15 @@ struct Peer {
     bool audio_requested = false;            // the operator's LISTEN intent; audio_active is it minus the talk duck
     bool with_talk = false;                  // the audio m-line was negotiated sendrecv (talkback possible)
     bool talk_active = false;                // operator is holding talk: their mic plays out the robot's speaker
-    // Privacy gate: the peer's RTP tap forwards to the speaker only while this is true. Read per sample
-    // on the peer's streaming thread (via a copy tagged on the tap), which must NOT take peers_mutex_ —
-    // ~Peer joins that thread under it. Purely read there, so a plain atomic suffices.
+    // Privacy gate: the peer's decode branch forwards to the speaker only while this is true. Read per
+    // sample on the peer's streaming thread (via a copy tagged on the branch), which must NOT take
+    // peers_mutex_ — ~Peer joins that thread under it. Purely read there, so a plain atomic suffices.
     std::shared_ptr<std::atomic<bool>> talk_gate = std::make_shared<std::atomic<bool>>(false);
+    // This peer's input to the shared speaker mixer: its own appsrc and the audiomixer request pad it
+    // feeds, both ref'd. Owned by the streamer, not by ~Peer — they live in the speaker pipeline and are
+    // released by destroy_peer once ~Peer has joined the streaming thread that pushes into them.
+    GstElement* talk_src = nullptr;
+    GstPad* talk_mix_pad = nullptr;
     // True only after webrtcbin CONNECTED; gates RTP fan-out into webrtcbin. Shared + atomic because it
     // is written from webrtcbin's PC thread (the connection-state callback, via a copy tagged on the
     // element) — that callback must NOT take peers_mutex_: ~Peer runs set_state(NULL) under the mutex,
@@ -167,9 +172,14 @@ class WebRTCStreamer : public rclcpp::Node {
     // ---- Talkback: the operator's mic, received on the audio m-line and played out the speaker ----
     static void on_talk_pad_added(GstElement* webrtc, GstPad* pad, gpointer user_data);
     static GstFlowReturn on_talk_sample(GstElement* appsink, gpointer user_data);
-    std::string speaker_pipeline_description() const;  // appsrc(RTP) -> depay -> decode -> [probe] -> speaker
-    bool build_speaker_pipeline();                     // built + PLAYING at startup; peers' taps feed it
-    void set_peer_talk(Peer* peer, bool on);           // flip the gate; caller holds peers_mutex_
+    std::string speaker_pipeline_description() const;  // audiomixer -> volume -> [probe] -> speaker
+    static std::string talk_decode_description();      // one peer's depay -> decode -> PCM appsink
+    bool build_speaker_pipeline();                     // built + PLAYING at startup; peers mix into it
+    // Give/take this peer its own appsrc + audiomixer pad. Both run on the executor thread with
+    // peers_mutex_ held; detach is safe only after ~Peer has joined the thread that pushes.
+    bool attach_speaker_input(Peer* peer);
+    void detach_speaker_input(GstElement* src, GstPad* pad);
+    void set_peer_talk(Peer* peer, bool on);  // flip the gate; caller holds peers_mutex_
     void reconcile_talk();  // publish /talkback/is_playing when the last talker stops (or the first starts)
 
     // ---- Shared audio (mic) — encoded once like the cameras, fanned out, gated for privacy ----
@@ -252,9 +262,11 @@ class WebRTCStreamer : public rclcpp::Node {
     std::atomic<uint64_t> audio_frames_{0};  // for status: is audio actually flowing
     bool audio_playing_ = false;             // current audio pipeline state (gated by want_audio_)
 
-    // ---- Talkback (browser mic -> robot speaker): per-peer RTP taps into one speaker pipeline ----
-    GstElement* speaker_pipeline_ = nullptr;  // appsrc..alsasink; PLAYING for the node's lifetime
-    GstElement* talk_appsrc_ = nullptr;       // ref'd; the taps push into it from peer streaming threads
+    // ---- Talkback (browser mic -> robot speaker): each peer decodes, all mix into one speaker ----
+    // One sink means one echo probe (what AEC needs); one mixer means N operators can still talk at once,
+    // each decoded on its own peer's thread so their RTP never shares a depayloader.
+    GstElement* speaker_pipeline_ = nullptr;  // audiomixer..alsasink; PLAYING for the node's lifetime
+    GstElement* talk_mixer_ = nullptr;        // ref'd; peers request their input pads from it
     std::atomic<int> want_talk_{0};           // # peers holding the talk button; >0 => the robot is audibly speaking
     bool talk_playing_ = false;               // last published /talkback/is_playing state
 

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -67,20 +67,6 @@ struct CameraEncoder {
     WebRTCStreamer* owner = nullptr;                 // for the static appsink new-sample callback
 };
 
-// The talkback switch one peer's playback branch obeys. The pad-added handler runs on webrtcbin's
-// streaming thread, which must NOT take peers_mutex_ (~Peer joins that thread under it) — hence its own
-// leaf mutex. The valve's drop property is written only under it and only from `open`, so a release can
-// never be overwritten by a stale snapshot.
-struct TalkGate {
-    std::mutex mutex;
-    bool open = false;            // the operator is holding talk
-    GstElement* valve = nullptr;  // this peer's playback valve, ref'd; set once by pad-added
-    ~TalkGate() {
-        if (valve)
-            gst_object_unref(valve);
-    }
-};
-
 // One connected WebRTC peer. The cameras are encoded ONCE in a persistent pipeline; each peer owns a
 // lightweight *transport* pipeline (appsrc(RTP) -> webrtcbin) that the shared encoders fan their RTP
 // out to. Creating/destroying a peer never touches the encoders, so memory stays flat and a dead peer
@@ -98,8 +84,10 @@ struct Peer {
     bool audio_requested = false;            // the operator's LISTEN intent; audio_active is it minus the talk duck
     bool with_talk = false;                  // the audio m-line was negotiated sendrecv (talkback possible)
     bool talk_active = false;                // operator is holding talk: their mic plays out the robot's speaker
-    // Shared with the pad-added handler via a copy tagged on the webrtcbin element (see TalkGate).
-    std::shared_ptr<TalkGate> talk_gate = std::make_shared<TalkGate>();
+    // Privacy gate: the peer's RTP tap forwards to the speaker only while this is true. Read per sample
+    // on the peer's streaming thread (via a copy tagged on the tap), which must NOT take peers_mutex_ —
+    // ~Peer joins that thread under it. Purely read there, so a plain atomic suffices.
+    std::shared_ptr<std::atomic<bool>> talk_gate = std::make_shared<std::atomic<bool>>(false);
     // True only after webrtcbin CONNECTED; gates RTP fan-out into webrtcbin. Shared + atomic because it
     // is written from webrtcbin's PC thread (the connection-state callback, via a copy tagged on the
     // element) — that callback must NOT take peers_mutex_: ~Peer runs set_state(NULL) under the mutex,
@@ -178,8 +166,10 @@ class WebRTCStreamer : public rclcpp::Node {
 
     // ---- Talkback: the operator's mic, received on the audio m-line and played out the speaker ----
     static void on_talk_pad_added(GstElement* webrtc, GstPad* pad, gpointer user_data);
-    std::string talk_branch_description() const;  // valve -> depay -> decode -> speaker
-    void set_peer_talk(Peer* peer, bool on);      // flip the gate + the valve; caller holds peers_mutex_
+    static GstFlowReturn on_talk_sample(GstElement* appsink, gpointer user_data);
+    std::string speaker_pipeline_description() const;  // appsrc(RTP) -> depay -> decode -> [probe] -> speaker
+    bool build_speaker_pipeline();                     // built + PLAYING at startup; peers' taps feed it
+    void set_peer_talk(Peer* peer, bool on);           // flip the gate; caller holds peers_mutex_
     void reconcile_talk();  // publish /talkback/is_playing when the last talker stops (or the first starts)
 
     // ---- Shared audio (mic) — encoded once like the cameras, fanned out, gated for privacy ----
@@ -262,9 +252,11 @@ class WebRTCStreamer : public rclcpp::Node {
     std::atomic<uint64_t> audio_frames_{0};  // for status: is audio actually flowing
     bool audio_playing_ = false;             // current audio pipeline state (gated by want_audio_)
 
-    // ---- Talkback (browser mic -> robot speaker): per-peer recv branches, gated by a valve ----
-    std::atomic<int> want_talk_{0};  // # peers holding the talk button; >0 => the robot is audibly speaking
-    bool talk_playing_ = false;      // last published /talkback/is_playing state
+    // ---- Talkback (browser mic -> robot speaker): per-peer RTP taps into one speaker pipeline ----
+    GstElement* speaker_pipeline_ = nullptr;  // appsrc..alsasink; PLAYING for the node's lifetime
+    GstElement* talk_appsrc_ = nullptr;       // ref'd; the taps push into it from peer streaming threads
+    std::atomic<int> want_talk_{0};           // # peers holding the talk button; >0 => the robot is audibly speaking
+    bool talk_playing_ = false;               // last published /talkback/is_playing state
 
     // ---- Peers ----
     std::map<std::string, std::unique_ptr<Peer>> peers_;
@@ -290,6 +282,7 @@ class WebRTCStreamer : public rclcpp::Node {
     std::string audio_source_element_ = "alsasrc";
     std::string audio_capture_device_;
     bool enable_talkback_ = true;
+    bool enable_echo_cancel_ = false;  // AEC on the mic feed; lifts the half-duplex duck when on
     std::string audio_sink_element_ = "alsasink";
     std::string audio_playback_device_;
     double talkback_volume_ = 1.0;

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -87,7 +87,11 @@ def generate_launch_description():
                 "enable_audio": True,
                 "audio_source_element": "alsasrc",
                 "audio_capture_device": "sysdefault:CARD=Light",
-                "enable_talkback": True,  # operator push-to-talk out the robot speaker
+                "enable_talkback": True,  # operator voice out the robot speaker
+                # Cancel the speaker out of the mic (webrtcdsp): the robot stops hearing itself and
+                # the half-duplex duck lifts, so an unmuted operator still hears the room. Degrades
+                # to plain half-duplex if the plugin is missing.
+                "enable_echo_cancel": True,
                 # Bound the teleop receiver's de-jitter buffer (ms) via the playout-delay RTP
                 # extension. Measured effect on the LAN: once this extension advertises playout-delay
                 # support, Chrome (which already pins jitterBufferTarget=0) drops the buffer from

--- a/ros2_ws/src/mars_bot/mars_cam/launch/webrtc_streamer.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/webrtc_streamer.launch.py
@@ -23,7 +23,8 @@ def generate_launch_description():
                         "enable_audio": True,
                         "audio_source_element": "alsasrc",
                         "audio_capture_device": "sysdefault:CARD=Light",
-                        "enable_talkback": True,  # operator push-to-talk out the robot speaker
+                        "enable_talkback": True,  # operator voice out the robot speaker
+                        "enable_echo_cancel": True,  # see camera_composable.launch.py
                     }
                 ],
             )

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -264,10 +264,14 @@ bool WebRTCStreamer::build_audio_pipeline() {
         "queue leaky=downstream max-size-buffers=10 max-size-time=0 max-size-bytes=0 ! "
         "audioconvert ! audioresample ! audio/x-raw,rate=48000,channels=1 ! " +
         // AEC subtracts the speaker pipeline's playout (via its webrtcechoprobe) from the
-        // capture — what makes full-duplex talkback possible. delay-agnostic: capture and
-        // playout are separate pipelines on separate clocks, and dmix hides the true
-        // playout latency, so the canceller must estimate alignment itself.
-        std::string(enable_echo_cancel_ ? "webrtcdsp probe=talk_probe echo-cancel=true delay-agnostic=true ! " : "") +
+        // capture — what makes full-duplex talkback possible. delay-agnostic measured BROKEN
+        // on this hardware (data/aec_bench sweep, 2026-08-27: ERLE ~1 dB — the estimator never
+        // aligns through dmix); with reported latencies the canceller aligns from the first
+        // burst (ERLE ~50 dB, residual below the mic's own noise floor), and suppression can
+        // then stay at moderate, which keeps an interrupting far-end voice alive in double-talk.
+        std::string(enable_echo_cancel_ ? "webrtcdsp probe=talk_probe echo-cancel=true delay-agnostic=false "
+                                          "echo-suppression-level=moderate ! "
+                                        : "") +
         "opusenc bitrate=24000 audio-type=voice ! "
         "rtpopuspay name=pay_audio pt=98 ! "
         "appsink name=sink_audio emit-signals=true sync=false async=false max-buffers=4 drop=true ";

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -257,7 +257,12 @@ bool WebRTCStreamer::build_audio_pipeline() {
     std::string desc = src +
                        " do-timestamp=true ! "
                        "queue leaky=downstream max-size-buffers=10 max-size-time=0 max-size-bytes=0 ! "
-                       "audioconvert ! audioresample ! audio/x-raw,rate=48000,channels=1 ! "
+                       "audioconvert ! audioresample ! audio/x-raw,rate=48000,channels=1 ! " +
+                       // AEC subtracts the speaker pipeline's playout (via its webrtcechoprobe) from the
+                       // capture — what makes full-duplex talkback possible. delay-agnostic: capture and
+                       // playout are separate pipelines on separate clocks, and dmix hides the true
+                       // playout latency, so the canceller must estimate alignment itself.
+                       std::string(enable_echo_cancel_ ? "webrtcdsp echo-cancel=true delay-agnostic=true ! " : "") +
                        "opusenc bitrate=24000 audio-type=voice ! "
                        "rtpopuspay name=pay_audio pt=98 ! "
                        "appsink name=sink_audio emit-signals=true sync=false async=false max-buffers=4 drop=true ";
@@ -284,11 +289,12 @@ bool WebRTCStreamer::build_audio_pipeline() {
     return true;
 }
 
-// One peer's speaker path, hung off webrtcbin's recv pad. The valve is the privacy gate (closed until the
-// operator holds talk); the queue is what keeps a blocking ALSA write off webrtcbin's streaming thread.
-// The sink neither syncs nor prerolls: it is fed live, and behind a closed valve it would otherwise wait
-// forever for a first buffer and stall the branch's state change.
-std::string WebRTCStreamer::talk_branch_description() const {
+// The one speaker path every talking peer feeds (their taps push RTP into talk_src). One path means one
+// place for the echo probe — AEC needs a single reference of what the speaker plays. The probe keeps
+// GStreamer's auto-name webrtcechoprobe0, which the mic pipeline's webrtcdsp pairs with; it sits after
+// the volume so the reference matches the level actually played. The queue keeps a blocking ALSA write
+// off the pushing peer's streaming thread; the sink neither syncs nor prerolls (fed live).
+std::string WebRTCStreamer::speaker_pipeline_description() const {
     if (!is_plain_element(audio_sink_element_) || !is_plain_device(audio_playback_device_)) {
         return "";  // the constructor checks this once and disables talkback rather than parsing it
     }
@@ -296,13 +302,62 @@ std::string WebRTCStreamer::talk_branch_description() const {
     if (!audio_playback_device_.empty()) {
         sink += " device=\"" + audio_playback_device_ + "\"";
     }
-    return "valve name=talk_valve drop=true ! "
+    return "appsrc name=talk_src is-live=true format=time do-timestamp=true "
+           "caps=\"application/x-rtp,media=audio,clock-rate=48000,encoding-name=OPUS,payload=98\" ! "
            "rtpopusdepay ! opusdec plc=true ! audioconvert ! audioresample ! "
            "volume name=talk_volume volume=" +
-           std::to_string(talkback_volume_) +
-           " ! "
-           "queue leaky=downstream max-size-buffers=0 max-size-bytes=0 max-size-time=200000000 ! " +
-           sink + " name=talk_sink sync=false async=false";
+           std::to_string(talkback_volume_) + " ! " + std::string(enable_echo_cancel_ ? "webrtcechoprobe ! " : "") +
+           "queue leaky=downstream max-size-buffers=0 max-size-bytes=0 max-size-time=200000000 ! " + sink +
+           " name=talk_sink sync=false async=false";
+}
+
+// Built once and left PLAYING for the node's lifetime: the probe must exist before the mic pipeline's
+// webrtcdsp activates, and ALSA is dmix, so holding the playback device open costs nothing. With no
+// talker the appsrc is simply silent.
+bool WebRTCStreamer::build_speaker_pipeline() {
+    GError* error = nullptr;
+    speaker_pipeline_ = gst_parse_launch(speaker_pipeline_description().c_str(), &error);
+    if (error) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to create speaker pipeline: %s", error->message);
+        g_error_free(error);
+        if (speaker_pipeline_) {
+            gst_object_unref(speaker_pipeline_);
+            speaker_pipeline_ = nullptr;
+        }
+        return false;
+    }
+    talk_appsrc_ = gst_bin_get_by_name(GST_BIN(speaker_pipeline_), "talk_src");
+    if (!talk_appsrc_ || gst_element_set_state(speaker_pipeline_, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
+        RCLCPP_ERROR(this->get_logger(), "Speaker pipeline failed to start");
+        return false;
+    }
+    return true;
+}
+
+// A talking peer's RTP arriving, on that peer's streaming thread — it must not take peers_mutex_ (~Peer
+// joins this thread under it), so the gate rides on the tap and the appsrc is a set-once member. Two
+// peers talking at once interleave RTP into one depayloader and glitch; one talker at a time is the
+// supported shape.
+GstFlowReturn WebRTCStreamer::on_talk_sample(GstElement* appsink, gpointer user_data) {
+    auto* self = static_cast<WebRTCStreamer*>(user_data);
+    GstSample* sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink));
+    if (!sample) {
+        return GST_FLOW_OK;
+    }
+    auto* gate =
+        static_cast<std::shared_ptr<std::atomic<bool>>*>(g_object_get_data(G_OBJECT(appsink), "mars_talk_gate"));
+    GstBuffer* buffer = gst_sample_get_buffer(sample);
+    if (buffer && gate && (*gate)->load(std::memory_order_relaxed) && self->talk_appsrc_) {
+        GstBuffer* out = gst_buffer_copy(buffer);
+        GST_BUFFER_PTS(out) = GST_CLOCK_TIME_NONE;
+        GST_BUFFER_DTS(out) = GST_CLOCK_TIME_NONE;
+        GstFlowReturn ret;
+        // "push-buffer" is transfer-none (see fan_out) — unref or leak one packet per push.
+        g_signal_emit_by_name(self->talk_appsrc_, "push-buffer", out, &ret);
+        gst_buffer_unref(out);
+    }
+    gst_sample_unref(sample);
+    return GST_FLOW_OK;
 }
 
 void WebRTCStreamer::reconcile_talk() {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -29,6 +29,10 @@ bool is_plain_element(const std::string& name) {
                                         [](unsigned char c) { return std::isalnum(c) || c == '-' || c == '_'; });
 }
 
+// Every talker is converted to this before the mixer, so the inputs agree and the probe hands webrtcdsp
+// (48 kHz mono, as the mic pipeline captures) a reference in the shape it expects.
+constexpr const char* kTalkPcmCaps = "audio/x-raw,format=S16LE,rate=48000,channels=1,layout=interleaved";
+
 bool is_plain_device(const std::string& device) {
     return std::all_of(device.begin(), device.end(), [](unsigned char c) {
         return std::isalnum(c) || c == ':' || c == ',' || c == '.' || c == '=' || c == '-' || c == '_' || c == '/';
@@ -289,11 +293,12 @@ bool WebRTCStreamer::build_audio_pipeline() {
     return true;
 }
 
-// The one speaker path every talking peer feeds (their taps push RTP into talk_src). One path means one
-// place for the echo probe — AEC needs a single reference of what the speaker plays. The probe keeps
-// GStreamer's auto-name webrtcechoprobe0, which the mic pipeline's webrtcdsp pairs with; it sits after
-// the volume so the reference matches the level actually played. The queue keeps a blocking ALSA write
-// off the pushing peer's streaming thread; the sink neither syncs nor prerolls (fed live).
+// The speaker every talking peer mixes into. One SINK is what AEC needs — a single reference of what
+// was played, taken by the probe (auto-named webrtcechoprobe0, which the mic pipeline's webrtcdsp pairs
+// with) after the volume, so the reference matches the level actually heard. One MIXER is what keeps N
+// operators able to talk at once: each peer decodes on its own thread and contributes a mixer input, so
+// their streams are summed here rather than sharing a depayloader. The queue keeps a blocking ALSA write
+// off the mixer thread; the sink neither syncs nor prerolls (it is fed live).
 std::string WebRTCStreamer::speaker_pipeline_description() const {
     if (!is_plain_element(audio_sink_element_) || !is_plain_device(audio_playback_device_)) {
         return "";  // the constructor checks this once and disables talkback rather than parsing it
@@ -302,18 +307,27 @@ std::string WebRTCStreamer::speaker_pipeline_description() const {
     if (!audio_playback_device_.empty()) {
         sink += " device=\"" + audio_playback_device_ + "\"";
     }
-    return "appsrc name=talk_src is-live=true format=time do-timestamp=true "
-           "caps=\"application/x-rtp,media=audio,clock-rate=48000,encoding-name=OPUS,payload=98\" ! "
-           "rtpopusdepay ! opusdec plc=true ! audioconvert ! audioresample ! "
+    return "audiomixer name=talk_mix ! audioconvert ! audioresample ! "
            "volume name=talk_volume volume=" +
            std::to_string(talkback_volume_) + " ! " + std::string(enable_echo_cancel_ ? "webrtcechoprobe ! " : "") +
            "queue leaky=downstream max-size-buffers=0 max-size-bytes=0 max-size-time=200000000 ! " + sink +
            " name=talk_sink sync=false async=false";
 }
 
+// One peer's half of talkback, built into that peer's own transport pipeline: depayload and decode its
+// RTP where its own jitterbuffer's GAP events can still reach opusdec (that is what makes plc=true
+// conceal loss), then hand PCM to the mixer through an appsink. The caps are fixed here so every mixer
+// input agrees, and match what the mic's webrtcdsp expects of the probe.
+std::string WebRTCStreamer::talk_decode_description() {
+    return "queue leaky=downstream max-size-buffers=10 max-size-bytes=0 max-size-time=0 ! "
+           "rtpopusdepay ! opusdec plc=true ! audioconvert ! audioresample ! " +
+           std::string(kTalkPcmCaps) +
+           " ! appsink name=talk_pcm emit-signals=true sync=false async=false max-buffers=8 drop=true";
+}
+
 // Built once and left PLAYING for the node's lifetime: the probe must exist before the mic pipeline's
-// webrtcdsp activates, and ALSA is dmix, so holding the playback device open costs nothing. With no
-// talker the appsrc is simply silent.
+// webrtcdsp activates, and ALSA is dmix, so holding the playback device open costs nothing. With nobody
+// talking the mixer has no inputs (or only idle ones) and plays silence.
 bool WebRTCStreamer::build_speaker_pipeline() {
     GError* error = nullptr;
     speaker_pipeline_ = gst_parse_launch(speaker_pipeline_description().c_str(), &error);
@@ -326,34 +340,93 @@ bool WebRTCStreamer::build_speaker_pipeline() {
         }
         return false;
     }
-    talk_appsrc_ = gst_bin_get_by_name(GST_BIN(speaker_pipeline_), "talk_src");
-    if (!talk_appsrc_ || gst_element_set_state(speaker_pipeline_, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
+    talk_mixer_ = gst_bin_get_by_name(GST_BIN(speaker_pipeline_), "talk_mix");
+    if (!talk_mixer_ || gst_element_set_state(speaker_pipeline_, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
         RCLCPP_ERROR(this->get_logger(), "Speaker pipeline failed to start");
         return false;
     }
     return true;
 }
 
-// A talking peer's RTP arriving, on that peer's streaming thread — it must not take peers_mutex_ (~Peer
-// joins this thread under it), so the gate rides on the tap and the appsrc is a set-once member. Two
-// peers talking at once interleave RTP into one depayloader and glitch; one talker at a time is the
-// supported shape.
-GstFlowReturn WebRTCStreamer::on_talk_sample(GstElement* appsink, gpointer user_data) {
-    auto* self = static_cast<WebRTCStreamer*>(user_data);
+// Add this peer's input to the live mixer. An input that never carries audio does not stall the mix
+// (the mixer aggregates on the clock and treats an idle live source as silence), so the input is taken
+// for the peer's whole life and the talk button stays a pure atomic store — no pipeline surgery on a
+// press. Executor thread, peers_mutex_ held.
+bool WebRTCStreamer::attach_speaker_input(Peer* peer) {
+    if (!speaker_pipeline_ || !talk_mixer_) {
+        return false;
+    }
+    GstElement* src = gst_element_factory_make("appsrc", nullptr);
+    if (!src) {
+        return false;
+    }
+    GstCaps* caps = gst_caps_from_string(kTalkPcmCaps);
+    // do-timestamp: the decoded PCM carries the peer's own clock base, which is unrelated to every other
+    // peer's — restamping on arrival is what lets the mixer align live talkers against each other.
+    // Bounded + leaky like every other appsrc here, so a stalled speaker drops packets instead of growing.
+    g_object_set(src, "caps", caps, "is-live", TRUE, "format", GST_FORMAT_TIME, "do-timestamp", TRUE, "block", FALSE,
+                 "leaky-type", 2 /* downstream */, "max-bytes", guint64{256 * 1024}, nullptr);
+    gst_caps_unref(caps);
+
+    gst_bin_add(GST_BIN(speaker_pipeline_), src);  // takes the floating ref
+    GstPad* mix_pad = gst_element_request_pad_simple(talk_mixer_, "sink_%u");
+    GstPad* src_pad = gst_element_get_static_pad(src, "src");
+    const bool linked = mix_pad && src_pad && gst_pad_link(src_pad, mix_pad) == GST_PAD_LINK_OK;
+    if (src_pad) {
+        gst_object_unref(src_pad);
+    }
+    if (!linked) {
+        RCLCPP_ERROR(this->get_logger(), "Failed to link a speaker mixer input");
+        if (mix_pad) {
+            gst_element_release_request_pad(talk_mixer_, mix_pad);
+            gst_object_unref(mix_pad);
+        }
+        gst_bin_remove(GST_BIN(speaker_pipeline_), src);
+        return false;
+    }
+    gst_element_sync_state_with_parent(src);
+    peer->talk_src = GST_ELEMENT(gst_object_ref(src));
+    peer->talk_mix_pad = mix_pad;  // the request-pad ref is ours to release
+    return true;
+}
+
+// Release a departed peer's mixer input. Only safe once ~Peer has NULLed that peer's transport (joining
+// the streaming thread that pushes into this appsrc), so the caller detaches AFTER the erase.
+void WebRTCStreamer::detach_speaker_input(GstElement* src, GstPad* pad) {
+    if (src) {
+        gst_element_set_state(src, GST_STATE_NULL);
+        if (speaker_pipeline_) {
+            gst_bin_remove(GST_BIN(speaker_pipeline_), src);  // drops the bin's ref
+        }
+        gst_object_unref(src);  // ours
+    }
+    if (pad) {
+        if (talk_mixer_) {
+            gst_element_release_request_pad(talk_mixer_, pad);
+        }
+        gst_object_unref(pad);
+    }
+}
+
+// A talking peer's decoded PCM arriving, on that peer's streaming thread — it must not take peers_mutex_
+// (~Peer joins this thread under it), so both the gate and this peer's mixer appsrc ride on the appsink
+// as element data. Peers never share a decoder, so simultaneous talkers mix instead of interleaving.
+GstFlowReturn WebRTCStreamer::on_talk_sample(GstElement* appsink, gpointer) {
     GstSample* sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink));
     if (!sample) {
         return GST_FLOW_OK;
     }
     auto* gate =
         static_cast<std::shared_ptr<std::atomic<bool>>*>(g_object_get_data(G_OBJECT(appsink), "mars_talk_gate"));
+    auto* src = static_cast<GstElement*>(g_object_get_data(G_OBJECT(appsink), "mars_talk_src"));
     GstBuffer* buffer = gst_sample_get_buffer(sample);
-    if (buffer && gate && (*gate)->load(std::memory_order_relaxed) && self->talk_appsrc_) {
+    if (buffer && src && gate && (*gate)->load(std::memory_order_relaxed)) {
         GstBuffer* out = gst_buffer_copy(buffer);
         GST_BUFFER_PTS(out) = GST_CLOCK_TIME_NONE;
         GST_BUFFER_DTS(out) = GST_CLOCK_TIME_NONE;
         GstFlowReturn ret;
-        // "push-buffer" is transfer-none (see fan_out) — unref or leak one packet per push.
-        g_signal_emit_by_name(self->talk_appsrc_, "push-buffer", out, &ret);
+        // "push-buffer" is transfer-none (see fan_out) — unref or leak one buffer per push.
+        g_signal_emit_by_name(src, "push-buffer", out, &ret);
         gst_buffer_unref(out);
     }
     gst_sample_unref(sample);

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -258,18 +258,19 @@ bool WebRTCStreamer::build_audio_pipeline() {
     }
     // mic -> opus -> rtp -> appsink (the fan-out tap). Encoded once for all peers; matches the RTP caps
     // each peer's transport audio appsrc declares (OPUS/48000/pt98).
-    std::string desc = src +
-                       " do-timestamp=true ! "
-                       "queue leaky=downstream max-size-buffers=10 max-size-time=0 max-size-bytes=0 ! "
-                       "audioconvert ! audioresample ! audio/x-raw,rate=48000,channels=1 ! " +
-                       // AEC subtracts the speaker pipeline's playout (via its webrtcechoprobe) from the
-                       // capture — what makes full-duplex talkback possible. delay-agnostic: capture and
-                       // playout are separate pipelines on separate clocks, and dmix hides the true
-                       // playout latency, so the canceller must estimate alignment itself.
-                       std::string(enable_echo_cancel_ ? "webrtcdsp echo-cancel=true delay-agnostic=true ! " : "") +
-                       "opusenc bitrate=24000 audio-type=voice ! "
-                       "rtpopuspay name=pay_audio pt=98 ! "
-                       "appsink name=sink_audio emit-signals=true sync=false async=false max-buffers=4 drop=true ";
+    std::string desc =
+        src +
+        " do-timestamp=true ! "
+        "queue leaky=downstream max-size-buffers=10 max-size-time=0 max-size-bytes=0 ! "
+        "audioconvert ! audioresample ! audio/x-raw,rate=48000,channels=1 ! " +
+        // AEC subtracts the speaker pipeline's playout (via its webrtcechoprobe) from the
+        // capture — what makes full-duplex talkback possible. delay-agnostic: capture and
+        // playout are separate pipelines on separate clocks, and dmix hides the true
+        // playout latency, so the canceller must estimate alignment itself.
+        std::string(enable_echo_cancel_ ? "webrtcdsp probe=talk_probe echo-cancel=true delay-agnostic=true ! " : "") +
+        "opusenc bitrate=24000 audio-type=voice ! "
+        "rtpopuspay name=pay_audio pt=98 ! "
+        "appsink name=sink_audio emit-signals=true sync=false async=false max-buffers=4 drop=true ";
     GError* error = nullptr;
     audio_pipeline_ = gst_parse_launch(desc.c_str(), &error);
     if (error) {
@@ -294,11 +295,13 @@ bool WebRTCStreamer::build_audio_pipeline() {
 }
 
 // The speaker every talking peer mixes into. One SINK is what AEC needs — a single reference of what
-// was played, taken by the probe (auto-named webrtcechoprobe0, which the mic pipeline's webrtcdsp pairs
-// with) after the volume, so the reference matches the level actually heard. One MIXER is what keeps N
-// operators able to talk at once: each peer decodes on its own thread and contributes a mixer input, so
-// their streams are summed here rather than sharing a depayloader. The queue keeps a blocking ALSA write
-// off the mixer thread; the sink neither syncs nor prerolls (it is fed live).
+// was played, taken by the probe (named: webrtcdsp pairs by name, and the default auto-name is a
+// process-global counter, not a contract in a shared composable container) after the volume, so the
+// reference matches the level actually heard. The 48k-mono pin in front of it keeps the probe at the
+// capture's rate regardless of what the sink negotiates — webrtcdsp refuses a mismatched probe. One
+// MIXER is what keeps N operators able to talk at once: each peer decodes on its own thread and
+// contributes a mixer input, so their streams are summed here rather than sharing a depayloader. The
+// queue keeps a blocking ALSA write off the mixer thread; the sink neither syncs nor prerolls (fed live).
 std::string WebRTCStreamer::speaker_pipeline_description() const {
     if (!is_plain_element(audio_sink_element_) || !is_plain_device(audio_playback_device_)) {
         return "";  // the constructor checks this once and disables talkback rather than parsing it
@@ -309,7 +312,9 @@ std::string WebRTCStreamer::speaker_pipeline_description() const {
     }
     return "audiomixer name=talk_mix ! audioconvert ! audioresample ! "
            "volume name=talk_volume volume=" +
-           std::to_string(talkback_volume_) + " ! " + std::string(enable_echo_cancel_ ? "webrtcechoprobe ! " : "") +
+           std::to_string(talkback_volume_) + " ! " +
+           std::string(enable_echo_cancel_ ? "audio/x-raw,rate=48000,channels=1 ! webrtcechoprobe name=talk_probe ! "
+                                           : "") +
            "queue leaky=downstream max-size-buffers=0 max-size-bytes=0 max-size-time=200000000 ! " + sink +
            " name=talk_sink sync=false async=false";
 }
@@ -343,9 +348,42 @@ bool WebRTCStreamer::build_speaker_pipeline() {
     talk_mixer_ = gst_bin_get_by_name(GST_BIN(speaker_pipeline_), "talk_mix");
     if (!talk_mixer_ || gst_element_set_state(speaker_pipeline_, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
         RCLCPP_ERROR(this->get_logger(), "Speaker pipeline failed to start");
+        teardown_speaker_pipeline();
         return false;
     }
     return true;
+}
+
+// Only callable with no peers alive (constructor, destructor-after-peers, build failure): peers hold
+// mixer inputs inside this pipeline and push into them from their own streaming threads.
+void WebRTCStreamer::teardown_speaker_pipeline() {
+    if (talk_mixer_) {
+        gst_object_unref(talk_mixer_);
+        talk_mixer_ = nullptr;
+    }
+    if (speaker_pipeline_) {
+        gst_element_set_state(speaker_pipeline_, GST_STATE_NULL);
+        gst_object_unref(speaker_pipeline_);
+        speaker_pipeline_ = nullptr;
+    }
+}
+
+// The pipeline is shared and lifetime-scoped, so nothing rebuilds it after a runtime error (an unplugged
+// USB speaker, an ALSA fault). NULL->PLAYING re-opens the device in place — the same elements, so the
+// peers' mixer inputs ride through the cycle — throttled so a genuinely dead sink doesn't churn every
+// 200 ms health poll.
+void WebRTCStreamer::restart_speaker_pipeline() {
+    const int64_t now_ns = std::chrono::steady_clock::now().time_since_epoch().count();
+    if (now_ns - last_speaker_restart_ns_ < static_cast<int64_t>(5 * GST_SECOND)) {
+        return;
+    }
+    last_speaker_restart_ns_ = now_ns;
+    gst_element_set_state(speaker_pipeline_, GST_STATE_NULL);
+    if (gst_element_set_state(speaker_pipeline_, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
+        RCLCPP_WARN(this->get_logger(), "Speaker pipeline restart failed; retrying after backoff");
+    } else {
+        RCLCPP_INFO(this->get_logger(), "Speaker pipeline restarted after a bus error");
+    }
 }
 
 // Add this peer's input to the live mixer. An input that never carries audio does not stall the mix

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -90,6 +90,10 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     this->declare_parameter("audio_sink_element", "alsasink");
     this->declare_parameter("audio_playback_device", "");
     this->declare_parameter("talkback_volume", 1.0);
+    // Cancels the robot's own speaker out of its mic (webrtcdsp paired with the speaker pipeline's
+    // probe), which lifts the half-duplex duck: the talker keeps hearing the room. Off until validated
+    // on hardware — cancellation quality depends on dmix's unobservable playout latency.
+    this->declare_parameter("enable_echo_cancel", false);
     this->declare_parameter("playout_min_delay_ms", 0);
     this->declare_parameter("playout_max_delay_ms", 40);
     this->declare_parameter("enable_local_stun", true);
@@ -108,6 +112,7 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     audio_sink_element_ = this->get_parameter("audio_sink_element").as_string();
     audio_playback_device_ = this->get_parameter("audio_playback_device").as_string();
     talkback_volume_ = this->get_parameter("talkback_volume").as_double();
+    enable_echo_cancel_ = this->get_parameter("enable_echo_cancel").as_bool();
     playout_min_delay_ms_ = static_cast<guint>(this->get_parameter("playout_min_delay_ms").as_int());
     playout_max_delay_ms_ = static_cast<guint>(this->get_parameter("playout_max_delay_ms").as_int());
     enable_local_stun_ = this->get_parameter("enable_local_stun").as_bool();
@@ -154,18 +159,10 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
         RCLCPP_FATAL(this->get_logger(), "Failed to build the persistent encode pipeline");
         throw std::runtime_error("encode pipeline build failed");
     }
-    // Shared mic pipeline (encoded once, fanned out, gated NULL/PLAYING for privacy). Optional: if it
-    // can't be built (no mic), carry on video-only.
-    if (enable_audio_ && !build_audio_pipeline()) {
-        RCLCPP_WARN(this->get_logger(), "Audio pipeline build failed; continuing video-only");
-        enable_audio_ = false;
-    }
-    if (enable_talkback_ && talk_branch_description().empty()) {
+    if (enable_talkback_ && speaker_pipeline_description().empty()) {
         RCLCPP_ERROR(this->get_logger(), "audio_sink_element/audio_playback_device rejected; talkback disabled");
         enable_talkback_ = false;
     }
-    // The branch is only built when a peer's mic arrives, so check the speaker element up front rather
-    // than failing per-peer inside a GStreamer callback.
     if (enable_talkback_) {
         GstElementFactory* sink = gst_element_factory_find(audio_sink_element_.c_str());
         if (!sink) {
@@ -175,6 +172,18 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
         } else {
             gst_object_unref(sink);
         }
+    }
+    // Before the mic pipeline: its webrtcdsp pairs with this pipeline's probe, which must exist first.
+    if (enable_talkback_ && !build_speaker_pipeline()) {
+        enable_talkback_ = false;
+    }
+    // AEC exists to cancel talkback out of the mic; without talkback there is no probe to pair with.
+    enable_echo_cancel_ = enable_echo_cancel_ && enable_talkback_;
+    // Shared mic pipeline (encoded once, fanned out, gated NULL/PLAYING for privacy). Optional: if it
+    // can't be built (no mic), carry on video-only.
+    if (enable_audio_ && !build_audio_pipeline()) {
+        RCLCPP_WARN(this->get_logger(), "Audio pipeline build failed; continuing video-only");
+        enable_audio_ = false;
     }
     // Talkback is the RECEIVE half of the audio m-line, and that m-line exists only because the mic is
     // sending on it — no mic, no talkback. Lifting that would mean an add-transceiver(RECVONLY) m-line.
@@ -192,8 +201,9 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     RCLCPP_INFO(this->get_logger(), "WebRTC Streamer ready (%zu cameras, source: %s, compressed: %s)", cameras_.size(),
                 current_source_.c_str(), use_compressed_images_ ? "true" : "false");
     RCLCPP_INFO(this->get_logger(), "  Mic audio: %s", enable_audio_ ? "enabled (opt-in per peer)" : "disabled");
-    RCLCPP_INFO(this->get_logger(), "  Talkback: %s",
-                enable_talkback_ ? "enabled (push-to-talk per peer)" : "disabled");
+    RCLCPP_INFO(this->get_logger(), "  Talkback: %s%s",
+                enable_talkback_ ? "enabled (push-to-talk per peer)" : "disabled",
+                enable_echo_cancel_ ? ", echo-cancelled (full duplex)" : "");
     RCLCPP_INFO(this->get_logger(), "  Local STUN: %s", enable_local_stun_ ? "enabled" : "disabled");
     RCLCPP_INFO(this->get_logger(), "  RTCP-inactivity teardown: %.1f s", rtcp_inactivity_timeout_s_);
 }
@@ -282,6 +292,13 @@ WebRTCStreamer::~WebRTCStreamer() {
     if (audio_pipeline_) {
         gst_element_set_state(audio_pipeline_, GST_STATE_NULL);
         gst_object_unref(audio_pipeline_);
+    }
+    // After the peers: their taps push into talk_appsrc_ until their pipelines are down.
+    if (talk_appsrc_)
+        gst_object_unref(talk_appsrc_);
+    if (speaker_pipeline_) {
+        gst_element_set_state(speaker_pipeline_, GST_STATE_NULL);
+        gst_object_unref(speaker_pipeline_);
     }
 }
 
@@ -384,6 +401,7 @@ void WebRTCStreamer::poll_pipeline_health() {
 
     drain_bus(encode_pipeline_, "encode", /*expected_teardown=*/false);
     drain_bus(audio_pipeline_, "audio", /*expected_teardown=*/false);
+    drain_bus(speaker_pipeline_, "speaker", /*expected_teardown=*/false);
 
     std::unique_lock<std::mutex> lock(peers_mutex_);
     if (peers_.empty()) {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -173,6 +173,22 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
             gst_object_unref(sink);
         }
     }
+    // webrtcdsp is its own .so inside gstreamer1.0-plugins-bad (built only when webrtc-audio-processing
+    // is present); a system without it should degrade to plain half-duplex talkback, not lose talkback
+    // to a parse failure.
+    if (enable_echo_cancel_) {
+        GstElementFactory* dsp = gst_element_factory_find("webrtcdsp");
+        GstElementFactory* probe = gst_element_factory_find("webrtcechoprobe");
+        if (!dsp || !probe) {
+            RCLCPP_WARN(this->get_logger(),
+                        "webrtcdsp/webrtcechoprobe unavailable; echo cancel off (half-duplex talkback)");
+            enable_echo_cancel_ = false;
+        }
+        if (dsp)
+            gst_object_unref(dsp);
+        if (probe)
+            gst_object_unref(probe);
+    }
     // Before the mic pipeline: its webrtcdsp pairs with this pipeline's probe, which must exist first.
     if (enable_talkback_ && !build_speaker_pipeline()) {
         enable_talkback_ = false;
@@ -190,6 +206,8 @@ WebRTCStreamer::WebRTCStreamer(const rclcpp::NodeOptions& options)
     if (enable_talkback_ && !enable_audio_) {
         RCLCPP_WARN(this->get_logger(), "No audio m-line (mic unavailable); talkback disabled");
         enable_talkback_ = false;
+        enable_echo_cancel_ = false;
+        teardown_speaker_pipeline();  // just built above; keeping it PLAYING would hold ALSA open for nothing
     }
     start_local_stun_server();
 
@@ -294,12 +312,7 @@ WebRTCStreamer::~WebRTCStreamer() {
         gst_object_unref(audio_pipeline_);
     }
     // After the peers: destroy_peer pulls each one's input out of the mixer, so by here it has none.
-    if (talk_mixer_)
-        gst_object_unref(talk_mixer_);
-    if (speaker_pipeline_) {
-        gst_element_set_state(speaker_pipeline_, GST_STATE_NULL);
-        gst_object_unref(speaker_pipeline_);
-    }
+    teardown_speaker_pipeline();
 }
 
 // =============================================================================
@@ -401,7 +414,9 @@ void WebRTCStreamer::poll_pipeline_health() {
 
     drain_bus(encode_pipeline_, "encode", /*expected_teardown=*/false);
     drain_bus(audio_pipeline_, "audio", /*expected_teardown=*/false);
-    drain_bus(speaker_pipeline_, "speaker", /*expected_teardown=*/false);
+    if (drain_bus(speaker_pipeline_, "speaker", /*expected_teardown=*/false)) {
+        restart_speaker_pipeline();
+    }
 
     std::unique_lock<std::mutex> lock(peers_mutex_);
     if (peers_.empty()) {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -293,9 +293,9 @@ WebRTCStreamer::~WebRTCStreamer() {
         gst_element_set_state(audio_pipeline_, GST_STATE_NULL);
         gst_object_unref(audio_pipeline_);
     }
-    // After the peers: their taps push into talk_appsrc_ until their pipelines are down.
-    if (talk_appsrc_)
-        gst_object_unref(talk_appsrc_);
+    // After the peers: destroy_peer pulls each one's input out of the mixer, so by here it has none.
+    if (talk_mixer_)
+        gst_object_unref(talk_mixer_);
     if (speaker_pipeline_) {
         gst_element_set_state(speaker_pipeline_, GST_STATE_NULL);
         gst_object_unref(speaker_pipeline_);

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -164,23 +164,26 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         }
     }
     // Talkback rides that same m-line in reverse: claim the recv direction, then take the operator's
-    // mic off webrtcbin's pad-added (see TalkGate for why the gate is shared with that callback).
+    // mic off webrtcbin's pad-added (the gate rides element data because that callback and the tap's
+    // sample callback run on streaming threads that must not take peers_mutex_).
     if (ok && peer->with_audio && enable_talkback_) {
         peer->with_talk = enable_talk_direction(peer->webrtc, static_cast<guint>(negotiated.size()));
         if (peer->with_talk) {
-            peer->talk_gate->open = talk_active;  // pre-PLAYING: the pad-added thread does not exist yet
+            peer->talk_gate->store(talk_active, std::memory_order_relaxed);
             g_object_set_data_full(G_OBJECT(peer->webrtc), "mars_talk_gate",
-                                   new std::shared_ptr<TalkGate>(peer->talk_gate),
-                                   [](gpointer p) { delete static_cast<std::shared_ptr<TalkGate>*>(p); });
+                                   new std::shared_ptr<std::atomic<bool>>(peer->talk_gate),
+                                   [](gpointer p) { delete static_cast<std::shared_ptr<std::atomic<bool>>*>(p); });
             g_signal_connect(peer->webrtc, "pad-added", G_CALLBACK(on_talk_pad_added), this);
         } else {
             RCLCPP_WARN(this->get_logger(), "webrtcbin refused a sendrecv audio transceiver; talkback disabled");
         }
     }
     peer->talk_active = peer->with_talk && talk_active;
-    // Half-duplex: while the operator talks, stop sending them the robot's mic. The robot's speaker is
-    // within earshot of its own mic, so full duplex is an echo of the operator's own voice.
-    peer->audio_active = peer->with_audio && peer->audio_requested && !peer->talk_active;
+    // The robot's speaker is within earshot of its own mic, so without AEC the talker would hear their
+    // own voice come back — half-duplex ducks the mic to them. With AEC the echo is subtracted at the
+    // capture, so the duck (and the deafness it causes while talking) is lifted.
+    const bool talk_duck = peer->talk_active && !enable_echo_cancel_;
+    peer->audio_active = peer->with_audio && peer->audio_requested && !talk_duck;
     if (!ok) {
         RCLCPP_ERROR(this->get_logger(), "Transport pipeline missing/failed an rtp appsrc");
         return nullptr;  // ~Peer() tears down the pipeline + the rtp appsrcs stored so far
@@ -289,8 +292,8 @@ void WebRTCStreamer::update_peer_active(Peer* peer, const std::vector<std::strin
     }
     peer->active = next;
 
-    // Talkback toggles first: it ducks the outbound mic below, so the operator never hears their own voice
-    // come back off the robot's speaker.
+    // Talkback toggles first: without AEC it ducks the outbound mic below, so the operator never hears
+    // their own voice come back off the robot's speaker.
     const bool talk_now = peer->with_talk && talk_active;
     if (talk_now != peer->talk_active) {
         set_peer_talk(peer, talk_now);
@@ -304,7 +307,7 @@ void WebRTCStreamer::update_peer_active(Peer* peer, const std::vector<std::strin
     // the lock; closing it (want_audio_ -> 0) is deferred to the health poll, which runs without the lock,
     // because NULL-ing the audio pipeline joins the fan-out thread that also takes peers_mutex_.
     peer->audio_requested = audio_active;
-    const bool audio_now = peer->with_audio && audio_active && !peer->talk_active;
+    const bool audio_now = peer->with_audio && audio_active && !(peer->talk_active && !enable_echo_cancel_);
     if (audio_now != peer->audio_active) {
         if (audio_now) {
             want_audio_.fetch_add(1, std::memory_order_relaxed);
@@ -361,61 +364,57 @@ void WebRTCStreamer::on_talk_pad_added(GstElement* webrtc, GstPad* pad, gpointer
     if (!pipeline) {
         return;
     }
+    // A thin RTP tap, not a playback branch: decode and playout live in the shared speaker pipeline,
+    // so this peer's thread only pulls packets and (gate open) forwards them — see on_talk_sample.
     GError* error = nullptr;
-    GstElement* branch = gst_parse_bin_from_description(self->talk_branch_description().c_str(), TRUE, &error);
-    if (error || !branch) {
-        RCLCPP_ERROR(self->get_logger(), "Talkback branch failed to build: %s", error ? error->message : "unknown");
+    GstElement* tap = gst_parse_bin_from_description(
+        "queue leaky=downstream max-size-buffers=10 max-size-bytes=0 max-size-time=0 ! "
+        "appsink name=talk_tap emit-signals=true sync=false async=false max-buffers=8 drop=true",
+        TRUE, &error);
+    if (error || !tap) {
+        RCLCPP_ERROR(self->get_logger(), "Talkback tap failed to build: %s", error ? error->message : "unknown");
         if (error) {
             g_error_free(error);
         }
-        if (branch) {
-            gst_object_unref(branch);
+        if (tap) {
+            gst_object_unref(tap);
         }
         gst_object_unref(pipeline);
         return;
     }
+    auto* gate =
+        static_cast<std::shared_ptr<std::atomic<bool>>*>(g_object_get_data(G_OBJECT(webrtc), "mars_talk_gate"));
+    if (GstElement* talk_sink = gst_bin_get_by_name(GST_BIN(tap), "talk_tap")) {
+        if (gate) {
+            g_object_set_data_full(G_OBJECT(talk_sink), "mars_talk_gate", new std::shared_ptr<std::atomic<bool>>(*gate),
+                                   [](gpointer p) { delete static_cast<std::shared_ptr<std::atomic<bool>>*>(p); });
+        }
+        g_signal_connect(talk_sink, "new-sample", G_CALLBACK(on_talk_sample), self);
+        gst_object_unref(talk_sink);
+    }
 
-    gst_bin_add(GST_BIN(pipeline), branch);
-    gst_element_sync_state_with_parent(branch);
-    GstPad* sink = gst_element_get_static_pad(branch, "sink");
+    gst_bin_add(GST_BIN(pipeline), tap);
+    gst_element_sync_state_with_parent(tap);
+    GstPad* sink = gst_element_get_static_pad(tap, "sink");
     const bool linked = sink && gst_pad_link(pad, sink) == GST_PAD_LINK_OK;
     if (sink) {
         gst_object_unref(sink);
     }
     if (!linked) {
-        RCLCPP_ERROR(self->get_logger(), "Failed to link the talkback branch to webrtcbin");
-        gst_element_set_state(branch, GST_STATE_NULL);
-        gst_bin_remove(GST_BIN(pipeline), branch);
+        RCLCPP_ERROR(self->get_logger(), "Failed to link the talkback tap to webrtcbin");
+        gst_element_set_state(tap, GST_STATE_NULL);
+        gst_bin_remove(GST_BIN(pipeline), tap);
         gst_object_unref(pipeline);
         return;
     }
-    // Hand the valve to the gate and arm it in one critical section (see TalkGate). Until here the
-    // valve has dropped everything (built drop=true), so audio that raced the attach never leaked.
-    bool open_now = false;
-    auto* gate = static_cast<std::shared_ptr<TalkGate>*>(g_object_get_data(G_OBJECT(webrtc), "mars_talk_gate"));
-    GstElement* valve = gst_bin_get_by_name(GST_BIN(branch), "talk_valve");
-    if (gate && valve) {
-        std::lock_guard<std::mutex> lock((*gate)->mutex);
-        (*gate)->valve = valve;  // the gate keeps this ref; ~TalkGate releases it
-        open_now = (*gate)->open;
-        g_object_set(valve, "drop", open_now ? FALSE : TRUE, nullptr);
-    } else if (valve) {
-        gst_object_unref(valve);
-    }
     g_object_set_data(G_OBJECT(webrtc), "mars_talk_attached", GINT_TO_POINTER(1));
-    RCLCPP_INFO(self->get_logger(), "Talkback branch attached (speaker %s)", open_now ? "open" : "muted");
+    RCLCPP_INFO(self->get_logger(), "Talkback tap attached");
     gst_object_unref(pipeline);
 }
 
-// Open/close one peer's speaker path. The gate is the source of truth (the branch may not exist yet — the
-// operator can press talk before their first RTP packet arrives); the valve is flipped when it does.
 void WebRTCStreamer::set_peer_talk(Peer* peer, bool on) {
     peer->talk_active = on;
-    std::lock_guard<std::mutex> lock(peer->talk_gate->mutex);
-    peer->talk_gate->open = on;
-    if (peer->talk_gate->valve) {
-        g_object_set(peer->talk_gate->valve, "drop", on ? FALSE : TRUE, nullptr);
-    }
+    peer->talk_gate->store(on, std::memory_order_relaxed);
 }
 
 void WebRTCStreamer::on_negotiation_needed(GstElement* webrtc, gpointer user_data) {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -179,11 +179,7 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         }
     }
     peer->talk_active = peer->with_talk && talk_active;
-    // The robot's speaker is within earshot of its own mic, so without AEC the talker would hear their
-    // own voice come back — half-duplex ducks the mic to them. With AEC the echo is subtracted at the
-    // capture, so the duck (and the deafness it causes while talking) is lifted.
-    const bool talk_duck = peer->talk_active && !enable_echo_cancel_;
-    peer->audio_active = peer->with_audio && peer->audio_requested && !talk_duck;
+    peer->audio_active = peer_audio_active(*peer);
     if (!ok) {
         RCLCPP_ERROR(this->get_logger(), "Transport pipeline missing/failed an rtp appsrc");
         return nullptr;  // ~Peer() tears down the pipeline + the rtp appsrcs stored so far
@@ -242,7 +238,7 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         peer->with_talk = false;
         peer->talk_active = false;
         peer->talk_gate->store(false, std::memory_order_relaxed);
-        peer->audio_active = peer->with_audio && peer->audio_requested;  // nothing left to duck for
+        peer->audio_active = peer_audio_active(*peer);  // talk_active now false: nothing left to duck for
     }
     if (peer->with_talk) {
         g_object_set_data(G_OBJECT(peer->webrtc), "mars_talk_src", peer->talk_src);
@@ -321,7 +317,7 @@ void WebRTCStreamer::update_peer_active(Peer* peer, const std::vector<std::strin
     // the lock; closing it (want_audio_ -> 0) is deferred to the health poll, which runs without the lock,
     // because NULL-ing the audio pipeline joins the fan-out thread that also takes peers_mutex_.
     peer->audio_requested = audio_active;
-    const bool audio_now = peer->with_audio && audio_active && !(peer->talk_active && !enable_echo_cancel_);
+    const bool audio_now = peer_audio_active(*peer);
     if (audio_now != peer->audio_active) {
         if (audio_now) {
             want_audio_.fetch_add(1, std::memory_order_relaxed);
@@ -431,6 +427,13 @@ void WebRTCStreamer::on_talk_pad_added(GstElement* webrtc, GstPad* pad, gpointer
 void WebRTCStreamer::set_peer_talk(Peer* peer, bool on) {
     peer->talk_active = on;
     peer->talk_gate->store(on, std::memory_order_relaxed);
+}
+
+// The mic a peer hears is their LISTEN intent minus the talk duck: without AEC a talking operator would
+// hear their own voice come back off the robot's speaker; with AEC the echo is subtracted at the capture,
+// so the duck (and the deafness it causes while talking) is lifted.
+bool WebRTCStreamer::peer_audio_active(const Peer& peer) const {
+    return peer.with_audio && peer.audio_requested && !(peer.talk_active && !enable_echo_cancel_);
 }
 
 void WebRTCStreamer::on_negotiation_needed(GstElement* webrtc, gpointer user_data) {

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -164,8 +164,8 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         }
     }
     // Talkback rides that same m-line in reverse: claim the recv direction, then take the operator's
-    // mic off webrtcbin's pad-added (the gate rides element data because that callback and the tap's
-    // sample callback run on streaming threads that must not take peers_mutex_).
+    // mic off webrtcbin's pad-added (the gate rides element data because that callback and the decode
+    // branch's sample callback run on streaming threads that must not take peers_mutex_).
     if (ok && peer->with_audio && enable_talkback_) {
         peer->with_talk = enable_talk_direction(peer->webrtc, static_cast<guint>(negotiated.size()));
         if (peer->with_talk) {
@@ -232,6 +232,20 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
         RCLCPP_ERROR(this->get_logger(), "Transport pipeline failed to reach PLAYING (audio=%s)",
                      with_audio ? "on" : "off");
         return nullptr;  // ~Peer() tears down the pipeline
+    }
+
+    // Every failure return is behind us, so an attached mixer input can no longer be orphaned by one.
+    // This is also before the offer is created below, and a peer cannot receive RTP before it has
+    // offered — so the tag is always in place by the time pad-added fires.
+    if (peer->with_talk && !attach_speaker_input(peer.get())) {
+        RCLCPP_WARN(this->get_logger(), "No speaker input for peer '%s'; talkback disabled for it", client_id.c_str());
+        peer->with_talk = false;
+        peer->talk_active = false;
+        peer->talk_gate->store(false, std::memory_order_relaxed);
+        peer->audio_active = peer->with_audio && peer->audio_requested;  // nothing left to duck for
+    }
+    if (peer->with_talk) {
+        g_object_set_data(G_OBJECT(peer->webrtc), "mars_talk_src", peer->talk_src);
     }
 
     // Keep listening for future negotiation-needed signals, but create the first offer explicitly after all
@@ -364,51 +378,53 @@ void WebRTCStreamer::on_talk_pad_added(GstElement* webrtc, GstPad* pad, gpointer
     if (!pipeline) {
         return;
     }
-    // A thin RTP tap, not a playback branch: decode and playout live in the shared speaker pipeline,
-    // so this peer's thread only pulls packets and (gate open) forwards them — see on_talk_sample.
+    // This peer's own depayloader and decoder, in this peer's own pipeline — so its jitterbuffer's GAP
+    // events still reach opusdec (that is what plc=true conceals loss with), and so two operators talking
+    // at once never share a depayloader. Only the decoded PCM crosses into the shared speaker mixer.
     GError* error = nullptr;
-    GstElement* tap = gst_parse_bin_from_description(
-        "queue leaky=downstream max-size-buffers=10 max-size-bytes=0 max-size-time=0 ! "
-        "appsink name=talk_tap emit-signals=true sync=false async=false max-buffers=8 drop=true",
-        TRUE, &error);
-    if (error || !tap) {
-        RCLCPP_ERROR(self->get_logger(), "Talkback tap failed to build: %s", error ? error->message : "unknown");
+    GstElement* branch = gst_parse_bin_from_description(talk_decode_description().c_str(), TRUE, &error);
+    if (error || !branch) {
+        RCLCPP_ERROR(self->get_logger(), "Talkback branch failed to build: %s", error ? error->message : "unknown");
         if (error) {
             g_error_free(error);
         }
-        if (tap) {
-            gst_object_unref(tap);
+        if (branch) {
+            gst_object_unref(branch);
         }
         gst_object_unref(pipeline);
         return;
     }
+    // The gate and this peer's mixer input ride on the appsink: on_talk_sample runs on this peer's
+    // streaming thread, which must not reach into peers_ for either of them.
     auto* gate =
         static_cast<std::shared_ptr<std::atomic<bool>>*>(g_object_get_data(G_OBJECT(webrtc), "mars_talk_gate"));
-    if (GstElement* talk_sink = gst_bin_get_by_name(GST_BIN(tap), "talk_tap")) {
+    auto* talk_src = static_cast<GstElement*>(g_object_get_data(G_OBJECT(webrtc), "mars_talk_src"));
+    if (GstElement* pcm_sink = gst_bin_get_by_name(GST_BIN(branch), "talk_pcm")) {
         if (gate) {
-            g_object_set_data_full(G_OBJECT(talk_sink), "mars_talk_gate", new std::shared_ptr<std::atomic<bool>>(*gate),
+            g_object_set_data_full(G_OBJECT(pcm_sink), "mars_talk_gate", new std::shared_ptr<std::atomic<bool>>(*gate),
                                    [](gpointer p) { delete static_cast<std::shared_ptr<std::atomic<bool>>*>(p); });
         }
-        g_signal_connect(talk_sink, "new-sample", G_CALLBACK(on_talk_sample), self);
-        gst_object_unref(talk_sink);
+        g_object_set_data(G_OBJECT(pcm_sink), "mars_talk_src", talk_src);
+        g_signal_connect(pcm_sink, "new-sample", G_CALLBACK(on_talk_sample), self);
+        gst_object_unref(pcm_sink);
     }
 
-    gst_bin_add(GST_BIN(pipeline), tap);
-    gst_element_sync_state_with_parent(tap);
-    GstPad* sink = gst_element_get_static_pad(tap, "sink");
+    gst_bin_add(GST_BIN(pipeline), branch);
+    gst_element_sync_state_with_parent(branch);
+    GstPad* sink = gst_element_get_static_pad(branch, "sink");
     const bool linked = sink && gst_pad_link(pad, sink) == GST_PAD_LINK_OK;
     if (sink) {
         gst_object_unref(sink);
     }
     if (!linked) {
-        RCLCPP_ERROR(self->get_logger(), "Failed to link the talkback tap to webrtcbin");
-        gst_element_set_state(tap, GST_STATE_NULL);
-        gst_bin_remove(GST_BIN(pipeline), tap);
+        RCLCPP_ERROR(self->get_logger(), "Failed to link the talkback branch to webrtcbin");
+        gst_element_set_state(branch, GST_STATE_NULL);
+        gst_bin_remove(GST_BIN(pipeline), branch);
         gst_object_unref(pipeline);
         return;
     }
     g_object_set_data(G_OBJECT(webrtc), "mars_talk_attached", GINT_TO_POINTER(1));
-    RCLCPP_INFO(self->get_logger(), "Talkback tap attached");
+    RCLCPP_INFO(self->get_logger(), "Talkback branch attached (peer decodes into the speaker mixer)");
     gst_object_unref(pipeline);
 }
 
@@ -467,7 +483,12 @@ void WebRTCStreamer::destroy_peer(const std::string& client_id) {
     }
 
     RCLCPP_INFO(this->get_logger(), "Released peer '%s'", client_id.c_str());
-    peers_.erase(it);           // ~Peer() NULLs the transport (joining its streaming threads) and releases the refs
+    // Taken before the erase, released after it: ~Peer NULLs the transport (joining the streaming thread
+    // that pushes into this appsrc), so only then is pulling its mixer input out of the speaker safe.
+    GstElement* talk_src = p->talk_src;
+    GstPad* talk_mix_pad = p->talk_mix_pad;
+    peers_.erase(it);  // ~Peer() NULLs the transport (joining its streaming threads) and releases the refs
+    detach_speaker_input(talk_src, talk_mix_pad);
     reconcile_subscriptions();  // last peer wanting a camera may have just left — drop its sub if so
 }
 

--- a/webapp/js/micControl.js
+++ b/webapp/js/micControl.js
@@ -1,10 +1,11 @@
 // @ts-check
-// Hold-to-talk button: pointer-hold or spacebar, with the ripple/waveform glass
-// the agent composer introduced. Shared by the two pages that capture the
-// operator's voice — the agent page (sim), where speech becomes a transcript,
-// and teleop, where it plays live out the robot's speaker. Only the wording
-// differs; the hold semantics (and the rule that the spacebar belongs to
-// whatever the operator is typing in) are the same either way.
+// Operator mic button with the ripple/waveform glass the agent composer
+// introduced. Shared by the two pages that capture the operator's voice, in
+// two modes: "hold" (push-to-talk — pointer-hold or spacebar) on the agent
+// page (sim), where speech becomes a transcript, and "toggle" (Meet-style
+// mute/unmute — a click or a spacebar tap) on teleop, where it plays live out
+// the robot's speaker. In both modes the spacebar belongs to whatever the
+// operator is typing in.
 
 import { isTypingContext } from "./shell.js";
 
@@ -25,6 +26,7 @@ const WAVEFORM_DB_RANGE = 48;
  * @param {{
  *   startListening: () => void | Promise<void>,
  *   stopListening: () => void,
+ *   mode?: "hold" | "toggle",
  *   holdLabel?: string,
  *   listeningLabel?: string,
  *   buttonLabel?: string,
@@ -45,6 +47,7 @@ export function createMicControl(root, callbacks) {
   const {
     startListening,
     stopListening,
+    mode = "hold",
     holdLabel = "Hold to talk to the agent",
     listeningLabel = "Listening…",
     buttonLabel = "",
@@ -53,6 +56,10 @@ export function createMicControl(root, callbacks) {
     activeButtonHint = "Release to stop",
     composerInput = null,
   } = callbacks;
+  const isToggle = mode === "toggle";
+  const idleTitle = isToggle
+    ? "Toggle your mic — Spacebar or click"
+    : "Hold to talk — Spacebar, or click and hold";
 
   const control = document.createElement("div");
   control.className = "agent-mic-control";
@@ -62,7 +69,7 @@ export function createMicControl(root, callbacks) {
   button.className = "agent-mic-button";
   button.setAttribute("aria-label", holdLabel);
   button.setAttribute("aria-pressed", "false");
-  button.title = "Hold to talk — Spacebar, or click and hold";
+  button.title = idleTitle;
 
   const icon = decorativeSpan("agent-mic-icon");
   const action = document.createElement("span");
@@ -141,14 +148,14 @@ export function createMicControl(root, callbacks) {
       "aria-label",
       isUnavailable ? unavailableReason || "Microphone unavailable" : holdLabel,
     );
-    button.title = isUnavailable ? "" : "Hold to talk — Spacebar, or click and hold";
+    button.title = isUnavailable ? "" : idleTitle;
     let statusText = "";
     let visibleLabel = buttonLabel;
     let visibleHint = buttonHint;
     if (isWaiting) {
       statusText = "Starting…";
       visibleLabel = "CONNECTING";
-      visibleHint = "Keep holding";
+      visibleHint = isToggle ? "One moment" : "Keep holding";
     } else if (isListening) {
       statusText = listeningLabel;
       visibleLabel = activeButtonLabel;
@@ -236,6 +243,30 @@ export function createMicControl(root, callbacks) {
   function syncPushToTalk() {
     if (activeHoldSources.size > 0) void startPushToTalk();
     else stopPushToTalk();
+  }
+
+  function toggleMic() {
+    if (isPushToTalkActive) stopPushToTalk();
+    else void startPushToTalk();
+  }
+
+  /** @param {KeyboardEvent} event */
+  function onToggleKeyDown(event) {
+    if (event.code !== SPACEBAR_KEY_CODE) return;
+    if (
+      button.disabled ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      event.shiftKey ||
+      !spacebarCanControlMic()
+    ) {
+      return;
+    }
+    // Every repeat too, or a held spacebar scrolls the page; it also keeps a
+    // focused button from firing its native click on keyup (a double toggle).
+    event.preventDefault();
+    if (!event.repeat) toggleMic();
   }
 
   function cancelPendingPointerHold() {
@@ -354,15 +385,21 @@ export function createMicControl(root, callbacks) {
   }
 
   const listenerOptions = { signal: eventListenerController.signal };
-  button.addEventListener("pointerdown", onMicPointerDown, listenerOptions);
-  button.addEventListener("pointerup", onMicPointerUp, listenerOptions);
-  button.addEventListener("pointercancel", onMicPointerCancel, listenerOptions);
-  button.addEventListener("lostpointercapture", onMicPointerCancel, listenerOptions);
-  window.addEventListener("keydown", onWindowKeyDown, listenerOptions);
-  window.addEventListener("keyup", onWindowKeyUp, listenerOptions);
-  window.addEventListener("blur", releaseAllPushToTalkHolds, listenerOptions);
+  if (isToggle) {
+    button.addEventListener("click", toggleMic, listenerOptions);
+    window.addEventListener("keydown", onToggleKeyDown, listenerOptions);
+  } else {
+    button.addEventListener("pointerdown", onMicPointerDown, listenerOptions);
+    button.addEventListener("pointerup", onMicPointerUp, listenerOptions);
+    button.addEventListener("pointercancel", onMicPointerCancel, listenerOptions);
+    button.addEventListener("lostpointercapture", onMicPointerCancel, listenerOptions);
+    window.addEventListener("keydown", onWindowKeyDown, listenerOptions);
+    window.addEventListener("keyup", onWindowKeyUp, listenerOptions);
+    window.addEventListener("blur", releaseAllPushToTalkHolds, listenerOptions);
+    document.addEventListener("focusin", onDocumentFocusIn, listenerOptions);
+  }
+  // A hidden tab must not keep a live mic open (toggle) or a stuck hold (hold).
   document.addEventListener("visibilitychange", onDocumentVisibilityChange, listenerOptions);
-  document.addEventListener("focusin", onDocumentFocusIn, listenerOptions);
   document.addEventListener("pointerdown", dismissMicMessages, listenerOptions);
   renderMicState();
 

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -7,7 +7,7 @@
 // Disconnected: one quiet connect card. Connected: the video is the room —
 // full-bleed stage with glass overlays (telemetry top-left, head tilt and
 // mic toggle on the right edge, WASD chips bottom-left, joystick + speak bar
-// + hold-to-talk bottom-center). On reconnecting we keep the cockpit (frozen
+// + mic mute toggle bottom-center). On reconnecting we keep the cockpit (frozen
 // video, badge pulses); only an intentional disconnect or failed connect
 // shows the card.
 

--- a/webapp/js/teleop/talkControl.js
+++ b/webapp/js/teleop/talkControl.js
@@ -1,8 +1,15 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// Teleop half-duplex audio: hold to transmit, then listen until three seconds
-// of room silence. A new hold always preempts listening.
+// Teleop talkback behind a Meet-style mute toggle. Unmuted, the mic streams
+// continuously and the room stays audible — full duplex through the robot's
+// AEC — except while the operator speaks: voice activity drops local playback
+// to DUCK_VOLUME (a duck, not a mute: loud room events and an interrupting
+// voice still read through) and recovers DUCK_RELEASE_MS after the last
+// syllable, long enough for the echo the AEC lets leak to finish its
+// speaker→mic→return round trip. (A robot without AEC ducks the mic it sends
+// while talk is on; there the operator hears nothing while unmuted.) Muting
+// listens on until three seconds of room silence, as before.
 
 import { createMicControl } from "../micControl.js";
 import { createAudioToggle } from "./videoStage.js";
@@ -12,6 +19,11 @@ const FFT_SIZE = 256;
 const RECEIVE_QUIET_MS = 3_000;
 const REMOTE_ACTIVITY_THRESHOLD = 0.02;
 const LEVEL_SMOOTHING = 0.75;
+const SPEECH_THRESHOLD = 0.03;
+// Voice→speaker→robot-mic→back is ~300-500ms on the LAN; the release must outlast it plus reverb.
+const DUCK_RELEASE_MS = 900;
+// Low enough to bury the AEC's residual echo, high enough that a shout or an interruption registers.
+const DUCK_VOLUME = 0.12;
 
 /**
  * @param {HTMLElement} parent
@@ -26,18 +38,22 @@ export function createTalkControl(parent, session, audioEl) {
 
   let isReceiving = false;
   let alwaysListen = false;
+  let unmuted = false;
+  let ducked = false;
+  let lastVoiceAt = -Infinity;
   let receiveDeadline = 0;
   let receiveTimer = 0;
 
   const control = createMicControl(mount, {
+    mode: "toggle",
     startListening: startTransmitting,
     stopListening: stopTransmitting,
-    holdLabel: "Hold to transmit in two-way talk",
-    listeningLabel: "Transmitting — you are audible",
-    buttonLabel: "2-WAY TALK",
-    buttonHint: "Hold to transmit",
-    activeButtonLabel: "TRANSMITTING",
-    activeButtonHint: "Release to listen",
+    holdLabel: "Toggle your microphone",
+    listeningLabel: "Unmuted — you are audible",
+    buttonLabel: "MIC MUTED",
+    buttonHint: "Unmute to talk",
+    activeButtonLabel: "MIC LIVE",
+    activeButtonHint: "Room ducks while you speak",
   });
 
   /** @type {ReturnType<typeof createAudioToggle>} */
@@ -85,15 +101,32 @@ export function createTalkControl(parent, session, audioEl) {
     const level = rms(samples);
     control.setAudioFeedback({ level, waveform: buckets(samples) });
     smoothedLevel = smoothedLevel * LEVEL_SMOOTHING + level * (1 - LEVEL_SMOOTHING);
+    if (meterMode === "transmit") {
+      // Raw level, not smoothed: the duck must attack on the first frame of voice.
+      const now = performance.now();
+      if (level >= SPEECH_THRESHOLD) lastVoiceAt = now;
+      setDucked(now - lastVoiceAt < DUCK_RELEASE_MS);
+    }
     if (
       meterMode === "receive" &&
-      !alwaysListen &&
+      !receiveHeld() &&
       isReceiving &&
       smoothedLevel >= REMOTE_ACTIVITY_THRESHOLD
     ) {
       receiveDeadline = performance.now() + RECEIVE_QUIET_MS;
     }
     frame = requestAnimationFrame(tick);
+  }
+
+  /** @param {boolean} d */
+  function setDucked(d) {
+    if (ducked === d) return;
+    ducked = d;
+    audioEl.volume = d ? DUCK_VOLUME : 1;
+  }
+
+  function receiveHeld() {
+    return alwaysListen || unmuted;
   }
 
   function stopMetering() {
@@ -119,7 +152,7 @@ export function createTalkControl(parent, session, audioEl) {
     const remaining = Math.max(0, receiveDeadline - performance.now());
     receiveTimer = window.setTimeout(() => {
       receiveTimer = 0;
-      if (alwaysListen || !isReceiving) return;
+      if (receiveHeld() || !isReceiving) return;
       if (performance.now() < receiveDeadline) {
         scheduleReceiveClose();
         return;
@@ -144,7 +177,7 @@ export function createTalkControl(parent, session, audioEl) {
     renderReceiveState();
     session.setAudio(true);
     void audioEl.play().catch(() => {});
-    if (alwaysListen) {
+    if (receiveHeld()) {
       window.clearTimeout(receiveTimer);
       receiveTimer = 0;
     } else {
@@ -165,28 +198,32 @@ export function createTalkControl(parent, session, audioEl) {
   /** @param {boolean} active */
   function toggleAlwaysListen(active) {
     alwaysListen = active;
-    if (session.state.talkRequested) return;
+    if (unmuted) return; // receive is already held open while unmuted
     if (active) startReceiving();
     else stopReceiving();
   }
 
   async function startTransmitting() {
-    stopReceiving();
+    unmuted = true;
     listenToggle.setEnabled(false);
+    startReceiving(); // inside the click gesture, so audioEl.play() unlocks audible autoplay
     await session.setTalk(true);
   }
 
   function stopTransmitting() {
+    unmuted = false;
     listenToggle.setEnabled(true);
+    setDucked(false);
     const didTransmit = session.state.talkRequested;
     void session.setTalk(false);
-    if (didTransmit || alwaysListen) startReceiving();
+    if (didTransmit || alwaysListen) startReceiving(); // re-arms the 3s-quiet window
+    else stopReceiving();
   }
 
   const unsub = session.onChange((state) => {
-    listenToggle.setEnabled(!state.talkRequested);
-    if (state.talkRequested) listenToggle.setActive(false);
+    listenToggle.setEnabled(!state.talkRequested && !unmuted);
     control.setCaptureState({ on: state.talkRequested, busy: false, error: state.talkError });
+    if (!state.talkRequested) setDucked(false);
     if (state.talkRequested && state.talkStream) {
       meter(state.talkStream, "transmit");
       return;

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -14,9 +14,9 @@
 // fallback; only the main camera is exposed (the arm camera is ignored in v1).
 //
 // Talkback rides the SAME audio m-line in reverse: the robot offers it sendrecv,
-// so we answer sendrecv and keep an empty sender until the operator holds talk,
-// then replaceTrack(mic) — no renegotiation, and no getUserMedia (so no mic
-// permission prompt) until the button is actually pressed.
+// so we answer sendrecv and keep an empty sender until the operator first
+// unmutes, then replaceTrack(mic) — no renegotiation, and no getUserMedia (so
+// no mic permission prompt) until the mic is actually unmuted.
 //
 // Self-heal: 30 s initial-handshake watchdog, ICE disconnected/failed
 // persisting 10 s → re-handshake, and a re-handshake whenever the rosbridge
@@ -222,13 +222,13 @@ export class WebRtcSession {
   }
 
   /**
-   * Hold/release talkback: this browser's mic plays out the robot's speaker — a track swap on the
-   * already-sendrecv audio m-line plus a no-reneg START. getUserMedia waits for the first press.
+   * Unmute/mute talkback: this browser's mic plays out the robot's speaker — a track swap on the
+   * already-sendrecv audio m-line plus a no-reneg START. getUserMedia waits for the first unmute.
    * @param {boolean} on
    */
   async setTalk(on) {
-    // Recorded before any await: a release landing while getUserMedia is still pending must beat the
-    // press that is waiting on it, or the resumed press puts the operator live with the button already up.
+    // Recorded before any await: a mute landing while getUserMedia is still pending must beat the
+    // unmute that is waiting on it, or the resumed unmute puts the operator live after they muted.
     this.#talkDesired = on;
     if (this.#state.talkRequested === on) return;
     if (on && !(await this.#openMic())) return; // the failure is already in state.talkError
@@ -268,7 +268,7 @@ export class WebRtcSession {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         // Cancels what this browser is playing (the robot's mic, if the operator is also listening);
-        // the robot-side half-duplex duck is what handles the loop through its own speaker.
+        // the loop through the robot's own speaker is handled robot-side (AEC, or its half-duplex duck).
         audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true, autoGainControl: true },
       });
       if (epoch !== this.#micEpoch) {


### PR DESCRIPTION
## What

Lifts talkback's half-duplex limitation: with `enable_echo_cancel:=true`, the operator keeps hearing the robot's mic **while** they talk. The echo that half-duplex guarded against — the robot's speaker being within earshot of its own mic — is cancelled at the capture instead, by WebRTC's Audio Processing Module (`webrtcdsp` + `webrtcechoprobe`, already installed via `gstreamer1.0-plugins-bad`, the package `webrtcbin` comes from).

**Defaults off.** With the parameter false the duck stays and behavior is unchanged; flip it on the bench to validate cancellation quality before making it the default.

## How

AEC needs one reference signal of what the speaker actually plays, so the per-peer playback branches collapse into **one speaker pipeline**, built at startup and left PLAYING (ALSA is dmix; holding the device open costs nothing):

```
appsrc (RTP) → rtpopusdepay → opusdec → volume → [webrtcechoprobe] → queue → alsasink
```

Peers now attach a thin RTP **tap** (`queue → appsink`) on `pad-added` instead of a full decode branch; the tap forwards packets into the shared appsrc only while that peer's talk gate is open. The mic pipeline gains, when enabled:

```
… caps(48k mono) → webrtcdsp echo-cancel=true delay-agnostic=true → opusenc …
```

`delay-agnostic` because capture and playout are separate pipelines on separate clocks, and dmix hides the true playout latency — the canceller estimates alignment itself.

## What this deletes

The valve, and with it the entire gate-snapshot race class from the last review rounds: the gate is now only ever **read**, per packet, on the tap's streaming thread. There is no write-after-read left to interleave, so `TalkGate` shrinks back to an atomic bool. The tap callback takes no locks (`~Peer` joins that thread), matching the existing fan-out discipline.

## Ordering that matters

`webrtcdsp` **hard-errors at start** if its probe doesn't exist (verified live on the robot, not just from docs). Therefore: the speaker pipeline (which owns the probe) is built before the mic pipeline, and `enable_echo_cancel` is forced off whenever talkback is disabled — a mic pipeline with a probe-less DSP can never be built.

## Verified / not verified

- ✅ Builds clean, zero warnings; clang-format clean.
- ✅ The exact speaker chain parses and reaches PLAYING with the probe (gst-launch, on the robot).
- ✅ `webrtcechoprobe` + `webrtcdsp echo-cancel=true delay-agnostic=true` pair and run in one process.
- ❌ Cancellation quality with real speaker/mic acoustics — the reason the default is off.
- ❌ Talkback audio end to end — same standing caveat as the base branch.

## Known limit

Two peers talking simultaneously now interleave RTP into one depayloader and glitch; one talker at a time is the supported shape. (The old design mixed N talkers via dmix, but N sinks cannot host a single AEC probe.)
