### PR TITLE
fix(skills): pickAnything keeps picking the object it first saw (object permanence)

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -645,7 +645,10 @@ def _materialize_feed_annotations(cls) -> None:
             )
             continue
         resolved, optional = _split_optional(annotation)
-        if isinstance(resolved, type) and issubclass(resolved, Skill) and resolved is not Skill:
+        # py3.10 quirk: a subscripted generic (`tuple[float, float]`) passes
+        # isinstance(..., type) but crashes issubclass — and is never a feed.
+        is_class = isinstance(resolved, type) and get_origin(resolved) is None
+        if is_class and issubclass(resolved, Skill) and resolved is not Skill:
             if optional:
                 # The feed rule (`| None` = best effort) does not extend to
                 # composition: a declared sub-skill is always wired and its
@@ -660,7 +663,7 @@ def _materialize_feed_annotations(cls) -> None:
             setattr(cls, name, descriptor)
             descriptor.__set_name__(cls, name)
             continue
-        if isinstance(resolved, type) and issubclass(resolved, TrainedSkill) and resolved is not TrainedSkill:
+        if is_class and issubclass(resolved, TrainedSkill) and resolved is not TrainedSkill:
             # a generated physical-skill ref: same declaration shape as a code
             # sub-skill, materialized as the PhysicalSkill descriptor
             if optional:
@@ -679,7 +682,7 @@ def _materialize_feed_annotations(cls) -> None:
                 "(`gripper_open: GripperOpen`); bare `Skill` declares nothing."
             )
             continue
-        entry = feed_types.get(resolved) if isinstance(resolved, type) else None
+        entry = feed_types.get(resolved) if is_class else None
         if entry is None:
             hint = _feed_attr_hints().get(name)
             if hint is not None:

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -68,16 +68,29 @@ def _box_corners_px(det):
     return (x0 / 1000.0 * IMG_W, y0 / 1000.0 * IMG_H, x1 / 1000.0 * IMG_W, y1 / 1000.0 * IMG_H)
 
 
-def parse_det_px(text):
-    """Best (u, v) from a Gemini detection reply."""
+def parse_det_cands(text):
+    """All detections -> [(u, v, grip_strength | None)], best first.
+    (u, v) is the grasp_point when given, else the box center."""
+    cands = []
     for det in parse_dets(text):
         gp = det.get("grasp_point")
         if gp and len(gp) >= 2:
-            return (_norm1k(gp[1]) / 1000.0 * IMG_W, _norm1k(gp[0]) / 1000.0 * IMG_H)
-        c = _box_corners_px(det)
-        if c:
-            return ((c[0] + c[2]) / 2.0, (c[1] + c[3]) / 2.0)
-    return None
+            u, v = _norm1k(gp[1]) / 1000.0 * IMG_W, _norm1k(gp[0]) / 1000.0 * IMG_H
+        else:
+            c = _box_corners_px(det)
+            if not c:
+                continue
+            u, v = (c[0] + c[2]) / 2.0, (c[1] + c[3]) / 2.0
+        g = det.get("grip_strength")
+        grip = float(g) if isinstance(g, (int, float)) and not isinstance(g, bool) and math.isfinite(g) else None
+        cands.append((u, v, grip))
+    return cands
+
+
+def parse_det_px(text):
+    """Best (u, v) from a Gemini detection reply."""
+    cands = parse_det_cands(text)
+    return (cands[0][0], cands[0][1]) if cands else None
 
 
 def parse_det_grip(text):
@@ -89,8 +102,9 @@ def parse_det_grip(text):
     return None
 
 
-def parse_det_box(text):
-    """Best (x, y, w, h) from a Gemini detection reply."""
+def parse_det_boxes(text):
+    """All (x, y, w, h) boxes from a Gemini detection reply, best first."""
+    boxes = []
     for det in parse_dets(text):
         c = _box_corners_px(det)
         if not c:
@@ -98,8 +112,14 @@ def parse_det_box(text):
         x, y = int(c[0]), int(c[1])
         w, h = int(c[2]) - x, int(c[3]) - y
         if w >= 8 and h >= 8:
