### PR TITLE
fix(webapp): draw the mapfree route in the map frame

### DIFF
--- a/webapp/js/map/mapWidget.js
+++ b/webapp/js/map/mapWidget.js
@@ -976,14 +976,33 @@ export function createMap(root, opts = {}) {
   /** @type {string | null} */
   let activePlanTopic = null;
 
+  // The map<-odom correction implied by the composed (map-frame) pose vs raw
+  // odom — identity until AMCL's first fix, when the frames coincide.
+  function mapFromOdom() {
+    if (!pose || !odomPose) return { theta: 0, tx: 0, ty: 0 };
+    const theta = pose.yaw - odomPose.yaw;
+    const c = Math.cos(theta);
+    const s = Math.sin(theta);
+    return { theta, tx: pose.x - (odomPose.x * c - odomPose.y * s), ty: pose.y - (odomPose.x * s + odomPose.y * c) };
+  }
+
   /** @param {string} topic @param {any} msg nav_msgs/Path */
   function onPlan(topic, msg) {
     const poses = msg?.poses;
     if (!Array.isArray(poses)) return;
+    // The mapfree planner's costmap is in the ODOM frame (costmap.yaml), so its
+    // route — and the goal marker taken from its endpoint — needs the map<-odom
+    // correction before it can share the map canvas.
+    const frameId = typeof msg?.header?.frame_id === "string" ? msg.header.frame_id : "";
+    const { theta, tx, ty } = frameId.includes("odom") ? mapFromOdom() : { theta: 0, tx: 0, ty: 0 };
+    const c = Math.cos(theta);
+    const s = Math.sin(theta);
     const pts = [];
     for (const ps of poses) {
       const pos = ps?.pose?.position;
-      if (typeof pos?.x === "number" && typeof pos?.y === "number") pts.push({ x: pos.x, y: pos.y });
+      if (typeof pos?.x === "number" && typeof pos?.y === "number") {
+        pts.push({ x: tx + pos.x * c - pos.y * s, y: ty + pos.x * s + pos.y * c });
+      }
     }
     if (pts.length) {
       activePlanTopic = topic;
@@ -995,7 +1014,7 @@ export function createMap(root, opts = {}) {
         const end = poses[poses.length - 1]?.pose;
         const q = end?.orientation;
         if (q) {
-          const yaw = Math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z));
+          const yaw = theta + Math.atan2(2 * (q.w * q.z + q.x * q.y), 1 - 2 * (q.y * q.y + q.z * q.z));
           goalMarker = { x: pts[pts.length - 1].x, y: pts[pts.length - 1].y, yaw };
         }
       }
@@ -1125,20 +1144,9 @@ export function createMap(root, opts = {}) {
       ctx.drawImage(costOff, topLeft.px, topLeft.py, costGrid.width * cellPx, costGrid.height * cellPx);
     }
 
-    // Local costmap: its coordinates are in the ODOM frame, so place it via
-    // the map<-odom correction implied by the composed (map-frame) pose vs
-    // raw odom — identity until AMCL's first fix, when the frames coincide.
+    // Local costmap: its coordinates are in the ODOM frame.
     if (layers.local && localGrid) {
-      let theta = 0;
-      let tx = 0;
-      let ty = 0;
-      if (pose && odomPose) {
-        theta = pose.yaw - odomPose.yaw;
-        const c = Math.cos(theta);
-        const s = Math.sin(theta);
-        tx = pose.x - (odomPose.x * c - odomPose.y * s);
-        ty = pose.y - (odomPose.x * s + odomPose.y * c);
-      }
+      const { theta, tx, ty } = mapFromOdom();
       const c = Math.cos(theta);
       const s = Math.sin(theta);
       // The image's top-left corner (max-y edge, matching the row flip) in


### PR DESCRIPTION
## Problem

On the real robot, the Nav map showed the planned route and the green target far from the robot — out in unexplored space — while the robot itself navigated fine. The laser-scan overlay (drawn from the widget's own robot pose) lined up with the walls, so the robot marker was right; only the route and its endpoint were displaced.

## Cause

The map widget subscribes to both `/navigation/plan` and `/mapfree/plan`. The mapfree planner's costmap is `global_frame: odom` (`costmap.yaml`), so its route arrives in **odom** coordinates. `onPlan` ignored `header.frame_id`, drew the points straight onto the map canvas, and — when no `/nav/commanded_goal` had arrived — moved the goal marker to that odom-frame endpoint. Every agent-driven move goes through the mapfree planner (`mobility.py` / `navigate_to_position.py` send `behavior_tree="mapfree"`), so this showed on every "go forward 1 m". It never showed in sim because map←odom is identity there.

The teleop camera overlay (`trajectoryOverlay.js`) already checked the frame; the map widget didn't.

## Fix

- Extract the map←odom correction the widget already computed for the local costmap into `mapFromOdom()`.
- `onPlan` checks `frame_id`; odom-frame routes (and the fallback goal marker's position + yaw) are transformed into the map frame before display. Map-frame routes are untouched.
- The local-costmap block reuses the helper.

## Verification

- ES-module syntax check passes; `tsc --checkJs` on the file reports the same 5 pre-existing errors elsewhere in the webapp before and after, none in `mapWidget.js`.
- To confirm on hardware: ask the agent to "go forward 1 m" while watching the Nav map — the blue route should now start under the robot sprite.