### PR TITLE
feat(skills): pickAnything rolls the gripper onto the object's short side

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/robot/manipulation.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/robot/manipulation.py
@@ -344,6 +344,12 @@ class Manipulation:
         """Clamp (x, y) into the graspable reach box."""
         return (max(cls.REACH_X[0], min(cls.REACH_X[1], x)), max(cls.REACH_Y[0], min(cls.REACH_Y[1], y)))
 
+    def reachable(
+        self, x: float, y: float, z: float, *, roll: float = 0.0, pitch: float = 0.0, yaw: float = 0.0
+    ) -> bool:
+        """Whether IK finds a solution for the pose; the arm does not move."""
+        return self._solve_ik(x, y, z, roll, pitch, yaw) is not None
+
     # --- motion ---
 
     def move_to(

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -200,9 +200,10 @@ def seg_model(hsv, box):
 # +v, i.e. clockwise on screen, in [0, pi)) and major/minor elongation
 # (1 = round).
 Axis = tuple[float, float]
+Window = tuple[int, int, int, int]
 
 
-def _blob_axis(bp, window) -> Axis | None:
+def _blob_axis(bp: np.ndarray, window: Window) -> Axis | None:
     """Minimum-area rectangle of the thresholded blob under the window
     centre. CamShift's own ellipse is not usable: its window hugs only part
     of a blob that outgrows it, and the ellipse then follows the window."""
@@ -210,19 +211,18 @@ def _blob_axis(bp, window) -> Axis | None:
     x0, y0 = max(0, x - w), max(0, y - h)
     roi = bp[y0 : y + 2 * h, x0 : x + 2 * w]
     _thr, mask = cv2.threshold(roi, 0, 255, cv2.THRESH_BINARY | cv2.THRESH_OTSU)
-    n, labels, stats, _cents = cv2.connectedComponentsWithStats(mask, connectivity=8)
-    if n < 2:
+    contours, _hier = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
         return None
-    u = min(x + w // 2 - x0, labels.shape[1] - 1)
-    v = min(y + h // 2 - y0, labels.shape[0] - 1)
-    label = labels[v, u] or 1 + int(np.argmax(stats[1:, cv2.CC_STAT_AREA]))
-    pts = np.column_stack(np.nonzero(labels == label))[:, ::-1].astype(np.float32)
-    _center, (rw, rh), angle_deg = cv2.minAreaRect(pts)
+    centre = (float(x + w // 2 - x0), float(y + h // 2 - y0))
+    under = [c for c in contours if cv2.pointPolygonTest(c, centre, False) >= 0]
+    blob = max(under or contours, key=cv2.contourArea)
+    _center, (rw, rh), angle_deg = cv2.minAreaRect(blob)
     major, minor, theta_deg = (rw, rh, angle_deg) if rw >= rh else (rh, rw, angle_deg + 90.0)
     return math.radians(theta_deg) % math.pi, major / max(minor, 1.0)
 
 
-def backproject(hsv, model):
+def _backproject(hsv: np.ndarray, model: np.ndarray) -> np.ndarray:
     """Per-pixel object likelihood (uint8) from a seg_model LUT. Numpy bin
     lookup (cv2.calcBackProject broken for 3-D hist here)."""
     ih = (hsv[:, :, 0].astype(np.int32) * _SEG_BINS[0]) // 180
@@ -231,9 +231,11 @@ def backproject(hsv, model):
     return model[np.clip(ih, 0, _SEG_BINS[0] - 1), i_s, iv]
 
 
-def seg_track(hsv, model, window, min_score=25.0):
+def seg_track(
+    hsv: np.ndarray, model: np.ndarray, window: Window, min_score: float = 25.0
+) -> tuple[tuple[float, float] | None, Window, float, Axis | None]:
     """Back-project + CamShift -> (center|None, window, score, axis|None)."""
-    bp = backproject(hsv, model)
+    bp = _backproject(hsv, model)
     crit = (cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 10, 1)
     _rot, window = cv2.CamShift(bp, window, crit)
     x, y, w, h = window

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -196,19 +196,50 @@ def seg_model(hsv, box):
     return (255.0 * ratio / ratio.max()).astype(np.uint8)
 
 
-def seg_track(hsv, model, window, min_score=25.0):
-    """Back-project + CamShift -> (center|None, window, score).
-    Numpy bin lookup (cv2.calcBackProject broken for 3-D hist here)."""
+# Blob shape: major-axis angle in image coordinates (radians from +u toward
+# +v, i.e. clockwise on screen, in [0, pi)) and major/minor elongation
+# (1 = round).
+Axis = tuple[float, float]
+
+
+def _blob_axis(bp, window) -> Axis | None:
+    """Minimum-area rectangle of the thresholded blob under the window
+    centre. CamShift's own ellipse is not usable: its window hugs only part
+    of a blob that outgrows it, and the ellipse then follows the window."""
+    x, y, w, h = window
+    x0, y0 = max(0, x - w), max(0, y - h)
+    roi = bp[y0 : y + 2 * h, x0 : x + 2 * w]
+    _thr, mask = cv2.threshold(roi, 0, 255, cv2.THRESH_BINARY | cv2.THRESH_OTSU)
+    n, labels, stats, _cents = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    if n < 2:
+        return None
+    u = min(x + w // 2 - x0, labels.shape[1] - 1)
+    v = min(y + h // 2 - y0, labels.shape[0] - 1)
+    label = labels[v, u] or 1 + int(np.argmax(stats[1:, cv2.CC_STAT_AREA]))
+    pts = np.column_stack(np.nonzero(labels == label))[:, ::-1].astype(np.float32)
+    _center, (rw, rh), angle_deg = cv2.minAreaRect(pts)
+    major, minor, theta_deg = (rw, rh, angle_deg) if rw >= rh else (rh, rw, angle_deg + 90.0)
+    return math.radians(theta_deg) % math.pi, major / max(minor, 1.0)
+
+
+def backproject(hsv, model):
+    """Per-pixel object likelihood (uint8) from a seg_model LUT. Numpy bin
+    lookup (cv2.calcBackProject broken for 3-D hist here)."""
     ih = (hsv[:, :, 0].astype(np.int32) * _SEG_BINS[0]) // 180
     i_s = (hsv[:, :, 1].astype(np.int32) * _SEG_BINS[1]) // 256
     iv = (hsv[:, :, 2].astype(np.int32) * _SEG_BINS[2]) // 256
-    bp = model[np.clip(ih, 0, _SEG_BINS[0] - 1), i_s, iv]
+    return model[np.clip(ih, 0, _SEG_BINS[0] - 1), i_s, iv]
+
+
+def seg_track(hsv, model, window, min_score=25.0):
+    """Back-project + CamShift -> (center|None, window, score, axis|None)."""
+    bp = backproject(hsv, model)
     crit = (cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 10, 1)
     _rot, window = cv2.CamShift(bp, window, crit)
     x, y, w, h = window
     if w < 4 or h < 4 or w * h > 0.4 * IMG_W * IMG_H:
-        return None, window, 0.0
+        return None, window, 0.0, None
     score = float(bp[y : y + h, x : x + w].mean())
     if score < min_score:
-        return None, window, score
-    return (x + w / 2.0, y + h / 2.0), window, score
+        return None, window, score, None
+    return (x + w / 2.0, y + h / 2.0), window, score, _blob_axis(bp, window)

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -111,6 +111,11 @@ WRIST_CAM_ABOVE_EE = 0.07
 MIN_ELONGATION = 1.3
 ROLL_MAX = 1.5
 AXIS_MIN_Z = 0.07
+# Rolls under ROLL_MIN are not worth leaving the hardware-tuned unrolled
+# grasp for. ROLL_SIGN is verified in sim only: a mirrored wrist camera (as
+# the Gemini prompts below describe the real one) needs -1.
+ROLL_MIN = 0.1
+ROLL_SIGN = 1.0
 # Rolled fingers are level only with the tool axis vertical: at arm_pitch
 # 1.30 a 90 deg roll drops one fingertip 3 cm below the other, which lands on
 # the object and stalls the descent with the other pad above it.
@@ -331,20 +336,25 @@ class PickAnyObject(Skill):
             self.sleep(0.04)
         return None, last_b64
 
-    def _wrist_done(self, x, y, z, reason, axis: vision.Axis | None = None):
+    def _wrist_done(
+        self, x: float, y: float, z: float, reason: str, axis: vision.Axis | None = None
+    ) -> tuple[float, float, float, float]:
         roll = self._grasp_roll(axis)
         self.logger.info(f"[PickAnyObject] wrist stage: {reason} (z={z:.3f}, roll={math.degrees(roll):+.0f} deg)")
         return x, y, z, roll
 
     @staticmethod
     def _grasp_roll(axis: vision.Axis | None) -> float:
-        """Wrist roll that turns the fingers onto the blob's minor axis. The
-        wrist camera rolls with the fingers, which close along image u, so
-        the blob's image angle is already relative to the jaw: roll = angle
-        from v (verified in sim; negate here if a wrist camera is mirrored)."""
+        """Wrist roll that turns the fingers onto the blob's minor axis, or
+        0.0 for the tuned unrolled grasp. The wrist camera rolls with the
+        fingers, which close along image u, so the blob's image angle is
+        already relative to the jaw: roll = angle from v."""
         if axis is None or axis[1] < MIN_ELONGATION:
             return 0.0
-        return max(-ROLL_MAX, min(ROLL_MAX, axis[0] - math.pi / 2))
+        roll = ROLL_SIGN * (axis[0] - math.pi / 2)
+        if abs(roll) < ROLL_MIN:
+            return 0.0
+        return max(-ROLL_MAX, min(ROLL_MAX, roll))
 
     def _wrist_reseed(self, prompt, raw):
         """Persistent tracking loss: one Gemini look + a fresh color model,
@@ -407,7 +417,7 @@ class PickAnyObject(Skill):
                 break
 
             px = tracker.update(hsv)
-            if px is not None and z >= AXIS_MIN_Z:
+            if px is not None and z >= AXIS_MIN_Z and tracker.axis is not None:
                 axis = tracker.axis
             if px is None:
                 streak = centered = 0
@@ -481,19 +491,24 @@ class PickAnyObject(Skill):
         self.manipulation.move_joints(pose, duration=self._p["hover_s"])
         self.sleep(0.3)
 
-    def _grasp_pitch(self, roll):
-        return ROLLED_PITCH if roll else self._p["arm_pitch"]
+    def _grasp_orientation(self, x: float, y: float, roll: float) -> tuple[float, float, float]:
+        """(roll, pitch, yaw) for the descent and close. Unrolled is the
+        hardware-tuned grasp. Rolled needs the tool vertical, and then the
+        yaw must be the arm's own bearing: RPY is gimbal-locked at pitch
+        pi/2, and a yaw-0 target makes the solver dump the whole base
+        rotation into j5 (j5 = roll + j1). Out of the vertical pitch's
+        reach, the tuned grasp is kept rather than a descent that never
+        starts (follow's IK failure reads as a contact stall)."""
+        p = self._p
+        if roll == 0.0:
+            return 0.0, p["arm_pitch"], 0.0
+        yaw = math.atan2(y, x)
+        if not self.manipulation.reachable(x, y, p["floor_z"], roll=roll, pitch=ROLLED_PITCH, yaw=yaw):
+            self.logger.warning(f"[PickAnyObject] rolled grasp unreachable at ({x:.2f}, {y:.2f}); grasping unrolled")
+            return 0.0, p["arm_pitch"], 0.0
+        return roll, ROLLED_PITCH, yaw
 
-    def _grasp_yaw(self):
-        """The arm's own base yaw, so the IK target is exactly reachable. A
-        yaw-0 target is not: the solver spreads that error over the wrist,
-        and with the tool vertical all of it lands in j5 (j5 = roll + j1)."""
-        try:
-            return self._arm_joints()[0]
-        except LookupError:
-            return 0.0
-
-    def _push_to_floor(self, x, y, z_from, roll, yaw):
+    def _push_to_floor(self, x: float, y: float, z_from: float, roll: float, pitch: float, yaw: float) -> None:
         """Blind descent to floor as ONE multi-waypoint trajectory — the
         rung-by-rung version decelerated at every rung and looked choppy.
         Contact just stalls the final segments; abort if still high."""
@@ -503,7 +518,6 @@ class PickAnyObject(Skill):
         if rungs:
             # grip=GRIPPER_OPEN re-asserts an open claw even if it drifted
             # shut during the wrist descent (never re-seed from measured).
-            pitch = self._grasp_pitch(roll)
             waypoints = [Waypoint(x, y, z, roll=roll, pitch=pitch, yaw=yaw, duration=p["descend_s"]) for z in rungs]
             try:
                 self.manipulation.follow(waypoints, grip=self.manipulation.GRIPPER_OPEN)
@@ -531,14 +545,13 @@ class PickAnyObject(Skill):
             raise LookupError("joint states missing or short")
         return list(js.position[:6])
 
-    def _close_twist_lift(self, x, y, roll, yaw):
+    def _close_twist_lift(self, x: float, y: float, roll: float, pitch: float, yaw: float) -> None:
         """Close, joint-space twist+lift (IK would unwind j5). Uses time.sleep
         on purpose: the fingers have committed, and a cancel must not unwind
         mid-grip — the run finishes this and the teardown carries the object.
         Closing on air reaches ~GRIPPER_EMPTY_J6, which _grasp_verified's j6
         check catches."""
         p = self._p
-        pitch = self._grasp_pitch(roll)
         if p["close_lift_m"] > 0:
             try:
                 ee_z = self.manipulation.pose.z
@@ -575,7 +588,9 @@ class PickAnyObject(Skill):
         try:
             if soft:
                 j = self._arm_joints()
-                j[4] = max(-1.4, min(1.4, j[4] + p["twist_rad"]))
+                # A rolled wrist can already sit near the +1.4 stop: twist the way that has room.
+                twist = p["twist_rad"] if j[4] + p["twist_rad"] <= 1.4 else -p["twist_rad"]
+                j[4] = max(-1.4, min(1.4, j[4] + twist))
                 j[5] = grip
                 self.manipulation.move_joints(j, duration=1.0)
                 time.sleep(0.3)
@@ -598,7 +613,11 @@ class PickAnyObject(Skill):
             # and would zero the grip preload. move_to verifies by FK and
             # recover-retries, so the arm is confirmed off the floor (or the
             # run fails cleanly and teardown carries with the grip kept).
-            self.manipulation.move_to(x, y, 0.22, roll=roll, pitch=pitch, yaw=yaw, duration=2.0, tolerance_xy=0.10)
+            # arm_pitch, not the grasp pitch: the vertical tool axis is out of
+            # reach at 0.22 m and stops mattering once the object is held.
+            self.manipulation.move_to(
+                x, y, 0.22, roll=roll, pitch=p["arm_pitch"], yaw=yaw, duration=2.0, tolerance_xy=0.10
+            )
 
     def _grasp_at(self, prompt, xy):
         """Full grasp at floor xy (base_link)."""
@@ -616,10 +635,10 @@ class PickAnyObject(Skill):
             z, roll = p["hover_z"], 0.0
             self.manipulation.move_to(x, y, z, pitch=p["arm_pitch"], duration=p["hover_s"])
 
-        yaw = self._grasp_yaw()
-        self._push_to_floor(x, y, z, roll, yaw)
+        roll, pitch, yaw = self._grasp_orientation(x, y, roll)
+        self._push_to_floor(x, y, z, roll, pitch, yaw)
         self.check_cancelled()  # last exit before the fingers commit
-        self._close_twist_lift(x, y, roll, yaw)
+        self._close_twist_lift(x, y, roll, pitch, yaw)
 
     def _grasp_verified(self, prompt, approach: FloorApproach):
         """Back up, then check floor clear + gripper not open. Gemini gets both

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -104,6 +104,17 @@ WRIST_ALIGN_TIMEOUT_S = 60.0
 WRIST_MAX_JUMP_PX = 80.0
 WRIST_SEG_MIN_SCORE = 25.0
 WRIST_CAM_ABOVE_EE = 0.07
+# Wrist roll to the blob's minor axis (the gripper's 81 mm jaw is narrower
+# than most objects' long side). Blobs rounder than MIN_ELONGATION have no
+# axis worth chasing; below AXIS_MIN_Z the fingers straddle the blob in the
+# wrist view and clip its ends, so the last trusted reading is kept.
+MIN_ELONGATION = 1.3
+ROLL_MAX = 1.5
+AXIS_MIN_Z = 0.07
+# Rolled fingers are level only with the tool axis vertical: at arm_pitch
+# 1.30 a 90 deg roll drops one fingertip 3 cm below the other, which lands on
+# the object and stalls the descent with the other pad above it.
+ROLLED_PITCH = math.pi / 2
 # Gate rejections before the memory is treated as stale and re-anchored. At 2,
 # the first rejection still coasts — that is the case the gate exists for (the
 # target missed for one frame while a twin is detected) — and _localize_retry's
@@ -121,6 +132,7 @@ class _BlobTracker:
         self.window = box
         self.guess = px
         self.misses = 0
+        self.axis: vision.Axis | None = None
 
     @property
     def ok(self):
@@ -128,7 +140,7 @@ class _BlobTracker:
 
     def update(self, hsv):
         """Blob center, or None on miss (keeps last window for retry)."""
-        pt, window, _score = vision.seg_track(hsv, self.model, self.window, min_score=WRIST_SEG_MIN_SCORE)
+        pt, window, _score, axis = vision.seg_track(hsv, self.model, self.window, min_score=WRIST_SEG_MIN_SCORE)
         if pt is not None and math.hypot(pt[0] - self.guess[0], pt[1] - self.guess[1]) > WRIST_MAX_JUMP_PX:
             pt = None
         if pt is None:
@@ -137,6 +149,7 @@ class _BlobTracker:
         self.misses = 0
         self.window = window
         self.guess = pt
+        self.axis = axis
         return pt
 
 
@@ -318,9 +331,20 @@ class PickAnyObject(Skill):
             self.sleep(0.04)
         return None, last_b64
 
-    def _wrist_done(self, x, y, z, reason):
-        self.logger.info(f"[PickAnyObject] wrist stage: {reason} (z={z:.3f})")
-        return x, y, z
+    def _wrist_done(self, x, y, z, reason, axis: vision.Axis | None = None):
+        roll = self._grasp_roll(axis)
+        self.logger.info(f"[PickAnyObject] wrist stage: {reason} (z={z:.3f}, roll={math.degrees(roll):+.0f} deg)")
+        return x, y, z, roll
+
+    @staticmethod
+    def _grasp_roll(axis: vision.Axis | None) -> float:
+        """Wrist roll that turns the fingers onto the blob's minor axis. The
+        wrist camera rolls with the fingers, which close along image u, so
+        the blob's image angle is already relative to the jaw: roll = angle
+        from v (verified in sim; negate here if a wrist camera is mirrored)."""
+        if axis is None or axis[1] < MIN_ELONGATION:
+            return 0.0
+        return max(-ROLL_MAX, min(ROLL_MAX, axis[0] - math.pi / 2))
 
     def _wrist_reseed(self, prompt, raw):
         """Persistent tracking loss: one Gemini look + a fresh color model,
@@ -342,7 +366,7 @@ class PickAnyObject(Skill):
         A miss gets 2 frames of patience, then a Gemini re-seed (budget =
         wrist_steps - 1). Color model, not LK: the object grows/deforms
         during the descent and optical flow slides off.
-        Returns (x,y,z); falls back to (tx,ty) if never seen."""
+        Returns (x, y, z, roll); falls back to (tx, ty, roll 0) if never seen."""
         p = self._p
         try:
             ee = self.manipulation.pose.position
@@ -364,6 +388,7 @@ class PickAnyObject(Skill):
             return self._wrist_done(tx, ty, z, "not seen")
 
         deadline = time.monotonic() + WRIST_ALIGN_TIMEOUT_S
+        axis = None  # last blob axis read high enough to trust
         streak = 0  # verified matches since the arm last moved
         centered = 0  # consecutive matches INSIDE the box
         stalled = 0  # consecutive steps eaten by the reach clamp
@@ -382,6 +407,8 @@ class PickAnyObject(Skill):
                 break
 
             px = tracker.update(hsv)
+            if px is not None and z >= AXIS_MIN_Z:
+                axis = tracker.axis
             if px is None:
                 streak = centered = 0
                 if tracker.misses < 3:
@@ -441,7 +468,7 @@ class PickAnyObject(Skill):
                 streak = 0
                 centered = 0  # view shifted — re-confirm centering
 
-        return self._wrist_done(x, y, z, reason)
+        return self._wrist_done(x, y, z, reason, axis)
 
     def _goto_search_pose(self, bearing):
         """WRIST_SEARCH_ARM aimed at bearing; pins IK to elbow-up branch.
@@ -454,7 +481,19 @@ class PickAnyObject(Skill):
         self.manipulation.move_joints(pose, duration=self._p["hover_s"])
         self.sleep(0.3)
 
-    def _push_to_floor(self, x, y, z_from):
+    def _grasp_pitch(self, roll):
+        return ROLLED_PITCH if roll else self._p["arm_pitch"]
+
+    def _grasp_yaw(self):
+        """The arm's own base yaw, so the IK target is exactly reachable. A
+        yaw-0 target is not: the solver spreads that error over the wrist,
+        and with the tool vertical all of it lands in j5 (j5 = roll + j1)."""
+        try:
+            return self._arm_joints()[0]
+        except LookupError:
+            return 0.0
+
+    def _push_to_floor(self, x, y, z_from, roll, yaw):
         """Blind descent to floor as ONE multi-waypoint trajectory — the
         rung-by-rung version decelerated at every rung and looked choppy.
         Contact just stalls the final segments; abort if still high."""
@@ -464,7 +503,8 @@ class PickAnyObject(Skill):
         if rungs:
             # grip=GRIPPER_OPEN re-asserts an open claw even if it drifted
             # shut during the wrist descent (never re-seed from measured).
-            waypoints = [Waypoint(x, y, z, pitch=p["arm_pitch"], duration=p["descend_s"]) for z in rungs]
+            pitch = self._grasp_pitch(roll)
+            waypoints = [Waypoint(x, y, z, roll=roll, pitch=pitch, yaw=yaw, duration=p["descend_s"]) for z in rungs]
             try:
                 self.manipulation.follow(waypoints, grip=self.manipulation.GRIPPER_OPEN)
             except ArmFailed as e:
@@ -491,13 +531,14 @@ class PickAnyObject(Skill):
             raise LookupError("joint states missing or short")
         return list(js.position[:6])
 
-    def _close_twist_lift(self, x, y):
+    def _close_twist_lift(self, x, y, roll, yaw):
         """Close, joint-space twist+lift (IK would unwind j5). Uses time.sleep
         on purpose: the fingers have committed, and a cancel must not unwind
         mid-grip — the run finishes this and the teardown carries the object.
         Closing on air reaches ~GRIPPER_EMPTY_J6, which _grasp_verified's j6
         check catches."""
         p = self._p
+        pitch = self._grasp_pitch(roll)
         if p["close_lift_m"] > 0:
             try:
                 ee_z = self.manipulation.pose.z
@@ -505,7 +546,9 @@ class PickAnyObject(Skill):
                     x,
                     y,
                     ee_z + p["close_lift_m"],
-                    pitch=p["arm_pitch"],
+                    roll=roll,
+                    pitch=pitch,
+                    yaw=yaw,
                     duration=0.5,
                     tolerance_xy=None,
                     tolerance_z=None,
@@ -555,7 +598,7 @@ class PickAnyObject(Skill):
             # and would zero the grip preload. move_to verifies by FK and
             # recover-retries, so the arm is confirmed off the floor (or the
             # run fails cleanly and teardown carries with the grip kept).
-            self.manipulation.move_to(x, y, 0.22, pitch=p["arm_pitch"], duration=2.0, tolerance_xy=0.10)
+            self.manipulation.move_to(x, y, 0.22, roll=roll, pitch=pitch, yaw=yaw, duration=2.0, tolerance_xy=0.10)
 
     def _grasp_at(self, prompt, xy):
         """Full grasp at floor xy (base_link)."""
@@ -568,14 +611,15 @@ class PickAnyObject(Skill):
         self.manipulation.gripper_open(duration=1.0)
         if p["wrist_steps"] >= 1:
             self._goto_search_pose(math.atan2(y, x))
-            x, y, z = self._wrist_descend(prompt, x, y)
+            x, y, z, roll = self._wrist_descend(prompt, x, y)
         else:
-            z = p["hover_z"]
+            z, roll = p["hover_z"], 0.0
             self.manipulation.move_to(x, y, z, pitch=p["arm_pitch"], duration=p["hover_s"])
 
-        self._push_to_floor(x, y, z)
+        yaw = self._grasp_yaw()
+        self._push_to_floor(x, y, z, roll, yaw)
         self.check_cancelled()  # last exit before the fingers commit
-        self._close_twist_lift(x, y)
+        self._close_twist_lift(x, y, roll, yaw)
 
     def _grasp_verified(self, prompt, approach: FloorApproach):
         """Back up, then check floor clear + gripper not open. Gemini gets both


### PR DESCRIPTION
## What

`pick_any_object` always closed the gripper at the same roll. Its 81 mm jaw is narrower than most objects' long side, so anything elongated lying across the fingers was missed. The wrist stage now measures the object's main axis from the object-vs-floor mask it already tracks, and rolls the wrist so the fingers close across the object's **short** side.

## How

- **`innate.vision.seg_track`** also returns the blob's `Axis` (major-axis angle in image coordinates, elongation). It is the min-area rectangle of the Otsu-thresholded back-projection component under the CamShift window. CamShift's own ellipse was tried first and rejected: its window only hugs part of a blob that grows during the descent, and the angle drifted 0°→35° over one descent while the mask rectangle stayed within 3–6° at every height.
- **Roll = image angle − 90°.** The wrist camera rolls with the fingers, which close along image horizontal, so the blob's image angle is already relative to the jaw; no frame conversion. The last reading above `AXIS_MIN_Z` (7 cm) is used, because below that the fingers straddle and clip the blob in the wrist view. Blobs rounder than `MIN_ELONGATION` keep roll 0 (socks, balls, cubes behave as before).
- **Rolled grasps descend with a vertical tool axis** (`ROLLED_PITCH`). At `arm_pitch` 1.30 a 90° roll puts one fingertip 3 cm below the other; the low finger lands on a 3 cm bar and the descent stalls with the other pad above it (measured in MuJoCo, reproduced in the ROS stack at ee z 0.047 → miss). The real IK reaches π/2 at the push heights across the pick box.
- **IK yaw = the arm's own j1** for the push/close moves. At vertical pitch RPY is gimbal-locked and a yaw-0 target makes the solver put all of j1 into j5 (up to 22° of roll error, seen as j5 = roll + j1 in the logs). With yaw = j1 the target is exactly reachable and j5 == roll in every trial.

## Sim evidence

Full ROS stack in `innate-sim`, real skill via `innate skill run innate-os/pick_any_object @prompt="the orange bar"`, bar prop 1 m ahead of spawn at four world yaws, ground truth from the world-server stream.

| | before | after |
|---|---|---|
| bar orientations graspable | 1 of 4 (along x only) | 4 of 4 |
| bar runs, final code | | 5 / 7 held |
| sock runs (no-regression) | | 2 / 2 held |

The two misses were marginal pinches (j6 0.20–0.26 at close) that slipped during the twist/lift, not roll errors; measured roll was within 5° of ideal in every run. Rig physics (headless `VirtualMars`) says the jaw tolerates ~15–30° of roll error.

## Hardware checks before trusting this on a MARS

- Roll sign was verified in sim only. If a real wrist camera is mirrored, negate in `_grasp_roll` (one line, noted in its docstring).
- The vertical pitch for rolled grasps is untested on hardware; the IK reaches it for x 0.25–0.31 m at z ≤ 0.10 m, not at x 0.36 m.
- Pre-existing, not fixed here: the wrist CamShift tracker occasionally never locks on a thin diagonal bar, in which case the skill falls back to today's unrolled blind push.

## Checks

ruff + format clean on `brain_client/` and the skill, basedpyright 0 errors on `innate/vision.py`, 281 brain_client tests pass in the sim container.
