### PR TITLE
feat: drop_in_box — pick something up, put it in a box

### DIFF
--- a/ros2_ws/src/brain/brain_client/innate/geometry.py
+++ b/ros2_ws/src/brain/brain_client/innate/geometry.py
@@ -10,10 +10,12 @@ import math
 HEAD_ORIGIN = (-0.040751, -0.0002, 0.25882)  # base_link -> head joint (URDF)
 CAM_IN_HEAD = (0.04327, 0.0297, -0.000275)  # head -> left camera optical
 IMG_W, IMG_H = 640, 480
-HFOV_DEG = 70.0
 
-FX = IMG_W / (2.0 * math.tan(math.radians(HFOV_DEG) / 2.0))
-CX, CY = IMG_W / 2.0, IMG_H / 2.0
+# Left-eye factory intrinsics (1280x720, fx~=fy~=400.8) through the driver's
+# NON-UNIFORM resize to 640x480, so FX != FY. Tape-measured 2026-08-28: the old
+# 70 deg model read 0.156 m as 0.33. Tune FY first — it dominates range.
+FX, FY = 200.3, 267.3
+CX, CY = 319.1, 248.7
 
 
 def _head_rot(tilt_rad):
@@ -36,7 +38,7 @@ def _cam_pose(head_tilt_deg):
 def pixel_to_floor(u, v, head_tilt_deg):
     """Pixel (u,v) -> floor (x,y) in base_link, or None."""
     cam, fwd, right, down = _cam_pose(head_tilt_deg)
-    xo, yo = (u - CX) / FX, (v - CY) / FX
+    xo, yo = (u - CX) / FX, (v - CY) / FY
     d = tuple(fwd[i] + xo * right[i] + yo * down[i] for i in range(3))
     if d[2] >= -1e-6:
         return None
@@ -54,4 +56,17 @@ def floor_to_pixel(x, y, head_tilt_deg):
         return None
     b = sum(D[i] * right[i] for i in range(3))
     c = sum(D[i] * down[i] for i in range(3))
-    return (CX + (b / a) * FX, CY + (c / a) * FX)
+    return (CX + (b / a) * FX, CY + (c / a) * FY)
+
+
+def pixel_to_height(u, v, head_tilt_deg, x):
+    """Height (base_link z) where pixel (u,v)'s ray crosses the vertical line
+    at forward distance ``x``, or None. Reads the rim height of a box whose
+    floor-contact edge has already been localized to ``x``."""
+    cam, fwd, right, down = _cam_pose(head_tilt_deg)
+    xo, yo = (u - CX) / FX, (v - CY) / FY
+    d = tuple(fwd[i] + xo * right[i] + yo * down[i] for i in range(3))
+    if abs(d[0]) < 1e-6:
+        return None
+    t = (x - cam[0]) / d[0]
+    return cam[2] + t * d[2] if t > 0 else None

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/constants.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/constants.py
@@ -5,16 +5,23 @@ side (core.py / world_server.py). Kept MuJoCo-free on purpose: the adapter
 runs in the OS container, which does not ship MuJoCo -- the world itself
 always runs on the host (see world_server.py)."""
 
+import math
+
+# Wire resolution: what every consumer sees.
 CAMERA_WIDTH, CAMERA_HEIGHT = 640, 480
-# Vertical FOV matching the REAL head camera's focal length, best-estimated
-# at fx ~= 355 @640x480 (back-solved from pick_any_object's hardware tuning
-# note "0.37 grasps at ~0.32"; consistent with stereo_depth_estimator.yaml's
-# blind-range comment). The previous 80 degrees was the viewer's display
-# FOV, not the camera -- through it the skill's range model over-read 1.6x
-# instead of the 1.3x its tuning cancels. Replace with camera_info's K[4]
-# when read off a calibrated robot; sim/viewer's ROBOT_CAMERA_VFOV tracks
-# this.
-CAMERA_FOVY = 68.5  # 2*atan(240/355), in degrees
+
+# The REAL head camera (calibrated 2026-08-28): a ~116 deg lens resized
+# non-uniformly to 640x480, hence fx != fy and an off-centre principal point.
+# innate.geometry models exactly these; rendering any other lens miscalibrates
+# every skill.
+CAMERA_FX, CAMERA_FY = 200.3, 267.3
+CAMERA_CX, CAMERA_CY = 319.1, 248.7
+# MuJoCo's principal_pixel is the SENSOR shift: negated on both axes against
+# an image-space (cx, cy). Determined by rendering, not assumed.
+CAMERA_PRINCIPAL_PIXEL = (CAMERA_WIDTH / 2 - CAMERA_CX, CAMERA_HEIGHT / 2 - CAMERA_CY)
+# Kept for the viewer's preview camera, which has square pixels and so can
+# only match one axis; the vertical is the honest one.
+CAMERA_FOVY = math.degrees(2 * math.atan(CAMERA_HEIGHT / (2 * CAMERA_FY)))  # ~83.9
 
 # The wrist camera is a different, uncalibrated lens; the skill's wrist-servo
 # constants are tuned on it and converge in sim at 80, so it keeps 80 until

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -21,7 +21,14 @@ import numpy as np
 from PIL import Image
 
 from . import world
-from .constants import CAMERA_FOVY, CAMERA_HEIGHT, CAMERA_WIDTH, WRIST_CAMERA_FOVY
+from .constants import (
+    CAMERA_FX,
+    CAMERA_FY,
+    CAMERA_HEIGHT,
+    CAMERA_PRINCIPAL_PIXEL,
+    CAMERA_WIDTH,
+    WRIST_CAMERA_FOVY,
+)
 from .drive_limits import clamp_cmd_vel
 from .props import PropRegistry
 from .world import ARM_HOME, SPAWN_X, SPAWN_Y, SPAWN_YAW_DEG
@@ -252,9 +259,16 @@ class VirtualMars:
             for cam_name, (body_name, forward, up) in CAMERAS.items():
                 cam = world_spec.body(body_name).add_camera()
                 cam.name = cam_name
-                # Per-camera FOV: the head and wrist cameras are different
-                # physical lenses (see constants.py).
-                cam.fovy = WRIST_CAMERA_FOVY if cam_name == "wrist" else CAMERA_FOVY
+                # The head renders the measured lens (anisotropic focal,
+                # off-centre principal point — no fovy can express it). The
+                # wrist keeps a fovy: its servo constants are tuned against one.
+                if cam_name == "wrist":
+                    cam.fovy = WRIST_CAMERA_FOVY
+                else:
+                    cam.resolution = [CAMERA_WIDTH, CAMERA_HEIGHT]
+                    cam.focal_pixel = [CAMERA_FX, CAMERA_FY]
+                    cam.principal_pixel = list(CAMERA_PRINCIPAL_PIXEL)
+                    cam.sensor_size = [0.0064, 0.0048]  # any size; the pixel forms override it
                 cam.quat = _camera_quat(forward, up)
 
             self.model = world_spec.compile()
@@ -339,9 +353,17 @@ class VirtualMars:
         self._cmd_sim_time = self.data.time
 
     def set_joint_target(self, name: str, value: float) -> None:
-        if name in self._joints:
-            qadr, dadr, _home = self._joints[name]
-            self._joints[name] = (qadr, dadr, value)
+        if name not in self._joints:
+            return
+        qadr, dadr, _home = self._joints[name]
+        # The gripper close is commanded 0.6 rad past the mechanical stop
+        # (hardware squeezes at its current limit there). Clamped, the error
+        # still saturates the torque ceiling; the blades stop at the stop.
+        jid = self.model.joint(f"robot_{name}").id
+        if self.model.jnt_limited[jid]:
+            lo, hi = self.model.jnt_range[jid]
+            value = max(lo, min(hi, value))
+        self._joints[name] = (qadr, dadr, value)
 
     def joint_targets(self) -> dict[str, float]:
         return {name: target for name, (_q, _d, target) in self._joints.items()}

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
@@ -54,7 +54,7 @@ from std_msgs.msg import Empty, Float64MultiArray, Int32, Int64, String
 from std_srvs.srv import Trigger
 from tf2_ros import TransformBroadcaster
 
-from .constants import CAMERA_FOVY, CAMERA_HEIGHT, CAMERA_WIDTH
+from .constants import CAMERA_CX, CAMERA_CY, CAMERA_FX, CAMERA_FY, CAMERA_HEIGHT, CAMERA_WIDTH
 from .remote_world import RemoteWorld
 
 try:
@@ -86,10 +86,10 @@ DEPTH_MAX_M = 2.0
 
 ARM_JOINTS = ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"]
 
-# Pinhole intrinsics implied by the render (square pixels, principal point
-# centered): fy from the vertical FOV, fx = fy.
-FOCAL = CAMERA_HEIGHT / (2 * math.tan(math.radians(CAMERA_FOVY) / 2))
-CX, CY = CAMERA_WIDTH / 2, CAMERA_HEIGHT / 2
+# The real camera's intrinsics, which the render reproduces: not square
+# pixels, not a centred principal point, and camera_info must say so.
+FX, FY = CAMERA_FX, CAMERA_FY
+CX, CY = CAMERA_CX, CAMERA_CY
 
 WORLD_DEFAULT_ENDPOINT = "127.0.0.1:8799"
 
@@ -564,10 +564,11 @@ class VirtualMarsNode(Node):
         if want_points:
             step = max(1, POINTS_SUBSAMPLE // img_scale)
             vs, us = _points_grid(depth.shape[0], depth.shape[1], step)
-            f, cx, cy = FOCAL / img_scale, CX / img_scale, CY / img_scale
+            fx, fy = FX / img_scale, FY / img_scale
+            cx, cy = CX / img_scale, CY / img_scale
             z = np.where(invalid, np.nan, depth)[::step, ::step].astype(np.float32)
-            x = (us - cx) / f * z
-            y = (vs - cy) / f * z
+            x = (us - cx) / fx * z
+            y = (vs - cy) / fy * z
             cloud = np.stack([x, y, z], axis=-1)
 
             msg = PointCloud2()
@@ -591,9 +592,9 @@ class VirtualMarsNode(Node):
         msg.width, msg.height = CAMERA_WIDTH, CAMERA_HEIGHT
         msg.distortion_model = "plumb_bob"
         msg.d = [0.0] * 5
-        msg.k = [FOCAL, 0.0, CX, 0.0, FOCAL, CY, 0.0, 0.0, 1.0]
+        msg.k = [FX, 0.0, CX, 0.0, FY, CY, 0.0, 0.0, 1.0]
         msg.r = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
-        msg.p = [FOCAL, 0.0, CX, 0.0, 0.0, FOCAL, CY, 0.0, 0.0, 0.0, 1.0, 0.0]
+        msg.p = [FX, 0.0, CX, 0.0, 0.0, FY, CY, 0.0, 0.0, 0.0, 1.0, 0.0]
         self._caminfo_pub.publish(msg)
 
     def _publish_joint_states(self) -> None:

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/props.py
@@ -57,10 +57,14 @@ class Prop:
     mesh_scale: float = 1.0  # 0.01 for a centimetre-unit scan
     texture: str | None = None  # defaults to "<mesh stem>_basecolor.png"
     # How the prop collides: a primitive ("box"/"sphere"/"cylinder", sized by
-    # `size`), "hull" (the visual mesh's own convex hull), or "pieces" (the
-    # convex decomposition sitting next to the mesh as <stem>_collision_*.obj).
+    # `size`), "open_box" (a floor and four walls of thickness `wall` inside
+    # the `size` half-extents, hollow above -- the one shape a mesh cannot
+    # give, since MuJoCo hulls every mesh collider solid), "hull" (the visual
+    # mesh's own convex hull), or "pieces" (the convex decomposition sitting
+    # next to the mesh as <stem>_collision_*.obj).
     collision: str = "box"
     size: tuple[float, ...] = (0.02, 0.02, 0.02)
+    wall: float = 0.012
 
     # -- contact model --
     density: float = 700.0
@@ -105,6 +109,8 @@ class Prop:
             self.title = self.name.replace("_", " ").capitalize()
         if self.drop_z is None:
             self.drop_z = self.rest_z
+        if self.collision == "open_box" and len(self.size) != 3:
+            raise ValueError(f"{self.name}: an open_box needs three half-extents, got {self.size}")
 
     # -- resolved asset paths --
 
@@ -148,10 +154,29 @@ class Prop:
 
     def _primitive_geom(self, name: str, group: int, physical: bool) -> str:
         shape = self.collision
+        if shape == "open_box":
+            return self._open_box_geoms(name, group, physical)
         if shape not in ("box", "sphere", "cylinder"):
             shape = self._PRIMITIVE_FOR_SIZE.get(len(self.size), "box")
         size = " ".join(f"{s:g}" for s in self.size)
         return self._geom(name, f'type="{shape}" size="{size}"', group, physical)
+
+    def _open_box_geoms(self, name: str, group: int, physical: bool) -> str:
+        hx, hy, hz = self.size
+        w = min(self.wall, hx, hy, hz)
+        slabs = {
+            "floor": ((hx, hy, w / 2), (0, 0, -hz + w / 2)),
+            "xneg": ((w / 2, hy, hz), (-hx + w / 2, 0, 0)),
+            "xpos": ((w / 2, hy, hz), (hx - w / 2, 0, 0)),
+            "yneg": ((hx - w, w / 2, hz), (0, -hy + w / 2, 0)),
+            "ypos": ((hx - w, w / 2, hz), (0, hy - w / 2, 0)),
+        }
+        out = ""
+        for part, (half, pos) in slabs.items():
+            size = " ".join(f"{s:g}" for s in half)
+            at = " ".join(f"{c:g}" for c in pos)
+            out += self._geom(f"{name}_{part}", f'type="box" size="{size}" pos="{at}"', group, physical)
+        return out
 
     def _geom(self, name: str, shape: str, group: int, physical: bool) -> str:
         """One geom. `physical` false makes it a pure visual surface: no
