### PR TITLE
fix(sim): three small fixes to the sim stage's overlays

### DIFF
--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -172,7 +172,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
   modeSwitch.append(robotButton, spotButton);
   const placementHint = document.createElement("p");
   placementHint.className = "sim-placement-hint";
-  let placement: PlacementState = { kind: "near-robot" };
+  let placement: PlacementState = { kind: "choose-prop" };
   const selectedProp = (): string | null =>
     placement.kind === "following" || placement.kind === "rotating" ? placement.prop : null;
   const refreshPlacementHint = () => {

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -18,6 +18,14 @@ const THUMB_FRAME_DIV = 2;
 // visible gain (~75Hz interpolated state) and the load jitters everything.
 const MIN_FRAME_MS = 1000 / 62;
 
+// Scene setup and the webapp's challenge panel expand over the same corner of
+// the stage, so at most one may be open. They ship in separate bundles -- this
+// one is vite-built and imported at runtime -- so the handshake is a document
+// event rather than a shared module: the event name and the detail.panel values
+// are a contract with webapp/js/agent/challengePanel.js.
+const PANEL_OPEN_EVENT = "innate:panel-open";
+const PANEL_ID = "sim-scene-setup";
+
 const VIEW_FOR: Record<string, CameraView> = { main: "main", arm: "arm", orbit: "orbit" };
 const ROTATION_DRAG_PX = 6;
 const PROP_FORWARD_ANGLE = Math.PI / 2;
@@ -84,7 +92,16 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
     setupToggle.setAttribute("aria-expanded", String(open));
     setupToggle.setAttribute("aria-label", open ? "Close scene setup" : "Open scene setup");
     localStorage.setItem("sim-scene-panel-open", String(open));
+    if (open) document.dispatchEvent(new CustomEvent(PANEL_OPEN_EVENT, { detail: { panel: PANEL_ID } }));
   };
+  const onPanelOpen = (event: Event) => {
+    const opened = (event as CustomEvent<{ panel?: string }>).detail?.panel;
+    if (opened === PANEL_ID || !setupOpen) return;
+    setSetupOpen(false);
+    // An armed prop would keep following the cursor with the panel gone.
+    clearPlacementSelection();
+  };
+  document.addEventListener(PANEL_OPEN_EVENT, onPanelOpen);
   setupToggle.onclick = () => setSetupOpen(!setupOpen);
   setup.append(setupBody, setupToggle);
   debugStack.appendChild(setup);
@@ -541,6 +558,7 @@ export function createSimStage(parent: HTMLElement, session: SimSession): { audi
       longTaskObserver?.disconnect();
       window.removeEventListener("pointerup", finishDrop);
       window.removeEventListener("pointercancel", cancelDrop);
+      document.removeEventListener(PANEL_OPEN_EVENT, onPanelOpen);
       scene.dispose();
       wrap.remove();
     },

--- a/webapp/js/agent/challengePanel.js
+++ b/webapp/js/agent/challengePanel.js
@@ -8,6 +8,14 @@
 
 import { maybeShowChallengeIntro, showChallengeIntro } from "./challengeIntro.js";
 
+// This panel and the sim's scene setup expand over the same corner of the stage,
+// so at most one may be open. Scene setup lives in the separately-built sim
+// viewer bundle (sim/viewer/src/simStage.ts), so the handshake is a document
+// event rather than a shared module: the event name and the detail.panel values
+// are a contract with it.
+const PANEL_OPEN_EVENT = "innate:panel-open";
+const PANEL_ID = "agent-challenges";
+
 /**
  * @param {HTMLElement} root
  * @param {any} session sim session exposing onChallenge/startChallenge/abortChallenge
@@ -43,11 +51,19 @@ export function createChallengePanel(root, session) {
     dock.classList.toggle("open", next);
     launcher.setAttribute("aria-expanded", String(next));
     launcher.setAttribute("aria-label", next ? "Close challenges" : "Open challenges");
-    if (next && !revealed) {
-      revealed = true;
-      intro = maybeShowChallengeIntro();
-    }
+    if (!next) return;
+    document.dispatchEvent(new CustomEvent(PANEL_OPEN_EVENT, { detail: { panel: PANEL_ID } }));
+    if (revealed) return;
+    revealed = true;
+    intro = maybeShowChallengeIntro();
   };
+  // Deliberately opening the other panel closes this one even mid-run — unlike
+  // dismiss(), which protects a live goal list from a stray click on the scene.
+  const onPanelOpen = (/** @type {Event} */ event) => {
+    const opened = /** @type {CustomEvent<{ panel?: string }>} */ (event).detail?.panel;
+    if (opened !== PANEL_ID && open) setOpen(false);
+  };
+  document.addEventListener(PANEL_OPEN_EVENT, onPanelOpen);
   launcher.addEventListener("click", () => setOpen(!open));
   // Subtle standing hint back to the docs — reopens the first-run intro
   // (challengeIntro.js) with the tutorial link and preview.
