### PR TITLE
feat(sim): spatialize world audio

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -426,7 +426,6 @@ class BrainClientNode(Node):
         except (KeyError, ValueError) as exc:
             self.get_logger().warning(f"Ignoring invalid environment speech request: {exc}")
             return
-
         shown = threading.Event()
 
         def show() -> None:
@@ -449,6 +448,7 @@ class BrainClientNode(Node):
             on_start=show,
             on_done=deliver,
             protected=True,  # another character's line: agent flushes must not cancel it
+            audio_source=payload.get("source"),
         )
         if not queued:
             deliver(False)

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/tts.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/tts.py
@@ -8,6 +8,7 @@ Generates speech audio and plays it through the robot's audio system.
 
 import base64
 import io
+import json
 import queue
 import struct
 import subprocess
@@ -34,6 +35,7 @@ class _Utterance:
     on_done: Callable[[bool], None] | None
     reply_id: str | None  # sentences of one streamed reply share an id
     protected: bool  # never flushed (environment speech: not our backlog)
+    audio_source: str | None = "robot"  # which simulated body speaks; None means nowhere in particular
 
 
 def _survives_flush(item: _Utterance, playing_reply_id: str | None) -> bool:
@@ -160,6 +162,7 @@ class TTSHandler:
         text: str,
         voice_config: dict[str, Any] | None = None,
         on_start: Callable[[], None] | None = None,
+        audio_source: str | None = "robot",
     ) -> bool:
         """
         Convert text to speech and play it.
@@ -168,6 +171,7 @@ class TTSHandler:
             text: Text to speak
             voice_config: Optional voice configuration override
             on_start: Called once the first audio reaches the speaker
+            audio_source: Simulated body the sound comes from (sim only; the webapp fades it by camera distance)
 
         Returns:
             True if speech was successfully generated and played, False otherwise
@@ -201,7 +205,7 @@ class TTSHandler:
             }
 
             if self._simulator_mode and self.tts_audio_pub is not None:
-                success = self._synthesize_to_topic(text, voice, t_start, on_start)
+                success = self._synthesize_to_topic(text, voice, t_start, on_start, audio_source)
             else:
                 success = self._synthesize_to_aplay(text, voice, t_start, on_start)
         except Exception as e:
@@ -348,8 +352,9 @@ class TTSHandler:
         voice: dict[str, Any],
         t_start: float,
         on_start: Callable[[], None] | None = None,
+        audio_source: str | None = "robot",
     ) -> bool:
-        """Synthesize the full clip and publish it (base64 WAV) on /tts/audio.
+        """Synthesize the full clip and publish it (JSON: base64 WAV + source) on /tts/audio.
 
         The sim container has no audio device, so the webapp is the speaker. We
         collect the whole clip (utterances are short) and publish it once.
@@ -370,7 +375,7 @@ class TTSHandler:
             return False
 
         wav = _finalize_wav(bytes(buf))
-        self._publish_audio(wav)
+        self._publish_audio(wav, audio_source)
         if on_start is not None:
             on_start()
         # Publishing the full clip is the beginning of playback, not the end.
@@ -386,14 +391,13 @@ class TTSHandler:
         )
         return True
 
-    def _publish_audio(self, wav: bytes) -> None:
-        """Publish one already-finalized clip on /tts/audio as base64 WAV."""
+    def _publish_audio(self, wav: bytes, audio_source: str | None) -> None:
         if self.tts_audio_pub is None or not wav:
             return
         from std_msgs.msg import String
 
-        payload = base64.b64encode(wav).decode("ascii")
-        self.tts_audio_pub.publish(String(data=payload))
+        payload = {"audio": base64.b64encode(wav).decode("ascii"), "source": audio_source}
+        self.tts_audio_pub.publish(String(data=json.dumps(payload, separators=(",", ":"))))
 
     def speak_text_async(
         self,
@@ -404,6 +408,7 @@ class TTSHandler:
         on_done: Callable[[bool], None] | None = None,
         reply_id: str | None = None,
         protected: bool = False,
+        audio_source: str | None = "robot",
     ) -> bool:
         """
         Queue text to be spoken. Utterances play in order, one at a time;
