### PR TITLE
sim: self-contained demo image for per-session hosting

### DIFF
--- a/.github/workflows/publish-sim-demo.yml
+++ b/.github/workflows/publish-sim-demo.yml
@@ -1,0 +1,68 @@
+name: Publish Sim Demo Image
+
+# The image the sim-broker hands to visitors. Nothing built it before, so its
+# tag was moved by hand and went stale silently -- a demo four hours behind main
+# looks fine, it is just not what you shipped.
+#
+# SECURITY: mirrors publish-sim-images.yml. Triggers stay push +
+# workflow_dispatch ONLY -- never pull_request or pull_request_target, which
+# would let a fork's code mint GCP credentials. Jobs are additionally guarded on
+# repository and event name.
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/publish-sim-demo.yml
+      - ci/cloudbuild.sim-demo.yaml
+      - sim/demo/**
+      - sim/launcher/config.py
+      - ros2_ws/src/**
+      - webapp/**
+      - workspace/**
+  workflow_dispatch:
+
+concurrency:
+  group: publish-sim-demo
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository == 'innate-inc/innate-os' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Submit Cloud Build
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short HEAD)"
+          # Only main moves `latest`; a workflow_dispatch on a branch publishes
+          # its sha and nothing else.
+          latest_tag=""
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            latest_tag="latest"
+          fi
+
+          gcloud builds submit \
+            --project="${{ vars.GCP_PROJECT_ID }}" \
+            --region="${{ vars.GCP_REGION }}" \
+            --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \
+            --service-account="projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_CLOUD_BUILD_SERVICE_ACCOUNT }}" \
+            --config=ci/cloudbuild.sim-demo.yaml \
+            --substitutions="_IMAGE_TAG=sha-${short_sha},_LATEST_TAG=${latest_tag},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }}"
+
+          echo "Published sha-${short_sha}${latest_tag:+ and }${latest_tag}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-sim-demo.yml
+++ b/.github/workflows/publish-sim-demo.yml
@@ -1,13 +1,8 @@
 name: Publish Sim Demo Image
 
-# The image the sim-broker hands to visitors. Nothing built it before, so its
-# tag was moved by hand and went stale silently -- a demo four hours behind main
-# looks fine, it is just not what you shipped.
-#
-# SECURITY: mirrors publish-sim-images.yml. Triggers stay push +
-# workflow_dispatch ONLY -- never pull_request or pull_request_target, which
-# would let a fork's code mint GCP credentials. Jobs are additionally guarded on
-# repository and event name.
+# The image the sim-broker hands to visitors.
+# SECURITY: as publish-sim-images.yml -- push + workflow_dispatch only, never
+# pull_request*, which would let a fork mint GCP credentials.
 on:
   push:
     branches: [main]
@@ -50,8 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           short_sha="$(git rev-parse --short HEAD)"
-          # Only main moves `latest`; a workflow_dispatch on a branch publishes
-          # its sha and nothing else.
+          # Only main moves `latest`.
           latest_tag=""
           if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             latest_tag="latest"

--- a/ci/cloudbuild.sim-demo.yaml
+++ b/ci/cloudbuild.sim-demo.yaml
@@ -1,10 +1,5 @@
-# Builds the public sim demo image -- the one the broker hands to visitors.
-#
-# On Cloud Build rather than a GitHub runner because the image is ~9GB and
-# pulls three more (ros, assets, viewer) to assemble it. The build itself is
-# sim/demo/build.sh unchanged: it resolves the content-addressed asset and
-# viewer tags from sim/launcher/config.py, which is what keeps the demo showing
-# the same apartment a dev checkout does.
+# The public sim demo image, via sim/demo/build.sh. Cloud Build rather than a
+# runner: ~9GB, assembled from three more.
 timeout: 7200s
 
 substitutions:
@@ -12,7 +7,7 @@ substitutions:
   _IMAGE_TAG: manual
   _GHCR_USERNAME_SECRET: innate-os-sim-ghcr-username
   _GHCR_TOKEN_SECRET: innate-os-sim-ghcr-token
-  # Only main moves it. A one-off build must not become what every visitor gets.
+  # Only main moves it.
   _LATEST_TAG: ""
 
 steps:
@@ -28,9 +23,7 @@ steps:
       - -c
       - |
         set -euo pipefail
-        # The three base images live on GHCR and are private.
         echo "$$GHCR_TOKEN" | docker login ghcr.io -u "$$GHCR_USERNAME" --password-stdin
-        # buildx with a container driver: --push and registry cache need it.
         docker buildx create --use --driver docker-container --name demo >/dev/null
         sim/demo/build.sh --push
 

--- a/ci/cloudbuild.sim-demo.yaml
+++ b/ci/cloudbuild.sim-demo.yaml
@@ -1,0 +1,47 @@
+# Builds the public sim demo image -- the one the broker hands to visitors.
+#
+# On Cloud Build rather than a GitHub runner because the image is ~9GB and
+# pulls three more (ros, assets, viewer) to assemble it. The build itself is
+# sim/demo/build.sh unchanged: it resolves the content-addressed asset and
+# viewer tags from sim/launcher/config.py, which is what keeps the demo showing
+# the same apartment a dev checkout does.
+timeout: 7200s
+
+substitutions:
+  _IMAGE: us-central1-docker.pkg.dev/innate-managed-infra/sim/innate-os-sim-demo
+  _IMAGE_TAG: manual
+  _GHCR_USERNAME_SECRET: innate-os-sim-ghcr-username
+  _GHCR_TOKEN_SECRET: innate-os-sim-ghcr-token
+  # Only main moves it. A one-off build must not become what every visitor gets.
+  _LATEST_TAG: ""
+
+steps:
+  - id: build-and-push-sim-demo
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    secretEnv: [GHCR_TOKEN, GHCR_USERNAME]
+    env:
+      - IMAGE=${_IMAGE}
+      - TAG=${_IMAGE_TAG}
+      - LATEST_TAG=${_LATEST_TAG}
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        # The three base images live on GHCR and are private.
+        echo "$$GHCR_TOKEN" | docker login ghcr.io -u "$$GHCR_USERNAME" --password-stdin
+        # buildx with a container driver: --push and registry cache need it.
+        docker buildx create --use --driver docker-container --name demo >/dev/null
+        sim/demo/build.sh --push
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/${_GHCR_TOKEN_SECRET}/versions/latest
+      env: GHCR_TOKEN
+    - versionName: projects/$PROJECT_ID/secrets/${_GHCR_USERNAME_SECRET}/versions/latest
+      env: GHCR_USERNAME
+
+options:
+  machineType: E2_HIGHCPU_32
+  diskSizeGb: 200
+  logging: CLOUD_LOGGING_ONLY

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -120,11 +120,8 @@ if TYPE_CHECKING:
 
 
 def repo_root() -> Path:
-    """The innate-os tree this module belongs to, found by walking up for the
-    two directories that mark it. A fixed parents[N] cannot do this: colcon
-    installs this file deeper than a dev checkout, where the same index lands on
-    ros2_ws/install and every path built from it -- props, challenges -- resolves
-    to a directory that does not exist, silently and with no error."""
+    """Walk up to the tree that holds sim/ and ros2_ws/. A fixed parents[N] lands
+    on ros2_ws/install once colcon has installed this file, silently."""
     here = Path(__file__).resolve()
     for candidate in here.parents:
         if (candidate / "sim").is_dir() and (candidate / "ros2_ws").is_dir():

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -120,9 +120,16 @@ if TYPE_CHECKING:
 
 
 def repo_root() -> Path:
-    """Best-effort repo root for dev checkouts (this file lives at
-    ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py)."""
-    return Path(__file__).resolve().parents[5]
+    """The innate-os tree this module belongs to, found by walking up for the
+    two directories that mark it. A fixed parents[N] cannot do this: colcon
+    installs this file deeper than a dev checkout, where the same index lands on
+    ros2_ws/install and every path built from it -- props, challenges -- resolves
+    to a directory that does not exist, silently and with no error."""
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / "sim").is_dir() and (candidate / "ros2_ws").is_dir():
+            return candidate
+    return here.parents[5]
 
 
 def default_assets_dir() -> Path:

--- a/sim/demo/Dockerfile
+++ b/sim/demo/Dockerfile
@@ -1,21 +1,6 @@
 # syntax=docker/dockerfile:1.7
-#
-# The public sim demo image: one self-contained container that IS a full sim
-# session. No bind mounts, no host process, no launcher -- start it, route :80,
-# throw it away. That is what makes it schedulable on a per-session platform
-# (Fly Machines, Cloudflare Containers, a slot on your own box).
-#
-# It differs from the dev sim (sim/docker-compose.dev.yml) in three ways:
-#   1. the MuJoCo world server runs IN here (sim_driver.launch.py's documented
-#      VIRTUAL_MARS_REMOTE escape hatch) -- the host-side rule buys native GL,
-#      which a headless cloud instance does not have to begin with;
-#   2. every source tree and asset is baked in, not mounted;
-#   3. nothing that writes is exposed: no .env, no ssh/git credentials, no
-#      settings POST, no /restart.
-#
-# Build with sim/demo/build.sh -- it resolves the asset/viewer image tags the
-# same way the launcher does, so this never drifts from what `./innate-sim up`
-# would install.
+# The public sim demo: one container that is a whole session, world server
+# included (VIRTUAL_MARS_REMOTE). Build with sim/demo/build.sh; see README.md.
 
 ARG ROS_IMAGE=ghcr.io/innate-inc/innate-os-sim-ros:main
 ARG ASSETS_IMAGE=ghcr.io/innate-inc/innate-os-sim-assets:main
@@ -28,12 +13,8 @@ FROM ${ROS_IMAGE} AS demo
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# The rendering libraries sim/README.md tells a Linux host to install. They are
-# absent from the dev image because the dev sim renders on the host; hosting the
-# world in here moves that prerequisite in here too. `import mujoco` builds the
-# MUJOCO_GL context at import time, so a missing libOSMesa fails the build, not
-# the first render. libegl1/libgl1/libopengl0 are for the MUJOCO_GL=egl path on
-# a GPU instance.
+# The world renders in here, not on a host. `import mujoco` opens the GL
+# context at import time, so a missing libOSMesa fails the build, not a session.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -42,17 +23,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libgl1 \
         libopengl0
 
-# The dev image deliberately ships no MuJoCo -- its driver node is a pure RPC
-# client and the world runs on the host. The demo hosts the world itself, so it
-# needs the physics. numpy/pillow/websockets are already in the base; the pin
-# keeps mujoco on the base image's numpy<2.
+# The pin keeps mujoco on the base image's numpy<2.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     uv pip install --system 'mujoco>=3.2,<4'
 
 WORKDIR /root/innate-os
 
-# Source. Ordered least- to most-churning so an edit to workspace/ or webapp/
-# does not reinstall the ROS workspace above it.
+# Least- to most-churning, so a webapp edit does not rebuild the workspace.
 COPY ros2_ws /root/innate-os/ros2_ws
 COPY scripts /root/innate-os/scripts
 COPY config /root/innate-os/config
@@ -62,22 +39,16 @@ COPY sim/props /root/innate-os/sim/props
 COPY sim/challenges /root/innate-os/sim/challenges
 COPY sim/demo /root/innate-os/sim/demo
 
-# Generated geometry + the viewer bundle, straight off the images the launcher
-# installs from on a dev machine (assets layer `work` -> sim/assets, layer
-# `viewer` -> the viewer's public assets).
+# Generated geometry and the viewer bundle, from the images the launcher installs.
 COPY --from=assets /work /root/innate-os/sim/assets
 COPY --from=assets /viewer /root/innate-os/sim/viewer/public
 COPY --from=viewer /bundle /root/innate-os/sim/viewer/dist-lib
 
-# data/ is runtime state (maps, robot_info.json), gitignored and absent from the
-# build context; the dev sim gets it as a bind mount.
+# Runtime state the dev sim bind-mounts; gitignored, so absent from the context.
 RUN mkdir -p /root/innate-os/data/maps
 
-# Skill assets (replay episodes) are declared in each skill's metadata.json and
-# fetched by post_update.sh on hardware, ensure_skill_assets() for the dev sim.
-# The demo runs neither, so a replay skill like wave shipped with no episode:
-# in_training, and the launcher hides it. Bake them in -- a session container
-# has no reason to reach the internet at boot.
+# Replay episodes are fetched by post_update.sh on hardware and by the dev
+# launcher; the demo runs neither, and a skill without its episode is hidden.
 RUN python3 - <<'PY'
 import json, urllib.request
 from pathlib import Path
@@ -94,11 +65,9 @@ for meta_file in sorted(workspace.glob("*_skills/*/metadata.json")):
             dest.write_bytes(response.read())
 PY
 
