### PR TITLE
Fix joystick hitbox to match round pad

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1285,7 +1285,6 @@ select.skill-input {
   --joystick-strafe: 0;
   --joystick-forward: 0;
   --joystick-forward-strength: abs(var(--joystick-forward));
-  --joystick-hit-size: 264px;
   --joystick-pad-size: 184px;
   left: 50%;
   bottom: 84px;
@@ -2203,22 +2202,21 @@ select.skill-input {
 
 .joystick-hit-target {
   display: grid;
-  grid-template-rows: 1fr var(--joystick-pad-size);
-  justify-items: center;
-  width: var(--joystick-hit-size);
-  height: var(--joystick-hit-size);
+  width: var(--joystick-pad-size);
+  height: var(--joystick-pad-size);
+  border-radius: 50%;
   touch-action: none;
-  cursor: default;
+  cursor: grab;
 }
 
-.joystick-hit-target.engaged,
-.joystick-hit-target.engaged .joystick-pad {
+.joystick-hit-target.engaged {
   cursor: grabbing;
 }
 
 .joystick-hit-target > * {
-  grid-area: 2 / 1;
+  grid-area: 1 / 1;
   place-self: center;
+  pointer-events: none;
 }
 
 .joystick-pad {
@@ -9558,7 +9556,6 @@ select.skill-input {
 
   /* Full-size joystick swallows half a phone screen. */
   .overlay-joystick {
-    --joystick-hit-size: 150px;
     --joystick-pad-size: 120px;
   }
 
@@ -10130,7 +10127,7 @@ select.skill-input {
      order alone keeps the joystick / WASD chips / head tilt painting on top
      (same trick as .cam-map-host.big). An explicit z-index here would let the
      opaque video cover the controls. */
-  /* Grow to 360px; on narrow scenes, stop at the centred 264px joystick hit target. */
+  /* Grow to 360px; on narrow scenes, stop before the centred joystick. */
   width: min(360px, calc(50% - 144px));
   aspect-ratio: 4 / 3;
   overflow: hidden;

--- a/webapp/js/teleop/joystick.js
+++ b/webapp/js/teleop/joystick.js
@@ -59,7 +59,7 @@ export function createJoystick(parent, driveController) {
     parent.style.setProperty("--joystick-throw", String(throwAmt));
     parent.style.setProperty("--joystick-strafe", String(strengthenVisualFeedback(p.dx / PAD_RADIUS)));
     parent.style.setProperty("--joystick-forward", String(strengthenVisualFeedback(-p.dy / PAD_RADIUS)));
-    // Scale from the visible pad — hit target may be larger and bottom-aligned.
+    // Scale from the visible pad so responsive CSS sizes preserve the same input range.
     const toCss = (pad.clientWidth || PAD_SIZE) / PAD_SIZE;
     knob.style.transform =
       `translate(${p.dx * toCss}px, ${p.dy * toCss}px) scale(${1 + throwAmt * 0.05})`;


### PR DESCRIPTION
## Summary
- size the joystick interaction target to the visible pad
- make the hit target circular and prevent child visuals from extending pointer hit-testing
- use the same responsive pad size for desktop and mobile

## Testing
- all `webapp/tests/*.test.js` pass
- browser hit-test: center and circular edge hit; corners and the former oversized region do not
- `git diff --check`

## Note
- optional whole-tree `tsc --noEmit` remains blocked by pre-existing errors in Arm SDK, settings, and vendored Three.js files