### PR TITLE
fix(webrtc): stop artifacting on tunneled remote links

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_internal.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_internal.hpp
@@ -60,11 +60,14 @@ inline guint cam_ssrc_for_index(size_t index) {
     return 0x1A2B3C00u + static_cast<guint>(index) + 1u;
 }
 
-// RTP payload type per camera (96, 97, 99, 100, …) — skips 98, which the audio (opus) payloader uses.
+// PTs must be unique across the whole BUNDLE (RFC 8843 §9.1), INCLUDING the red/ulpfec/rtx/rtx PTs
+// webrtcbin auto-assigns per video m-line — sequentially after that m-line's media PT, at link time.
+// A 5-PT stride (96, 101, 106, …) leaves each m-line its 4 aux slots; audio sits above them all.
 inline int cam_pt_for_index(size_t index) {
-    const int pt = 96 + static_cast<int>(index);
-    return pt >= 98 ? pt + 1 : pt;
+    return 96 + 5 * static_cast<int>(index);
 }
+
+inline constexpr int kAudioPt = 127;
 
 // Chrome/Firefox often obfuscate their host ICE candidates as "<uuid>.local" mDNS names (one per local
 // interface). These parsing helpers are kept for diagnostics and for a future non-destructive fast path:

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_internal.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_internal.hpp
@@ -69,6 +69,10 @@ inline int cam_pt_for_index(size_t index) {
 
 inline constexpr int kAudioPt = 127;
 
+// The dynamic PT range is 96-127; camera 6 would land on 126 and push its aux block onto (and past)
+// kAudioPt, so the stride fits exactly 6 cameras. configure_cameras enforces this.
+inline constexpr size_t kMaxCameras = 6;
+
 // Chrome/Firefox often obfuscate their host ICE candidates as "<uuid>.local" mDNS names (one per local
 // interface). These parsing helpers are kept for diagnostics and for a future non-destructive fast path:
 // if we ever resolve a .local name ourselves, we must ADD the resolved-IP candidate, not replace/drop the

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/webrtc_streamer.hpp
@@ -44,7 +44,7 @@ class WebRTCStreamer;  // CameraEncoder back-references the node for the static 
 struct CameraEncoder {
     std::string name;
     std::string live_topic, replay_topic;
-    int pt = 96;      // RTP payload type, unique per camera (audio uses 98)
+    int pt = 96;      // RTP payload type, unique per camera (see cam_pt_for_index)
     int fps = 30;     // encoder framerate (appsrc caps)
     int width = 640;  // encode resolution (appsrc caps); incoming frames are resized to it
     int height = 480;

--- a/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
+++ b/ros2_ws/src/mars_bot/mars_cam/launch/camera_composable.launch.py
@@ -106,6 +106,9 @@ def generate_launch_description():
                 # once two cameras streamed, and the resulting keyframe storms compounded the loss.
                 "main_bitrate_kbps": 1500,
                 "arm_bitrate_kbps": 800,
+                # Must match the driver's real capture rate (stereo_depth_estimator.yaml): the encoder's
+                # caps, per-frame rate-control budget, and the 4 s keyframe backstop all key off it.
+                "main_fps": 15,
                 # Local-only STUN Binding responder. Browsers still obfuscate host candidates as mDNS,
                 # but when they query stun:<robot-lan-ip>:3478, the srflx candidate they emit is the LAN
                 # IP:port observed by the robot, not a public NAT hairpin route.

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -279,13 +279,13 @@ bool WebRTCStreamer::build_audio_pipeline() {
         src += " device=\"" + audio_capture_device_ + "\"";
     }
     // mic -> opus -> rtp -> appsink (the fan-out tap). Encoded once for all peers; matches the RTP caps
-    // each peer's transport audio appsrc declares (OPUS/48000/pt98).
+    // each peer's transport audio appsrc declares (OPUS/48000, kAudioPt).
     std::string desc = src +
                        " do-timestamp=true ! "
                        "queue leaky=downstream max-size-buffers=10 max-size-time=0 max-size-bytes=0 ! "
                        "audioconvert ! audioresample ! audio/x-raw,rate=48000,channels=1 ! "
                        "opusenc bitrate=24000 audio-type=voice ! "
-                       "rtpopuspay name=pay_audio pt=98 ! "
+                       "rtpopuspay name=pay_audio pt=" + std::to_string(kAudioPt) + " ! "
                        "appsink name=sink_audio emit-signals=true sync=false async=false max-buffers=4 drop=true ";
     GError* error = nullptr;
     audio_pipeline_ = gst_parse_launch(desc.c_str(), &error);

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_encode.cpp
@@ -42,14 +42,21 @@ std::string WebRTCStreamer::video_encode_branch(const CameraEncoder& cam) const 
            "videoconvert ! "
            "vp8enc name=enc_" +
            cam.name + " deadline=1 target-bitrate=" + std::to_string(cam.bitrate_kbps * 1000) +
-           " cpu-used=4 error-resilient=partitions keyframe-max-dist=" + std::to_string(cam.fps * 4) +
+           // error-resilient=default is libvpx's loss-resilience mode (partitions only splits token
+           // partitions — a no-op with one partition). max-intra-bitrate caps an IDR at 3x the per-frame
+           // budget so a recovery keyframe can't eat the 600 ms CBR buffer and slam the quantizer.
+           " cpu-used=4 error-resilient=default max-intra-bitrate=300 keyframe-max-dist=" +
+           std::to_string(cam.fps * 4) +
            " end-usage=cbr buffer-size=600 buffer-initial-size=400 buffer-optimal-size=500 ! "
            // picture-id-mode is required for browsers: without picture IDs Chrome can't prove frame
            // continuity after loss and discards every delta frame until the next keyframe — NACK/RTX
            // repair lands and is thrown away (measured: 5 fps + keyframe cycling at 5% loss).
+           // mtu sized for tunneled paths (Tailscale/WireGuard: 1280 - 28 IP/UDP = 1252 on the wire):
+           // media +1 RED +10 SRTP and the ~14-bytes-bigger FEC packets must all fit. The 1400 default
+           // fragmented every full packet, and either lost fragment kills it — measured ~2x native loss.
            "rtpvp8pay name=pay_" +
            cam.name + " pt=" + std::to_string(cam.pt) + " ssrc=" + std::to_string(cam.ssrc) +
-           " picture-id-mode=15-bit ! "
+           " picture-id-mode=15-bit mtu=1200 ! "
            "appsink name=sink_" +
            cam.name + " emit-signals=true sync=false async=false max-buffers=2 drop=true ";
 }

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -337,9 +337,11 @@ void WebRTCStreamer::on_peer_stats(GstPromise* promise, gpointer user_data) {
                 type != GST_WEBRTC_STATS_REMOTE_INBOUND_RTP) {
                 return TRUE;
             }
-            // rb-fractionlost is the RR's 0-255 fraction; round-trip-time is seconds (double).
-            if (guint fl = 0; gst_structure_get_uint(s, "rb-fractionlost", &fl)) {
-                const int promille = static_cast<int>(fl * 1000 / 255);
+            // fraction-lost is the RR's loss as a double in [0,1); round-trip-time is seconds (double).
+            // (rb-fractionlost exists only on webrtcbin's INTERNAL input stats, never in this reply —
+            // reading it here left the controller loss-blind, adapting on RTT alone.)
+            if (gdouble fl = 0.0; gst_structure_get_double(s, "fraction-lost", &fl)) {
+                const int promille = static_cast<int>(fl * 1000.0);
                 if (promille > self->rtcp_loss_promille_.load(std::memory_order_relaxed)) {
                     self->rtcp_loss_promille_.store(promille, std::memory_order_relaxed);
                 }
@@ -388,9 +390,11 @@ void WebRTCStreamer::apply_adaptation(bool degraded, int loss_promille, int rtt_
                                  : "GOOD: full bitrate, on-demand keyframes, base FEC";
     if (loss_promille < 0 && rtt_ms < 0) {
         RCLCPP_INFO(this->get_logger(), "Network adaptation -> %s (no viewer reports)", state);
+    } else if (loss_promille < 0) {
+        RCLCPP_INFO(this->get_logger(), "Network adaptation -> %s (viewer loss n/a, rtt %d ms)", state, rtt_ms);
     } else {
         RCLCPP_INFO(this->get_logger(), "Network adaptation -> %s (viewer loss %.1f%%, rtt %d ms)", state,
-                    loss_promille < 0 ? 0.0 : loss_promille / 10.0, rtt_ms);
+                    loss_promille / 10.0, rtt_ms);
     }
 }
 
@@ -424,11 +428,11 @@ void WebRTCStreamer::poll_network_adaptation() {
     }
 
     // Enter DEGRADED fast (2 s of trouble), leave slowly (15 s without it) — flapping re-keyframes
-    // hurt more than staying conservative. clean is exactly !bad: any value band between the two
-    // would freeze the exit counter and make DEGRADED permanent (e.g. a steady 200 ms RTT path).
-    // A tick with no report leaves the counters unchanged (get-stats answers land between ticks).
+    // hurt more than staying conservative. Loss-only: RTT is a property of the path, not damage — a
+    // tunneled remote link sits at 250-350 ms forever, and an RTT trigger flapped DEGRADED every ~30 s
+    // on exactly that path. A tick with no report leaves the counters unchanged.
     const bool report = loss >= 0 || rtt >= 0;
-    const bool bad = loss >= 30 || rtt >= 250;
+    const bool bad = loss >= 30;
     if (report) {
         adapt_bad_ticks_ = bad ? adapt_bad_ticks_ + 1 : 0;
         adapt_good_ticks_ = bad ? 0 : adapt_good_ticks_ + 1;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_streamer.cpp
@@ -186,6 +186,11 @@ void WebRTCStreamer::configure_cameras() {
     };
     const auto names = this->declare_parameter<std::vector<std::string>>("cameras", {"main", "arm"});
     for (const auto& name : names) {
+        if (cameras_.size() >= kMaxCameras) {
+            RCLCPP_ERROR(this->get_logger(), "Camera '%s' dropped: the RTP payload-type space fits %zu cameras",
+                         name.c_str(), kMaxCameras);
+            continue;
+        }
         std::string def_live, def_replay;
         int def_fps = 30;
         if (auto it = kDefaults.find(name); it != kDefaults.end()) {
@@ -430,8 +435,9 @@ void WebRTCStreamer::poll_network_adaptation() {
     // Enter DEGRADED fast (2 s of trouble), leave slowly (15 s without it) — flapping re-keyframes
     // hurt more than staying conservative. Loss-only: RTT is a property of the path, not damage — a
     // tunneled remote link sits at 250-350 ms forever, and an RTT trigger flapped DEGRADED every ~30 s
-    // on exactly that path. A tick with no report leaves the counters unchanged.
-    const bool report = loss >= 0 || rtt >= 0;
+    // on exactly that path. A tick without a loss measurement leaves the counters unchanged — an
+    // RTT-only report can't prove the link clean.
+    const bool report = loss >= 0;
     const bool bad = loss >= 30;
     if (report) {
         adapt_bad_ticks_ = bad ? adapt_bad_ticks_ + 1 : 0;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/webrtc_transport.cpp
@@ -209,7 +209,7 @@ Peer* WebRTCStreamer::create_peer_transport(const std::string& client_id, const 
             GstCaps* caps =
                 gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, "audio", "encoding-name",
                                     G_TYPE_STRING, "OPUS", "clock-rate", G_TYPE_INT, 48000, "encoding-params",
-                                    G_TYPE_STRING, "2", "payload", G_TYPE_INT, 98, nullptr);
+                                    G_TYPE_STRING, "2", "payload", G_TYPE_INT, kAudioPt, nullptr);
             if (link_rtp_appsrc(peer->webrtc, asrc, caps, 1 * 1024 * 1024)) {
                 peer->rtp["audio"] = asrc;  // keep the ref
             } else {

--- a/ros2_ws/src/mars_bot/mars_cam/test/test_webrtc_internal.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/test/test_webrtc_internal.cpp
@@ -13,9 +13,10 @@ TEST(CamPt, StrideLeavesAuxSlotsAndAudioClear) {
     EXPECT_EQ(cam_pt_for_index(0), 96);
     EXPECT_EQ(cam_pt_for_index(1), 101);
     EXPECT_EQ(cam_pt_for_index(2), 106);
-    for (size_t i = 0; i < 6; ++i) {
+    for (size_t i = 0; i < kMaxCameras; ++i) {
         EXPECT_LT(cam_pt_for_index(i) + 4, kAudioPt);  // aux block clear of audio
     }
+    EXPECT_GE(cam_pt_for_index(kMaxCameras) + 4, kAudioPt);  // one more would collide — the cap is tight
 }
 
 // ---- SSRCs: fixed, unique per camera, 1-based off the base ----

--- a/ros2_ws/src/mars_bot/mars_cam/test/test_webrtc_internal.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/test/test_webrtc_internal.cpp
@@ -8,13 +8,14 @@
 
 using namespace mars_cam;
 
-// ---- RTP payload types: 96, 97, then skip 98 (reserved for opus audio), 99, 100, … ----
-TEST(CamPt, SkipsAudioPayloadType98) {
+// ---- RTP payload types: 5-PT stride so each m-line's red/ulpfec/rtx/rtx aux PTs stay unique ----
+TEST(CamPt, StrideLeavesAuxSlotsAndAudioClear) {
     EXPECT_EQ(cam_pt_for_index(0), 96);
-    EXPECT_EQ(cam_pt_for_index(1), 97);
-    EXPECT_EQ(cam_pt_for_index(2), 99);  // 98 is opus
-    EXPECT_EQ(cam_pt_for_index(3), 100);
-    EXPECT_NE(cam_pt_for_index(2), 98);
+    EXPECT_EQ(cam_pt_for_index(1), 101);
+    EXPECT_EQ(cam_pt_for_index(2), 106);
+    for (size_t i = 0; i < 6; ++i) {
+        EXPECT_LT(cam_pt_for_index(i) + 4, kAudioPt);  // aux block clear of audio
+    }
 }
 
 // ---- SSRCs: fixed, unique per camera, 1-based off the base ----

--- a/ros2_ws/src/mars_bot/mars_cam/test/webrtc_consumer.py
+++ b/ros2_ws/src/mars_bot/mars_cam/test/webrtc_consumer.py
@@ -51,8 +51,8 @@ START = "/webrtc/start"
 ACTIVE = "/webrtc/active_streams"
 OFFER_ID = "/webrtc/offer_id"
 
-# rtp payload types the node assigns: pt96 = main cam, pt97 = arm cam, pt98 = opus mic.
-PT = {96: "main", 97: "arm", 98: "audio"}
+# rtp payload types the node assigns: pt96 = main cam, pt101 = arm cam, pt127 = opus mic.
+PT = {96: "main", 101: "arm", 127: "audio"}
 
 
 class Driver:

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -49,11 +49,14 @@ const OFFER_GUARD_RESET_MS = 1_000;
 // Bounded retries instead of a single long stare-at-black, which is what made
 // refreshing feel faster.
 const MAX_HANDSHAKE_ATTEMPTS = 3;
-// Adaptive receive jitter buffer: receivers attach pinned to 0 (lowest latency,
-// right on LAN), then every poll the target is re-derived from path RTT + recent
-// video loss. On WAN a NACK retransmit arrives ~1 RTT after the gap, so the
-// buffer must cover that or loss plays out as artifacts/freezes.
+// Adaptive receive jitter buffer: receivers attach at the pc's last-known target
+// (0 until the path is measured — right on LAN), re-derived every poll from path
+// RTT + recent video loss. On WAN a NACK retransmit arrives ~1 RTT after the gap,
+// so the buffer must cover that or loss plays out as artifacts/freezes. Polls run
+// fast until the first RTT sample lands (ICE just connected): the first seconds
+// are exactly when an unbuffered receiver on a long path shows every loss.
 const JITTER_POLL_MS = 3_000;
+const JITTER_POLL_FAST_MS = 500;
 
 export class WebRtcSession {
   /** @type {import("./rosClient.js").RosClient} */ #ros;
@@ -369,17 +372,18 @@ export class WebRtcSession {
       return;
     }
 
-    // Start the video receiver's jitter buffer at zero (lowest latency, right
-    // on LAN); #adaptJitterBuffer raises it when RTT/loss show retransmits need
-    // room to land. Units differ: jitterBufferTarget is in milliseconds,
-    // playoutDelayHint in seconds (a 40ms target is 40 vs 0.04). Modern Chrome
-    // honors jitterBufferTarget and ignores the hint (not a strict fallback —
-    // both are set whenever present).
+    // Start the video receiver's jitter buffer at this pc's last-known target (0
+    // until the first RTT sample — lowest latency, right on LAN), not a hard 0: a
+    // track arriving after the path was measured must not reset to an unbuffered
+    // state the adapt poll already rejected. Units differ: jitterBufferTarget is
+    // in milliseconds, playoutDelayHint in seconds (a 40ms target is 40 vs 0.04).
+    // Modern Chrome honors jitterBufferTarget and ignores the hint (not a strict
+    // fallback — both are set whenever present).
     const receiver = event.receiver;
     if (receiver) {
       try {
-        if ("jitterBufferTarget" in receiver) receiver.jitterBufferTarget = 0;
-        if ("playoutDelayHint" in receiver) receiver.playoutDelayHint = 0;
+        if ("jitterBufferTarget" in receiver) receiver.jitterBufferTarget = this.#lastJitterTargetMs;
+        if ("playoutDelayHint" in receiver) receiver.playoutDelayHint = this.#lastJitterTargetMs / 1000;
       } catch {
         // unsupported; default buffer applies
       }
@@ -585,25 +589,36 @@ export class WebRtcSession {
 
   #startJitterPoll() {
     this.#clearJitterPoll();
-    this.#lastJitterTargetMs = 0; // the new pc's receivers attach pinned to 0 (#onTrack)
+    // #lastJitterTargetMs deliberately carries over from the previous pc: a rebuild talks to the
+    // same robot over the same path, so its tracks attach already buffered (#onTrack) instead of
+    // replaying the unbuffered first seconds. A stale value costs one fast poll to correct.
     this.#lastVideoPackets = { received: 0, lost: 0 };
-    this.#jitterPoll = setInterval(() => void this.#adaptJitterBuffer(), JITTER_POLL_MS);
+    const pc = this.#pc;
+    const tick = async () => {
+      if (this.#pc !== pc) return; // superseded mid-flight; don't re-arm a dead chain
+      const measured = await this.#adaptJitterBuffer();
+      if (this.#pc !== pc) return;
+      this.#jitterPoll = setTimeout(tick, measured ? JITTER_POLL_MS : JITTER_POLL_FAST_MS);
+    };
+    this.#jitterPoll = setTimeout(tick, JITTER_POLL_FAST_MS);
   }
 
   #clearJitterPoll() {
     if (this.#jitterPoll !== null) {
-      clearInterval(this.#jitterPoll);
+      clearTimeout(this.#jitterPoll);
       this.#jitterPoll = null;
     }
   }
 
   // Clean fast path (LAN-ish RTT, ~no loss) → 0. Otherwise ~1.2×RTT + 30ms, capped at 500,
   // so a NACK retransmit lands before playout. 20ms hysteresis avoids churning the decoder.
+  // Returns whether an RTT sample was available, so #startJitterPoll keeps the fast cadence
+  // until the path is measured.
   async #adaptJitterBuffer() {
     const pc = this.#pc;
-    if (!pc) return;
+    if (!pc) return false;
     const stats = await pc.getStats().catch(() => null);
-    if (!stats || this.#pc !== pc) return;
+    if (!stats || this.#pc !== pc) return false;
 
     /** @type {number | null} */ let rttMs = null;
     const packets = { received: 0, lost: 0 };
@@ -618,11 +633,11 @@ export class WebRtcSession {
     const dReceived = packets.received - this.#lastVideoPackets.received;
     const dLost = packets.lost - this.#lastVideoPackets.lost;
     this.#lastVideoPackets = packets;
-    if (rttMs === null) return;
+    if (rttMs === null) return false;
 
     const loss = dLost > 0 ? dLost / (dReceived + dLost) : 0;
     const target = rttMs < 60 && loss < 0.005 ? 0 : Math.min(500, Math.round(rttMs * 1.2 + 30));
-    if (Math.abs(target - this.#lastJitterTargetMs) <= 20) return;
+    if (Math.abs(target - this.#lastJitterTargetMs) <= 20) return true;
     this.#lastJitterTargetMs = target;
     for (const receiver of pc.getReceivers()) {
       if (receiver.track.kind !== "video") continue;
@@ -634,6 +649,7 @@ export class WebRtcSession {
       }
     }
     console.log(`[webrtc] jitter target -> ${target}ms (rtt ${Math.round(rttMs)}ms, loss ${(loss * 100).toFixed(1)}%)`);
+    return true;
   }
 
   #closePc() {


### PR DESCRIPTION
Follow-up to #664: artifacts persisted on a real remote link. Root-caused live on R7-27 with the
viewer connected over Tailscale (RTT 226–445 ms). Three independent bugs:

## 1. RTP packets didn't fit the path (the dominant cause)

The media path is a WireGuard tunnel: **MTU 1280**, so 1252 usable on the wire. `rtpvp8pay`'s
default `mtu=1400` (+1 RED, +10 SRTP) fragmented **every full-size packet** — and either lost
fragment kills the whole RTP packet. Measured on the live path:

| ICMP payload | loss |
|---|---|
| 56 B | 0.83% |
| 1200 B | 1.67% |
| 1400 B (fragmented) | **2.5%** |

FEC packets are ~14 B *bigger* than the media packets they protect, so the repair traffic
fragmented and died at the same rate. → `mtu=1200`.

## 2. The sender adaptation was loss-blind and flapped on RTT

`on_peer_stats` read `rb-fractionlost` (uint) — that field only exists on webrtcbin's *internal*
input stats, never in the `get-stats` reply (verified by disassembling the shipping
`libgstwebrtc.so`: the reply carries **`fraction-lost` as a double in [0,1)**). So
`rtcp_loss_promille_` never left −1, "viewer loss 0.0%" in the logs was the sentinel, and the
DEGRADED trigger degenerated to `rtt >= 250` — which a tunneled path straddles forever.
Observed: **17 GOOD↔DEGRADED flaps in 8 minutes**, each entry = bitrate cut + 100% FEC +
1 Hz forced keyframes on a link that had no loss spike.

Now: the real loss field is read, loss is the *only* trigger (RTT is a property of the path, not
damage), and an absent report logs `loss n/a` instead of a reassuring `0.0%`.

## 3. Encoder tuning made every recovery keyframe hurt

- `error-resilient=partitions` was a no-op (only splits token partitions; `token-parts` is 1).
  `default` is the actual libvpx loss-resilience mode.
- IDR size was unbounded: a recovery keyframe ate the 600 ms CBR buffer and libvpx answered with
  a quantizer slam on the following frames — the blocky pulsing after every PLI/DEGRADED entry.
  `max-intra-bitrate=300` caps it at 3× the per-frame budget (same neighborhood libwebrtc uses).
- `main_fps` defaulted to 30 but the driver captures 15 (`stereo_depth_estimator.yaml`), so the
  keyframe backstop was silently 8 s and rate control got a doubled per-frame budget.

## Also: duplicate payload types across the BUNDLE

The live offer carried `pt 97 = red(video0)` **and** `VP8(video1)`, `pt 98 = ulpfec(video0)`
**and** `opus` — webrtcbin assigns each m-line's red/ulpfec/rtx PTs sequentially after that
m-line's media PT, and 96/97/98 left no room. RFC 8843 §9.1 forbids duplicates in a bundle;
Chrome tolerates it today via the signaled `a=ssrc` lines, newer Chrome rejects the offer.
Cameras now stride 5 PTs apart (96, 101, …) reserving each m-line's aux block; audio moves
to 127. Updated the two tests that pinned the old scheme.

## Verified

- `colcon build --packages-select mars_cam` clean; `test_webrtc_internal` 7/7 pass.
- New pipeline strings parse and apply on **both** stacks: system GStreamer 1.20.3 and
  `/opt/gst` 1.24.12 (`error-resilient=default`, `max-intra-bitrate=300`, `mtu=1200`, `pt=127`).
- Not yet soak-tested live — needs a container restart on a robot with a remote viewer.

## Test plan

1. `innate restart`, connect the webapp over the remote path, press `p`.
2. Expect: loss well under 1% (no fragmentation), no 30 s GOOD↔DEGRADED cycle in the
   `webrtc_streamer` logs, `viewer loss` showing real numbers (or `n/a`, never a fake 0.0%),
   and no blocky pulse after keyframes.
3. Sanity-check a LAN viewer too: nothing here should change the clean-path behavior beyond
   ~17% more (smaller) packets from mtu=1200.
