### PR TITLE
sim: move every published host port as one block, so checkouts run side by side

### DIFF
--- a/sim/README.md
+++ b/sim/README.md
@@ -412,18 +412,14 @@ individual override that wins over the base:
 | +5 | world server RPC | `SIM_WORLD_PORT` | 8799 |
 | +6 | world state stream | `SIM_WORLD_STATE_PORT` | 8800 |
 
-Set nothing and you get exactly the ports above, so a single-checkout setup is
-unaffected. Export the variable in the second checkout's shell (or its
-direnv/`.envrc`) — it has to be set for every `./innate-sim` command in that
-checkout, not just `up`, since `down`, `status` and `logs` look for the same
-ports.
+Set nothing and you get exactly the ports above. The variable has to be set for
+every `./innate-sim` command in that checkout, not just `up` — `down`, `status`
+and `logs` look for the same ports — so export it or put it in an `.envrc`.
 
-Two stacks means two full ROS fleets plus two MuJoCo world servers rendering
-on the host. It works, but budget the RAM and the GPU.
-
-`./innate-sim up` refuses with the list of conflicting ports if anything else
-already holds one — naming a free block to move to — rather than letting Docker
-fail halfway or letting the second stack restart the first one's world server.
+Any number of checkouts can run at once this way; each is a full ROS fleet plus
+a MuJoCo world server rendering on the host, so the limit is your RAM and GPU.
+`./innate-sim up` refuses with the list of conflicting ports if anything already
+holds one, and names a free block to move to.
 
 ---
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -151,7 +151,8 @@ which key it thinks with:
 Rerun `./innate-sim setup` anytime to switch.
 
 **Open [https://localhost](https://localhost)** (accept the self-signed
-certificate) — you are looking at the robot's web app. Drive with the
+certificate; a different `INNATE_SIM_PORT_BASE` moves it — the dashboard
+prints the URL) — you are looking at the robot's web app. Drive with the
 joystick or WASD, switch between the 3D view, the robot's cameras, and the
 map, trigger skills, and chat with the agent. Add `?simperf` to the URL for
 a frame-time / latency HUD.
