### PR TITLE
sim: share one Three.js stage across pages, plus Respawn and touch panel fixes

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/node.py
@@ -50,7 +50,7 @@ from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, QoSProfile, qos_profile_sensor_data
 from sensor_msgs.msg import CameraInfo, CompressedImage, Image, JointState, LaserScan, PointCloud2, PointField
-from std_msgs.msg import Empty, Float64MultiArray, Int32, Int64, String
+from std_msgs.msg import Bool, Float64MultiArray, Int32, Int64, String
 from std_srvs.srv import Trigger
 from tf2_ros import TransformBroadcaster
 
@@ -167,9 +167,9 @@ class VirtualMarsNode(Node):
             Float64MultiArray, "/mars/arm/commands", self._on_arm_commands, qos_profile_sensor_data
         )
         self.create_subscription(Int32, "/mars/head/set_position", self._on_head_position, 10)
-        # Sim-only convenience (no real-robot equivalent): respawn at the
-        # spawn pose, used by sim/viewer's Reset button in connected mode.
-        self.create_subscription(Empty, "/virtual_mars/reset", self._on_reset, 10)
+        # Sim-only. Bool, not Empty: rws cannot deserialize a zero-field message
+        # from a browser and takes this subscriber down with it.
+        self.create_subscription(Bool, "/virtual_mars/reset", self._on_reset, 10)
 
         services = ReentrantCallbackGroup()  # goto services block; don't starve timers
         if GotoJS is not None:
@@ -260,7 +260,7 @@ class VirtualMarsNode(Node):
                 self._segments.pop(0)
                 self._segment_started = None
 
-    def _on_reset(self, _msg: Empty) -> None:
+    def _on_reset(self, _msg: Bool) -> None:
         with self._lock:
             self._fail_active_traj()
             self.sim.reset()

--- a/sim/README.md
+++ b/sim/README.md
@@ -529,7 +529,7 @@ highlights:
   still plays back at the commanded rate
 - latched `/robot_info` `{"simulated": true}` — how the webapp knows to
   render the Three.js view instead of opening WebRTC
