### PR TITLE
fix(sim): objects no longer slide out of the gripper

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -269,7 +269,10 @@ def build_world_xml(
 <mujoco model="apartment">
   <!-- implicitfast damps the single-step impulse spikes hull seams can
        produce -- what makes 1200+ hulls stable at all. -->
-  <option timestep="0.002" gravity="0 0 -9.81" integrator="implicitfast"/>
+  <option timestep="0.002" gravity="0 0 -9.81" integrator="implicitfast"
+          cone="elliptic" impratio="10"/>
+  <!-- cone/impratio: soft contacts let a grasped object creep out of the closed
+       claw no matter the friction (MuJoCo docs, "Preventing slip"). -->
   <visual>
     <global azimuth="{azimuth}" elevation="{elevation}" offwidth="1280" offheight="960"/>
   </visual>


### PR DESCRIPTION
## Symptom

In sim, a picked object crept out of the closed claw as soon as the base moved — held statically, on the floor within one 90° turn. The real gripper holds fine; this was sim-only, and it made any carry-then-place flow (e.g. pick → drop into a box) impossible to run in simulation.

Measured with the 63 g bar prop, turn-in-place used as the dynamic load so there is nothing to collide with:

| | before | after |
|---|---|---|
| after pick | z = 0.057 (held) | z = 0.067 (held) |
| after 1 × 90° turn | **z = 0.015 (on the floor)** | z = 0.066 |
| after 4 × 90° turns | — | **z = 0.066, zero creep** |

## Why it was never friction

Fifteen contact-parameter sweeps moved nothing: finger friction (slide 2→4, torsion 0.05→0.5), the prop's own friction, `condim` (already 6), `multiccd` (26 contacts either way), `solimp` in both directions, joint damping, armature, grip force (4× down made it strictly worse), backlash symmetry. Slip that is invariant to every friction and stiffness knob is not Coulomb sliding.

MuJoCo's soft contact model permits gradual slip even when the friction cone is not violated — the docs cover this under **"Preventing slip"** — and the documented remedy is the elliptic friction cone with friction impedance raised above normal impedance:

```xml
<option ... cone="elliptic" impratio="10"/>
```

One line. Everything else (friction, solref, solimp, condim, priorities) stays at its shipped value.

## Corroboration

This is exactly the configuration the **SO-101** and **SO-ARM100** models ship in MuJoCo Menagerie — both grasp reliably with *lower* friction than our fingers (SO-101: slide 1.0, torsion 0.005 vs our 2.0 / 0.05). The lead came from a research pass over how published MuJoCo grippers (SO-101, SO-ARM100, Panda/robosuite, xArm7, Robotiq 2F-85) handle grasp stability; none of them solve it by raising μ.

## Side effects

`impratio` stiffens friction relative to normal impedance for **every** contact in the world. Measured on the shepherd soccer ball (kicked on a bare floor plane, distance to rest):

| kick | pyramidal (before) | elliptic + impratio 10 |
|---|---|---|
| 0.5 m/s | 2.80 m — still moving at 30 s | 0.54 m, stops in 3.6 s |
| 1.0 m/s | 6.82 m — still moving at 30 s | 2.15 m, stops in 6.5 s |
| 2.0 m/s | 16.30 m — still moving at 30 s | 8.65 m, stops in 12.5 s |

Rolls 2–5× shorter — a real change, but in the direction the ball's own sidecar documents as intended ("condim 6 adds rolling friction, so a nudged ball rolls and gently stops **instead of rolling forever**"): before this change rolling friction was barely acting and the ball never came to rest inside 30 s. The shepherd challenge (push the ball ~4 m to the dog) still gets 0.5–2 m per push, and is worth one live re-run before relying on it.

Pick/grasp behaviour verified unchanged: pick succeeds first-try on the bar and cube, and held objects were additionally exercised interactively across several props.

Sim-only — no robot-side code or tuning is touched.
