### PR TITLE
Make PickAnyObject retry and recenter missed grasps

### DIFF
--- a/tests/test_pick_any_object_retry.py
+++ b/tests/test_pick_any_object_retry.py
@@ -39,6 +39,14 @@ class _Manipulation:
             self.skill.joint_states.position[5] = -0.085
 
 
+class _Approach:
+    def __init__(self):
+        self.moves = []
+
+    def drive(self, distance):
+        self.moves.append(distance)
+
+
 def _skill(*, closes_empty, empties_on_lift=False):
     skill = PickAnyObject.__new__(PickAnyObject)
     skill._p = dict(PARAMS)
@@ -48,30 +56,33 @@ def _skill(*, closes_empty, empties_on_lift=False):
     skill._grip_strength = 0.0
     skill._holding = False
     skill.manipulation = _Manipulation(skill, closes_empty=closes_empty, empties_on_lift=empties_on_lift)
+    skill._goto_search_pose = lambda _bearing: skill.manipulation.events.append(("search",))
+    skill._wrist_descend = lambda _prompt, x, y: (x - 0.01, y + 0.01, 0.05, 0.0)
+    skill._grasp_orientation = lambda _x, _y, roll: (roll, 1.3, 0.0)
     return skill
 
 
-def test_air_close_retries_once_lower_but_held_object_does_not(monkeypatch):
+def test_empty_grasp_recenters_twice_but_held_object_does_not_retry(monkeypatch):
     monkeypatch.setattr("innate_skills.pick_any_object.time.sleep", lambda _seconds: None)
 
     missed = _skill(closes_empty=True)
-    missed._close_once()
-    assert missed._retry_lower_if_empty(0.25, 0.0, 0.0, 1.3, 0.0)
-    assert missed.manipulation.events == [
-        ("close", 0.6, 1.5),
-        ("open", 1.0),
-        ("follow", [0.02], 0.8),
-        ("move_to", 0.03),
-        ("close", 0.6, 1.5),
-    ]
+    missed._close_twist_lift("brick", 0.25, 0.0, 0.0, 1.3, 0.0)
+    assert [event[0] for event in missed.manipulation.events].count("open") == 2
+    assert [event[0] for event in missed.manipulation.events].count("search") == 2
+    assert [event[0] for event in missed.manipulation.events].count("close") == 3
 
     held = _skill(closes_empty=False)
-    held._close_once()
-    assert not held._retry_lower_if_empty(0.25, 0.0, 0.0, 1.3, 0.0)
-    assert held.manipulation.events == [("close", 0.6, 1.5)]
+    held._close_twist_lift("brick", 0.25, 0.0, 0.0, 1.3, 0.0)
+    assert [event[0] for event in held.manipulation.events].count("open") == 0
+    assert [event[0] for event in held.manipulation.events].count("close") == 1
 
     dropped = _skill(closes_empty=False, empties_on_lift=True)
-    dropped._close_twist_lift(0.25, 0.0, 0.0, 1.3, 0.0)
-    assert [event[0] for event in dropped.manipulation.events].count("open") == 1
-    assert [event[0] for event in dropped.manipulation.events].count("close") == 2
-    assert [event[0] for event in dropped.manipulation.events].count("lift") == 2
+    dropped._close_twist_lift("brick", 0.25, 0.0, 0.0, 1.3, 0.0)
+    assert [event[0] for event in dropped.manipulation.events].count("open") == 2
+    assert [event[0] for event in dropped.manipulation.events].count("close") == 3
+    assert [event[0] for event in dropped.manipulation.events].count("lift") == 3
+
+    approach = _Approach()
+    held.sleep = lambda _seconds: None
+    assert held._grasp_verified("brick", approach)
+    assert approach.moves == []

--- a/tests/test_pick_any_object_retry.py
+++ b/tests/test_pick_any_object_retry.py
@@ -1,10 +1,51 @@
 import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "workspace"))
 