-# Reuse the install tree sim/Dockerfile.ros-prebuilt baked into the base -- but
-# only when it was built from THIS source. The base tracks main; a demo built
-# off a branch would otherwise ship main's binaries against the branch's source
-# and fail in ways that look like anything but a stale build. Same source digest
-# the prebuilt stage writes, so the two are comparable by construction.
+# Reuse the base's prebuilt install only if it was built from this exact source:
+# the base tracks main, and main's binaries against a branch's source fail in
+# ways that look like anything but a stale build.
 RUN --mount=type=cache,target=/root/.cache/ccache,sharing=locked \
     set -e; \
     prebuilt=/opt/innate-os-prebuilt/ros2_ws; \
@@ -128,9 +97,8 @@ ENV INNATE_OS_ROOT=/root/innate-os \
     INNATE_WEBAPP_READONLY=1 \
     INNATE_DEMO_LEASE_SECONDS=600
 
-# LAST: the cache key hashes every asset file's mtime+size, so any COPY after
-# this silently invalidates the .mjb and puts a multi-minute compile back on the
-# session-start path.
+# Last: the cache key hashes asset mtimes, so any COPY after this silently
+# puts a multi-minute compile back on the session-start path.
 RUN source /opt/ros/humble/setup.bash && \
     source /root/innate-os/ros2_ws/install/setup.bash && \
     python3 /root/innate-os/sim/demo/prewarm_model.py

--- a/sim/demo/Dockerfile
+++ b/sim/demo/Dockerfile
@@ -59,6 +59,7 @@ COPY config /root/innate-os/config
 COPY workspace /root/innate-os/workspace
 COPY webapp /root/innate-os/webapp
 COPY sim/props /root/innate-os/sim/props
+COPY sim/challenges /root/innate-os/sim/challenges
 COPY sim/demo /root/innate-os/sim/demo
 
 # Generated geometry + the viewer bundle, straight off the images the launcher

--- a/sim/demo/Dockerfile
+++ b/sim/demo/Dockerfile
@@ -28,6 +28,20 @@ FROM ${ROS_IMAGE} AS demo
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# The rendering libraries sim/README.md tells a Linux host to install. They are
+# absent from the dev image because the dev sim renders on the host; hosting the
+# world in here moves that prerequisite in here too. `import mujoco` builds the
+# MUJOCO_GL context at import time, so a missing libOSMesa fails the build, not
+# the first render. libegl1/libgl1/libopengl0 are for the MUJOCO_GL=egl path on
+# a GPU instance.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+        libosmesa6 \
+        libegl1 \
+        libgl1 \
+        libopengl0
+
 # The dev image deliberately ships no MuJoCo -- its driver node is a pure RPC
 # client and the world runs on the host. The demo hosts the world itself, so it
 # needs the physics. numpy/pillow/websockets are already in the base; the pin

--- a/sim/demo/Dockerfile
+++ b/sim/demo/Dockerfile
@@ -1,0 +1,103 @@
+# syntax=docker/dockerfile:1.7
+#
+# The public sim demo image: one self-contained container that IS a full sim
+# session. No bind mounts, no host process, no launcher -- start it, route :80,
+# throw it away. That is what makes it schedulable on a per-session platform
+# (Fly Machines, Cloudflare Containers, a slot on your own box).
+#
+# It differs from the dev sim (sim/docker-compose.dev.yml) in three ways:
+#   1. the MuJoCo world server runs IN here (sim_driver.launch.py's documented
+#      VIRTUAL_MARS_REMOTE escape hatch) -- the host-side rule buys native GL,
+#      which a headless cloud instance does not have to begin with;
+#   2. every source tree and asset is baked in, not mounted;
+#   3. nothing that writes is exposed: no .env, no ssh/git credentials, no
+#      settings POST, no /restart.
+#
+# Build with sim/demo/build.sh -- it resolves the asset/viewer image tags the
+# same way the launcher does, so this never drifts from what `./innate-sim up`
+# would install.
+
+ARG ROS_IMAGE=ghcr.io/innate-inc/innate-os-sim-ros:main
+ARG ASSETS_IMAGE=ghcr.io/innate-inc/innate-os-sim-assets:main
+ARG VIEWER_IMAGE=ghcr.io/innate-inc/innate-os-sim-viewer:main
+
+FROM ${ASSETS_IMAGE} AS assets
+FROM ${VIEWER_IMAGE} AS viewer
+
+FROM ${ROS_IMAGE} AS demo
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# The dev image deliberately ships no MuJoCo -- its driver node is a pure RPC
+# client and the world runs on the host. The demo hosts the world itself, so it
+# needs the physics. numpy/pillow/websockets are already in the base; the pin
+# keeps mujoco on the base image's numpy<2.
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    uv pip install --system 'mujoco>=3.2,<4'
+
+WORKDIR /root/innate-os
+
+# Source. Ordered least- to most-churning so an edit to workspace/ or webapp/
+# does not reinstall the ROS workspace above it.
+COPY ros2_ws /root/innate-os/ros2_ws
+COPY scripts /root/innate-os/scripts
+COPY config /root/innate-os/config
+COPY workspace /root/innate-os/workspace
+COPY webapp /root/innate-os/webapp
+COPY sim/props /root/innate-os/sim/props
+COPY sim/demo /root/innate-os/sim/demo
+
+# Generated geometry + the viewer bundle, straight off the images the launcher
+# installs from on a dev machine (assets layer `work` -> sim/assets, layer
+# `viewer` -> the viewer's public assets).
+COPY --from=assets /work /root/innate-os/sim/assets
+COPY --from=assets /viewer /root/innate-os/sim/viewer/public
+COPY --from=viewer /bundle /root/innate-os/sim/viewer/dist-lib
+
+# data/ is runtime state (maps, robot_info.json), gitignored and absent from the
+# build context; the dev sim gets it as a bind mount.
+RUN mkdir -p /root/innate-os/data/maps
+
+# Reuse the install tree sim/Dockerfile.ros-prebuilt baked into the base -- but
+# only when it was built from THIS source. The base tracks main; a demo built
+# off a branch would otherwise ship main's binaries against the branch's source
+# and fail in ways that look like anything but a stale build. Same source digest
+# the prebuilt stage writes, so the two are comparable by construction.
+RUN --mount=type=cache,target=/root/.cache/ccache,sharing=locked \
+    set -e; \
+    prebuilt=/opt/innate-os-prebuilt/ros2_ws; \
+    cd /root/innate-os/ros2_ws; \
+    here=$(find src -type f ! -path '*/__pycache__/*' ! -name '*.pyc' -print0 \
+           | sort -z | xargs -0 -r sha256sum | sha256sum | awk '{print $1}'); \
+    there=$(cat "$prebuilt/source.sha256" 2>/dev/null || echo none); \
+    if [ "$here" = "$there" ]; then \
+        echo "prebuilt workspace matches this source ($here) -- reusing"; \
+        cp -a "$prebuilt/install" /root/innate-os/ros2_ws/install; \
+    else \
+        echo "prebuilt workspace is for different source ($there != $here) -- rebuilding"; \
+        source /opt/ros/humble/setup.bash; \
+        export CCACHE_DIR=/root/.cache/ccache; \
+        colcon build --cmake-args \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache; \
+    fi
+
+ENV INNATE_OS_ROOT=/root/innate-os \
+    VIRTUAL_MARS_ASSETS=/root/innate-os/sim/assets \
+    VIRTUAL_MARS_REMOTE=127.0.0.1:8799 \
+    INNATE_WORLD_STATE_PORT=8800 \
+    INNATE_ZENOH_DISABLE_SHM=1 \
+    SKIP_UPDATE_CHECK=1 \
+    MUJOCO_GL=osmesa \
+    INNATE_SIM_RENDER_SCALE=2 \
+    INNATE_WEBAPP_READONLY=1 \
+    INNATE_DEMO_LEASE_SECONDS=600
+
+# LAST: the cache key hashes every asset file's mtime+size, so any COPY after
+# this silently invalidates the .mjb and puts a multi-minute compile back on the
+# session-start path.
+RUN source /opt/ros/humble/setup.bash && \
+    source /root/innate-os/ros2_ws/install/setup.bash && \
+    python3 /root/innate-os/sim/demo/prewarm_model.py
+
+EXPOSE 80
+ENTRYPOINT ["/root/innate-os/sim/demo/entrypoint.sh"]

