### PR TITLE
feat(webapp): reuse one WebRTC session across page switches

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -88,6 +88,7 @@ js/
   rosClient.js          shared rosbridge socket (reconnect, sub replay, services)
   driveController.js    /joystick heartbeat + joystick/keyboard arbitration
   webrtcSession.js      camera + mic over WebRTC, signaled through rosbridge
+  sharedVideoSession.js one app-level WebRtcSession shared by every video page
   dynamixel.js          leader-arm WebSerial reader (Protocol 2.0)
   shell.js              icon rail on every page
   railLayout.js         the rail's grouped roster (pure — tests/railLayout.test.js)

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -41,6 +41,7 @@
     <link rel="modulepreload" href="/js/agent/agentMicControl.js" />
     <link rel="modulepreload" href="/js/pageMount.js" />
     <link rel="modulepreload" href="/js/robotSession.js" />
+    <link rel="modulepreload" href="/js/sharedVideoSession.js" />
     <link rel="modulepreload" href="/js/webrtcSession.js" />
     <link rel="modulepreload" href="/js/webrtcConfig.js" />
     <link rel="modulepreload" href="/js/clipboard.js" />

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -38,7 +38,7 @@ const config = await getConfig();
 // Resolved once at import time (the router's dynamic import awaits it):
 // WebRTC for real robots, the Three.js SimSession in simulation (see
 // robotSession.js).
-const { createSession, createStage } = await robotSessionFactory();
+const { createSession, releaseSession, createStage } = await robotSessionFactory();
 const MIN_AGENT_VIEW_WIDTH = 1281;
 
 /** @param {HTMLElement} stage */