-            return (x, y, w, h)
-    return None
+            boxes.append((x, y, w, h))
+    return boxes
+
+
+def parse_det_box(text):
+    """Best (x, y, w, h) from a Gemini detection reply."""
+    boxes = parse_det_boxes(text)
+    return boxes[0] if boxes else None
 
 
 LK_PARAMS: dict[str, Any] = dict(

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -52,20 +52,51 @@ def parse_dets(text):
 
 
 def _norm1k(v):
-    """Gemini's normalized 0-1000 coords drift slightly out of range; clamp so
-    downstream slicing/CamShift never sees negative or off-image pixels."""
+    """Gemini's normalized 0-1000 coord -> clamped float, or None when it is
+    not a number. Clamped because the values drift slightly out of range and
+    downstream slicing/CamShift must never see negative or off-image pixels;
+    None because every match is now parsed, so one `null` coordinate late in
+    the reply must not sink the usable matches ahead of it."""
+    if isinstance(v, bool) or not isinstance(v, (int, float)) or not math.isfinite(v):
+        return None
     return min(1000.0, max(0.0, float(v)))
 
 
 def _box_corners_px(det):
     """box_2d [ymin,xmin,ymax,xmax] 0-1000 -> (x0,y0,x1,y1) px."""
     b = det.get("box_2d")
-    if not b or len(b) < 4:
+    if not isinstance(b, (list, tuple)) or len(b) < 4:
         return None
-    y0, x0, y1, x1 = [_norm1k(v) for v in b[:4]]
+    y0, x0, y1, x1 = (_norm1k(v) for v in b[:4])
+    if y0 is None or x0 is None or y1 is None or x1 is None:
+        return None
     y0, y1 = sorted((y0, y1))
     x0, x1 = sorted((x0, x1))
     return (x0 / 1000.0 * IMG_W, y0 / 1000.0 * IMG_H, x1 / 1000.0 * IMG_W, y1 / 1000.0 * IMG_H)
+
+
+def _grasp_px(det):
+    """grasp_point [y,x] 0-1000 -> (u, v) px, or None."""
+    gp = det.get("grasp_point")
+    if not isinstance(gp, (list, tuple)) or len(gp) < 2:
+        return None
+    y, x = _norm1k(gp[0]), _norm1k(gp[1])
+    if x is None or y is None:
+        return None
+    return (x / 1000.0 * IMG_W, y / 1000.0 * IMG_H)
+
+
+def _grip(det):
+    """grip_strength as a float, or None when absent or not a number."""
+    g = det.get("grip_strength")
+    if isinstance(g, bool) or not isinstance(g, (int, float)) or not math.isfinite(g):
+        return None
+    return float(g)
+
+
+def _center_px(det):
+    c = _box_corners_px(det)
+    return ((c[0] + c[2]) / 2.0, (c[1] + c[3]) / 2.0) if c else None
 
 
 def parse_det_cands(text):
@@ -73,17 +104,10 @@ def parse_det_cands(text):
     (u, v) is the grasp_point when given, else the box center."""
     cands = []
     for det in parse_dets(text):
-        gp = det.get("grasp_point")
-        if gp and len(gp) >= 2:
-            u, v = _norm1k(gp[1]) / 1000.0 * IMG_W, _norm1k(gp[0]) / 1000.0 * IMG_H
-        else:
-            c = _box_corners_px(det)
-            if not c:
-                continue
-            u, v = (c[0] + c[2]) / 2.0, (c[1] + c[3]) / 2.0
-        g = det.get("grip_strength")
-        grip = float(g) if isinstance(g, (int, float)) and not isinstance(g, bool) and math.isfinite(g) else None
-        cands.append((u, v, grip))
+        px = _grasp_px(det) or _center_px(det)
+        if px is None:
+            continue
+        cands.append((px[0], px[1], _grip(det)))
     return cands
 
 
@@ -96,9 +120,9 @@ def parse_det_px(text):
 def parse_det_grip(text):
     """grip_strength (float) from the best detection, or None."""
     for det in parse_dets(text):
-        g = det.get("grip_strength")
-        if isinstance(g, (int, float)) and not isinstance(g, bool) and math.isfinite(g):
-            return float(g)
+        g = _grip(det)
+        if g is not None:
+            return g
     return None
 
 

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -45,6 +45,10 @@ PARAMS = {
     # FIND / LOCALIZE
     "tilt_deg": -20.0,
     "settle_s": 1.2,
+    # Objects don't teleport: a match farther than this from the last sighting
+    # is a different instance (e.g. an identical twin), not the target. Sized
+    # above the worst back-projection disagreement between consecutive looks.
+    "mem_gate_m": 0.5,
     # POSITION. sweet_x ceiling is 0.43 (reach clamp); 0.37 grasps at ~0.32 —
     # grasping at the 0.40 reach edge stalls the wrist and overloads servo 2.
     "sweet_x": 0.37,
@@ -162,14 +166,53 @@ class PickAnyObject(Skill):
     _p = PARAMS
     _grip_strength: float | None = None
     _holding = False  # fingers committed on an object this run
+    _last_seen_odom: tuple[float, float] | None = None
 
     @resource
     def _proxy(self):
         return gemlib.make_client()
 
+    def _base_to_odom(self, xy):
+        """base_link floor point -> odom frame, or None without odometry."""
+        o = self._odom_xyt()
+        if o is None:
+            return None
+        ox, oy, th = o
+        c, s = math.cos(th), math.sin(th)
+        return (ox + c * xy[0] - s * xy[1], oy + s * xy[0] + c * xy[1])
+
+    def _memory_dist(self, cand):
+        """Metres from a candidate to the remembered target; inf when the
+        back-projection or odometry is unavailable."""
+        xy = pixel_to_floor(cand[0], cand[1], self._p["tilt_deg"])
+        wxy = self._base_to_odom(xy) if xy else None
+        if wxy is None or self._last_seen_odom is None:
+            return math.inf
+        return math.hypot(wxy[0] - self._last_seen_odom[0], wxy[1] - self._last_seen_odom[1])
+
+    def _choose_cand(self, cands):
+        """Object permanence: among several identical-looking matches, keep the
+        instance we've been tracking — the one nearest to where the target was
+        last seen (odom frame, so the memory survives base motion between
+        looks). A best match outside mem_gate_m is a different instance, so
+        the target counts as not seen this frame rather than re-anchoring on
+        a twin. Gemini's best-first order only breaks the first look."""
+        if self._last_seen_odom is None:
+            return cands[0]
+        best = min(cands, key=self._memory_dist)
+        d = self._memory_dist(best)
+        if d > self._p["mem_gate_m"]:
+            self.logger.info(f"[PickAnyObject] {len(cands)} match(es), nearest {d:.2f}m from last sighting — coasting")
+            return None
+        if len(cands) > 1:
+            self.logger.info(
+                f"[PickAnyObject] {len(cands)} matches; kept #{cands.index(best) + 1} ({d:.2f}m from last sighting)"
+            )
+        return best
+
     def _detect_px(self, prompt):
-        """Head frame -> best grasp pixel, or None. Also records Gemini's
-        per-object grip_strength for the close."""
+        """Head frame -> grasp pixel of the remembered target, or None. Also
+        records Gemini's per-object grip_strength for the close."""
         self.mobility.stop()
         self.sleep(self._p["settle_s"])
         img = self.main_image
@@ -180,7 +223,8 @@ class PickAnyObject(Skill):
             img,
             f"Find '{prompt}' lying on the floor in this image. Match precisely — "
             "not paper/packaging when asked for clothing, and NOT anything held "
-            "by the robot arm. Return ONLY a JSON list of matches, each "
+            "by the robot arm. Return ONLY a JSON list of ALL matches (every "
+            "one, if several look alike), each "
             '{"box_2d":[ymin,xmin,ymax,xmax], "grasp_point":[y,x], '
             '"grip_strength":s} normalized 0-1000, best first. grasp_point is '
             "the CENTER of the object (geometric middle of the visible blob), "
@@ -192,12 +236,19 @@ class PickAnyObject(Skill):
             "Empty list if not present.",
             logger=self.logger,
         )
