### PR TITLE
fix(webapp): the chat transcript survives drops, refreshes and noise

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
@@ -12,6 +12,7 @@ pubs/subs/service and delegates here.
 from __future__ import annotations
 
 import json
+import re
 import time
 from typing import Any
 
@@ -23,6 +24,10 @@ from brain_client.inputs.loader import InputLoader
 from brain_client.inputs.types import InputDevice
 
 MIC_DEVICE_NAME = "micro"
+# A transcript with no letter or digit anywhere is room tone the recogniser
+# punctuated — a bare "." or "?". Publishing it would post a junk chat bubble
+# and spend an agent turn answering nobody.
+_HAS_CONTENT = re.compile(r"[^\W_]")
 
 
 class InputDeviceManager:
@@ -72,6 +77,9 @@ class InputDeviceManager:
         try:
             text = data if isinstance(data, str) else data.get("text", "")
             if data_type == "chat_in":
+                if not _HAS_CONTENT.search(text):
+                    self._logger.debug(f"🔇 Dropped contentless transcript from '{device_name}': {text!r}")
+                    return
                 data_dict = {"text": text, "sender": "user", "timestamp": time.time()}
             else:
                 data_dict = {"text": data} if isinstance(data, str) else data.copy()

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
@@ -24,9 +24,8 @@ from brain_client.inputs.loader import InputLoader
 from brain_client.inputs.types import InputDevice
 
 MIC_DEVICE_NAME = "micro"
-# A transcript with no letter or digit anywhere is room tone the recogniser
-# punctuated — a bare "." or "?". Publishing it would post a junk chat bubble
-# and spend an agent turn answering nobody.
+# Room tone the recogniser punctuated — a bare "." or "?". Publishing it posts
+# a junk bubble and spends an agent turn answering nobody.
 _HAS_CONTENT = re.compile(r"[^\W_]")
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/manager.py
@@ -24,8 +24,6 @@ from brain_client.inputs.loader import InputLoader
 from brain_client.inputs.types import InputDevice
 
 MIC_DEVICE_NAME = "micro"
-# Room tone the recogniser punctuated — a bare "." or "?". Publishing it posts
-# a junk bubble and spends an agent turn answering nobody.
 _HAS_CONTENT = re.compile(r"[^\W_]")
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -402,10 +402,12 @@ class BrainClientNode(Node):
         self.brain.on_custom_input(data)
 
     def _on_tts(self, msg: String) -> None:
+        """Speak a line a skill sent, and show it — emit, not speak: anything the
+        robot says aloud belongs in the transcript, or Skill.say goes unrecorded."""
         text = msg.data
         if text and text.strip():
             self.get_logger().info(f"TTS request received: {text[:50]}...")
-            self.chat.speak(text)
+            self.chat.emit(Sender.ROBOT, text)
 
     def _on_environment_speech(self, payload: dict) -> None:
         """Speak a simulated character: the line reaches the chat as the voice

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -522,13 +522,11 @@ class BrainClientNode(Node):
         )
 
     def _on_skill_status(self, msg: String) -> None:
-        """Record every skill run in the chat history, so a replayed transcript
-        keeps its cards.
+        """Record every skill run, so a replayed transcript keeps its cards.
 
-        The live topic is the only place an agent-run skill ever appears — the
-        runner leaves the echo to the skills server, which is a different
-        process and cannot reach this history. Both publishers can announce the
-        same run, so a run/status pair is recorded once.
+        An agent-run skill appears only here — the runner leaves the echo to the
+        skills server, a different process that cannot reach this history — and
+        both publishers can announce one run, so a run/status pair lands once.
         """
         try:
             payload = json.loads(msg.data)

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+from collections import deque
 
 import rclpy
 from brain_messages.srv import ForgetMemory, GetAvailableDirectives, GetChatHistory, ReloadSkillsAgents, ResetBrain
@@ -169,6 +170,7 @@ class BrainClientNode(Node):
     def _build_collaborators(self) -> None:
         cfg, state = self.config, self.state
         self.chat = ChatManager(self.get_logger(), self.chat_out_pub, self.task_status_pub, self._tts_handler)
+        self._recorded_skill_runs: deque[tuple[str, str]] = deque(maxlen=256)
         self.camera = CameraCapture(self, cfg)
         self.pose_tracker = PoseTracker(self, odom_topic=cfg.odom_topic, nav_mode_topic=cfg.current_nav_mode_topic)
         self.scan_health = ScanHealthMonitor(self, scan_topic=cfg.scan_topic, stale_after_sec=cfg.scan_stale_after_sec)
@@ -273,6 +275,7 @@ class BrainClientNode(Node):
         self.create_subscription(String, "/brain/set_directive", self._on_set_directive, 10)
         self.create_subscription(String, "/brain/set_active_skills", self._on_set_active_skills, 10)
         self.create_subscription(String, "/brain/manual_skill_event", self._on_manual_skill_event, 10)
+        self.create_subscription(String, "/brain/skill_status_update", self._on_skill_status, 10)
 
     def _create_services(self) -> None:
         self.create_service(GetChatHistory, "/brain/get_chat_history", self._svc_get_chat_history)
@@ -517,15 +520,41 @@ class BrainClientNode(Node):
             skill_id=skill_id,
             reason=reason,
         )