@@ -199,10 +224,17 @@ class Prop:
             # visible and collidable, all from one geom.
             geoms = self._primitive_geom(f"{self.name}_geom", visual_group, physical=True)
         else:
-            material = f' material="mat_{self.name}"' if self.texture_path is not None else self._fill(visual_group)
+            # _fill already carries group=; a textured prop swaps rgba for a
+            # material and has to bring its own, or an untextured mesh emits
+            # group= twice and MuJoCo rejects the whole model.
+            material = (
+                f' material="mat_{self.name}" group="{visual_group}"'
+                if self.texture_path is not None
+                else self._fill(visual_group)
+            )
             geoms = (
                 f'\n      <geom name="{self.name}_visual" mesh="{self.name}" type="mesh"{material}'
-                f' contype="0" conaffinity="0" density="0" group="{visual_group}"/>'
+                f' contype="0" conaffinity="0" density="0"/>'
             )
             pieces = self.collision_pieces
             if pieces:
@@ -236,6 +268,7 @@ class Prop:
             "group": self.group,
             "collision": self.collision,
             "size": list(self.size),
+            "wall": self.wall,
             "rgba": list(self.rgba),
             "viewer": self.viewer,
         }

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -43,6 +43,7 @@ MAX_BASE_ANGULAR_SPEED = 6.0
 
 DRIVEN_JOINTS = ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6", "joint_head"]
 MIMIC_JOINT = ("joint6M", "joint6", -1.0)  # (name, source, multiplier)
+GRIPPER_CLOSED_ON_AIR_RAD = -0.085  # hardware encoder, jaws shut on nothing
 
 # --- contact tuning (see tune_contacts) ----------------------------------
 #
@@ -356,6 +357,14 @@ def tune_contacts(robot_spec: mujoco.MjSpec) -> None:
             geom.solimp = FINGER_SOLIMP
 
     robot_spec.add_exclude(bodyname1=FINGER_LINKS[0], bodyname2=FINGER_LINKS[1])
+
+    # The real claw's hard stop sits past nominal zero: closed on air the
+    # encoder reads GRIPPER_CLOSED_ON_AIR_RAD (pick's GRIPPER_EMPTY_J6).
+    # Unclamped, the -0.6 close target scissors the blades through each other.
+    j6 = robot_spec.joint(MIMIC_JOINT[1])
+    j6m = robot_spec.joint(MIMIC_JOINT[0])
+    j6.range = [GRIPPER_CLOSED_ON_AIR_RAD, j6.range[1]]
+    j6m.range = [j6m.range[0], -GRIPPER_CLOSED_ON_AIR_RAD]
 
     mimic_name, source_name, _mult = MIMIC_JOINT
     for name in (source_name, mimic_name):

--- a/sim/challenges/40_tidy_up.py
+++ b/sim/challenges/40_tidy_up.py
@@ -1,0 +1,30 @@
+"""Tidy up: pick the ball off the floor and drop it into the crate."""
+
+from mars_sim_driver.challenges import Challenge, Drop, Goal, Hold, Near, SkillDone
+
+# The containment goal is xy-only (WorldState.centers carries no z), so the
+# radius carries it: 0.13 sits inside the crate's 0.158 half-width less the
+# ball's 0.0225, and no spot beside the crate is that close to its centre.
+CHALLENGE = Challenge(
+    id="tidy_up",
+    title="Tidy up",
+    # Props are named by APPEARANCE: the words here reach pick_any_object's
+    # vision prompt, and a prop name the render does not match finds nothing.
+    brief=(
+        "A small green ball is on the floor right in front of you, with an open "
+        "cardboard box a little beyond it. Pick up the ball and drop it into the box."
+    ),
+    # Both dead ahead of the spawn (-4.34, -0.17, facing -y): ball 0.65 m out,
+    # crate 0.53 m beyond, so the run starts on manipulation, not a search.
+    # Measured spots — props dropped here settle upright in the head camera.
+    setup=[
+        Drop("ball", -4.34, -0.82),
+        Drop("crate", -4.34, -1.35),
+    ],
+    goals=[
+        Goal("Pick up the ball", SkillDone("pick_any_object")),
+        Goal("Reach the box", Near("robot", "crate", 0.85)),
+        Goal("Ball in the box", Hold(Near("ball", "crate", 0.13), 2.0)),
+    ],
+    time_limit_s=600,
+)

--- a/sim/props/16_crate.py
+++ b/sim/props/16_crate.py
@@ -1,0 +1,26 @@
+"""Crate: drop_in_box's design target -- an open-top container the arm can
+actually reach over."""
+
+from mars_sim_driver.props import Prop
+
+# Sized from the arm envelope: at z=0.19 (a 0.14 m rim plus release
+# clearance) the gripper reaches 0.394 m, enough to release inside; a 0.25 m
+# rim it cannot.
+PROP = Prop(
+    name="crate",
+    label="📦",
+    group="manipulation",
+    title="Crate",
+    collision="open_box",
+    # Outer half-extents; rest_z is the half-height.
+    size=(0.17, 0.17, 0.07),
+    wall=0.012,
+    # Cardboard: a graze nudges it rather than launching it.
+    density=250,
+    condim=4,
+    friction=(1.0, 0.02, 0.001),
+    rgba=(0.70, 0.55, 0.36, 1.0),
+    rest_z=0.07,
+    # Past the bumper, about where drop_in_box parks -- "lay out the set, run".
+    reach=(0.62, 0.0),
+)

--- a/sim/viewer/src/props.ts
+++ b/sim/viewer/src/props.ts
@@ -18,6 +18,7 @@
 // only decides how long to wait for one.
 
 import * as THREE from "three";
+import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 import { clone as cloneSkeleton } from "three/examples/jsm/utils/SkeletonUtils.js";
 import { PropModels } from "./propModels";
 
@@ -108,6 +109,8 @@ export interface PropInfo {
   group: string | null;
   collision: string;
   size: number[];
+  /** Wall thickness of an "open_box" (props.py `wall`). */
+  wall: number;
   rgba: number[];
   viewer: PropViewerDef;
 }