-from innate_skills.pick_any_object import PARAMS, PickAnyObject
+# The host-side CI intentionally does not install the ROS-backed innate SDK.
+# This test exercises only the grasp state machine, so provide its import-time
+# types without pretending to implement any robot behavior.
+innate = ModuleType("innate")
+innate.Skill = object
+innate.SkillReturn = type("SkillReturn", (), {})
+for resource_type in ("Head", "JointStates", "MainImage", "Manipulation", "Mobility", "Odometry", "WristImage"):
+    setattr(innate, resource_type, type(resource_type, (), {}))
+
+
+class _Waypoint:
+    def __init__(self, _x, _y, z, **_kwargs):
+        self.z = z
+
+
+innate.Waypoint = _Waypoint
+innate.resource = lambda function: function
+innate.gemini = ModuleType("innate.gemini")
+innate.vision = ModuleType("innate.vision")
+innate.vision.Axis = type("Axis", (), {})
+sys.modules["innate"] = innate
+sys.modules["innate.gemini"] = innate.gemini
+sys.modules["innate.vision"] = innate.vision
+
+exceptions = ModuleType("innate.exceptions")
+for exception_type in ("ArmFailed", "ArmUnhealthy", "SkillFailed"):
+    setattr(exceptions, exception_type, type(exception_type, (Exception,), {}))
+sys.modules["innate.exceptions"] = exceptions
+
+geometry = ModuleType("innate.geometry")
+geometry.pixel_to_floor = lambda *_args: None
+sys.modules["innate.geometry"] = geometry
+
+approach = ModuleType("innate_skills.approach")
+approach.APPROACH_PARAMS = {"settle_s": 0.0, "tilt_deg": 35.0}
+approach.FloorApproach = type("FloorApproach", (), {})
+approach.ask_head = lambda *_args, **_kwargs: (None, None)
+approach.base_to_odom = lambda *_args: None
+approach.inside_box = lambda *_args: False
+sys.modules["innate_skills.approach"] = approach
+
+from innate_skills.pick_any_object import PARAMS, PickAnyObject  # noqa: E402
 
 
 class _Manipulation:

--- a/tests/test_pick_any_object_retry.py
+++ b/tests/test_pick_any_object_retry.py
@@ -1,0 +1,77 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "workspace"))
+
+from innate_skills.pick_any_object import PARAMS, PickAnyObject
+
+
+class _Manipulation:
+    GRIPPER_OPEN = 0.8
+
+    def __init__(self, skill, *, closes_empty, empties_on_lift=False):
+        self.skill = skill
+        self.pose = SimpleNamespace(z=0.04)
+        self.closes_empty = closes_empty
+        self.empties_on_lift = empties_on_lift
+        self.events = []
+
+    def gripper_open(self, duration):
+        self.events.append(("open", duration))
+
+    def gripper_close(self, strength, duration):
+        self.events.append(("close", strength, duration))
+        self.skill.joint_states.position[5] = -0.085 if self.closes_empty else 0.1
+
+    def follow(self, waypoints, grip):
+        self.events.append(("follow", [wp.z for wp in waypoints], grip))
+        self.pose.z = waypoints[-1].z
+
+    def move_to(self, _x, _y, z, **_kwargs):
+        self.events.append(("move_to", z))
+        self.pose.z = z
+
+    def move_joints(self, _joints, duration):
+        self.events.append(("lift", duration))
+        self.pose.z = 0.22
+        if self.empties_on_lift:
+            self.skill.joint_states.position[5] = -0.085
+
+
+def _skill(*, closes_empty, empties_on_lift=False):
+    skill = PickAnyObject.__new__(PickAnyObject)
+    skill._p = dict(PARAMS)
+    skill.joint_states = SimpleNamespace(position=[0.0] * 6)
+    skill.logger = SimpleNamespace(info=lambda *_args: None, warning=lambda *_args: None)
+    skill.check_cancelled = lambda: None
+    skill._grip_strength = 0.0
+    skill._holding = False
+    skill.manipulation = _Manipulation(skill, closes_empty=closes_empty, empties_on_lift=empties_on_lift)
+    return skill
+
+
+def test_air_close_retries_once_lower_but_held_object_does_not(monkeypatch):
+    monkeypatch.setattr("innate_skills.pick_any_object.time.sleep", lambda _seconds: None)
+
+    missed = _skill(closes_empty=True)
+    missed._close_once()
+    assert missed._retry_lower_if_empty(0.25, 0.0, 0.0, 1.3, 0.0)
+    assert missed.manipulation.events == [
+        ("close", 0.6, 1.5),
+        ("open", 1.0),
+        ("follow", [0.02], 0.8),
+        ("move_to", 0.03),
+        ("close", 0.6, 1.5),
+    ]
+
+    held = _skill(closes_empty=False)
+    held._close_once()
+    assert not held._retry_lower_if_empty(0.25, 0.0, 0.0, 1.3, 0.0)
+    assert held.manipulation.events == [("close", 0.6, 1.5)]
+
+    dropped = _skill(closes_empty=False, empties_on_lift=True)
+    dropped._close_twist_lift(0.25, 0.0, 0.0, 1.3, 0.0)
+    assert [event[0] for event in dropped.manipulation.events].count("open") == 1
+    assert [event[0] for event in dropped.manipulation.events].count("close") == 2
+    assert [event[0] for event in dropped.manipulation.events].count("lift") == 2

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -8,6 +8,7 @@ No depth camera — URDF + pinhole model.
 """
 
 import math
+import os
 import re
 import time
 
@@ -68,9 +69,15 @@ PARAMS = {
     "wrist_pitch": 0.82,
     "wrist_box_u": 320.0,
     # Below image center: the wrist cam sits above the fingertips, so
-    # mid-frame aims short of them. 350 is the hardware-tuned parallax bias.
-    "wrist_box_v": 350.0,
+    # mid-frame aims short of them. Keep the hardware-tuned 350 target on a
+    # robot; the simulator camera model needs 310 or the fingertip centre ends
+    # up about 3 cm beyond a floor target. The simulator launcher exports its
+    # world-state port into every service container.
+    "wrist_box_v": 310.0 if os.environ.get("INNATE_WORLD_STATE_PORT") else 350.0,
     "wrist_half_px": 60.0,
+    # The broad box gets the arm down quickly; near the floor, require the
+    # object to be genuinely central before committing to a grasp.
+    "wrist_final_half_px": 20.0,
     "wrist_kx": -0.04,
     "wrist_ky": -0.04,
     "wrist_step_max": 0.04,
@@ -88,6 +95,7 @@ PARAMS = {
     # normal attempt remains carpet-safe; only a confirmed miss goes 1 cm
     # lower, before the robot has backed away from the target.
     "retry_floor_z": 0.02,
+    "grasp_retries": 2.0,
     "descend_s": 1.2,
     "descend_abort_z": 0.12,
     "arm_pitch": 1.30,
@@ -344,7 +352,10 @@ class PickAnyObject(Skill):
         self, x: float, y: float, z: float, reason: str, axis: vision.Axis | None = None
     ) -> tuple[float, float, float, float]:
         roll = self._grasp_roll(axis)
-        self.logger.info(f"[PickAnyObject] wrist stage: {reason} (z={z:.3f}, roll={math.degrees(roll):+.0f} deg)")
+        self.logger.info(
+            f"[PickAnyObject] wrist stage: {reason} "
+            f"(x={x:.3f}, y={y:.3f}, z={z:.3f}, roll={math.degrees(roll):+.0f} deg)"
+        )
         return x, y, z, roll
 
     @staticmethod
@@ -440,7 +451,8 @@ class PickAnyObject(Skill):
 
             err_u = px[0] - p["wrist_box_u"]
             err_v = px[1] - p["wrist_box_v"]
-            inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
+            half_px = p["wrist_final_half_px"] if z <= AXIS_MIN_Z else p["wrist_half_px"]
+            inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], half_px)
             centered = centered + 1 if inside else 0
             if streak < 2:
                 continue  # watch one more frame before trusting it
@@ -569,7 +581,10 @@ class PickAnyObject(Skill):
         held object merely because telemetry dropped out.
         """
         js = self.joint_states
-        return js is not None and len(js.position) > 5 and js.position[5] <= GRIPPER_EMPTY_J6 + 0.02
+        j6 = js.position[5] if js is not None and len(js.position) > 5 else None
+        empty = j6 is not None and j6 <= GRIPPER_EMPTY_J6 + 0.02
+        self.logger.info(f"[PickAnyObject] grip check: j6={j6} -> {'EMPTY' if empty else 'HELD/UNKNOWN'}")
+        return empty
 
     def _pre_close_lift(self, x: float, y: float, roll: float, pitch: float, yaw: float) -> None:
         p = self._p