-        px = vision.parse_det_px(text)
-        grip = vision.parse_det_grip(text)
-        if px is not None and grip is not None:
+        cands = vision.parse_det_cands(text)
+        cand = self._choose_cand(cands) if cands else None
+        if cand is None:
+            return None
+        u, v, grip = cand
+        if grip is not None:
             lo, hi = GRIP_STRENGTH_RANGE
             self._grip_strength = max(lo, min(hi, grip))
-        return px
+        xy = pixel_to_floor(u, v, self._p["tilt_deg"])
+        wxy = self._base_to_odom(xy) if xy else None
+        if wxy is not None:
+            self._last_seen_odom = wxy
+        return (u, v)
 
     def _localize_px(self, prompt):
         """Detect + back-project -> ((x,y)|None, pixel|None)."""
@@ -409,7 +460,7 @@ class PickAnyObject(Skill):
                 img,
                 f"Wrist camera on a robot gripper, looking down at the floor. "
                 f"Find '{prompt}' on the floor. Ignore the gripper fingers "
-                "themselves. Return ONLY a JSON list of matches, each "
+                "themselves. Return ONLY a JSON list of ALL matches, each "
                 '{"box_2d":[ymin,xmin,ymax,xmax]} normalized 0-1000, best first, '
                 "each box TIGHT around its object. Empty list if not visible.",
                 logger=self.logger,
