### PR TITLE
test: smoke-test the auto code-review hook (do not merge)

### DIFF
--- a/docs/PR_REVIEW_SMOKE_TEST.md
+++ b/docs/PR_REVIEW_SMOKE_TEST.md
@@ -1,0 +1,4 @@
+# PR review smoke test
+
+Throwaway file used to verify that the local auto code-review hook fires on
+`gh pr create`. Safe to delete — this PR is not meant to be merged.


### PR DESCRIPTION
Throwaway PR to verify the local auto code-review hook fires on `gh pr create`. Adds one markdown file, no code paths touched. Will be closed as soon as the test is done — please ignore.