@@ -599,24 +614,20 @@ class PickAnyObject(Skill):
             raise ArmUnhealthy(f"gripper would not close: {e}") from e
         time.sleep(p["close_settle_s"])
 
-    def _retry_lower_if_empty(self, x: float, y: float, roll: float, pitch: float, yaw: float) -> bool:
-        """Retry one centimetre lower, once, after a confirmed air close."""
-        if not self._gripper_closed_on_air():
-            return False
+    def _prepare_grasp_retry(
+        self, prompt: str, x: float, y: float
+    ) -> tuple[float, float, float, float, float]:
+        """Reopen, reacquire the object with the wrist, and descend lower."""
         p = self._p
         retry_z = p["retry_floor_z"]
-        self.logger.warning(f"[PickAnyObject] claw closed on air; retrying grasp at z={retry_z:.3f}")
         self._holding = False
         self.manipulation.gripper_open(duration=1.0)
-        try:
-            z_from = self.manipulation.pose.z
-        except ArmFailed:
-            z_from = p["floor_z"] + p["close_lift_m"]
-        self._push_to_floor(x, y, z_from, roll, pitch, yaw, floor_z=retry_z)
+        self._goto_search_pose(math.atan2(y, x))
+        x, y, z, roll = self._wrist_descend(prompt, x, y)
+        roll, pitch, yaw = self._grasp_orientation(x, y, roll)
+        self._push_to_floor(x, y, z, roll, pitch, yaw, floor_z=retry_z)
         self._pre_close_lift(x, y, roll, pitch, yaw)
-        self._close_once()
-        self._holding = True
-        return True
+        return x, y, roll, pitch, yaw
 
     def _lift_grasp(self, x: float, y: float, roll: float, yaw: float) -> None:
         """Lift a closed grasp; joint space keeps a rolled wrist wound."""
@@ -660,25 +671,42 @@ class PickAnyObject(Skill):
                 x, y, 0.22, roll=roll, pitch=p["arm_pitch"], yaw=yaw, duration=2.0, tolerance_xy=0.10
             )
 
