### PR TITLE
fix(stt): drop the leading punctuation Scribe glues onto a transcript

### DIFF
--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -128,6 +128,13 @@ def _scribe_previous_text(keyterms: "list[str]") -> str:
     return f"Likely words: {', '.join(fitted)}" if fitted else ""
 
 
+_LEADING_PUNCTUATION = re.compile(r"^[\s.,!?;:…\-–—]+")
+
+
+def strip_leading_punctuation(text: str) -> str:
+    return _LEADING_PUNCTUATION.sub("", text).strip()
+
+
 class SlowAgc:
     """Software gain for the quiet far-field mic: instant attack (a loud onset
     can never be pushed past the target), slow release (~16 s back to full
@@ -860,12 +867,14 @@ class MicroInput(InputDevice):
 
     def _on_transcript(self, text: str) -> None:
         """Called when transcript is ready."""
-        if text:
-            self.logger.info(f"🎤 Transcript: {text}")
+        text = strip_leading_punctuation(text)
+        if not text:
+            return
+        self.logger.info(f"🎤 Transcript: {text}")
 
-            self.send_data(text, data_type="chat_in")
-            self._last_transcript = text
-            self._send_vad_status()
+        self.send_data(text, data_type="chat_in")
+        self._last_transcript = text
+        self._send_vad_status()
 
 
 # ========== Audio Streaming Helpers ==========

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -33,6 +33,7 @@ import json
 import queue
 import re
 import shutil
+import string
 import subprocess
 import threading
 import time
@@ -128,10 +129,13 @@ def _scribe_previous_text(keyterms: "list[str]") -> str:
     return f"Likely words: {', '.join(fitted)}" if fitted else ""
 
 
-_LEADING_PUNCTUATION = re.compile(r"^[\s.,!?;:…\-–—]+")
+_PUNCTUATION = ".,!?;:…-–—"
+_LEADING_PUNCTUATION = re.compile(rf"^[{re.escape(_PUNCTUATION)}]+\s+")
 
 
 def strip_leading_punctuation(text: str) -> str:
+    if not text.strip(_PUNCTUATION + string.whitespace):
+        return ""
     return _LEADING_PUNCTUATION.sub("", text).strip()
 
 


### PR DESCRIPTION
Transcripts sometimes reach chat with a stray period on the front — `". Hey."`.

### Why

A commit boundary can flush the punctuation that closed the previous segment onto the front of the next one, so a real utterance arrives with a leading `.`. Separately, a cough or a click can commit as a bare `"."`, which passed the old `if text:` guard and posted an empty-looking chat bubble.

<img width="438" height="164" alt="transcript-punct" src="https://github.com/user-attachments/assets/8c8ee1a2-93b8-4b33-a18b-b7ef46d61937" />

### The change

One pure helper plus an early return at `MicroInput._on_transcript` — the single funnel all three STT backends (Scribe realtime, Scribe batch, Gemini) converge on:

```python
_PUNCTUATION = ".,!?;:…-–—"
_LEADING_PUNCTUATION = re.compile(rf"^[{re.escape(_PUNCTUATION)}]+\s+")


def strip_leading_punctuation(text: str) -> str:
    if not text.strip(_PUNCTUATION + string.whitespace):
        return ""
    return _LEADING_PUNCTUATION.sub("", text).strip()
```

The artifact is always mark-then-space, so the space is required — that keeps a leading mark that belongs to a value:

| in | out |
|---|---|
| `". Hey."` | `"Hey."` |
| `"... um, hi"` | `"um, hi"` |
| `"."`, `"..."`, `" . . "` | dropped |
| `".5 meters"`, `"-5 degrees"` | unchanged |
| `"Hey MARS."`, `"wait... what?"` | unchanged |

### Verification

`ruff check` and `ruff format --check` pass on the file. The brain_client pytest suite and basedpyright were not run — they need the ROS environment (`rclpy`, `mars_msgs`, `innate_proxy`), which isn't available on the dev Mac; this change lives in `workspace/`, which neither target covers.