@@ -417,9 +468,16 @@ class PickAnyObject(Skill):
             if img
             else None
         )
-        box = vision.parse_det_box(text)
+        boxes = vision.parse_det_boxes(text)
+        # The base already centred the tracked instance under the arm, so among
+        # identical twins the box nearest the servo aim point is ours.
+        box = min(boxes, key=self._wrist_aim_dist) if boxes else None
         px = (box[0] + box[2] / 2.0, box[1] + box[3] / 2.0) if box else None
         return px, box
+
+    def _wrist_aim_dist(self, box):
+        u, v = box[0] + box[2] / 2.0, box[1] + box[3] / 2.0
+        return math.hypot(u - self._p["wrist_box_u"], v - self._p["wrist_box_v"])
 
     def _next_wrist_hsv(self, last_b64, timeout=1.5):
         """Wait for a new wrist frame -> (hsv|None, b64)."""
@@ -720,13 +778,17 @@ class PickAnyObject(Skill):
             gemlib.ask_image(
                 self._proxy,
                 images,
-                f"Robot just tried to pick up '{prompt}'. {' '.join(labels)} "
-                f"Is '{prompt}' lying loose on the floor/carpet, OUT of the "
+                f"Robot just tried to pick up '{prompt}' and backed up a step. "
+                f"{' '.join(labels)} "
+                f"Is '{prompt}' lying loose on the floor/carpet DIRECTLY in "
+                "front of the robot (the spot it just grabbed at), OUT of the "
                 "robot's gripper? An object held between the gripper fingers "
                 "counts as grabbed even if it is still touching or resting on "
                 "the floor — answer NO for that, as for anything hanging from "
-                "the gripper. Answer YES only if the object is on the floor "
-                "free of the gripper. Answer only YES or NO.",
+                "the gripper. If several similar objects are visible, judge "
+                "ONLY the grab spot just ahead — identical objects lying "
+                "elsewhere do not count. Answer YES only if the object is on "
+                "the floor free of the gripper. Answer only YES or NO.",
                 logger=self.logger,
             )
             if images
@@ -764,6 +826,7 @@ class PickAnyObject(Skill):
         # Per-run reset: don't carry the last run's object or grip rating.
         self._grip_strength = None
         self._holding = False