@@ -440,7 +445,9 @@ class TTSHandler:
                 self._speech_queue.extend(kept)
             queued = len(self._speech_queue) < self._speech_queue_maxlen
             if queued:
-                self._speech_queue.append(_Utterance(text, voice_config, on_start, on_done, reply_id, protected))
+                self._speech_queue.append(
+                    _Utterance(text, voice_config, on_start, on_done, reply_id, protected, audio_source)
+                )
                 self._speech_cv.notify()
         if not queued:
             self.logger.warning(f"🔇 Speech queue full, dropping: '{text[:60]}'")
@@ -516,12 +523,12 @@ class TTSHandler:
             # reply's flush spares siblings of speech nobody has heard, and they
             # play ahead of the newer answer.
             take_floor = self._floor_taken_on_start(item.reply_id, self._once(item.on_start))
-            success = self.speak_text(item.text, item.voice_config, take_floor)
+            success = self.speak_text(item.text, item.voice_config, take_floor, item.audio_source)
             if not success:
                 self._set_playing_reply(None)
                 self.logger.info("🔄 Retrying TTS after 1 second...")
                 time.sleep(1)
-                success = self.speak_text(item.text, item.voice_config, take_floor)
+                success = self.speak_text(item.text, item.voice_config, take_floor, item.audio_source)
             if not success:
                 self._set_playing_reply(None)
                 self._drop_queued_reply(item.reply_id)

--- a/ros2_ws/src/brain/brain_client/test/test_tts.py
+++ b/ros2_ws/src/brain/brain_client/test/test_tts.py
@@ -46,7 +46,7 @@ def test_failed_reply_no_longer_holds_the_floor(monkeypatch):
     handler._speech_cv = threading.Condition()
     handler._playing_reply_id = None
     handler.logger = SimpleNamespace(info=lambda _message: None, error=lambda _message: None)
-    handler.speak_text = lambda _text, _voice, _on_start=None: False
+    handler.speak_text = lambda _text, _voice, _on_start=None, _audio_source="robot": False
     monkeypatch.setattr("brain_client.transport.tts.time.sleep", lambda _seconds: None)
 
     handler._speech_loop()
@@ -83,7 +83,7 @@ def test_a_reply_nobody_has_heard_loses_its_siblings_to_a_newer_one(monkeypatch,
         assert handler.speak_text_async("new reply", replace_pending=True, reply_id="new-reply")
         handler._speech_queue.append(None)
 
-    def speak(text, _voice, on_start=None):
+    def speak(text, _voice, on_start=None, _audio_source="robot"):
         spoken.append(text)
         if text == "failed first":
             attempt = spoken.count(text)

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/challenges.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/challenges.py
@@ -304,6 +304,7 @@ class EnvironmentReply:
     speaker: str
     text: str
     voice_id: str
+    source: str | None = None
 
 
 @dataclass
@@ -697,6 +698,8 @@ class ChallengeEngine:
                                     "text": reply.text,
                                     "voice_id": reply.voice_id,
                                 }
+                                if reply.source:
+                                    payload["source"] = reply.source
                             elif isinstance(reply, str):
                                 payload = {"sender": "user", "text": reply, "timestamp": time.time()}
                             else:

--- a/sim/challenges/40_household_orders/runtime.py
+++ b/sim/challenges/40_household_orders/runtime.py
@@ -179,19 +179,23 @@ class HouseholdOrdersRuntime(ChallengeRuntime):
                         resident.name,
                         f"I'm {resident.name} and I want {resident.order} Please repeat the complete order back to me.",
                         resident.voice_id,
+                        resident.prop,
                     )
                 )
                 continue
             if self._matches(resident, event["text"]):
                 self._confirmed.add(resident.id)
                 result.events.append({"type": "resident_order_confirmed", "resident": resident.id})
-                result.replies.append(EnvironmentReply(resident.name, "That's correct. Thank you.", resident.voice_id))
+                result.replies.append(
+                    EnvironmentReply(resident.name, "That's correct. Thank you.", resident.voice_id, resident.prop)
+                )
             else:
                 result.replies.append(
                     EnvironmentReply(
                         resident.name,
                         f"Not quite. I want {resident.order} Please repeat the complete order back to me.",
                         resident.voice_id,
+                        resident.prop,
                     )
                 )
         return result