-- `/virtual_mars/reset` (sim-only)
+- `/virtual_mars/reset` (sim-only, `std_msgs/Bool` — see node.py)
 
 Camera topics render lazily — no subscribers, no render requests, no GL
 work — which is what makes headless runs cheap.

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -1104,6 +1104,19 @@ export class SimScene {
     this.robotRoot.visible = true;
     this.robotRoot.position.set(x, y, 0);
     this.robotRoot.rotation.set(0, 0, yaw);
+    this.frameFacing(x, y, yaw);
+    this.renderer.domElement.style.visibility = "";
+    this.followPrevXY = [x, y];
+  }
+
+  /** Re-frame on the robot where it stands (see simStage's attach). */
+  frameRobot(): void {
+    if (!this.spawned) return; // no real pose yet -- spawnAt still owes the first framing
+    this.frameFacing(this.robotRoot.position.x, this.robotRoot.position.y, this.robotRoot.rotation.z);
+  }
+
+  private frameFacing(x: number, y: number, yaw: number): void {
+    this.cameraTween = undefined; // an overview fly-out in flight would drag it straight back off
 
     const forwardX = Math.cos(yaw);
     const forwardY = Math.sin(yaw);
@@ -1125,9 +1138,6 @@ export class SimScene {
     this.camera.position.copy(target).addScaledVector(perch.sub(target), pullback);
     this.controls.target.copy(target);
     this.controls.update();
-    this.renderer.domElement.style.visibility = "";
-
-    this.followPrevXY = [x, y];
   }
 
   /** Move the robot root to a 2D pose (meters, yaw radians about +Z). */

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -66,6 +66,8 @@ const TOUCH_PLACEMENT_HINT: Partial<Record<PlacementState["kind"], string>> = {
 export function createSimStage(
   parent: HTMLElement,
   session: SimSession,
+  // Via the ROS node, not the world server: it fails the in-flight arm trajectory.
+  onRespawn: () => void,
 ): {
   audioEl: null;
   setSafeInsets: (insets: { right?: number }) => void;
@@ -107,6 +109,7 @@ export function createSimStage(
     '<span class="sim-scene-toggle-icon sim-scene-toggle-shapes" aria-hidden="true"></span>' +
     '<svg class="sim-scene-toggle-icon sim-scene-toggle-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><path d="m7 7 10 10M17 7 7 17"/></svg>';
 
+  const coarsePointer = window.matchMedia("(hover: none)");
   let setupOpen = localStorage.getItem("sim-scene-panel-open") === "true";
   const setSetupOpen = (open: boolean) => {
     setupOpen = open;
@@ -124,6 +127,13 @@ export function createSimStage(
     clearPlacementSelection();
   };
   document.addEventListener(PANEL_OPEN_EVENT, onPanelOpen);
+  // Touch only: on a mouse, clicking the scene is how an armed prop gets placed.
+  const onOutsidePointer = (event: PointerEvent) => {
+    if (!setupOpen || !coarsePointer.matches) return;
+    if (event.target instanceof Node && setup.contains(event.target)) return;
+    setSetupOpen(false);
+  };
+  document.addEventListener("pointerdown", onOutsidePointer, true);
   setupToggle.onclick = () => setSetupOpen(!setupOpen);
   setup.append(setupBody, setupToggle);
   debugStack.appendChild(setup);
@@ -199,7 +209,6 @@ export function createSimStage(
   placementToast.className = "sim-placement-toast";
   placementToast.hidden = true;
   wrap.appendChild(placementToast);
-  const coarsePointer = window.matchMedia("(hover: none)");
   let placement: PlacementState = { kind: "choose-prop" };
   const selectedProp = (): string | null =>
     placement.kind === "following" || placement.kind === "rotating" ? placement.prop : null;
@@ -254,7 +263,17 @@ export function createSimStage(
   viewAids.appendChild(viewAidsLabel);
   addToggle(viewAids, "Lidar", (on) => session.setLidarVisible(on));
   addToggle(viewAids, "Collisions", (on) => session.setCollisionHullsVisible(on));
-  utilitySection.append(cameraModes, viewAids);
+  const robotRow = document.createElement("div");
+  robotRow.className = "sim-view-aids";
+  const robotRowLabel = document.createElement("span");
+  robotRowLabel.textContent = "Robot";
+  const respawnChip = makeChip("Respawn", "Back to the spawn pose, arm home, every prop parked");
+  respawnChip.onclick = () => {
+    clearPlacementSelection();
+    onRespawn();
+  };
+  robotRow.append(robotRowLabel, respawnChip);
+  utilitySection.append(cameraModes, viewAids, robotRow);
   setupBody.appendChild(utilitySection);
 
   const propChips = new Map<string, HTMLButtonElement>();
@@ -630,6 +649,7 @@ export function createSimStage(
       window.removeEventListener("pointerup", finishDrop);
       window.removeEventListener("pointercancel", cancelDrop);
       document.removeEventListener(PANEL_OPEN_EVENT, onPanelOpen);
+      document.removeEventListener("pointerdown", onOutsidePointer, true);
       scene.dispose();
       wrap.remove();
     },

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -3,6 +3,11 @@
 // so the webapp's CSS behaves identically. Owns all rendering: primary view
 // full-res every frame, PiP thumbnails scissor-rendered from the same GL
 // context and blitted out.
+//
+// One stage serves every page: detach() parks it out of the DOM, attach()
+// drops it into the next one. Rebuilding it per page refetched ~80 MB of
+// models and never gave the memory back (~450 MB of renderer RSS a switch),
+// which walked a phone into the OS memory killer.
 
 import * as THREE from "three";
 import { SimScene, type CameraMode, type CameraView } from "./scene";
@@ -61,7 +66,13 @@ const TOUCH_PLACEMENT_HINT: Partial<Record<PlacementState["kind"], string>> = {
 export function createSimStage(
   parent: HTMLElement,
   session: SimSession,
-): { audioEl: null; setSafeInsets: (insets: { right?: number }) => void; destroy: () => void } {
+): {
+  audioEl: null;
+  setSafeInsets: (insets: { right?: number }) => void;
+  attach: (parent: HTMLElement) => void;
+  detach: () => void;
+  destroy: () => void;
+} {
   const wrap = document.createElement("div");
   // The class's position:absolute+inset:0 must survive: overriding it once had
   // the wrap size itself off the canvas buffer, ignoring window resizes.
@@ -486,6 +497,19 @@ export function createSimStage(
   let thumbCursor = 0;
   let lastTime = performance.now();
   let disposed = false;
+  let attached = true;
+
+  // rAF is throttled for a hidden tab but not for a detached canvas, so a
+  // parked stage would render full-rate into nothing.
+  const startLoop = () => {
+    if (raf !== 0 || !attached || disposed) return;
+    lastTime = performance.now(); // a paused stage must not integrate the gap as one dt
+    raf = requestAnimationFrame(loop);
+  };
+  const stopLoop = () => {
+    cancelAnimationFrame(raf);
+    raf = 0;
+  };
 
   const loop = (now: number) => {
     raf = requestAnimationFrame(loop);
@@ -543,7 +567,7 @@ export function createSimStage(
       // replaces it. Bail at each await if the stage was destroyed mid-load
       // (SPA remount) -- else we'd mutate a disposed scene.
       session.stageReady();
-      raf = requestAnimationFrame(loop);
+      startLoop();
       // The apartment manifest first (a few KB, unqueued): it draws every
       // room's placeholder box and frames the camera on them, so the first
       // frames show the apartment's wireframe layout rather than an empty
@@ -575,12 +599,32 @@ export function createSimStage(
   return {
     audioEl: null, // sim has no robot mic; the pages skip the mic toggle in sim mode
     setSafeInsets: (insets) => scene.setSafeInsets(insets),
+    attach(next: HTMLElement) {
+      attached = true;
+      next.appendChild(wrap);
+      startLoop();
+      resize();
+      // A page used to get a new scene, so entering one always framed the
+      // robot in free orbit; that is page state, not session state.
+      scene.setCameraMode("free");
+      scene.frameRobot();
+    },
+    detach() {
+      attached = false;
+      stopLoop();
+      // The agent page lifts this into its own layout; take it back before
+      // that page clears its DOM.
+      wrap.appendChild(debugStack);
+      scene.setSafeInsets({ right: 0 }); // the agent dock's inset must not follow the stage
+      clearPlacementSelection(); // an armed prop must not follow the pointer either
+      wrap.remove();
+    },
     destroy() {
       disposed = true;
       queue.cancel(); // stop pulling new downloads for a stage that's gone
       unsubscribe();
       unsubscribeProps();
-      cancelAnimationFrame(raf);
+      stopLoop();
       observer.disconnect();
       longTaskObserver?.disconnect();
       window.removeEventListener("pointerup", finishDrop);

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -5981,7 +5981,7 @@ select.episodes-tool {
 
 .skills-pop-search {
   position: relative;
-  margin: 8px 8px 0;
+  margin: 8px;
 }
 
 /* The popover opens upward from the pill, so the search goes to its near end
@@ -5993,7 +5993,6 @@ select.episodes-tool {
 
   .skills-pop-search {
     order: 1; /* after the list, which keeps the default 0 */
-    margin: 8px; /* clear of the list above and the popover's edge below */
   }
 }
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -390,6 +390,12 @@ select.skill-input {
     grid-row: 2;
   }
 
+  /* The cockpit's scene is the page, so it runs the full height and the
+     wordmark sits on it. Every other page keeps the band. */
+  .stage:has(.cockpit) {
+    grid-row: 1 / -1;
+  }
+
   /* Touch has no hover, so the desktop hover-expand never fires. */
   .rail:hover {
     width: 216px;
@@ -7396,7 +7402,9 @@ select.skill-input {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  min-height: 0;
+  /* Header + gap + one row. Stops here rather than shrinking on, so the roster
+     scrolls while there is room for a row and the panel scrolls once there is not. */
+  min-height: 106px;
 }
 
 .sim-scene-section-header {
@@ -7429,10 +7437,21 @@ select.skill-input {
 .sim-prop-grid {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  min-height: 64px; /* a row of objects survives even the shortest screen */
+  min-height: 64px; /* one whole row of objects, plus a sliver of the next */
   gap: 7px;
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+
+@media (max-height: 720px) {
+  .sim-scene-panel {
+    gap: 10px;
+  }
+
+  .sim-scene-section,
+  .sim-scene-utilities {
+    gap: 8px;
+  }
 }
 
 .sim-scene-button,

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -7229,11 +7229,16 @@ select.skill-input {
   position: absolute;
   bottom: 66px;
   left: 0;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   width: min(360px, calc(100vw - 92px));
+  /* It grows upward from a fixed bottom, so a short screen clipped its top off.
+     66px of its own offset + the stack's 132px + room for the phone rail. */
+  max-height: calc(100dvh - 264px);
   padding: 0 13px 13px;
   gap: 14px;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   background: rgb(8 8 10 / 42%);
   backdrop-filter: blur(30px) saturate(1.1) brightness(0.82);
   -webkit-backdrop-filter: blur(30px) saturate(1.1) brightness(0.82);
@@ -7387,6 +7392,13 @@ select.skill-input {
   gap: 12px;
 }
 
+.sim-scene-section:has(.sim-prop-grid) {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .sim-scene-section-header {
   display: flex;
   min-height: 30px;
@@ -7417,7 +7429,10 @@ select.skill-input {
 .sim-prop-grid {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
+  min-height: 64px; /* a row of objects survives even the shortest screen */
   gap: 7px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .sim-scene-button,

--- a/webapp/js/agent/challengePanel.js
+++ b/webapp/js/agent/challengePanel.js
@@ -64,6 +64,14 @@ export function createChallengePanel(root, session) {
     if (opened !== PANEL_ID && open) setOpen(false);
   };
   document.addEventListener(PANEL_OPEN_EVENT, onPanelOpen);
+  // Touch only, and never over a live goal list — the rule dismiss() follows.
+  const coarsePointer = window.matchMedia("(hover: none)");
+  const onOutsidePointer = (/** @type {PointerEvent} */ event) => {
+    if (!open || !coarsePointer.matches || challengeRunning) return;
+    if (event.target instanceof Node && dock.contains(event.target)) return;
+    setOpen(false);
+  };
+  document.addEventListener("pointerdown", onOutsidePointer, true);
   launcher.addEventListener("click", () => setOpen(!open));
   // Subtle standing hint back to the docs — reopens the first-run intro
   // (challengeIntro.js) with the tutorial link and preview.
@@ -256,6 +264,7 @@ export function createChallengePanel(root, session) {
       intro?.close();
       unsub();
       document.removeEventListener(PANEL_OPEN_EVENT, onPanelOpen);
+      document.removeEventListener("pointerdown", onOutsidePointer, true);
       dock.remove();
     },
   };

--- a/webapp/js/agent/chatStream.js
+++ b/webapp/js/agent/chatStream.js
@@ -79,6 +79,15 @@ export function createChatStream() {
     if (wasAtBottom) stream.scrollTop = stream.scrollHeight;
   }
 
+  // A shorter sheet keeps scrollTop, pinning the top of the view and pushing
+  // the newest turn out of sight.
+  let pinnedToBottom = true;
+  stream.addEventListener("scroll", () => {
+    pinnedToBottom = atBottom();
+  });
+  const streamResize = new ResizeObserver(() => settleStreamAfterMutation(pinnedToBottom));
+  streamResize.observe(stream);
+
   /** @param {HTMLElement} el */
   function appendStreamItem(el) {
     stream.append(el);
@@ -478,6 +487,7 @@ export function createChatStream() {
     replay,
     setMode: setStreamMode,
     destroy() {
+      streamResize.disconnect();
       for (const timer of compactEnterTimers) clearTimeout(timer);
     },
   };

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -377,4 +377,8 @@ export const STEREO_CALIB_DEFAULT_MIN_CORNERS = 10;
 // zero-new-ROS-code proxy for "the robot currently has a calibration file".
 export const MAIN_CAMERA_DEPTH_TOPIC = "/mars/main_camera/depth/image_rect_raw";
 
+// Sim only: put the robot back at its spawn pose, arm home, every prop parked.
+// std_msgs/Bool for the same rws reason as STEREO_CALIB_CAPTURE_TOPIC above.
+export const SIM_RESPAWN_TOPIC = "/virtual_mars/reset";
+
 export const LAST_IP_KEY = "innate.lastRobotIP";

--- a/webapp/js/robotSession.js
+++ b/webapp/js/robotSession.js
@@ -20,6 +20,8 @@
 import { WebRtcSession } from "./webrtcSession.js";
 import { acquireVideoSession, releaseVideoSession } from "./sharedVideoSession.js";
 import { getConfig } from "./config.js";
+import { ros } from "./rosClient.js";
+import { SIM_RESPAWN_TOPIC } from "./constants.js";
 
 /** @typedef {{ audioEl: null, attach: (parent: HTMLElement) => void, detach: () => void, destroy: () => void, setSafeInsets: (insets: { right?: number }) => void }} SimStage */
 
@@ -46,6 +48,8 @@ export async function robotSessionFactory() {
       // URL, not a module path tsc can resolve.
       // @ts-ignore
       const mod = await import("/sim-viewer/sim-session.js");
+      // rws resolves a bare publish against the graph; nothing else publishes here.
+      ros.advertise(SIM_RESPAWN_TOPIC, "std_msgs/msg/Bool");
       return {
         createSession: () => acquireSimSession(mod, config),
         releaseSession: () => releaseSimSession(),
@@ -93,7 +97,10 @@ function releaseSimSession() {
  */
 function acquireSimStage(mod, root, session) {
   if (simStage) simStage.attach(root);
-  else simStage = /** @type {SimStage} */ (mod.createSimStage(root, session));
+  else {
+    const respawn = () => ros.publish(SIM_RESPAWN_TOPIC, { data: true });
+    simStage = /** @type {SimStage} */ (mod.createSimStage(root, session, respawn));
+  }
   const stage = simStage;
   return { ...stage, destroy: () => stage.detach() };
 }

--- a/webapp/js/robotSession.js
+++ b/webapp/js/robotSession.js
@@ -10,15 +10,27 @@
 //   ...inside buildCockpit:
 //     const session = createSession();
 //     const stage = createStage ? createStage(root, session) : createVideoStage(root, session);
-//   ...inside destroy: releaseSession(session), never session.destroy().
+//   ...inside destroy: stage.destroy() then releaseSession(session), never session.destroy().
 //
-// Real robots hand every page the app-level shared WebRtcSession (see
-// sharedVideoSession.js), so page switches reuse the live link. Sim sessions
-// stay per-page: they render local canvases, so there is no link to keep warm.
+// Either backend hands every page ONE app-level session: real robots keep the
+// live WebRTC link (sharedVideoSession.js), and the sim keeps its whole stage,
+// whose page-facing destroy() only detaches it. Rebuilding that stage per page
+// never gave its memory back, which killed the tab on a phone (simStage.ts).
 
 import { WebRtcSession } from "./webrtcSession.js";
 import { acquireVideoSession, releaseVideoSession } from "./sharedVideoSession.js";
 import { getConfig } from "./config.js";
+
+/** @typedef {{ audioEl: null, attach: (parent: HTMLElement) => void, detach: () => void, destroy: () => void, setSafeInsets: (insets: { right?: number }) => void }} SimStage */
+
+// Long next to sharedVideoSession's 10s: a detour to Settings must not pay to
+// reparse ~80 MB of models.
+const SIM_LINGER_MS = 60_000;
+
+/** @type {any} */ let simSession = null;
+/** @type {SimStage | null} */ let simStage = null;
+let simHolders = 0;
+/** @type {number | null} */ let simLinger = null;
 
 /**
  * @returns {Promise<{ createSession: () => WebRtcSession, releaseSession: (session: WebRtcSession) => void, createStage: ((root: HTMLElement, session: WebRtcSession) => { audioEl: HTMLAudioElement | null, destroy: () => void }) | null }>}
@@ -35,13 +47,53 @@ export async function robotSessionFactory() {
       // @ts-ignore
       const mod = await import("/sim-viewer/sim-session.js");
       return {
-        createSession: () => /** @type {any} */ (mod.createSimSession({ statePort: config.worldStatePort })),
-        releaseSession: (session) => session.destroy(),
-        createStage: (root, session) => mod.createSimStage(root, /** @type {any} */ (session)),
+        createSession: () => acquireSimSession(mod, config),
+        releaseSession: () => releaseSimSession(),
+        createStage: (root, session) => acquireSimStage(mod, root, session),
       };
     } catch (err) {
       console.error("[robotSession] sim viewer bundle unavailable, falling back to WebRTC:", err);
     }
   }
   return { createSession: acquireVideoSession, releaseSession: releaseVideoSession, createStage: null };
+}
+
+/**
+ * @param {any} mod
+ * @param {any} config
+ */
+function acquireSimSession(mod, config) {
+  if (simLinger !== null) {
+    clearTimeout(simLinger);
+    simLinger = null;
+  }
+  simSession ??= mod.createSimSession({ statePort: config.worldStatePort });
+  simHolders += 1;
+  return /** @type {any} */ (simSession);
+}
+
+function releaseSimSession() {
+  if (!simSession || simHolders === 0) return;
+  simHolders -= 1;
+  if (simHolders > 0) return;
+  simLinger = setTimeout(() => {
+    simLinger = null;
+    simStage?.destroy();
+    simStage = null;
+    simSession?.destroy();
+    simSession = null;
+  }, SIM_LINGER_MS);
+}
+
+/**
+ * The one stage, re-parented into each page it serves.
+ * @param {any} mod
+ * @param {HTMLElement} root
+ * @param {any} session
+ */
+function acquireSimStage(mod, root, session) {
+  if (simStage) simStage.attach(root);
+  else simStage = /** @type {SimStage} */ (mod.createSimStage(root, session));
+  const stage = simStage;
+  return { ...stage, destroy: () => stage.detach() };
 }

--- a/webapp/js/robotSession.js
+++ b/webapp/js/robotSession.js
@@ -60,7 +60,7 @@ export async function robotSessionFactory() {
 
 /**
  * @param {any} mod
- * @param {any} config
+ * @param {{ worldStatePort?: number }} config
  */
 function acquireSimSession(mod, config) {
   if (simLinger !== null) {

--- a/webapp/js/teleop/cameraSwitch.js
+++ b/webapp/js/teleop/cameraSwitch.js
@@ -79,8 +79,10 @@ export function createCameraSwitch(parent, session, ros, opts = {}) {
   camsToggle.hidden = true;
   camsToggle.innerHTML =
     '<svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
-    '<path d="M3 8.8A2.3 2.3 0 0 1 5.3 6.5h1.4a1.5 1.5 0 0 0 1.25-.67l.6-.9a1.5 1.5 0 0 1 1.25-.68h4.4a1.5 1.5 0 0 1 1.25.68l.6.9a1.5 1.5 0 0 0 1.25.67h1.4A2.3 2.3 0 0 1 21 8.8v7.9a2.3 2.3 0 0 1-2.3 2.3H5.3A2.3 2.3 0 0 1 3 16.7z"/>' +
-    '<circle cx="12" cy="12.5" r="3.3"/></svg>';
+    // An eye, not a camera body: this shows and hides the view tiles, and a
+    // camera glyph reads as "take a photo".
+    '<path d="M2.4 12S6.2 5.6 12 5.6 21.6 12 21.6 12 17.8 18.4 12 18.4 2.4 12 2.4 12Z"/>' +
+    '<circle cx="12" cy="12" r="3.1"/></svg>';
   (opts.stripParent ?? parent).append(camsToggle, strip);
 
   // Collapsible only where the room is tight; wide stages keep the tiles up.

--- a/webapp/js/teleop/skillsMenu.js
+++ b/webapp/js/teleop/skillsMenu.js
@@ -240,6 +240,8 @@ export function createSkillsMenu(parent, rosClient) {
     return { inputs: out };
   }
 
+  const coarsePointer = window.matchMedia("(hover: none)");
+
   // ---- run lifecycle ------------------------------------------------------
 
   /** @param {any} skill @param {boolean} [closeOnStart] */
@@ -269,7 +271,9 @@ export function createSkillsMenu(parent, rosClient) {
     );
     run = { skillId: skill.id, cancel, text: "Running…", error: false, canceling: false, done: false };
     render();
-    if (closeOnStart) {
+    // Touch has no keyboard to hand back to, and focusing the search box there
+    // just raises the on-screen one over the stage you came to watch.
+    if (closeOnStart || coarsePointer.matches) {
       setOpen(false);
       // Return keyboard control to the page. Keeping focus on the closed Skills
       // button makes the next Enter reopen this menu instead of focusing chat.


### PR DESCRIPTION
Started as one fix and picked up a handful of small sim/UI items along the way. They're described separately below; the first is the substantial one.

## 1. One Three.js stage for the whole app

Switching between Agent and Teleop in sim crashed the tab on a phone, and after a few crashes Safari showed *"A problem repeatedly occurred"* for the origin.

The sim stage was per-page. `robotSession.js` gave real robots the shared `WebRtcSession` but said sim sessions "stay per-page: they render local canvases, so there is no link to keep warm" — a local canvas turned out not to be cheap. Every rail click destroyed the stage and built a new one: a fresh GL context, the apartment + robot URDF/STLs, and `prefetchPropModels()` reparsing every prop glb (the human alone is 23 MB of glb → 67 MB of decoded texture), unconditionally, on both pages.

Measured against a running sim, 5 agent↔teleop round trips:

| | before | after |
|---|---|---|
| model/mesh requests per switch | 22 | **0** |
| renderer+GPU RSS over 5 round trips | **+4.4 GB** (~450 MB a switch, never reclaimed) | +20 MB |
| JS heap after forced GC | +3 MB per round trip, linear | flat, 7–8 MB |

The memory not coming back is what made this fatal rather than merely slow.

- **`simStage.ts`** — `attach(parent)` / `detach()`. Detach stops the render loop (rAF is throttled for a hidden tab but not for a detached canvas), reclaims the debug stack the agent page lifts into its own layout, clears the agent dock's safe-inset and any armed prop, and parks the wrap out of the DOM.
- **`robotSession.js`** — one module-level sim session + stage with acquire/release and a 60s linger, mirroring `sharedVideoSession`. A page's `stage.destroy()` only detaches.
- **`scene.ts`** — `frameRobot()`, the camera half of `spawnAt` extracted. `spawnAt` fires once per *session*, so a shared session lost the "face the robot on entry" framing; `attach()` restores it along with free orbit mode, matching what a rebuilt scene gave.

## 2. Respawn chip

A `Robot › Respawn` chip in the sim's Scene setup panel: robot back to its spawn pose, arm home, every prop parked.

`/virtual_mars/reset` already did exactly this. It was built for a Reset button in the old standalone viewer (the comment in `node.py` still said so) and survived into a state where **nothing published it** — reachable only by hand with `ros2 topic pub`. The chip publishes it over the rosbridge socket the app already holds, rather than adding a world-server stage command, so `_on_reset` fails the in-flight arm trajectory before teleporting the base.

**This changes a topic's message type, which is the part worth a careful look.** `/virtual_mars/reset` was `std_msgs/Empty`, and a browser cannot publish that: rws cannot deserialize a zero-field message and *takes the subscriber node down with it* — the reason `STEREO_CALIB_CAPTURE_TOPIC` is already a Bool. So the subscription is now `std_msgs/Bool`. Since the topic had no publishers, the only thing this breaks is a hand-typed `ros2 topic pub ... std_msgs/msg/Empty`; `sim/README.md` now names the type. If you'd rather not touch a published contract, the alternative is a second Bool topic alongside the Empty one, at the cost of two topics doing one job.

## 3. Touch: tap away to close

Scene setup and Challenges could only be closed with their ✕. On a phone both cover the stage, so a pointerdown outside them now closes them. Gated on `(hover: none)`, matching how Scene setup already decides touch behaviour — mouse behaviour is unchanged, where clicking the scene is how an armed prop gets placed. A running challenge still holds its goal list, the rule `dismiss()` already followed.

## 4. Compact agent sheet keeps the newest message

Dragging the sheet shorter left `scrollTop` where it was, pinning the top of the view and pushing the last message out of sight. The transcript now follows its own height — but only for a reader who was already at the bottom, so scrollback is still never yanked.

## 5. Scene setup fits a phone screen

The panel grows upward from a fixed bottom with no height cap, so on a phone its top ran off the stage — Objects and Clear all were simply unreachable. It is now capped to the room above the debug stack, with the object roster taking the squeeze since that is the part that grows with the prop list. The panel becomes a flex column so the roster can actually shrink (grid auto rows do not), with a floor of one row and a scroll on the panel itself as a last resort, so no control is ever cut off.

The section floors at one whole row rather than shrinking on, so the roster scrolls while a row fits and the panel itself scrolls only once it does not; short screens also tighten their gaps. Measured across viewports (agent and teleop, panel open): fits at 844, 700, 667 and 640px tall, where it previously overflowed the top by up to 120px, with no section overlapping another. Desktop is unchanged.

## 6. Cockpit runs under the wordmark on phones

On phones `body` is a two-row grid and the stage sat in row 2, so every cockpit opened below a black band holding the wordmark. The scene is the page there, so it now spans both rows with the wordmark over it. Other pages keep the band — their headers vary too much for each to hold itself clear. The camera strip and the top-left overlay stack both clear the 64px wordmark.

## 7. Eye, not a camera, for the view-tiles toggle

The button that folds the camera tiles away carried a camera-body glyph, which reads as "take a photo". It is an eye now; same stroke weight, same `Camera views` label.

## 8. Run closes the skills menu on touch

Running a skill left the menu open and focused its search box, so the next pick needs no reach for the mouse. On a phone that raises the on-screen keyboard over the stage you launched the skill to watch, and there is no hardware keyboard to hand control back to — so on `(hover: none)` running closes the menu instead. Desktop is unchanged: the menu stays open with the search box focused.

## 9. Skills search had no bottom margin

`margin: 8px 8px 0` left the search field flush against the legend band below it on desktop. Phones already overrode it to `8px` all round, which is why only desktop looked wrong; the base rule now matches and the phone override is down to the reorder that earns it.

## Verified

Browser-driven against a live sim (headless Chrome over CDP, plus an emulated iPhone viewport for the touch items):

- Same canvas element across both page switches, 0 model refetches, no loading pill, scene-setup panel survives the round trip. A detour to Settings parks the stage and returns it intact; past the linger it rebuilds cleanly. 0 console errors.
- Camera framing pixel-identical to the opening view after dragging away and navigating back; mode chips agree.
- The Respawn chip renders and publishes — the topic reads `Publisher count: 1` with the browser as a `std_msgs/Bool` publisher.
- Tap outside closes both panels; taps inside keep them open (the prop chip still closes Scene setup, which is the pre-existing arming behaviour).
- Shrinking the sheet keeps the transcript at the bottom; a scrolled-up reader is left alone.
- The scene setup panel fits every phone viewport tested, and its roster scrolls under a touch drag without dismissing the panel.
- Running a skill on an emulated phone closes the menu with nothing focused; on a real-mouse desktop the menu stays open and the search box keeps focus.
- `tsc --noEmit` clean on `sim/viewer`; the touched webapp files add no new errors (`skillsMenu.js` carries 5 pre-existing ones, unchanged before and after).

`ruff` was not available on this machine, so `node.py` is unlinted here — it is a type swap plus a comment, and CI's pre-commit will cover it.

## Note for reviewers

Two behaviours now persist across a page switch that previously reset with the scene: **camera mode** is deliberately reset to `free` on entry (matching the old behaviour), but **prop placements and the scene-setup panel state** now carry over. That reads as the improvement, not a regression — worth a second opinion.




