### PR TITLE
fix(arm): give the gripper a derivative gain so it stops limit-cycling

### DIFF
--- a/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
+++ b/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
@@ -123,8 +123,11 @@
       # Close gently — the current cap means it presses in rather than impacts.
       profile_velocity: 60
       profile_acceleration: 30
-      gains_near: [400, 0, 0, 0, 0]
-      gains_teleop: [400, 0, 0, 0, 0]     # November teleop gains
+      # kd, not kp, is what mode 5 needs: the current cap saturates the position loop and
+      # the light free-swinging jaw then limit-cycles +/-0.2 rad forever once a fast move
+      # excites it. Measured unstable below kd 60-100; grip force is kp against the cap.
+      gains_near: [400, 0, 400, 0, 0]
+      gains_teleop: [400, 0, 400, 0, 0]   # November teleop gains + kd
 
     joint_7:
       servo_id: 7


### PR DESCRIPTION
## The bug

After any wave, the gripper swings open/closed ~22° and **never stops** — while the commanded position sits perfectly still. Recorded on R7-27:

```
commanded j6:  constant -0.0000  (8872 samples, one distinct value)
measured  j6:  -0.189 .. +0.203,  period ~1.09 s,  centred exactly on the setpoint
```

Torque-off was the only way to end it. A symmetric limit cycle around a static setpoint is a servo-side instability, not a bad command.

## Cause

#542 (2026-07-31) rebuilt the gripper's control config:

| | before | after |
|---|---|---|
| `control_mode` | 4 (extended position) | **5** (current-based position) |
| `current_limit` | 100 | **1300** |
| `goal_current` | — | **700** |
| `profile_velocity` / `_acceleration` | — | **60 / 30** |
| `gains_near` / `gains_teleop` | `[400,0,0,0,0]` | `[400,0,0,0,0]` ← unchanged since February |

New plant, old controller. Mode 5's current cap is a saturating nonlinearity inside the position loop; a light free-swinging jaw with **kd = 0** has nothing to dissipate energy, so it sits on the stability boundary. A fast move excites it — the wave replay steps the gripper **0.4755 rad in a single 50 Hz frame (23.8 rad/s)** — and it never decays. Under the old mode-4 config the joint didn't have the authority to sustain it, which is why this only shows up after 2026-07-31.

Every other position-controlled joint already carries a kd (1000 / 100 / 3600 / 1000). Joints 5 and 6 were the only two at zero.

## Ruled out

- **The 200 Hz Goal Position rewrite.** `torque_on` clears `has_target_`; one static command then hammered at 200 Hz settles at span 0.0015. Not the cause.
- **Anything specific to setpoint 0.0.** Same pose, same command oscillated on one approach and settled with span 0.0000 on another — excitation-dependent, i.e. marginal stability.

## Sweep (wave as excitation, 2–3 trials each)

| kd | j6 span (rad) | |
|---|---|---|
| 0 | 0.39–0.41 | oscillates |
| 10 | 0.39–0.41 | oscillates |
| 30 | 0.35–0.38 | oscillates |
| 60 | 0.26 | oscillates |
| **100** | 0.0015 | clean |
| 250 / 400 / 500 / 1500 / 4000 | 0.0015 | clean |

Threshold is between 60 and 100, with amplitude falling smoothly as kd rises — textbook damping. **400** is ~4× the threshold and still well under joint_4's 3600.

## Grip force is unaffected

Driving the jaw hard against its stop:

| | settled | sustained effort |
|---|---|---|
| kd = 0 | +0.5505 | **−100.0** |
| kd = 400 | +0.4924 | **−100.0** |

Identical, saturated at the 700 mA cap. kd damps velocity; the standing position error that *becomes* grip force is kp against that cap. The 700 mA grip #542 tuned for `pick_any_object` is untouched.

## Verified

Config edited, `colcon build --packages-select mars_arm`, `innate restart`, then 3 fresh wave runs from the shipped config: **span 0.0015 rad every time** (the encoder quantisation floor).

## Not fixed here

Joint 5 is also `kd = 0` and shows ±12 effort chatter while positionally static. Same latent issue, just not excited as hard — it wants its own tuning pass rather than a guessed value.

/cc the #542 author, since this touches the pick path's grip tuning.