+
+    def _on_skill_status(self, msg: String) -> None:
+        """Record every skill run in the chat history, so a replayed transcript
+        keeps its cards.
+
+        The live topic is the only place an agent-run skill ever appears — the
+        runner leaves the echo to the skills server, which is a different
+        process and cannot reach this history. Both publishers can announce the
+        same run, so a run/status pair is recorded once.
+        """
+        try:
+            payload = json.loads(msg.data)
+            status = str(payload["status"])
+        except (json.JSONDecodeError, TypeError, KeyError):
+            return
+        name = str(payload.get("primitive_name") or payload.get("skill_name") or "")
+        if not name:
+            return
+        skill_id = payload.get("skill_id")
+        primitive_id = payload.get("primitive_id")
+        key = (str(primitive_id or skill_id or name), status)
+        if key in self._recorded_skill_runs:
+            return
+        self._recorded_skill_runs.append(key)
+        reason = payload.get("reason")
         self.chat.history.append(
             {
                 "sender": "task_activated",
-                "text": primitive_name,
+                "text": name,
                 "timestamp": payload.get("timestamp", time.time()),
                 "taskStatus": status,
                 "primitiveId": primitive_id,
                 "skillId": skill_id,
                 **({"failureReason": reason} if reason else {}),
+                **({"args": payload["args"]} if payload.get("args") else {}),
             }
         )
 

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -232,23 +232,18 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   // A topic delivers only what arrives after we subscribe, so a gap in delivery
   // is permanent — the brain's record is the only thing that can close it.
   let loadingHistory = false;
-  let newestRenderedTs = 0;
-
-  /** @param {number} ts */
-  function markRendered(ts) {
-    if (ts > newestRenderedTs) newestRenderedTs = ts;
-  }
+  let lastSnapshot = "";
 
   async function loadHistory() {
     if (loadingHistory) return;
     loadingHistory = true;
     try {
       const res = await rosClient.callService(GET_CHAT_HISTORY_SERVICE, {});
-      const entries = JSON.parse(res?.history ?? "[]");
+      const raw = String(res?.history ?? "");
+      if (raw === lastSnapshot) return;
+      const entries = JSON.parse(raw || "[]");
       if (!Array.isArray(entries) || !entries.length) return;
-      const newest = entries.reduce((max, e) => Math.max(max, Number(e?.timestamp) || 0), 0);
-      if (newest <= newestRenderedTs) return; // in sync — replaying would only jump the scroll
-      markRendered(newest);
+      lastSnapshot = raw;
       chat.replay(entries);
     } catch {
       // best-effort — the live stream still works without the backfill
@@ -280,9 +275,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     if (String(payload?.sender ?? "") !== "user") return;
     const text = String(payload?.text ?? "");
     if (!text) return;
-    const ts = Number(payload?.timestamp) || Date.now() / 1000;
-    markRendered(ts);
-    chat.addMessage("user", text, ts);
+    chat.addMessage("user", text, Number(payload?.timestamp) || Date.now() / 1000);
   }, undefined, "std_msgs/msg/String");
 
   const unsubOut = rosClient.subscribe(CHAT_OUT_TOPIC, (m) => {
@@ -296,9 +289,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     const sender = String(payload?.sender ?? "");
     const text = String(payload?.text ?? "");
     if (!sender || !text) return;
-    const ts = Number(payload?.timestamp) || Date.now() / 1000;
-    markRendered(ts);
-    chat.routeChatOut(sender, text, ts);
+    chat.routeChatOut(sender, text, Number(payload?.timestamp) || Date.now() / 1000);
   }, undefined, "std_msgs/msg/String");
 
   const unsubSkill = rosClient.subscribe(SKILL_STATUS_UPDATE_TOPIC, (m) => {
@@ -315,7 +306,6 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     const key = String(payload?.primitive_id ?? payload?.skill_id ?? name);
     const reason = typeof payload?.reason === "string" ? payload.reason : "";
     const ts = Number(payload?.timestamp) || Date.now() / 1000;
-    markRendered(ts);
     chat.addSkillRun(key, name, status, ts, reason, payload?.args);
   }, undefined, "std_msgs/msg/String");
 

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -245,8 +245,8 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       if (!Array.isArray(entries) || !entries.length) return;
       lastSnapshot = raw;
       chat.replay(entries);
-    } catch {
-      // best-effort — the live stream still works without the backfill
+    } catch (err) {
+      console.warn("[chat] reconcile failed:", err);
     } finally {
       loadingHistory = false;
     }

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -23,8 +23,6 @@ import {
 import { createChatStream } from "./chatStream.js";
 import { createDirectiveControls } from "./directiveControls.js";
 
-// Free in the steady state (see loadHistory), so this only has to beat a
-// reader's patience with a missing message.
 const HISTORY_RECONCILE_MS = 30_000;
 
 const CHAT_EXAMPLES = [
@@ -231,9 +229,8 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   });
 
   // ---- history backfill ---------------------------------------------------
-  // Live topics carry only what arrives after we subscribe, so any gap leaves a
-  // hole nothing fills. Reconcile against the brain's record rather than trust
-  // the socket — in sync costs no DOM work, cheap enough to run on a timer.
+  // A topic delivers only what arrives after we subscribe, so a gap in delivery
+  // is permanent — the brain's record is the only thing that can close it.
   let loadingHistory = false;
   let newestRenderedTs = 0;
 
@@ -264,8 +261,6 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     if (s === "connected") void loadHistory();
   });
 