--- a/sim/demo/Dockerfile
+++ b/sim/demo/Dockerfile
@@ -73,6 +73,27 @@ COPY --from=viewer /bundle /root/innate-os/sim/viewer/dist-lib
 # build context; the dev sim gets it as a bind mount.
 RUN mkdir -p /root/innate-os/data/maps
 
+# Skill assets (replay episodes) are declared in each skill's metadata.json and
+# fetched by post_update.sh on hardware, ensure_skill_assets() for the dev sim.
+# The demo runs neither, so a replay skill like wave shipped with no episode:
+# in_training, and the launcher hides it. Bake them in -- a session container
+# has no reason to reach the internet at boot.
+RUN python3 - <<'PY'
+import json, urllib.request
+from pathlib import Path
+
+workspace = Path("/root/innate-os/workspace")
+for meta_file in sorted(workspace.glob("*_skills/*/metadata.json")):
+    downloads = json.loads(meta_file.read_text()).get("downloads") or {}
+    for name, url in downloads.items():
+        dest = meta_file.parent / name
+        if dest.exists():
+            continue
+        print(f"fetching {dest.relative_to(workspace)}", flush=True)
+        with urllib.request.urlopen(url, timeout=300) as response:
+            dest.write_bytes(response.read())
+PY
+
 # Reuse the install tree sim/Dockerfile.ros-prebuilt baked into the base -- but
 # only when it was built from THIS source. The base tracks main; a demo built
 # off a branch would otherwise ship main's binaries against the branch's source

--- a/sim/demo/Dockerfile.dockerignore
+++ b/sim/demo/Dockerfile.dockerignore
@@ -1,0 +1,30 @@
+# Sidecar for sim/demo/Dockerfile. The root .dockerignore is `**` plus a narrow
+# allowlist for the ROS images, which excludes most of what this stage COPYs.
+#
+# Exclude everything, then admit exactly the tracked trees. The generated
+# geometry and the viewer bundle are NOT here on purpose -- they come from the
+# published asset/viewer images, the same source the launcher installs from.
+**
+
+!ros2_ws/**
+!scripts/**
+!config/**
+!workspace/**
+!webapp/**
+!sim/props/**
+!sim/demo/**
+
+# Secrets and local state must never enter a public demo image.
+.env
+**/.env
+**/.git
+**/.venv
+**/node_modules
+**/__pycache__
+**/*.pyc
+ros2_ws/build/**
+ros2_ws/install/**
+ros2_ws/log/**
+config/settings.yaml
+config/ssh/**
+config/security/**

--- a/sim/demo/Dockerfile.dockerignore
+++ b/sim/demo/Dockerfile.dockerignore
@@ -1,9 +1,5 @@
-# Sidecar for sim/demo/Dockerfile. The root .dockerignore is `**` plus a narrow
-# allowlist for the ROS images, which excludes most of what this stage COPYs.
-#
-# Exclude everything, then admit exactly the tracked trees. The generated
-# geometry and the viewer bundle are NOT here on purpose -- they come from the
-# published asset/viewer images, the same source the launcher installs from.
+# For sim/demo/Dockerfile: exclude everything, admit the tracked trees it COPYs.
+# Generated geometry and the viewer bundle come from the published images instead.
 **
 
 !ros2_ws/**
@@ -15,7 +11,7 @@
 !sim/challenges/**
 !sim/demo/**
 
-# Secrets and local state must never enter a public demo image.
+# Secrets and local state never enter a public image.
 .env
 **/.env
 **/.git

