### PR TITLE
fix(webapp): the I-beam only where text can be typed or selected

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -112,6 +112,33 @@ body {
   outline-offset: 2px;
 }
 
+/* An app, not a document: the initial `cursor: auto` puts an I-beam over every
+   readout and panel label, promising text entry on surfaces that take none.
+   Arrow by default — `button` and the `cursor: pointer` rules still win. */
+body {
+  cursor: default;
+}
+
+/* The caret opts back in for the two things it can honestly mean: type here, or
+   select-and-copy here (the surfaces that also override `user-select: none`). */
+input:not([type]),
+input[type="text"],
+input[type="search"],
+input[type="number"],
+input[type="password"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+textarea,
+[contenteditable],
+.agent-stream,
+.skills-pop-status,
+.challenge-active,
+.col-msg,
+.logs-view {
+  cursor: text;
+}
+
 button {
   font: inherit;
   color: inherit;


### PR DESCRIPTION
Hovering almost anything in the web app gave a text caret — panel titles, telemetry
readouts, stat tiles, legend labels, rail labels — as if you could click and type there.

## Why

Nothing in the app ever set a cursor policy, so every element fell through to CSS's
initial `cursor: auto`, which means "I-beam over text, arrow elsewhere". In a document
that's right. In a control room where nearly every pixel is a label or a readout, it
means the caret is on almost everything.

A sweep of all 11 routes with the app running against a stub rosbridge found **602
visible elements** showing the caret with no way to type into them. After: **0**.

## The fix

`body { cursor: default }`, and the caret opts back in for the two things it can honestly
mean:

- **type here** — text/search/number/password/email/url/tel inputs, `textarea`,
  `[contenteditable]` (`.set-num-wrap` already had it: clicking the field's padded frame
  focuses the input inside)
- **select-and-copy here** — the reading surfaces that already override the overlays'
  `user-select: none` (`.agent-stream`, `.skills-pop-status`, `.challenge-active`) plus
  the log views (`.col-msg`, `.logs-view`)

`button { cursor: pointer }` and the ~70 existing `cursor:` rules are direct matches, so
they beat the inherited default and keep winning everywhere they already applied.

## Verified

Served the app against a stub rosbridge and walked every route
(`/agent /teleop /nav /logging /datasets /collect /training /profiling /calibration
/armsdk /settings` + the `?demo` brain monitor), reading `getComputedStyle().cursor` on
every visible element:

| | before | after |
|---|---|---|
| non-typable elements showing a caret | 602 | 0 |
| text fields *not* showing a caret | 0 | 0 |
| buttons/links/selects showing a caret | 0 | 0 |

Also injected the detailed-mode chat structures (thought blocks, skill groups with
icons and chevrons) to confirm the caret does not leak from `.agent-stream` onto its
chrome — every interactive row there is a `<button>`, so its whole subtree stays
`pointer`. `webapp/tests/*.test.js` all pass.

## One judgement call

I kept the caret on the chat/thoughts stream and the log views, since there it means
"select and copy this" rather than "type here". If you'd rather the whole app were arrow
with no exceptions, deleting the five class selectors from the second rule does it.