-  // A reconnect is not the only way to miss one, and the stale-socket watchdog
-  // needs 70s to be sure — so also reconcile on return, and slowly while read.
   const onVisible = () => {
     if (document.visibilityState === "visible") void loadHistory();
   };

--- a/webapp/js/agent/agentPanel.js
+++ b/webapp/js/agent/agentPanel.js
@@ -23,6 +23,10 @@ import {
 import { createChatStream } from "./chatStream.js";
 import { createDirectiveControls } from "./directiveControls.js";
 
+// Free in the steady state (see loadHistory), so this only has to beat a
+// reader's patience with a missing message.
+const HISTORY_RECONCILE_MS = 30_000;
+
 const CHAT_EXAMPLES = [
   "What can you see?",
   "What do you remember here?",
@@ -227,11 +231,16 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   });
 
   // ---- history backfill ---------------------------------------------------
-  // Live topics only carry messages from after we subscribe, so a fresh page
-  // load starts blank and every dropped socket leaves a hole the live stream
-  // never fills. The brain keeps the full conversation: refetch it on *every*
-  // connect and replay through the same renderers, then keep appending live.
+  // Live topics carry only what arrives after we subscribe, so any gap leaves a
+  // hole nothing fills. Reconcile against the brain's record rather than trust
+  // the socket — in sync costs no DOM work, cheap enough to run on a timer.
   let loadingHistory = false;