@@ -217,7 +217,7 @@ function buildAgentView(root) {
   return {
     destroy() {
       for (const part of parts) part.destroy();
-      session.destroy();
+      releaseSession(session);
       root.innerHTML = "";
     },
   };

--- a/webapp/js/calibration/main.js
+++ b/webapp/js/calibration/main.js
@@ -12,7 +12,7 @@
 
 import { ros } from "../rosClient.js";
 import { mountPage } from "../pageMount.js";
-import { WebRtcSession } from "../webrtcSession.js";
+import { acquireVideoSession, releaseVideoSession } from "../sharedVideoSession.js";
 import { createVideoStage } from "../teleop/videoStage.js";
 import {
   RUN_STEREO_CALIBRATION_ACTION,
@@ -64,7 +64,9 @@ const CALIBRATION_BOARD_PDF_URL =
  * @returns {{ destroy: () => void }}
  */
 function buildView(root) {
-  const session = new WebRtcSession(ros);
+  const session = acquireVideoSession();
+  // No camera switcher here; the shared session may arrive on another page's view.
+  session.showMainCamera();
 
   // ---- header ---------------------------------------------------------
   const head = document.createElement("div");
@@ -544,7 +546,7 @@ function buildView(root) {
       if (leftCoverage.img.dataset.blobUrl) URL.revokeObjectURL(leftCoverage.img.dataset.blobUrl);
       if (rightCoverage.img.dataset.blobUrl) URL.revokeObjectURL(rightCoverage.img.dataset.blobUrl);
       videoStage.destroy();
-      session.destroy();
+      releaseVideoSession();
       root.innerHTML = "";
     },
   };

--- a/webapp/js/collect/main.js
+++ b/webapp/js/collect/main.js
@@ -27,7 +27,7 @@ import { createRecordPanel } from "./recordPanel.js";
 // Resolved once at import time (the router's dynamic import awaits it):
 // WebRTC for real robots, the Three.js SimSession in simulation (see
 // robotSession.js).
-const { createSession, createStage } = await robotSessionFactory();
+const { createSession, releaseSession, createStage } = await robotSessionFactory();
 
 /** @type {any} */
 const config = await getConfig();
@@ -43,6 +43,9 @@ export function mount(stage) {
  */
 function buildCockpit(root) {
   const session = createSession();
+  // No camera switcher on this page; the shared session may arrive on another
+  // page's view. (Sim sessions are per-page and lack the method.)
+  session.showMainCamera?.();
 
   const videoStage = createStage ? createStage(root, session) : createVideoStage(root, session);
 
@@ -106,7 +109,7 @@ function buildCockpit(root) {
     destroy() {
       drive.haltAll();
       for (const part of parts) part.destroy();
-      session.destroy();
+      releaseSession(session);
       root.innerHTML = "";
     },
   };

--- a/webapp/js/nav/driveKit.js
+++ b/webapp/js/nav/driveKit.js
@@ -21,7 +21,7 @@ import { createKeyboardDrive, createWasdChips } from "../teleop/keyboardDrive.js
 import { createHeadTilt } from "../teleop/headTilt.js";
 
 // One factory for the page's lifetime (it fetches config + maybe the sim
-// viewer bundle); sessions themselves are per-mapping-run.
+// viewer bundle); the session is acquired per mapping run and released after.
 const factoryPromise = robotSessionFactory();
 
 /**
@@ -29,11 +29,13 @@ const factoryPromise = robotSessionFactory();
  * @returns {Promise<{ destroy: () => void }>}
  */
 export async function createDriveKit(scene) {
-  const { createSession, createStage } = await factoryPromise;
+  const { createSession, releaseSession, createStage } = await factoryPromise;
   const session = createSession();
+  // The PiP always shows the main camera; the shared session may arrive on
+  // another page's view. (Sim sessions are per-page and lack the method.)
+  session.showMainCamera?.();
 
-  // Main-camera PiP, bottom-right — the session bootstraps with the "main"
-  // camera, so no roster handling is needed here.
+  // Main-camera PiP, bottom-right.
   const pip = document.createElement("div");
   pip.className = "nav-cam-pip";
   const stickOverlay = document.createElement("div");
@@ -60,7 +62,7 @@ export async function createDriveKit(scene) {
     destroy() {
       drive.haltAll();
       for (const part of parts) part.destroy();
-      session.destroy();
+      releaseSession(session);
       pip.remove();
       stickOverlay.remove();
       chipsOverlay.remove();

--- a/webapp/js/robotSession.js
+++ b/webapp/js/robotSession.js
@@ -6,17 +6,22 @@
 // videoStage/cameraSwitch/profiling consume either without knowing.
 //
 // Usage (module top level -- the import must resolve before buildCockpit):
-//   const { createSession, createStage } = await robotSessionFactory();
+//   const { createSession, releaseSession, createStage } = await robotSessionFactory();
 //   ...inside buildCockpit:
 //     const session = createSession();
 //     const stage = createStage ? createStage(root, session) : createVideoStage(root, session);
+//   ...inside destroy: releaseSession(session), never session.destroy().
+//
+// Real robots hand every page the app-level shared WebRtcSession (see
+// sharedVideoSession.js), so page switches reuse the live link. Sim sessions
+// stay per-page: they render local canvases, so there is no link to keep warm.
 
 import { WebRtcSession } from "./webrtcSession.js";
-import { ros } from "./rosClient.js";
+import { acquireVideoSession, releaseVideoSession } from "./sharedVideoSession.js";
 import { getConfig } from "./config.js";
 
 /**
- * @returns {Promise<{ createSession: () => WebRtcSession, createStage: ((root: HTMLElement, session: WebRtcSession) => { audioEl: HTMLAudioElement | null, destroy: () => void }) | null }>}
+ * @returns {Promise<{ createSession: () => WebRtcSession, releaseSession: (session: WebRtcSession) => void, createStage: ((root: HTMLElement, session: WebRtcSession) => { audioEl: HTMLAudioElement | null, destroy: () => void }) | null }>}
  * createStage is null for real robots (pages use createVideoStage); in sim it
  * mounts the live Three.js canvas (full resolution, drag-to-orbit).
  */
@@ -31,11 +36,12 @@ export async function robotSessionFactory() {
       const mod = await import("/sim-viewer/sim-session.js");
       return {
         createSession: () => /** @type {any} */ (mod.createSimSession()),
+        releaseSession: (session) => session.destroy(),
         createStage: (root, session) => mod.createSimStage(root, /** @type {any} */ (session)),
       };
     } catch (err) {
       console.error("[robotSession] sim viewer bundle unavailable, falling back to WebRTC:", err);
     }
   }
-  return { createSession: () => new WebRtcSession(ros), createStage: null };
+  return { createSession: acquireVideoSession, releaseSession: releaseVideoSession, createStage: null };
 }

--- a/webapp/js/sharedVideoSession.js
+++ b/webapp/js/sharedVideoSession.js
@@ -1,0 +1,44 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// The app-level WebRTC session: one WebRtcSession (one RTCPeerConnection, one
+// client_id) shared by every video page. Navigating between pages reuses the
+// live link, so a tab switch is the robot's no-reneg camera switch (instant)
+// instead of a cold handshake (offer/ICE/DTLS/keyframe — seconds, and tens of
+// seconds if a fire-and-forget signaling message is dropped).
+//
+// Pages acquire on mount and release on unmount. Releasing always mutes the
+// robot mic (leaving a page must never keep it audible); once no page holds
+// the session, a short linger keeps the link warm through quick detours
+// (Settings, Datasets) before the peer is genuinely released.
+
+import { WebRtcSession } from "./webrtcSession.js";
+import { ros } from "./rosClient.js";
+
+const LINGER_MS = 10_000;
+
+/** @type {WebRtcSession | null} */ let session = null;
+let holders = 0;
+/** @type {number | null} */ let lingerTimer = null;
+
+/** @returns {WebRtcSession} */
+export function acquireVideoSession() {
+  if (lingerTimer !== null) {
+    clearTimeout(lingerTimer);
+    lingerTimer = null;
+  }
+  session ??= new WebRtcSession(ros);
+  holders += 1;
+  return session;
+}
+
+export function releaseVideoSession() {
+  if (!session || holders === 0) return;
+  holders -= 1;
+  if (holders > 0) return;
+  session.setAudio(false);
+  lingerTimer = setTimeout(() => {
+    lingerTimer = null;
+    session?.stop();
+  }, LINGER_MS);
+}

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -43,7 +43,7 @@ const dbg = { ros, drive, session: null };
 // Resolved once at import time (the router's dynamic import awaits it):
 // WebRTC for real robots, the Three.js SimSession in simulation (see
 // robotSession.js).
-const { createSession, createStage } = await robotSessionFactory();
+const { createSession, releaseSession, createStage } = await robotSessionFactory();
 
 /** @param {HTMLElement} stage */
 export function mount(stage) {
@@ -107,7 +107,7 @@ function buildCockpit(root) {
       // navigating away doesn't leave one floating over the next page.
       dismissAllConfirms();
       for (const part of parts) part.destroy();
-      session.destroy();
+      releaseSession(session);
       root.innerHTML = "";
     },
   };

--- a/webapp/js/webrtcSession.js
+++ b/webapp/js/webrtcSession.js
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
 // WebRtcSession — one long-lived RTCPeerConnection signaled over the shared
-// RosClient (no second socket).
+// RosClient (no second socket). Pages share one instance via
+// sharedVideoSession.js: start() reuses a live link, so navigation costs a
+// no-reneg camera switch instead of a cold handshake.
 //
 // Handshake (robot is the offerer): build pc → publish /webrtc/start →
 // robot sends SDP offer on /webrtc/offer → setRemoteDescription, drain the
@@ -153,6 +155,7 @@ export class WebRtcSession {
   start() {
     this.#started = true;
     this.#handshakeAttempts = 0;
+    if (this.#pc) return; // live or mid-handshake (watchdogs own recovery) — a page switch must not rebuild it
     this.#handshake();
   }
 
@@ -160,6 +163,13 @@ export class WebRtcSession {
   stop() {
     this.#started = false;
     this.#useFallbackStun = false;
+    // Tell the robot to free this peer now — otherwise its encoders keep running
+    // until the 15 s RTCP-inactivity reap notices we're gone.
+    if (this.#pc && this.#ros.state === "connected") {
+      this.#ros.publish(WEBRTC_START_TOPIC, {
+        data: JSON.stringify({ source: "live", video: [], audio: false, client_id: this.#clientId }),
+      });
+    }
     this.#closePc();
     this.#clearAudioDebounce();
     // No mic stream once stopped (e.g. leaving the teleop page) — let TTS play.
@@ -247,6 +257,16 @@ export class WebRtcSession {
   /** @returns {{ index: number, name: string }} the currently displayed (big) camera */
   get primaryCamera() {
     return { index: this.#primaryIndex, name: this.#primaryName };
+  }
+
+  /**
+   * Restore the bootstrap view: the main camera streaming, big. For pages
+   * without a camera switcher — the shared session may arrive showing whatever
+   * set/primary the previous page left.
+   */
+  showMainCamera() {
+    this.setActiveCameras(["main"]);
+    this.setPrimaryCamera(0, "main");
   }
 
   // ---- handshake ----------------------------------------------------------


### PR DESCRIPTION
## Why

Switching tabs in the webapp shows "establishing video link" for seconds — sometimes tens of seconds. The per-client WebRTC protocol (#per-client `_id` lazy multi-peer backend) made camera/mic switching instant *within* a page, but every page still built its **own** `WebRtcSession` with a fresh `client_id` and destroyed it on unmount. So every tab switch was a full cold handshake: START → new robot transport pipeline → SDP offer → answer → trickle ICE → DTLS → first keyframe. If the fire-and-forget START/offer was dropped, the client stared at the overlay for the full 12 s `OFFER_TIMEOUT_MS` before retrying (up to 3 attempts of 7 s each after that).

## What

- **`sharedVideoSession.js`** — one app-level `WebRtcSession` (one pc, one `client_id`) shared by every video page. Pages acquire on mount, release on unmount. Releasing mutes the robot mic (same behavior as the old per-page teardown); once no page holds the session, a 10 s linger keeps the link warm through quick detours (Settings, Datasets) before the peer is genuinely released.
- **`WebRtcSession.start()`** reuses a live or mid-handshake pc instead of unconditionally rebuilding — a tab switch now costs the robot's no-reneg camera switch (instant) instead of a cold handshake. The Retry button still forces a rebuild (error state closes the pc first).
- **`WebRtcSession.stop()`** publishes an empty START so the robot frees the peer immediately, rather than encoding for a vanished viewer until the 15 s RTCP-inactivity reap.
- **`robotSessionFactory`** now returns `releaseSession` alongside `createSession`; on real robots these are the shared acquire/release, in sim they stay per-page (`session.destroy()`) since sim sessions render local canvases and have no link to keep warm.
- Pages without a camera switcher (collect, calibration, nav's mapping drive kit) call `showMainCamera()` on mount, since the shared session may arrive showing another page's camera set/primary. Teleop and Agent keep asserting their own saved sets through the camera switch strip, as before.
- `index.html` modulepreload updated (caught by `tests/preload.test.js`).

## Verification

- `npx tsc --noEmit`: no errors in touched files (pre-existing errors in armsdk/vendor/etc. unchanged).
- `node --test tests/`: 8/8 pass (preload test failed until the modulepreload entry was added).
- Not yet exercised on robot hardware — worth a quick manual pass: teleop ↔ agent ↔ collect switches should keep the video live; leaving all video pages should release the robot peer ~10 s later (`START requested no streams; releasing peer` in mars_cam logs); robot mic must go silent on navigation.