--- a/sim/demo/Dockerfile.dockerignore
+++ b/sim/demo/Dockerfile.dockerignore
@@ -12,6 +12,7 @@
 !workspace/**
 !webapp/**
 !sim/props/**
+!sim/challenges/**
 !sim/demo/**
 
 # Secrets and local state must never enter a public demo image.

--- a/sim/demo/README.md
+++ b/sim/demo/README.md
@@ -32,16 +32,6 @@ Everything else follows from being public:
 | lifetime | until `down` | `INNATE_DEMO_LEASE_SECONDS` (600) |
 | render scale | 1 | 2 |
 
-## Files
-
-| | |
-|---|---|
-| `Dockerfile` | the image; three base images in, one session container out |
-| `build.sh` | resolves the content-addressed asset/viewer tags the way the launcher does |
-| `entrypoint.sh` | PID 1: world server → health gate → ROS fleet → lease → exit |
-| `launch_demo.zsh` | the trimmed fleet (`scripts/launch_sim_in_tmux.zsh` minus what a visitor can't reach) |
-| `prewarm_model.py` | compiles the world at build time so a session start loads a `.mjb`, not 1300 hulls |
-
 ## The two numbers that decide whether this works
 
 **Render speed.** Software GL is the demo's quality risk. The world server logs

--- a/sim/demo/README.md
+++ b/sim/demo/README.md
@@ -1,26 +1,23 @@
 # sim/demo — the public sim demo image
 
-One self-contained container that **is** a full sim session: start it, route
-port 80, throw it away. No bind mounts, no host process, no launcher — which is
-what makes it schedulable per session on Fly Machines, Cloudflare Containers, or
-a slot on your own box.
+One container that is a whole sim session, world server included: start it,
+route port 80, throw it away. The broker in innate-cloud (`apps/sim-broker`)
+hands one to each visitor of sim.innate.bot and destroys it after the lease.
 
 ```bash
-sim/demo/build.sh                 # -> ghcr.io/innate-inc/innate-os-sim-demo:<sha>
-docker run --rm -p 8080:80 ghcr.io/innate-inc/innate-os-sim-demo:latest
-# then open http://localhost:8080
+sim/demo/build.sh          # -> us-central1-docker.pkg.dev/innate-managed-infra/sim/innate-os-sim-demo:<sha>
+docker run --rm -p 8080:80 us-central1-docker.pkg.dev/innate-managed-infra/sim/innate-os-sim-demo:latest
 ```
+
+Every push to main publishes `sha-<commit>` and moves `latest`
+(`.github/workflows/publish-sim-demo.yml`); the broker's `/admin` page picks
+which tag sessions run.
 
 ## How it differs from the dev sim
 
-`./innate-sim up` runs the ROS fleet in a container and the MuJoCo world
-**natively on the host**, because native GL renders ~7x faster than software GL
-in Docker. A headless cloud instance has no native GL either way, so the demo
-hosts the world in the same container via the escape hatch
-`mars_sim_driver/launch/sim_driver.launch.py` documents:
-`VIRTUAL_MARS_REMOTE=127.0.0.1:8799`.
-
-Everything else follows from being public:
+`./innate-sim up` keeps the MuJoCo world on the host for native GL. A cloud
+instance has no native GL either way, so the demo runs the world in-container
+(`VIRTUAL_MARS_REMOTE=127.0.0.1:8799`) under software GL.
 
 | | dev sim | demo |
 |---|---|---|
@@ -32,30 +29,15 @@ Everything else follows from being public:
 | lifetime | until `down` | `INNATE_DEMO_LEASE_SECONDS` (600) |
 | render scale | 1 | 2 |
 
-## The two numbers that decide whether this works
+## The two numbers that decide whether it works
 
-**Render speed.** Software GL is the demo's quality risk. The world server logs
-its measurement on every boot:
+**Render speed.** The world server logs `GL self-test (osmesa): N ms/frame` on
+boot. Cameras render on demand at ~8Hz, so N much above ~120ms starves the
+camera panel and the agent's vision. Levers: a higher `INNATE_SIM_RENDER_SCALE`
+(cost falls with the square), more cores, or a GPU instance with `MUJOCO_GL=egl`.
+The scale is baked into the compiled model at build time; the entrypoint refuses
+a different one rather than booting slowly for reasons nobody can see.
 
-```bash
-docker logs <container> 2>&1 | grep "GL self-test"
-```
-
-`GL self-test (osmesa): N ms/frame`. Cameras render on demand at ~8Hz, so N much
-above ~120ms starves the camera panel and the agent's vision. Levers, in order:
-rebuild with a higher `INNATE_SIM_RENDER_SCALE` (cost falls with the square),
-give the instance more cores, or move to a GPU instance and set `MUJOCO_GL=egl`.
-
-The scale is a **build-time** choice: it sets the texture cap baked into the
-compiled model, so changing it at run time would miss the `.mjb` cache. The
-entrypoint refuses that rather than booting slowly for reasons nobody can see.
-
-**Boot time.** From `docker run` to a usable app, with the `.mjb` baked in.
-Budget ~30–60s for the ROS fleet. Anything much longer means the model cache
-missed — check the build log for `model cache:` and confirm no `COPY` was added
-after the prewarm step (the cache key hashes every asset's mtime+size).
-
-## Deploying it
-
-The image is hardened; handing out sessions, keys, limits and the challenge are
-the broker's job: `apps/sim-broker` in innate-cloud.
+**Boot time.** From container start to a usable app: ~30s, with the `.mjb`
+baked in. Much longer means the model cache missed -- check the build log for
+`model cache:` and that no `COPY` was added after the prewarm step.

--- a/sim/demo/README.md
+++ b/sim/demo/README.md
@@ -28,7 +28,7 @@ Everything else follows from being public:
 | world server | host process (`uv`) | in-container |
 | `.env`, `~/.ssh`, `~/.gitconfig` | mounted | **absent** |
 | `POST /settings.json`, `/restart` | on | **off** (`INNATE_WEBAPP_READONLY=1`) |
-| foxglove, leader receiver, console | on | off |
+| foxglove, leader receiver | on | off |
 | lifetime | until `down` | `INNATE_DEMO_LEASE_SECONDS` (600) |
 | render scale | 1 | 2 |
 
@@ -65,15 +65,7 @@ Budget ~30–60s for the ROS fleet. Anything much longer means the model cache
 missed — check the build log for `model cache:` and confirm no `COPY` was added
 after the prewarm step (the cache key hashes every asset's mtime+size).
 
-## Before this is public
+## Deploying it
 
-The image is hardened, the deployment is not. Still required:
-
-- **A demo-only `INNATE_SERVICE_KEY`**, injected at run time, never baked. Not
-  the fleet key — if it leaks you want to rotate something no robot uses.
-- **Egress blocked** except the LLM proxy.
-- **CPU/memory caps** per container.
-- **Turnstile** in front of whatever hands out sessions.
-- The lease here is a backstop, not the enforcement point: a broker that loses
-  track of a container must not leave it running, but the broker still owns the
-  clock.
+The image is hardened; handing out sessions, keys, limits and the challenge are
+the broker's job: `apps/sim-broker` in innate-cloud.

--- a/sim/demo/README.md
+++ b/sim/demo/README.md
@@ -1,0 +1,79 @@
+# sim/demo — the public sim demo image
+
+One self-contained container that **is** a full sim session: start it, route
+port 80, throw it away. No bind mounts, no host process, no launcher — which is
+what makes it schedulable per session on Fly Machines, Cloudflare Containers, or
+a slot on your own box.
+
+```bash
+sim/demo/build.sh                 # -> ghcr.io/innate-inc/innate-os-sim-demo:<sha>
+docker run --rm -p 8080:80 ghcr.io/innate-inc/innate-os-sim-demo:latest
+# then open http://localhost:8080
+```
+
+## How it differs from the dev sim
+
+`./innate-sim up` runs the ROS fleet in a container and the MuJoCo world
+**natively on the host**, because native GL renders ~7x faster than software GL
+in Docker. A headless cloud instance has no native GL either way, so the demo
+hosts the world in the same container via the escape hatch
+`mars_sim_driver/launch/sim_driver.launch.py` documents:
+`VIRTUAL_MARS_REMOTE=127.0.0.1:8799`.
+
+Everything else follows from being public:
+
+| | dev sim | demo |
+|---|---|---|
+| source, assets, viewer | bind-mounted from a checkout | baked in |
+| world server | host process (`uv`) | in-container |
+| `.env`, `~/.ssh`, `~/.gitconfig` | mounted | **absent** |
+| `POST /settings.json`, `/restart` | on | **off** (`INNATE_WEBAPP_READONLY=1`) |
+| foxglove, leader receiver, console | on | off |
+| lifetime | until `down` | `INNATE_DEMO_LEASE_SECONDS` (600) |
+| render scale | 1 | 2 |
+
+## Files
+
+| | |
+|---|---|
+| `Dockerfile` | the image; three base images in, one session container out |
+| `build.sh` | resolves the content-addressed asset/viewer tags the way the launcher does |
+| `entrypoint.sh` | PID 1: world server → health gate → ROS fleet → lease → exit |
+| `launch_demo.zsh` | the trimmed fleet (`scripts/launch_sim_in_tmux.zsh` minus what a visitor can't reach) |
+| `prewarm_model.py` | compiles the world at build time so a session start loads a `.mjb`, not 1300 hulls |
+
+## The two numbers that decide whether this works
+
+**Render speed.** Software GL is the demo's quality risk. The world server logs
+its measurement on every boot:
+
+```bash
+docker logs <container> 2>&1 | grep "GL self-test"
+```
+
+`GL self-test (osmesa): N ms/frame`. Cameras render on demand at ~8Hz, so N much
+above ~120ms starves the camera panel and the agent's vision. Levers, in order:
+rebuild with a higher `INNATE_SIM_RENDER_SCALE` (cost falls with the square),
+give the instance more cores, or move to a GPU instance and set `MUJOCO_GL=egl`.
+
+The scale is a **build-time** choice: it sets the texture cap baked into the
+compiled model, so changing it at run time would miss the `.mjb` cache. The
+entrypoint refuses that rather than booting slowly for reasons nobody can see.
+
+**Boot time.** From `docker run` to a usable app, with the `.mjb` baked in.
+Budget ~30–60s for the ROS fleet. Anything much longer means the model cache
+missed — check the build log for `model cache:` and confirm no `COPY` was added
+after the prewarm step (the cache key hashes every asset's mtime+size).
+
+## Before this is public
+
+The image is hardened, the deployment is not. Still required:
+
+- **A demo-only `INNATE_SERVICE_KEY`**, injected at run time, never baked. Not
+  the fleet key — if it leaks you want to rotate something no robot uses.
+- **Egress blocked** except the LLM proxy.
+- **CPU/memory caps** per container.
+- **Turnstile** in front of whatever hands out sessions.
+- The lease here is a backstop, not the enforcement point: a broker that loses
+  track of a container must not leave it running, but the broker still owns the
+  clock.

--- a/sim/demo/build.sh
+++ b/sim/demo/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build the public sim demo image.
+#
+# The asset and viewer images are content-addressed (inputs-<hash>), so the tags
+# are computed, never typed: this asks sim/launcher/config.py for the same refs
+# `./innate-sim up` would install from, which is what keeps the demo image and a
+# dev checkout showing the same apartment.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+IMAGE="${IMAGE:-ghcr.io/innate-inc/innate-os-sim-demo}"
+TAG="${TAG:-$(git rev-parse --short HEAD)}"
+ROS_IMAGE="${ROS_IMAGE:-ghcr.io/innate-inc/innate-os-sim-ros:main}"
+
+resolve() {
+    python3 - "$1" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path.cwd() / "sim" / "launcher"))
+import config
+
+root = Path.cwd()
+print(getattr(config, f"resolve_{sys.argv[1]}_image")(root))
+PY
+}
+
+ASSETS_IMAGE="${ASSETS_IMAGE:-$(resolve assets)}"
+VIEWER_IMAGE="${VIEWER_IMAGE:-$(resolve viewer)}"
+
+echo "ros    : $ROS_IMAGE"
+echo "assets : $ASSETS_IMAGE"
+echo "viewer : $VIEWER_IMAGE"
+echo "output : $IMAGE:$TAG"
+
+# linux/amd64 explicitly: the demo runs on x86 cloud instances, and a silent
+# arm64 build on an Apple Silicon laptop would only fail at deploy time.
+exec docker buildx build \
+    --platform linux/amd64 \
+    --build-arg "ROS_IMAGE=$ROS_IMAGE" \
+    --build-arg "ASSETS_IMAGE=$ASSETS_IMAGE" \
+    --build-arg "VIEWER_IMAGE=$VIEWER_IMAGE" \
+    --cache-from "type=registry,ref=$IMAGE:buildcache" \
+    --tag "$IMAGE:$TAG" \
+    --tag "$IMAGE:latest" \
+    -f sim/demo/Dockerfile \
+    "$@" \
+    .

--- a/sim/demo/build.sh
+++ b/sim/demo/build.sh
@@ -13,6 +13,10 @@ cd "$REPO_ROOT"
 IMAGE="${IMAGE:-ghcr.io/innate-inc/innate-os-sim-demo}"
 TAG="${TAG:-$(git rev-parse --short HEAD)}"
 ROS_IMAGE="${ROS_IMAGE:-ghcr.io/innate-inc/innate-os-sim-ros:main}"
+# Set empty to build without moving the floating tag -- CI does that for
+# anything that is not main, so a one-off build cannot become what every
+# visitor gets.
+LATEST_TAG="${LATEST_TAG-latest}"
 
 resolve() {
     python3 - "$1" <<'PY'
@@ -44,7 +48,7 @@ exec docker buildx build \
     --build-arg "VIEWER_IMAGE=$VIEWER_IMAGE" \
     --cache-from "type=registry,ref=$IMAGE:buildcache" \
     --tag "$IMAGE:$TAG" \
-    --tag "$IMAGE:latest" \
+    ${LATEST_TAG:+--tag "$IMAGE:$LATEST_TAG"} \
     -f sim/demo/Dockerfile \
     "$@" \
     .

--- a/sim/demo/build.sh
+++ b/sim/demo/build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
-IMAGE="${IMAGE:-ghcr.io/innate-inc/innate-os-sim-demo}"
+IMAGE="${IMAGE:-us-central1-docker.pkg.dev/innate-managed-infra/sim/innate-os-sim-demo}"
 TAG="${TAG:-$(git rev-parse --short HEAD)}"
 ROS_IMAGE="${ROS_IMAGE:-ghcr.io/innate-inc/innate-os-sim-ros:main}"
 # Set empty (CI does, off main) so a one-off build cannot become what visitors get.

--- a/sim/demo/build.sh
+++ b/sim/demo/build.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
-# Build the public sim demo image.
-#
-# The asset and viewer images are content-addressed (inputs-<hash>), so the tags
-# are computed, never typed: this asks sim/launcher/config.py for the same refs
-# `./innate-sim up` would install from, which is what keeps the demo image and a
-# dev checkout showing the same apartment.
+# Build the public sim demo image. The asset and viewer tags are content-addressed,
+# so they are resolved from sim/launcher/config.py exactly as `./innate-sim up` does.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -13,10 +9,10 @@ cd "$REPO_ROOT"
 IMAGE="${IMAGE:-ghcr.io/innate-inc/innate-os-sim-demo}"
 TAG="${TAG:-$(git rev-parse --short HEAD)}"
 ROS_IMAGE="${ROS_IMAGE:-ghcr.io/innate-inc/innate-os-sim-ros:main}"
-# Set empty to build without moving the floating tag -- CI does that for
-# anything that is not main, so a one-off build cannot become what every
-# visitor gets.
+# Set empty (CI does, off main) so a one-off build cannot become what visitors get.
 LATEST_TAG="${LATEST_TAG-latest}"
+# A docker-container builder exports nowhere by default; load unless pushing.
+case " $* " in *" --push "*) ;; *) set -- --load "$@" ;; esac
 
 resolve() {
     python3 - "$1" <<'PY'
@@ -39,8 +35,7 @@ echo "assets : $ASSETS_IMAGE"
 echo "viewer : $VIEWER_IMAGE"
 echo "output : $IMAGE:$TAG"
 
-# linux/amd64 explicitly: the demo runs on x86 cloud instances, and a silent
-# arm64 build on an Apple Silicon laptop would only fail at deploy time.
+# amd64 explicitly: a silent arm64 build on a laptop would only fail at deploy.
 exec docker buildx build \
     --platform linux/amd64 \
     --build-arg "ROS_IMAGE=$ROS_IMAGE" \

--- a/sim/demo/entrypoint.sh
+++ b/sim/demo/entrypoint.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# PID 1 of a demo session container: bring up the world, then the ROS fleet,
+# then hold the session open for its lease and exit.
+#
+# Unlike the dev sim there is no launcher and no host process -- the world
+# server runs in this container (sim_driver.launch.py documents the
+# VIRTUAL_MARS_REMOTE escape hatch). The dev sim keeps the world on the host
+# because native GL renders ~7x faster than software GL; a headless cloud
+# instance has no native GL either way, so that reason does not apply here.
+set -euo pipefail
+
+# Only what the world server needs -- it links no rclpy, so the Zenoh/RMW env
+# (config/dds/setup_dds.zsh) belongs to the tmux shells, which get it from .zshrc.
+source /opt/ros/humble/setup.bash
+source /root/innate-os/ros2_ws/install/setup.bash
+
+: "${INNATE_DEMO_LEASE_SECONDS:=600}"
+: "${INNATE_SIM_RENDER_SCALE:=2}"
+: "${MUJOCO_GL:=osmesa}"
+export MUJOCO_GL INNATE_SIM_RENDER_SCALE
+
+WORLD_LOG=/root/world-server.log
+
+# The render scale is baked into the compiled model (it sets the texture cap),
+# so overriding it here would miss the cache and put a multi-minute compile on
+# the session-start path. Refuse rather than boot mysteriously slowly.
+BAKED_SCALE_FILE="$VIRTUAL_MARS_ASSETS/.model_cache/render_scale"
+if [ -f "$BAKED_SCALE_FILE" ]; then
+    BAKED_SCALE=$(cat "$BAKED_SCALE_FILE")
+    if [ "$BAKED_SCALE" != "$INNATE_SIM_RENDER_SCALE" ]; then
+        echo "[demo] INNATE_SIM_RENDER_SCALE=$INNATE_SIM_RENDER_SCALE but the model cache was" \
+             "baked at $BAKED_SCALE -- rebuild the image with that scale instead." >&2
+        exit 1
+    fi
+fi
+
+shutdown() {
+    tmux kill-server >/dev/null 2>&1 || true
+    kill "${WORLD_PID:-}" >/dev/null 2>&1 || true
+}
+trap shutdown EXIT
+
+echo "[demo] starting world server (MUJOCO_GL=$MUJOCO_GL, render-scale=$INNATE_SIM_RENDER_SCALE)"
+ros2 run mars_sim_driver world_server \
+    --bind 127.0.0.1 --port 8799 --state-port 8800 \
+    --render-scale "$INNATE_SIM_RENDER_SCALE" >"$WORLD_LOG" 2>&1 &
+WORLD_PID=$!
+
+# The world must answer before the driver node connects, or sim_driver dies on
+# its first RPC and the fleet comes up against a world that isn't there.
+for _ in $(seq 1 120); do
+    if grep -q "GL self-test" "$WORLD_LOG" 2>/dev/null; then break; fi
+    if ! kill -0 "$WORLD_PID" 2>/dev/null; then
+        echo "[demo] world server died on boot:" >&2
+        cat "$WORLD_LOG" >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+grep "GL self-test" "$WORLD_LOG" || { echo "[demo] world server never reported GL readiness" >&2; exit 1; }
+
+echo "[demo] starting ROS fleet"
+/root/innate-os/sim/demo/launch_demo.zsh
+
+# The lease is enforced by the broker too; this is the backstop for a session
+# the broker loses track of. Exiting PID 1 is what stops the billing.
+if [ "$INNATE_DEMO_LEASE_SECONDS" -gt 0 ]; then
+    echo "[demo] session lease: ${INNATE_DEMO_LEASE_SECONDS}s"
+    sleep "$INNATE_DEMO_LEASE_SECONDS"
+    echo "[demo] lease expired, shutting down"
+else
+    echo "[demo] no lease (INNATE_DEMO_LEASE_SECONDS=0), running until stopped"
+    sleep infinity
+fi

--- a/sim/demo/entrypoint.sh
+++ b/sim/demo/entrypoint.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
-# PID 1 of a demo session container: bring up the world, then the ROS fleet,
-# then hold the session open for its lease and exit.
-#
-# Unlike the dev sim there is no launcher and no host process -- the world
-# server runs in this container (sim_driver.launch.py documents the
-# VIRTUAL_MARS_REMOTE escape hatch). The dev sim keeps the world on the host
-# because native GL renders ~7x faster than software GL; a headless cloud
-# instance has no native GL either way, so that reason does not apply here.
+# PID 1 of a session: world server, then the ROS fleet, then hold for the lease.
 set -euo pipefail
 
-# Only what the world server needs -- it links no rclpy, so the Zenoh/RMW env
-# (config/dds/setup_dds.zsh) belongs to the tmux shells, which get it from .zshrc.
 # ROS's setup.bash reads AMENT_TRACE_SETUP_FILES while unset, which -u makes fatal.
 set +u
 source /opt/ros/humble/setup.bash
@@ -24,9 +15,8 @@ export MUJOCO_GL INNATE_SIM_RENDER_SCALE
 
 WORLD_LOG=/root/world-server.log
 
-# The render scale is baked into the compiled model (it sets the texture cap),
-# so overriding it here would miss the cache and put a multi-minute compile on
-# the session-start path. Refuse rather than boot mysteriously slowly.
+# The scale is baked into the compiled model; a different one misses the cache
+# and puts a multi-minute compile on the session-start path. Refuse instead.
 BAKED_SCALE_FILE="$VIRTUAL_MARS_ASSETS/.model_cache/render_scale"
 if [ -f "$BAKED_SCALE_FILE" ]; then
     BAKED_SCALE=$(cat "$BAKED_SCALE_FILE")
@@ -49,8 +39,7 @@ ros2 run mars_sim_driver world_server \
     --render-scale "$INNATE_SIM_RENDER_SCALE" >"$WORLD_LOG" 2>&1 &
 WORLD_PID=$!
 
-# The world must answer before the driver node connects, or sim_driver dies on
-# its first RPC and the fleet comes up against a world that isn't there.
+# sim_driver dies on its first RPC if the world is not up yet.
 for _ in $(seq 1 120); do
     if grep -q "GL self-test" "$WORLD_LOG" 2>/dev/null; then break; fi
     if ! kill -0 "$WORLD_PID" 2>/dev/null; then
@@ -65,8 +54,7 @@ grep "GL self-test" "$WORLD_LOG" || { echo "[demo] world server never reported G
 echo "[demo] starting ROS fleet"
 /root/innate-os/sim/demo/launch_demo.zsh
 
-# The lease is enforced by the broker too; this is the backstop for a session
-# the broker loses track of. Exiting PID 1 is what stops the billing.
+# Backstop for a session the broker loses track of: exiting PID 1 stops the bill.
 if [ "$INNATE_DEMO_LEASE_SECONDS" -gt 0 ]; then
     echo "[demo] session lease: ${INNATE_DEMO_LEASE_SECONDS}s"
     sleep "$INNATE_DEMO_LEASE_SECONDS"

--- a/sim/demo/entrypoint.sh
+++ b/sim/demo/entrypoint.sh
@@ -11,8 +11,11 @@ set -euo pipefail
 
 # Only what the world server needs -- it links no rclpy, so the Zenoh/RMW env
 # (config/dds/setup_dds.zsh) belongs to the tmux shells, which get it from .zshrc.
+# ROS's setup.bash reads AMENT_TRACE_SETUP_FILES while unset, which -u makes fatal.
+set +u
 source /opt/ros/humble/setup.bash
 source /root/innate-os/ros2_ws/install/setup.bash
+set -u
 
 : "${INNATE_DEMO_LEASE_SECONDS:=600}"
 : "${INNATE_SIM_RENDER_SCALE:=2}"

--- a/sim/demo/launch_demo.zsh
+++ b/sim/demo/launch_demo.zsh
@@ -36,10 +36,8 @@ tmux send-keys -t "${SESSION_NAME}:behavior.1" "ros2 launch brain_client input_m
 tmux new-window -t "$SESSION_NAME" -n arm-ik
 tmux send-keys -t "${SESSION_NAME}:arm-ik" "ros2 run mars_arm ik.py" C-m
 
-if [[ "${INNATE_DEMO_UNINAVID:-1}" == "1" ]]; then
-  tmux new-window -t "$SESSION_NAME" -n vision-nav
-  tmux send-keys -t "${SESSION_NAME}:vision-nav" "ros2 launch innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel" C-m
-fi
+tmux new-window -t "$SESSION_NAME" -n vision-nav
+tmux send-keys -t "${SESSION_NAME}:vision-nav" "ros2 launch innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel" C-m
 
 # Only :80 is routed to a visitor; TLS terminates upstream.
 tmux new-window -t "$SESSION_NAME" -n webapp

--- a/sim/demo/launch_demo.zsh
+++ b/sim/demo/launch_demo.zsh
@@ -7,9 +7,11 @@
 # Dropped vs the dev sim:
 #   foxglove_bridge        -- ws:8765 is never published to a demo visitor
 #   udp_leader_receiver    -- leader-arm teleop needs hardware on the operator side
-#   innate_console         -- the terminal console is not exposed
 # Kept: rosbridge, app, sim driver, nav, brain, behavior, input manager, arm IK,
-# uninavid (the VLN demo), webapp.
+# uninavid (the VLN demo), webapp, innate_console.
+#
+# innate_console pipes every pane's stdout to the visitor's Logging page. No node
+# may print a secret: the demo's INNATE_SERVICE_KEY would land in the browser.
 
 set -e
 
@@ -54,5 +56,9 @@ fi
 tmux new-window -t "$SESSION_NAME" -n webapp
 tmux send-keys -t "${SESSION_NAME}:webapp" \
   "cd ~/innate-os/webapp && while true; do WEBAPP_SIM_CONTROLS=1 INNATE_WEBAPP_READONLY=1 python3 proxy/https_server.py; sleep 2; done" C-m
+
+# Last: it taps every pane with tmux pipe-pane, so they have to exist first.
+tmux new-window -t "$SESSION_NAME" -n console
+tmux send-keys -t "${SESSION_NAME}:console" "ros2 launch innate_console console.launch.py" C-m
 
 echo "demo stack started in tmux session '$SESSION_NAME'."

--- a/sim/demo/launch_demo.zsh
+++ b/sim/demo/launch_demo.zsh
@@ -1,0 +1,58 @@
+#!/bin/zsh -l
+#
+# The demo stack: scripts/launch_sim_in_tmux.zsh minus everything a browser
+# visitor cannot reach. Kept as its own file rather than flags on the dev
+# launcher so a change to the dev sim can never silently widen the demo.
+#
+# Dropped vs the dev sim:
+#   foxglove_bridge        -- ws:8765 is never published to a demo visitor
+#   udp_leader_receiver    -- leader-arm teleop needs hardware on the operator side
+#   innate_console         -- the terminal console is not exposed
+# Kept: rosbridge, app, sim driver, nav, brain, behavior, input manager, arm IK,
+# uninavid (the VLN demo), webapp.
+
+set -e
+
+SESSION_NAME="${INNATE_SIM_TMUX_SESSION:-innate}"
+
+tmux kill-session -t "$SESSION_NAME" 2>/dev/null || true
+
+tmux new-session -d -x 240 -y 72 -s "$SESSION_NAME" -n zenoh
+tmux send-keys -t "${SESSION_NAME}:zenoh" "ros2 run rmw_zenoh_cpp rmw_zenohd" C-m
+
+tmux new-window -t "$SESSION_NAME" -n rosbridge-app
+tmux send-keys -t "${SESSION_NAME}:rosbridge-app" "ros2 launch mars_sim_bringup sim_rosbridge.launch.py" C-m
+tmux split-window -t "${SESSION_NAME}:rosbridge-app" -h
+tmux send-keys -t "${SESSION_NAME}:rosbridge-app.1" "ros2 launch mars_control app.sim.launch.py" C-m
+
+tmux new-window -t "$SESSION_NAME" -n sim-driver
+tmux send-keys -t "${SESSION_NAME}:sim-driver" "ros2 launch mars_sim_driver sim_driver.launch.py" C-m
+
+mkdir -p ~/innate-os/data/maps
+cp ~/innate-os/sim/assets/map/sim_apartment.* ~/innate-os/data/maps/ 2>/dev/null || true
+
+tmux new-window -t "$SESSION_NAME" -n nav-brain
+tmux send-keys -t "${SESSION_NAME}:nav-brain" "ros2 launch mars_nav mode_manager.launch.py" C-m
+tmux split-window -t "${SESSION_NAME}:nav-brain" -h
+tmux send-keys -t "${SESSION_NAME}:nav-brain.1" "ros2 launch brain_client brain_client.sim.launch.py" C-m
+
+tmux new-window -t "$SESSION_NAME" -n behavior
+tmux send-keys -t "${SESSION_NAME}:behavior" "ros2 launch manipulation behavior.launch.py" C-m
+tmux split-window -t "${SESSION_NAME}:behavior" -h
+tmux send-keys -t "${SESSION_NAME}:behavior.1" "ros2 launch brain_client input_manager.launch.py" C-m
+
+tmux new-window -t "$SESSION_NAME" -n arm-ik
+tmux send-keys -t "${SESSION_NAME}:arm-ik" "ros2 run mars_arm ik.py" C-m
+
+if [[ "${INNATE_DEMO_UNINAVID:-1}" == "1" ]]; then
+  tmux new-window -t "$SESSION_NAME" -n vision-nav
+  tmux send-keys -t "${SESSION_NAME}:vision-nav" "ros2 launch innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel" C-m
+fi
+
+# Only :80 is ever routed to a visitor -- the demo sits behind a TLS-terminating
+# proxy, so the self-signed cert on :443 (and the warning it costs) never shows.
+tmux new-window -t "$SESSION_NAME" -n webapp
+tmux send-keys -t "${SESSION_NAME}:webapp" \
+  "cd ~/innate-os/webapp && while true; do WEBAPP_SIM_CONTROLS=1 INNATE_WEBAPP_READONLY=1 python3 proxy/https_server.py; sleep 2; done" C-m
+
+echo "demo stack started in tmux session '$SESSION_NAME'."

--- a/sim/demo/launch_demo.zsh
+++ b/sim/demo/launch_demo.zsh
@@ -1,17 +1,7 @@
 #!/bin/zsh -l
-#
-# The demo stack: scripts/launch_sim_in_tmux.zsh minus everything a browser
-# visitor cannot reach. Kept as its own file rather than flags on the dev
-# launcher so a change to the dev sim can never silently widen the demo.
-#
-# Dropped vs the dev sim:
-#   foxglove_bridge        -- ws:8765 is never published to a demo visitor
-#   udp_leader_receiver    -- leader-arm teleop needs hardware on the operator side
-# Kept: rosbridge, app, sim driver, nav, brain, behavior, input manager, arm IK,
-# uninavid (the VLN demo), webapp, innate_console.
-#
-# innate_console pipes every pane's stdout to the visitor's Logging page. No node
-# may print a secret: the demo's INNATE_SERVICE_KEY would land in the browser.
+# scripts/launch_sim_in_tmux.zsh minus foxglove and the leader receiver, which a
+# visitor cannot reach. A separate file, so a dev-sim change cannot widen the demo.
+# innate_console pipes every pane to the visitor's Logging page: never print a secret.
 
 set -e
 
@@ -51,13 +41,12 @@ if [[ "${INNATE_DEMO_UNINAVID:-1}" == "1" ]]; then
   tmux send-keys -t "${SESSION_NAME}:vision-nav" "ros2 launch innate_uninavid uninavid.launch.py cmd_vel_topic:=/cmd_vel" C-m
 fi
 
-# Only :80 is ever routed to a visitor -- the demo sits behind a TLS-terminating
-# proxy, so the self-signed cert on :443 (and the warning it costs) never shows.
+# Only :80 is routed to a visitor; TLS terminates upstream.
 tmux new-window -t "$SESSION_NAME" -n webapp
 tmux send-keys -t "${SESSION_NAME}:webapp" \
   "cd ~/innate-os/webapp && while true; do WEBAPP_SIM_CONTROLS=1 INNATE_WEBAPP_READONLY=1 python3 proxy/https_server.py; sleep 2; done" C-m
 
-# Last: it taps every pane with tmux pipe-pane, so they have to exist first.
+# Last: it pipe-panes every window, so they must exist first.
 tmux new-window -t "$SESSION_NAME" -n console
 tmux send-keys -t "${SESSION_NAME}:console" "ros2 launch innate_console console.launch.py" C-m
 

--- a/sim/demo/prewarm_model.py
+++ b/sim/demo/prewarm_model.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Compile the MuJoCo world once at image build time so the .mjb cache ships
+baked in. Compiling 1300+ hulls costs minutes; loading the binary costs ~50ms
+(mars_sim_driver.core._model_cache_path) -- the difference between a demo
+session starting in seconds and starting in minutes.
+
+Three ways to bake a cache the runtime then misses, all silent:
+
+- Importing mars_sim_driver from ros2_ws/src instead of the sourced install
+  overlay. The cache key hashes each asset's PATH as well as its mtime+size,
+  and world.py/core.py are themselves assets, so the two trees key differently.
+  Hence no sys.path games here: source install/setup.bash and import.
+- Building the world at a different render scale than the world server will.
+  The scale sets the visual-room texture cap (core._texture_cap), which is
+  baked into the compiled model -- so scale 1 and scale 2 are different worlds.
+- COPYing anything into the image after this runs, which moves an mtime.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+from mars_sim_driver import core, world
+from mars_sim_driver.constants import CAMERA_HEIGHT, CAMERA_WIDTH
+from mars_sim_driver.core import VirtualMars
+from mars_sim_driver.world_server import DEPTH_WH
+
+INSTALL_ROOT = Path("/root/innate-os/ros2_ws/install")
+SCALE_MARKER = "render_scale"
+
+
+def main() -> int:
+    for module in (core, world):
+        path = Path(module.__file__ or "")
+        if not path.is_relative_to(INSTALL_ROOT):
+            print(
+                f"ERROR: {module.__name__} imported from {path}, not the install tree.\n"
+                "The baked cache would key differently from the running world server.",
+                file=sys.stderr,
+            )
+            return 1
+
+    scale = int(os.environ.get("INNATE_SIM_RENDER_SCALE", "1"))
+    assets = Path(os.environ["VIRTUAL_MARS_ASSETS"])
+
+    # Exactly what world_server.main() builds, so the cache key matches.
+    sim = VirtualMars(
+        render_wh=(CAMERA_WIDTH // scale, CAMERA_HEIGHT // scale),
+        depth_render_wh=DEPTH_WH,
+    )
+    print(f"compiled world at render scale {scale}: {sim.model.nbody} bodies, {sim.model.ngeom} geoms")
+
+    cache_dir = assets / ".model_cache"
+    cached = sorted(cache_dir.glob("world-*.mjb"))
+    if not cached:
+        print("ERROR: no .mjb written -- every session would compile on boot.", file=sys.stderr)
+        return 1
+    for path in cached:
+        print(f"model cache: {path} ({path.stat().st_size / 1e6:.0f} MB)")
+
+    # entrypoint.sh reads this to refuse a render scale the cache was not baked for.
+    (cache_dir / SCALE_MARKER).write_text(f"{scale}\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sim/demo/prewarm_model.py
+++ b/sim/demo/prewarm_model.py
@@ -1,20 +1,8 @@
 #!/usr/bin/env python3
-"""Compile the MuJoCo world once at image build time so the .mjb cache ships
-baked in. Compiling 1300+ hulls costs minutes; loading the binary costs ~50ms
-(mars_sim_driver.core._model_cache_path) -- the difference between a demo
-session starting in seconds and starting in minutes.
-
-Three ways to bake a cache the runtime then misses, all silent:
-
-- Importing mars_sim_driver from ros2_ws/src instead of the sourced install
-  overlay. The cache key hashes each asset's PATH as well as its mtime+size,
-  and world.py/core.py are themselves assets, so the two trees key differently.
-  Hence no sys.path games here: source install/setup.bash and import.
-- Building the world at a different render scale than the world server will.
-  The scale sets the visual-room texture cap (core._texture_cap), which is
-  baked into the compiled model -- so scale 1 and scale 2 are different worlds.
-- COPYing anything into the image after this runs, which moves an mtime.
-"""
+"""Compile the MuJoCo world at build time so a session loads a .mjb in ~50ms
+instead of compiling 1300 hulls for minutes. The cache key hashes asset paths,
+mtimes and the render scale, so this must import from the sourced install tree,
+build at the scale the world server will use, and run after every COPY."""
 
 import os
 import sys
@@ -68,11 +56,8 @@ def main() -> int:
         return 1
     print(f"model cache: {cached[0]} ({cached[0].stat().st_size / 1e6:.0f} MB)")
 
-    # Building a second time is the only honest proof: a .mjb sitting at some
-    # other key would satisfy the glob above while the runtime still compiles
-    # from scratch. VirtualMars writes the binary only on the compile path, so
-    # an untouched file is the hit -- elapsed time is not, because a cold
-    # compile is ~1s on a big build host and no ceiling separates the two.
+    # A second build is the only proof: the binary is rewritten only on the
+    # compile path, so an untouched file is a hit. Elapsed time cannot tell.
     baked = cached[0].stat().st_mtime_ns
     reload_s = build()
     print(f"cache reload: {reload_s:.2f}s")
@@ -84,7 +69,7 @@ def main() -> int:
         )
         return 1
 
-    # entrypoint.sh reads this to refuse a render scale the cache was not baked for.
+    # entrypoint.sh refuses a scale the cache was not baked for.
     (cache_dir / SCALE_MARKER).write_text(f"{scale}\n", encoding="utf-8")
     return 0
 

--- a/sim/demo/prewarm_model.py
+++ b/sim/demo/prewarm_model.py
@@ -18,6 +18,7 @@ Three ways to bake a cache the runtime then misses, all silent:
 
 import os
 import sys
+import time
 from pathlib import Path
 
 from mars_sim_driver import core, world
@@ -27,6 +28,8 @@ from mars_sim_driver.world_server import DEPTH_WH
 
 INSTALL_ROOT = Path("/root/innate-os/ros2_ws/install")
 SCALE_MARKER = "render_scale"
+# A cache hit loads a ~250MB .mjb; a miss recompiles. Nothing lands between.
+CACHE_HIT_CEILING_S = 10.0
 
 
 def main() -> int:
@@ -43,12 +46,17 @@ def main() -> int:
     scale = int(os.environ.get("INNATE_SIM_RENDER_SCALE", "1"))
     assets = Path(os.environ["VIRTUAL_MARS_ASSETS"])
 
-    # Exactly what world_server.main() builds, so the cache key matches.
-    sim = VirtualMars(
-        render_wh=(CAMERA_WIDTH // scale, CAMERA_HEIGHT // scale),
-        depth_render_wh=DEPTH_WH,
-    )
-    print(f"compiled world at render scale {scale}: {sim.model.nbody} bodies, {sim.model.ngeom} geoms")
+    def build() -> float:
+        # Exactly what world_server.main() builds, so the cache key matches.
+        start = time.monotonic()
+        VirtualMars(
+            render_wh=(CAMERA_WIDTH // scale, CAMERA_HEIGHT // scale),
+            depth_render_wh=DEPTH_WH,
+        )
+        return time.monotonic() - start
+
+    compiled = build()
+    print(f"world at render scale {scale}: first build {compiled:.1f}s")
 
     cache_dir = assets / ".model_cache"
     cached = sorted(cache_dir.glob("world-*.mjb"))
@@ -57,6 +65,19 @@ def main() -> int:
         return 1
     for path in cached:
         print(f"model cache: {path} ({path.stat().st_size / 1e6:.0f} MB)")
+
+    # Building a second time is the only honest proof: a .mjb sitting at some
+    # other key would satisfy the glob above while the runtime still compiles
+    # from scratch. A cache hit is a ~50ms load, so anything slow means miss.
+    reload_s = build()
+    print(f"cache reload: {reload_s:.2f}s")
+    if reload_s > CACHE_HIT_CEILING_S:
+        print(
+            f"ERROR: rebuilding took {reload_s:.1f}s, so the cache is not being hit -- "
+            "every session would pay this on boot.",
+            file=sys.stderr,
+        )
+        return 1
 
     # entrypoint.sh reads this to refuse a render scale the cache was not baked for.
     (cache_dir / SCALE_MARKER).write_text(f"{scale}\n", encoding="utf-8")

--- a/sim/demo/prewarm_model.py
+++ b/sim/demo/prewarm_model.py
@@ -28,8 +28,6 @@ from mars_sim_driver.world_server import DEPTH_WH
 
 INSTALL_ROOT = Path("/root/innate-os/ros2_ws/install")
 SCALE_MARKER = "render_scale"
-# A cache hit loads a ~250MB .mjb; a miss recompiles. Nothing lands between.
-CACHE_HIT_CEILING_S = 10.0
 
 
 def main() -> int:
@@ -60,21 +58,28 @@ def main() -> int:
 
     cache_dir = assets / ".model_cache"
     cached = sorted(cache_dir.glob("world-*.mjb"))
-    if not cached:
-        print("ERROR: no .mjb written -- every session would compile on boot.", file=sys.stderr)
+    if len(cached) != 1:
+        names = [p.name for p in cached] or ["<none>"]
+        print(
+            f"ERROR: expected exactly one .mjb, found {len(cached)}: {names}.\n"
+            "Cannot tell which one the runtime would resolve to.",
+            file=sys.stderr,
+        )
         return 1
-    for path in cached:
-        print(f"model cache: {path} ({path.stat().st_size / 1e6:.0f} MB)")
+    print(f"model cache: {cached[0]} ({cached[0].stat().st_size / 1e6:.0f} MB)")
 
     # Building a second time is the only honest proof: a .mjb sitting at some
     # other key would satisfy the glob above while the runtime still compiles
-    # from scratch. A cache hit is a ~50ms load, so anything slow means miss.
+    # from scratch. VirtualMars writes the binary only on the compile path, so
+    # an untouched file is the hit -- elapsed time is not, because a cold
+    # compile is ~1s on a big build host and no ceiling separates the two.
+    baked = cached[0].stat().st_mtime_ns
     reload_s = build()
     print(f"cache reload: {reload_s:.2f}s")
-    if reload_s > CACHE_HIT_CEILING_S:
+    after = sorted(cache_dir.glob("world-*.mjb"))
+    if [p.name for p in after] != [cached[0].name] or after[0].stat().st_mtime_ns != baked:
         print(
-            f"ERROR: rebuilding took {reload_s:.1f}s, so the cache is not being hit -- "
-            "every session would pay this on boot.",
+            "ERROR: the second build rewrote the cache, so the runtime misses it and every session would recompile.",
             file=sys.stderr,
         )
         return 1

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -77,6 +77,10 @@ ROOT = Path(__file__).resolve().parent.parent
 # Position + FPS/queue) surface without editing the committed (robot-default)
 # config.json. Overlaid onto /config.json at request time.
 WEBAPP_SIM_CONTROLS = os.environ.get("WEBAPP_SIM_CONTROLS", "").strip().lower() in ("1", "true", "yes")
+# Drops the two routes that mutate the running stack (settings write, restart).
+# Set by the public sim demo, where every visitor is unauthenticated: nothing
+# else in the app writes, so this leaves the surface read-only.
+WEBAPP_READONLY = os.environ.get("INNATE_WEBAPP_READONLY", "").strip().lower() in ("1", "true", "yes")
 CERT_DIR = Path.home() / ".innate-webapp-tls"
 ROSBRIDGE_URL = "ws://127.0.0.1:9090"
 
@@ -510,8 +514,9 @@ def build_app() -> web.Application:
     app.router.add_get("/run/info", run_info_response)
     app.router.add_get("/run/log", run_log_response)
     app.router.add_get("/settings.json", settings_get)
-    app.router.add_post("/settings.json", settings_apply)
-    app.router.add_get("/restart", restart_handler)
+    if not WEBAPP_READONLY:
+        app.router.add_post("/settings.json", settings_apply)
+        app.router.add_get("/restart", restart_handler)
     # Before the catch-all; the bare /armsdk page route stays on the SPA shell.
     app.router.add_get("/armsdk/model/{tail:.*}", armsdk_model)
     # Prefix routes must precede the catch-all so /models/foo.glb doesn't fall to

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -77,9 +77,8 @@ ROOT = Path(__file__).resolve().parent.parent
 # Position + FPS/queue) surface without editing the committed (robot-default)
 # config.json. Overlaid onto /config.json at request time.
 WEBAPP_SIM_CONTROLS = os.environ.get("WEBAPP_SIM_CONTROLS", "").strip().lower() in ("1", "true", "yes")
-# Drops the two routes that mutate the running stack (settings write, restart).
-# Set by the public sim demo, where every visitor is unauthenticated: nothing
-# else in the app writes, so this leaves the surface read-only.
+# The public demo sets this: its visitors are unauthenticated, and these two
+# routes are the only ones that write.
 WEBAPP_READONLY = os.environ.get("INNATE_WEBAPP_READONLY", "").strip().lower() in ("1", "true", "yes")
 CERT_DIR = Path.home() / ".innate-webapp-tls"
 ROSBRIDGE_URL = "ws://127.0.0.1:9090"


### PR DESCRIPTION
A self-contained image that boots the whole sim stack in one container, so a
browser visitor gets their own simulated MARS with nothing installed locally.

`sim/demo/` is deliberately its own launcher rather than flags on the dev one:
a change to the dev sim can never silently widen what a demo visitor reaches.
Dropped vs the dev sim are `foxglove_bridge` and `udp_leader_receiver`.

## What is in here

- **The image** (`Dockerfile`, `build.sh`, `entrypoint.sh`, `launch_demo.zsh`) —
  world server, ROS fleet and webapp in one container, built on the published
  asset/viewer images so it shows the same apartment a dev checkout does.
- **A baked model cache** (`prewarm_model.py`) — the MuJoCo world is compiled at
  build time so a session starts in seconds. The check proves the *runtime* hits
  that cache rather than that some `.mjb` exists: it builds the world a second
  time and requires the file to come back untouched, since `VirtualMars` writes
  the binary only on the compile path. Timing cannot tell a hit from a miss —
  a cold compile is ~1s on a big build host.
- **`repo_root()` fixed** — this is the only change outside `sim/demo/`, and it
  is a real bug beyond this image. See below.
- **Logging on for visitors** — `innate_console` now runs, so the webapp's
  Logging page has its source.

## The repo_root() bug

`repo_root()` was `parents[5]`, correct only for a dev checkout. colcon installs
the module deeper, so the same index lands on `ros2_ws/install` and every path
built from it points into a tree that does not exist — silently. Props resolved
to nothing, so Scene setup listed no objects and there was nothing to pick up;
challenge roots and the progress path missed the same way. `default_assets_dir()`
survived only because `VIRTUAL_MARS_ASSETS` overrides it.

It now walks up for the directories that mark the tree, which is the same answer
in both layouts. **Anyone running the driver from an install tree was affected,
not just this image.**

## Verified

Booted the image and driven end to end, both locally and hosted on Cloudflare
Containers (a spike, not part of this PR):

| | |
|---|---|
| GL self-test (osmesa) | 12–17 ms/frame |
| boot to serving | ~8s local, ~25s hosted cold |
| props in Scene setup | 12 (was 0) |
| lidar overlay, teleop | working |
| Logging page | `/innate/console` + backfill |
| robot speech | synthesized and played in-browser |

## Known follow-ups (not in this PR)

- Editing `mars_sim_driver` renames the assets image, because that path feeds
  the assets input hash. CI has not published the new tag, so `build.sh` needs
  `ASSETS_IMAGE` pinned by hand. Either CI publishes it, or `build.sh` gains the
  fallback `innate-sim up` already has. **This is the one thing I would settle
  before merge.**
- The demo image is not built in CI at all.
- `chess_agent` fails to load every boot: `No module named 'chess'`.