@@ -385,6 +386,44 @@ Prefer your own ROS tooling? A rosbridge server is also available at
   (the wire format stays 640×480). On machines stuck with software rendering
   (`software-speed` in the dashboard's World field), `2` makes each frame
   ~4× cheaper and noticeably lowers end-to-end latency.
+
+### Running two checkouts at once
+
+Each checkout already gets its own container, its own compose project and its
+own workspace build (all keyed to the checkout's path), but the ports a stack
+publishes belong to the machine. `INNATE_SIM_PORT_BASE` moves all seven at
+once, so a second checkout runs alongside the first:
+
+```bash
+cd ~/dev/innate-os-2
+INNATE_SIM_PORT_BASE=8600 ./innate-sim up   # webapp at https://localhost:8600
+```
+
+The block is laid out in a fixed order, and every port also takes an
+individual override that wins over the base:
+
+| Offset | Service | Override | Default |
+|---|---|---|---|
+| +0 | webapp (https) | `SIM_HTTPS_PORT` | 443 |
+| +1 | webapp (http) | `SIM_HTTP_PORT` | 80 |
+| +2 | rosbridge | `SIM_ROSBRIDGE_PORT` | 9090 |
+| +3 | leader receiver (UDP) | `SIM_UDP_PORT` | 9999 |
+| +4 | Foxglove bridge | `SIM_FOXGLOVE_PORT` | 8765 |
+| +5 | world server RPC | `SIM_WORLD_PORT` | 8799 |
+| +6 | world state stream | `SIM_WORLD_STATE_PORT` | 8800 |
+
+Set nothing and you get exactly the ports above, so a single-checkout setup is
+unaffected. Export the variable in the second checkout's shell (or its
+direnv/`.envrc`) — it has to be set for every `./innate-sim` command in that
+checkout, not just `up`, since `down`, `status` and `logs` look for the same
+ports.
+
+Two stacks means two full ROS fleets plus two MuJoCo world servers rendering
+on the host. It works, but budget the RAM and the GPU.
+
+`./innate-sim up` refuses with the list of conflicting ports if anything else
+already holds one — naming a free block to move to — rather than letting Docker
+fail halfway or letting the second stack restart the first one's world server.
 
 ---
 

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -16,7 +16,8 @@ services:
     ports:
       # novnc's browser view of the container X display (optional; the sim
       # renders headless). Override the published side when 8080 is taken:
-      # NOVNC_PORT=8081 ./innate-sim up.
+      # NOVNC_PORT=8081 ./innate-sim up. Not part of the INNATE_SIM_PORT_BASE
+      # block -- the x11 profile is off by default, so it never collides.
       - "${NOVNC_PORT:-8080}:8080"
     networks:
       - x11
@@ -55,14 +56,22 @@ services:
       # (innate foxglove status) can print the address that actually works
       # from the host. Must match the ports entry below.
       - SIM_FOXGLOVE_PORT=${SIM_FOXGLOVE_PORT:-8765}
+      # Host port of the world server's observer stream, for the webapp proxy's
+      # /worldstate relay -- the world runs on the host, so this is a host port.
+      - INNATE_WORLD_STATE_PORT=${SIM_WORLD_STATE_PORT:-8800}
     ports:
+      # Every published side takes an override, and the launcher fills them all
+      # in from INNATE_SIM_PORT_BASE, so a second checkout gets its own block
+      # (sim/README.md "Running two checkouts at once"). The container side is
+      # fixed -- only what the host publishes moves.
+      #
       # rosbridge (rws). Loopback by default: publishing on 0.0.0.0 invites
       # internet probes that open, send nothing, and disconnect, spamming the
       # rws log. Set SIM_ROSBRIDGE_BIND=0.0.0.0 to let LAN devices (e.g. a
       # phone/laptop opening the sim viewer) reach it.
-      - "9090:9090"
+      - "${SIM_ROSBRIDGE_PORT:-9090}:9090"
       # UDP leader receiver.
-      - "9999:9999/udp"
+      - "${SIM_UDP_PORT:-9999}:9999/udp"
       # webapp front door (replaces the deprecated sim/frontend UI): the in-container
       # python server binds 443 (https) + 80 (http), both serving the full app.
       # Override the published side (e.g. SIM_HTTPS_PORT=8443 ./innate-sim up) to

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -16,8 +16,8 @@ services:
     ports:
       # novnc's browser view of the container X display (optional; the sim
       # renders headless). Override the published side when 8080 is taken:
-      # NOVNC_PORT=8081 ./innate-sim up. Not part of the INNATE_SIM_PORT_BASE
-      # block -- the x11 profile is off by default, so it never collides.
+      # NOVNC_PORT=8081 ./innate-sim up. Outside the INNATE_SIM_PORT_BASE block:
+      # the x11 profile is off by default, so it never collides.
       - "${NOVNC_PORT:-8080}:8080"
     networks:
       - x11
@@ -56,14 +56,12 @@ services:
       # (innate foxglove status) can print the address that actually works
       # from the host. Must match the ports entry below.
       - SIM_FOXGLOVE_PORT=${SIM_FOXGLOVE_PORT:-8765}
-      # Host port of the world server's observer stream, for the webapp proxy's
-      # /worldstate relay -- the world runs on the host, so this is a host port.
+      # A HOST port: the world server runs outside the container, and the
+      # webapp proxy relays /worldstate to it.
       - INNATE_WORLD_STATE_PORT=${SIM_WORLD_STATE_PORT:-8800}
     ports:
-      # Every published side takes an override, and the launcher fills them all
-      # in from INNATE_SIM_PORT_BASE, so a second checkout gets its own block
-      # (sim/README.md "Running two checkouts at once"). The container side is
-      # fixed -- only what the host publishes moves.
+      # The launcher fills every published side in from INNATE_SIM_PORT_BASE
+      # (sim/README.md "Running two checkouts at once").
       #
       # rosbridge (rws). Loopback by default: publishing on 0.0.0.0 invites
       # internet probes that open, send nothing, and disconnect, spamming the

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -39,10 +39,8 @@ OS_BUILD_LOG_PATH = LOG_DIR / "os-build.log"
 VIEWER_BUILD_LOG_PATH = LOG_DIR / "viewer-build.log"
 WORLD_SERVER_LOG_PATH = LOG_DIR / "world-server.log"
 WORLD_SERVER_PID_PATH = STATE_DIR / "world-server.pid"
-# The two host ports the running world server was STARTED with, recorded rather
-# than inferred: after a port override the configured ports and the running
-# server's ports are exactly what differ, so the collision guard cannot ask the
-# configuration which ports are already ours.
+# Recorded, not inferred: after a port override the configuration and the
+# running server's ports are exactly what differ.
 WORLD_SERVER_PORTS_PATH = STATE_DIR / "world-server.ports"
 # Content digest of the model sources the running world server compiled
 # (see runtime._world_model_sources_digest); written next to the pid.
@@ -53,17 +51,12 @@ ROS_INSTALL_STATE_PATH = STATE_DIR / "ros-install.inputs.sha256"
 OS_SESSION_READY_POLL_SECONDS = 0.25
 GENERATED_OS_ENV_PATH = STATE_DIR / "innate-os.env"
 
-# Every host port the sim publishes, as one movable block: a second checkout
-# runs alongside a first with `INNATE_SIM_PORT_BASE=8500 ./innate-sim up`, or
-# one port at a time with the individual overrides. The defaults are the
-# classic ports, so a single-checkout setup sees no change.
 PORT_BASE_ENV = "INNATE_SIM_PORT_BASE"
 
 
 def _resolve_port(name: str, offset: int, classic: int) -> int:
-    """One published host port: its own override wins, then PORT_BASE_ENV plus
-    this port's offset within the block, then the classic port. Exits rather
-    than raising -- this runs at import, outside main()'s StackError boundary."""
+    """Own override, else PORT_BASE_ENV plus this port's offset, else `classic`.
+    Exits rather than raising: this runs at import, outside main()'s boundary."""
     for source, raw, shift in (
         (name, os.environ.get(name, "").strip(), 0),
         (PORT_BASE_ENV, os.environ.get(PORT_BASE_ENV, "").strip(), offset),
@@ -84,8 +77,8 @@ SIM_UDP_PORT = _resolve_port("SIM_UDP_PORT", 3, 9999)
 SIM_FOXGLOVE_PORT = _resolve_port("SIM_FOXGLOVE_PORT", 4, 8765)
 WORLD_SERVER_PORT = _resolve_port("SIM_WORLD_PORT", 5, 8799)
 WORLD_STATE_PORT = _resolve_port("SIM_WORLD_STATE_PORT", 6, 8800)
-# Resolved here and injected into compose's environment, so a base-only
-# override reaches the compose file without it knowing the base exists.
+# Injected into compose's environment, so a base-only override reaches the
+# compose file without it knowing the base exists.
 PUBLISHED_PORT_ENV = {
     "SIM_HTTPS_PORT": str(SIM_HTTPS_PORT),
     "SIM_HTTP_PORT": str(SIM_HTTP_PORT),
@@ -698,8 +691,7 @@ def get_config() -> dict[str, object]:
         )
 
     merged_env = dict(raw_env)
-    # Container-side: 9090 is rosbridge's port INSIDE the container, which the
-    # published-port block never moves.
+    # 9090 is rosbridge's port INSIDE the container, which no override moves.
     merged_env.setdefault("ROSBRIDGE_URI", "ws://localhost:9090")
 
     os_repo = require_path(REPO_ROOT, "innate-os repository")

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -42,12 +42,52 @@ WORLD_SERVER_PID_PATH = STATE_DIR / "world-server.pid"
 # Content digest of the model sources the running world server compiled
 # (see runtime._world_model_sources_digest); written next to the pid.
 WORLD_SERVER_MODEL_DIGEST_PATH = STATE_DIR / "world-server.model-digest"
-WORLD_SERVER_PORT = 8799
 OS_SESSION_LOG_PATH = LOG_DIR / "os-session.log"
 DOWN_LOG_PATH = LOG_DIR / "down.log"
 ROS_INSTALL_STATE_PATH = STATE_DIR / "ros-install.inputs.sha256"
 OS_SESSION_READY_POLL_SECONDS = 0.25
 GENERATED_OS_ENV_PATH = STATE_DIR / "innate-os.env"
+
+# Every host port the sim publishes, as one movable block: a second checkout
+# runs alongside a first with `INNATE_SIM_PORT_BASE=8500 ./innate-sim up`, or
+# one port at a time with the individual overrides. The defaults are the
+# classic ports, so a single-checkout setup sees no change.
+PORT_BASE_ENV = "INNATE_SIM_PORT_BASE"
+
+
+def _resolve_port(name: str, offset: int, classic: int) -> int:
+    """One published host port: its own override wins, then PORT_BASE_ENV plus
+    this port's offset within the block, then the classic port. Exits rather
+    than raising -- this runs at import, outside main()'s StackError boundary."""
+    for source, raw, shift in (
+        (name, os.environ.get(name, "").strip(), 0),
+        (PORT_BASE_ENV, os.environ.get(PORT_BASE_ENV, "").strip(), offset),
+    ):
+        if not raw:
+            continue
+        if raw.isdigit() and 1 <= int(raw) + shift <= 65535:
+            return int(raw) + shift
+        print(f"Error: {source}={raw!r} is not a usable port for {name}.", file=sys.stderr)
+        raise SystemExit(1)
+    return classic
+
+
+SIM_HTTPS_PORT = _resolve_port("SIM_HTTPS_PORT", 0, 443)
+SIM_HTTP_PORT = _resolve_port("SIM_HTTP_PORT", 1, 80)
+SIM_ROSBRIDGE_PORT = _resolve_port("SIM_ROSBRIDGE_PORT", 2, 9090)
+SIM_UDP_PORT = _resolve_port("SIM_UDP_PORT", 3, 9999)
+SIM_FOXGLOVE_PORT = _resolve_port("SIM_FOXGLOVE_PORT", 4, 8765)
+WORLD_SERVER_PORT = _resolve_port("SIM_WORLD_PORT", 5, 8799)
+WORLD_STATE_PORT = _resolve_port("SIM_WORLD_STATE_PORT", 6, 8800)
+# Resolved here and injected into compose's environment, so a base-only
+# override reaches the compose file without it knowing the base exists.
+PUBLISHED_PORT_ENV = {
+    "SIM_HTTPS_PORT": str(SIM_HTTPS_PORT),
+    "SIM_HTTP_PORT": str(SIM_HTTP_PORT),
+    "SIM_ROSBRIDGE_PORT": str(SIM_ROSBRIDGE_PORT),
+    "SIM_UDP_PORT": str(SIM_UDP_PORT),
+    "SIM_FOXGLOVE_PORT": str(SIM_FOXGLOVE_PORT),
+}
 # How brain_client reaches Gemini: through the Innate proxy with a service key,
 # straight at Google with a Gemini key, or not at all.
 INNATE_BACKEND = "innate"
@@ -653,9 +693,9 @@ def get_config() -> dict[str, object]:
         )
 
     merged_env = dict(raw_env)
+    # Container-side: 9090 is rosbridge's port INSIDE the container, which the
+    # published-port block never moves.
     merged_env.setdefault("ROSBRIDGE_URI", "ws://localhost:9090")
-
-    foxglove_port = os.environ.get("SIM_FOXGLOVE_PORT", "").strip() or "8765"
 
     os_repo = require_path(REPO_ROOT, "innate-os repository")
     sim_repo = require_path(REPO_ROOT / "sim", "sim repository")
@@ -675,7 +715,9 @@ def get_config() -> dict[str, object]:
         "brain_backend": resolve_brain_backend(merged_env),
         "os_repo": os_repo,
         "sim_repo": sim_repo,
-        "foxglove_port": foxglove_port,
+        "foxglove_port": str(SIM_FOXGLOVE_PORT),
+        "webapp_url": "https://localhost" + ("" if SIM_HTTPS_PORT == 443 else f":{SIM_HTTPS_PORT}"),
+        "rosbridge_url": f"ws://localhost:{SIM_ROSBRIDGE_PORT}",
         "os_image": os_image,
         "os_image_auto": os_image_auto,
         "os_pull_image": os_pull_image if os_pull_image is not None else True,

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -39,6 +39,11 @@ OS_BUILD_LOG_PATH = LOG_DIR / "os-build.log"
 VIEWER_BUILD_LOG_PATH = LOG_DIR / "viewer-build.log"
 WORLD_SERVER_LOG_PATH = LOG_DIR / "world-server.log"
 WORLD_SERVER_PID_PATH = STATE_DIR / "world-server.pid"
+# The two host ports the running world server was STARTED with, recorded rather
+# than inferred: after a port override the configured ports and the running
+# server's ports are exactly what differ, so the collision guard cannot ask the
+# configuration which ports are already ours.
+WORLD_SERVER_PORTS_PATH = STATE_DIR / "world-server.ports"
 # Content digest of the model sources the running world server compiled
 # (see runtime._world_model_sources_digest); written next to the pid.
 WORLD_SERVER_MODEL_DIGEST_PATH = STATE_DIR / "world-server.model-digest"

--- a/sim/launcher/dashboard.py
+++ b/sim/launcher/dashboard.py
@@ -914,7 +914,7 @@ def render_status(
     # What to do, then where -- an instruction reads better than a URL with a
     # caption after it. The editor row is only offered when one is installed.
     destinations = [
-        (GREEN, "▸", "Open simulator in browser", "https://localhost"),
+        (GREEN, "▸", "Open simulator in browser", str(config["webapp_url"])),
         (CYAN, "✎", "Edit code in", checkout),
     ]
     editor = detect_editor()
@@ -931,7 +931,7 @@ def render_status(
     print_dashboard_line(
         "   ".join(
             [
-                f"{DIM}rosbridge{NC} ws://localhost:9090",
+                f"{DIM}rosbridge{NC} {config['rosbridge_url']}",
                 f"{DIM}foxglove{NC} ws://localhost:{config['foxglove_port']}",
                 f"{DIM}logs{NC} {options.cli_sim} logs startup",
                 f"{DIM}shell{NC} {options.cli_sim} sh",

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -55,6 +55,7 @@ from runtime import (
     open_os_container_shell,
     prefetch_runtime,
     print_startup_checks,
+    refuse_if_ports_taken,
     remove_superseded_containers,
     runtime_already_running,
     stop_world_server,
@@ -127,6 +128,9 @@ def cmd_up(
             log("Innate sim runtime is already running. Opening dashboard...")
             show_runtime_dashboard(config, watch=watch)
             return
+        # Before the downloads and before the world server: a port this stack
+        # cannot claim must fail in a second, not after a multi-gigabyte fetch.
+        refuse_if_ports_taken()
 
         os_env_file = build_os_env(config)
         if offline:

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -128,8 +128,6 @@ def cmd_up(
             log("Innate sim runtime is already running. Opening dashboard...")
             show_runtime_dashboard(config, watch=watch)
             return
-        # Before the downloads and before the world server: a port this stack
-        # cannot claim must fail in a second, not after a multi-gigabyte fetch.
         refuse_if_ports_taken()
 
         os_env_file = build_os_env(config)

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -809,6 +809,12 @@ def ensure_home_mount_sources() -> None:
             ssh_dir.mkdir(mode=0o700)
 
 
+def world_endpoint() -> str:
+    """The address the container reaches the host world server on (see
+    _world_server_bind_addresses for which host address that resolves to)."""
+    return f"host.docker.internal:{WORLD_SERVER_PORT}"
+
+
 # Container port -> the host port this launcher now publishes it on. Container
 # ports never move; only the published side does.
 _CONTAINER_PORT_PUBLISH = (
@@ -818,6 +824,40 @@ _CONTAINER_PORT_PUBLISH = (
     ("9999/udp", SIM_UDP_PORT),
     ("8765/tcp", SIM_FOXGLOVE_PORT),
 )
+
+
+# Container env the port block decides. Neither appears in the published ports,
+# so a world-port change alone would otherwise leave a reused container talking
+# to the old server. The third field is what an ABSENT variable means: it
+# mirrors the consumer's own fallback, so a container from before the variable
+# existed is not read as drift.
+_CONTAINER_ENV_PUBLISH = (
+    ("VIRTUAL_MARS_REMOTE", world_endpoint(), ""),
+    ("INNATE_WORLD_STATE_PORT", str(WORLD_STATE_PORT), "8800"),
+)
+
+
+def _container_env(name: str) -> dict[str, str] | None:
+    """The container's baked environment, or None when the probe cannot answer."""
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "-f", "{{json .Config.Env}}", name],
+            text=True,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+            timeout=DOCKER_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        entries = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    pairs = (entry.partition("=") for entry in entries)
+    return {key: value for key, sep, value in pairs if sep}
 
 
 def _container_port_map(name: str) -> dict[str, set[int]] | None:
@@ -845,20 +885,28 @@ def _container_port_map(name: str) -> dict[str, set[int]] | None:
     return mapping
 
 
-def os_container_ports_current() -> bool:
-    """False when the running OS container publishes any service on a host port
-    other than the one the launcher now resolves.
+def os_container_current() -> bool:
+    """False when the running OS container publishes a service on a host port,
+    or carries a world-server address, other than what the launcher now
+    resolves.
 
-    A running container's published ports cannot be changed in place, so drift
-    costs a recreate. Two ways to drift: checkouts that ran the brain in a
-    cloud-agent container shifted Foxglove to 8766 (the agent owned 8765), and
-    any INNATE_SIM_PORT_BASE change moves all five at once. An unanswered probe
-    reports "current" -- a flaky answer must not cost a recreate.
+    Neither a running container's published ports nor its environment can be
+    changed in place, so drift in either costs a recreate. Three ways to drift:
+    checkouts that ran the brain in a cloud-agent container shifted Foxglove to
+    8766 (the agent owned 8765), an INNATE_SIM_PORT_BASE change moves all five
+    publishes at once, and a world-port change moves only the environment. An
+    unanswered probe reports "current" -- a flaky answer must not cost a
+    recreate.
     """
     published = _container_port_map(OS_CONTAINER_NAME)
     if published is None:
         return True
-    return all(host in published.get(spec, set()) for spec, host in _CONTAINER_PORT_PUBLISH)
+    if not all(host in published.get(spec, set()) for spec, host in _CONTAINER_PORT_PUBLISH):
+        return False
+    env = _container_env(OS_CONTAINER_NAME)
+    if env is None:
+        return True
+    return all(env.get(key, absent) == expected for key, expected, absent in _CONTAINER_ENV_PUBLISH)
 
 
 def retitle_step(message: str) -> None:
@@ -872,8 +920,8 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
     os_image = str(config["os_image"]).strip()
     os_image_auto = bool(config["os_image_auto"])
     reuse_running_container = container_running(OS_CONTAINER_NAME)
-    if reuse_running_container and not os_container_ports_current():
-        log(f"The running OS container publishes on older host ports; recreating it to serve {config['webapp_url']}.")
+    if reuse_running_container and not os_container_current():
+        log(f"The running OS container is bound to an older port block; recreating it to serve {config['webapp_url']}.")
         reuse_running_container = False
 
     if reuse_running_container:
@@ -1231,7 +1279,7 @@ def _host_port_free(port: int, *, udp: bool) -> bool:
 def _container_published_ports(name: str) -> set[int]:
     """Host ports a container publishes. Read rather than assumed: a container
     started under a different port block still publishes the OLD ones, and
-    os_container_ports_current is what recreates it for that."""
+    os_container_current is what recreates it for that."""
     published = _container_port_map(name)
     return set() if published is None else {port for ports in published.values() for port in ports}
 
@@ -1624,7 +1672,7 @@ def runtime_already_running(config: dict[str, object]) -> bool:
     a different port block still publishes the ports the dashboard no longer
     prints, and only a recreate can move them -- so it is not reusable, however
     healthy it looks."""
-    return os_runtime_ready(config) and os_container_ports_current()
+    return os_runtime_ready(config) and os_container_current()
 
 
 def format_startup_check(ok: bool, label: str, detail: str) -> str:
@@ -2404,7 +2452,7 @@ def ensure_world_server(config: dict[str, object]) -> str:
         raise StackError(_UV_MISSING_MESSAGE)
 
     sim_repo: Path = config["sim_repo"]  # type: ignore[assignment]
-    endpoint = f"host.docker.internal:{WORLD_SERVER_PORT}"
+    endpoint = world_endpoint()
     bind = os.environ.get("INNATE_SIM_WORLD_BIND", "").strip() or _world_server_bind_addresses()
     if not bind:
         # Fail closed: no host-only bind must never widen to 0.0.0.0.
@@ -2418,7 +2466,11 @@ def ensure_world_server(config: dict[str, object]) -> str:
     if reply is not None:
         expected_binds = {b.strip() for b in bind.split(",") if b.strip()}
         actual_binds = reply.get("binds")
-        if reply.get("state_port") and actual_binds is not None and set(actual_binds) == expected_binds:
+        if (
+            reply.get("state_port") == WORLD_STATE_PORT
+            and actual_binds is not None
+            and set(actual_binds) == expected_binds
+        ):
             # The MuJoCo model is compiled at server start; a URDF or
             # world-module edit since then is not in the running physics.
             running_digest = ""
@@ -2434,6 +2486,11 @@ def ensure_world_server(config: dict[str, object]) -> str:
         # INNATE_SIM_WORLD_BIND=0.0.0.0 server) -- restart instead.
         elif not reply.get("state_port"):
             log("Host world server is outdated (no observer state stream) -- restarting it...")
+        elif reply["state_port"] != WORLD_STATE_PORT:
+            log(
+                f"Host world server streams observer state on port {reply['state_port']}, but the "
+                f"webapp and viewer were told {WORLD_STATE_PORT} -- restarting it..."
+            )
         elif actual_binds is None:
             log("Host world server predates bind reporting -- restarting it...")
         else:

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -809,18 +809,23 @@ def ensure_home_mount_sources() -> None:
             ssh_dir.mkdir(mode=0o700)
 
 
-def os_container_foxglove_port_current(config: dict[str, object]) -> bool:
-    """False when a running OS container publishes the Foxglove bridge on a host
-    port other than the one the launcher now advertises.
+# Container port -> the host port this launcher now publishes it on. Container
+# ports never move; only the published side does.
+_CONTAINER_PORT_PUBLISH = (
+    ("443/tcp", SIM_HTTPS_PORT),
+    ("80/tcp", SIM_HTTP_PORT),
+    ("9090/tcp", SIM_ROSBRIDGE_PORT),
+    ("9999/udp", SIM_UDP_PORT),
+    ("8765/tcp", SIM_FOXGLOVE_PORT),
+)
 
-    Checkouts that ran the brain in a cloud-agent container shifted the publish
-    to 8766 (the agent owned 8765); a running container's published ports cannot
-    be changed in place, so such a container has to be recreated. An unanswered
-    probe reports "current" -- a flaky answer must not cost a recreate.
-    """
+
+def _container_port_map(name: str) -> dict[str, set[int]] | None:
+    """`docker port` as {"443/tcp": {443}}, or None when the probe could not
+    answer -- not running, or a wedged daemon. None is "unknown", never "drift"."""
     try:
         result = subprocess.run(
-            ["docker", "port", OS_CONTAINER_NAME, "8765"],
+            ["docker", "port", name],
             text=True,
             stdin=subprocess.DEVNULL,
             capture_output=True,
@@ -828,11 +833,32 @@ def os_container_foxglove_port_current(config: dict[str, object]) -> bool:
             timeout=DOCKER_PROBE_TIMEOUT_S,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return True
+        return None
     if result.returncode != 0:
+        return None
+    mapping: dict[str, set[int]] = {}
+    for line in result.stdout.splitlines():
+        spec, arrow, published = line.partition(" -> ")
+        host_port = published.rpartition(":")[2].strip()
+        if arrow and host_port.isdigit():
+            mapping.setdefault(spec.strip(), set()).add(int(host_port))
+    return mapping
+
+
+def os_container_ports_current() -> bool:
+    """False when the running OS container publishes any service on a host port
+    other than the one the launcher now resolves.
+
+    A running container's published ports cannot be changed in place, so drift
+    costs a recreate. Two ways to drift: checkouts that ran the brain in a
+    cloud-agent container shifted Foxglove to 8766 (the agent owned 8765), and
+    any INNATE_SIM_PORT_BASE change moves all five at once. An unanswered probe
+    reports "current" -- a flaky answer must not cost a recreate.
+    """
+    published = _container_port_map(OS_CONTAINER_NAME)
+    if published is None:
         return True
-    published = str(config["foxglove_port"])
-    return any(line.strip().endswith(f":{published}") for line in result.stdout.splitlines())
+    return all(host in published.get(spec, set()) for spec, host in _CONTAINER_PORT_PUBLISH)
 
 
 def retitle_step(message: str) -> None:
@@ -846,11 +872,8 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
     os_image = str(config["os_image"]).strip()
     os_image_auto = bool(config["os_image_auto"])
     reuse_running_container = container_running(OS_CONTAINER_NAME)
-    if reuse_running_container and not os_container_foxglove_port_current(config):
-        log(
-            "The running OS container publishes Foxglove on an older host port; "
-            f"recreating it to serve ws://localhost:{config['foxglove_port']}."
-        )
+    if reuse_running_container and not os_container_ports_current():
+        log(f"The running OS container publishes on older host ports; recreating it to serve {config['webapp_url']}.")
         reuse_running_container = False
 
     if reuse_running_container:
@@ -1207,23 +1230,10 @@ def _host_port_free(port: int, *, udp: bool) -> bool:
 
 def _container_published_ports(name: str) -> set[int]:
     """Host ports a container publishes. Read rather than assumed: a container
-    started under a different port block still publishes the OLD ports, and
-    os_container_foxglove_port_current is what recreates it for that."""
-    try:
-        result = subprocess.run(
-            ["docker", "port", name],
-            text=True,
-            stdin=subprocess.DEVNULL,
-            capture_output=True,
-            check=False,
-            timeout=DOCKER_PROBE_TIMEOUT_S,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return set()
-    if result.returncode != 0:
-        return set()  # not running, or publishing nothing
-    published = (line.rpartition(":")[2].strip() for line in result.stdout.splitlines())
-    return {int(port) for port in published if port.isdigit()}
+    started under a different port block still publishes the OLD ones, and
+    os_container_ports_current is what recreates it for that."""
+    published = _container_port_map(name)
+    return set() if published is None else {port for ports in published.values() for port in ports}
 
 
 def _own_world_server_alive() -> bool:
@@ -1610,10 +1620,11 @@ def wait_for_virtual_mars(config: dict[str, object], *, timeout_seconds: float =
 
 
 def runtime_already_running(config: dict[str, object]) -> bool:
-    """The running stack is both complete and current. A container from an older
-    checkout serves the Foxglove bridge on a host port the dashboard no longer
-    prints, and only a recreate can move it -- so that stack is not reusable."""
-    return os_runtime_ready(config) and os_container_foxglove_port_current(config)
+    """The running stack is both complete and current. A container started under
+    a different port block still publishes the ports the dashboard no longer
+    prints, and only a recreate can move them -- so it is not reusable, however
+    healthy it looks."""
+    return os_runtime_ready(config) and os_container_ports_current()
 
 
 def format_startup_check(ok: bool, label: str, detail: str) -> str:

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -811,13 +811,11 @@ def ensure_home_mount_sources() -> None:
 
 
 def world_endpoint() -> str:
-    """The address the container reaches the host world server on (see
-    _world_server_bind_addresses for which host address that resolves to)."""
+    """The address the container reaches the host world server on."""
     return f"host.docker.internal:{WORLD_SERVER_PORT}"
 
 
-# Container port -> the host port this launcher now publishes it on. Container
-# ports never move; only the published side does.
+# Container ports never move; only the host side they are published on does.
 _CONTAINER_PORT_PUBLISH = (
     ("443/tcp", SIM_HTTPS_PORT),
     ("80/tcp", SIM_HTTP_PORT),
@@ -827,11 +825,9 @@ _CONTAINER_PORT_PUBLISH = (
 )
 
 
-# Container env the port block decides. Neither appears in the published ports,
-# so a world-port change alone would otherwise leave a reused container talking
-# to the old server. The third field is what an ABSENT variable means: it
-# mirrors the consumer's own fallback, so a container from before the variable
-# existed is not read as drift.
+# The world ports reach the container as env, not as a publish, so they need
+# their own drift check. Third field: what an ABSENT variable means, mirroring
+# the consumer's fallback, so a container predating it is not read as drift.
 _CONTAINER_ENV_PUBLISH = (
     ("VIRTUAL_MARS_REMOTE", world_endpoint(), ""),
     ("INNATE_WORLD_STATE_PORT", str(WORLD_STATE_PORT), "8800"),
@@ -862,8 +858,7 @@ def _container_env(name: str) -> dict[str, str] | None:
 
 
 def _container_port_map(name: str) -> dict[str, set[int]] | None:
-    """`docker port` as {"443/tcp": {443}}, or None when the probe could not
-    answer -- not running, or a wedged daemon. None is "unknown", never "drift"."""
+    """`docker port` as {"443/tcp": {443}}. None is "unknown", never "drift"."""
     try:
         result = subprocess.run(
             ["docker", "port", name],
@@ -887,18 +882,9 @@ def _container_port_map(name: str) -> dict[str, set[int]] | None:
 
 
 def os_container_current() -> bool:
-    """False when the running OS container publishes a service on a host port,
-    or carries a world-server address, other than what the launcher now
-    resolves.
-
-    Neither a running container's published ports nor its environment can be
-    changed in place, so drift in either costs a recreate. Three ways to drift:
-    checkouts that ran the brain in a cloud-agent container shifted Foxglove to
-    8766 (the agent owned 8765), an INNATE_SIM_PORT_BASE change moves all five
-    publishes at once, and a world-port change moves only the environment. An
-    unanswered probe reports "current" -- a flaky answer must not cost a
-    recreate.
-    """
+    """Whether the running container's publishes and world-server env still match
+    what the launcher resolves. Neither can be changed in place, so drift costs a
+    recreate; an unanswered probe reports current, since a flaky answer must not."""
     published = _container_port_map(OS_CONTAINER_NAME)
     if published is None:
         return True
@@ -1231,8 +1217,6 @@ def running_stack_from_another_checkout() -> tuple[str, str] | None:
     return None
 
 
-# Every host port a running stack holds, in the order INNATE_SIM_PORT_BASE
-# lays them out. The container's own ports never move; only what is published.
 _PUBLISHED_HOST_PORTS = (
     ("webapp (https)", SIM_HTTPS_PORT, False),
     ("webapp (http)", SIM_HTTP_PORT, False),
@@ -1262,13 +1246,9 @@ def _tcp_listener_answers(port: int) -> bool:
 
 
 def _host_port_free(port: int, *, udp: bool) -> bool:
-    """Whether Docker can still publish this host port.
-
-    Only EADDRINUSE proves a collision. Linux refuses ports below 1024 to a
-    non-root binder while the Docker daemon that publishes them runs as root,
-    so that EACCES asks whether anything already answers there instead --
-    binding 443 must never be mistaken for 443 being taken.
-    """
+    """Whether Docker can still publish this host port. Only EADDRINUSE proves a
+    collision: Linux refuses ports below 1024 to a non-root binder while the
+    daemon that publishes them runs as root, so a free 443 refuses the probe."""
     refusal = _bind_refusal(port, udp=udp)
     if refusal is None:
         return True
@@ -1278,22 +1258,16 @@ def _host_port_free(port: int, *, udp: bool) -> bool:
 
 
 def _container_published_ports(name: str) -> set[int]:
-    """Host ports a container publishes. Read rather than assumed: a container
-    started under a different port block still publishes the OLD ones, and
-    os_container_current is what recreates it for that."""
+    """Host ports a container publishes -- the OLD ones if it outlived a port
+    change, which is the point: those are the ports it is really holding."""
     published = _container_port_map(name)
     return set() if published is None else {port for ports in published.values() for port in ports}
 
 
 def _own_world_server_ports() -> set[int]:
-    """The ports the world server THIS checkout started is holding, so the guard
-    exempts what it will replace rather than what it was configured to want.
-
-    Read from the recorded pair, never from the current configuration: a port
-    override is precisely the case where the two disagree, and inferring from
-    the configuration exempts a newly requested port nobody owns while flagging
-    the running server's own port as a collision. A live pid is enough -- a
-    wedged server still holds its ports, and ensure_world_server stops it."""
+    """Ports the world server this checkout started is holding, from the recorded
+    pair rather than the configuration (see WORLD_SERVER_PORTS_PATH). A live pid
+    is enough: a wedged server still holds them, and ensure_world_server stops it."""
     try:
         pid = int(WORLD_SERVER_PID_PATH.read_text(encoding="utf-8").strip())
         ports = {int(port) for port in WORLD_SERVER_PORTS_PATH.read_text(encoding="utf-8").split()}
@@ -1307,8 +1281,8 @@ def _own_world_server_ports() -> set[int]:
 
 
 def _suggest_port_base() -> int | None:
-    """A base whose whole block is free, so the remedy names a base that will
-    work rather than echoing back the one that just failed."""
+    """A base whose whole block is free, so the remedy cannot echo back the base
+    that just failed."""
     for base in range(8600, 9600, 10):
         if all(_host_port_free(base + offset, udp=udp) for offset, (_, _, udp) in enumerate(_PUBLISHED_HOST_PORTS)):
             return base
@@ -1325,13 +1299,10 @@ def _other_checkout_holding(ports: set[int]) -> tuple[str, str] | None:
 
 
 def refuse_if_ports_taken() -> None:
-    """Refuse before anything claims a host port this stack needs.
-
-    Checked ahead of the world server, not just ahead of compose: a second
-    checkout sharing the port block would otherwise have its
-    _stop_stale_world_server SIGTERM the first one's physics before Docker ever
-    complained about 443.
-    """
+    """Refuse before anything claims a host port this stack needs. Ahead of the
+    world server, not just ahead of compose: a second checkout sharing the block
+    would otherwise SIGTERM the first one's physics (_stop_stale_world_server)
+    before Docker ever complained about 443."""
     ours = _container_published_ports(OS_CONTAINER_NAME) | _own_world_server_ports()
     taken = [
         (label, port)
@@ -1674,10 +1645,8 @@ def wait_for_virtual_mars(config: dict[str, object], *, timeout_seconds: float =
 
 
 def runtime_already_running(config: dict[str, object]) -> bool:
-    """The running stack is both complete and current. A container started under
-    a different port block still publishes the ports the dashboard no longer
-    prints, and only a recreate can move them -- so it is not reusable, however
-    healthy it looks."""
+    """The running stack is both complete and current. A container on a stale port
+    block is not reusable however healthy it looks -- only a recreate moves it."""
     return os_runtime_ready(config) and os_container_current()
 
 

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -65,6 +65,7 @@ from config import (
     WORLD_SERVER_MODEL_DIGEST_PATH,
     WORLD_SERVER_PID_PATH,
     WORLD_SERVER_PORT,
+    WORLD_SERVER_PORTS_PATH,
     WORLD_STATE_PORT,
     DockerUnresponsiveError,
     StackError,
@@ -1284,18 +1285,25 @@ def _container_published_ports(name: str) -> set[int]:
     return set() if published is None else {port for ports in published.values() for port in ports}
 
 
-def _own_world_server_alive() -> bool:
-    """Whether the world server THIS checkout started still answers. Its ports
-    are then not a collision -- ensure_world_server reuses or restarts it."""
+def _own_world_server_ports() -> set[int]:
+    """The ports the world server THIS checkout started is holding, so the guard
+    exempts what it will replace rather than what it was configured to want.
+
+    Read from the recorded pair, never from the current configuration: a port
+    override is precisely the case where the two disagree, and inferring from
+    the configuration exempts a newly requested port nobody owns while flagging
+    the running server's own port as a collision. A live pid is enough -- a
+    wedged server still holds its ports, and ensure_world_server stops it."""
     try:
         pid = int(WORLD_SERVER_PID_PATH.read_text(encoding="utf-8").strip())
+        ports = {int(port) for port in WORLD_SERVER_PORTS_PATH.read_text(encoding="utf-8").split()}
     except (OSError, ValueError):
-        return False
+        return set()
     try:
         os.kill(pid, 0)
     except OSError:
-        return False
-    return _world_server_ping(WORLD_SERVER_PORT, timeout=0.5)
+        return set()
+    return ports
 
 
 def _suggest_port_base() -> int | None:
@@ -1324,9 +1332,7 @@ def refuse_if_ports_taken() -> None:
     _stop_stale_world_server SIGTERM the first one's physics before Docker ever
     complained about 443.
     """
-    ours = _container_published_ports(OS_CONTAINER_NAME)
-    if _own_world_server_alive():
-        ours |= {WORLD_SERVER_PORT, WORLD_STATE_PORT}
+    ours = _container_published_ports(OS_CONTAINER_NAME) | _own_world_server_ports()
     taken = [
         (label, port)
         for label, port, udp in _PUBLISHED_HOST_PORTS
@@ -2634,6 +2640,7 @@ def _start_world_server(uv: str, sim_repo: Path, *, bind: str, mujoco_gl: str | 
             stderr=subprocess.STDOUT,
         )
     WORLD_SERVER_PID_PATH.write_text(f"{proc.pid}\n", encoding="utf-8")
+    WORLD_SERVER_PORTS_PATH.write_text(f"{WORLD_SERVER_PORT} {WORLD_STATE_PORT}\n", encoding="utf-8")
     # Patient while alive: the first run downloads the Python env (uv sync)
     # and builds the MuJoCo model, which takes minutes on slow machines --
     # killing a live process on a stopwatch misdiagnosed a Raspberry Pi's
@@ -2653,6 +2660,7 @@ def _start_world_server(uv: str, sim_repo: Path, *, bind: str, mujoco_gl: str | 
     with contextlib.suppress(ProcessLookupError, OSError):
         proc.kill()
     WORLD_SERVER_PID_PATH.unlink(missing_ok=True)
+    WORLD_SERVER_PORTS_PATH.unlink(missing_ok=True)
     WORLD_SERVER_MODEL_DIGEST_PATH.unlink(missing_ok=True)
     return False
 
@@ -2708,6 +2716,7 @@ def stop_world_server() -> None:
         pass
     with contextlib.suppress(OSError):  # read-only fs: the kill still counts
         WORLD_SERVER_PID_PATH.unlink(missing_ok=True)
+        WORLD_SERVER_PORTS_PATH.unlink(missing_ok=True)
         WORLD_SERVER_MODEL_DIGEST_PATH.unlink(missing_ok=True)
 
 

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import functools
 import grp
 import hashlib
@@ -45,11 +46,18 @@ from config import (
     OS_CONTAINER_TMUX_CMD,
     OS_SESSION_LOG_PATH,
     OS_SESSION_READY_POLL_SECONDS,
+    PORT_BASE_ENV,
+    PUBLISHED_PORT_ENV,
     REPO_ROOT,
     ROS_INSTALL_STATE_PATH,
     SIM_ASSET_UNITS,
     SIM_ASSET_UNITS_AUTHORED,
     SIM_ASSET_UNITS_DERIVED,
+    SIM_FOXGLOVE_PORT,
+    SIM_HTTP_PORT,
+    SIM_HTTPS_PORT,
+    SIM_ROSBRIDGE_PORT,
+    SIM_UDP_PORT,
     TMUX_SESSION_NAME,
     VIEWER_BUILD_LOG_PATH,
     VIEWER_TREE_PATH,
@@ -57,6 +65,7 @@ from config import (
     WORLD_SERVER_MODEL_DIGEST_PATH,
     WORLD_SERVER_PID_PATH,
     WORLD_SERVER_PORT,
+    WORLD_STATE_PORT,
     DockerUnresponsiveError,
     StackError,
     compute_geometry_inputs_hash,
@@ -574,6 +583,8 @@ def os_compose_env(
     values = {
         "INNATE_OS_ENV_FILE": str(env_file),
         "INNATE_OS_CONTAINER_NAME": OS_CONTAINER_NAME,
+        "SIM_WORLD_STATE_PORT": str(WORLD_STATE_PORT),
+        **PUBLISHED_PORT_ENV,
     }
     if base_env:
         values.update(base_env)
@@ -845,7 +856,6 @@ def ensure_os_container(config: dict[str, object], os_env_file: Path, *, offline
     if reuse_running_container:
         log("Innate OS dev container already running.")
     else:
-        refuse_if_another_checkout_is_running()
         up_cmd = docker_compose_cmd("up", "-d")
         if offline:
             # Reuse an image that is already local; never pull or build, which
@@ -1149,17 +1159,142 @@ def running_stack_from_another_checkout() -> tuple[str, str] | None:
     return None
 
 
-def refuse_if_another_checkout_is_running() -> None:
+# Every host port a running stack holds, in the order INNATE_SIM_PORT_BASE
+# lays them out. The container's own ports never move; only what is published.
+_PUBLISHED_HOST_PORTS = (
+    ("webapp (https)", SIM_HTTPS_PORT, False),
+    ("webapp (http)", SIM_HTTP_PORT, False),
+    ("rosbridge", SIM_ROSBRIDGE_PORT, False),
+    ("leader receiver", SIM_UDP_PORT, True),
+    ("foxglove bridge", SIM_FOXGLOVE_PORT, False),
+    ("world server", WORLD_SERVER_PORT, False),
+    ("world state stream", WORLD_STATE_PORT, False),
+)
+
+
+def _bind_refusal(port: int, *, udp: bool) -> int | None:
+    """errno from claiming the port the way Docker will (0.0.0.0, no
+    SO_REUSEADDR), or None when the bind succeeds."""
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM if udp else socket.SOCK_STREAM) as probe:
+        try:
+            probe.bind(("0.0.0.0", port))
+        except OSError as exc:
+            return exc.errno
+    return None
+
+
+def _tcp_listener_answers(port: int) -> bool:
+    with contextlib.suppress(OSError), socket.create_connection(("127.0.0.1", port), timeout=0.5):
+        return True
+    return False
+
+
+def _host_port_free(port: int, *, udp: bool) -> bool:
+    """Whether Docker can still publish this host port.
+
+    Only EADDRINUSE proves a collision. Linux refuses ports below 1024 to a
+    non-root binder while the Docker daemon that publishes them runs as root,
+    so that EACCES asks whether anything already answers there instead --
+    binding 443 must never be mistaken for 443 being taken.
+    """
+    refusal = _bind_refusal(port, udp=udp)
+    if refusal is None:
+        return True
+    if refusal == errno.EACCES and not udp:
+        return not _tcp_listener_answers(port)
+    return refusal != errno.EADDRINUSE
+
+
+def _container_published_ports(name: str) -> set[int]:
+    """Host ports a container publishes. Read rather than assumed: a container
+    started under a different port block still publishes the OLD ports, and
+    os_container_foxglove_port_current is what recreates it for that."""
+    try:
+        result = subprocess.run(
+            ["docker", "port", name],
+            text=True,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+            timeout=DOCKER_PROBE_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return set()
+    if result.returncode != 0:
+        return set()  # not running, or publishing nothing
+    published = (line.rpartition(":")[2].strip() for line in result.stdout.splitlines())
+    return {int(port) for port in published if port.isdigit()}
+
+
+def _own_world_server_alive() -> bool:
+    """Whether the world server THIS checkout started still answers. Its ports
+    are then not a collision -- ensure_world_server reuses or restarts it."""
+    try:
+        pid = int(WORLD_SERVER_PID_PATH.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return _world_server_ping(WORLD_SERVER_PORT, timeout=0.5)
+
+
+def _suggest_port_base() -> int | None:
+    """A base whose whole block is free, so the remedy names a base that will
+    work rather than echoing back the one that just failed."""
+    for base in range(8600, 9600, 10):
+        if all(_host_port_free(base + offset, udp=udp) for offset, (_, _, udp) in enumerate(_PUBLISHED_HOST_PORTS)):
+            return base
+    return None
+
+
+def _other_checkout_holding(ports: set[int]) -> tuple[str, str] | None:
+    """The other checkout's stack, but only when it actually publishes one of
+    these ports -- an unrelated listener must not be reported as a simulator."""
     found = running_stack_from_another_checkout()
-    if found is None:
+    if found is None or not ports & _container_published_ports(found[0]):
+        return None
+    return found
+
+
+def refuse_if_ports_taken() -> None:
+    """Refuse before anything claims a host port this stack needs.
+
+    Checked ahead of the world server, not just ahead of compose: a second
+    checkout sharing the port block would otherwise have its
+    _stop_stale_world_server SIGTERM the first one's physics before Docker ever
+    complained about 443.
+    """
+    ours = _container_published_ports(OS_CONTAINER_NAME)
+    if _own_world_server_alive():
+        ours |= {WORLD_SERVER_PORT, WORLD_STATE_PORT}
+    taken = [
+        (label, port)
+        for label, port, udp in _PUBLISHED_HOST_PORTS
+        if port not in ours and not _host_port_free(port, udp=udp)
+    ]
+    if not taken:
         return
-    container, checkout = found
+    listing = "\n".join(f"  {port:<5} {label}" for label, port in taken)
+    suggestion = _suggest_port_base()
+    move = (
+        f"move this checkout to a block that is free:\n  {PORT_BASE_ENV}={suggestion} {CLI_SIM} up"
+        if suggestion is not None
+        else f"set {PORT_BASE_ENV} to the start of seven free ports"
+    )
+    other = _other_checkout_holding({port for _, port in taken})
+    if other is None:
+        raise StackError(
+            f"These host ports are already in use:\n{listing}\n\n"
+            f"Stop whatever owns them (lsof -nP -iTCP:{taken[0][1]}), or {move}"
+        )
+    container, checkout = other
     where = f"  cd {checkout} && {CLI_SIM} down" if checkout else f"  docker stop {container}"
     raise StackError(
-        f"Another checkout's simulator is already running ({container}).\n"
-        "Each checkout keeps its own container and workspace build, but they share this machine's "
-        "ports (9090 and 9999 are not overridable), so only one can be up at a time.\n"
-        f"Stop that one first:\n{where}"
+        f"These host ports are already in use:\n{listing}\n\n"
+        f"Another checkout's simulator holds them ({container}). Stop it:\n{where}\n\n"
+        f"Or {move}"
     )
 
 
@@ -1379,7 +1514,7 @@ def _rosbridge_live(os_status: dict[str, bool]) -> bool:
     if not process_live:
         _rosbridge_ws_confirmed = False
     elif not _rosbridge_ws_confirmed:
-        _rosbridge_ws_confirmed = websocket_port_open(9090)
+        _rosbridge_ws_confirmed = websocket_port_open(SIM_ROSBRIDGE_PORT)
     return process_live and _rosbridge_ws_confirmed
 
 
@@ -1444,7 +1579,7 @@ def os_runtime_ready(config: dict[str, object]) -> bool:
         os_status["os_session_running"]
         and os_status["rosbridge_process_live"]
         and os_status["brain_process_live"]
-        and websocket_port_open(9090)
+        and websocket_port_open(SIM_ROSBRIDGE_PORT)
     )
 
 
@@ -1539,7 +1674,7 @@ def print_startup_checks(
         (
             bool(probe["rosbridge_live"]),
             "bridge",
-            "ws://localhost:9090 live" if probe["rosbridge_live"] else "not accepting connections",
+            f"ws://localhost:{SIM_ROSBRIDGE_PORT} live" if probe["rosbridge_live"] else "not accepting connections",
         ),
         (
             os_status["brain_process_live"],
@@ -2408,7 +2543,22 @@ def _start_world_server(uv: str, sim_repo: Path, *, bind: str, mujoco_gl: str | 
         env["MUJOCO_GL"] = mujoco_gl
     with WORLD_SERVER_LOG_PATH.open("a", encoding="utf-8") as log_file:
         proc = subprocess.Popen(
-            [uv, "run", "--project", str(sim_repo), "python", "-c", bootstrap, "--bind", bind] + _render_scale_args(),
+            [
+                uv,
+                "run",
+                "--project",
+                str(sim_repo),
+                "python",
+                "-c",
+                bootstrap,
+                "--bind",
+                bind,
+                "--port",
+                str(WORLD_SERVER_PORT),
+                "--state-port",
+                str(WORLD_STATE_PORT),
+            ]
+            + _render_scale_args(),
             cwd=sim_repo.parent,
             env=env,
             stdin=subprocess.DEVNULL,

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -815,13 +815,16 @@ def world_endpoint() -> str:
     return f"host.docker.internal:{WORLD_SERVER_PORT}"
 
 
-# Container ports never move; only the host side they are published on does.
-_CONTAINER_PORT_PUBLISH = (
-    ("443/tcp", SIM_HTTPS_PORT),
-    ("80/tcp", SIM_HTTP_PORT),
-    ("9090/tcp", SIM_ROSBRIDGE_PORT),
-    ("9999/udp", SIM_UDP_PORT),
-    ("8765/tcp", SIM_FOXGLOVE_PORT),
+# Label, host port, and the container port published there -- None for the world
+# server, which runs outside Docker. Container ports never move; the host side does.
+_STACK_PORTS = (
+    ("webapp (https)", SIM_HTTPS_PORT, "443/tcp"),
+    ("webapp (http)", SIM_HTTP_PORT, "80/tcp"),
+    ("rosbridge", SIM_ROSBRIDGE_PORT, "9090/tcp"),
+    ("leader receiver", SIM_UDP_PORT, "9999/udp"),
+    ("foxglove bridge", SIM_FOXGLOVE_PORT, "8765/tcp"),
+    ("world server", WORLD_SERVER_PORT, None),
+    ("world state stream", WORLD_STATE_PORT, None),
 )
 
 
@@ -888,7 +891,7 @@ def os_container_current() -> bool:
     published = _container_port_map(OS_CONTAINER_NAME)
     if published is None:
         return True
-    if not all(host in published.get(spec, set()) for spec, host in _CONTAINER_PORT_PUBLISH):
+    if not all(host in published.get(spec, set()) for _, host, spec in _STACK_PORTS if spec):
         return False
     env = _container_env(OS_CONTAINER_NAME)
     if env is None:
@@ -1217,17 +1220,6 @@ def running_stack_from_another_checkout() -> tuple[str, str] | None:
     return None
 
 
-_PUBLISHED_HOST_PORTS = (
-    ("webapp (https)", SIM_HTTPS_PORT, False),
-    ("webapp (http)", SIM_HTTP_PORT, False),
-    ("rosbridge", SIM_ROSBRIDGE_PORT, False),
-    ("leader receiver", SIM_UDP_PORT, True),
-    ("foxglove bridge", SIM_FOXGLOVE_PORT, False),
-    ("world server", WORLD_SERVER_PORT, False),
-    ("world state stream", WORLD_STATE_PORT, False),
-)
-
-
 def _bind_refusal(port: int, *, udp: bool) -> int | None:
     """errno from claiming the port the way Docker will (0.0.0.0, no
     SO_REUSEADDR), or None when the bind succeeds."""
@@ -1284,7 +1276,10 @@ def _suggest_port_base() -> int | None:
     """A base whose whole block is free, so the remedy cannot echo back the base
     that just failed."""
     for base in range(8600, 9600, 10):
-        if all(_host_port_free(base + offset, udp=udp) for offset, (_, _, udp) in enumerate(_PUBLISHED_HOST_PORTS)):
+        if all(
+            _host_port_free(base + offset, udp=(spec or "").endswith("/udp"))
+            for offset, (_, _, spec) in enumerate(_STACK_PORTS)
+        ):
             return base
     return None
 
@@ -1306,8 +1301,8 @@ def refuse_if_ports_taken() -> None:
     ours = _container_published_ports(OS_CONTAINER_NAME) | _own_world_server_ports()
     taken = [
         (label, port)
-        for label, port, udp in _PUBLISHED_HOST_PORTS
-        if port not in ours and not _host_port_free(port, udp=udp)
+        for label, port, spec in _STACK_PORTS
+        if port not in ours and not _host_port_free(port, udp=(spec or "").endswith("/udp"))
     ]
     if not taken:
         return
@@ -1320,17 +1315,12 @@ def refuse_if_ports_taken() -> None:
     )
     other = _other_checkout_holding({port for _, port in taken})
     if other is None:
-        raise StackError(
-            f"These host ports are already in use:\n{listing}\n\n"
-            f"Stop whatever owns them (lsof -nP -iTCP:{taken[0][1]}), or {move}"
-        )
-    container, checkout = other
-    where = f"  cd {checkout} && {CLI_SIM} down" if checkout else f"  docker stop {container}"
-    raise StackError(
-        f"These host ports are already in use:\n{listing}\n\n"
-        f"Another checkout's simulator holds them ({container}). Stop it:\n{where}\n\n"
-        f"Or {move}"
-    )
+        culprit = f"Stop whatever owns them (lsof -nP -iTCP:{taken[0][1]}), or "
+    else:
+        container, checkout = other
+        stop = f"  cd {checkout} && {CLI_SIM} down" if checkout else f"  docker stop {container}"
+        culprit = f"Another checkout's simulator holds them ({container}). Stop it:\n{stop}\n\nOr "
+    raise StackError(f"These host ports are already in use:\n{listing}\n\n{culprit}{move}")
 
 
 def remove_legacy_shared_container() -> None:

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -129,17 +129,18 @@ export class SimSession {
   #challengeJson = "";
   #challengeListeners = new Set<(view: ChallengeView) => void>();
 
-  constructor(opts: { stateUrl?: string; rosUrl?: string } = {}) {
+  constructor(opts: { stateUrl?: string; statePort?: number; rosUrl?: string } = {}) {
     const scheme = location.protocol === "https:" ? "wss" : "ws";
     const proxied = `${scheme}://${location.host}/worldstate`;
     // Local browsers connect straight to the world server (loopback is
     // mixed-content-exempt in Chrome/Firefox, and skips the container
     // relay's latency tail); Safari and remote browsers fall back to the
-    // proxied route.
+    // proxied route. statePort arrives from /config.json -- the world
+    // server's host port moves with INNATE_SIM_PORT_BASE.
     this.#stateUrls = opts.stateUrl
       ? [opts.stateUrl]
       : ["localhost", "127.0.0.1"].includes(location.hostname)
-        ? ["ws://127.0.0.1:8800", proxied]
+        ? [`ws://127.0.0.1:${opts.statePort ?? 8800}`, proxied]
         : [proxied];
     this.#rosUrl = opts.rosUrl ?? `${scheme}://${location.host}/ws`;
   }
@@ -511,7 +512,9 @@ export class SimSession {
   }
 }
 
-export function createSimSession(opts: { stateUrl?: string; rosUrl?: string } = {}): SimSession {
+export function createSimSession(
+  opts: { stateUrl?: string; statePort?: number; rosUrl?: string } = {},
+): SimSession {
   return new SimSession(opts);
 }
 

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -135,8 +135,8 @@ export class SimSession {
     // Local browsers connect straight to the world server (loopback is
     // mixed-content-exempt in Chrome/Firefox, and skips the container
     // relay's latency tail); Safari and remote browsers fall back to the
-    // proxied route. statePort arrives from /config.json -- the world
-    // server's host port moves with INNATE_SIM_PORT_BASE.
+    // proxied route. statePort arrives from /config.json: only the server
+    // knows which port the world server was published on.
     this.#stateUrls = opts.stateUrl
       ? [opts.stateUrl]
       : ["localhost", "127.0.0.1"].includes(location.hostname)

--- a/webapp/js/robotSession.js
+++ b/webapp/js/robotSession.js
@@ -35,7 +35,7 @@ export async function robotSessionFactory() {
       // @ts-ignore
       const mod = await import("/sim-viewer/sim-session.js");
       return {
-        createSession: () => /** @type {any} */ (mod.createSimSession()),
+        createSession: () => /** @type {any} */ (mod.createSimSession({ statePort: config.worldStatePort })),
         releaseSession: (session) => session.destroy(),
         createStage: (root, session) => mod.createSimStage(root, /** @type {any} */ (session)),
       };

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -81,9 +81,11 @@ CERT_DIR = Path.home() / ".innate-webapp-tls"
 ROSBRIDGE_URL = "ws://127.0.0.1:9090"
 
 # /worldstate -> the sim world server's observer stream: host of
-# VIRTUAL_MARS_REMOTE (else in-container), always port 8800 (its default).
+# VIRTUAL_MARS_REMOTE (else in-container), on the port the launcher published
+# it on (INNATE_SIM_PORT_BASE moves it; 8800 is the world server's default).
 _WORLD_HOST = os.environ.get("VIRTUAL_MARS_REMOTE", "").strip().partition(":")[0] or "127.0.0.1"
-WORLD_STATE_URL = f"ws://{_WORLD_HOST}:8800"
+WORLD_STATE_PORT = int(os.environ.get("INNATE_WORLD_STATE_PORT", "").strip() or "8800")
+WORLD_STATE_URL = f"ws://{_WORLD_HOST}:{WORLD_STATE_PORT}"
 
 # Ping both legs of every relay so a peer that vanishes without a FIN (a robot's
 # WiFi dropping mid-teleop) is reaped in ~heartbeat seconds instead of lingering
@@ -360,6 +362,9 @@ async def config_handler(request: web.Request) -> web.Response:
         cfg = {}
     if WEBAPP_SIM_CONTROLS:
         cfg["simControls"] = True
+        # The 3D view prefers a direct loopback socket to the world server over
+        # this proxy's relay, and only the server knows which port that is.
+        cfg["worldStatePort"] = WORLD_STATE_PORT
     return web.json_response(cfg, headers={"Cache-Control": "no-cache"})
 
 

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -81,8 +81,7 @@ CERT_DIR = Path.home() / ".innate-webapp-tls"
 ROSBRIDGE_URL = "ws://127.0.0.1:9090"
 
 # /worldstate -> the sim world server's observer stream: host of
-# VIRTUAL_MARS_REMOTE (else in-container), on the port the launcher published
-# it on (INNATE_SIM_PORT_BASE moves it; 8800 is the world server's default).
+# VIRTUAL_MARS_REMOTE (else in-container), on the port the launcher published.
 _WORLD_HOST = os.environ.get("VIRTUAL_MARS_REMOTE", "").strip().partition(":")[0] or "127.0.0.1"
 WORLD_STATE_PORT = int(os.environ.get("INNATE_WORLD_STATE_PORT", "").strip() or "8800")
 WORLD_STATE_URL = f"ws://{_WORLD_HOST}:{WORLD_STATE_PORT}"
@@ -362,8 +361,7 @@ async def config_handler(request: web.Request) -> web.Response:
         cfg = {}
     if WEBAPP_SIM_CONTROLS:
         cfg["simControls"] = True
-        # The 3D view prefers a direct loopback socket to the world server over
-        # this proxy's relay, and only the server knows which port that is.
+        # The 3D view prefers a direct loopback socket over this relay.
         cfg["worldStatePort"] = WORLD_STATE_PORT
     return web.json_response(cfg, headers={"Cache-Control": "no-cache"})
 


### PR DESCRIPTION
## Why

Sim stacks are already per-checkout — container, compose project and workspace build are all keyed to the checkout's path — but the ports they publish belong to the machine. `up` refused outright whenever another clone's container was running:

> Each checkout keeps its own container and workspace build, but they share this machine's ports (9090 and 9999 are not overridable), so only one can be up at a time.

With several clones in play, stopping one to start another is real friction.

## What

`INNATE_SIM_PORT_BASE=B` assigns a contiguous block of seven host ports. Each still takes its own override, which wins over the base. **Unset, every port is exactly what it was**, so a single-checkout setup is untouched.

| Offset | Service | Override | Default |
|---|---|---|---|
| +0 | webapp (https) | `SIM_HTTPS_PORT` | 443 |
| +1 | webapp (http) | `SIM_HTTP_PORT` | 80 |
| +2 | rosbridge | `SIM_ROSBRIDGE_PORT` | 9090 |
| +3 | leader receiver (UDP) | `SIM_UDP_PORT` | 9999 |
| +4 | Foxglove bridge | `SIM_FOXGLOVE_PORT` | 8765 |
| +5 | world server RPC | `SIM_WORLD_PORT` | 8799 |
| +6 | world state stream | `SIM_WORLD_STATE_PORT` | 8800 |

The launcher resolves all seven and injects them into compose's environment, so the compose file never has to know the base exists.

The host world server was the tangled part: its two ports were a launcher constant plus an argparse default the launcher never passed, and 8800 was additionally hardcoded in the webapp proxy *and* in the browser-side viewer. The proxy now reads `INNATE_WORLD_STATE_PORT`; the viewer learns it from `/config.json`.

## The guard

`refuse_if_another_checkout_is_running` became `refuse_if_ports_taken`, and moved ahead of the world server in `cmd_up`. Two checkouts sharing a block would otherwise have the second one's `_stop_stale_world_server` SIGTERM the first one's physics before Docker ever complained about 443. It also fails in about a second, before the asset downloads.

Three things worth a reviewer's eye:

- **Only `EADDRINUSE` counts as a collision.** A bare bind test reads every *free* 443 as taken on Linux, where a non-root binder is refused ports below 1024 while the Docker daemon that publishes them runs as root. `EACCES` falls back to asking whether anything actually answers.
- **The other checkout is named only when it publishes a conflicting port.** The first version blamed a running sim for port 8501, which was an unrelated editor process.
- **The remedy names a block that is actually free**, found by scanning, rather than echoing back a base that just failed.

`ROSBRIDGE_URI` in the generated container env stays `ws://localhost:9090` on purpose — that is rosbridge's port *inside* the container, which the published block never moves.

## Testing

Verified on macOS with two stacks up at once — one checkout on the default ports, one on `INNATE_SIM_PORT_BASE=8600`:

- defaults unchanged (dashboard URLs, webapp, 3D view, rosbridge)
- second stack fully functional on the moved block; 3D view confirmed connecting to `ws://127.0.0.1:8606` rather than 8800
- Foxglove reachable on the moved port, and `innate foxglove status` reports it
- guard refuses correctly for a base that collides, for the default block held by another checkout, and passes on a free block
- `docker compose config` renders both moved and default blocks correctly
- ruff clean; `tests/` 67 passed

## Not in scope

This is the "N worlds on one machine" axis only. Hosting **one** world that multiple innate-os instances connect to is a separate and much larger piece of work — `VirtualMars` is single-robot throughout (one base, one joint dict, global `main`/`wrist` cameras, a global three-entry render-product cache, a world-wide `reset`), and serving it off-box additionally needs auth, TLS, and a latency story for the blocking 30 Hz state RPC.