+        self._last_seen_odom = None
         try:
             self.head.set_position(int(round(self._p["tilt_deg"])))
             # Fold to rest so the arm doesn't occlude the head camera

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -46,9 +46,14 @@ PARAMS = {
     "tilt_deg": -20.0,
     "settle_s": 1.2,
     # Objects don't teleport: a match farther than this from the last sighting
-    # is a different instance (e.g. an identical twin), not the target. Sized
-    # above the worst back-projection disagreement between consecutive looks.
-    "mem_gate_m": 0.5,
+    # is a different instance (e.g. an identical twin), not the target. The
+    # allowance grows with the range the memory was taken at, because
+    # pixel_to_floor over-ranges an object whose visible centre sits above the
+    # floor by ~range * height / camera_height (0.26 m) — a 6 cm object at 2 m
+    # back-projects 0.6 m too far, and only 0.11 m too far at the 0.37 m pick
+    # range, so a flat gate would reject the very object it is protecting.
+    "mem_gate_m": 0.35,
+    "mem_gate_frac": 0.4,
     # POSITION. sweet_x ceiling is 0.43 (reach clamp); 0.37 grasps at ~0.32 —
     # grasping at the 0.40 reach edge stalls the wrist and overloads servo 2.
     "sweet_x": 0.37,
@@ -111,6 +116,12 @@ WRIST_ALIGN_TIMEOUT_S = 60.0
 WRIST_MAX_JUMP_PX = 80.0
 WRIST_SEG_MIN_SCORE = 25.0
 WRIST_CAM_ABOVE_EE = 0.07
+# Gate rejections before the memory is treated as stale and re-anchored. At 2,
+# the first rejection still coasts — that is the case the gate exists for (the
+# target missed for one frame while a twin is detected) — and _localize_retry's
+# second look re-anchors instead of turning a wrong memory into a run-ending
+# "could not centre".
+MEM_COAST_LIMIT = 2
 WRIST_SEARCH_ARM = [0.1473, -0.0706, -0.4449, 1.3376, -0.0491]
 
 
@@ -166,7 +177,9 @@ class PickAnyObject(Skill):
     _p = PARAMS
     _grip_strength: float | None = None
     _holding = False  # fingers committed on an object this run
-    _last_seen_odom: tuple[float, float] | None = None
+    # (odom x, odom y, range from the base at that sighting)
+    _last_seen: tuple[float, float, float] | None = None
+    _coasts = 0  # consecutive looks the memory gate rejected
 
     @resource
     def _proxy(self):
@@ -181,29 +194,54 @@ class PickAnyObject(Skill):
         c, s = math.cos(th), math.sin(th)
         return (ox + c * xy[0] - s * xy[1], oy + s * xy[0] + c * xy[1])
 
+    def _sighting(self, cand):
+        """Candidate pixel -> (odom x, odom y, range from the base), or None
+        when it doesn't back-project or odometry is missing."""
+        xy = pixel_to_floor(cand[0], cand[1], self._p["tilt_deg"])
+        wxy = self._base_to_odom(xy) if xy else None
+        return (wxy[0], wxy[1], math.hypot(xy[0], xy[1])) if wxy else None
+
     def _memory_dist(self, cand):
         """Metres from a candidate to the remembered target; inf when the
         back-projection or odometry is unavailable."""
-        xy = pixel_to_floor(cand[0], cand[1], self._p["tilt_deg"])
-        wxy = self._base_to_odom(xy) if xy else None
-        if wxy is None or self._last_seen_odom is None:
+        seen = self._sighting(cand)
+        if seen is None or self._last_seen is None:
             return math.inf
-        return math.hypot(wxy[0] - self._last_seen_odom[0], wxy[1] - self._last_seen_odom[1])
+        return math.hypot(seen[0] - self._last_seen[0], seen[1] - self._last_seen[1])
 
     def _choose_cand(self, cands):
         """Object permanence: among several identical-looking matches, keep the
         instance we've been tracking — the one nearest to where the target was
         last seen (odom frame, so the memory survives base motion between
-        looks). A best match outside mem_gate_m is a different instance, so
-        the target counts as not seen this frame rather than re-anchoring on
-        a twin. Gemini's best-first order only breaks the first look."""
-        if self._last_seen_odom is None:
+        looks). A best match outside the gate is a different instance, so the
+        target counts as not seen this frame rather than re-anchoring on a
+        twin. Gemini's best-first order only breaks the first look.
+
+        The pick of the nearest candidate is immune to back-projection bias
+        (identical twins in one frame share it); only the absolute gate is
+        not, hence its range term."""
+        if self._last_seen is None:
             return cands[0]
         best = min(cands, key=self._memory_dist)
         d = self._memory_dist(best)
-        if d > self._p["mem_gate_m"]:
-            self.logger.info(f"[PickAnyObject] {len(cands)} match(es), nearest {d:.2f}m from last sighting — coasting")
-            return None
+        gate = self._p["mem_gate_m"] + self._p["mem_gate_frac"] * self._last_seen[2]
+        if d > gate:
+            self._coasts += 1
+            if self._coasts < MEM_COAST_LIMIT:
+                self.logger.info(
+                    f"[PickAnyObject] {len(cands)} match(es), nearest {d:.2f}m from last sighting "
+                    f"(gate {gate:.2f}m) — coasting"
+                )
+                return None
+            # Disagreeing look after look means the memory is stale, not that
+            # the object teleported. Drop it and re-anchor: coasting forever
+            # would strand the run in "could not centre" while Gemini is
+            # returning the object in every frame.
+            self.logger.info(f"[PickAnyObject] memory {d:.2f}m off for {self._coasts} looks — re-anchoring")
+            self._last_seen = None
+            self._coasts = 0
+            return cands[0]
+        self._coasts = 0
         if len(cands) > 1:
             self.logger.info(
                 f"[PickAnyObject] {len(cands)} matches; kept #{cands.index(best) + 1} ({d:.2f}m from last sighting)"
@@ -244,10 +282,9 @@ class PickAnyObject(Skill):
         if grip is not None:
             lo, hi = GRIP_STRENGTH_RANGE
             self._grip_strength = max(lo, min(hi, grip))
-        xy = pixel_to_floor(u, v, self._p["tilt_deg"])
-        wxy = self._base_to_odom(xy) if xy else None
-        if wxy is not None:
-            self._last_seen_odom = wxy
+        seen = self._sighting(cand)
+        if seen is not None:
+            self._last_seen = seen
         return (u, v)
 
     def _localize_px(self, prompt):
@@ -826,7 +863,8 @@ class PickAnyObject(Skill):
         # Per-run reset: don't carry the last run's object or grip rating.
         self._grip_strength = None
         self._holding = False
-        self._last_seen_odom = None
+        self._last_seen = None
+        self._coasts = 0
         try:
             self.head.set_position(int(round(self._p["tilt_deg"])))
             # Fold to rest so the arm doesn't occlude the head camera


### PR DESCRIPTION
## Problem

With several identical objects in view (two white socks), every Gemini look in `pick_any_object` took the **"best first"** match. Gemini's ordering is not stable between calls, so the skill could silently switch instances between the search, the re-localizations during positioning, and the wrist seed — and grab the wrong twin.

## Mechanism

A minimal single-target tracker on top of the existing pipeline:

- **Parse all matches** — `innate.vision` gains `parse_det_cands` / `parse_det_boxes` (the singular parsers remain as thin wrappers), and both Gemini prompts ask for ALL matches.
- **Odom-anchored memory** — the first detection anchors `_last_seen_odom`; every later look back-projects each candidate to the floor and keeps the one nearest the memory. Odom is the right frame: continuous (no relocalization jumps mid-run), cm-scale drift over a pick run, and every Gemini look happens with the base stopped, so the odom read matches the frame's capture pose. Without odometry it degrades exactly to today's behavior.
- **Validation gate (`mem_gate_m` = 0.5 m)** — objects don't teleport: a lone match farther than the gate from the last sighting is a *different* instance, so the skill coasts ("not seen this frame") instead of re-anchoring on a twin. This closes the hijack case where the tracked sock is missed for one frame (arm occlusion, frame edge) while the twin is detected. Sized above worst-case back-projection disagreement between consecutive looks (~0.3 m/deg of tilt error at 2 m, largely systematic, and the memory refreshes every localize).
- **Wrist stage** — seeds from the box nearest the servo aim point rather than Gemini's first. Grounded because `_position_above` only returns once the target is proven inside the accept box and the arm is aimed at its bearing.
- **Verify stage** — grasp verification now judges only the grab spot directly ahead. Previously, after a *successful* pick, the twin still on the floor made Gemini truthfully answer "YES, the sock is on the floor" → the pick was reported as a miss → teardown opened the gripper and dropped the held sock.
- **Observability** — the skill logs `N matches; kept #k (d m from last sighting)`; any run keeping a non-first candidate is direct evidence the old code would have switched socks.

## Prerequisite framework fix (first commit)

Annotating a skill attribute `tuple[float, float] | None = None` crashed skill loading: py3.10's `isinstance(tuple[float, float], type)` quirk let a generic alias reach `issubclass()` in the feed materializer. It now filters with `get_origin` — a subscripted generic is never a feed. Any skill author could have hit this.

## Verification

- ruff check + format clean on all touched files
- Full brain_client suite: **274 passed** (fullbuild image, overlay recipe)
- basedpyright: identical error counts to origin/main under both the brain_client scope and the repo pyrightconfig scope (all pre-existing env artifacts) — zero new errors
- Skill loads with zero `_declaration_issues` and exactly the four real feeds
- Unit-level checks (run in-container, then deleted per repo convention): both matches parsed; memory beats Gemini order; memory survives a 90° base rotation; lone far twin coasted with the anchor untouched; near lone match accepted; unprojectable candidates coast; no-memory falls back to best-first

End-to-end two-sock trials in the MuJoCo sim are running now; results will be posted on this PR.

## Hardware note

The approach assumes odom drift stays small relative to twin separation within one run (holds easily for the drives involved). A real two-socks-close-together run on a robot is the convincing final check.