### PR TITLE
fix(skills): pickAnything searches with the arm clear of the head camera

### DIFF
--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -40,6 +40,11 @@ SOFT_GRIP_MIN = 0.5
 # j2 = -0.50: the coupling limit at j1~0.05 clamps past it and logs forever.
 CARRY_ARM = [0.0537, -0.50, 0.4157, 0.9434, -0.0077]
 
+# Search/approach pose (j1-5). REST's j4 = -0.3 pitches the gripper UP into the
+# head camera, over the very floor patch the object sits on; the same fold with
+# the wrist flattened and rolled clears the frame.
+NAV_ARM = [1.5708, -1.2195, 1.5723, 0.06, -0.47]
+
 # Pick parameters, tuned on hardware.
 PARAMS = {
     # FIND / LOCALIZE
@@ -867,9 +872,9 @@ class PickAnyObject(Skill):
         self._coasts = 0
         try:
             self.head.set_position(int(round(self._p["tilt_deg"])))
-            # Fold to rest so the arm doesn't occlude the head camera
+            # Fold clear of the head camera before searching
             # (5-joint move: the claw keeps whatever it currently holds).
-            self.manipulation.move_joints(self.manipulation.REST[:5], duration=3.0)
+            self.manipulation.move_joints(NAV_ARM, duration=3.0)
 
             self.say(f"Looking for {prompt}.")
             xy = self._search(prompt)


### PR DESCRIPTION
## The bug

`pickAnything` folds the arm to `Manipulation.REST` before searching and holds it there for the entire search + approach — nothing re-poses the arm until `_grasp_at`.

c1bd8c5f moved `REST`'s j4 from `+0.30` to `-0.30` so the gripper would stop catching on rugs and thresholds while driving. Negative j4 pitches the gripper **up** in that fold, which puts it in the head camera's lower-centre — the same region the pick box occupies (`floor_to_pixel(0.37, 0.0, -20°)` = px `(351, 349)`).

With the object occluded on approach, the head look stops returning the object in front of the base and returns a lookalike near the horizon instead. `pixel_to_floor` has no range clamp, so a detection at row ~78 px back-projects tens of metres out.

## Evidence, on hardware today

Two consecutive runs, both dying the same way immediately after the base had correctly driven into the box:

```
px=(353,309) -> base_link (0.379,-0.044)
1 match(es), nearest 27.47m from last sighting (gate 0.50m) — coasting
failure: Could not centre 'the airpod case' in the approach box

px=(329,302) -> base_link (0.400,0.007)
1 match(es), nearest 23.50m from last sighting (gate 0.51m) — coasting
failure: Could not centre 'the airpod case' in the approach box
```

For contrast, runs from before the j4 flip (2026-08-04/05), where every confirming look lands inside the box and the pick completes:

```
px=(345,352) -> base_link (0.364,0.006)   -> success
px=(351,337) -> base_link (0.390,-0.001)  -> success
px=(334,333) -> base_link (0.397,0.015)   -> success
```

## The change

Search and approach use a new `NAV_ARM` — the same fold as `REST`, wrist flattened to `j4 = 0.06` and rolled to `j5 = -0.47` — tuned live on the arm via the stream_joints sliders and confirmed to fix the behaviour on the robot.

Teardown (`_rest_arm`) still folds to `REST`: after a failed descent the gripper can be near the floor, and that fold's lifted wrist is exactly what keeps it clear.

The gripper hangs lower at `j4 = 0.06` than at `-0.30`, so the rug-catching c1bd8c5f fixed is partly back in play during the approach — but `0.06` is far flatter than the `+0.30` that commit was reacting to, and the approach is a slow drive over the patch the robot is already looking at.

## Not fixed here

The `27 m` phantom is a second, independent weakness: `_localize_px` will happily anchor on a candidate that back-projects past any sane pick range. A range sanity check at the localize stage would keep an occluded or hallucinated far-field match from ever becoming the target. Worth a follow-up.