--- a/sim/viewer/src/props.ts
+++ b/sim/viewer/src/props.ts
@@ -276,6 +276,15 @@ export class PropLibrary {
     return [...this.roots.values()].filter((r) => r.visible);
   }
 
+  /** Live world positions keyed by the authoritative prop names. */
+  get audioSourcePositions(): Record<string, [number, number, number]> {
+    const positions: Record<string, [number, number, number]> = {};
+    for (const [name, root] of this.roots) {
+      if (root.visible) positions[name] = [root.position.x, root.position.y, root.position.z];
+    }
+    return positions;
+  }
+
   private buildPlacementPreview(name: string): PlacementPreview | undefined {
     const info = this.info.get(name);
     if (!info) return undefined;

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -154,6 +154,11 @@ const TOP_FALLBACK_HEIGHT_M = 12;
 // Robot-mounted camera views: frames, axis conventions, FOV and near plane
 // match the driver's cameras (mars_sim_driver.core's CAMERAS).
 export type CameraView = "orbit" | "main" | "arm";
+export interface SimAudioPerspective {
+  view: CameraView;
+  listener: [number, number, number];
+  sources: Record<string, [number, number, number]>;
+}
 // Track mars_sim_driver/constants.py: per-camera FOVs matching what the
 // driver renders (the head and wrist are different physical lenses), so the
 // operator's preview frames what the robot consumes. main is the head's real
@@ -887,6 +892,21 @@ export class SimScene {
   setView(view: CameraView): void {
     this.activeView = view === "orbit" || this.robotCameras.has(view) ? view : "orbit";
     this.applyControlsEnabled();
+  }
+
+  /** Snapshot from the exact scene state used by the primary render. */
+  audioPerspective(): SimAudioPerspective {
+    const activeCamera =
+      (this.activeView !== "orbit" ? this.robotCameras.get(this.activeView) : undefined) ?? this.camera;
+    const listener = activeCamera.getWorldPosition(new THREE.Vector3());
+    return {
+      view: this.activeView,
+      listener: [listener.x, listener.y, listener.z],
+      sources: {
+        robot: [this.robotRoot.position.x, this.robotRoot.position.y, this.robotRoot.position.z],
+        ...this.props.audioSourcePositions,
+      },
+    };
   }
 
   /** While a placement drag owns the pointer the orbit controls stay off,

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -31,6 +31,7 @@ const MIN_FRAME_MS = 1000 / 62;
 // are a contract with webapp/js/agent/challengePanel.js.
 const PANEL_OPEN_EVENT = "innate:panel-open";
 const PANEL_ID = "sim-scene-setup";
+const AUDIO_PERSPECTIVE_EVENT = "innate:sim-audio-perspective";
 
 const VIEW_FOR: Record<string, CameraView> = { main: "main", arm: "arm", orbit: "orbit" };
 const ROTATION_DRAG_PX = 6;
@@ -555,6 +556,9 @@ export function createSimStage(
     cancelAnimationFrame(raf);
     raf = 0;
   };
+  const clearAudioPerspective = () => {
+    document.dispatchEvent(new CustomEvent(AUDIO_PERSPECTIVE_EVENT, { detail: null }));
+  };
 
   const loop = (now: number) => {
     raf = requestAnimationFrame(loop);
@@ -581,6 +585,7 @@ export function createSimStage(
     // ...then the primary view full-frame on top.
     scene.setView(VIEW_FOR[session.primaryCamera] ?? "orbit");
     scene.render();
+    document.dispatchEvent(new CustomEvent(AUDIO_PERSPECTIVE_EVENT, { detail: scene.audioPerspective() }));
     frame++;
 
     if (perfEl) {
@@ -685,6 +690,7 @@ export function createSimStage(
     detach() {
       attached = false;
       stopLoop();
+      clearAudioPerspective();
       // The agent page lifts this into its own layout; take it back before
       // that page clears its DOM.
       wrap.appendChild(debugStack);
@@ -699,6 +705,7 @@ export function createSimStage(
       unsubscribeProps();
       unsubscribeEnvironment();
       stopLoop();
+      clearAudioPerspective();
       observer.disconnect();
       longTaskObserver?.disconnect();
       window.removeEventListener("pointerup", finishDrop);

--- a/tests/test_challenge_runtime.py
+++ b/tests/test_challenge_runtime.py
@@ -51,7 +51,9 @@ class ReplyRuntime(ChallengeRuntime):
                 continue
             resident = event["text"]
             result.events.append({"type": "confirmed", "resident": resident})
-            result.replies.append(EnvironmentReply(resident.title(), "Confirmed", f"voice-{resident}"))
+            result.replies.append(
+                EnvironmentReply(resident.title(), "Confirmed", f"voice-{resident}", f"resident-{resident}")
+            )
         return result
 
 
@@ -126,6 +128,7 @@ def test_environment_reply_is_a_speech_request_the_brain_voices(tmp_path):
     assert payload["speaker"] == "A"
     assert payload["sender"] == "environment_speech"
     assert payload["voice_id"] == "voice-a"
+    assert payload["source"] == "resident-a"
 
 
 def test_restart_invalidates_queued_and_dequeued_replies(tmp_path):

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -30,6 +30,7 @@
     <link rel="modulepreload" href="/js/pressActivate.js" />
     <link rel="modulepreload" href="/js/ttsAudio.js" />
     <link rel="modulepreload" href="/js/motorSoundAudio.js" />
+    <link rel="modulepreload" href="/js/simSpatialAudio.js" />
     <link rel="modulepreload" href="/js/micAudioState.js" />
     <link rel="modulepreload" href="/js/agent/main.js" />
     <link rel="modulepreload" href="/js/agent/agentPanel.js" />

--- a/webapp/js/motorSoundAudio.js
+++ b/webapp/js/motorSoundAudio.js
@@ -6,6 +6,7 @@
 
 import { ros } from "./rosClient.js";
 import { base64ToBytes, isRobotAudioSpeaker } from "./ttsAudio.js";
+import { followSimAudioSource } from "./simSpatialAudio.js";
 
 const TOPIC = "/motor_sound/audio";
 const LEAD_S = 0.12;
@@ -14,6 +15,8 @@ const MAX_QUEUED_S = 0.5;
 let started = false;
 /** @type {AudioContext | null} */
 let context = null;
+/** @type {GainNode | null} */
+let output = null;
 let nextAt = 0;
 
 export function initMotorSoundAudio() {
@@ -25,7 +28,12 @@ export function initMotorSoundAudio() {
   const unlock = () => {
     if (!context) {
       const Context = window.AudioContext || /** @type {any} */ (window).webkitAudioContext;
-      if (Context) context = new Context();
+      if (Context) {
+        context = new Context();
+        output = context.createGain();
+        output.connect(context.destination);
+        followSimAudioSource("robot", (gain) => output?.gain.setTargetAtTime(gain, context?.currentTime ?? 0, 0.05));
+      }
     }
     void context?.resume();
   };
@@ -40,27 +48,30 @@ export function initMotorSoundAudio() {
   });
 
   ros.subscribe(TOPIC, (msg) => {
-    if (!context || document.visibilityState === "hidden" || !isRobotAudioSpeaker() || typeof msg?.data !== "string") {
+    if (!output || document.visibilityState === "hidden" || !isRobotAudioSpeaker() || typeof msg?.data !== "string") {
       return;
     }
+    const out = output;
+    const ctx = /** @type {AudioContext} */ (out.context);
     let payload;
     try {
       payload = JSON.parse(msg.data);
     } catch {
       return; // a malformed audio packet must not disrupt the shell
     }
-    if (context.state === "running") {
-      schedule(context, payload);
+    if (ctx.state === "running") {
+      schedule(out, payload);
       return;
     }
-    void context.resume().then(() => {
-      if (context && document.visibilityState !== "hidden") schedule(context, payload);
+    void ctx.resume().then(() => {
+      if (document.visibilityState !== "hidden") schedule(out, payload);
     }).catch(() => {});
   }, undefined, "std_msgs/msg/String");
 }
 
-/** @param {AudioContext} ctx @param {{ sample_rate?: unknown, pcm?: unknown }} payload */
-function schedule(ctx, payload) {
+/** @param {GainNode} out @param {{ sample_rate?: unknown, pcm?: unknown }} payload */
+function schedule(out, payload) {
+  const ctx = /** @type {AudioContext} */ (out.context);
   const rate = Number(payload?.sample_rate);
   if (!Number.isFinite(rate) || rate < 8_000 || rate > 192_000 || typeof payload?.pcm !== "string") return;
   let bytes;
@@ -81,7 +92,7 @@ function schedule(ctx, payload) {
   for (let i = 0; i < samples.length; i++) channel[i] = samples[i] / 32768;
   const source = ctx.createBufferSource();
   source.buffer = buffer;
-  source.connect(ctx.destination);
+  source.connect(out);
   source.start(nextAt);
   nextAt += buffer.duration;
 }

--- a/webapp/js/simSpatialAudio.js
+++ b/webapp/js/simSpatialAudio.js
@@ -1,0 +1,47 @@
+// @ts-check
+// Distance falloff for sound emitted inside the simulated world. The viewer
+// dispatches a perspective snapshot after every primary render (null on
+// teardown; never on hardware pages). Robot-camera views stay at full
+// loudness; only the third-person orbit view fades sound with camera distance.
+
+export const SIM_AUDIO_PERSPECTIVE_EVENT = "innate:sim-audio-perspective";
+
+const FULL_VOLUME_RADIUS_M = 2;
+const ROLLOFF_M = 2.5;
+const FAR_GAIN = 0.08;
+
+/** @typedef {[number, number, number]} Point3 */
+/** @typedef {{ view: "orbit" | "main" | "arm", listener: Point3, sources: Record<string, Point3> }} Perspective */
+
+/** @type {Perspective | null} */
+let perspective = null;
+/** @type {Set<() => void>} */
+const followers = new Set();
+
+document.addEventListener(SIM_AUDIO_PERSPECTIVE_EVENT, (event) => {
+  perspective = /** @type {CustomEvent<Perspective | null>} */ (event).detail;
+  for (const notify of followers) notify();
+});
+
+/** @param {string | null | undefined} source */
+export function simAudioGain(source) {
+  const point = source == null ? undefined : perspective?.sources[source];
+  if (!perspective || perspective.view !== "orbit" || !point) return 1;
+  const [lx, ly, lz] = perspective.listener;
+  const distance = Math.hypot(point[0] - lx, point[1] - ly, point[2] - lz);
+  if (distance <= FULL_VOLUME_RADIUS_M) return 1;
+  const beyondNearField = (distance - FULL_VOLUME_RADIUS_M) / ROLLOFF_M;
+  return Math.max(FAR_GAIN, 1 / (1 + beyondNearField * beyondNearField));
+}
+
+/**
+ * Feed `apply` the gain for `source` now and on every viewer frame.
+ * @param {string | null | undefined} source @param {(gain: number) => void} apply
+ * @returns {() => void} stop following
+ */
+export function followSimAudioSource(source, apply) {
+  const notify = () => apply(simAudioGain(source));
+  followers.add(notify);
+  notify();
+  return () => followers.delete(notify);
+}

--- a/webapp/js/ttsAudio.js
+++ b/webapp/js/ttsAudio.js
@@ -1,8 +1,8 @@
 // @ts-check
 // Robot speech playback. In SIM mode the brain publishes synthesized speech
-// (base64 WAV) on /tts/audio whenever it speaks — "make the robot speak", agent
-// replies, skill narration — because the sim has no audio device, so the
-// browser is the speaker. The real robot plays speech out its own physical
+// on /tts/audio whenever it speaks — "make the robot speak", agent replies,
+// skill narration — because the sim has no audio device, so the browser is the
+// speaker. Each clip is JSON: base64 WAV plus the simulated body it comes from. The real robot plays speech out its own physical
 // speaker and publishes nothing here (a browser playing it too would double
 // the voice), so against a robot this module simply never fires.
 // Mounted from the shell (which loads on every page), so speech plays no matter
@@ -10,6 +10,7 @@
 
 import { ros } from "./rosClient.js";
 import { isMicAudioActive, setTtsPlaying } from "./micAudioState.js";
+import { followSimAudioSource } from "./simSpatialAudio.js";
 
 const TTS_AUDIO_TOPIC = "/tts/audio";
 
@@ -36,12 +37,17 @@ export function initTtsAudio() {
 
   ros.subscribe(TTS_AUDIO_TOPIC, (msg) => {
     if (!speaker) return; // another tab is the elected speaker
-    const b64 = msg?.data;
-    if (typeof b64 !== "string" || !b64) return;
+    if (typeof msg?.data !== "string") return;
     // Defensive: if a clip does arrive while the operator has the robot mic
     // open, skip it — the speaker would be heard through the mic as well.
     if (isMicAudioActive()) return;
-    enqueue(b64);
+    let clip;
+    try {
+      clip = JSON.parse(msg.data);
+    } catch {
+      return;
+    }
+    if (typeof clip?.audio === "string" && clip.audio) enqueue(clip);
   }, undefined, "std_msgs/msg/String");
 }
 
@@ -49,7 +55,8 @@ export function initTtsAudio() {
 // aplay finishes. In sim a clip is "done" once published, so the robot half can
 // only serialize synthesis — played on arrival, a two-sentence reply talks over
 // itself. This queue is what puts that behavior back.
-/** @type {string[]} */
+/** @typedef {{ audio: string, source: string | null }} Clip */
+/** @type {Clip[]} */
 const pending = [];
 let playing = false;
 
@@ -57,9 +64,9 @@ let playing = false;
 // reason speak_text_async drops superseded speech).
 const MAX_PENDING = 4;
 
-/** @param {string} b64 */
-function enqueue(b64) {
-  pending.push(b64);
+/** @param {Clip} clip */
+function enqueue(clip) {
+  pending.push(clip);
   while (pending.length > MAX_PENDING) {
     pending.shift();
     console.warn("[tts] playback backlog full — dropping the oldest clip");
@@ -68,25 +75,30 @@ function enqueue(b64) {
 }
 
 function playNext() {
-  const b64 = pending.shift();
-  if (b64 === undefined) {
+  const clip = pending.shift();
+  if (clip === undefined) {
     playing = false;
     return;
   }
   playing = true;
   try {
-    play(b64);
+    play(clip);
   } catch (err) {
     console.warn("[tts] failed to play audio:", err);
     playNext(); // one bad clip must not strand the rest of the reply
   }
 }
 
-/** @param {string} b64 base64-encoded WAV */
-function play(b64) {
-  const blob = new Blob([/** @type {BlobPart} */ (base64ToBytes(b64))], { type: "audio/wav" });
+/** @param {Clip} clip */
+function play(clip) {
+  const blob = new Blob([/** @type {BlobPart} */ (base64ToBytes(clip.audio))], { type: "audio/wav" });
   const url = URL.createObjectURL(blob);
   const audio = new Audio(url);
+  // Bound at playback, not arrival: a clip that waited in the queue must use
+  // the camera position it actually plays under.
+  const stopFollowing = followSimAudioSource(clip.source, (gain) => {
+    audio.volume = gain;
+  });
   // The mic stream stops publishing while this is set, so every path must
   // release it — one that never finishes mutes the microphone for the session.
   setTtsPlaying(true);
@@ -94,6 +106,7 @@ function play(b64) {
   const done = () => {
     if (released) return;
     released = true;
+    stopFollowing();
     setTtsPlaying(false);
     URL.revokeObjectURL(url);
     playNext();


### PR DESCRIPTION
## Summary
- derive the listener and sound-source positions from the simulator viewer's authoritative active camera, robot pose, and prop transforms
- keep robot-camera views at full loudness while third-person orbit view uses a smooth inverse-distance-style falloff with a 2 m near field and quiet audible floor
- apply the same gain path to Mad Mars motor audio, robot speech, and positioned NPC speech; queued TTS clips bind to the latest scene state when playback begins

## Validation
- `node --test webapp/tests/*.test.js`
- `npm run typecheck && npm run build:lib` in `sim/viewer`
- `pytest -q tests/test_challenge_runtime.py tests/test_household_npc.py` (19 passed)
- `pytest -q ros2_ws/src/brain/brain_client/test/test_tts.py` (8 passed)
- targeted Ruff format/lint checks and `git diff --check`
- live simulator: Mad drive audio, robot TTS, and NPC TTS played through the browser; NPC transport identified `resident_alex`; orbit-distance falloff and first-person restoration were exercised; no audio playback errors appeared in browser diagnostics

Stacked on #750 because it owns the simulator motor-audio stream and PCM player. The stack includes #750's latest follow-up commit and is based on current `main`.
