### PR TITLE
fix(webapp): head slider thumb tracks the real head position

### DIFF
--- a/webapp/js/teleop/headTilt.js
+++ b/webapp/js/teleop/headTilt.js
@@ -4,9 +4,10 @@
 // Head tilt — thin vertical slider on the right edge, hairline tick at 0°.
 // Drag publishes std_msgs/Int32 to /mars/head/set_position at ~10 Hz.
 // Feedback from /mars/head/current_position (JSON-in-String) drives the
-// thumb whenever the operator isn't dragging — so a skill moving the head
-// keeps the slider honest — and a marker shows where the head really is
-// mid-drag. The default ±range is only a fallback: the feedback payload
+// thumb whenever the operator isn't dragging (after a short post-release
+// hold, so lagging reports don't yank the gesture back) — a skill moving
+// the head keeps the slider honest — and a marker shows where the head
+// really is mid-drag. The default ±range is only a fallback: the feedback payload
 // carries the robot's real min/max angles (e.g. ±25° on MARS) and the
 // slider adopts them on first contact.
 
@@ -18,6 +19,7 @@ import {
 } from "../constants.js";
 
 const PUBLISH_GAP_MS = 100;
+const FEEDBACK_GRACE_MS = 500;
 
 /**
  * @param {HTMLElement} parent
@@ -93,6 +95,9 @@ export function createHeadTilt(parent, rosClient) {
 
   let dragging = false;
   let lastPublishAt = 0;
+  // Feedback lags a release (transport + head travel), so the first post-drag
+  // report would yank the thumb back before it chases; hold the gesture briefly.
+  let feedbackHoldUntil = 0;
   /** @type {number | null} */
   let shownDeg = null;
 
@@ -142,6 +147,7 @@ export function createHeadTilt(parent, rosClient) {
     if (!dragging) return;
     dragging = false;
     wrap.classList.remove("engaged");
+    feedbackHoldUntil = performance.now() + FEEDBACK_GRACE_MS;
     command(degreesFrom(e), true); // final value always goes out
   }
 
@@ -166,7 +172,7 @@ export function createHeadTilt(parent, rosClient) {
     const deg = Math.max(minDeg, Math.min(maxDeg, parsed.current_position));
     actual.hidden = false;
     place(actual, deg);
-    if (!dragging) show(deg);
+    if (!dragging && performance.now() >= feedbackHoldUntil) show(deg);
   }, undefined, "std_msgs/msg/String");
 
   return {

--- a/webapp/js/teleop/headTilt.js
+++ b/webapp/js/teleop/headTilt.js
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
 // Head tilt — thin vertical slider on the right edge, hairline tick at 0°.
-// Drag publishes std_msgs/Int32 to /mars/head/set_position at ~10 Hz; a
-// marker fed from /mars/head/current_position (JSON-in-String) shows where
-// the head really is. The default ±range is only a fallback: the feedback
-// payload carries the robot's real min/max angles (e.g. ±25° on MARS) and
-// the slider adopts them on first contact.
+// Drag publishes std_msgs/Int32 to /mars/head/set_position at ~10 Hz.
+// Feedback from /mars/head/current_position (JSON-in-String) drives the
+// thumb whenever the operator isn't dragging — so a skill moving the head
+// keeps the slider honest — and a marker shows where the head really is
+// mid-drag. The default ±range is only a fallback: the feedback payload
+// carries the robot's real min/max angles (e.g. ±25° on MARS) and the
+// slider adopts them on first contact.
 
 import {
   HEAD_SET_POSITION_TOPIC,
@@ -81,7 +83,7 @@ export function createHeadTilt(parent, rosClient) {
     topLabel.textContent = `+${Math.round(maxDeg)}`;
     bottomLabel.textContent = String(Math.round(minDeg));
     zeroTick.style.top = `${fractionFor(0) * 100}%`;
-    if (commanded !== null) place(thumb, commanded);
+    if (shownDeg !== null) place(thumb, shownDeg);
   }
 
   /** @param {HTMLElement} el @param {number} deg */
@@ -92,7 +94,14 @@ export function createHeadTilt(parent, rosClient) {
   let dragging = false;
   let lastPublishAt = 0;
   /** @type {number | null} */
-  let commanded = null;
+  let shownDeg = null;
+
+  /** @param {number} deg */
+  function show(deg) {
+    shownDeg = deg;
+    place(thumb, deg);
+    readout.textContent = `${Math.round(deg)}°`;
+  }
 
   /** @param {PointerEvent} e @returns {number} */
   function degreesFrom(e) {
@@ -103,9 +112,7 @@ export function createHeadTilt(parent, rosClient) {
 
   /** @param {number} deg @param {boolean} force */
   function command(deg, force) {
-    commanded = deg;
-    place(thumb, deg);
-    readout.textContent = `${deg}°`;
+    show(deg);
     const now = performance.now();
     if (force || now - lastPublishAt >= PUBLISH_GAP_MS) {
       lastPublishAt = now;
@@ -159,11 +166,7 @@ export function createHeadTilt(parent, rosClient) {
     const deg = Math.max(minDeg, Math.min(maxDeg, parsed.current_position));
     actual.hidden = false;
     place(actual, deg);
-    // Until the operator commands something, the thumb tracks reality.
-    if (!dragging && commanded === null) {
-      place(thumb, deg);
-      readout.textContent = `${Math.round(deg)}°`;
-    }
+    if (!dragging) show(deg);
   }, undefined, "std_msgs/msg/String");
 
   return {


### PR DESCRIPTION
## Problem

Once the operator dragged the head-tilt slider once, the thumb froze at the last commanded value forever. When something else moved the head — a skill, the agent, another client — only the small "actual" marker moved; the slider thumb and the degree readout kept showing a stale position.

## Fix

The thumb and readout now mirror the feedback from `/mars/head/current_position` whenever the operator isn't actively dragging, instead of only before the first command. While dragging, the thumb still follows the pointer and the marker still shows where the head really is (the lag indicator).

One shared component (`webapp/js/teleop/headTilt.js`) serves Teleop, Collect, and Nav, so all three pages get the fix.

## Verification

- `npx tsc --noEmit` in `webapp/`: same pre-existing error count as `main` (all in vendor/armsdk files), `headTilt.js` clean.
- `webapp/tests/*.test.js` all pass.