-    def _close_twist_lift(self, x: float, y: float, roll: float, pitch: float, yaw: float) -> None:
-        """Close, retry a proven miss lower once, then lift.
+    def _close_twist_lift(
+        self, prompt: str, x: float, y: float, roll: float, pitch: float, yaw: float
+    ) -> None:
+        """Close and lift, reacquiring and retrying a proven miss.
 
         The encoder is checked both after closing and after the first lift. A
         floor or edge contact can initially hold the claw open even though no
         object comes up; that miss must also retry before the base backs away.
         """
         self._pre_close_lift(x, y, roll, pitch, yaw)
-        self._close_once()
-        retried = self._retry_lower_if_empty(x, y, roll, pitch, yaw)
-        # Fingers have committed: from here teardown must fold with the grip
-        # kept, not open over the floor mid-carry — only a verified miss
-        # clears the flag. Set here, not after _grasp_at returns: an exception
-        # in the lift below must not release a just-grasped object on the way
-        # home.
-        self._holding = True
-        self._lift_grasp(x, y, roll, yaw)
-        if not retried and self._retry_lower_if_empty(x, y, roll, pitch, yaw):
-            self._lift_grasp(x, y, roll, yaw)
+        retries = int(self._p["grasp_retries"])
+        for attempt in range(retries + 1):
+            self._close_once()
+            empty = self._gripper_closed_on_air()
+            lifted = False
+            # Fingers may initially be held apart by a floor/edge contact. A
+            # lift distinguishes that from a grasp before the base moves.
+            if not empty:
+                self._holding = True
+                self._lift_grasp(x, y, roll, yaw)
+                lifted = True
+                empty = self._gripper_closed_on_air()
+                if not empty:
+                    return
+            if attempt >= retries:
+                # Keep the old safe teardown posture even when the final
+                # attempt is empty; verification will report the miss.
+                self._holding = True
+                if not lifted:
+                    self._lift_grasp(x, y, roll, yaw)
+                return
+            self.logger.warning(
+                f"[PickAnyObject] grasp attempt {attempt + 1} closed on air; "
+                f"re-centering for retry {attempt + 2}/{retries + 1}"
+            )
+            x, y, roll, pitch, yaw = self._prepare_grasp_retry(prompt, x, y)
 
     def _grasp_at(self, prompt, xy):
         """Full grasp at floor xy (base_link)."""
@@ -699,12 +727,31 @@ class PickAnyObject(Skill):
         roll, pitch, yaw = self._grasp_orientation(x, y, roll)
         self._push_to_floor(x, y, z, roll, pitch, yaw)
         self.check_cancelled()  # last exit before the fingers commit
-        self._close_twist_lift(x, y, roll, pitch, yaw)
+        self._close_twist_lift(prompt, x, y, roll, pitch, yaw)
 
     def _grasp_verified(self, prompt, approach: FloorApproach):
-        """Back up, then check floor clear + gripper not open. Gemini gets both
-        cameras: the wrist view can show the object in the fingers, so a held
-        object isn't mistaken for a dropped one."""
+        """Verify a lifted grasp, backing up only when mechanics are unclear.
+
+        A non-empty claw after the lift, with the end effector measurably clear
+        of the floor, is already strong evidence of a grasp.  Do not drive the
+        base away in that state: a rigid object can be secure vertically but
+        get knocked loose by the horizontal verification move.  The existing
+        camera check remains the fallback for missing or ambiguous telemetry.
+        """
+        js = self.joint_states
+        j6 = js.position[5] if js is not None and len(js.position) > 5 else None
+        j6_ok = j6 is not None and j6 > GRIPPER_EMPTY_J6 + 0.02
+        try:
+            ee_z = self.manipulation.pose.z
+        except ArmFailed:
+            ee_z = None
+        lifted_clear = ee_z is not None and ee_z >= self._p["floor_z"] + 0.07
+        if j6_ok and lifted_clear:
+            self.logger.info(
+                f"[PickAnyObject] verify: lifted grasp j6={j6} z={ee_z:.3f} -> HELD"
+            )
+            return True
+
         approach.drive(-VERIFY_BACKUP_M)
         self.sleep(self._p["settle_s"])
         js = self.joint_states

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -84,6 +84,10 @@ PARAMS = {
     "descend_z3": 0.045,
     # ee_link target, not fingertip height. 0.01 dug into carpet and aborted.
     "floor_z": 0.03,
+    # One bounded retry after the encoder proves the claw closed on air. The
+    # normal attempt remains carpet-safe; only a confirmed miss goes 1 cm
+    # lower, before the robot has backed away from the target.
+    "retry_floor_z": 0.02,
     "descend_s": 1.2,
     "descend_abort_z": 0.12,
     "arm_pitch": 1.30,
@@ -508,13 +512,24 @@ class PickAnyObject(Skill):
             return 0.0, p["arm_pitch"], 0.0
         return roll, ROLLED_PITCH, yaw
 
-    def _push_to_floor(self, x: float, y: float, z_from: float, roll: float, pitch: float, yaw: float) -> None:
+    def _push_to_floor(
+        self,
+        x: float,
+        y: float,
+        z_from: float,
+        roll: float,
+        pitch: float,
+        yaw: float,
+        *,
+        floor_z: float | None = None,
+    ) -> None:
         """Blind descent to floor as ONE multi-waypoint trajectory — the
         rung-by-rung version decelerated at every rung and looked choppy.
         Contact just stalls the final segments; abort if still high."""
         p = self._p
+        target_z = p["floor_z"] if floor_z is None else floor_z
         self.check_cancelled()
-        rungs = [z for z in (p["descend_z1"], p["descend_z2"], p["descend_z3"], p["floor_z"]) if z < z_from - 1e-6]
+        rungs = [z for z in (p["descend_z1"], p["descend_z2"], p["descend_z3"], target_z) if z < z_from - 1e-6]
         if rungs:
             # grip=GRIPPER_OPEN re-asserts an open claw even if it drifted
             # shut during the wrist descent (never re-seed from measured).
@@ -533,6 +548,8 @@ class PickAnyObject(Skill):
             ee_z = self.manipulation.pose.z
         except ArmFailed:
             ee_z = None
+        if ee_z is not None:
+            self.logger.info(f"[PickAnyObject] descent target={target_z:.3f}, settled z={ee_z:.3f}")
         if ee_z is not None and ee_z > p["descend_abort_z"]:
             self.manipulation.recover()
             raise ArmUnhealthy("arm would not descend")
@@ -545,41 +562,65 @@ class PickAnyObject(Skill):
             raise LookupError("joint states missing or short")
         return list(js.position[:6])
 
-    def _close_twist_lift(self, x: float, y: float, roll: float, pitch: float, yaw: float) -> None:
-        """Close, joint-space twist+lift (IK would unwind j5). Uses time.sleep
-        on purpose: the fingers have committed, and a cancel must not unwind
-        mid-grip — the run finishes this and the teardown carries the object.
-        Closing on air reaches ~GRIPPER_EMPTY_J6, which _grasp_verified's j6
-        check catches."""
+    def _gripper_closed_on_air(self) -> bool:
+        """Whether fresh encoder state proves the last close caught nothing.
+
+        Missing state is deliberately inconclusive: never reopen a possibly
+        held object merely because telemetry dropped out.
+        """
+        js = self.joint_states
+        return js is not None and len(js.position) > 5 and js.position[5] <= GRIPPER_EMPTY_J6 + 0.02
+
+    def _pre_close_lift(self, x: float, y: float, roll: float, pitch: float, yaw: float) -> None:
         p = self._p
-        if p["close_lift_m"] > 0:
-            try:
-                ee_z = self.manipulation.pose.z
-                self.manipulation.move_to(
-                    x,
-                    y,
-                    ee_z + p["close_lift_m"],
-                    roll=roll,
-                    pitch=pitch,
-                    yaw=yaw,
-                    duration=0.5,
-                    tolerance_xy=None,
-                    tolerance_z=None,
-                )
-            except ArmFailed:
-                pass  # best-effort pre-close lift; the grasp decides below
+        if p["close_lift_m"] <= 0:
+            return
+        try:
+            ee_z = self.manipulation.pose.z
+            self.manipulation.move_to(
+                x,
+                y,
+                ee_z + p["close_lift_m"],
+                roll=roll,
+                pitch=pitch,
+                yaw=yaw,
+                duration=0.5,
+                tolerance_xy=None,
+                tolerance_z=None,
+            )
+        except ArmFailed:
+            pass  # best-effort pre-close lift; the grasp decides below
+
+    def _close_once(self) -> None:
+        p = self._p
         try:
             self.manipulation.gripper_close(p["close_strength"], duration=p["close_s"])
         except ArmFailed as e:
             raise ArmUnhealthy(f"gripper would not close: {e}") from e
-        # Fingers have committed: from here teardown must fold with the grip
-        # kept, not open over the floor mid-carry — only a verified miss
-        # clears the flag. Set here, not after _grasp_at returns: an exception
-        # in the twist/lift below (e.g. ArmUnhealthy from the LookupError
-        # fallback) must not release a just-grasped object on the way home.
-        self._holding = True
         time.sleep(p["close_settle_s"])
 
+    def _retry_lower_if_empty(self, x: float, y: float, roll: float, pitch: float, yaw: float) -> bool:
+        """Retry one centimetre lower, once, after a confirmed air close."""
+        if not self._gripper_closed_on_air():
+            return False
+        p = self._p
+        retry_z = p["retry_floor_z"]
+        self.logger.warning(f"[PickAnyObject] claw closed on air; retrying grasp at z={retry_z:.3f}")
+        self._holding = False
+        self.manipulation.gripper_open(duration=1.0)
+        try:
+            z_from = self.manipulation.pose.z
+        except ArmFailed:
+            z_from = p["floor_z"] + p["close_lift_m"]
+        self._push_to_floor(x, y, z_from, roll, pitch, yaw, floor_z=retry_z)
+        self._pre_close_lift(x, y, roll, pitch, yaw)
+        self._close_once()
+        self._holding = True
+        return True
+
+    def _lift_grasp(self, x: float, y: float, roll: float, yaw: float) -> None:
+        """Lift a closed grasp; joint space keeps a rolled wrist wound."""
+        p = self._p
         grip = -p["close_strength"]
         # The twist winds FABRIC onto the fingers; on a rigid shell it helps
         # eject the object. Gemini's grip_strength doubles as the hardness signal.
@@ -618,6 +659,26 @@ class PickAnyObject(Skill):
             self.manipulation.move_to(
                 x, y, 0.22, roll=roll, pitch=p["arm_pitch"], yaw=yaw, duration=2.0, tolerance_xy=0.10
             )
+
+    def _close_twist_lift(self, x: float, y: float, roll: float, pitch: float, yaw: float) -> None:
+        """Close, retry a proven miss lower once, then lift.
+
+        The encoder is checked both after closing and after the first lift. A
+        floor or edge contact can initially hold the claw open even though no
+        object comes up; that miss must also retry before the base backs away.
+        """
+        self._pre_close_lift(x, y, roll, pitch, yaw)
+        self._close_once()
+        retried = self._retry_lower_if_empty(x, y, roll, pitch, yaw)
+        # Fingers have committed: from here teardown must fold with the grip
+        # kept, not open over the floor mid-carry — only a verified miss
+        # clears the flag. Set here, not after _grasp_at returns: an exception
+        # in the lift below must not release a just-grasped object on the way
+        # home.
+        self._holding = True
+        self._lift_grasp(x, y, roll, yaw)
+        if not retried and self._retry_lower_if_empty(x, y, roll, pitch, yaw):
+            self._lift_grasp(x, y, roll, yaw)
 
     def _grasp_at(self, prompt, xy):
         """Full grasp at floor xy (base_link)."""

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -614,9 +614,7 @@ class PickAnyObject(Skill):
             raise ArmUnhealthy(f"gripper would not close: {e}") from e
         time.sleep(p["close_settle_s"])
 
-    def _prepare_grasp_retry(
-        self, prompt: str, x: float, y: float
-    ) -> tuple[float, float, float, float, float]:
+    def _prepare_grasp_retry(self, prompt: str, x: float, y: float) -> tuple[float, float, float, float, float]:
         """Reopen, reacquire the object with the wrist, and descend lower."""
         p = self._p
         retry_z = p["retry_floor_z"]
@@ -671,9 +669,7 @@ class PickAnyObject(Skill):
                 x, y, 0.22, roll=roll, pitch=p["arm_pitch"], yaw=yaw, duration=2.0, tolerance_xy=0.10
             )
 