@@ -239,6 +255,7 @@ export function createChallengePanel(root, session) {
     destroy() {
       intro?.close();
       unsub();
+      document.removeEventListener(PANEL_OPEN_EVENT, onPanelOpen);
       dock.remove();
     },
   };

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -15,6 +15,10 @@ import { WEBRTC_ACTIVE_STREAMS_TOPIC } from "../constants.js";
 // The enabled set + which view is primary persist in localStorage; by default only the default primary
 // camera and the map are on. A closed tile genuinely stops streaming (each live tile is a full-bitrate
 // WebRTC stream), so collapsing views is how an operator sheds bandwidth.
+//
+// In sim there is no such stream — a tile is a scissor render of the scene already on screen, round-robined
+// across frames, so a second camera costs nothing to shed. Sim cameras therefore skip the off rung entirely:
+// every camera is live, and its tile carries no ×.
 
 const STORE_KEY = "innate.cameras";
 
@@ -52,6 +56,13 @@ const MAP_ZOOM_DEFAULT = { small: 6, big: 16 }; // tighter as a thumbnail, wider
  */
 export function createCameraSwitch(parent, session, ros, opts = {}) {
   const storeKey = opts.storeKey || STORE_KEY;
+
+  // SimSession reaches here through robotSession.js's runtime import, so tsc only sees
+  // WebRtcSession -- duck-type the sim-only surface instead.
+  const maybeSim = /** @type {{ thumbnailCanvas?: (i: number) => HTMLCanvasElement | null }} */ (
+    /** @type {unknown} */ (session)
+  );
+  const simCams = typeof maybeSim.thumbnailCanvas === "function";
 
   const strip = document.createElement("div");
   strip.className = "cam-strip";
@@ -118,6 +129,7 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   // the default primary camera streams, plus the map.
   function reconcile() {
     enabledCams = new Set([...enabledCams].filter((n) => roster.includes(n)));
+    if (simCams) for (const name of roster) enabledCams.add(name);
     if (primary === "") mapOn = true; // nothing persisted yet — the map starts on
     // Roster membership is the validity test: the tail below re-enables the primary, so a
     // primaryOnMount view (or a migrated v1 primary) outside the saved enabled set still wins.
@@ -259,19 +271,14 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     if (!enabledCams.has(name)) return offTile(name, displayLabel(name), `Turn on the ${name} camera`);
     const index = roster.indexOf(name);
     const label = displayLabel(name);
-    const tile = liveTile(name, label, `Switch to ${label} view`);
+    const tile = liveTile(name, label, `Switch to ${label} view`, !simCams);
     const status = document.createElement("span");
     status.className = "cam-tile-status";
     status.textContent = "connecting…";
     tile.append(status);
     // Sim sessions expose live canvases (no MediaStream pipeline -- canvas
     // capture pinned page composition to its capture rate); mount those
-    // directly. Real robots keep the <video> + WebRTC stream path. SimSession
-    // reaches here through robotSession.js's runtime import, so tsc only sees
-    // WebRtcSession -- duck-type the sim-only method instead.
-    const maybeSim = /** @type {{ thumbnailCanvas?: (i: number) => HTMLCanvasElement | null }} */ (
-      /** @type {unknown} */ (session)
-    );
+    // directly. Real robots keep the <video> + WebRTC stream path.
     const thumbCanvas = maybeSim.thumbnailCanvas?.(index) ?? null;
     if (thumbCanvas) {
       thumbCanvas.style.cssText = "width:100%;height:100%;object-fit:cover;display:block;";
@@ -318,8 +325,10 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     return tile;
   }
 
-  /** Live thumbnail shell (caller prepends the video/map). @param {string} id @param {string} label @param {string} title */
-  function liveTile(id, label, title) {
+  /** Live thumbnail shell (caller prepends the video/map).
+   *  @param {string} id @param {string} label @param {string} title
+   *  @param {boolean} [closable] false drops the × for a view that cannot be turned off. */
+  function liveTile(id, label, title, closable = true) {
     const tile = document.createElement("div");
     tile.className = "cam-tile live";
     tile.tabIndex = 0;
@@ -339,6 +348,8 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
     const tag = document.createElement("span");
     tag.className = "cam-tile-label";
     tag.textContent = label;
+    tile.append(tag);
+    if (!closable) return tile;
     const close = document.createElement("button");
     close.type = "button";
     close.className = "cam-tile-close";
@@ -348,7 +359,7 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
       e.stopPropagation();
       disable(id);
     });
-    tile.append(tag, close);
+    tile.append(close);
     return tile;
   }
 


### PR DESCRIPTION
Three independent papercuts on the Agent page in simulation, one commit each.

### 1. Camera tiles are always live in sim (`6a3a321c`)

The strip's `off` rung is a bandwidth control from #664: on a real robot each live tile is a full-bitrate WebRTC stream, so a fresh profile opens with the primary camera only and the rest read **"tap to view"**.

In sim there is no stream to shed. A tile is a scissor render of the scene already on screen, round-robined one per every other frame in `simStage`, blitted into a canvas the tile mounts directly — two live thumbnails cost the same total GPU work as one, each refreshing at half the rate. The off rung was charging a click for nothing.

Sim cameras skip it: `reconcile()` enables the whole roster, and the tiles carry no close `×` since there is nothing to turn off. The map keeps its `×` — that widget is genuinely heavy (lazy import, ROS subscriptions, canvas).

**Real robots are untouched** — `simCams` is false and every path is byte-identical to #664 as merged: the ladder, the off tiles, the `×`, the v2 migration. Profiles that already persisted the sim default heal themselves on the first `/webrtc/active_streams` message, so nobody has to clear localStorage.

@theo-michel — flagging since this is your area: #664 restored the ladder globally and the sim carve-out went with it, but the PR only argues about WebRTC bitrate, so this reads as collateral rather than something you'd have wanted. Shout if I've misread it.

### 2. Scene setup and Challenges open exclusively (`a7965bb2`)

Their toggles sit side by side in the stage's bottom-left corner and both panels expand upward from there, up to 360px wide — so opening the second laid it over the first, headers and close buttons stacked:

Opening either now closes the other. They ship in separate bundles (the sim viewer is vite-built and imported at runtime by `robotSession.js`), so the handshake is a document event rather than a shared module; the event name and panel ids are a contract between the two files, stated in both.

Closing scene setup this way also drops any armed prop, which would otherwise keep following the cursor with its panel gone.

The challenge panel yields **even mid-run**: deliberately opening scene setup is a clear enough intent, and nothing is lost — the judge state is server-side, so reopening shows the live goals and timer. That is deliberately the opposite of the existing `dismiss()`, which refuses to close a running challenge, because there the trigger is a stray click on the scene rather than an intent.

### 3. Placement defaults to "choose spot" (`f250a30a`)

Near-robot drops everything at the same reach offset in front of the robot, so setting up a scene meant placing, driving, placing again. Choose-spot is the mode that actually builds a scene, and it is one click away from the same result — objects still land wherever you click, including in front of the robot. Both modes are unchanged; only which one the panel opens in.

## Verification

- `sim/viewer`: `npm run typecheck` clean, `npm run build:lib` clean
- `webapp`: `tsc --noEmit` — 0 errors in both touched files; repo total 5177 before and after, an unchanged baseline (almost entirely `public/vendor/three.module.min.r160.js`, which `tsconfig.json` does not exclude)
- `webapp`: `node --test tests/*.test.js` — 8/8 pass

Not exercised in a running sim — worth a click-through of the two panels before merge.

## Noticed while here, not fixed

`webapp` has no `tsc` in CI and no npm script for it, and `tsconfig.json` doesn't exclude `public/vendor/`, so the check reports 5177 errors and can't work as a gate. Adding `"exclude": ["public/vendor/**"]` would drop it to the ~30 real ones in `armsdk/viz.js`, `brain/main.js`, `settings/main.js`, `teleop/agentState.js`, `keyboardDrive.js`. Happy to do it as a follow-up.