### PR TITLE
feat(brain): compact history in chunks so Gemini's implicit cache hits

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -689,6 +689,7 @@ class BrainAgent:
             streak=self._error_streak,
             running=running.primitive_name if running else None,
             history=self._context.history_len if self._context else 0,
+            tokens=self._context.last_usage if self._context else {},
             uptime=round(time.monotonic() - self._activated_at, 0) if self._state.is_brain_active else 0,
             motion=round(self._camera.motion_peak(), 4),
         )

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/context.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/context.py
@@ -5,8 +5,10 @@
 The native API — unlike the OpenAI-compatible layer — returns *thought
 summaries* (parts flagged ``thought: true``), which the agent surfaces in the
 app chat as robot thoughts. A response is distilled into a plain
-:class:`Decision` the agent loop acts on, and the bounded content history
-prunes old camera frames so requests stay small.
+:class:`Decision` the agent loop acts on, and the bounded content history is
+compacted in chunks — old camera frames masked, oldest turns evicted — so
+requests stay small while consecutive requests keep the shared byte prefix
+Gemini's implicit prompt cache needs (see :meth:`GeminiContext._prune`).
 
 Threading contract: :meth:`GeminiContext.generate` is the only blocking network
 call and only *reads* the history, so the agent awaits it on a worker thread
@@ -64,6 +66,9 @@ class GeminiContext:
         # goes on the wire (from generate's thread). The body must be treated
         # as read-only — it shares structure with the live history.
         self.on_request: Callable[[dict], None] | None = None
+        # usageMetadata of the newest response — prompt/cached/output token
+        # counts, surfaced on the trace snapshot (cache-hit observability).
+        self.last_usage: dict[str, int] = {}
 
     def clear(self) -> None:
         self._history = []
@@ -134,13 +139,21 @@ class GeminiContext:
             self.on_request(body)
         parts: list[dict] = []
         last_chunk: dict = {}
+        usage: dict = {}
         for chunk in self._transport(self._model, body):
             last_chunk = chunk
+            if "usageMetadata" in chunk:
+                usage = chunk["usageMetadata"]
             content = _model_content(chunk) or {}
             for part in content.get("parts") or []:
                 parts.append(part)
                 if on_speech and part.get("text") and not part.get("thought"):
                     on_speech(part["text"])
+        self.last_usage = {
+            "prompt": usage.get("promptTokenCount", 0),
+            "cached": usage.get("cachedContentTokenCount", 0),
+            "output": usage.get("candidatesTokenCount", 0),
+        }
         if not parts:
             # A 200 stream with no content at all: a safety block, a malformed
             # function call, or an empty candidate. Committing it would record
@@ -196,23 +209,35 @@ class GeminiContext:
         self._history.append({"role": "user", "parts": parts})
 
     def _prune(self) -> None:
+        """Compact the history in chunks, never one entry per turn.
+
+        Gemini's implicit prompt cache only hits when a prior request is a
+        byte prefix of the new one, so evicting or masking anything every turn
+        forfeits the cache on every request. The history therefore grows
+        append-only until a budget trips, and one compaction then evicts down
+        to half the cap and masks old frames in the same step — a single cache
+        miss per window instead of one per turn.
+        """
         history = self._history
-        while len(history) > self._max_history:
-            history.pop(0)
-        # The history must start with a plain user turn: a leading model turn or
-        # an orphaned function response (whose call was just pruned) is rejected.
-        while history and (
-            history[0].get("role") != "user" or any("functionResponse" in p for p in history[0].get("parts") or [])
-        ):
-            history.pop(0)
-        # A pruned turn must not stay pinned as the latest-only holder: absorb
-        # would "prune" an orphan dict nothing reads, and the reference would
-        # keep its base64 wrist frame alive for as long as the arm feed is stale.
-        if self._latest_only_turn is not None and not any(c is self._latest_only_turn[0] for c in history):
-            self._latest_only_turn = None
-        # Keep camera frames only in the newest few user turns (none at all if
-        # the configured keep-count is zero or nonsensical).
         keep = max(self._max_image_turns, 0)