-    def _close_twist_lift(
-        self, prompt: str, x: float, y: float, roll: float, pitch: float, yaw: float
-    ) -> None:
+    def _close_twist_lift(self, prompt: str, x: float, y: float, roll: float, pitch: float, yaw: float) -> None:
         """Close and lift, reacquiring and retrying a proven miss.
 
         The encoder is checked both after closing and after the first lift. A
@@ -747,9 +743,7 @@ class PickAnyObject(Skill):
             ee_z = None
         lifted_clear = ee_z is not None and ee_z >= self._p["floor_z"] + 0.07
         if j6_ok and lifted_clear:
-            self.logger.info(
-                f"[PickAnyObject] verify: lifted grasp j6={j6} z={ee_z:.3f} -> HELD"
-            )
+            self.logger.info(f"[PickAnyObject] verify: lifted grasp j6={j6} z={ee_z:.3f} -> HELD")
             return True
 
         approach.drive(-VERIFY_BACKUP_M)


### PR DESCRIPTION
## Summary
- detect empty closes and retry a bounded two times before the robot backs away
- reacquire and tightly recenter the target with the wrist camera before every retry
- keep the hardware wrist-camera calibration while correcting the simulator aim point
- accept a clearly lifted, non-empty grasp before the verification backup can knock it loose

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ... python3 -m pytest -q tests/test_pick_any_object_retry.py`
- `ruff check workspace/innate_skills/pick_any_object.py tests/test_pick_any_object_retry.py`
- `git diff --check`
- live simulator trace confirmed the wrist-centering correction reduced target offset from about 3.3 cm to about 1.5 cm and lifted the LEGO brick; the remaining drop was isolated to the now-bypassed verification backup