### PR TITLE
docs: simplify README around skills and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,237 +1,101 @@
-<!-- markdownlint-disable MD033 MD046 -->
+<!-- markdownlint-disable MD013 MD033 MD041 MD046 -->
 <div align="center">
 
 <p>
   <img src="docs/assets/readme/innate-os-repo-intro.png" alt="Innate OS" width="80%">
 </p>
 
-**The lightweight agentic operating system for general-purpose robots**
+## Make MARS do new things with Python
+
+Innate OS is the open-source software for building skills and autonomous agents on MARS.
+
+[Try the simulator](#try-it-without-a-robot) · [Write a skill](#write-a-skill) · [Build an agent](#build-an-agent) · [Read the docs](https://docs.innate.bot)
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20our%20community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/innate)
 [![Documentation](https://img.shields.io/badge/Docs-Read%20the%20docs-blue?style=for-the-badge&logo=readthedocs&logoColor=white)](https://docs.innate.bot)
 [![Website](https://img.shields.io/badge/Website-Visit%20us-orange?style=for-the-badge&logo=safari&logoColor=white)](https://innate.bot)
-[![ROS 2](https://img.shields.io/badge/ROS%202-Humble-22314E?style=for-the-badge&logo=ros&logoColor=white)](https://docs.ros.org/en/humble/)
 
 </div>
 
-<div align="center">
+A **skill** makes the robot do one thing: navigate, grasp, speak, call an API, or run a learned policy. An **agent** observes the world and chooses which skills to run as it works toward a goal.
 
-<img src="docs/assets/readme/mars-compatible.png" alt="MARS robot, the first robot compatible with Innate OS" width="250px"><br>
-<sub><strong>MARS</strong>, a small agentic robot for your home.</sub>
-
-</div>
-
-Start with [skills](#skills), [agents](#agents), [additional inputs](#additional-inputs), the [simulator](#simulator), or the [ROS reference](#ros-reference).
-
-> [!TIP]
-> Don't have a robot? You can still experiment with the simulator!
-
-<table>
-  <tr>
-    <td width="37%" align="center" valign="top">
-      <img src="docs/assets/readme/screenshot-webapp-card.png" alt="Innate web app control interface" height="300"><br>
-      <sub>Web app</sub>
-    </td>
-    <td width="26%" align="center" valign="top">
-      <img src="docs/assets/readme/screenshot-mobile-card.png" alt="Innate mobile app running an agent" height="300"><br>
-      <sub>Mobile app</sub>
-    </td>
-    <td width="37%" align="center" valign="top">
-      <img src="docs/assets/readme/screenshot-simulator-card.png" alt="Innate simulator interface" height="300"><br>
-      <sub>Simulator</sub>
-    </td>
-  </tr>
-</table>
-
-_Innate OS is developed for MARS; if you want to port it to your robot, we are happy to feature it._
-
----
-
-## Table of Contents
-
-- [Control](#control)
-- [Skills](#skills)
-- [Agents](#agents)
-- [Simulator](#simulator)
-- [Foxglove](#foxglove)
-- [Additional Inputs](#additional-inputs)
-- [ROS Reference](#ros-reference)
-- [More Docs](#more-docs)
-- [Contribute](#contribute)
-
----
-
-## Control
-
-### Web app
-
-With the Innate web app, you can control the robot in real time. Use the virtual joystick controls to drive the base, move the arm, and trigger skills manually.
-
-<img src="docs/assets/readme/screenshot-webapp-card.png" alt="Innate web app" height="300">
-
-It is available at `https://<robot-address>` which can either be its IP or hostname.
-
-### Mobile app
-
-The Innate mobile app is available on both iOS and Android. It allows you to control the robot in real time, just like the web app, but with a more convenient interface.
-
-<table>
-  <tr>
-    <td width="45%" align="center" valign="top">
-      <img src="docs/assets/readme/screenshot-mobile-card.png" alt="Innate mobile app" height="340"><br>
-      <sub>Innate Controller app</sub>
-    </td>
-    <td width="55%" valign="middle">
-      <strong>Download the Innate Controller app</strong><br>
-      Connect to MARS, drive the robot, run agents and skills, record training data, and manage maps from your phone.<br><br>
-      <a href="https://cdn.innate.bot/innate-app-latest-1.3.0.apk"><strong>Android APK (1.3.0)</strong></a><br>
-      <sub>Direct APK download.</sub><br><br>
-      <a href="https://testflight.apple.com/join/YeChe4A7"><strong>iOS TestFlight</strong></a><br>
-      <sub>Join the iOS beta.</sub><br><br>
-      <a href="https://docs.innate.bot/robots/innate-controller-app">Controller app docs</a>
-    </td>
-  </tr>
-</table>
-
----
-
-## Skills
-
-Skills are the core unit of action on Innate robots.
-
-A skill can be digital, like calling a tool, a service or another agent; or physical, like navigating, waving, grasping, recording a demonstration, or executing a learned manipulation policy.
-
-<p align="center">
-  <img src="docs/assets/readme/skills-chess-door-opening.gif" alt="Two standalone physical skills: moving a chess piece, then opening a door" width="520"><br>
-  <sub>Two standalone skill examples, shown sequentially: moving a chess piece, then opening a door.</sub>
-</p>
-
-- **Execute manually** — Run skills from the `innate` CLI.
-- **Operate from apps** — Trigger skills through the web app or Innate mobile apps.
-- **Run autonomously** — Let agents select and interrupt skills as the world changes.
-
-### Running a skill
-
-On the robot, skills can be inspected and called through the CLI:
-
-```bash
-innate skill type innate-os/arm_zero_position
-innate skill run innate-os/arm_zero_position @duration=3
+```text
+camera + robot state → agent → skills → navigation · manipulation · speech · APIs
 ```
 
-Custom skills use the same `@name=value` input syntax.
+The same skills and agents run on a physical MARS and in the simulator.
 
-### Trained skills
+<p align="center">
+  <img src="docs/assets/readme/skills-chess-door-opening.gif" alt="MARS moving a chess piece and opening a door with two skills" width="48%">
+  <img src="docs/assets/readme/agent-clean-room.gif" alt="MARS using an agent to pick up and put away objects" width="48%">
+</p>
 
-Some physical skills can be learned from demonstrations.
+## Try it without a robot
 
-- Record episodes from the phone app or web app.
-- Train a policy with one of the models available on Innate Cloud or locally.
-- Deploy the trained model as a skill.
+The simulator runs the real Innate OS navigation stack, skills, agent runtime, and web app against a MuJoCo digital twin of MARS.
 
-Start here: [Training overview](https://docs.innate.bot/training/overview). To ship a trained model back to the robot, see [Deploy a trained skill](https://docs.innate.bot/training/deploy-trained-skill).
+```bash
+curl -fsSL https://link.innate.bot/sim | sh
+cd innate-os
+./innate-sim up
+```
 
-You will find skills in two different directories:
+Open [https://localhost](https://localhost) to drive MARS, run skills and agents, and watch the simulated robot move through its environment.
 
-- **Built-in skills** — Located in `workspace/innate_skills/`.
-- **Your custom skills** — Stored in `workspace/custom_skills/`. Gitignored and yours to play with.
-- **Skill packs** — Any other folder dropped into `workspace/` loads as its own package (ids `<folder>/<name>`). A pack that lives elsewhere on disk is symlinked in (`ln -s /opt/team/skills workspace/team_skills`) and works the same, hot reload included.
+Already have a checkout? Run `./innate-sim setup`, then `./innate-sim up`.
 
-Helpers work like normal Python: any `.py` in your skills folder that doesn't define a `Skill` is just a module — `import` it, use relative imports inside subfolders, share across packages by bare name (`from innate_skills import arm_utils`). Device helpers are methods on the interfaces (`self.manipulation.move_to(...)`, `self.mobility.rotate_by(...)`); camera math and Gemini live under `innate` (`from innate import geometry, vision, gemini`).
+```bash
+./innate-sim status          # Show runtime health
+./innate-sim sh              # Open a shell in Innate OS
+./innate-sim logs os-session # Inspect runtime logs
+./innate-sim down            # Stop the simulator
+```
 
-### Skill definition
+See the [simulator guide](sim/README.md) for challenges, day-to-day development, the ROS-free VirtualMars API, and architecture.
 
-<table>
-  <tr>
-    <td width="50%" valign="top">
-      <strong>Replay skill</strong> — replay a recorded motion file.<br>
-      Saved as <code>workspace/custom_skills/greet/metadata.json</code>:
-      <pre lang="json">{
-    "name": "greet",
-    "type": "replay",
-    "guidelines": "Greet the user with a friendly arm wave.",
-    "inputs": {},
-    "wheeled": false,
-    "downloads": {
-        "episode_0.h5": "https://your-cdn.com/greet/episode_0.h5"
-    },
-    "execution": {
-        "model_type": "replay",
-        "replay_file": "episode_0.h5",
-        "replay_frequency": 50.0,
-        "start_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0],
-        "end_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0]
-    }
-}</pre>
-    </td>
-    <td width="50%" valign="top">
-      <strong>Code skill</strong> — call the mobility interface to move forward.<br>
-      Saved as <code>workspace/custom_skills/move_forward.py</code>:
-      <pre lang="python">from innate import Mobility, Skill, SkillReturn
+## Write a skill
+
+Skills are the reusable actions available to people, apps, and agents. A skill can control the robot, call another skill, use a digital service, or execute a learned manipulation policy.
+
+Create `workspace/custom_skills/move_forward.py`:
+
+```python
+from innate import Mobility, Skill, SkillReturn
 
 
 class MoveForward(Skill):
     """Move the robot forward by a given distance in meters."""
 
-    mobility: Mobility          # declare what you use; the runtime injects it
+    mobility: Mobility
 
     def execute(self, distance_m: float = 0.5) -> SkillReturn:
-        speed = 0.2  # m/s
+        speed = 0.2
         duration = distance_m / speed
         self.mobility.send_cmd_vel(linear_x=speed, duration=duration)
-        self.sleep(duration)    # like time.sleep, but a Stop unwinds it
+        self.sleep(duration)
         return f"Moved forward {distance_m} m"
-</pre>
-      The return value is the run's result message; call
-      <code>self.fail(message)</code> to end the run as a failure.
-      Cancellation is the framework's job: <code>self.sleep</code> (and every
-      blocking framework call) raises the moment a Stop lands, the base is
-      braked automatically, and the run reports CANCELLED — skills carry no
-      cancel code.
-    </td>
-  </tr>
-</table>
+```
 
----
+Innate OS injects the declared robot interface and handles cancellation. Saving the file hot-reloads the skill; run it from the robot or simulator shell:
 
-## Agents
+```bash
+innate skill run local/move_forward @distance_m=0.5
+```
 
-Agents allow Innate robots to run autonomously following your instructions.
+Built-in skills live in `workspace/innate_skills/`; your skills stay in the gitignored `workspace/custom_skills/`. See the [workspace guide](workspace/README.md) and [skills documentation](https://docs.innate.bot/software/skills) for composition, physical skills, shared helpers, inputs, and packaging.
 
-They make the robot think in a high-frequency loop using a multimodal model, for example a VLM that is constantly observing the world.
+## Build an agent
 
-An agent consists of:
+An agent continuously observes the robot and its environment, then selects and interrupts the skills it is allowed to use.
 
-- A **set of skills** the robot is allowed to use
-- A **system prompt** that defines the robot's behavior
-- An **agent loop** that connects the model to observations, memory, tools, and robot actions
-
-<p align="center">
-  <img src="docs/assets/readme/agent-clean-room.gif" alt="Pick up and put away skills chained in an agent to clean a room" width="520"><br>
-  <sub>Pick up and put away skills chained in an agent to clean a room.</sub>
-</p>
-
-### Specificities of multimodal agents
-
-Multimodal agents have different constraints than purely digital agents: they need to **observe continuously**, run at a **high frequency** to react, and to be able to **interrupt** a running skill when the world has changed.
-
-### Agent definitions
-
-You can find agents in two different directories:
-
-- **[`workspace/innate_agents/`](workspace/innate_agents/)** — Built-in agents shipped with Innate OS.
-- **[`workspace/custom_agents/`](workspace/custom_agents/)** — Your local agents. Gitignored and yours to play with.
-
-Here is an example of a simple agent to navigate:
-
-A minimal agent file, saved as `workspace/custom_agents/navigate_agent.py`:
+Create `workspace/custom_agents/navigate_agent.py`:
 
 ```python
-from brain_client.agents.types import Agent
+from innate import Agent
 
 
 class NavigateAgent(Agent):
-    """An agent that can navigate to requested positions."""
+    """Navigate to places requested by the user."""
 
     @property
     def id(self):
@@ -248,169 +112,53 @@ class NavigateAgent(Agent):
         return ["micro"]
 
     def get_prompt(self):
-        return "You are a helpful robot. When asked, navigate to the requested location using the navigate_to_position skill."
+        return "Navigate to the location requested by the user."
 ```
 
-### Testing agents in sim
+Saving the file makes the agent available in the web app. Test it in simulation before running it on a physical robot. See the [agents documentation](https://docs.innate.bot/software/agents) for observations, memory, prompts, skills, and custom inputs.
 
-Use the [simulator](#simulator) to test custom agents before running them on a physical robot.
+## Teach a skill from demonstrations
 
----
+Some physical skills are easier to demonstrate than to program:
 
-## Simulator
+```text
+record demonstrations → train a policy → deploy it as a skill → call it from an agent
+```
 
-Innate OS includes a MuJoCo digital twin of MARS that runs the **real robot software** -- the same navigation stack, skills, brain client, and webapp as the physical robot, with only the hardware drivers swapped for a simulated equivalent. Use it to build and test skills, agents, and input devices before you have a robot on your desk.
+Record episodes from the web or mobile app, train locally or with Innate Cloud, and deploy the resulting model back to MARS. Start with the [training overview](https://docs.innate.bot/training/overview).
+
+## Control MARS
+
+Every MARS serves its own web app at `https://<robot-address>`. Use it to drive, move the arm, run skills and agents, record demonstrations, and manage maps.
+
+The Innate Controller app provides the same controls on iOS and Android:
+
+- [iOS TestFlight](https://testflight.apple.com/join/YeChe4A7)
+- [Android APK](https://cdn.innate.bot/innate-app-latest-1.3.0.apk)
+- [Controller app documentation](https://docs.innate.bot/robots/innate-controller-app)
 
 <p align="center">
-  <img src="docs/assets/readme/sim.png" alt="Driving the simulated MARS robot through its apartment in the browser" width="85%">
+  <img src="docs/assets/readme/screenshot-webapp-card.png" alt="Innate web app controlling MARS" height="260">
+  <img src="docs/assets/readme/screenshot-mobile-card.png" alt="Innate Controller app running an agent" height="260">
 </p>
 
-```bash
-curl -fsSL https://link.innate.bot/sim | sh
-```
+## Go deeper
 
-One command on macOS, Linux and WSL2. It asks before installing anything missing (Docker, uv, git), clones this repository into `innate-os/` in the directory you run it from, asks how the agent should reach a cloud LLM, and downloads everything the simulator needs (simulation assets, the 3D viewer bundle, the Docker image). Already have a checkout? `./innate-sim setup` does the same from inside it.
+| I want to… | Start here |
+|---|---|
+| Build and package skills | [Workspace guide](workspace/README.md) · [Skills documentation](https://docs.innate.bot/software/skills) |
+| Create autonomous agents | [Agents documentation](https://docs.innate.bot/software/agents) |
+| Train and deploy manipulation policies | [Training overview](https://docs.innate.bot/training/overview) |
+| Add a sensor or data source to agents | [Input device guide](docs/INPUT_DEVICES.md) |
+| Develop without a robot | [Simulator guide](sim/README.md) |
+| Understand the runtime | [System overview](docs/SYSTEM_OVERVIEW.md) |
+| Debug ROS state, images, and transforms | [Foxglove guide](sim/README.md#foxglove) |
+| Work on robot updates and services | [Update system guide](scripts/update/README.md) |
 
-```bash
-cd innate-os && ./innate-sim up
-```
+Innate OS is built on ROS 2 Humble with Zenoh as its DDS transport. Most builders should work through skills, agents, and the simulator; contributors changing the core runtime can start in [`ros2_ws/`](ros2_ws/) and the [system overview](docs/SYSTEM_OVERVIEW.md).
 
-The terminal opens a live dashboard, and the robot webapp at [https://localhost](https://localhost) is the sim UI -- drive and operate the simulated MARS exactly like a real one, with a live 3D view instead of camera streams.
-
-```bash
-./innate-sim status         # show current runtime state
-./innate-sim sh             # open a shell inside the ROS container
-./innate-sim logs os-session # inspect runtime logs (see `logs --help` for targets)
-./innate-sim down           # stop the runtime
-```
-
-See [`sim/README.md`](sim/README.md) for everything else: the day-to-day workflow, the ROS-free VirtualMars Python API (with a walkthrough notebook), and the architecture.
-
----
-
-## Foxglove
-
-[Foxglove Studio](https://foxglove.dev) gives you a live view of TF, `/scan`, camera images, point clouds, and `/cmd_vel` teleop for debugging. In the [simulator](#simulator) the bridge is always on; on a physical robot it is opt-in:
-
-```bash
-innate foxglove start   # start the bridge (ws://<robot-ip>:8765)
-innate foxglove stop    # stop it
-innate foxglove         # status
-```
-
-Then connect Foxglove Studio to the printed `ws://` URL.
-
-> **Over Wi-Fi, subscribe to the `/mars/main_camera/remote/*` topics, not the raw ones.** The raw camera images (~0.9 MB/frame) and point clouds (`/mars/main_camera/points`, ~10 MB/s) are far more than a Wi-Fi link can carry, so every panel — including `/cmd_vel` — falls seconds behind. The `remote/` namespace carries the same topics throttled to ~2 Hz (and images already compressed), which fits comfortably. Prefer `.../compressed` image topics and mono `remote/points` over `remote/points_color`.
-
----
-
-## Additional Inputs
-
-Innate OS provides an SDK for streaming new data into running agents. Innate robots are designed to be naturally expandable: add a new sensor, expose it as an input device, and let agents request it by name.
-
-Input devices live in [`workspace/inputs/`](workspace/inputs/) and are pure Python. They should not import ROS directly.
-
-<details>
-<summary>Thermometer input example</summary>
-
-```python
-# workspace/inputs/thermometer_input.py
-
-import threading
-import time
-
-from brain_client.inputs.types import InputDevice
-
-
-def read_thermometer_celsius() -> float:
-    # Replace this with your hardware, websocket, serial, or API read.
-    return 21.5
-
-
-class ThermometerInput(InputDevice):
-    def __init__(self, logger=None):
-        super().__init__(logger)
-        self._stop_event = threading.Event()
-        self._thread = None
-
-    @property
-    def name(self) -> str:
-        return "thermometer"
-
-    def on_open(self):
-        self._stop_event.clear()
-        self._thread = threading.Thread(target=self._loop, daemon=True)
-        self._thread.start()
-
-    def on_close(self):
-        self._stop_event.set()
-        if self._thread:
-            self._thread.join(timeout=1.0)
-
-    def _loop(self):
-        while not self._stop_event.is_set():
-            self.send_data(
-                {"celsius": read_thermometer_celsius(), "timestamp": time.time()},
-                data_type="custom",
-            )
-            time.sleep(1.0)
-```
-
-An agent or directive can then request the input by name:
-
-```python
-def get_inputs(self):
-    return ["thermometer"]
-```
-
-</details>
-
-See [`docs/INPUT_DEVICES.md`](docs/INPUT_DEVICES.md) for the full input-device lifecycle.
-
----
-
-## ROS Reference
-
-Innate OS is currently based on ROS 2, the reference framework for robotics operating systems. Most builders should start with skills, agents, inputs, and the simulator. Changing the core OS is not recommended for normal usage, but it is possible.
-
-<table>
-  <tr>
-    <td width="20%" valign="top"><strong><a href="ros2_ws/">ros2_ws/</a></strong><br>Robot runtime workspace.</td>
-    <td width="20%" valign="top"><strong><a href="docs/SYSTEM_OVERVIEW.md">System Overview</a></strong><br>Architecture reference.</td>
-    <td width="20%" valign="top"><strong><a href="scripts/launch_ros_in_tmux.sh">Startup</a></strong><br>Robot node wiring.</td>
-    <td width="20%" valign="top"><strong><a href="scripts/update/README.md">Updates</a></strong><br>Services and CLI commands.</td>
-    <td width="20%" valign="top"><strong><a href="config/">config/</a></strong><br>DDS, systemd, udev, audio, Bluetooth, sounds, and shell setup.</td>
-  </tr>
-</table>
-
-<details>
-<summary>Main ROS 2 runtime packages</summary>
-
-- **[mars_control](ros2_ws/src/mars_bot/mars_control)** - top-level robot app node, rosbridge websocket server for the mobile/web app, and low-latency UDP receiver for leader-arm teleop.
-- **[mars_bringup](ros2_ws/src/mars_bot/mars_bringup)** - hardware bringup for motors, base, IMU, and LiDAR, plus `robot_state_publisher` for the TF tree.
-- **[mars_arm](ros2_ws/src/mars_bot/mars_arm)** - arm and head servo driver and KDL-based IK solver.
-- **[mars_cam](ros2_ws/src/mars_bot/mars_cam)** - stereo main camera, arm camera, VPI stereo depth estimator, WebRTC streamer, and stereo calibration action server.
-- **[mars_nav](ros2_ws/src/mars_bot/mars_nav)** - Nav2-based navigation, SLAM mapping, and the mode manager that switches between `mapfree`, `mapping`, and `navigation`.
-- **[brain_client](ros2_ws/src/brain/brain_client)** - bridge to the Innate cloud brain, websocket client, skills action server, and user input manager.
-- **[manipulation](ros2_ws/src/brain/manipulation)** - records and replays manipulation demonstrations and runs learned or scripted manipulation policies.
-- **[innate_logger](ros2_ws/src/cloud/innate_logger)** - uploads robot logs and telemetry to the Innate cloud.
-- **[innate_training_node](ros2_ws/src/cloud/innate_training_node)** - collects training episodes and pushes them to the training cloud.
-- **[innate_uninavid](ros2_ws/src/cloud/innate_uninavid)** - UniNaVid vision-language navigation client.
-
-</details>
-
----
-
-## More Docs
-
-- [Innate documentation](https://docs.innate.bot) - canonical docs for setup, simulator, skills, agents, training, and robot operation.
-
----
+Innate OS is developed for MARS. If you port it to another robot, we would be happy to feature it.
 
 ## Contribute
 
-We welcome contributions to Innate OS and will be happy to feature applications written on top of it here–and robots using it.
-
-A huge thanks to all people in the community who helped by contributing, providing feedback, and building on Innate OS.
-
-If you want to help, feel free to reach out on [Discord](https://discord.gg/innate).
+Contributions, feedback, applications built on Innate OS, and ports to new robots are welcome. Open an issue or pull request, or join the community on [Discord](https://discord.gg/innate).


### PR DESCRIPTION
## Summary

- reduce the root README from 416 to 164 lines
- explain Innate OS through one mental model: agents observe and choose skills
- lead with the no-hardware simulator path and one runnable skill and agent
- preserve control, training, input, debugging, update, and ROS details through focused links

## Why

The README currently presents controls, apps, skills, agents, simulation, inputs, Foxglove, and ROS as peer concepts. This makes a new builder work out the product hierarchy before they can get started.

This proposal makes the first journey linear:

```text
understand skills and agents -> start the simulator -> build one behavior -> choose a deeper path
```

## Validation

- both Python examples parse
- every local README link target exists
- every external documentation, installer, controller, and download link returns HTTP 200
- GitHub GFM rendering succeeds
- `markdownlint-cli2 README.md` passes
- repository pre-commit checks applicable to `README.md` pass