+        if len(history) > self._max_history:
+            del history[: len(history) - self._max_history // 2]
+            # The history must start with a plain user turn: a leading model turn or
+            # an orphaned function response (whose call was just evicted) is rejected.
+            while history and (
+                history[0].get("role") != "user" or any("functionResponse" in p for p in history[0].get("parts") or [])
+            ):
+                history.pop(0)
+            # An evicted turn must not stay pinned as the latest-only holder: absorb
+            # would "prune" an orphan dict nothing reads, and the reference would
+            # keep its base64 wrist frame alive for as long as the arm feed is stale.
+            if self._latest_only_turn is not None and not any(c is self._latest_only_turn[0] for c in history):
+                self._latest_only_turn = None
+        elif self.image_turn_count <= 2 * keep:
+            return  # under both budgets: stay append-only, the cache is warm
+        # Mask down to the newest few frame turns (none at all if the keep-count
+        # is zero or nonsensical). Until a compaction, older frames ride the
+        # cached prefix at a tenth of the input price — cheap to carry.
         image_turns = [
             c for c in history if c.get("role") == "user" and any("inlineData" in p for p in c.get("parts") or [])
         ]


### PR DESCRIPTION
## Problem

Gemini's implicit prompt cache only hits when a previously sent request is a **byte prefix** of the new one. The brain's `_prune` ran on every absorb and, once the history saturated (~2 minutes into a session at 60 entries), did two prefix mutations per turn:

- `history.pop(0)` — slid the window, changing `contents[0]` on every request
- masked the oldest camera frame's `inlineData` in place — a mutation ~4.2k tokens into the prompt

Either one alone is a total cache miss. Measured on mars-the-47th by replaying real captured `/brain/trace` request bodies through the proxy:

```
B0 (repeat, control)                 prompt= 9950 cached=7853  (79%)
B0 grown by 2 (append-only)          prompt=12157 cached=7902  hit
B0 slid by 2 (what the robot does)   prompt=12025 cached=   0  miss
mask one frame mid-history           prompt= 8892 cached=   0  miss
```

So ~7.9k of ~10k prompt tokens per turn — system prompt, tools, text history, and the three older camera frames — were re-billed at full price on **every** turn. At gemini-3.6-flash rates that's ~71% of the brain's input spend (~$5.80/robot/hour of active brain) thrown away. Only the newest turn's frames are genuinely uncacheable.

(Latency is unaffected either way at this prompt size: paired cold/warm runs show the difference is noise below ~100k prompt tokens. This is a cost fix.)

## Fix

`_prune` becomes a chunked compaction. Between compactions the history is strictly append-only, so consecutive requests share the byte prefix and the cache hits. A compaction fires when either budget trips:

- history over `max_history` → evict down to **half** the cap (plus the existing legality fix-up)
- unmasked frame turns over **2× `max_image_turns`** → mask back down to the keep-count

Both actions run in the same step — each compaction is one cache miss, so paying both at once is free. In a 40-turn replay this turns 40/40 prefix breaks into 10/40 (~75% of requests are pure appends).

Trade-offs, deliberately accepted:
- Between compactions up to 2× the keep-count of frame turns ride the request (~3 extra frames ≈ 180KB upload, ~3.3k tokens — but cached tokens bill at a tenth of the input price, so carrying them is cheaper than re-billing the whole prefix).
- After a cap eviction the model keeps ≥ half the window instead of always-full.
- Wrist-frame latest-only masking is **untouched**: a stale gripper close-up misleading the model is a correctness rule (see the docstring), worth the cache miss it costs during manipulation.

## Observability

Nothing in the stack surfaced `cachedContentTokenCount` before (the brain never read `usageMetadata`; the proxy skips token extraction for streaming responses entirely). `generate()` now captures `usageMetadata` off the final stream chunk and the 1 Hz snapshot traces it as `tokens={prompt, cached, output}` on `/brain/trace`, so the hit rate is visible live.

Follow-up candidate (separate repo): the service-proxy's analytics also drop usage for streaming responses and have no cached-tokens column — the same blind spot on the billing side.

## Verification

- `ruff check` + `ruff format --check`: clean
- brain_client suite in `innate-os-test:fullbuild` (overlay recipe): **274 passed** — the existing prune/wrist/zero-image tests pass unchanged under the new semantics
- `basedpyright` in the same env: 15 errors on both origin/main and this branch (the documented env-artifact baseline; zero added)
- 40-turn synthetic replay through the real `GeminiContext`: byte-prefix stability between compactions, history cap, leading-turn legality, wrist masking, and zero-image config all asserted (dev harness, not shipped)
- Cache behavior measurements above ran on mars-the-47th through the production proxy against gemini-3.6-flash