@@ -125,6 +128,7 @@ interface PlacementPreview {
 function primitiveGeometry(info: PropInfo): THREE.BufferGeometry {
   const s = info.size;
   let shape = info.collision;
+  if (shape === "open_box") return openBoxGeometry(s, info.wall);
   if (shape !== "box" && shape !== "sphere" && shape !== "cylinder") {
     shape = s.length === 1 ? "sphere" : s.length === 2 ? "cylinder" : "box";
   }
@@ -140,6 +144,23 @@ function primitiveGeometry(info: PropInfo): THREE.BufferGeometry {
   }
   // MuJoCo box sizes are half-extents.
   return new THREE.BoxGeometry(s[0] * 2, s[1] * 2, s[2] * 2);
+}
+
+/** Floor plus four walls, hollow above — the same five box geoms props.py
+ * writes for an open_box, so a crate reads as something to drop into rather
+ * than a solid block. */
+function openBoxGeometry(s: number[], wall: number): THREE.BufferGeometry {
+  const [hx, hy, hz] = s;
+  const w = Math.min(wall, hx, hy, hz);
+  const slab = (sx: number, sy: number, sz: number, x: number, y: number, z: number) =>
+    new THREE.BoxGeometry(sx, sy, sz).translate(x, y, z);
+  return mergeGeometries([
+    slab(hx * 2, hy * 2, w, 0, 0, -hz + w / 2),
+    slab(w, hy * 2, hz * 2, -hx + w / 2, 0, 0),
+    slab(w, hy * 2, hz * 2, hx - w / 2, 0, 0),
+    slab((hx - w) * 2, w, hz * 2, 0, -hy + w / 2, 0),
+    slab((hx - w) * 2, w, hz * 2, 0, hy - w / 2, 0),
+  ]);
 }
 
 /**

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -142,8 +142,10 @@ const TOP_FALLBACK_HEIGHT_M = 12;
 export type CameraView = "orbit" | "main" | "arm";
 // Track mars_sim_driver/constants.py: per-camera FOVs matching what the
 // driver renders (the head and wrist are different physical lenses), so the
-// operator's preview frames exactly what the robot consumes.
-const ROBOT_CAMERA_VFOV: Record<"main" | "arm", number> = { main: 68.5, arm: 80 };
+// operator's preview frames what the robot consumes. main is the head's real
+// ~84 deg vertical; its 116 deg horizontal cannot be matched by a square-pixel
+// three.js camera, so the preview runs narrower sideways than the real frame.
+const ROBOT_CAMERA_VFOV: Record<"main" | "arm", number> = { main: 83.9, arm: 80 };
 // Don't shrink to fix the near-clipped gripper: the origin sits inside the
 // wrist housing, so a smaller near renders the housing interior instead.
 const ROBOT_CAMERA_NEAR = 0.03;

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -3,6 +3,7 @@
 from innate_skills.change_volume import ChangeVolume
 from innate_skills.check_battery import CheckBattery
 from innate_skills.close_gripper import CloseGripper
+from innate_skills.drop_in_box import DropInBox
 from innate_skills.head_emotion import HeadEmotion
 from innate_skills.navigate_to_position import NavigateToPosition
 from innate_skills.open_gripper import OpenGripper
@@ -40,6 +41,7 @@ class DemoAgent(Agent):
             HeadEmotion,
             ChangeVolume,
             CheckBattery,
+            DropInBox,
         ]
 
     def get_inputs(self) -> list[InputRef]:

--- a/workspace/innate_skills/approach.py
+++ b/workspace/innate_skills/approach.py
@@ -54,9 +54,12 @@ APPROACH_PARAMS = {
     # calibration (the old model read ranges ~2x long); same pixel target.
     "sweet_x": 0.285,
     "box_y": 0.0,
-    "box_half_px": 40.0,
-    "box_half_v_px": 40.0,
-    "accept_frac": 0.5,
+    # frac 1.0 collapses hold onto accept: pick's ±20 px park is the grasp
+    # capture window, tuned on hardware, and a looser hold band would let a
+    # Gemini re-read certify a park the gripper cannot reach from.
+    "box_half_px": 20.0,
+    "box_half_v_px": 20.0,
+    "accept_frac": 1.0,
     "box_steps": 6.0,
     "bearing_go_deg": 4.0,
     "follow_gain_ang": 0.3,
@@ -204,9 +207,13 @@ class FloorApproach:
     # --- position the base ---
 
     def _sweet_box(self):
-        """(centre, (outer_u, outer_v), (accept_u, accept_v)); stop only inside
-        accept. Two axes, two tolerances: near the park one image row is ~cm of
-        RANGE but sub-mm of bearing, so one box cannot serve both."""
+        """(centre, (hold_u, hold_v), (accept_u, accept_v)). Two boxes because
+        two things measure the park: `accept` is the flow servo's deadband,
+        tight because a tracked pixel is precise; `hold` is what a Gemini
+        re-read must fall inside to count as parked, loose because a detector
+        whose box edge jitters tens of pixels cannot resolve millimetres.
+        Two axes as well: near the park one image row is ~cm of RANGE but
+        sub-mm of bearing, so one tolerance cannot serve both."""
         c = floor_to_pixel(self.p["sweet_x"], self.p["box_y"], self.p["tilt_deg"])
         if c is None or not (0 <= c[0] < IMG_W and 0 <= c[1] < IMG_H):
             raise SkillFailed("approach box off-image — check tilt_deg/sweet_x")
@@ -359,8 +366,8 @@ class FloorApproach:
                     self._position_failed(prompt)
             # Arrival checked BEFORE servoing: a tracker that dies on a
             # parked base must not burn the step budget re-seeding.
-            (cu, cv), _half, accept = self._sweet_box()
-            if xy is not None and inside_box(seed, cu, cv, accept[0], accept[1]):
+            (cu, cv), hold, _accept = self._sweet_box()
+            if xy is not None and inside_box(seed, cu, cv, hold[0], hold[1]):
                 return xy
             rem = _remaining()
             if rem is not None and rem[0] <= stop_x:
@@ -383,10 +390,12 @@ class FloorApproach:
                 seed = None
                 continue
             lost = 0
+            # The flow servo already parked this within `accept`; re-demanding
+            # that of a Gemini box edge only re-servos on detector noise.
             xy2, px2 = self._localize_retry(prompt)
             if px2 is None:
                 self._position_failed(prompt)
-            if xy2 is not None and inside_box(px2, cu, cv, accept[0], accept[1]):
+            if xy2 is not None and inside_box(px2, cu, cv, hold[0], hold[1]):
                 return xy2
             xy, seed = xy2, (px2 if xy2 is not None else None)
         if xy is not None and xy[0] <= self.p["sweet_x"] + PLATEAU_SLACK_M:
@@ -406,8 +415,8 @@ class FloorApproach:
                 xy, px = self._localize_retry(prompt)
                 if px is None:
                     self._position_failed(prompt)
-            (cu, cv), _half, accept = self._sweet_box()
-            if xy is not None and inside_box(px, cu, cv, accept[0], accept[1]):
+            (cu, cv), hold, _accept = self._sweet_box()
+            if xy is not None and inside_box(px, cu, cv, hold[0], hold[1]):
                 return xy
             if xy is None:
                 px = None

--- a/workspace/innate_skills/approach.py
+++ b/workspace/innate_skills/approach.py
@@ -54,12 +54,14 @@ APPROACH_PARAMS = {
     # calibration (the old model read ranges ~2x long); same pixel target.
     "sweet_x": 0.285,
     "box_y": 0.0,
-    # frac 1.0 collapses hold onto accept: pick's ±20 px park is the grasp
-    # capture window, tuned on hardware, and a looser hold band would let a
-    # Gemini re-read certify a park the gripper cannot reach from.
-    "box_half_px": 20.0,
-    "box_half_v_px": 20.0,
-    "accept_frac": 1.0,
+    "box_half_px": 40.0,
+    "box_half_v_px": 40.0,
+    "accept_frac": 0.5,
+    # Equal to accept_frac, so by default the two boxes coincide and a skill
+    # tests one box exactly as it did before `hold` existed. Pick keeps that:
+    # its ±20 px park is the grasp capture window, and a looser hold band
+    # would let a Gemini re-read certify a park the gripper cannot reach from.
+    "hold_frac": 0.5,
     "box_steps": 6.0,
     "bearing_go_deg": 4.0,
     "follow_gain_ang": 0.3,
@@ -218,8 +220,8 @@ class FloorApproach:
         if c is None or not (0 <= c[0] < IMG_W and 0 <= c[1] < IMG_H):
             raise SkillFailed("approach box off-image — check tilt_deg/sweet_x")
         hu, hv = self.p["box_half_px"], self.p["box_half_v_px"]
-        frac = self.p["accept_frac"]
-        return (c[0], c[1]), (hu, hv), (hu * frac, hv * frac)
+        hold, accept = self.p["hold_frac"], self.p["accept_frac"]
+        return (c[0], c[1]), (hu * hold, hv * hold), (hu * accept, hv * accept)
 
     def _follow_into_box(self, seed_px, max_forward=None):
         """Optical-flow base servo into the sweet box. No Gemini.

--- a/workspace/innate_skills/approach.py
+++ b/workspace/innate_skills/approach.py
@@ -324,8 +324,15 @@ class FloorApproach:
             xy2, px2 = self._localize_retry(prompt)
             if px2 is None:
                 self._position_failed(prompt)
-            if xy2 is not None:
-                xy = xy2
+            if xy2 is None:
+                # Keeping the pre-rotation xy would pin target_odo below against
+                # the POST-rotation pose, putting the world target a whole turn
+                # off — and the base would dead-reckon to it.
+                raise SkillFailed(
+                    f"Turned toward '{prompt}', but it no longer back-projects onto the "
+                    "floor ahead — it does not look like something resting on the floor"
+                )
+            xy = xy2
             seed = px2
         else:
             seed = floor_to_pixel(xy[0], xy[1], self.p["tilt_deg"])

--- a/workspace/innate_skills/approach.py
+++ b/workspace/innate_skills/approach.py
@@ -1,0 +1,427 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Find a thing on the floor and drive the base until it sits in a chosen spot.
+A collaborator, not a base class: a skill builds one per run with itself as the
+host, its params (where to park) and a detect callable (which pixel of the
+target touches the floor), so pick and drop share one hardware-tuned approach.
+"""
+
+import math
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol
+
+from innate import gemini as gemlib
+from innate import vision
+from innate.exceptions import SkillFailed
+from innate.geometry import FX, FY, HEAD_ORIGIN, IMG_H, IMG_W, floor_to_pixel, pixel_to_floor
+
+if TYPE_CHECKING:
+    from innate import MainImage, Mobility, Odometry
+    from innate_proxy import ProxyClient
+
+Pixel = tuple[float, float]
+FloorXY = tuple[float, float]
+Detect = Callable[[str], "Pixel | None"]
+OdomXYT = tuple[float, float, float]
+
+
+class _Logger(Protocol):
+    def info(self, msg: str) -> None: ...
+    def warning(self, msg: str) -> None: ...
+
+
+class ApproachHost(Protocol):
+    """What a skill offers to host a FloorApproach: the feeds it declares and
+    the cancel-aware waits only a Skill can provide."""
+
+    mobility: "Mobility"
+    main_image: "MainImage | None"
+    odom: "Odometry | None"
+
+    @property
+    def logger(self) -> _Logger: ...
+    @property
+    def name(self) -> str: ...
+    def sleep(self, seconds: float) -> None: ...
+    def say(self, text: str, wait: bool = False) -> None: ...
+
+
+APPROACH_PARAMS = {
+    "tilt_deg": -20.0,
+    "settle_s": 1.2,
+    # 0.285 = the 0.37 pick was tuned to, renumbered by the 2026-08-28 camera
+    # calibration (the old model read ranges ~2x long); same pixel target.
+    "sweet_x": 0.285,
+    "box_y": 0.0,
+    "box_half_px": 40.0,
+    "box_half_v_px": 40.0,
+    "accept_frac": 0.5,
+    "box_steps": 6.0,
+    "bearing_go_deg": 4.0,
+    "follow_gain_ang": 0.3,
+    "follow_gain_lin": 0.06,
+    "rot_tol_deg": 2.5,
+    "rot_kp": 1.2,
+    "rot_wz_max": 0.5,
+    "rot_wz_min": 0.15,
+    "drive_tol_m": 0.015,
+    "drive_kp": 0.3,
+    "drive_v_max": 0.10,
+    "drive_v_min": 0.04,
+}
+
+FOLLOW_TIMEOUT_S = 20.0
+# How far past the park the dead-reckoned target may come before the drive
+# stops: a target filling the frame reads a stable "2 cm short" even with the
+# bumper against it, so only odometry can bound the endgame.
+TRAVEL_MARGIN_M = 0.08
+# The same wall bias plateaus the final reading ~2 cm outside the accept band;
+# within this slack the run is parked and the reach clamp absorbs it.
+PLATEAU_SLACK_M = 0.05
+# A pixel glued in place through real base motion is on the robot (or a pushed
+# box), not the floor: static = under a third of _min_px_shift's minimum.
+STATIC_MIN_PX = 5.0
+
+
+def _min_px_shift(o0, o1, floor_xy):
+    """Least pixel travel a floor point must show between two odometry poses;
+    0 without odometry. FY*h/x^2 over-reads ~1.6x up close — deliberately: the
+    exact gradient measured 0/6 picks against this formula's 3/6."""
+    if o0 is None or o1 is None:
+        return 0.0
+    dyaw = abs(math.atan2(math.sin(o1[2] - o0[2]), math.cos(o1[2] - o0[2])))
+    dist = math.hypot(o1[0] - o0[0], o1[1] - o0[1])
+    fwd = dist * FY * HEAD_ORIGIN[2] / max(floor_xy[0], 0.15) ** 2 if floor_xy else 0.0
+    return dyaw * FX + fwd
+
+
+def ask_head(host: ApproachHost, proxy: "ProxyClient | None", question: str, settle_s: float):
+    """Settle the base, then put the current head frame to Gemini.
+    -> (reply_text|None, frame|None)."""
+    host.mobility.stop()
+    host.sleep(settle_s)
+    img = host.main_image
+    if not img:
+        return None, None
+    return gemlib.ask_image(proxy, img, question, logger=host.logger), img
+
+
+def base_to_odom(o: "OdomXYT | None", xy: FloorXY) -> "FloorXY | None":
+    """base_link floor point -> odom frame, or None without odometry."""
+    if o is None:
+        return None
+    ox, oy, th = o
+    c, s = math.cos(th), math.sin(th)
+    return (ox + c * xy[0] - s * xy[1], oy + s * xy[0] + c * xy[1])
+
+
+def odom_to_base(o: "OdomXYT | None", wxy: FloorXY) -> "FloorXY | None":
+    """odom-frame floor point -> current base_link, or None without odometry."""
+    if o is None:
+        return None
+    ox, oy, th = o
+    c, s = math.cos(th), math.sin(th)
+    dx, dy = wxy[0] - ox, wxy[1] - oy
+    return (c * dx + s * dy, -s * dx + c * dy)
+
+
+def inside_box(px, cu, cv, half_u, half_v=None):
+    return abs(px[0] - cu) <= half_u and abs(px[1] - cv) <= (half_u if half_v is None else half_v)
+
+
+class FloorApproach:
+    """Head-camera localize + base servo for one run of a hosting skill."""
+
+    def __init__(self, host: ApproachHost, params: dict, detect: Detect):
+        self.host = host
+        self.p = params
+        self.detect = detect
+
+    # --- localize ---
+
+    def _localize_px(self, prompt):
+        """Detect + back-project -> ((x,y)|None, pixel|None)."""
+        px = self.detect(prompt)
+        if px is None:
+            return None, None
+        xy = pixel_to_floor(px[0], px[1], self.p["tilt_deg"])
+        if xy:
+            self.host.logger.info(
+                f"[{self.host.name}] px=({px[0]:.0f},{px[1]:.0f}) -> base_link ({xy[0]:.3f},{xy[1]:.3f})"
+            )
+        return xy, px
+
+    def _localize_retry(self, prompt):
+        """One retry: a single "not visible" is noise, not absence."""
+        xy, px = self._localize_px(prompt)
+        if px is None:
+            xy, px = self._localize_px(prompt)
+        return xy, px
+
+    def search(self, prompt):
+        """Scan: straight, right 30°, left 60°. First hit wins. (+yaw=left)"""
+        for i, turn in enumerate((0.0, -math.radians(30), math.radians(60))):
+            if turn:
+                if i == 1:
+                    self.host.say("Scanning around for it.")
+                # Best-effort: a rotate cut short (timeout / odom loss) still
+                # changed the view, and the localize below measures from
+                # wherever the base actually ended up.
+                self.rotate_by(turn)
+            xy, _px = self._localize_px(prompt)
+            if xy is not None:
+                return xy
+        raise SkillFailed(f"Could not find '{prompt}' on the floor, even after scanning")
+
+    # --- base motion ---
+
+    def odom_xyt(self):
+        return self.host.mobility.odom_xyt(self.host.odom)
+
+    def rotate_by(self, angle):
+        return self.host.mobility.rotate_by(
+            self.odom_xyt,
+            angle,
+            kp=self.p["rot_kp"],
+            wz_max=self.p["rot_wz_max"],
+            wz_min=self.p["rot_wz_min"],
+            tolerance=math.radians(self.p["rot_tol_deg"]),
+            logger=self.host.logger,
+        )
+
+    def drive(self, dist):
+        return self.host.mobility.drive(
+            self.odom_xyt,
+            dist,
+            kp=self.p["drive_kp"],
+            v_max=self.p["drive_v_max"],
+            v_min=self.p["drive_v_min"],
+            tolerance=self.p["drive_tol_m"],
+            logger=self.host.logger,
+        )
+
+    # --- position the base ---
+
+    def _sweet_box(self):
+        """(centre, (outer_u, outer_v), (accept_u, accept_v)); stop only inside
+        accept. Two axes, two tolerances: near the park one image row is ~cm of
+        RANGE but sub-mm of bearing, so one box cannot serve both."""
+        c = floor_to_pixel(self.p["sweet_x"], self.p["box_y"], self.p["tilt_deg"])
+        if c is None or not (0 <= c[0] < IMG_W and 0 <= c[1] < IMG_H):
+            raise SkillFailed("approach box off-image — check tilt_deg/sweet_x")
+        hu, hv = self.p["box_half_px"], self.p["box_half_v_px"]
+        frac = self.p["accept_frac"]
+        return (c[0], c[1]), (hu, hv), (hu * frac, hv * frac)
+
+    def _follow_into_box(self, seed_px, max_forward=None):
+        """Optical-flow base servo into the sweet box. No Gemini.
+        Returns ('in_box'|'lost'|'timeout'|'noframe'|'budget', px|None);
+        'budget' means max_forward metres of odometry were spent."""
+        raw = self.host.main_image
+        prev = vision.b64_to_gray(raw) if raw else None
+        if prev is None:
+            return "noframe", None
+        u, v = seed_px
+        grid = vision.grid_pts(u, v)
+        in_box = 0
+        (cu, cv), _half, accept = self._sweet_box()
+        t0 = time.monotonic()
+        anchor, anchor_odo = (u, v), self.odom_xyt()
+        seg_start = anchor_odo
+        while time.monotonic() - t0 < FOLLOW_TIMEOUT_S:
+            # Only track NEW frames: the camera runs slower than this loop,
+            # and a stale frame re-tracked would count one observation twice.
+            # Compare by identity, not content: the provider builds one Image
+            # per ROS message, and in sim consecutive frames of a static scene
+            # are byte-identical, so `==` would deadlock waiting for a change.
+            img = self.host.main_image
+            if not img or img is raw:
+                self.host.sleep(0.03)
+                continue
+            gray = vision.b64_to_gray(img)
+            raw = img
+            if gray is None:
+                self.host.sleep(0.03)
+                continue
+            tracked = vision.track_point(prev, gray, grid)
+            prev = gray
+            if tracked is None:
+                self.host.mobility.stop()
+                return "lost", None
+            u, v = tracked
+            grid = vision.grid_pts(u, v)
+            if not (0 <= u < IMG_W and 0 <= v < IMG_H):
+                self.host.mobility.stop()
+                return "lost", None
+
+            if inside_box((u, v), cu, cv, accept[0], accept[1]):
+                in_box += 1
+                self.host.mobility.stop()
+                anchor, anchor_odo = (u, v), self.odom_xyt()
+                if in_box >= 3:
+                    return "in_box", (u, v)
+                self.host.sleep(0.03)
+                continue
+            in_box = 0
+
+            floor_est = pixel_to_floor(u, v, self.p["tilt_deg"])
+            if floor_est is None:
+                # Above the horizon: not a floor point any more.
+                self.host.mobility.stop()
+                return "lost", None
+            if math.hypot(u - anchor[0], v - anchor[1]) >= STATIC_MIN_PX:
+                anchor, anchor_odo = (u, v), self.odom_xyt()
+            elif _min_px_shift(anchor_odo, self.odom_xyt(), floor_est) >= 3 * STATIC_MIN_PX:
+                self.host.mobility.stop()
+                return "lost", None
+
+            now_odo = self.odom_xyt()
+            if (
+                max_forward is not None
+                and seg_start is not None
+                and now_odo is not None
+                and math.hypot(now_odo[0] - seg_start[0], now_odo[1] - seg_start[1]) >= max_forward
+            ):
+                self.host.mobility.stop()
+                return "budget", (u, v)
+
+            # Deadband = accept (inner) box; right -> -wz, too close (low) -> -vx.
+            wz = self.host.mobility.servo_vel(
+                u - cu, self.p["follow_gain_ang"], self.p["rot_wz_min"], self.p["rot_wz_max"], accept[0]
+            )
+            vx = self.host.mobility.servo_vel(
+                v - cv, self.p["follow_gain_lin"], self.p["drive_v_min"], self.p["drive_v_max"], accept[1]
+            )
+            self.host.mobility.send_cmd_vel(vx, wz, 0.15)
+            self.host.sleep(0.03)
+        self.host.mobility.stop()
+        return "timeout", None
+
+    def _position_failed(self, prompt):
+        raise SkillFailed(f"Could not centre '{prompt}' in the approach box")
+
+    def position_above(self, prompt, xy):
+        """Flow-follow into the sweet box; Gemini reseed/confirm. Stepwise if
+        no cam. Raises SkillFailed if the target cannot be centred."""
+        if not self.host.main_image:
+            return self._position_stepwise(prompt, xy)
+
+        # Centre first: a seed near a frame edge can land on the arm or the
+        # carried object, and the servo would chase the robot itself.
+        bearing = math.atan2(xy[1], xy[0])
+        if abs(bearing) > math.radians(self.p["bearing_go_deg"]):
+            self.rotate_by(bearing)
+            xy2, px2 = self._localize_retry(prompt)
+            if px2 is None:
+                self._position_failed(prompt)
+            if xy2 is not None:
+                xy = xy2
+            seed = px2
+        else:
+            seed = floor_to_pixel(xy[0], xy[1], self.p["tilt_deg"])
+        lost = 0
+        # The target pinned in the odom frame by the first honest measurement;
+        # transformed back per iteration it stays frame-correct however the
+        # base curves, where "range minus displacement" only holds for a line.
+        target_odo = base_to_odom(self.odom_xyt(), xy)
+        stop_x = self.p["sweet_x"] - TRAVEL_MARGIN_M
+
+        def _remaining():
+            return odom_to_base(self.odom_xyt(), target_odo) if target_odo is not None else None
+
+        def _current_xy():
+            # The target in the CURRENT base frame: a measurement taken before
+            # the servo moved the base is in an obsolete one, so with neither
+            # odometry nor a fresh look there is nothing honest to drive toward.
+            rem = _remaining()
+            if rem is not None:
+                return rem
+            fresh, _px = self._localize_retry(prompt)
+            if fresh is None:
+                raise SkillFailed(f"Lost '{prompt}' with neither camera nor odometry to relocate it")
+            return fresh
+
+        def _parked(rem):
+            # Dead-reckoned, not re-measured: the wall illusion that spent the
+            # budget reads ~0.25 m regardless of the truth.
+            self.host.mobility.stop()
+            near, y = max(0.10, min(0.60, rem[0])), max(-0.15, min(0.15, rem[1]))
+            self.host.logger.info(
+                f"[{self.host.name}] odometry budget spent: dead-reckoned park at ({near:.2f}, {y:+.2f})"
+            )
+            return (near, y)
+
+        for _attempt in range(int(self.p["box_steps"])):
+            if seed is None:
+                xy, seed = self._localize_retry(prompt)
+                if seed is None:
+                    self._position_failed(prompt)
+            # Arrival checked BEFORE servoing: a tracker that dies on a
+            # parked base must not burn the step budget re-seeding.
+            (cu, cv), _half, accept = self._sweet_box()
+            if xy is not None and inside_box(seed, cu, cv, accept[0], accept[1]):
+                return xy
+            rem = _remaining()
+            if rem is not None and rem[0] <= stop_x:
+                return _parked(rem)
+            result, _pt = self._follow_into_box(seed, max_forward=(rem[0] - stop_x) if rem is not None else None)
+            if result == "budget":
+                rem = _remaining()
+                if rem is not None:
+                    return _parked(rem)
+                seed = None
+                continue
+            if result == "noframe":
+                return self._position_stepwise(prompt, _current_xy())
+            if result == "lost":
+                # Two losses running: flow has nothing to hold on a big
+                # low-contrast face; the stepper closes on odometry instead.
+                lost += 1
+                if lost >= 2:
+                    return self._position_stepwise(prompt, _current_xy())
+                seed = None
+                continue
+            lost = 0
+            xy2, px2 = self._localize_retry(prompt)
+            if px2 is None:
+                self._position_failed(prompt)
+            if xy2 is not None and inside_box(px2, cu, cv, accept[0], accept[1]):
+                return xy2
+            xy, seed = xy2, (px2 if xy2 is not None else None)
+        if xy is not None and xy[0] <= self.p["sweet_x"] + PLATEAU_SLACK_M:
+            self.host.mobility.stop()
+            self.host.logger.info(f"[{self.host.name}] settling for the measured park at {xy[0]:.3f} m")
+            return xy
+        self._position_failed(prompt)
+
+    def _position_stepwise(self, prompt, xy):
+        """No-camera fallback: turn OR drive, re-detect, repeat.
+        Raises SkillFailed if the target cannot be centred."""
+        target_bearing = math.atan2(self.p["box_y"], self.p["sweet_x"])
+        target_range = math.hypot(self.p["sweet_x"], self.p["box_y"])
+        px = floor_to_pixel(xy[0], xy[1], self.p["tilt_deg"])
+        for _step in range(int(self.p["box_steps"])):
+            if px is None:
+                xy, px = self._localize_retry(prompt)
+                if px is None:
+                    self._position_failed(prompt)
+            (cu, cv), _half, accept = self._sweet_box()
+            if xy is not None and inside_box(px, cu, cv, accept[0], accept[1]):
+                return xy
+            if xy is None:
+                px = None
+                continue
+            bearing_err = math.atan2(xy[1], xy[0]) - target_bearing
+            if abs(bearing_err) > math.radians(self.p["bearing_go_deg"]):
+                moved = self.rotate_by(bearing_err)
+            else:
+                moved = self.drive(math.hypot(xy[0], xy[1]) - target_range)
+            if not moved:
+                # Odom loss or a stuck base: this closed-odometry stepper
+                # cannot make progress, so burning the remaining steps (a
+                # Gemini localize each) would just end in a misleading
+                # "could not centre".
+                raise SkillFailed("Base positioning failed (odometry lost or motion timed out)")
+            px = None
+        self._position_failed(prompt)

--- a/workspace/innate_skills/drop_in_box.py
+++ b/workspace/innate_skills/drop_in_box.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Drop a held object into a box, bin or basket. Built on _FloorApproach; a
+container changes two things: localize by its BOTTOM edge (a rim-height point
+back-projects far past the box) and park short of it rather than over it.
+"""
+
+import math
+import re
+import time
+
+from innate_skills.approach import APPROACH_PARAMS, FloorApproach, ask_head
+
+from innate import (
+    Head,
+    JointStates,
+    MainImage,
+    Manipulation,
+    Mobility,
+    Odometry,
+    Skill,
+    SkillReturn,
+    WristImage,
+    resource,
+    vision,
+)
+from innate import gemini as gemlib
+from innate.exceptions import ArmFailed, ArmUnhealthy, SkillFailed
+from innate.geometry import IMG_H, IMG_W, pixel_to_floor, pixel_to_height
+
+# Arm reach as a sphere about the shoulder (URDF: joint2 at (0.086, 0.0845),
+# 0.326 m of link past it). It predicts a 0.407 m floor-height limit — where
+# Manipulation.REACH_X's 0.40 comes from.
+SHOULDER_X, SHOULDER_Z = 0.086, 0.0845
+ARM_REACH = 0.326
+
+# j6 band that PROVES a hold on its own, valid only after a fresh close.
+# Below 0.05 the joints cannot tell a squeezed-thin object from a claw that
+# silently never moved off its parked 0.003 — there the wrist camera decides.
+HOLDING_J6 = (0.05, 0.80)
+
+VERIFY_BACKUP_M = 0.15
+
+# Every arm move made while holding passes tolerance_xy/z=None: the verified
+# path answers a missed pose with Manipulation.recover, which reboots the
+# servos torque-off — the fingers open and the object drops.
+
+# A detection touching the frame top has its rim cropped: any height read off
+# it is meaningless.
+CLIP_MARGIN_PX = 3.0
+
+PARAMS = {
+    **APPROACH_PARAMS,
+    # -12 sees floor from 0.19 m out — just short of the 0.23 park, so a
+    # clipped detection cannot self-certify as parked.
+    "tilt_deg": -12.0,
+    # Near floor edge parks here. Close on purpose: at 0.33 the reach clamp
+    # trimmed every release to a rim hug; still clear of the body (the
+    # shoulder at 0.086 is the frontmost part).
+    "sweet_x": 0.23,
+    # Bearing loose (a close container runs off the frame edges), range tight
+    # (the bumper-to-reach window is ~5 cm; the 7 px accept is ~1.5 cm).
+    "box_half_px": 50.0,
+    "box_half_v_px": 12.0,
+    "accept_frac": 0.6,
+    # Reach past the near face. 0.03 draped a sock on the rim; the reach
+    # clamp trims tall rims down to drop_inset_min at worst.
+    "drop_inset": 0.08,
+    # Release height above the rim; the arm opens here, no descent. At
+    # arm_pitch the fingertips already hang below the rim, so the object is
+    # inside before it is let go.
+    "release_clear_m": 0.04,
+    "release_settle_s": 0.8,
+    # Posed live on hardware for least head-camera occlusion (2026-08-28).
+    # 5 joints; move_joints carries the standing grip as j6.
+    "travel_joints": [-1.72, 0.31, -1.84, 1.70, -0.26],
+    # Where the object is lifted to at the container before reaching over the
+    # rim, at the release bearing.
+    "carry_x": 0.24,
+    "carry_z": 0.30,
+    "carry_s": 2.0,
+    # Re-squeeze before driving: move_to carries only the standing grip target,
+    # which the object may have worked loose from. GRIPPER_MAX_STRENGTH; above
+    # it the real servo overcurrent-trips.
+    "carry_grip": 0.60,
+    "carry_grip_s": 0.8,
+    "lift_after_m": 0.08,  # the fingertips hang below the rim even at hover
+    "hover_s": 2.5,
+    "arm_pitch": 1.30,
+    # Least the gripper may sit past the near face and still be over the
+    # interior. Below this the object would land on the rim.
+    "drop_inset_min": 0.03,
+    # Keep off the kinematic edge: pick already notes that working at the 0.40
+    # reach limit stalls the wrist and overloads servo 2.
+    "reach_margin": 0.03,
+    # Rim estimate band: below it the geometry is noise; 0.22 is the tallest
+    # rim the release was ever proven on.
+    "rim_z_min": 0.04,
+    "rim_z_max": 0.22,
+}
+
+
+class DropInBox(Skill):
+    """Put an object the robot is ALREADY HOLDING into a container — a box,
+    bin, basket or crate (prompt='the cardboard box', 'the laundry basket').
+    The robot finds the container with its head camera, drives up to it,
+    reaches over the rim and opens the gripper. Run pick_any_object first;
+    this fails immediately if the gripper is empty. Only works for containers
+    low enough for the arm to reach over — roughly shoebox height.
+    Call this only if the box is actually visible, otherwise search for it
+    first by looking around."""
+
+    manipulation: Manipulation
+    mobility: Mobility
+    head: Head
+    main_image: MainImage | None
+    odom: Odometry | None
+    # `| None` — best effort: the hold check falls back to the wrist camera
+    # without joint states, and to the joints without wrist frames.
+    wrist_image: WristImage | None
+    joint_states: JointStates | None
+
+    _p = PARAMS
+
+    @resource
+    def _proxy(self):
+        return gemlib.make_client()
+
+    # Two scalars, not the box tuple: a subscripted generic in a class-level
+    # annotation crashes the feed-annotation machinery at import.
+    _box_u: float | None = None
+    _box_top_v: float | None = None
+    _near_rim_v: float | None = None
+    _rim_z: float | None = None
+    _label = "the box"
+    _over_rim = False  # the gripper is inside the container's footprint
+    _released = False  # the object has left the claw
+
+    def _detect_px(self, prompt: str) -> tuple[float, float] | None:
+        """Head frame -> the container's near floor-contact pixel, or None.
+        Bottom edge midpoint, NOT the centre: a point at rim height
+        back-projects far past the box (a 0.15 m rim at 0.6 m reads 0.88)."""
+        text, img = ask_head(
+            self,
+            self._proxy,
+            f"Find '{prompt}' in this image — an open container (box, bin, basket, crate) "
+            "standing on the floor. Ignore the robot's own gripper and anything it is "
+            "holding. Return ONLY a JSON list of matches, each "
+            '{"box_2d":[ymin,xmin,ymax,xmax], "near_rim_y":y} normalized 0-1000, best '
+            "first. box_2d is TIGHT around the whole container, including where it rests "
+            "on the floor. near_rim_y is the image row of the TOP EDGE OF THE WALL "
+            "NEAREST THE CAMERA — the front rim you would reach over, not the far rim "
+            "behind it. Empty list if no container is visible.",
+            self._p["settle_s"],
+        )
+        box = vision.parse_det_box(text)
+        self._near_rim_v = _near_rim_v(text)
+        if box is None:
+            self._box_u = self._box_top_v = None
+            return None
+        x, y, w, h = box
+        self._box_u = min(float(IMG_W - 1), x + w / 2.0)
+        self._box_top_v = float(y)
+        px = (self._box_u, min(float(IMG_H - 1), float(y + h)))
+        self._measure_rim(px)
+        return px
+
+    def _measure_rim(self, px: tuple[float, float]) -> None:
+        """Bank the rim height while the container is still whole in frame:
+        parked, the rim is cropped off the top and cannot be measured."""
+        v = self._near_rim_v if self._near_rim_v is not None else self._box_top_v
+        if v is None or v <= CLIP_MARGIN_PX or self._box_top_v is None or self._box_top_v <= CLIP_MARGIN_PX:
+            return
+        xy = pixel_to_floor(px[0], px[1], self._p["tilt_deg"])
+        if xy is None or self._box_u is None:
+            return
+        raw = pixel_to_height(self._box_u, v, self._p["tilt_deg"], xy[0])
+        if raw is None:
+            return
+        self._rim_z = max(self._p["rim_z_min"], min(self._p["rim_z_max"], raw))
+        self.logger.info(f"[DropInBox] rim {self._rim_z:.3f} (raw={raw:.3f}) measured at range {xy[0]:.2f}")
+
+    def _rim_height(self, near_x: float) -> float:
+        """The rim height banked by _measure_rim, or the floor of the band if
+        no detection ever caught the container uncropped."""
+        rim = self._rim_z if self._rim_z is not None else self._p["rim_z_min"]
+        return rim
+
+    def _j6(self) -> float | None:
+        js = self.joint_states
+        return js.position[5] if js is not None and len(js.position) > 5 else None
+
+    def _wrist_sees_object(self) -> bool | None:
+        """Wrist-camera opinion on whether the fingers hold something.
+        None when there is no frame or no verdict."""
+        img = self.wrist_image
+        if not img:
+            return None
+        text = gemlib.ask_image(
+            self._proxy,
+            img,
+            "Wrist camera mounted beside a robot gripper's fingers (the view is mirrored). "
+            "Are the fingers holding an object right now? Answer only YES or NO.",
+            logger=self.logger,
+        )
+        return _yes_no(text)
+
+    def _holding(self, closed: bool) -> bool:
+        """The gripper has something in it: j6 clearly at an object's width
+        after a fresh close, or the wrist camera seeing one. Neither a failed
+        close nor a low j6 counts alone."""
+        j6 = self._j6()
+        by_joint = closed and j6 is not None and HOLDING_J6[0] < j6 < HOLDING_J6[1]
+        seen = self._wrist_sees_object()
+        held = by_joint or seen is True
+        self.logger.info(f"[DropInBox] hold check: j6={j6} joints={by_joint} wrist={seen} -> {held}")
+        return held
+
+    def _secure_grip(self) -> bool:
+        """Re-close the claw before the drive; True if the close went through
+        (_holding trusts j6 only against a fresh close)."""
+        p = self._p
+        self.manipulation.torque_on()
+        try:
+            self.manipulation.gripper_close(p["carry_grip"], duration=p["carry_grip_s"])
+        except (ArmFailed, ArmUnhealthy) as e:
+            self.logger.warning(f"[DropInBox] could not re-grip before the drive ({e})")
+            return False
+        return True
+
+    def _carry_pose(self, joints: list[float]) -> None:
+        """Move the held object to a 5-joint pose (grip kept); a refused pose
+        falls back to Manipulation.rest, also grip-preserving."""
+        try:
+            self.manipulation.move_joints(joints, duration=self._p["carry_s"])
+            return
+        except (ArmFailed, ArmUnhealthy) as e:
+            self.logger.warning(f"[DropInBox] carry pose refused ({e}); folding to rest instead")
+        try:
+            self.manipulation.rest(duration=self._p["carry_s"])
+        except (ArmFailed, ArmUnhealthy) as e:
+            self.logger.warning(f"[DropInBox] could not fold either ({e}); carrying on as-is")
+
+    def _lift_clear(self, y: float) -> None:
+        """Raise the object above rim height at the release bearing, so the
+        reach comes down from above the near wall, not through it."""
+        p = self._p
+        try:
+            self.manipulation.move_to(
+                p["carry_x"],
+                y,
+                p["carry_z"],
+                pitch=p["arm_pitch"],
+                duration=p["carry_s"],
+                tolerance_xy=None,
+                tolerance_z=None,
+            )
+        except (ArmFailed, ArmUnhealthy) as e:
+            self.logger.warning(f"[DropInBox] could not lift clear of the rim ({e}); reaching from where it is")
+
+    def _release_x(self, near_x: float, z: float) -> float:
+        """How far forward the gripper may hover at height `z`, or raise if the
+        rim is high enough that nothing over the interior is still in reach."""
+        p = self._p
+        limit = reach_x_max(z)
+        limit = None if limit is None else limit - p["reach_margin"]
+        floor = near_x + p["drop_inset_min"]
+        if limit is None or limit < floor:
+            raise SkillFailed(
+                f"'{self._label}' is too tall to reach over — its rim needs the gripper at "
+                f"z={z:.2f} m, where the arm only reaches x={limit or 0.0:.2f} m and the "
+                f"container's near wall is already at x={near_x:.2f} m"
+            )
+        return min(near_x + p["drop_inset"], limit)
+
+    def _release_at(self, near_x: float, near_y: float) -> tuple[float, float, float]:
+        """Hover over the container interior and open the claw."""
+        p = self._p
+        rim = self._rim_height(near_x)
+        z = rim + p["release_clear_m"]
+        x, y = self.manipulation.clamp_reach(self._release_x(near_x, z), near_y)
+
+        self.manipulation.torque_on()
+        self._lift_clear(y)
+        try:
+            self.manipulation.move_to(
+                x, y, z, pitch=p["arm_pitch"], duration=p["hover_s"], tolerance_xy=None, tolerance_z=None
+            )
+        except ArmFailed as e:
+            raise SkillFailed(
+                f"Could not hold the gripper over the rim at z={z:.2f} m — "
+                f"the container looks too tall for this arm ({e})"
+            ) from e
+        # Latched BEFORE the claw opens: a cancel during the settle below must
+        # still lift the fingers out of the container, and an unlatched flag
+        # folded REST straight through the wall.
+        self._over_rim = True
+
+        self.check_cancelled()  # last exit before the object leaves the claw
+        self.manipulation.gripper_open(duration=1.0)
+        self._released = True
+        self.sleep(p["release_settle_s"])
+        # Out of the container BEFORE anything drives: the verification backs
+        # the base up 0.15 m, and doing that with the claw still hooked over
+        # the rim drags the container along with it.
+        self._lift_out()
+        return x, y, z
+
+    def _lift_out(self) -> None:
+        """Straight up until the fingers clear the rim. Never raises; clears
+        the over-rim latch only on success, so a failed lift still tells
+        teardown the gripper is in the container."""
+        try:
+            self.manipulation.move_by(dz=self._p["lift_after_m"], duration=1.0, tolerance_xy=None, tolerance_z=None)
+            self._over_rim = False
+        except (ArmFailed, ArmUnhealthy) as e:
+            self.logger.warning(f"[DropInBox] could not lift clear of the container ({e})")
+
+    def _retract(self) -> None:
+        """Best-effort teardown, never raises: straight up off the rim (REST
+        swings the gripper forward and down, through the wall), then fold. A
+        run that never released folds via Manipulation.rest with the grip kept —
+        REST's 6th element is a claw command."""
+        try:
+            if self._over_rim:
+                # Only reached when the normal lift-out never ran (a cancel
+                # mid-release, or a lift that failed). Committed teardown:
+                # time.sleep on purpose.
+                self.manipulation.move_by(dz=self._p["lift_after_m"], duration=1.0, tolerance_xy=None, tolerance_z=None)
+                time.sleep(0.3)
+            if self._released:
+                self.manipulation.move_joints(self.manipulation.REST, duration=3.0)
+            else:
+                self.manipulation.rest(duration=3.0)  # keeps the grip on a run that never released
+        except Exception as e:  # noqa: BLE001 — teardown must not mask the run result
+            self.logger.warning(f"[DropInBox] retract failed: {e}")
+
+    def _landed(self, prompt: str, approach: FloorApproach) -> bool:
+        """Back up, then look for evidence the object did NOT go in."""
+        approach.drive(-VERIFY_BACKUP_M)
+        self.sleep(self._p["settle_s"])
+        main_img, wrist_img = self.main_image, self.wrist_image
+        images = [img for img in (main_img, wrist_img) if img]
+        if not images:
+            j6 = self._j6()
+            still_held = j6 is not None and HOLDING_J6[0] < j6 < HOLDING_J6[1]
+            return not still_held
+        labels = []
+        if main_img:
+            labels.append(f"Image {len(labels) + 1} is the head camera looking at the floor.")
+        if wrist_img:
+            labels.append(f"Image {len(labels) + 1} is the WRIST camera beside the gripper fingers (mirrored).")
+        # Burden of proof on FAILURE: a successful drop is usually invisible
+        # (below the rim, behind the near wall) — affirming "inside" produced
+        # false misses on tall boxes. Only seeing the object outside counts.
+        text = gemlib.ask_image(
+            self._proxy,
+            images,
+            f"The robot just dropped an object into '{prompt}'. {' '.join(labels)} "
+            "Can you SEE the dropped object OUTSIDE the container — lying on the floor "
+            "next to it, or still between the gripper fingers? A successful drop leaves "
+            "the object hidden inside the container, so if you cannot see it anywhere, "
+            "answer NO. Answer only YES or NO.",
+            logger=self.logger,
+        )
+        missed = _yes_no(text)
+        self.logger.info(f"[DropInBox] landed: reply={text!r} -> {missed is not True}")
+        # No usable verdict is not a failure: the claw is open and the object
+        # is no longer held, which is as much as this skill promised.
+        return missed is not True
+
+    def execute(self, prompt: str = "the box") -> SkillReturn:
+        """Drop whatever the gripper holds into `prompt`."""
+        if self._proxy is None:
+            self.fail("Innate proxy not configured (INNATE_SERVICE_KEY)")
+
+        self._box_u = self._box_top_v = None
+        self._near_rim_v = None
+        self._rim_z = None
+        self._over_rim = False
+        self._released = False
+        self._label = prompt
+        released_z = None
+        try:
+            self.head.set_position(int(round(self._p["tilt_deg"])))
+            # The 50 Hz feeds start with the run: the first read is empty and
+            # would report a held object as an empty claw.
+            self.wait_for(lambda: self.joint_states, timeout=3.0)
+            # Close before judging: _holding reads j6 against a fresh close.
+            closed = self._secure_grip()
+            if not self._holding(closed):
+                if not closed:
+                    self.fail("The gripper isn't responding, so I can't tell whether I'm holding anything")
+                self.fail("I'm not holding anything to put away (or can't confirm it without a wrist view)")
+
+            self._carry_pose(self._p["travel_joints"])
+            approach = FloorApproach(self, self._p, self._detect_px)
+            self.say(f"Looking for {prompt}.")
+            xy = approach.search(prompt)
+            xy = approach.position_above(prompt, xy)
+            self.say("Dropping it in.")
+            _x, _y, released_z = self._release_at(xy[0], xy[1])
+
+            if not self._landed(prompt, approach):
+                self.say("It missed the box.")
+                raise SkillFailed(f"Released, but the object did not land in '{prompt}'")
+            self.say("Done.")
+            rim = f"{self._rim_z:.2f}" if self._rim_z is not None else "?"
+            return f"Dropped the object into '{prompt}' (rim ~{rim} m, released at z={released_z:.2f})"
+        except ArmFailed as e:
+            self.fail(str(e))
+        except ArmUnhealthy as e:
+            self.say("My arm isn't responding properly, stopping.")
+            self.fail(f"Arm servo failure: {e}")
+        finally:
+            self.mobility.stop()
+            self._retract()
+            self.head.set_position(0)
+
+
+def reach_x_max(z: float) -> float | None:
+    """Furthest forward (base_link x) the gripper reaches at height `z`."""
+    span = ARM_REACH**2 - (z - SHOULDER_Z) ** 2
+    return SHOULDER_X + math.sqrt(span) if span > 0 else None
+
+
+def _near_rim_v(text: str | None) -> float | None:
+    """The best detection's near_rim_y as an image row, or None."""
+    for det in vision.parse_dets(text):
+        y = det.get("near_rim_y")
+        if isinstance(y, (int, float)) and not isinstance(y, bool) and math.isfinite(y):
+            return min(1000.0, max(0.0, float(y))) / 1000.0 * IMG_H
+    return None
+
+
+def _yes_no(text: str | None) -> bool | None:
+    """YES/NO as a whole-word scan; None when the reply is empty, hedged or
+    says both. Anchored prefix matching read 'It is not in the box.' as a yes."""
+    verdict = (text or "").upper()
+    yes = re.search(r"\bYES\b", verdict) is not None
+    no = re.search(r"\bNO\b", verdict) is not None
+    return None if yes == no else yes

--- a/workspace/innate_skills/drop_in_box.py
+++ b/workspace/innate_skills/drop_in_box.py
@@ -67,6 +67,7 @@ PARAMS = {
     "box_half_px": 50.0,
     "box_half_v_px": 25.0,
     "accept_frac": 0.6,
+    "hold_frac": 1.0,
     # Reach past the near face. 0.03 draped a sock on the rim; the reach
     # clamp trims tall rims down to drop_inset_min at worst.
     "drop_inset": 0.08,

--- a/workspace/innate_skills/drop_in_box.py
+++ b/workspace/innate_skills/drop_in_box.py
@@ -26,7 +26,7 @@ from innate import (
 )
 from innate import gemini as gemlib
 from innate.exceptions import ArmFailed, ArmUnhealthy, SkillFailed
-from innate.geometry import IMG_H, IMG_W, pixel_to_floor, pixel_to_height
+from innate.geometry import IMG_H, IMG_W, floor_to_pixel, pixel_to_floor, pixel_to_height
 
 # Arm reach as a sphere about the shoulder (URDF: joint2 at (0.086, 0.0845),
 # 0.326 m of link past it). It predicts a 0.407 m floor-height limit — where
@@ -51,17 +51,21 @@ CLIP_MARGIN_PX = 3.0
 
 PARAMS = {
     **APPROACH_PARAMS,
-    # -12 sees floor from 0.19 m out — just short of the 0.23 park, so a
-    # clipped detection cannot self-certify as parked.
+    # -12 sees floor from 0.19 m out, so the 0.23 park sits 40 px above the
+    # frame bottom; past it the contact line leaves frame (see _park_if_clipped).
     "tilt_deg": -12.0,
     # Near floor edge parks here. Close on purpose: at 0.33 the reach clamp
     # trimmed every release to a rim hug; still clear of the body (the
     # shoulder at 0.086 is the frontmost part).
     "sweet_x": 0.23,
-    # Bearing loose (a close container runs off the frame edges), range tight
-    # (the bumper-to-reach window is ~5 cm; the 7 px accept is ~1.5 cm).
+    # Bearing loose (a close container runs off the frame edges). Range was
+    # 12 px — a 16 mm accept band the servo cannot resolve: the feed is 7.5 Hz
+    # and drive_v_min 0.04 m/s, so its smallest blind step is ~6 mm and it
+    # limit-cycled instead of parking. 25 px gives a 34 mm deadband (~6 steps)
+    # and a 57 mm hold band, both well inside the 0.15-0.30 m park that
+    # _release_x tolerates at every rim in the band.
     "box_half_px": 50.0,
-    "box_half_v_px": 12.0,
+    "box_half_v_px": 25.0,
     "accept_frac": 0.6,
     # Reach past the near face. 0.03 draped a sock on the rim; the reach
     # clamp trims tall rims down to drop_inset_min at worst.
@@ -163,7 +167,22 @@ class DropInBox(Skill):
         self._box_top_v = float(y)
         px = (self._box_u, min(float(IMG_H - 1), float(y + h)))
         self._measure_rim(px)
-        return px
+        return self._park_if_clipped(px, float(y + h))
+
+    def _park_if_clipped(self, px: tuple[float, float], contact_v: float) -> tuple[float, float]:
+        """A floor-contact row at or past the frame bottom means the container
+        is nearer than the 0.19 m this tilt can see — at or past the park, not
+        somewhere measurable. Clamped to the last row it back-projects to a
+        fixed 0.19 that reads 'too close' forever, walking the base backwards
+        and burning a step each time; report the park row and keep only the
+        bearing this detection can still see."""
+        if contact_v < IMG_H - 1:
+            return px
+        park = floor_to_pixel(self._p["sweet_x"], self._p["box_y"], self._p["tilt_deg"])
+        if park is None:
+            return px
+        self.logger.info(f"[DropInBox] contact row clipped at v={contact_v:.0f}; treating as parked")
+        return (px[0], park[1])
 
     def _measure_rim(self, px: tuple[float, float]) -> None:
         """Bank the rim height while the container is still whole in frame:

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -11,6 +11,8 @@ import math
 import re
 import time
 
+from innate_skills.approach import APPROACH_PARAMS, FloorApproach, ask_head, base_to_odom, inside_box
+
 from innate import (
     Head,
     JointStates,
@@ -27,7 +29,7 @@ from innate import (
 )
 from innate import gemini as gemlib
 from innate.exceptions import ArmFailed, ArmUnhealthy, SkillFailed
-from innate.geometry import IMG_H, IMG_W, floor_to_pixel, pixel_to_floor
+from innate.geometry import pixel_to_floor
 
 GRIPPER_EMPTY_J6 = -0.085
 VERIFY_BACKUP_M = 0.15
@@ -45,11 +47,10 @@ CARRY_ARM = [0.0537, -0.50, 0.4157, 0.9434, -0.0077]
 # the wrist flattened and rolled clears the frame.
 NAV_ARM = [1.5708, -1.2195, 1.5723, 0.06, -0.47]
 
-# Pick parameters, tuned on hardware.
+# Pick parameters, tuned on hardware; the find/position half is APPROACH_PARAMS.
+# Grasping at the 0.40 reach edge stalls the wrist and overloads servo 2.
 PARAMS = {
-    # FIND / LOCALIZE
-    "tilt_deg": -20.0,
-    "settle_s": 1.2,
+    **APPROACH_PARAMS,
     # Objects don't teleport: a match farther than this from the last sighting
     # is a different instance (e.g. an identical twin), not the target. The
     # allowance grows with the range the memory was taken at, because
@@ -59,24 +60,6 @@ PARAMS = {
     # range, so a flat gate would reject the very object it is protecting.
     "mem_gate_m": 0.35,
     "mem_gate_frac": 0.4,
-    # POSITION. sweet_x ceiling is 0.43 (reach clamp); 0.37 grasps at ~0.32 —
-    # grasping at the 0.40 reach edge stalls the wrist and overloads servo 2.
-    "sweet_x": 0.37,
-    "box_y": 0.0,
-    "box_half_px": 40.0,
-    "accept_frac": 0.5,
-    "box_steps": 6.0,
-    "bearing_go_deg": 4.0,
-    "follow_gain_ang": 0.3,
-    "follow_gain_lin": 0.06,
-    "rot_tol_deg": 2.5,
-    "rot_kp": 1.2,
-    "rot_wz_max": 0.5,
-    "rot_wz_min": 0.15,
-    "drive_tol_m": 0.015,
-    "drive_kp": 0.3,
-    "drive_v_max": 0.10,
-    "drive_v_min": 0.04,
     # WRIST ALIGN (0 wrist_steps = blind grasp)
     "wrist_steps": 2.0,
     "wrist_stop_z": 0.05,
@@ -130,10 +113,6 @@ MEM_COAST_LIMIT = 2
 WRIST_SEARCH_ARM = [0.1473, -0.0706, -0.4449, 1.3376, -0.0491]
 
 
-def _inside_box(px, cu, cv, half):
-    return abs(px[0] - cu) <= half and abs(px[1] - cv) <= half
-
-
 class _BlobTracker:
     """CamShift color-blob tracker seeded from a Gemini box."""
 
@@ -171,39 +150,30 @@ class PickAnyObject(Skill):
     manipulation: Manipulation
     mobility: Mobility
     head: Head
-    # `| None` — best effort, every read is guarded: positioning falls back
-    # to stepwise re-detection without head frames, the wrist stage degrades
-    # to the blind grasp without wrist frames.
+    # `| None` — best effort: the approach falls back to stepwise re-detection
+    # without head frames, the wrist stage to the blind grasp without wrist ones.
     main_image: MainImage | None
     wrist_image: WristImage | None
     joint_states: JointStates | None
     odom: Odometry | None
 
     _p = PARAMS
+
+    @resource
+    def _proxy(self):
+        return gemlib.make_client()
+
     _grip_strength: float | None = None
     _holding = False  # fingers committed on an object this run
     # (odom x, odom y, range from the base at that sighting)
     _last_seen: tuple[float, float, float] | None = None
     _coasts = 0  # consecutive looks the memory gate rejected
 
-    @resource
-    def _proxy(self):
-        return gemlib.make_client()
-
-    def _base_to_odom(self, xy):
-        """base_link floor point -> odom frame, or None without odometry."""
-        o = self._odom_xyt()
-        if o is None:
-            return None
-        ox, oy, th = o
-        c, s = math.cos(th), math.sin(th)
-        return (ox + c * xy[0] - s * xy[1], oy + s * xy[0] + c * xy[1])
-
     def _sighting(self, cand):
         """Candidate pixel -> (odom x, odom y, range from the base), or None
         when it doesn't back-project or odometry is missing."""
         xy = pixel_to_floor(cand[0], cand[1], self._p["tilt_deg"])
-        wxy = self._base_to_odom(xy) if xy else None
+        wxy = base_to_odom(self.mobility.odom_xyt(self.odom), xy) if xy else None
         return (wxy[0], wxy[1], math.hypot(xy[0], xy[1])) if wxy else None
 
     def _memory_dist(self, cand):
@@ -256,14 +226,9 @@ class PickAnyObject(Skill):
     def _detect_px(self, prompt):
         """Head frame -> grasp pixel of the remembered target, or None. Also
         records Gemini's per-object grip_strength for the close."""
-        self.mobility.stop()
-        self.sleep(self._p["settle_s"])
-        img = self.main_image
-        if not img:
-            return None
-        text = gemlib.ask_image(
+        text, img = ask_head(
+            self,
             self._proxy,
-            img,
             f"Find '{prompt}' lying on the floor in this image. Match precisely — "
             "not paper/packaging when asked for clothing, and NOT anything held "
             "by the robot arm. Return ONLY a JSON list of ALL matches (every "
@@ -277,7 +242,7 @@ class PickAnyObject(Skill):
             "objects (metal, hard plastic, wood, ceramic) need 0.30-0.40 — "
             "squeezing them harder stalls the gripper servo. "
             "Empty list if not present.",
-            logger=self.logger,
+            self._p["settle_s"],
         )
         cands = vision.parse_det_cands(text)
         cand = self._choose_cand(cands) if cands else None
@@ -291,48 +256,6 @@ class PickAnyObject(Skill):
         if seen is not None:
             self._last_seen = seen
         return (u, v)
-
-    def _localize_px(self, prompt):
-        """Detect + back-project -> ((x,y)|None, pixel|None)."""
-        px = self._detect_px(prompt)
-        if px is None:
-            return None, None
-        xy = pixel_to_floor(px[0], px[1], self._p["tilt_deg"])
-        if xy:
-            self.logger.info(f"[PickAnyObject] px=({px[0]:.0f},{px[1]:.0f}) -> base_link ({xy[0]:.3f},{xy[1]:.3f})")
-        return xy, px
-
-    def _localize_retry(self, prompt):
-        """One retry: a single "not visible" is noise, not absence."""
-        xy, px = self._localize_px(prompt)
-        if px is None:
-            xy, px = self._localize_px(prompt)
-        return xy, px
-
-    def _odom_xyt(self):
-        return self.mobility.odom_xyt(self.odom)
-
-    def _rotate_by(self, angle):
-        return self.mobility.rotate_by(
-            self._odom_xyt,
-            angle,
-            kp=self._p["rot_kp"],
-            wz_max=self._p["rot_wz_max"],
-            wz_min=self._p["rot_wz_min"],
-            tolerance=math.radians(self._p["rot_tol_deg"]),
-            logger=self.logger,
-        )
-
-    def _drive(self, dist):
-        return self.mobility.drive(
-            self._odom_xyt,
-            dist,
-            kp=self._p["drive_kp"],
-            v_max=self._p["drive_v_max"],
-            v_min=self._p["drive_v_min"],
-            tolerance=self._p["drive_tol_m"],
-            logger=self.logger,
-        )
 
     def _rest_arm(self, keep_grip):
         """Best-effort teardown: carry if holding, else fold to rest. Never
@@ -348,150 +271,6 @@ class PickAnyObject(Skill):
         except Exception as e:  # noqa: BLE001 — teardown must not mask the run result
             self.logger.warning(f"[PickAnyObject] rest-arm failed: {e}")
 
-    def _search(self, prompt):
-        """Scan: straight, right 30°, left 60°. First hit wins. (+yaw=left)"""
-        for i, turn in enumerate((0.0, -math.radians(30), math.radians(60))):
-            if turn:
-                if i == 1:
-                    self.say("Scanning around for it.")
-                # Best-effort: a rotate cut short (timeout / odom loss) still
-                # changed the view, and the localize below measures from
-                # wherever the base actually ended up.
-                self._rotate_by(turn)
-            xy, _px = self._localize_px(prompt)
-            if xy is not None:
-                return xy
-        raise SkillFailed(f"Could not find '{prompt}' on the floor, even after scanning")
-
-    def _sweet_box(self):
-        """(center_px, outer_half, accept_half). Stop only inside accept."""
-        c = floor_to_pixel(self._p["sweet_x"], self._p["box_y"], self._p["tilt_deg"])
-        if c is None or not (0 <= c[0] < IMG_W and 0 <= c[1] < IMG_H):
-            raise SkillFailed("pick box off-image — check tilt_deg/sweet_x")
-        half = self._p["box_half_px"]
-        return (c[0], c[1]), half, half * self._p["accept_frac"]
-
-    def _follow_into_box(self, seed_px):
-        """Optical-flow base servo into pick box. No Gemini.
-        Returns ('in_box'|'lost'|'timeout'|'noframe', px|None)."""
-        raw = self.main_image
-        prev = vision.b64_to_gray(raw) if raw else None
-        if prev is None:
-            return "noframe", None
-        u, v = seed_px
-        grid = vision.grid_pts(u, v)
-        in_box = 0
-        (cu, cv), _half, accept = self._sweet_box()
-        t0 = time.monotonic()
-        while time.monotonic() - t0 < FOLLOW_TIMEOUT_S:
-            # Only track NEW frames: the camera runs slower than this loop,
-            # and a stale frame re-tracked would count one observation twice.
-            # Compare by identity, not content: the provider builds one Image
-            # per ROS message, and in sim consecutive frames of a static scene
-            # are byte-identical, so `==` would deadlock waiting for a change.
-            img = self.main_image
-            if not img or img is raw:
-                self.sleep(0.03)
-                continue
-            gray = vision.b64_to_gray(img)
-            raw = img
-            if gray is None:
-                self.sleep(0.03)
-                continue
-            tracked = vision.track_point(prev, gray, grid)
-            prev = gray
-            if tracked is None:
-                self.mobility.stop()
-                return "lost", None
-            u, v = tracked
-            grid = vision.grid_pts(u, v)
-            if not (0 <= u < IMG_W and 0 <= v < IMG_H):
-                self.mobility.stop()
-                return "lost", None
-
-            if _inside_box((u, v), cu, cv, accept):
-                in_box += 1
-                self.mobility.stop()
-                if in_box >= 3:
-                    return "in_box", (u, v)
-                self.sleep(0.03)
-                continue
-            in_box = 0
-
-            # Deadband = accept (inner) box; right -> -wz, too close (low) -> -vx.
-            wz = self.mobility.servo_vel(
-                u - cu, self._p["follow_gain_ang"], self._p["rot_wz_min"], self._p["rot_wz_max"], accept
-            )
-            vx = self.mobility.servo_vel(
-                v - cv, self._p["follow_gain_lin"], self._p["drive_v_min"], self._p["drive_v_max"], accept
-            )
-            self.mobility.send_cmd_vel(vx, wz, 0.15)
-            self.sleep(0.03)
-        self.mobility.stop()
-        return "timeout", None
-
-    def _position_failed(self, prompt):
-        raise SkillFailed(f"Could not centre '{prompt}' in the pick box")
-
-    def _position_above(self, prompt, xy):
-        """Flow-follow into pick box; Gemini reseed/confirm. Stepwise if no cam.
-        Raises SkillFailed if the object cannot be centred."""
-        if not self.main_image:
-            return self._position_stepwise(prompt, xy)
-
-        seed = floor_to_pixel(xy[0], xy[1], self._p["tilt_deg"])
-        for _attempt in range(int(self._p["box_steps"])):
-            if seed is None:
-                seed = self._detect_px(prompt) or self._detect_px(prompt)
-                if seed is None:
-                    self._position_failed(prompt)
-            result, _pt = self._follow_into_box(seed)
-            if result == "noframe":
-                return self._position_stepwise(prompt, xy)
-            if result == "lost":
-                seed = None
-                continue
-            xy2, px2 = self._localize_retry(prompt)
-            if px2 is None:
-                self._position_failed(prompt)
-            (cu, cv), _half, accept = self._sweet_box()
-            if xy2 is not None and _inside_box(px2, cu, cv, accept):
-                return xy2
-            seed = px2 if xy2 is not None else None
-        self._position_failed(prompt)
-
-    def _position_stepwise(self, prompt, xy):
-        """No-camera fallback: turn OR drive, re-detect, repeat.
-        Raises SkillFailed if the object cannot be centred."""
-        target_bearing = math.atan2(self._p["box_y"], self._p["sweet_x"])
-        target_range = math.hypot(self._p["sweet_x"], self._p["box_y"])
-        px = floor_to_pixel(xy[0], xy[1], self._p["tilt_deg"])
-        for _step in range(int(self._p["box_steps"])):
-            if px is None:
-                xy, px = self._localize_retry(prompt)
-                if px is None:
-                    self._position_failed(prompt)
-            (cu, cv), _half, accept = self._sweet_box()
-            if xy is not None and _inside_box(px, cu, cv, accept):
-                return xy
-            if xy is None:
-                px = None
-                continue
-            bearing_err = math.atan2(xy[1], xy[0]) - target_bearing
-            if abs(bearing_err) > math.radians(self._p["bearing_go_deg"]):
-                moved = self._rotate_by(bearing_err)
-            else:
-                moved = self._drive(math.hypot(xy[0], xy[1]) - target_range)
-            if not moved:
-                # Odom loss or a stuck base: this closed-odometry stepper
-                # cannot make progress, so burning the remaining steps (a
-                # Gemini localize each) would just end in a misleading
-                # "could not centre".
-                raise SkillFailed("Base positioning failed (odometry lost or motion timed out)")
-            px = None
-        self._position_failed(prompt)
-
-    # GRASP: search pose -> seed -> servo down -> blind push -> close/twist/lift
     def _wrist_seed(self, prompt):
         """Wrist Gemini box -> (center_px, box) or (None, None)."""
         self.sleep(self._p["wrist_settle_s"])
@@ -620,7 +399,7 @@ class PickAnyObject(Skill):
 
             err_u = px[0] - p["wrist_box_u"]
             err_v = px[1] - p["wrist_box_v"]
-            inside = _inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
+            inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
             centered = centered + 1 if inside else 0
             if streak < 2:
                 continue  # watch one more frame before trusting it
@@ -798,11 +577,11 @@ class PickAnyObject(Skill):
         self.check_cancelled()  # last exit before the fingers commit
         self._close_twist_lift(x, y)
 
-    def _grasp_verified(self, prompt):
+    def _grasp_verified(self, prompt, approach: FloorApproach):
         """Back up, then check floor clear + gripper not open. Gemini gets both
         cameras: the wrist view can show the object in the fingers, so a held
         object isn't mistaken for a dropped one."""
-        self._drive(-VERIFY_BACKUP_M)
+        approach.drive(-VERIFY_BACKUP_M)
         self.sleep(self._p["settle_s"])
         js = self.joint_states
         j6 = js.position[5] if js is not None and len(js.position) > 5 else None
@@ -876,14 +655,15 @@ class PickAnyObject(Skill):
             # (5-joint move: the claw keeps whatever it currently holds).
             self.manipulation.move_joints(NAV_ARM, duration=3.0)
 
+            approach = FloorApproach(self, self._p, self._detect_px)
             self.say(f"Looking for {prompt}.")
-            xy = self._search(prompt)
-            xy = self._position_above(prompt, xy)
+            xy = approach.search(prompt)
+            xy = approach.position_above(prompt, xy)
             self.say("Picking it up.")
             self._grasp_at(prompt, xy)
             # _close_twist_lift latched self._holding the moment the fingers
             # committed — only a verified miss clears it.
-            if not self._grasp_verified(prompt):
+            if not self._grasp_verified(prompt, approach):
                 self._holding = False
                 self.say("I couldn't get a grip on it.")
                 raise SkillFailed(f"Grasp missed — '{prompt}' is still on the floor (verified after backing up)")


### PR DESCRIPTION
Adds `drop_in_box`: with an object already in the gripper (from `pick_any_object`), find a container by prompt, drive to it, reach over the rim, release inside, verify. Iterated on sim and live hardware; every geometry constant is hardware-measured.

## What's in the PR

**`workspace/innate_skills/approach.py` — `FloorApproach`, a shared collaborator (composition, not inheritance).** Pick's *find* and *approach* stages (Gemini detect → floor point, scan, optical-flow base servo into a park spot) extracted into an object a skill builds per run: `FloorApproach(self, params, detect)` — the skill as host, its params (where to park), and a detect callable (which pixel of the target touches the floor). An explicit `ApproachHost` Protocol names what a hosting skill provides: its declared feeds plus `sleep`/`say`/`logger`/`name`. `ask_head` and the base↔odom transforms are plain functions. The servo, its hardware-tuned constants and the odometry guards live once; both skills below use it and both still inherit `Skill` directly.

**`pick_any_object.py` — now hosts a `FloorApproach`.** ~240 lines moved out unchanged; the grasp stage (wrist servo, descent, close/twist/lift, verification) is untouched, and the skill declares its own feeds as before. Behaviour on hardware is the same except for the endgame guards it now gets from the approach.

**`drop_in_box.py` — the new skill.** Stages: confirm something is held → re-grip → travel pose → find and approach the container (inherited) → measure the rim → reach over it → open → lift out → back up and verify → grip-aware teardown. Exposed to the demo agent.

**`innate/geometry.py` — camera calibration.** The pinhole model was a guess; the real intrinsics are now in, plus `pixel_to_height` (a ray's height at a known forward distance, used to read a container's rim).

**Sim.** A `crate` prop — the first with an open interior, built with no mesh at all: `collision="open_box"` in `props.py` writes a floor and four walls as box geoms from the prop's half-extents and a wall thickness (MuJoCo hulls every mesh collider solid, so a hollow mesh would need a convex decomposition committed or published beside it), and the viewer builds the same five boxes from the manifest; a `tidy_up` challenge chaining pick → drop; the head camera rendered with the real intrinsics; the claw's hard stop modelled; and a latent `props.py` fix (untextured mesh props emitted `group=` twice and MuJoCo rejected the model).

## Why the pieces look the way they do

**The head-camera model was wrong by 2×.** `geometry.py` assumed a 70° pinhole; the real lens is ~116°, and the driver resizes each 1280×720 eye non-uniformly to 640×480, so the frame is anisotropic (fx=200.3, fy=267.3, cx=319.1, cy=248.7). Tape-measured: a point at 0.156 m reported as 0.33. Every release plan before this computed its reach from a fictional distance. `sweet_x` renumbered 0.37→0.285 — same physical park.

**The sim then had to render that lens.** It was still rendering 68.5° square pixels; skills read lateral offsets 1.6× large and the centring servo over-turned and oscillated. MuJoCo takes real intrinsics directly (`focal_pixel`/`principal_pixel` — the latter a sensor shift, negated on both axes, determined by rendering markers at known floor positions). Verified to 1.4 px mean against `geometry.floor_to_pixel`.

**The vision endgame cannot be trusted near a container.** Close in, the detected "floor-contact" pixel is up the container's wall and back-projects to a stable ~0.25 m regardless of truth — measured still reading 0.25 with the base 0.07 m past the wall, having tipped the crate to 57°. Hence the two guards in `FloorApproach`: an odometry budget (the first honest measurement pins the target in the odom frame; the drive stops when the dead-reckoned target comes within the park distance minus 8 cm and that pose is returned — frame-correct however the base curves) and plateau slack (a parked base whose final reading sits ~2 cm outside the accept band completes instead of raising "could not centre" and skipping the release).

**The sim claw could scissor through objects.** The close is commanded 0.6 rad past the joint's closed end; the soft limit doesn't resist a saturated servo and the blades don't collide with each other. The joint now ends at the hardware's closed-on-air angle (−0.085 = `GRIPPER_EMPTY_J6`) and targets clamp; squeeze unchanged.

**A drop's success is invisible.** A correctly dropped object sits below the rim behind the near wall — asking the verifier to affirm "inside" produced false failures on tall boxes. Burden of proof is on failure: only *seeing* the object outside counts as a miss. The complementary risk — an empty claw reported as success — is closed at the front: j6 counts only against a fresh, confirmed close and only clearly at an object's width; below 0.05 the wrist camera decides, and no verdict means an honest refusal.

**Rim height is measured at range.** Parked, the rim is cropped off the top of the frame, so the near-rim row is banked while the container is whole in view (measured 0.135–0.143 for the crate's true 0.14). The release reaches in from the hover — at `arm_pitch` the fingertips already hang below rim height, so there is no descent — and the arm lifts out *before* the verification backup, which previously dragged the container along by the still-hooked claw.

## Commits

| commit | scope |
|---|---|
| `feat(sim): a crate to drop things into` | `open_box` collision (procedural, no assets), crate prop, hollow viewer rendering, `tidy_up`, `props.py` fix |
| `fix(geometry): calibrate the head camera` | measured intrinsics, `pixel_to_height` |
| `fix(sim): render the real head camera` | MuJoCo camera gets the measured lens; `camera_info` matches |
| `fix(sim): the claw stops at its stop` | joint range ends at −0.085, targets clamped |
| `refactor(skills): extract the approach as a collaborator` | `FloorApproach` + `ApproachHost`; pick hosts it; endgame guards |
| `feat(skills): drop_in_box` | the skill, wired into the demo agent |

## Validation

- Sim: the full pick → carry → drop chain passes — cube released at z=0.18 over a 0.143-measured rim ends inside the crate 2.8 cm from centre, crate upright.
- Sim, final code (composition refactor, fail-closed fallback, procedural crate): 3/3 pick → drop chains, cube on the crate's inner floor each time (z=0.032, 6–7 cm from centre, crate never moved); the `tidy_up` challenge passes all three goals end-to-end in 123 s (ball inside at z=0.034, 8.5 cm from centre).
- Hardware: drop iterated live 2026-08-28 (calibrated camera, travel pose posed on the live view, flipped verification wording).
- Review: twelve Greptile rounds, every finding real and folded into the commits above; 5/5.
- CI has published the sim asset image for this branch's inputs hash, so `./innate-sim up` needs no overrides. The crate itself needs no asset at all.

Carry stability (objects creeping out of the closed gripper on any base motion) was fixed separately in #730 — elliptic friction cone; no friction value could fix it, and fifteen contact-parameter sweeps proved it.