+  let newestRenderedTs = 0;
+
+  /** @param {number} ts */
+  function markRendered(ts) {
+    if (ts > newestRenderedTs) newestRenderedTs = ts;
+  }
 
   async function loadHistory() {
     if (loadingHistory) return;
@@ -239,7 +248,11 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     try {
       const res = await rosClient.callService(GET_CHAT_HISTORY_SERVICE, {});
       const entries = JSON.parse(res?.history ?? "[]");
-      if (Array.isArray(entries) && entries.length) chat.replay(entries);
+      if (!Array.isArray(entries) || !entries.length) return;
+      const newest = entries.reduce((max, e) => Math.max(max, Number(e?.timestamp) || 0), 0);
+      if (newest <= newestRenderedTs) return; // in sync — replaying would only jump the scroll
+      markRendered(newest);
+      chat.replay(entries);
     } catch {
       // best-effort — the live stream still works without the backfill
     } finally {
@@ -250,6 +263,14 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
   const unsubConn = rosClient.onStateChange((s) => {
     if (s === "connected") void loadHistory();
   });
+
+  // A reconnect is not the only way to miss one, and the stale-socket watchdog
+  // needs 70s to be sure — so also reconcile on return, and slowly while read.
+  const onVisible = () => {
+    if (document.visibilityState === "visible") void loadHistory();
+  };
+  document.addEventListener("visibilitychange", onVisible);
+  const historyPoll = setInterval(onVisible, HISTORY_RECONCILE_MS);
 
   // ---- live subscriptions -------------------------------------------------
   const unsubIn = rosClient.subscribe(CHAT_IN_TOPIC, (m) => {
@@ -264,7 +285,9 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     if (String(payload?.sender ?? "") !== "user") return;
     const text = String(payload?.text ?? "");
     if (!text) return;
-    chat.addMessage("user", text, Number(payload?.timestamp) || Date.now() / 1000);
+    const ts = Number(payload?.timestamp) || Date.now() / 1000;
+    markRendered(ts);
+    chat.addMessage("user", text, ts);
   }, undefined, "std_msgs/msg/String");
 
   const unsubOut = rosClient.subscribe(CHAT_OUT_TOPIC, (m) => {
@@ -279,6 +302,7 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     const text = String(payload?.text ?? "");
     if (!sender || !text) return;
     const ts = Number(payload?.timestamp) || Date.now() / 1000;
+    markRendered(ts);
     chat.routeChatOut(sender, text, ts);
   }, undefined, "std_msgs/msg/String");
 
@@ -295,7 +319,9 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
     if (!name || !status) return;
     const key = String(payload?.primitive_id ?? payload?.skill_id ?? name);
     const reason = typeof payload?.reason === "string" ? payload.reason : "";
-    chat.addSkillRun(key, name, status, Number(payload?.timestamp) || Date.now() / 1000, reason, payload?.args);
+    const ts = Number(payload?.timestamp) || Date.now() / 1000;
+    markRendered(ts);
+    chat.addSkillRun(key, name, status, ts, reason, payload?.args);
   }, undefined, "std_msgs/msg/String");
 
   return {
@@ -308,6 +334,8 @@ export function createAgentPanel(root, rosClient, agentState, opts) {
       clearInterval(placeholderInterval);
       if (placeholderSwapTimer) clearTimeout(placeholderSwapTimer);
       chat.destroy();
+      document.removeEventListener("visibilitychange", onVisible);
+      clearInterval(historyPoll);
       unsubConn();
       unsubIn();
       unsubOut();

--- a/webapp/js/agent/chatStream.js
+++ b/webapp/js/agent/chatStream.js
@@ -460,6 +460,8 @@ export function createChatStream(opts = {}) {
    *  wholesale rather than trying to merge.
    *  @param {any[]} entries */
   function replay(entries) {
+    const wasAtBottom = atBottom();
+    const priorTop = stream.scrollTop;
     stream.replaceChildren();
     for (const timer of compactEnterTimers) clearTimeout(timer);
     compactEnterTimers.clear();
@@ -475,7 +477,8 @@ export function createChatStream(opts = {}) {
       replayingHistory = false;
       stream.classList.remove("replaying");
     }
-    stream.scrollTop = stream.scrollHeight;
+    // A reconcile can land while the reader is up in the scrollback.
+    stream.scrollTop = wasAtBottom ? stream.scrollHeight : priorTop;
   }
 
   return {

--- a/webapp/js/brain/main.js
+++ b/webapp/js/brain/main.js
@@ -764,10 +764,9 @@ export function createBrainMonitor(root, opts = {}) {
   let destroyed = false;
   const demoMode = new URLSearchParams(location.search).has("demo");
 
-  // Both of these are wire-heavy, so they run only while the monitor is on
-  // screen (see setVisible), unlike the cheap status feeds: trace carries the
-  // whole request body and its frames at ~1 MB per turn, and the camera
-  // fallback pulls base64 JPEGs on a page that already streams WebRTC video.
+  // On screen only (see setVisible), unlike the cheap status feeds: trace
+  // carries the whole request body and its frames at ~1 MB per turn, and the
+  // camera fallback pulls base64 JPEGs onto a page already streaming WebRTC.
   const subscribeTrace = () => ros.subscribe("/brain/trace", jsonHandler(onTrace), 0, "std_msgs/msg/String");
 
   const subscribeCam = () =>

--- a/webapp/js/brain/main.js
+++ b/webapp/js/brain/main.js
@@ -44,9 +44,10 @@ const RING_C = 2 * Math.PI * RING_R;
 /**
  * Build the monitor into `root` (the Agent page's brain layer) and start its
  * feeds. `onRequestClose` is the monitor asking to flip back to the live view
- * (Escape with no inspector open). While hidden (`setVisible(false)`) the trace
- * feeds stay live so turn history keeps accumulating, but the animation loop
- * and the wire-heavy live-camera fallback pause.
+ * (Escape with no inspector open). While hidden (`setVisible(false)`) the cheap
+ * status feeds stay live, but the animation loop and the two wire-heavy
+ * subscriptions — the live-camera fallback and /brain/trace — pause, so turn
+ * history covers only the stretches the monitor was on screen.
  * @param {HTMLElement} root
  * @param {{ onRequestClose?: () => void }} [opts]
  * @returns {{ destroy: () => void, setVisible: (visible: boolean) => void }}
@@ -757,13 +758,18 @@ export function createBrainMonitor(root, opts = {}) {
   /** @type {(() => void) | null} */
   let camUnsub = null;
   /** @type {(() => void) | null} */
+  let traceUnsub = null;
+  /** @type {(() => void) | null} */
   let demoStop = null;
   let destroyed = false;
   const demoMode = new URLSearchParams(location.search).has("demo");
 
-  // The live-camera fallback pulls base64 JPEGs over rosbridge, on a page that
-  // already streams WebRTC video — so it runs only while the monitor is on
-  // screen (see setVisible), unlike the cheap trace/status feeds.
+  // Both of these are wire-heavy, so they run only while the monitor is on
+  // screen (see setVisible), unlike the cheap status feeds: trace carries the
+  // whole request body and its frames at ~1 MB per turn, and the camera
+  // fallback pulls base64 JPEGs on a page that already streams WebRTC video.
+  const subscribeTrace = () => ros.subscribe("/brain/trace", jsonHandler(onTrace), 0, "std_msgs/msg/String");
+
   const subscribeCam = () =>
     ros.subscribe(
       CAM_TOPIC,
@@ -784,7 +790,6 @@ export function createBrainMonitor(root, opts = {}) {
     });
   } else {
     unsubs = [
-      ros.subscribe("/brain/trace", jsonHandler(onTrace), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/agent_status", jsonHandler(onAgentStatus), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/websocket_status", jsonHandler(onBrainStatus), 0, "std_msgs/msg/String"),
       ros.subscribe("/brain/skill_status_update", jsonHandler(onSkill), 0, "std_msgs/msg/String"),
@@ -801,6 +806,7 @@ export function createBrainMonitor(root, opts = {}) {
       ),
     ];
     camUnsub = subscribeCam();
+    traceUnsub = subscribeTrace();
   }
 
   /** @param {boolean} v */
@@ -812,10 +818,15 @@ export function createBrainMonitor(root, opts = {}) {
       cancelAnimationFrame(raf);
       camUnsub?.();
       camUnsub = null;
+      traceUnsub?.();
+      traceUnsub = null;
       return;
     }
     raf = requestAnimationFrame(tickUI);
-    if (!demoMode) camUnsub = subscribeCam();
+    if (!demoMode) {
+      camUnsub = subscribeCam();
+      traceUnsub = subscribeTrace();
+    }
   }
 
   return {
@@ -828,6 +839,7 @@ export function createBrainMonitor(root, opts = {}) {
       for (const id of uiTimers) window.clearTimeout(id);
       window.removeEventListener("keydown", onKey);
       unsubs.forEach((u) => u());
+      traceUnsub?.();
       camUnsub?.();
       demoStop?.();
       document.querySelector(".connect-layer")?.classList.remove("br-hidden");

--- a/webapp/js/brain/main.js
+++ b/webapp/js/brain/main.js
@@ -764,9 +764,8 @@ export function createBrainMonitor(root, opts = {}) {
   let destroyed = false;
   const demoMode = new URLSearchParams(location.search).has("demo");
 
-  // On screen only (see setVisible), unlike the cheap status feeds: trace
-  // carries the whole request body and its frames at ~1 MB per turn, and the
-  // camera fallback pulls base64 JPEGs onto a page already streaming WebRTC.
+  // Both cost ~1 MB per turn on the wire, so they follow the monitor on screen
+  // (see setVisible) rather than run all session like the status feeds.
   const subscribeTrace = () => ros.subscribe("/brain/trace", jsonHandler(onTrace), 0, "std_msgs/msg/String");
 
   const subscribeCam = () =>

--- a/webapp/js/rosClient.js
+++ b/webapp/js/rosClient.js
@@ -19,10 +19,9 @@ const RECONNECT_BASE_MS = 1_000;
 const MAX_ORPHANED_GOALS = 8;
 const RECONNECT_CAP_MS = 10_000;
 const SUB_RETRY_CAP_MS = 30_000;
-// A half-open socket (phone asleep, WiFi roamed) never fires onclose, so the
-// client would sit in "connected" on a dead pipe until the OS TCP timeout —
-// silently, since ping/pong is invisible to page scripts. The /ws proxy emits a
-// keepalive frame every 20s; three missed in a row means the socket is gone.
+// Ping/pong is invisible to page scripts, so a half-open socket (phone asleep,
+// WiFi roamed) reads as a healthy idle one until the OS TCP timeout. The /ws
+// proxy fills the silence every 20s; three missed means the socket is gone.
 const STALE_SOCKET_MS = 70_000;
 const STALE_CHECK_MS = 15_000;
 
@@ -95,6 +94,7 @@ export class RosClient {
   /** @type {number | null} */ #connectTimer = null;
   /** @type {number | null} */ #staleTimer = null;
   /** Timestamp of the newest frame off the socket; drives the stale check. */ #lastFrameAt = 0;
+  /** Whether this socket is one the keepalive reaches — see #dropIfStale. */ #keepaliveExpected = false;
   /** True once the current target IP has had a successful open; gates the
    * reconnect-forever loop so a typo'd address fails fast instead. */
   #everConnected = false;
@@ -114,17 +114,16 @@ export class RosClient {
         publishZero();
         return;
       }
-      // Background tabs get their timers throttled or frozen, so the periodic
-      // check can't be trusted to have run while away — verify on the spot.
+      // Background tabs freeze timers, so the periodic check may never have run.
       this.#dropIfStale();
     });
   }
 
-  /** Force a reconnect when the socket has gone silent past the keepalive
-   *  budget. Closing is enough: onclose runs the normal reconnect path, which
-   *  replays subscriptions and lets consumers refetch on "connected". */
+  /** Force a reconnect once the keepalive has gone missing — closing is enough,
+   *  onclose runs the normal replay-and-refetch path. */
   #dropIfStale() {
-    if (this.#state !== "connected" || Date.now() - this.#lastFrameAt < STALE_SOCKET_MS) return;
+    if (!this.#keepaliveExpected || this.#state !== "connected") return;
+    if (Date.now() - this.#lastFrameAt < STALE_SOCKET_MS) return;
     console.warn("[ros] socket silent past the keepalive budget — reconnecting");
     this.#teardownSocket();
     this.#handleClose();
@@ -353,6 +352,8 @@ export class RosClient {
     const ip = this.#ip;
     if (!ip) return;
     this.#setState(phase);
+    // A direct rws socket gets no keepalive and is legitimately silent when idle.
+    this.#keepaliveExpected = this.#isServingHost(ip);
     let ws;
     try {
       ws = new WebSocket(this.#urlFor(ip));
@@ -396,7 +397,9 @@ export class RosClient {
         this.#send({ op: "cancel_action_goal", id: goal.id, action: goal.action, goal_id: goal.goalId });
       }
       this.#lastFrameAt = Date.now();
-      this.#staleTimer = setInterval(() => this.#dropIfStale(), STALE_CHECK_MS);
+      if (this.#keepaliveExpected) {
+        this.#staleTimer = setInterval(() => this.#dropIfStale(), STALE_CHECK_MS);
+      }
       this.#setState("connected");
     };
 

--- a/webapp/js/rosClient.js
+++ b/webapp/js/rosClient.js
@@ -19,6 +19,12 @@ const RECONNECT_BASE_MS = 1_000;
 const MAX_ORPHANED_GOALS = 8;
 const RECONNECT_CAP_MS = 10_000;
 const SUB_RETRY_CAP_MS = 30_000;
+// A half-open socket (phone asleep, WiFi roamed) never fires onclose, so the
+// client would sit in "connected" on a dead pipe until the OS TCP timeout —
+// silently, since ping/pong is invisible to page scripts. The /ws proxy emits a
+// keepalive frame every 20s; three missed in a row means the socket is gone.
+const STALE_SOCKET_MS = 70_000;
+const STALE_CHECK_MS = 15_000;
 
 /**
  * True when a value carries no actual data: null/undefined, or an object/array
@@ -87,6 +93,8 @@ export class RosClient {
   #reconnectDelay = RECONNECT_BASE_MS;
   /** @type {number | null} */ #reconnectTimer = null;
   /** @type {number | null} */ #connectTimer = null;
+  /** @type {number | null} */ #staleTimer = null;
+  /** Timestamp of the newest frame off the socket; drives the stale check. */ #lastFrameAt = 0;
   /** True once the current target IP has had a successful open; gates the
    * reconnect-forever loop so a typo'd address fails fast instead. */
   #everConnected = false;
@@ -102,8 +110,24 @@ export class RosClient {
     };
     window.addEventListener("pagehide", publishZero);
     document.addEventListener("visibilitychange", () => {
-      if (document.visibilityState === "hidden") publishZero();
+      if (document.visibilityState === "hidden") {
+        publishZero();
+        return;
+      }
+      // Background tabs get their timers throttled or frozen, so the periodic
+      // check can't be trusted to have run while away — verify on the spot.
+      this.#dropIfStale();
     });
+  }
+
+  /** Force a reconnect when the socket has gone silent past the keepalive
+   *  budget. Closing is enough: onclose runs the normal reconnect path, which
+   *  replays subscriptions and lets consumers refetch on "connected". */
+  #dropIfStale() {
+    if (this.#state !== "connected" || Date.now() - this.#lastFrameAt < STALE_SOCKET_MS) return;
+    console.warn("[ros] socket silent past the keepalive budget — reconnecting");
+    this.#teardownSocket();
+    this.#handleClose();
   }
 
   /** @returns {ConnState} */
@@ -371,6 +395,8 @@ export class RosClient {
       for (const goal of this.#orphanedGoals.splice(0)) {
         this.#send({ op: "cancel_action_goal", id: goal.id, action: goal.action, goal_id: goal.goalId });
       }
+      this.#lastFrameAt = Date.now();
+      this.#staleTimer = setInterval(() => this.#dropIfStale(), STALE_CHECK_MS);
       this.#setState("connected");
     };
 
@@ -391,6 +417,7 @@ export class RosClient {
 
   #handleClose() {
     this.#clearConnectTimer();
+    this.#clearStaleTimer();
     this.#ws = null;
     this.#rejectAllPending(new Error("Connection closed"));
     for (const sub of this.#subs.values()) {
@@ -417,6 +444,7 @@ export class RosClient {
 
   /** @param {string} raw */
   #handleFrame(raw) {
+    this.#lastFrameAt = Date.now();
     /** @type {any} */
     let data;
     try {
@@ -566,6 +594,7 @@ export class RosClient {
 
   #teardownSocket() {
     this.#clearConnectTimer();
+    this.#clearStaleTimer();
     const ws = this.#ws;
     this.#ws = null;
     if (ws) {
@@ -587,6 +616,13 @@ export class RosClient {
       this.#reconnectTimer = null;
     }
     this.#reconnectDelay = RECONNECT_BASE_MS;
+  }
+
+  #clearStaleTimer() {
+    if (this.#staleTimer !== null) {
+      clearInterval(this.#staleTimer);
+      this.#staleTimer = null;
+    }
   }
 
   #clearConnectTimer() {

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -93,8 +93,8 @@ WORLD_STATE_URL = f"ws://{_WORLD_HOST}:{WORLD_STATE_PORT}"
 # the 10s deadline was closing healthy sockets that share WiFi with the streams.
 WS_HEARTBEAT = 60.0
 
-# Cadence of the JS-visible keepalive (see _keepalive). The webapp is served by
-# this same process, so client and server always agree on it.
+# Cadence of the JS-visible keepalive (see _keepalive). This process serves the
+# webapp too, so client and server never disagree on it.
 WS_KEEPALIVE = 20.0
 _KEEPALIVE_FRAME = json.dumps({"op": "keepalive"})
 
@@ -448,12 +448,10 @@ async def _pump(src: "web.WebSocketResponse | aiohttp.ClientWebSocketResponse", 
 
 
 async def _keepalive(ws: web.WebSocketResponse) -> None:
-    """Emit a frame the *browser's JavaScript* can see, forever.
+    """Emit a frame the browser's *JavaScript* can see.
 
-    WebSocket ping/pong is invisible to page scripts, so an idle-but-healthy
-    socket and a half-open dead one look identical to rosClient — it cannot
-    distinguish them without something arriving on a schedule. rosClient treats
-    a long gap in these as a dead socket and reconnects (see WS_KEEPALIVE).
+    Ping/pong never reaches page scripts, so without this an idle socket and a
+    dead one are indistinguishable to rosClient, which reconnects on the gap.
     """
     while True:
         await asyncio.sleep(WS_KEEPALIVE)
@@ -472,8 +470,7 @@ async def ws_proxy(request: web.Request) -> web.WebSocketResponse:
     try:
         async with session.ws_connect(upstream_url, max_msg_size=0, heartbeat=WS_HEARTBEAT) as upstream:
             tasks = [asyncio.create_task(_pump(ws, upstream)), asyncio.create_task(_pump(upstream, ws))]
-            # Only the rosbridge leg: the sim viewer's world-state parser has no
-            # reason to tolerate a frame that isn't world state.
+            # Not /worldstate: the sim viewer parses only world state.
             if not worldstate:
                 tasks.append(asyncio.create_task(_keepalive(ws)))
             _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -93,8 +93,6 @@ WORLD_STATE_URL = f"ws://{_WORLD_HOST}:{WORLD_STATE_PORT}"
 # the 10s deadline was closing healthy sockets that share WiFi with the streams.
 WS_HEARTBEAT = 60.0
 
-# Cadence of the JS-visible keepalive (see _keepalive). This process serves the
-# webapp too, so client and server never disagree on it.
 WS_KEEPALIVE = 20.0
 _KEEPALIVE_FRAME = json.dumps({"op": "keepalive"})
 

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -93,6 +93,11 @@ WORLD_STATE_URL = f"ws://{_WORLD_HOST}:{WORLD_STATE_PORT}"
 # the 10s deadline was closing healthy sockets that share WiFi with the streams.
 WS_HEARTBEAT = 60.0
 
+# Cadence of the JS-visible keepalive (see _keepalive). The webapp is served by
+# this same process, so client and server always agree on it.
+WS_KEEPALIVE = 20.0
+_KEEPALIVE_FRAME = json.dumps({"op": "keepalive"})
+
 
 def _quiet_benign_disconnects() -> None:
     """Drop the traceback aiohttp logs when a client vanishes mid-request —
@@ -442,17 +447,35 @@ async def _pump(src: "web.WebSocketResponse | aiohttp.ClientWebSocketResponse", 
             break
 
 
+async def _keepalive(ws: web.WebSocketResponse) -> None:
+    """Emit a frame the *browser's JavaScript* can see, forever.
+
+    WebSocket ping/pong is invisible to page scripts, so an idle-but-healthy
+    socket and a half-open dead one look identical to rosClient — it cannot
+    distinguish them without something arriving on a schedule. rosClient treats
+    a long gap in these as a dead socket and reconnects (see WS_KEEPALIVE).
+    """
+    while True:
+        await asyncio.sleep(WS_KEEPALIVE)
+        await ws.send_str(_KEEPALIVE_FRAME)
+
+
 async def ws_proxy(request: web.Request) -> web.WebSocketResponse:
     """Bidirectional relay: /ws <-> rosbridge, /worldstate <-> the sim world
     server's observer stream. max_msg_size=0 lifts aiohttp's default cap for the
     large point-cloud / world-state frames."""
     ws = web.WebSocketResponse(max_msg_size=0, heartbeat=WS_HEARTBEAT)
     await ws.prepare(request)
-    upstream_url = WORLD_STATE_URL if request.path == "/worldstate" else ROSBRIDGE_URL
+    worldstate = request.path == "/worldstate"
+    upstream_url = WORLD_STATE_URL if worldstate else ROSBRIDGE_URL
     session = request.app[CLIENT]
     try:
         async with session.ws_connect(upstream_url, max_msg_size=0, heartbeat=WS_HEARTBEAT) as upstream:
             tasks = [asyncio.create_task(_pump(ws, upstream)), asyncio.create_task(_pump(upstream, ws))]
+            # Only the rosbridge leg: the sim viewer's world-state parser has no
+            # reason to tolerate a frame that isn't world state.
+            if not worldstate:
+                tasks.append(asyncio.create_task(_keepalive(ws)))
             _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
             for task in pending:
                 task.cancel()


### PR DESCRIPTION
Three independent faults were making the agent chat drift out of sync with what the robot was actually doing. They look like one bug from the outside — "the chat stops updating and only a reload fixes it" — but they have separate causes and separate fixes.

None of them are regressions from recent work; all three predate #717.

---

## 1. A dead socket the client never noticed

**Symptom.** Mid-conversation the chat stops updating. The robot keeps working — a reload shows everything that was missed. No error, no disconnect indicator.

**Cause.** `rosClient` reconnects correctly *when it is told the socket closed*. The problem is the case where it never is. When a TCP connection dies without a FIN — phone sleeps, WiFi roams, the proxy restarts abruptly — the browser sits at `readyState === OPEN` until the OS TCP timeout, which on mobile can be many minutes or effectively never while suspended.

The reason the client can't tell: **WebSocket ping/pong is invisible to page scripts.** The `/ws` relay pings every 60s and the browser's network stack answers automatically, but JavaScript sees none of it. So an idle-but-healthy socket and a half-open dead one are literally indistinguishable at the JS layer — silence proves nothing.

The consequence is that `onclose` never fires, `#handleClose` never runs, state stays `"connected"`, `onStateChange` never emits — and therefore the history refetch added in #717 **never gets a chance to run.** That fix only heals drops the client observes; this is the class it can't see.

**Fix, part one — stop trusting the socket.** The panel now reconciles against the brain's own record: on reconnect, on tab wake, and every 30s while the tab is visible. A snapshot whose newest entry is not newer than what is already on screen costs one service call and no DOM work:

```js
const raw = String(res?.history ?? "");
if (raw === lastSnapshot) return;
```

Comparing the snapshot to the last one replayed is deliberately dumb. An earlier version of this compared timestamps — newest-in-history against newest-rendered — and it latched itself off: a skill republishing `running` is many card updates on screen but one deduped history entry, so the rendered clock ran permanently ahead of anything the snapshot could contain, and the reconcile then skipped every poll for the rest of the session. Nothing the live stream does can move a string comparison.

This is the fix that matters, because it does not care *why* a message went missing — dead socket, dropped frame, a cause not yet found. It converges regardless.

Replaying more often is the cost, so `replay()` now keeps the reader's scroll position unless they were already at the bottom, and a failed reconcile logs instead of being swallowed.

It also improves the reconnect path from #717: that one rebuilt the whole transcript and yanked the reader to the bottom even when nothing had been missed.

**Fix, part two — notice the dead socket anyway.** Reconciliation heals the transcript but leaves the socket dead, so subscriptions, publishes and action goals stay broken until something reconnects. The `/ws` relay now emits `{"op":"keepalive"}` every 20s — a normal text frame, so `#handleFrame` sees it and stamps `#lastFrameAt` — and `rosClient` reconnects once three in a row are missed.

Three details:

- **Proxied sockets only.** `#urlFor` connects directly to `ws://<ip>:9090` when the target is not the serving host, and rws sends no keepalive. Arming the watchdog there would tear down healthy idle connections every 70s, so `#keepaliveExpected` gates it. Direct connections keep today's behaviour — no liveness detection, but no false teardowns. (Caught in review; see 6995023b.)
- **Also checked on tab wake.** Background tabs freeze timers, so the periodic check cannot be trusted to have run while away.
- **Not on `/worldstate`.** The sim viewer's parser has no reason to tolerate a frame that isn't world state.

Client and server never disagree on the cadence, because the webapp is served by the same process that sends the keepalive. Verified against the live proxy: keepalives arrive at 20.0s intervals.

---

## 2. Skill cards vanished on refresh

**Symptom.** Skill cards ("navigate to position — Failed", "drop in box — Failed") render live but disappear on reload. Chat messages survive; only the cards are lost.

**Cause.** There are two writers for skill status, and only one recorded history:

- **Manual runs** (pressing a skill in the app) went through `_on_manual_skill_event`, which appended a `task_activated` entry.
- **Agent-run skills** go through `runner.py`, which publishes to `/brain/skill_status_update` for the live UI and never touches `chat.history`.

That isn't an oversight in the runner so much as a process boundary: the runner deliberately leaves the echo to the skills server (see the comments at `runner.py:66` and `:182`), and the skills server is a **different node in a different process** — it has no way to reach the brain node's chat history. It also never publishes terminal events for agent runs itself; the action server does.

Measured on the live robot, a session's history read:

```
user            91
skill_output    30
system           6
robot            5
task_activated   0     ← every card the agent ran
```

**Fix.** The brain node now subscribes to `/brain/skill_status_update` and records from there. That is the one place every run appears regardless of who started it, and it is the only place carrying `args` — which the cards need for their parameter line (`x 2.65 m · y 4.23 m · −1° · Map`), and which the old manual-only entries were dropping anyway. Both publishers can announce the same run, so entries are deduped on `(run id, status)` over a bounded window.

---

## 3. Room tone became chat messages

**Symptom.** A small bubble containing a single `.` appears in the transcript.

**Cause.** Not a rendering artifact — a real `user` entry with text `"."`. The recogniser punctuates ambient noise, and nothing filtered it: the STT paths only `.strip()` their result, so a punctuation-only transcript is published like any other utterance. Each one also costs the agent a turn answering nobody.

**Fix.** Drop transcripts with no letter or digit anywhere, at `_handle_device_data` — the single point every input device routes through, so it covers all STT backends and any workspace input at once. `"."`, `"?"`, `"..."` are dropped; `"ok"`, `"3"`, `"Mm-hmm."`, `"ça va"` all pass.

---

## 4. Lines the robot spoke aloud never reached the transcript

**Symptom.** The robot says something over the speaker — "Got it.", "Here is the second red sock" — and nothing appears in the chat. Not a sync gap: it was never published, so a reload doesn't recover it either.

**Cause.** `Skill.say()` publishes to `/brain/tts`, and that handler called `chat.speak(text)`. `speak()` only forwards to the TTS engine; it is `emit()` that appends to history *and* publishes `chat_out`. So every line a skill voiced was audible and invisible.

`pick_any_object` alone says five of them ("Looking for {prompt}.", "Picking it up.", "Got it.", "I couldn't get a grip on it.", "My arm isn't responding properly, stopping."), and `follow_aruco` two more.

**Fix.** `_on_tts` emits instead of speaking. `speak` defaults to `True` for the `ROBOT` sender, so the audio path is byte-identical — the line just now also lands in history and on `chat_out`. `_on_environment_speech` already worked this way; its docstring ("the line reaches the chat as the voice starts") is the contract `_on_tts` was missing.

No double-publish risk: the agent's own replies reach TTS in-process through `SpeechStreamer`, never over `/brain/tts`.

---

## Also included

The Brain monitor kept its `/brain/trace` subscription forever once opened — `setVisible(false)` paused the animation loop and the camera fallback but not the heaviest feed. Measured at **627 KB mean / 748 KB max** per `turn_request` and ~230 KB/s sustained, that meant a hidden monitor parsed ~1 MB of JSON every few seconds for the rest of the session. It now follows the same on-screen-only rule as the camera fallback.

Tradeoff: turn history now covers only the stretches the monitor was actually on screen. The docstring says so.

---

## Verification

- `ruff check` + `ruff format --check` — clean
- `pytest` — 281 passed
- `basedpyright` — 15 errors, byte-identical before and after, none in the touched files
- `tsc --noEmit` — 34 errors in `js/`, identical before and after, none new

Behavioural checks against the live robot: the history service contents above, the trace payload sizes, the keepalive cadence off the running proxy (20.0s, confirmed with a websocket client), and history payload size for the poll (17.4 KB / 92 entries, ~194 B/entry).

**Not verified end-to-end in a browser:** the reconciliation healing a real stall. That needs a hard reload to pick up the new `rosClient.js` and `agentPanel.js`, then a stall to occur. The signature to look for is a missing message appearing on its own within 30s instead of needing F5.

**Known follow-up:** `ChatManager.history` is unbounded, so the poll's payload grows over a session. Fine for hours at 194 B/entry, but bounding it — or adding a cheap newest-timestamp service so the poll need not pull the whole transcript — is the clean next step.



