### PR TITLE
feat(sim): Low Poly Town traffic on top of environment hot switching

### DIFF
--- a/.github/workflows/launcher-tests.yml
+++ b/.github/workflows/launcher-tests.yml
@@ -23,5 +23,17 @@ jobs:
 
       - name: Run the host-side test suite
         run: |
-          pip install pytest pyyaml
+          pip install pytest pyyaml numpy trimesh pillow mujoco
           python -m pytest tests/ -q
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Test the viewer's traffic rendering
+        working-directory: sim/viewer
+        run: |
+          npm ci
+          npm run typecheck
+          npm run test:traffic

--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ sim/viewer/public/
 sim/viewer/assets/
 # licensed environment packs that must never be published from this repo
 sim/environments.local/
+sim/viewer/local-environments/
 sim/.sim-assets.tmp*
 
 # boot sounds: WAV assets fetched by post_update.sh from GCS (too heavy for git)

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -32,6 +32,7 @@ from .constants import (
 from .drive_limits import clamp_cmd_vel
 from .environments import DEFAULT_ENVIRONMENT_ID, Environment
 from .props import PropRegistry
+from .traffic import TrafficController
 from .world import ARM_HOME
 
 # Stop the base if the last Twist is stale, like a real base watchdog.
@@ -217,6 +218,7 @@ class VirtualMars:
         # Droppable props: sidecars from the tracked source dir plus any the
         # asset bundle shipped, each parked off-map until something places it.
         self.props = PropRegistry.load([world.repo_root() / "sim" / "props", ASSETS_DIR / "props"])
+        self.traffic = TrafficController(self.environment.id)
         xml = world.build_world_xml(
             rooms,
             include_placeholder_robot=False,
@@ -224,6 +226,7 @@ class VirtualMars:
             texture_max=_texture_cap(self._render_w),
             props=self.props,
             spawn_pose=self._spawn,
+            traffic_bodies=self.traffic.bodies_xml(),
         )
         # Lidar rays hit only the textured visual meshes (true surfaces, like
         # a real lidar) when available -- without them, fall back to all
@@ -243,6 +246,7 @@ class VirtualMars:
             Path(world.__file__),
             Path(__file__),
             Path(__file__).with_name("constants.py"),
+            Path(__file__).with_name("traffic.py"),
             *(f for pieces in rooms.values() for f in pieces),
             *(p for obj in visual_rooms.values() for p in (obj, obj.with_suffix(".png"))),
             *(f for f in urdf_path.parent.rglob("*") if f.suffix in (".stl", ".dae", ".obj", ".png", ".urdf")),
@@ -259,6 +263,7 @@ class VirtualMars:
             robot_spec = world.load_robot_spec(urdf_path)
             world.add_planar_base(robot_spec)
             world.tune_contacts(robot_spec)
+            self.traffic.configure_robot_spec(robot_spec)
             world_spec.attach(robot_spec, frame=world_spec.worldbody.add_frame(), prefix="robot_")
 
             for cam_name, (body_name, forward, up) in CAMERAS.items():
@@ -285,6 +290,7 @@ class VirtualMars:
                         stale.unlink(missing_ok=True)
                 mujoco.mj_saveModel(self.model, str(cache_path), None)
         world.style_robot_geoms(self.model)
+        self.traffic.bind(self.model)
         # The planar base pins z at the plane, so the ground's 7mm contact
         # margin reads as permanent penetration -- huge normal force whose
         # friction cone glues the base. The worker's ground has no margin.
@@ -348,6 +354,7 @@ class VirtualMars:
         mq, _md, source, mult = self._mimic
         self.data.qpos[mq] = mult * ARM_HOME[source]
         self.props.mark_all_parked()  # mj_resetData already re-parked every prop
+        self.traffic.reset(self.data)
         self._cmd_vx = self._cmd_wz = 0.0
         self._cmd_sim_time = -math.inf
         self._hold = None
@@ -387,6 +394,7 @@ class VirtualMars:
         end = self.data.time + duration
         while self.data.time < end:
             self._apply_control()
+            self.traffic.step(self.data, float(self.model.opt.timestep), self.pose()[:2])
             mujoco.mj_step(self.model, self.data)
             if not np.all(np.isfinite(self.data.qpos)):
                 self.reset()
@@ -801,6 +809,14 @@ class VirtualMars:
     def prop_manifest(self) -> list[dict]:
         """What every prop is and how to draw it (props.py), for the viewer."""
         return self.props.manifest()
+
+    def traffic_manifest(self) -> dict | None:
+        """The pack's procedural cars and signals for observer viewers (traffic.py)."""
+        return self.traffic.manifest()
+
+    def traffic_state(self) -> dict | None:
+        """Authoritative traffic state on the same sim clock as the robot pose."""
+        return self.traffic.state(float(self.data.time), self.world_epoch)
 
     def drop_prop_at(self, name: str, x: float, y: float, yaw: float = 0.0) -> bool:
         """Release one prop above (x, y) and let physics settle it onto

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/traffic.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/traffic.py
@@ -1,0 +1,496 @@
+"""Deterministic intersection traffic for the locally licensed town pack.
+
+MuJoCo owns the clock, signal aspects, and car poses.  The browser receives a
+primitive model manifest plus snapshots of that authoritative state; it never
+runs a second traffic simulation.  Cars are mocap bodies: their paths and
+signal compliance stay deterministic while their collision boxes remain real
+obstacles to MARS and their group-1 visual primitives remain visible to the
+robot cameras and lidar.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from dataclasses import dataclass
+from html import escape
+from typing import Any
+
+TOWN_ENVIRONMENT_ID = "low-poly-town"
+
+NS = "north_south"
+EW = "east_west"
+RED = "red"
+YELLOW = "yellow"
+GREEN = "green"
+
+GREEN_S = 12.0
+YELLOW_S = 3.0
+ALL_RED_S = 4.0
+CYCLE_S = 2 * (GREEN_S + YELLOW_S + ALL_RED_S)
+
+CRUISE_SPEED_MPS = 3.0
+ACCEL_MPS2 = 1.5
+BRAKE_MPS2 = 3.0
+STOP_EPS_M = 0.015
+COMMIT_MARGIN_M = 0.20
+ROBOT_RADIUS_M = 0.28
+ROBOT_FOLLOW_GAP_M = 0.55
+
+CAR_LENGTH_M = 3.60
+CAR_WIDTH_M = 1.55
+CAR_HALF_LENGTH_M = CAR_LENGTH_M / 2
+# Cars at the authored stop centres keep their front bumper just outside this
+# box. A vehicle already overlapping it owns the junction until its rear has
+# cleared, preventing cross traffic from driving through a MARS-blocked car.
+INTERSECTION_MIN_M = -6.35
+INTERSECTION_MAX_M = 6.35
+
+# A private collision category: cars ignore the town's closed road-end walls
+# and scenery, while configure_robot_spec() adds this bit to the robot before
+# compilation so the car boxes still collide with MARS.
+CAR_COLLISION_BIT = 2
+
+SIGNAL_MATERIALS = {
+    NS: {RED: "Signal_NS_Red", YELLOW: "Signal_NS_Yellow", GREEN: "Signal_NS_Green"},
+    EW: {RED: "Signal_EW_Red", YELLOW: "Signal_EW_Yellow", GREEN: "Signal_EW_Green"},
+}
+
+SIGNAL_COLORS = {RED: "#ff4b55", YELLOW: "#ffd45a", GREEN: "#5ee27a"}
+
+# Three builds these primitives directly; _part_xml converts the same
+# descriptors to MJCF half-sizes and degrees.
+CAR_MODEL = {
+    "length": CAR_LENGTH_M,
+    "width": CAR_WIDTH_M,
+    "parts": [
+        # Leave the lamps slightly proud of the body.  Coplanar outer faces
+        # shimmer badly at distance in both MuJoCo and Three's depth buffers.
+        {"shape": "box", "size": [3.54, 1.55, 0.56], "position": [0.0, 0.0, 0.45], "material": "body"},
+        {"shape": "box", "size": [1.70, 1.30, 0.60], "position": [-0.10, 0.0, 1.00], "material": "body"},
+        {"shape": "box", "size": [1.35, 1.33, 0.10], "position": [-0.10, 0.0, 1.30], "material": "body"},
+        {"shape": "box", "size": [0.04, 1.14, 0.36], "position": [0.77, 0.0, 1.01], "material": "glass"},
+        {"shape": "box", "size": [0.04, 1.14, 0.36], "position": [-0.97, 0.0, 1.01], "material": "glass"},
+        {"shape": "box", "size": [1.20, 0.035, 0.36], "position": [-0.10, 0.665, 1.01], "material": "glass"},
+        {"shape": "box", "size": [1.20, 0.035, 0.36], "position": [-0.10, -0.665, 1.01], "material": "glass"},
+        *(
+            {
+                "shape": "cylinder",
+                "radius": 0.30,
+                "length": 0.18,
+                "position": [x, y, 0.30],
+                "rotation": [math.pi / 2, 0.0, 0.0],
+                "material": "rubber",
+            }
+            for x in (-1.125, 1.125)
+            for y in (-0.685, 0.685)
+        ),
+        {"shape": "box", "size": [0.05, 0.32, 0.18], "position": [1.775, 0.46, 0.52], "material": "headlight"},
+        {"shape": "box", "size": [0.05, 0.32, 0.18], "position": [1.775, -0.46, 0.52], "material": "headlight"},
+        {"shape": "box", "size": [0.05, 0.28, 0.17], "position": [-1.775, 0.48, 0.52], "material": "taillight"},
+        {"shape": "box", "size": [0.05, 0.28, 0.17], "position": [-1.775, -0.48, 0.52], "material": "taillight"},
+    ],
+    "colliders": [
+        {"shape": "box", "size": [3.60, 1.56, 0.73], "position": [0.0, 0.0, 0.365]},
+        {"shape": "box", "size": [1.70, 1.32, 0.60], "position": [-0.10, 0.0, 1.00]},
+    ],
+    "materials": {
+        "glass": "#263641",
+        "rubber": "#202328",
+        "headlight": "#fff0a8",
+        "taillight": "#d7353f",
+    },
+}
+
+
+@dataclass(frozen=True)
+class Lane:
+    id: str
+    signal_group: str
+    axis: str
+    direction: int
+    fixed: float
+    start: float
+    end: float
+    stop: float
+    yaw: float
+    color: str
+    initial_position: float
+
+
+LANES = (
+    # Route endpoints put the whole 3.6m car beyond the authored town bounds,
+    # so a recycle never visibly pops in the middle of a road-edge facade.
+    Lane("eastbound", EW, "x", 1, -1.51, -17.0, 17.0, -8.22, 0.0, "#e05b47", -11.7),
+    Lane("westbound", EW, "x", -1, 1.81, 17.0, -17.0, 8.48, math.pi, "#4d83d1", 11.7),
+    # MARS spawns in the northbound lane at y=-9.  Start this car beyond the
+    # junction; after it recycles at the south edge, robot following prevents
+    # it from spawning through or driving through the stationary robot.
+    Lane("northbound", NS, "y", 1, 1.79, -17.0, 17.0, -8.20, math.pi / 2, "#e2b643", 7.0),
+    Lane("southbound", NS, "y", -1, -1.53, 17.0, -17.0, 8.50, -math.pi / 2, "#55a96f", 11.7),
+)
+
+
+@dataclass
+class Car:
+    lane: Lane
+    position: float
+    speed: float = 0.0
+    spawn_seq: int = 0
+    active: bool = True
+    committed: bool = False
+
+
+def phase_at(sim_time: float) -> tuple[str, dict[str, str]]:
+    """Return the scheduled phase and signal aspects at ``sim_time``."""
+    t = sim_time % CYCLE_S
+    if t < ALL_RED_S:
+        return "all_red_to_ns", {NS: RED, EW: RED}
+    if t < ALL_RED_S + GREEN_S:
+        return "ns_green", {NS: GREEN, EW: RED}
+    if t < ALL_RED_S + GREEN_S + YELLOW_S:
+        return "ns_yellow", {NS: YELLOW, EW: RED}
+    if t < 2 * ALL_RED_S + GREEN_S + YELLOW_S:
+        return "all_red_to_ew", {NS: RED, EW: RED}
+    if t < 2 * ALL_RED_S + 2 * GREEN_S + YELLOW_S:
+        return "ew_green", {NS: RED, EW: GREEN}
+    return "ew_yellow", {NS: RED, EW: YELLOW}
+
+
+def _rgba(hex_color: str) -> str:
+    value = hex_color.lstrip("#")
+    rgb = [int(value[index : index + 2], 16) / 255 for index in (0, 2, 4)]
+    return " ".join(f"{channel:.6g}" for channel in (*rgb, 1.0))
+
+
+def _vec(values: list[float]) -> str:
+    return " ".join(f"{value:.6g}" for value in values)
+
+
+def _part_xml(part: dict[str, Any], body_color: str) -> str:
+    material = part["material"]
+    color = body_color if material == "body" else CAR_MODEL["materials"][material]
+    common = f'pos="{_vec(part["position"])}" rgba="{_rgba(color)}" contype="0" conaffinity="0" group="1"'
+    if part["shape"] == "box":
+        half = [value / 2 for value in part["size"]]
+        return f'      <geom type="box" size="{_vec(half)}" {common}/>'
+    rotation = [math.degrees(value) for value in part["rotation"]]
+    return (
+        f'      <geom type="cylinder" size="{part["radius"]:.6g} {part["length"] / 2:.6g}" '
+        f'euler="{_vec(rotation)}" {common}/>'
+    )
+
+
+def _collider_xml(collider: dict[str, Any]) -> str:
+    half = [value / 2 for value in collider["size"]]
+    return (
+        f'      <geom type="box" size="{_vec(half)}" '
+        f'pos="{_vec(collider["position"])}" contype="{CAR_COLLISION_BIT}" conaffinity="0" '
+        'friction="0.8 0.01 0.001" group="3" rgba="0 0 0 0"/>'
+    )
+
+
+class TrafficController:
+    """Environment-scoped traffic clock, cars, and MuJoCo bindings."""
+
+    def __init__(self, environment_id: str):
+        self.enabled = environment_id == TOWN_ENVIRONMENT_ID
+        self.cars = [Car(lane, lane.initial_position) for lane in LANES] if self.enabled else []
+        self._mocap_ids: dict[str, int] = {}
+        self._signal_material_ids: dict[str, dict[str, int]] = {}
+        self._model: Any | None = None
+        self._last_aspects: dict[str, str] | None = None
+        self._current_phase, initial_aspects = phase_at(0.0)
+        self._current_aspects = dict(initial_aspects)
+
+    def bodies_xml(self) -> str:
+        if not self.enabled:
+            return ""
+        bodies = []
+        for car in self.cars:
+            name = escape(f"traffic_car_{car.lane.id}", quote=True)
+            visuals = "\n".join(_part_xml(part, car.lane.color) for part in CAR_MODEL["parts"])
+            colliders = "\n".join(_collider_xml(collider) for collider in CAR_MODEL["colliders"])
+            bodies.append(f'    <body name="{name}" mocap="true">\n{visuals}\n{colliders}\n    </body>')
+        return "\n".join(bodies)
+
+    def configure_robot_spec(self, robot_spec: Any) -> None:
+        """Opt robot collisions into the private car category pre-compile.
+
+        MuJoCo aggregates geom masks into body_contype/body_conaffinity while
+        compiling. Mutating only model.geom_conaffinity later looks correct in
+        an inspector but leaves broad-phase car/robot pairing disabled.
+        """
+        if not self.enabled:
+            return
+        colliders = 0
+        for geom in robot_spec.geoms:
+            if int(geom.contype) == 0:
+                continue
+            geom.conaffinity = int(geom.conaffinity) | CAR_COLLISION_BIT
+            colliders += 1
+        if colliders == 0:
+            raise RuntimeError("traffic requires at least one collidable robot geom")
+
+    def bind(self, model: Any) -> None:
+        if not self.enabled:
+            return
+        self._model = model
+        self._mocap_ids = {
+            car.lane.id: int(model.body_mocapid[model.body(f"traffic_car_{car.lane.id}").id]) for car in self.cars
+        }
+        if any(mocap_id < 0 for mocap_id in self._mocap_ids.values()):
+            raise RuntimeError("traffic car body was not compiled as a MuJoCo mocap body")
+
+        missing = []
+        for group, aspects in SIGNAL_MATERIALS.items():
+            ids: dict[str, int] = {}
+            for aspect, source_name in aspects.items():
+                material_name = f"mat_{source_name.lower().replace('_', '-')}"
+                try:
+                    ids[aspect] = int(model.mat(material_name).id)
+                except KeyError:
+                    missing.append(material_name)
+            self._signal_material_ids[group] = ids
+        if missing:
+            raise RuntimeError(
+                "town traffic-signal materials are missing ("
+                + ", ".join(missing)
+                + "). Rebuild the licensed town with sim/tools/build_low_poly_town.py."
+            )
+
+        # configure_robot_spec() must run before compile: body-level collision
+        # masks are precomputed and cannot be repaired by changing only geoms.
+        for geom_id in range(model.ngeom):
+            body_id = int(model.geom_bodyid[geom_id])
+            body_name = model.body(body_id).name or ""
+            if (
+                body_name.startswith("robot_")
+                and int(model.geom_contype[geom_id]) != 0
+                and (
+                    not int(model.geom_conaffinity[geom_id]) & CAR_COLLISION_BIT
+                    or not int(model.body_conaffinity[body_id]) & CAR_COLLISION_BIT
+                )
+            ):
+                raise RuntimeError("robot collision bodies were not compiled into the traffic collision category")
+
+    def reset(self, data: Any | None = None) -> None:
+        if not self.enabled:
+            return
+        for car in self.cars:
+            car.position = car.lane.initial_position
+            car.speed = 0.0
+            car.spawn_seq = 0
+            car.active = True
+            car.committed = False
+        self._last_aspects = None
+        if data is not None:
+            self._current_phase, self._current_aspects = self._effective_signals(float(data.time))
+            self._write_mocap(data)
+            self._apply_signal_materials(self._current_aspects)
+
+    def advance(self, dt: float, sim_time: float, robot_xy: tuple[float, float] | None = None) -> None:
+        if not self.enabled:
+            return
+        self._current_phase, aspects = self._effective_signals(sim_time)
+        self._current_aspects = dict(aspects)
+        occupied = self._occupied_groups()
+        for car in self.cars:
+            conflicting_group = EW if car.lane.signal_group == NS else NS
+            self._advance_car(car, dt, aspects[car.lane.signal_group], occupied[conflicting_group], robot_xy)
+        self._apply_signal_materials(aspects)
+
+    def _occupied_groups(self) -> dict[str, bool]:
+        occupied = {NS: False, EW: False}
+        for car in self.cars:
+            if (
+                car.active
+                and car.position + CAR_HALF_LENGTH_M > INTERSECTION_MIN_M
+                and car.position - CAR_HALF_LENGTH_M < INTERSECTION_MAX_M
+            ):
+                occupied[car.lane.signal_group] = True
+        return occupied
+
+    def _effective_signals(self, sim_time: float) -> tuple[str, dict[str, str]]:
+        """Hold the next direction at red until the conflict box is empty.
+
+        The scheduled all-red interval is normally ample.  This interlock also
+        covers an exceptional obstruction (for example, MARS physically
+        pinning a committed car in the junction), so the visible lamps never
+        invite traffic into a box that the controller itself considers unsafe.
+        """
+        phase, scheduled = phase_at(sim_time)
+        aspects = dict(scheduled)
+        occupied = self._occupied_groups()
+        if aspects[NS] != RED and occupied[EW]:
+            aspects[NS] = RED
+        if aspects[EW] != RED and occupied[NS]:
+            aspects[EW] = RED
+        if aspects != scheduled:
+            phase = f"{phase}_clearance_hold"
+        return phase, aspects
+
+    def step(self, data: Any, dt: float, robot_xy: tuple[float, float]) -> None:
+        self.advance(dt, float(data.time) + dt, robot_xy)
+        self._write_mocap(data)
+
+    def _advance_car(
+        self,
+        car: Car,
+        dt: float,
+        aspect: str,
+        conflicting_occupied: bool,
+        robot_xy: tuple[float, float] | None,
+    ) -> None:
+        lane = car.lane
+        if not car.active:
+            if self._spawn_is_clear(lane, robot_xy):
+                car.position = lane.start
+                car.speed = 0.0
+                car.spawn_seq += 1
+                car.active = True
+                car.committed = False
+            return
+
+        entered = lane.direction * (car.position - lane.stop) > STOP_EPS_M
+        # Commitment is a yellow-clearance decision, not permission to wait
+        # before the line through an entire all-red and then enter against red.
+        # A robot obstruction that lasts until red therefore cancels it; cars
+        # already over the line remain committed and keep clearing the box.
+        if aspect == RED and not entered:
+            car.committed = False
+        distance_to_stop = max(0.0, lane.direction * (lane.stop - car.position))
+        if entered:
+            car.committed = True
+        permission = aspect == GREEN and not conflicting_occupied
+        if not entered and permission:
+            # Dilemma-zone rule: once normal braking can no longer keep the
+            # centre behind the line, finish the crossing through yellow and
+            # all-red. This avoids impossible instantaneous stops and lets a
+            # driver arriving late in green behave naturally.
+            braking_distance = car.speed * car.speed / (2 * BRAKE_MPS2)
+            if distance_to_stop <= braking_distance + COMMIT_MARGIN_M:
+                car.committed = True
+        can_enter = permission or car.committed
+        limits: list[float] = []  # distance the car centre may still travel
+        if not entered and not can_enter:
+            limits.append(max(0.0, lane.direction * (lane.stop - car.position)))
+
+        if robot_xy is not None:
+            robot_axis = robot_xy[0] if lane.axis == "x" else robot_xy[1]
+            robot_fixed = robot_xy[1] if lane.axis == "x" else robot_xy[0]
+            if abs(robot_fixed - lane.fixed) <= CAR_WIDTH_M / 2 + ROBOT_RADIUS_M:
+                centre_gap = lane.direction * (robot_axis - car.position)
+                clearance = CAR_HALF_LENGTH_M + ROBOT_RADIUS_M + ROBOT_FOLLOW_GAP_M
+                if centre_gap >= 0:
+                    limits.append(max(0.0, centre_gap - clearance))
+
+        desired = CRUISE_SPEED_MPS
+        if limits:
+            travel = min(limits)
+            desired = min(desired, math.sqrt(max(0.0, 2 * BRAKE_MPS2 * travel)))
+            if travel <= STOP_EPS_M:
+                desired = 0.0
+
+        if car.speed < desired:
+            car.speed = min(desired, car.speed + ACCEL_MPS2 * dt)
+        else:
+            car.speed = max(desired, car.speed - BRAKE_MPS2 * dt)
+
+        travel = car.speed * dt
+        if limits:
+            travel = min(travel, min(limits))
+            if min(limits) <= STOP_EPS_M:
+                car.speed = 0.0
+        car.position += lane.direction * travel
+
+        if lane.direction * (car.position - lane.end) >= 0:
+            car.speed = 0.0
+            if self._spawn_is_clear(lane, robot_xy):
+                car.position = lane.start
+                car.spawn_seq += 1
+                car.committed = False
+            else:
+                # Keep the actor physically and visually out of the world
+                # until the next clear step rather than teleporting onto MARS.
+                car.position = lane.end
+                car.active = False
+                car.committed = False
+
+    @staticmethod
+    def _spawn_is_clear(lane: Lane, robot_xy: tuple[float, float] | None) -> bool:
+        if robot_xy is None:
+            return True
+        robot_axis = robot_xy[0] if lane.axis == "x" else robot_xy[1]
+        robot_fixed = robot_xy[1] if lane.axis == "x" else robot_xy[0]
+        if abs(robot_fixed - lane.fixed) > CAR_WIDTH_M / 2 + ROBOT_RADIUS_M:
+            return True
+        # Traffic is generated at the edge of the authored town.  If MARS is
+        # already occupying this approach, keep the next car off-scene instead
+        # of introducing a permanent queue between the follow camera and the
+        # robot.  An already-visible car still follows the ordinary braking
+        # rule above if MARS moves into its lane later.
+        route_length = lane.direction * (lane.end - lane.start)
+        distance_along_route = lane.direction * (robot_axis - lane.start)
+        return not (0.0 <= distance_along_route <= route_length)
+
+    def _write_mocap(self, data: Any) -> None:
+        if not self._mocap_ids:
+            return
+        for index, car in enumerate(self.cars):
+            mocap_id = self._mocap_ids[car.lane.id]
+            if not car.active:
+                data.mocap_pos[mocap_id] = (1_000.0 + 10.0 * index, 1_000.0, 0.0)
+                data.mocap_quat[mocap_id] = (1.0, 0.0, 0.0, 0.0)
+                continue
+            if car.lane.axis == "x":
+                x, y = car.position, car.lane.fixed
+            else:
+                x, y = car.lane.fixed, car.position
+            data.mocap_pos[mocap_id] = (x, y, 0.0)
+            half_yaw = car.lane.yaw / 2
+            data.mocap_quat[mocap_id] = (math.cos(half_yaw), 0.0, 0.0, math.sin(half_yaw))
+
+    def _apply_signal_materials(self, aspects: dict[str, str]) -> None:
+        if self._model is None or aspects == self._last_aspects:
+            return
+        for group, selected in aspects.items():
+            for aspect, material_id in self._signal_material_ids[group].items():
+                active = aspect == selected
+                self._model.mat_rgba[material_id] = (1.0, 1.0, 1.0, 1.0) if active else (0.10, 0.10, 0.10, 1.0)
+                self._model.mat_emission[material_id] = 0.45 if active else 0.0
+        self._last_aspects = dict(aspects)
+
+    def manifest(self) -> dict[str, Any] | None:
+        if not self.enabled:
+            return None
+        return {
+            "schema_version": 1,
+            "car_model": copy.deepcopy(CAR_MODEL),
+            "cars": [{"id": car.lane.id, "color": car.lane.color} for car in self.cars],
+            "signal_materials": copy.deepcopy(SIGNAL_MATERIALS),
+            "signal_colors": dict(SIGNAL_COLORS),
+        }
+
+    def state(self, _sim_time: float, world_epoch: int) -> dict[str, Any] | None:
+        if not self.enabled:
+            return None
+        # advance() chose the interlocked aspects used for both vehicle
+        # permission and MuJoCo materials.  Publish that exact choice rather
+        # than recomputing the static schedule and risking a contradictory UI.
+        cars = {}
+        for car in self.cars:
+            if not car.active:
+                continue
+            x, y = (car.position, car.lane.fixed) if car.lane.axis == "x" else (car.lane.fixed, car.position)
+            cars[car.lane.id] = {
+                "pose": [x, y, car.lane.yaw],
+                "speed": car.speed,
+                "spawn_seq": car.spawn_seq,
+            }
+        return {
+            "world_epoch": world_epoch,
+            "phase": self._current_phase,
+            "signals": dict(self._current_aspects),
+            "cars": cars,
+        }

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -219,10 +219,13 @@ def build_world_xml(
     texture_max: int | None = None,
     props: "PropRegistry | None" = None,
     spawn_pose: tuple[float, float, float] = (SPAWN_X, SPAWN_Y, SPAWN_YAW_DEG),
+    traffic_bodies: str = "",
 ) -> str:
     """The apartment environment MJCF (floor plane + decomposed room hulls,
     optionally the textured visual rooms in their own geom group, plus every
-    droppable prop parked off-map -- see props.py).
+    droppable prop parked off-map -- see props.py). Environment-owned dynamic
+    bodies such as town traffic are inserted directly under worldbody via
+    traffic_bodies, already expressed in simulator Z-up coordinates.
     texture_max caps the visual textures' resolution (see capped_texture_path)."""
     prop_assets = props.assets_xml(VISUAL_GROUP) if props else ""
     prop_bodies = props.bodies_xml(VISUAL_GROUP, COLLISION_GROUP) if props else ""
@@ -300,6 +303,7 @@ def build_world_xml(
 {chr(10).join(geom_lines)}
 {chr(10).join(visual_geom_lines)}
     </body>{prop_bodies}{robot_body}
+{traffic_bodies}
   </worldbody>
 </mujoco>
 """

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world_server.py
@@ -5,9 +5,10 @@ sim/README.md "world_server.py"):
   Framing: 4-byte big-endian length | JSON; responses are one JSON frame,
   then one binary frame iff the JSON says "blob": <nbytes>.
 - observer state stream (--state-port): a WebSocket broadcasting ground
-  truth ({t, wall, world_epoch, pose, joints, objects}) after every physics
-  slice, and accepting stage commands ({"op": "drop_prop_at", ...}) back. A
-  roster frame ({props, challenges, environment, environments, switch}) opens
+  truth ({t, wall, world_epoch, pose, joints, objects, traffic}) after every
+  physics slice, and accepting stage commands ({"op": "drop_prop_at", ...})
+  back. A roster frame ({props, traffic_manifest, challenges, environment,
+  environments, switch}) opens
   every connection and is resent whenever the environment changes. Ground
   truth and scenery only -- robot software must never consume or drive it.
 
@@ -150,6 +151,7 @@ class WorldServer:
             x, y, yaw = self.sim.pose()
             joints = self.sim.joint_positions()
             objects = self.sim.object_poses()
+            traffic = self.sim.traffic_state()
             # Prop CENTRES for the judge (props.py center_offset): a distance
             # to the human has to mean its body, not the feet its origin sits
             # at. Gathered here because the judge runs without the sim.
@@ -183,6 +185,7 @@ class WorldServer:
                 "pose": [x, y, yaw],
                 "joints": joints,
                 "objects": objects,
+                "traffic": traffic,
                 "challenge": challenge,
             }
         )
@@ -272,6 +275,7 @@ class WorldServer:
         return json.dumps(
             {
                 "props": self.sim.prop_manifest(),
+                "traffic_manifest": self.sim.traffic_manifest(),
                 "challenges": self.challenges.roster(),
                 "environment": environment.public() if environment else None,
                 "environments": [candidate.summary() for candidate in self.environments],

--- a/scripts/launch_sim_in_tmux.zsh
+++ b/scripts/launch_sim_in_tmux.zsh
@@ -95,6 +95,7 @@ echo "Started UDP leader receiver (:9999/udp)..."
 # can switch it between packs (/nav/change_navigation_map).
 mkdir -p ~/innate-os/data/maps
 cp ~/innate-os/sim/assets/map/*.yaml ~/innate-os/sim/assets/map/*.pgm ~/innate-os/data/maps/ 2>/dev/null || true
+cp ~/innate-os/sim/assets/local-environments/*/map/*.yaml ~/innate-os/sim/assets/local-environments/*/map/*.pgm ~/innate-os/data/maps/ 2>/dev/null || true
 tmux new-window -t "$SESSION_NAME" -n nav-brain
 tmux send-keys -t "${TMUX_TARGET_PREFIX}:nav-brain" "ros2 launch mars_nav mode_manager.launch.py" C-m
 echo "Started navigation system..."

--- a/sim/README.md
+++ b/sim/README.md
@@ -181,7 +181,11 @@ collision and visual meshes and Nav2 map (under `sim/assets/`), the browser glb
 or per-room manifest and collision hulls (under `sim/viewer/public/`), and the
 spawn pose -- `sim/environments/backrooms/manifest.json` is the template, and
 `sim/tools/build_environment_pack.py` derives every one of those files from a
-single glTF scene (the asset image runs it; see `sim/Dockerfile.assets`). Meshes are in
+single glTF scene (the asset image runs it; see `sim/Dockerfile.assets`).
+A locally licensed pack keeps its generated files under `local-environments/`
+roots -- in `sim/assets` and in `sim/viewer` (served at `/local-environments/`)
+-- which an asset-image refresh never touches; `sim/tools/build_low_poly_town.py`
+is one such build. Meshes are in
 meters, glTF Y-up, with the floor at y = 0: physics stands the robot on the
 MJCF ground plane there, and the 3D view's floor grid sits just below it.
 Licensed packs the repository must not ship go in `sim/environments.local/`

--- a/sim/docker-compose.dev.yml
+++ b/sim/docker-compose.dev.yml
@@ -108,6 +108,9 @@ services:
       # (runtime.install_layer_subtree).
       - ../sim/viewer/public:/root/innate-os/sim/viewer/public:ro
       - ../sim/viewer/dist-lib:/root/innate-os/sim/viewer/dist-lib:ro
+      # Locally built environment packs' browser files (served at
+      # /local-environments/); the launcher pre-creates the directory.
+      - ../sim/viewer/local-environments:/root/innate-os/sim/viewer/local-environments:ro
       - ${INNATE_OS_ENV_FILE:-../.env}:/root/innate-os/.env:ro
 
       # 2) Keep build/install/log folders as Docker named volumes, so they won't pollute your host

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -774,6 +774,8 @@ WORKSPACE_USER_DIRS = ("custom_agents", "custom_skills")
 def ensure_workspace_dirs(config: dict[str, object]) -> None:
     """Pre-create container-written workspace dirs as the invoking user."""
     os_repo: Path = config["os_repo"]  # type: ignore[assignment]
+    # Also a bind-mount source Docker would otherwise create root-owned.
+    (os_repo / "sim" / "viewer" / "local-environments").mkdir(parents=True, exist_ok=True)
     for name in WORKSPACE_USER_DIRS:
         path = os_repo / "workspace" / name
         try:

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -2411,7 +2411,7 @@ def _world_model_sources_digest(config: dict[str, object]) -> str:
     driver = mars_bot / "mars_sim_driver" / "mars_sim_driver"
     candidates = sorted((mars_bot / "mars_sim" / "urdf").glob("*"))
     candidates += sorted((mars_bot / "mars_sim" / "meshes").glob("*"))
-    candidates += [driver / name for name in ("world.py", "core.py", "constants.py", "environments.py")]
+    candidates += [driver / name for name in ("world.py", "core.py", "constants.py", "environments.py", "traffic.py")]
     candidates += [sim_repo / "assets" / ".assets-tag"]
     candidates += sorted((sim_repo / "environments").rglob("manifest.json"))
     digest = hashlib.sha256()

--- a/sim/tools/build_low_poly_town.py
+++ b/sim/tools/build_low_poly_town.py
@@ -1,0 +1,742 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Build the locally licensed Low Poly Town simulator environment.
+
+The purchased CGTrader source stays under ``sim/viewer/assets`` and every
+generated file stays in gitignored ``local-environments`` directories: the
+MuJoCo meshes and Nav2 map under ``sim/assets``, the browser files under
+``sim/viewer`` (served at /local-environments/, and outside ``sim/viewer/public``
+so an asset-image refresh never wipes them), and the manifest under
+``sim/environments.local``. This keeps the model usable in the simulator
+without publishing retrievable model files from the open repository.
+
+Usage (from the repository root):
+
+    sim/.venv/bin/python sim/tools/build_low_poly_town.py \
+      --source-obj sim/viewer/assets/low_poly_town/town.obj \
+      --source-mtl sim/viewer/assets/low_poly_town/town.mtl
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import trimesh
+from PIL import Image
+
+SIM = Path(__file__).resolve().parents[1]
+PACK_ID = "low-poly-town"
+PACK_DISPLAY_NAME = "Town Intersection"
+PACK_ROOT = Path("local-environments") / PACK_ID
+
+# The asphalt and painted markings share this authored Blender Z coordinate.
+# OBJ/glTF export maps Blender Z to glTF Y, so subtracting it puts the visible
+# driving surface at simulator ground level without changing the horizontal
+# frame. The large gray base slab ends lower and is hidden a little further to
+# keep it out of the road's depth plane.
+ROAD_SURFACE_Y = 0.543620586
+ROAD_MARKING_SOURCE_Y = 0.543620586
+BASE_SLAB_SOURCE_TOP_Y = 0.489483
+ROAD_MARKING_LIFT = 0.002
+BASE_SLAB_CLEARANCE = 0.01
+# The rendered sidewalks are about 10 cm above the road after the town is
+# grounded. Keep the collision proxy faithful to that visible step so MARS
+# does not encounter the previous, artificial 22 cm curb.
+CURB_COLLISION_HEIGHT = 0.10
+
+MAP_RESOLUTION = 0.05
+MAP_ORIGIN_X = -15.0
+MAP_ORIGIN_Y = -15.0
+MAP_MAX_X = 15.0
+MAP_MAX_Y = 15.0
+PGM_OCCUPIED = 0
+PGM_UNKNOWN = 205
+PGM_FREE = 254
+
+SPAWN_X = 1.6
+SPAWN_Y = -9.0
+SPAWN_YAW_DEGREES = 90.0
+
+# (world x, world y). Four mast-and-arm signals sit just inside the corners;
+# the remaining pedestrian signals sit along the curb. Only their narrow masts
+# collide: the overhead signal arms deliberately remain passable underneath.
+TRAFFIC_LIGHT_CENTERS = (
+    (-6.5135, -3.8356),
+    (-3.6347, -3.6142),
+    (-3.8561, -6.4930),
+    (6.7733, -3.8356),
+    (4.1159, -6.4930),
+    (3.8945, -3.6142),
+    (6.7733, 4.1364),
+    (4.1159, 6.7938),
+    (3.8945, 3.9150),
+    (-6.5135, 4.1364),
+    (-3.8561, 6.7938),
+    (-3.6347, 3.9150),
+)
+
+SIGNAL_ASPECTS = ("Red", "Yellow", "Green")
+SIGNAL_OBJECT_PHASE = {
+    "Traffic_Light.001_Cube.009": "NS",
+    "Traffic_Light.002_Cube.010": "NS",
+    "Traffic_Light.003_Cube.011": "NS",
+    "Traffic_Light_Cube.008": "NS",
+    "Traffic_Light.009_Cube.018": "NS",
+    "Traffic_Light.011_Cube.024": "NS",
+    "Traffic_Light.004_Cube.012": "EW",
+    "Traffic_Light.005_Cube.013": "EW",
+    "Traffic_Light.006_Cube.014": "EW",
+    "Traffic_Light.007_Cube.019": "EW",
+    "Traffic_Light.008_Cube.016": "EW",
+    "Traffic_Light.010_Cube.020": "EW",
+}
+
+
+def isolate_signal_materials(obj_text: str, mtl_text: str) -> tuple[str, str]:
+    """Split the source's shared lens colors into NS and EW materials."""
+    current_phase: str | None = None
+    counts = {(phase, aspect): 0 for phase in ("NS", "EW") for aspect in SIGNAL_ASPECTS}
+    rewritten: list[str] = []
+    for line in obj_text.splitlines():
+        if line.startswith("o "):
+            current_phase = SIGNAL_OBJECT_PHASE.get(line.removeprefix("o ").strip())
+        if line.startswith("usemtl ") and current_phase is not None:
+            aspect = line.removeprefix("usemtl ").strip()
+            if aspect in SIGNAL_ASPECTS:
+                counts[(current_phase, aspect)] += 1
+                line = f"usemtl Signal_{current_phase}_{aspect}"
+        rewritten.append(line)
+    wrong = {key: count for key, count in counts.items() if count != 6}
+    if wrong:
+        raise RuntimeError(f"unexpected traffic-light material assignments: {wrong}")
+
+    blocks: dict[str, list[str]] = {}
+    current_material: str | None = None
+    for line in mtl_text.splitlines():
+        if line.startswith("newmtl "):
+            current_material = line.removeprefix("newmtl ").strip()
+            blocks[current_material] = []
+        elif current_material is not None:
+            blocks[current_material].append(line)
+    missing = [aspect for aspect in SIGNAL_ASPECTS if aspect not in blocks]
+    if missing:
+        raise RuntimeError(f"town MTL is missing signal source materials: {missing}")
+
+    aliases = ["", "# Simulator-only traffic phase materials (generated)."]
+    for phase in ("NS", "EW"):
+        for aspect in SIGNAL_ASPECTS:
+            aliases.extend((f"newmtl Signal_{phase}_{aspect}", *blocks[aspect]))
+    return "\n".join(rewritten) + "\n", mtl_text.rstrip() + "\n" + "\n".join(aliases) + "\n"
+
+
+@dataclass
+class _GeneratedOutput:
+    staged: Path
+    target: Path
+    backup_directory: Path | None = None
+    backup: Path | None = None
+    published: bool = False
+
+
+def _path_exists(path: Path) -> bool:
+    """Like exists(), but a broken generated symlink still needs replacing."""
+    return path.exists() or path.is_symlink()
+
+
+def _remove_generated_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _staging_directory(parent: Path) -> Path:
+    parent.mkdir(parents=True, exist_ok=True)
+    directory = Path(tempfile.mkdtemp(prefix=f".{PACK_ID}.build-", dir=parent))
+    # mkdtemp intentionally creates 0700 directories. Once renamed, these are
+    # served by containers that may not share the invoking user's uid.
+    directory.chmod(0o755)
+    return directory
+
+
+def _publish_generated_outputs(outputs: list[_GeneratedOutput]) -> None:
+    """Replace every generated target and restore all old targets on error.
+
+    Each rename stays on one filesystem and is atomic. The manifest is passed
+    last by build(), so a successful publish exposes the commit marker only
+    after both asset trees are in place.
+    """
+    try:
+        for output in outputs:
+            output.target.parent.mkdir(parents=True, exist_ok=True)
+            if _path_exists(output.target):
+                output.backup_directory = Path(
+                    tempfile.mkdtemp(prefix=f".{output.target.name}.backup-", dir=output.target.parent)
+                )
+                output.backup = output.backup_directory / output.target.name
+                output.target.replace(output.backup)
+            # Mark the slot before rename so KeyboardInterrupt between the
+            # atomic filesystem operation and Python bookkeeping still removes
+            # a newly published target during rollback.
+            output.published = True
+            output.staged.replace(output.target)
+    except BaseException as publish_error:
+        rollback_errors: list[str] = []
+        for output in reversed(outputs):
+            try:
+                if output.published and _path_exists(output.target):
+                    _remove_generated_path(output.target)
+                if output.backup is not None and _path_exists(output.backup):
+                    if _path_exists(output.target):
+                        _remove_generated_path(output.target)
+                    output.backup.replace(output.target)
+            except OSError as rollback_error:
+                rollback_errors.append(f"{output.target}: {rollback_error}")
+
+        for output in outputs:
+            if output.backup_directory is not None and output.backup_directory.is_dir():
+                try:
+                    output.backup_directory.rmdir()
+                except OSError:
+                    # A failed restore deliberately leaves its backup intact.
+                    pass
+
+        if rollback_errors:
+            details = "; ".join(rollback_errors)
+            raise RuntimeError(
+                f"town asset publish failed ({publish_error}); rollback was incomplete: {details}"
+            ) from publish_error
+        raise
+
+    for output in outputs:
+        if output.backup_directory is not None:
+            shutil.rmtree(output.backup_directory, ignore_errors=True)
+
+
+def _cross_2d(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> float:
+    return float((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]))
+
+
+def _triangulate_face(tokens: list[str], vertices: list[tuple[float, float, float]]) -> list[list[str]]:
+    """Ear-clip one planar OBJ polygon instead of using a concave-unsafe fan."""
+    if len(tokens) == 3:
+        return [tokens]
+
+    positions = np.asarray([vertices[int(token.split("/", 1)[0]) - 1] for token in tokens], dtype=np.float64)
+    normal = np.zeros(3, dtype=np.float64)
+    for point, following in zip(positions, np.roll(positions, -1, axis=0), strict=True):
+        normal += np.cross(point, following)
+    normal_length = float(np.linalg.norm(normal))
+    if normal_length < 1e-12:
+        return []
+    spatial_scale = max(float(np.ptp(positions, axis=0).max()), 1.0)
+    plane_distance = np.abs((positions - positions[0]) @ (normal / normal_length))
+    if float(plane_distance.max()) > spatial_scale * 1e-6:
+        # A few tiny bevel polygons in the source are intentionally folded in
+        # 3D. They have no single 2D interior, so retain their authored fan.
+        return [[tokens[0], tokens[index], tokens[index + 1]] for index in range(1, len(tokens) - 1)]
+
+    projected = np.delete(positions, int(np.argmax(np.abs(normal))), axis=1)
+    scale = max(float(np.ptp(projected[:, 0])), float(np.ptp(projected[:, 1])), 1.0)
+    epsilon = scale * scale * 1e-12
+    signed_area = sum(_cross_2d(projected[0], projected[i], projected[i + 1]) for i in range(1, len(tokens) - 1))
+    orientation = 1.0 if signed_area > 0 else -1.0
+    remaining = list(range(len(tokens)))
+    triangles: list[list[str]] = []
+
+    def inside_triangle(point: np.ndarray, a: np.ndarray, b: np.ndarray, c: np.ndarray) -> bool:
+        return (
+            orientation * _cross_2d(a, b, point) >= -epsilon
+            and orientation * _cross_2d(b, c, point) >= -epsilon
+            and orientation * _cross_2d(c, a, point) >= -epsilon
+        )
+
+    while len(remaining) > 3:
+        for offset, current in enumerate(remaining):
+            previous = remaining[offset - 1]
+            following = remaining[(offset + 1) % len(remaining)]
+            a, b, c = projected[[previous, current, following]]
+            if orientation * _cross_2d(a, b, c) <= epsilon:
+                continue
+            if any(
+                inside_triangle(projected[other], a, b, c)
+                for other in remaining
+                if other not in {previous, current, following}
+            ):
+                continue
+            triangles.append([tokens[previous], tokens[current], tokens[following]])
+            del remaining[offset]
+            break
+        else:
+            raise RuntimeError(f"cannot ear-clip OBJ polygon with {len(tokens)} vertices")
+
+    triangles.append([tokens[index] for index in remaining])
+    return triangles
+
+
+def _triangulate_obj(text: str) -> tuple[str, int]:
+    """Triangulate authored n-gons without bridging their concave cutouts."""
+    vertices = [tuple(map(float, line.split()[1:4])) for line in text.splitlines() if line.startswith("v ")]
+    output: list[str] = []
+    polygon_count = 0
+    for line in text.splitlines():
+        if not line.startswith("f "):
+            output.append(line)
+            continue
+        tokens = line.split()[1:]
+        triangles = _triangulate_face(tokens, vertices)
+        polygon_count += int(len(tokens) > 3)
+        output.extend("f " + " ".join(triangle) for triangle in triangles)
+    return "\n".join(output) + "\n", polygon_count
+
+
+def _load_authored_scene(source_obj: Path, source_mtl: Path) -> trimesh.Scene:
+    if not source_obj.is_file() or not source_mtl.is_file():
+        raise FileNotFoundError(
+            "Low Poly Town source is not installed. Copy the purchased OBJ and MTL to "
+            "sim/viewer/assets/low_poly_town/town.obj and town.mtl."
+        )
+
+    # The marketplace download names the files with '+' while the OBJ points
+    # at a space-separated MTL name. Stage canonical names so every resolver,
+    # including trimesh's, loads the 25 authored materials deterministically.
+    with tempfile.TemporaryDirectory(prefix="innate-low-poly-town-") as temporary:
+        staged = Path(temporary)
+        staged_obj = staged / "town.obj"
+        staged_mtl = staged / "town.mtl"
+        text = source_obj.read_text(encoding="utf-8")
+        text, replacements = re.subn(r"(?m)^mtllib\s+.*$", "mtllib town.mtl", text, count=1)
+        if replacements != 1:
+            text = f"mtllib town.mtl\n{text}"
+        text, material_text = isolate_signal_materials(text, source_mtl.read_text(encoding="utf-8"))
+        text, polygon_count = _triangulate_obj(text)
+        if polygon_count < 1_000:
+            raise RuntimeError(f"expected the authored town to contain many n-gons, found {polygon_count}")
+        staged_obj.write_text(text, encoding="utf-8")
+        staged_mtl.write_text(material_text, encoding="utf-8")
+        loaded = trimesh.load(staged_obj, force="scene", process=False, maintain_order=True)
+
+    if not isinstance(loaded, trimesh.Scene) or len(loaded.geometry) < 20:
+        raise RuntimeError("the Low Poly Town OBJ did not load as the expected multi-material scene")
+    if not np.allclose(loaded.extents, (29.129641, 9.330295, 28.345164), atol=0.15):
+        raise RuntimeError(f"unexpected Low Poly Town dimensions: {loaded.extents}")
+
+    for mesh in loaded.geometry.values():
+        mesh.apply_translation((0.0, -ROAD_SURFACE_Y, 0.0))
+    expected_signal_faces = 864
+    signal_faces: dict[str, int] = {}
+    for mesh in loaded.geometry.values():
+        name = str(getattr(getattr(mesh.visual, "material", None), "name", ""))
+        if name.startswith("Signal_"):
+            signal_faces[name] = len(mesh.faces)
+    expected_names = {f"Signal_{phase}_{aspect}" for phase in ("NS", "EW") for aspect in SIGNAL_ASPECTS}
+    if set(signal_faces) != expected_names or any(count != expected_signal_faces for count in signal_faces.values()):
+        raise RuntimeError(f"unexpected generated traffic signal meshes: {signal_faces}")
+    return loaded
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "material"
+
+
+def _write_obj(mesh: trimesh.Trimesh, path: Path) -> None:
+    compact = mesh.copy()
+    compact.remove_unreferenced_vertices()
+    lines = [*(f"v {x:.8g} {y:.8g} {z:.8g}" for x, y, z in compact.vertices)]
+    lines.extend(f"f {a + 1} {b + 1} {c + 1}" for a, b, c in compact.faces)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _lift_road_markings(scene: trimesh.Scene) -> None:
+    """Separate the coplanar white markings from the asphalt depth plane."""
+    candidates: list[trimesh.Trimesh] = []
+    expected_height = ROAD_MARKING_SOURCE_Y - ROAD_SURFACE_Y
+    for mesh in scene.geometry.values():
+        material = getattr(mesh.visual, "material", None)
+        if (
+            str(getattr(material, "name", "")).casefold() == "white"
+            and mesh.extents[1] < 0.0002
+            and abs(float(mesh.centroid[1]) - expected_height) < 0.0002
+        ):
+            candidates.append(mesh)
+
+    if len(candidates) != 1:
+        raise RuntimeError(f"expected one flat white road-marking mesh, found {len(candidates)}")
+    candidates[0].apply_translation((0.0, ROAD_MARKING_LIFT, 0.0))
+
+
+def _lower_base_slab(scene: trimesh.Scene) -> None:
+    """Move the hidden town slab below coplanar asphalt and landscaping."""
+    candidates: list[trimesh.Trimesh] = []
+    expected_top = BASE_SLAB_SOURCE_TOP_Y - ROAD_SURFACE_Y
+    for mesh in scene.geometry.values():
+        material = getattr(mesh.visual, "material", None)
+        if (
+            str(getattr(material, "name", "")).casefold() == "gray"
+            and mesh.extents[0] > 25.0
+            and mesh.extents[2] > 25.0
+            and abs(float(mesh.bounds[1, 1]) - expected_top) < 0.0002
+        ):
+            candidates.append(mesh)
+
+    if len(candidates) != 1:
+        raise RuntimeError(f"expected one full-town gray base slab, found {len(candidates)}")
+    candidates[0].apply_translation((0.0, -BASE_SLAB_CLEARANCE, 0.0))
+
+
+def _apply_flat_shading(scene: trimesh.Scene) -> None:
+    """Replace the OBJ's corrupt shared normals with low-poly face normals."""
+    for mesh in scene.geometry.values():
+        mesh.unmerge_vertices()
+        mesh.vertex_normals = np.repeat(mesh.face_normals, 3, axis=0)
+
+
+def _prepare_daylight_materials(scene: trimesh.Scene) -> None:
+    """Convert the OBJ's linear diffuse colors for our sRGB renderers.
+
+    The marketplace preview was authored through Blender color management, but
+    OBJ ``Kd`` values are linear light. Treating those values as already-sRGB
+    makes the town nearly black in both Three.js and MuJoCo. Keep the authored
+    palette while encoding it for display and use a matte low-poly finish.
+    """
+    for index, mesh in enumerate(scene.geometry.values()):
+        source = getattr(mesh.visual, "material", None)
+        linear = np.asarray(getattr(source, "main_color", (160, 160, 160, 255))[:3], dtype=np.float64) / 255.0
+        srgb = np.where(
+            linear <= 0.0031308,
+            linear * 12.92,
+            1.055 * np.power(linear, 1.0 / 2.4) - 0.055,
+        )
+        # Full sRGB encoding is too bright under the simulator's high-exposure
+        # daylight rig. Split the difference with the authored linear value:
+        # dark colors remain legible without washing out roads and façades.
+        display = 0.5 * (linear + srgb)
+        color = np.concatenate((np.clip(np.rint(display * 255.0), 0, 255), [255])).astype(np.uint8)
+        name = str(getattr(source, "name", "") or f"material-{index}")
+        mesh.visual.material = trimesh.visual.material.PBRMaterial(
+            name=name,
+            baseColorFactor=color,
+            metallicFactor=0.0,
+            roughnessFactor=0.9,
+        )
+
+
+def _write_browser_scene(scene: trimesh.Scene, viewer_pack_root: Path) -> None:
+    payload = scene.export(file_type="glb")
+    if not isinstance(payload, bytes) or not payload.startswith(b"glTF"):
+        raise RuntimeError("failed to export a binary glTF town scene")
+    (viewer_pack_root / "scene.glb").write_bytes(payload)
+
+
+def _write_mujoco_visuals(scene: trimesh.Scene, visual_root: Path) -> int:
+    used_names: set[str] = set()
+    for index, mesh in enumerate(scene.geometry.values()):
+        material = getattr(mesh.visual, "material", None)
+        material_name = str(getattr(material, "name", "") or f"material-{index}")
+        base_name = _slug(material_name)
+        name = base_name
+        suffix = 2
+        while name in used_names:
+            name = f"{base_name}-{suffix}"
+            suffix += 1
+        used_names.add(name)
+
+        room = visual_root / name
+        room.mkdir()
+        _write_obj(mesh, room / f"{name}.obj")
+        color = tuple(int(channel) for channel in getattr(material, "main_color", (160, 160, 160, 255))[:3])
+        Image.new("RGB", (4, 4), color).save(room / f"{name}.png")
+    return len(used_names)
+
+
+def _box_mesh(
+    xmin: float,
+    xmax: float,
+    ymin: float,
+    ymax: float,
+    bottom: float,
+    top: float,
+) -> trimesh.Trimesh:
+    # glTF/OBJ Y is up. Simulator world Y maps to negative glTF Z, matching
+    # Blender's standard Y-up export and the driver's +90-degree X rotation.
+    vertices = np.asarray(
+        [
+            (xmin, bottom, -ymin),
+            (xmax, bottom, -ymin),
+            (xmax, bottom, -ymax),
+            (xmin, bottom, -ymax),
+            (xmin, top, -ymin),
+            (xmax, top, -ymin),
+            (xmax, top, -ymax),
+            (xmin, top, -ymax),
+        ],
+        dtype=np.float64,
+    )
+    faces = np.asarray(
+        [
+            (0, 2, 1),
+            (0, 3, 2),
+            (4, 5, 6),
+            (4, 6, 7),
+            (0, 1, 5),
+            (0, 5, 4),
+            (1, 2, 6),
+            (1, 6, 5),
+            (2, 3, 7),
+            (2, 7, 6),
+            (3, 0, 4),
+            (3, 4, 7),
+        ],
+        dtype=np.int64,
+    )
+    return trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+
+
+def _collision_proxies() -> list[tuple[str, trimesh.Trimesh]]:
+    proxies = [
+        ("southwest-curb", _box_mesh(-14.04, -4.30, -14.02, -4.28, -0.05, CURB_COLLISION_HEIGHT)),
+        ("southeast-curb", _box_mesh(4.56, 14.30, -14.02, -4.28, -0.05, CURB_COLLISION_HEIGHT)),
+        ("northwest-curb", _box_mesh(-14.04, -4.30, 4.58, 14.32, -0.05, CURB_COLLISION_HEIGHT)),
+        ("northeast-curb", _box_mesh(4.56, 14.30, 4.58, 14.32, -0.05, CURB_COLLISION_HEIGHT)),
+        ("west-boundary", _box_mesh(-14.35, -14.04, -14.32, 14.62, -0.05, 0.75)),
+        ("east-boundary", _box_mesh(14.30, 14.61, -14.32, 14.62, -0.05, 0.75)),
+        ("south-boundary", _box_mesh(-14.04, 14.30, -14.33, -14.02, -0.05, 0.75)),
+        ("north-boundary", _box_mesh(-14.04, 14.30, 14.32, 14.63, -0.05, 0.75)),
+    ]
+    for index, (x, y) in enumerate(TRAFFIC_LIGHT_CENTERS):
+        proxies.append((f"traffic-light-{index:02d}", _box_mesh(x - 0.18, x + 0.18, y - 0.18, y + 0.18, 0.12, 2.65)))
+    return proxies
+
+
+def _write_collision_proxies(collision_root: Path, viewer_collision_root: Path) -> int:
+    room = collision_root / "town"
+    room.mkdir()
+    names: list[str] = []
+    soup: list[np.ndarray] = []
+    for index, (_label, mesh) in enumerate(_collision_proxies()):
+        name = f"town_collision_{index:03d}.obj"
+        _write_obj(mesh, room / name)
+        _write_obj(mesh, viewer_collision_root / name)
+        names.append(name)
+        soup.append(mesh.vertices[mesh.faces].astype(np.float32).reshape(-1, 3))
+
+    (viewer_collision_root / "manifest.json").write_text(json.dumps(names, indent=2) + "\n", encoding="utf-8")
+    (viewer_collision_root / "hulls.f32").write_bytes(np.concatenate(soup).astype(np.float32).tobytes())
+    return len(names)
+
+
+def _cell_index(grid: np.ndarray, x: float, y: float) -> tuple[int, int]:
+    return (
+        int(np.floor((y - MAP_ORIGIN_Y) / MAP_RESOLUTION)),
+        int(np.floor((x - MAP_ORIGIN_X) / MAP_RESOLUTION)),
+    )
+
+
+def _reachable_free_cells(grid: np.ndarray, start: tuple[int, int]) -> set[tuple[int, int]]:
+    reached = {start}
+    pending = deque([start])
+    while pending:
+        row, col = pending.popleft()
+        for candidate in ((row - 1, col), (row + 1, col), (row, col - 1), (row, col + 1)):
+            next_row, next_col = candidate
+            if (
+                0 <= next_row < grid.shape[0]
+                and 0 <= next_col < grid.shape[1]
+                and candidate not in reached
+                and grid[candidate] == 0
+            ):
+                reached.add(candidate)
+                pending.append(candidate)
+    return reached
+
+
+def _write_navigation_map(map_root: Path) -> tuple[int, int]:
+    columns = round((MAP_MAX_X - MAP_ORIGIN_X) / MAP_RESOLUTION)
+    rows = round((MAP_MAX_Y - MAP_ORIGIN_Y) / MAP_RESOLUTION)
+    xs = MAP_ORIGIN_X + (np.arange(columns) + 0.5) * MAP_RESOLUTION
+    ys = MAP_ORIGIN_Y + (np.arange(rows) + 0.5) * MAP_RESOLUTION
+    x, y = np.meshgrid(xs, ys)
+
+    grid = np.full((rows, columns), -1, dtype=np.int8)
+    town = (x >= -14.04) & (x <= 14.30) & (y >= -14.02) & (y <= 14.32)
+    grid[town] = 100
+    horizontal_road = (x >= -13.90) & (x <= 14.16) & (y >= -4.10) & (y <= 4.40)
+    vertical_road = (x >= -4.12) & (x <= 4.38) & (y >= -13.88) & (y <= 14.18)
+    grid[town & (horizontal_road | vertical_road)] = 0
+
+    for pole_x, pole_y in TRAFFIC_LIGHT_CENTERS:
+        pole = (np.abs(x - pole_x) <= 0.24) & (np.abs(y - pole_y) <= 0.24)
+        grid[pole] = 100
+
+    spawn = _cell_index(grid, SPAWN_X, SPAWN_Y)
+    if grid[spawn] != 0:
+        raise RuntimeError("town spawn is not on known-free road")
+    reachable = _reachable_free_cells(grid, spawn)
+    if len(reachable) != int(np.count_nonzero(grid == 0)):
+        raise RuntimeError("town navigation roads are not one connected component")
+
+    image = np.where(grid == 100, PGM_OCCUPIED, np.where(grid == 0, PGM_FREE, PGM_UNKNOWN)).astype(np.uint8)
+    Image.fromarray(image[::-1]).save(map_root / "town.pgm")
+    (map_root / "town.yaml").write_text(
+        "image: town.pgm\n"
+        "mode: trinary\n"
+        f"resolution: {MAP_RESOLUTION}\n"
+        f"origin: [{MAP_ORIGIN_X:.4f}, {MAP_ORIGIN_Y:.4f}, 0.0]\n"
+        "negate: 0\n"
+        "occupied_thresh: 0.65\n"
+        "free_thresh: 0.196\n",
+        encoding="utf-8",
+    )
+    return columns, rows
+
+
+def _tree_digest(*directories: Path) -> str:
+    digest = hashlib.sha256()
+    for directory in directories:
+        for path in sorted(candidate for candidate in directory.rglob("*") if candidate.is_file()):
+            digest.update(path.relative_to(directory).as_posix().encode())
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _write_local_manifest(source_obj: Path, generated_digest: str, manifest_directory: Path) -> Path:
+    source_digest = hashlib.sha256(source_obj.read_bytes()).hexdigest()
+    manifest = {
+        "schema_version": 1,
+        "id": PACK_ID,
+        "display_name": PACK_DISPLAY_NAME,
+        "coordinate_system": "gltf-y-up-meters",
+        "physics": {
+            "collision_dir": f"{PACK_ROOT.as_posix()}/collisions",
+            "visual_dir": f"{PACK_ROOT.as_posix()}/visual",
+        },
+        "viewer": {
+            "type": "glb",
+            "model": f"{PACK_ROOT.as_posix()}/scene.glb",
+            "collision_dir": f"{PACK_ROOT.as_posix()}/collisions",
+        },
+        "navigation": {
+            "map_yaml": f"{PACK_ROOT.as_posix()}/map/town.yaml",
+            "map_image": f"{PACK_ROOT.as_posix()}/map/town.pgm",
+        },
+        "spawn": {"x": SPAWN_X, "y": SPAWN_Y, "yaw_degrees": SPAWN_YAW_DEGREES},
+        "attribution": {
+            "name": "Low Poly Town",
+            "author": "im-blendin-it",
+            "license": "CGTrader Royalty Free License (local licensed asset; do not redistribute)",
+            "source": (
+                "https://www.cgtrader.com/3d-models/exterior/cityscape/"
+                "low-poly-town-6f87eee7-7975-46ca-99c0-33aedbc0b4c4"
+            ),
+            "source_sha256": source_digest,
+            "generated_assets_sha256": generated_digest,
+        },
+    }
+    manifest_directory.mkdir(parents=True, exist_ok=True)
+    path = manifest_directory / "manifest.json"
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _build(source_obj: Path, source_mtl: Path) -> None:
+    assets_pack_root = SIM / "assets" / PACK_ROOT
+    viewer_pack_root = SIM / "viewer" / PACK_ROOT
+    manifest_directory = SIM / "environments.local"
+    manifest_path = manifest_directory / PACK_ID / "manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Source validation and every in-memory rewrite happen before touching the
+    # last working pack. A bad download therefore cannot turn a usable local
+    # environment into two empty output directories plus a stale manifest.
+    scene = _load_authored_scene(source_obj, source_mtl)
+    _lower_base_slab(scene)
+    _lift_road_markings(scene)
+    _apply_flat_shading(scene)
+    _prepare_daylight_materials(scene)
+
+    staging_roots: list[Path] = []
+    try:
+        assets_stage = _staging_directory(assets_pack_root.parent)
+        staging_roots.append(assets_stage)
+        viewer_stage = _staging_directory(viewer_pack_root.parent)
+        staging_roots.append(viewer_stage)
+        manifest_stage = _staging_directory(manifest_directory)
+        staging_roots.append(manifest_stage)
+
+        collision_root = assets_stage / "collisions"
+        visual_root = assets_stage / "visual"
+        map_root = assets_stage / "map"
+        viewer_collision_root = viewer_stage / "collisions"
+        for directory in (collision_root, visual_root, map_root, viewer_collision_root):
+            directory.mkdir(parents=True)
+
+        _write_browser_scene(scene, viewer_stage)
+        material_count = _write_mujoco_visuals(scene, visual_root)
+        collision_count = _write_collision_proxies(collision_root, viewer_collision_root)
+        map_width, map_height = _write_navigation_map(map_root)
+        generated_digest = _tree_digest(assets_stage, viewer_stage)
+        staged_manifest = _write_local_manifest(source_obj, generated_digest, manifest_stage)
+
+        _publish_generated_outputs(
+            [
+                _GeneratedOutput(assets_stage, assets_pack_root),
+                _GeneratedOutput(viewer_stage, viewer_pack_root),
+                _GeneratedOutput(staged_manifest, manifest_path),
+            ]
+        )
+    finally:
+        # Published stage paths no longer exist. Failed builds are removed here;
+        # rollback backups are separate and are retained if restoration failed.
+        for staged in staging_roots:
+            with contextlib.suppress(OSError):
+                if _path_exists(staged):
+                    _remove_generated_path(staged)
+
+    print(
+        f"built {PACK_DISPLAY_NAME}: {material_count} visual materials, "
+        f"{collision_count} convex collision proxies, {map_width}x{map_height} Nav2 map"
+    )
+    print(f"manifest: {manifest_path}")
+
+
+def build(source_obj: Path, source_mtl: Path) -> None:
+    lock_path = SIM / "environments.local" / f".{PACK_ID}.build.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise RuntimeError(f"another {PACK_DISPLAY_NAME} build is already running") from exc
+        _build(source_obj, source_mtl)
+
+
+def parse_args() -> argparse.Namespace:
+    source_root = SIM / "viewer" / "assets" / "low_poly_town"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-obj", type=Path, default=source_root / "town.obj")
+    parser.add_argument("--source-mtl", type=Path, default=source_root / "town.mtl")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    build(args.source_obj.resolve(), args.source_mtl.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/viewer/package.json
+++ b/sim/viewer/package.json
@@ -6,6 +6,8 @@
   "description": "Three.js SimSession library the Innate webapp embeds to render the simulated MARS over rosbridge",
   "scripts": {
     "build:lib": "vite build --config vite.lib.config.ts",
+    "pretest:traffic": "npm run build:lib",
+    "test:traffic": "node --experimental-strip-types --test test/traffic.test.ts",
     "typecheck": "tsc --noEmit",
     "split:apartment": "node tools/split-apartment.mjs"
   },

--- a/sim/viewer/src/physics/worldStateController.ts
+++ b/sim/viewer/src/physics/worldStateController.ts
@@ -4,6 +4,7 @@
 // world_server.py "two interfaces".
 
 import type { PropInfo } from "../props";
+import { parseTrafficManifest, parseTrafficState, type TrafficManifest, type TrafficState } from "../trafficState";
 
 /** What a challenge IS: sent once per connection, like the prop roster,
  * because none of it changes while the server runs (challenges.py roster). */
@@ -58,6 +59,8 @@ export interface EnvironmentRoster {
   environment: EnvironmentInfo | null;
   environments: EnvironmentSummary[];
   switch: (EnvironmentSummary & { state: "loading" | "failed"; message?: string }) | null;
+  /** The pack's procedural cars and signals (traffic.py); null where it has none. */
+  traffic: TrafficManifest | null;
 }
 
 export interface WorldState {
@@ -72,6 +75,8 @@ export interface WorldState {
   /** Ground truth of every manipulation prop (world.py GRASP_OBJECTS), keyed
    * by name: [x, y, z, qw, qx, qy, qz]. Empty on servers that predate them. */
   objects: Record<string, number[]>;
+  /** The pack's traffic (traffic.py); null where the pack has none. */
+  traffic: TrafficState | null;
   /** Challenge judge state; null on servers that predate it. */
   challenge: ChallengeBlock | null;
 }
@@ -148,16 +153,22 @@ export class WorldStateController {
       environment?: EnvironmentInfo | null;
       environments?: EnvironmentSummary[];
       switch?: EnvironmentRoster["switch"];
+      traffic_manifest?: unknown;
     };
-    if (parsed.props || parsed.challenges) {
+    if (parsed.props || parsed.challenges || "environment" in parsed || "traffic_manifest" in parsed) {
       // Roster frame, not a state frame: it has no clock, opens the stream and
       // returns whenever the world changes (see world_server.serve_state).
       if (parsed.props) this.onProps?.(parsed.props);
       if (parsed.challenges) this.onChallenges?.(parsed.challenges);
+      const traffic = parseTrafficManifest(parsed.traffic_manifest);
+      if (parsed.traffic_manifest != null && traffic === null) {
+        console.error("[sim-viewer] ignoring a malformed traffic manifest");
+      }
       this.onEnvironment?.({
         environment: parsed.environment ?? null,
         environments: parsed.environments ?? [],
         switch: parsed.switch ?? null,
+        traffic,
       });
       return;
     }
@@ -167,8 +178,14 @@ export class WorldStateController {
       pose: [number, number, number];
       joints: Record<string, number>;
       objects?: Record<string, number[]> | null;
+      traffic?: unknown;
       challenge?: ChallengeBlock | null;
     };
+    const traffic = parseTrafficState(msg.traffic);
+    if (msg.traffic != null && traffic === null) {
+      console.warn("[sim-viewer] ignoring a world-state frame with malformed traffic");
+      return;
+    }
     const joints = msg.joints;
     // joint6M: the gripper's mirrored finger (URDF mimic of joint6, x-1).
     joints["joint6M"] = -(joints["joint6"] ?? 0);
@@ -180,6 +197,7 @@ export class WorldStateController {
       yaw: msg.pose[2],
       joints,
       objects: msg.objects ?? {},
+      traffic,
       challenge: msg.challenge ?? null,
     });
   }

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -15,6 +15,8 @@ import URDFLoader from "urdf-loader";
 import type { URDFRobot } from "urdf-loader";
 import { LoadQueue, queuedGLB } from "./loadQueue";
 import { PropLibrary, type PropInfo } from "./props";
+import { TrafficLibrary } from "./traffic";
+import type { TrafficManifest, TrafficState } from "./trafficState";
 
 /** An environment pack's browser assets as its manifest names them: paths
  * under sim/viewer/public, which the webapp serves at /models and /physics
@@ -222,6 +224,8 @@ export class SimScene {
   private hullMaterial = new THREE.MeshBasicMaterial({ color: 0x00ff88, wireframe: true });
   // Every prop in the world, built from the server's roster (props.ts).
   private props: PropLibrary;
+  // The pack's cars and signal lamps, driven by the world server (traffic.ts).
+  private traffic: TrafficLibrary;
   // While true a placement drag owns the pointer and orbit stays off.
   private placementMode = false;
   private cameraMode: CameraMode = "free";
@@ -273,6 +277,7 @@ export class SimScene {
       () => this.updateShadowVolume(),
       (model) => this.warmTextures(model),
     );
+    this.traffic = new TrafficLibrary(this.scene, this.hullMaterial, () => this.updateShadowVolume());
 
     this.camera = new THREE.PerspectiveCamera(55, w / h, 0.05, 200);
     this.camera.up.set(0, 0, 1);
@@ -449,6 +454,7 @@ export class SimScene {
   setCollisionHullsVisible(visible: boolean): void {
     this.hullsVisible = visible;
     this.props.setHullsVisible(visible);
+    this.traffic.setHullsVisible(visible);
     if (visible && !this.hullsPromise) {
       // ~1300 OBJ fetches; takes seconds on first show. A failure resets the
       // promise so toggling again retries instead of staying dead forever.
@@ -552,8 +558,28 @@ export class SimScene {
     return { group, rooms, monolith: false, baseUrl };
   }
 
-  /** Dispose environment assets; retain the robot and props for the next pose. */
+  /** Adopt the world server's traffic roster: cars to draw and the lamp
+   * materials to light. Throws when the loaded environment lacks a lamp the
+   * roster names (see TrafficLibrary); the session retries after a load. */
+  setTrafficManifest(manifest: TrafficManifest | null): void {
+    this.traffic.setManifest(manifest);
+  }
+
+  /** Every environment glb is in: the roster's lamp materials must exist now. */
+  markEnvironmentReady(): void {
+    this.traffic.markEnvironmentReady();
+  }
+
+  /** Mirror the authoritative signal aspects and car poses from MuJoCo. */
+  setTrafficState(state: TrafficState | null): void {
+    this.traffic.setState(state);
+  }
+
+  /** Drop the loaded environment -- rooms, placeholders, collision hulls,
+   * traffic -- ahead of another pack's load. The robot and props stay; the
+   * next pose spawns the robot into the new world and frames it there. */
   unloadEnvironment(): void {
+    this.traffic.resetEnvironment();
     for (const group of [this.layoutGroup, this.hullsGroup]) {
       if (!group) continue;
       this.scene.remove(group);
@@ -674,6 +700,7 @@ export class SimScene {
         else setFrontSide(obj.material);
       }
     });
+    this.traffic.registerEnvironment(root);
   }
 
   /** A thick wireframe outline of a box, used as a loading placeholder (room or
@@ -843,6 +870,12 @@ export class SimScene {
       const dx = root.position.x - this.robotXY[0];
       const dy = root.position.y - this.robotXY[1];
       if (Math.hypot(dx, dy) <= reach) points.push([root.position.x, root.position.y]);
+    }
+    for (const bounds of this.traffic.visibleBounds) {
+      const dx = Math.max(bounds.minX - this.robotXY[0], 0, this.robotXY[0] - bounds.maxX);
+      const dy = Math.max(bounds.minY - this.robotXY[1], 0, this.robotXY[1] - bounds.maxY);
+      if (Math.hypot(dx, dy) > reach) continue;
+      points.push([bounds.minX, bounds.minY], [bounds.minX, bounds.maxY], [bounds.maxX, bounds.minY], [bounds.maxX, bounds.maxY]);
     }
     const xs = points.map((pt) => pt[0]);
     const ys = points.map((pt) => pt[1]);
@@ -1233,6 +1266,7 @@ export class SimScene {
    * the oldest (~16), breaking the live view. */
   dispose(): void {
     this.props.clearPlacementPreview();
+    this.traffic.dispose();
     this.placeholderMat?.dispose();
     this.cameraEnv?.dispose(); // a PMREM render target, not a loaded image
     this.controls.dispose();

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -15,6 +15,7 @@ import type {
   EnvironmentRoster,
 } from "./physics/worldStateController";
 import type { PropInfo } from "./props";
+import { interpolateTraffic, type TrafficManifest, type TrafficState } from "./trafficState";
 
 /** One roster row as a renderer wants it: what the challenge is, plus how it
  * has gone so far. Merged here from the two halves the server sends. */
@@ -95,6 +96,7 @@ export class SimSession {
     yaw: number;
     joints: Record<string, number>;
     objects: Record<string, number[]>;
+    traffic: TrafficState | null;
   }[] = [];
   #gaps: number[] = []; // recent inter-arrival gaps: sizes the playback delay
   #lastArrival = 0;
@@ -123,6 +125,13 @@ export class SimSession {
 
   #environment: EnvironmentRoster | null = null;
   #environmentListeners = new Set<(roster: EnvironmentRoster) => void>();
+
+  // The pack's traffic roster, applied to the scene on the next tick. A scene
+  // rejects a roster whose lamp materials it lacks (a pack still streaming
+  // in); the latch stops that retrying every frame until refreshTraffic().
+  #trafficManifest: TrafficManifest | null = null;
+  #trafficManifestDirty = false;
+  #trafficManifestRetryBlocked = false;
 
   #stateUrls: string[];
   #rosUrl: string;
@@ -206,6 +215,9 @@ export class SimSession {
     this.#controller.onEnvironment = (roster) => {
       const previous = this.#environment?.environment?.id;
       this.#environment = roster;
+      this.#trafficManifest = roster.traffic;
+      this.#trafficManifestDirty = true;
+      this.#trafficManifestRetryBlocked = false;
       // Another world: its first pose must spawn (and frame) the robot afresh.
       if (roster.environment && roster.environment.id !== previous) {
         this.#samples = [];
@@ -229,11 +241,11 @@ export class SimSession {
 
       const last = this.#samples[this.#samples.length - 1];
       if (last === undefined || s.t > last.t) {
-        this.#samples.push({ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints, objects: s.objects });
+        this.#samples.push({ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints, objects: s.objects, traffic: s.traffic });
         if (this.#samples.length > 60) this.#samples.shift();
       } else if (s.t < last.t - 0.5) {
         // Sim clock jumped backwards (world-server restart): restart playback.
-        this.#samples = [{ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints, objects: s.objects }];
+        this.#samples = [{ t: s.t, x: s.x, y: s.y, yaw: s.yaw, joints: s.joints, objects: s.objects, traffic: s.traffic }];
         this.#playT = null;
       }
       this.#live = true;
@@ -330,7 +342,16 @@ export class SimSession {
     return () => this.#propListeners.delete(cb);
   }
 
-  /** Subscribe and replay the latest environment roster, if available. */
+  /** The stage finished loading a pack's scene: apply the roster's traffic to
+   * it now that its lamp materials exist. */
+  refreshTraffic(): void {
+    this.#trafficManifestDirty = true;
+    this.#trafficManifestRetryBlocked = false;
+  }
+
+  /** Subscribe to the environment roster (environments.py); fires immediately
+   * once it has arrived. The stage loads the pack's scene and builds its
+   * picker from this. */
   onEnvironment(cb: (roster: EnvironmentRoster) => void): () => void {
     this.#environmentListeners.add(cb);
     if (this.#environment) cb(this.#environment);
@@ -483,7 +504,19 @@ export class SimSession {
       this.#propsDirty = false;
       scene.setPropManifest(this.#props);
     }
+    if (this.#trafficManifestDirty && !this.#trafficManifestRetryBlocked) {
+      try {
+        scene.setTrafficManifest(this.#trafficManifest);
+        this.#trafficManifestDirty = false;
+      } catch (error) {
+        this.#trafficManifestRetryBlocked = true;
+        console.error("[sim-session] traffic roster rejected; keeping the last complete traffic frame:", error);
+      }
+    }
     scene.setObjectPoses(objects);
+    // A rejected roster keeps its last complete frame: states belong to the
+    // pending roster and could move shared car ids or relight its lamps.
+    if (!this.#trafficManifestDirty) scene.setTrafficState(interpolateTraffic(a.traffic, b.traffic, u));
 
     if (this.#overlaysDirty) {
       this.#overlaysDirty = false;

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -625,6 +625,8 @@ export function createSimStage(
       if (disposed || version !== loadVersion) return;
       await Promise.all([robotDone, scene.streamApartment(queue, layout)]);
       if (disposed || version !== loadVersion) return;
+      scene.markEnvironmentReady();
+      session.refreshTraffic();
       hideLoading();
       // Prefetch props after the scene, outside its progress bar.
       if (firstLoad) scene.prefetchPropModels();

--- a/sim/viewer/src/traffic.ts
+++ b/sim/viewer/src/traffic.ts
@@ -1,0 +1,305 @@
+import * as THREE from "three";
+import type { TrafficAspect, TrafficManifest, TrafficPart, TrafficState } from "./trafficState";
+
+const DEFAULT_SIGNAL_MATERIALS: TrafficManifest["signal_materials"] = {
+  north_south: { red: "Signal_NS_Red", yellow: "Signal_NS_Yellow", green: "Signal_NS_Green" },
+  east_west: { red: "Signal_EW_Red", yellow: "Signal_EW_Yellow", green: "Signal_EW_Green" },
+};
+const DEFAULT_SIGNAL_COLORS: Record<TrafficAspect, string> = {
+  red: "#ff4b55",
+  yellow: "#ffd45a",
+  green: "#5ee27a",
+};
+const OFF_COLOR = new THREE.Color("#171b1d");
+
+interface CarRender {
+  root: THREE.Group;
+  colliders: THREE.Object3D[];
+  halfLength: number;
+  halfWidth: number;
+}
+
+type ColoredMaterial = THREE.Material & { color: THREE.Color };
+type EmissiveMaterial = ColoredMaterial & { emissive: THREE.Color; emissiveIntensity: number };
+
+function normalizeName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function isColored(material: THREE.Material): material is ColoredMaterial {
+  return "color" in material && (material as { color?: unknown }).color instanceof THREE.Color;
+}
+
+function isEmissive(material: ColoredMaterial): material is EmissiveMaterial {
+  return "emissive" in material && (material as { emissive?: unknown }).emissive instanceof THREE.Color;
+}
+
+/** Procedural renderer for simulator-owned traffic. No browser clock or path
+ * logic lives here: it only materializes the opening manifest and snapshots. */
+export class TrafficLibrary {
+  #scene: THREE.Scene;
+  #hullMaterial: THREE.Material;
+  #onMoved: () => void;
+  #manifest: TrafficManifest | null = null;
+  #state: TrafficState | null = null;
+  #cars = new Map<string, CarRender>();
+  #environmentMaterials = new Set<THREE.Material>();
+  #signalMaterials = new Map<string, Map<TrafficAspect, Set<ColoredMaterial>>>();
+  #appliedSignals = new Map<string, TrafficAspect>();
+  #ownedGeometries = new Set<THREE.BufferGeometry>();
+  #ownedMaterials = new Set<THREE.Material>();
+  #hullsVisible = false;
+  #environmentReady = false;
+
+  constructor(scene: THREE.Scene, hullMaterial: THREE.Material, onMoved: () => void) {
+    this.#scene = scene;
+    this.#hullMaterial = hullMaterial;
+    this.#onMoved = onMoved;
+  }
+
+  /** Axis-aligned XY footprint of each visible car, including yaw. Shadow
+   * fitting needs corners: a 3.6m car cannot be represented by its center. */
+  get visibleBounds(): { minX: number; maxX: number; minY: number; maxY: number }[] {
+    return [...this.#cars.values()].flatMap(({ root, halfLength, halfWidth }) => {
+      if (!root.visible) return [];
+      const cosine = Math.abs(Math.cos(root.rotation.z));
+      const sine = Math.abs(Math.sin(root.rotation.z));
+      const dx = cosine * halfLength + sine * halfWidth;
+      const dy = sine * halfLength + cosine * halfWidth;
+      return [{ minX: root.position.x - dx, maxX: root.position.x + dx, minY: root.position.y - dy, maxY: root.position.y + dy }];
+    });
+  }
+
+  registerEnvironment(root: THREE.Object3D): void {
+    root.traverse((object) => {
+      if (!(object instanceof THREE.Mesh)) return;
+      const materials = Array.isArray(object.material) ? object.material : [object.material];
+      materials.forEach((material) => this.#environmentMaterials.add(material));
+    });
+    const indexed = this.#collectSignalMaterials(this.#manifest?.signal_materials ?? DEFAULT_SIGNAL_MATERIALS);
+    if (this.#environmentReady) this.#assertSignalMaterials(this.#manifest, indexed);
+    this.#signalMaterials = indexed;
+    this.#appliedSignals.clear();
+    this.#applySignals(); // fail-safe all-red even if the roster is still in flight
+  }
+
+  /** Called once every required environment GLB has loaded. A traffic roster
+   * without all six authored lamp materials is an unsafe/stale asset bundle. */
+  markEnvironmentReady(): void {
+    this.#assertSignalMaterials(this.#manifest, this.#signalMaterials);
+    this.#environmentReady = true;
+  }
+
+  setManifest(manifest: TrafficManifest | null): void {
+    const indexed = this.#collectSignalMaterials(manifest?.signal_materials ?? DEFAULT_SIGNAL_MATERIALS);
+    // Validate against the candidate mapping before touching the active cars,
+    // signal cache, or state. A stale asset bundle must leave the last complete
+    // frame intact so the caller can report the error and retry safely.
+    if (this.#environmentReady) this.#assertSignalMaterials(manifest, indexed);
+
+    // Restore the previous mapping to its fail-safe state before adopting a
+    // different one; otherwise a custom green material could stay lit after it
+    // stops being part of the new roster.
+    this.#state = null;
+    this.#applySignals();
+    this.#removeCars();
+    this.#manifest = manifest;
+    this.#signalMaterials = indexed;
+    this.#appliedSignals.clear();
+    if (manifest) {
+      this.#buildCars(manifest);
+    }
+    this.#applyState();
+  }
+
+  setState(state: TrafficState | null): void {
+    this.#state = state;
+    this.#applyState();
+  }
+
+  setHullsVisible(visible: boolean): void {
+    this.#hullsVisible = visible;
+    for (const car of this.#cars.values()) car.colliders.forEach((collider) => (collider.visible = visible));
+  }
+
+  clear(): void {
+    this.#state = null;
+    this.#applyState();
+  }
+
+  dispose(): void {
+    this.#removeCars();
+    this.#environmentMaterials.clear();
+    this.#signalMaterials.clear();
+    this.#appliedSignals.clear();
+  }
+
+  /** Forget the loaded environment ahead of another pack's: its cars, lamp
+   * materials and readiness go, so the next roster is checked against the
+   * next environment's materials rather than this one's. */
+  resetEnvironment(): void {
+    this.dispose();
+    this.#manifest = null;
+    this.#state = null;
+    this.#environmentReady = false;
+  }
+
+  #buildCars(manifest: TrafficManifest): void {
+    const model = manifest.car_model;
+    const geometries = model.parts.map((part) => this.#partGeometry(part));
+    const colliderGeometries = model.colliders.map((collider) => {
+      const geometry = new THREE.BoxGeometry(...collider.size);
+      this.#ownedGeometries.add(geometry);
+      return geometry;
+    });
+    const shared = Object.fromEntries(
+      Object.entries(model.materials).map(([role, color]) => {
+        const material = new THREE.MeshStandardMaterial({
+          color,
+          roughness: role === "glass" ? 0.25 : 0.72,
+          metalness: role === "glass" ? 0.1 : 0.0,
+          flatShading: true,
+        });
+        if (role === "headlight") {
+          material.emissive.set(color);
+          material.emissiveIntensity = 0.45;
+        }
+        this.#ownedMaterials.add(material);
+        return [role, material];
+      }),
+    ) as Record<Exclude<TrafficPart["material"], "body">, THREE.MeshStandardMaterial>;
+
+    for (const car of manifest.cars) {
+      const root = new THREE.Group();
+      root.name = `traffic_${car.id}`;
+      root.visible = false;
+      const bodyMaterial = new THREE.MeshStandardMaterial({
+        color: car.color,
+        roughness: 0.62,
+        metalness: 0.08,
+        flatShading: true,
+      });
+      this.#ownedMaterials.add(bodyMaterial);
+      model.parts.forEach((part, index) => {
+        const material = part.material === "body" ? bodyMaterial : shared[part.material];
+        const mesh = new THREE.Mesh(geometries[index], material);
+        mesh.position.set(...part.position);
+        if (part.rotation) mesh.rotation.set(...part.rotation);
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        root.add(mesh);
+      });
+      const colliders = model.colliders.map((collider, index) => {
+        const mesh = new THREE.Mesh(colliderGeometries[index], this.#hullMaterial);
+        mesh.position.set(...collider.position);
+        mesh.visible = this.#hullsVisible;
+        root.add(mesh);
+        return mesh;
+      });
+      this.#cars.set(car.id, {
+        root,
+        colliders,
+        halfLength: model.length / 2,
+        halfWidth: model.width / 2,
+      });
+      this.#scene.add(root);
+    }
+  }
+
+  #partGeometry(part: TrafficPart): THREE.BufferGeometry {
+    let geometry: THREE.BufferGeometry;
+    if (part.shape === "box" && part.size) {
+      geometry = new THREE.BoxGeometry(...part.size);
+    } else if (part.shape === "cylinder" && part.radius !== undefined && part.length !== undefined) {
+      geometry = new THREE.CylinderGeometry(part.radius, part.radius, part.length, 12, 1, false);
+      // Three cylinders are +Y; the shared descriptor starts at +Z like MJCF.
+      geometry.rotateX(Math.PI / 2);
+    } else {
+      throw new Error("invalid traffic primitive in a validated manifest");
+    }
+    this.#ownedGeometries.add(geometry);
+    return geometry;
+  }
+
+  #applyState(): void {
+    for (const [id, car] of this.#cars) {
+      const state = this.#state?.cars[id];
+      car.root.visible = state !== undefined;
+      if (!state) continue;
+      car.root.position.set(state.pose[0], state.pose[1], 0.0);
+      car.root.rotation.set(0, 0, state.pose[2]);
+    }
+    this.#applySignals();
+    this.#onMoved();
+  }
+
+  #collectSignalMaterials(
+    mapping: TrafficManifest["signal_materials"],
+  ): Map<string, Map<TrafficAspect, Set<ColoredMaterial>>> {
+    const indexed = new Map<string, Map<TrafficAspect, Set<ColoredMaterial>>>();
+    const lookup = new Map<string, [string, TrafficAspect]>();
+    for (const [group, aspects] of Object.entries(mapping)) {
+      for (const aspect of ["red", "yellow", "green"] as const) {
+        lookup.set(normalizeName(aspects[aspect]), [group, aspect]);
+      }
+    }
+    for (const material of this.#environmentMaterials) {
+      const match = lookup.get(normalizeName(material.name));
+      if (!match || !isColored(material)) continue;
+      const [group, aspect] = match;
+      const aspects = indexed.get(group) ?? new Map<TrafficAspect, Set<ColoredMaterial>>();
+      const materials = aspects.get(aspect) ?? new Set<ColoredMaterial>();
+      materials.add(material);
+      aspects.set(aspect, materials);
+      indexed.set(group, aspects);
+    }
+    return indexed;
+  }
+
+  #applySignals(): void {
+    const colors = this.#manifest?.signal_colors ?? DEFAULT_SIGNAL_COLORS;
+    for (const [group, aspects] of this.#signalMaterials) {
+      const requested = this.#state?.signals[group];
+      const selected: TrafficAspect = requested === "green" || requested === "yellow" ? requested : "red";
+      if (this.#appliedSignals.get(group) === selected) continue;
+      for (const [aspect, materials] of aspects) {
+        const active = aspect === selected;
+        const color = active ? new THREE.Color(colors[aspect]) : OFF_COLOR;
+        for (const material of materials) {
+          material.color.copy(color);
+          if (isEmissive(material)) {
+            material.emissive.copy(color);
+            material.emissiveIntensity = active ? 0.65 : 0.0;
+          }
+        }
+      }
+      this.#appliedSignals.set(group, selected);
+    }
+  }
+
+  #assertSignalMaterials(
+    manifest: TrafficManifest | null,
+    indexed: Map<string, Map<TrafficAspect, Set<ColoredMaterial>>>,
+  ): void {
+    if (!manifest) return;
+    const missing: string[] = [];
+    for (const [group, aspects] of Object.entries(manifest.signal_materials)) {
+      const materials = indexed.get(group);
+      for (const aspect of ["red", "yellow", "green"] as const) {
+        if (!materials?.get(aspect)?.size) missing.push(aspects[aspect]);
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error(`environment is missing traffic signal materials: ${missing.join(", ")}`);
+    }
+  }
+
+  #removeCars(): void {
+    for (const car of this.#cars.values()) this.#scene.remove(car.root);
+    this.#cars.clear();
+    for (const geometry of this.#ownedGeometries) geometry.dispose();
+    for (const material of this.#ownedMaterials) material.dispose();
+    this.#ownedGeometries.clear();
+    this.#ownedMaterials.clear();
+  }
+}

--- a/sim/viewer/src/trafficState.ts
+++ b/sim/viewer/src/trafficState.ts
@@ -1,0 +1,158 @@
+export type TrafficAspect = "red" | "yellow" | "green";
+
+export interface TrafficPart {
+  shape: "box" | "cylinder";
+  position: [number, number, number];
+  material: "body" | "glass" | "rubber" | "headlight" | "taillight";
+  size?: [number, number, number];
+  radius?: number;
+  length?: number;
+  rotation?: [number, number, number];
+}
+
+export interface TrafficCarModel {
+  length: number;
+  width: number;
+  parts: TrafficPart[];
+  colliders: { shape: "box"; position: [number, number, number]; size: [number, number, number] }[];
+  materials: Record<"glass" | "rubber" | "headlight" | "taillight", string>;
+}
+
+export interface TrafficManifest {
+  schema_version: 1;
+  car_model: TrafficCarModel;
+  cars: { id: string; color: string }[];
+  signal_materials: Record<string, Record<TrafficAspect, string>>;
+  signal_colors: Record<TrafficAspect, string>;
+}
+
+export interface TrafficCarState {
+  pose: [number, number, number];
+  speed: number;
+  spawn_seq: number;
+}
+
+export interface TrafficState {
+  world_epoch: number;
+  phase: string;
+  signals: Record<string, TrafficAspect>;
+  cars: Record<string, TrafficCarState>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function tuple3(value: unknown, positive = false): value is [number, number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 3 &&
+    value.every((item) => typeof item === "number" && Number.isFinite(item) && (!positive || item > 0))
+  );
+}
+
+const MATERIAL_ROLES = new Set<TrafficPart["material"]>(["body", "glass", "rubber", "headlight", "taillight"]);
+const ASPECTS = ["red", "yellow", "green"] as const;
+const nonEmptyString = (value: unknown): value is string => typeof value === "string" && value.length > 0;
+const positiveNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value) && value > 0;
+
+export function parseTrafficManifest(value: unknown): TrafficManifest | null {
+  if (!isRecord(value) || value.schema_version !== 1 || !isRecord(value.car_model)) return null;
+  const model = value.car_model;
+  if (
+    !positiveNumber(model.length) ||
+    !positiveNumber(model.width) ||
+    !Array.isArray(model.parts) ||
+    model.parts.length === 0 ||
+    !Array.isArray(model.colliders) ||
+    model.colliders.length === 0 ||
+    !isRecord(model.materials) ||
+    !Array.isArray(value.cars) ||
+    !isRecord(value.signal_materials) ||
+    !isRecord(value.signal_colors)
+  ) {
+    return null;
+  }
+  for (const part of model.parts) {
+    if (!isRecord(part) || !tuple3(part.position)) return null;
+    if (typeof part.material !== "string" || !MATERIAL_ROLES.has(part.material as TrafficPart["material"])) return null;
+    if (part.rotation !== undefined && !tuple3(part.rotation)) return null;
+    if (part.shape === "box" ? !tuple3(part.size, true) : part.shape !== "cylinder" || !positiveNumber(part.radius) || !positiveNumber(part.length) || !tuple3(part.rotation)) return null;
+  }
+  for (const collider of model.colliders) {
+    if (!isRecord(collider) || collider.shape !== "box" || !tuple3(collider.position) || !tuple3(collider.size, true)) return null;
+  }
+  for (const role of ["glass", "rubber", "headlight", "taillight"] as const) {
+    if (!nonEmptyString(model.materials[role])) return null;
+  }
+  const ids = new Set<string>();
+  for (const car of value.cars) {
+    if (!isRecord(car) || !nonEmptyString(car.id) || !nonEmptyString(car.color) || ids.has(car.id)) {
+      return null;
+    }
+    ids.add(car.id);
+  }
+  if (Object.keys(value.signal_materials).length === 0) return null;
+  for (const aspects of Object.values(value.signal_materials)) {
+    if (!isRecord(aspects) || ASPECTS.some((aspect) => !nonEmptyString(aspects[aspect]))) return null;
+  }
+  const signalColors = value.signal_colors as Record<string, unknown>;
+  if (ASPECTS.some((aspect) => !nonEmptyString(signalColors[aspect]))) return null;
+  return value as unknown as TrafficManifest;
+}
+
+export function parseTrafficState(value: unknown): TrafficState | null {
+  if (!isRecord(value)) return null;
+  if (
+    !Number.isInteger(value.world_epoch) ||
+    (value.world_epoch as number) < 0 ||
+    typeof value.phase !== "string" ||
+    !isRecord(value.signals) ||
+    !isRecord(value.cars)
+  ) {
+    return null;
+  }
+  if (Object.values(value.signals).some((aspect) => aspect !== "red" && aspect !== "yellow" && aspect !== "green")) {
+    return null;
+  }
+  for (const raw of Object.values(value.cars)) {
+    if (!isRecord(raw) || !tuple3(raw.pose) || typeof raw.speed !== "number" || !Number.isFinite(raw.speed)) return null;
+    if (!Number.isInteger(raw.spawn_seq) || (raw.spawn_seq as number) < 0 || raw.speed < 0) return null;
+  }
+  return value as unknown as TrafficState;
+}
+
+/** Interpolate traffic on the robot's playback timeline. Signal changes and
+ * respawns are discrete: holding a red to the next sample is safe, while
+ * blending a recycled car would streak it through the entire town. */
+export function interpolateTraffic(a: TrafficState | null, b: TrafficState | null, u: number): TrafficState | null {
+  if (a === null || b === null || a.world_epoch !== b.world_epoch) return u < 1 ? a : b;
+  const cars: Record<string, TrafficCarState> = {};
+  const ids = new Set([...Object.keys(a.cars), ...Object.keys(b.cars)]);
+  for (const id of ids) {
+    const from = a.cars[id];
+    const to = b.cars[id];
+    if (!from || !to || from.spawn_seq !== to.spawn_seq) {
+      const selected = u < 1 ? from : to;
+      if (selected) cars[id] = { ...selected, pose: [...selected.pose] };
+      continue;
+    }
+    const dyaw = Math.atan2(Math.sin(to.pose[2] - from.pose[2]), Math.cos(to.pose[2] - from.pose[2]));
+    cars[id] = {
+      pose: [
+        from.pose[0] + (to.pose[0] - from.pose[0]) * u,
+        from.pose[1] + (to.pose[1] - from.pose[1]) * u,
+        from.pose[2] + dyaw * u,
+      ],
+      speed: from.speed + (to.speed - from.speed) * u,
+      spawn_seq: from.spawn_seq,
+    };
+  }
+  const discrete = u < 1 ? a : b;
+  return {
+    world_epoch: a.world_epoch,
+    phase: discrete.phase,
+    signals: { ...discrete.signals },
+    cars,
+  };
+}

--- a/sim/viewer/test/traffic.test.ts
+++ b/sim/viewer/test/traffic.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as THREE from "three";
+import type { SimScene } from "../src/scene.ts";
+import { TrafficLibrary } from "../src/traffic.ts";
+import { interpolateTraffic, type TrafficManifest, type TrafficState } from "../src/trafficState.ts";
+
+const manifest: TrafficManifest = {
+  schema_version: 1,
+  car_model: {
+    length: 3.6,
+    width: 1.55,
+    parts: [
+      { shape: "box", size: [3.6, 1.55, 0.56], position: [0, 0, 0.45], material: "body" },
+      {
+        shape: "cylinder",
+        radius: 0.3,
+        length: 0.18,
+        position: [1.1, 0.77, 0.3],
+        rotation: [Math.PI / 2, 0, 0],
+        material: "rubber",
+      },
+    ],
+    colliders: [{ shape: "box", size: [3.6, 1.56, 0.56], position: [0, 0, 0.45] }],
+    materials: { glass: "#263641", rubber: "#202328", headlight: "#fff0a8", taillight: "#d7353f" },
+  },
+  cars: [{ id: "eastbound", color: "#e05b47" }],
+  signal_materials: {
+    north_south: { red: "Signal_NS_Red", yellow: "Signal_NS_Yellow", green: "Signal_NS_Green" },
+    east_west: { red: "Signal_EW_Red", yellow: "Signal_EW_Yellow", green: "Signal_EW_Green" },
+  },
+  signal_colors: { red: "#ff4b55", yellow: "#ffd45a", green: "#5ee27a" },
+};
+
+function state(x: number, spawnSeq = 0, ns: "red" | "yellow" | "green" = "red"): TrafficState {
+  return {
+    world_epoch: 2,
+    phase: `${ns}_phase`,
+    signals: { north_south: ns, east_west: "red" },
+    cars: { eastbound: { pose: [x, -1.51, 0], speed: 2, spawn_seq: spawnSeq } },
+  };
+}
+
+function addSignalMaterial(root: THREE.Group, name: string): THREE.MeshStandardMaterial {
+  const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  material.name = name;
+  root.add(new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.1, 0.1), material));
+  return material;
+}
+
+function addSignalMaterials(root: THREE.Group): Map<string, THREE.MeshStandardMaterial> {
+  const names = Object.values(manifest.signal_materials).flatMap((aspects) =>
+    ["red", "yellow", "green"].map((aspect) => aspects[aspect as keyof typeof aspects]),
+  );
+  return new Map(names.map((name) => [name, addSignalMaterial(root, name)]));
+}
+
+class SessionWebSocket {
+  static readonly OPEN = 1;
+  static instances: SessionWebSocket[] = [];
+  readyState = SessionWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  closeCalls: { code?: number; reason?: string }[] = [];
+
+  constructor(_url: string | URL) {
+    SessionWebSocket.instances.push(this);
+  }
+  send(_value: string): void {}
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+  }
+  open(): void {
+    this.onopen?.();
+  }
+  message(value: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(value) });
+  }
+}
+
+function worldFrame(t: number, x: number, traffic: TrafficState | null) {
+  return {
+    t,
+    wall: Date.now() / 1000,
+    world_epoch: 2,
+    pose: [x, 0, 0],
+    joints: {},
+    objects: {},
+    traffic,
+    challenge: null,
+  };
+}
+
+test("traffic runs from validated wire snapshots through safe scene swaps and Three rendering", async () => {
+  const before = state(-10, 3, "red");
+  const after = state(-8, 3, "green");
+  assert.equal(interpolateTraffic(before, after, 0.5)?.cars.eastbound.pose[0], -9);
+  assert.equal(interpolateTraffic(before, after, 0.5)?.signals.north_south, "red");
+  const respawned = state(10, 4, "green");
+  assert.equal(interpolateTraffic(after, respawned, 0.9)?.cars.eastbound.pose[0], -8);
+  assert.equal(interpolateTraffic(after, { ...respawned, world_epoch: 3 }, 1)?.world_epoch, 3);
+
+  const previousLocation = Object.getOwnPropertyDescriptor(globalThis, "location");
+  const previousDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  const previousWebSocket = globalThis.WebSocket;
+  const previousConsoleError = console.error;
+  const errors: unknown[][] = [];
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { protocol: "http:", host: "example.test", hostname: "example.test" },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: { createElement: () => ({ width: 0, height: 0, getContext: () => null }) },
+  });
+  globalThis.WebSocket = SessionWebSocket as unknown as typeof WebSocket;
+  console.error = (...args: unknown[]) => errors.push(args);
+  SessionWebSocket.instances = [];
+
+  const threeScene = new THREE.Scene();
+  const hull = new THREE.MeshBasicMaterial({ color: 0x00ff88, wireframe: true });
+  const library = new TrafficLibrary(threeScene, hull, () => undefined);
+  const renderedCar = () => threeScene.getObjectByName("traffic_eastbound") as THREE.Group | undefined;
+  const environment = new THREE.Group();
+  const signalMaterials = addSignalMaterials(environment);
+  library.registerEnvironment(environment);
+  library.markEnvironmentReady();
+  assert.equal(signalMaterials.get("Signal_NS_Red")?.color.getHexString(), "ff4b55");
+  assert.equal(signalMaterials.get("Signal_NS_Green")?.color.getHexString(), "171b1d");
+  let robotX = 0;
+  let manifestAttempts = 0;
+  let renderedTraffic: TrafficState | null = null;
+  const scene = {
+    environmentFingerprint: "town-v1",
+    clearWorldState: () => undefined,
+    setPropManifest: () => undefined,
+    setTrafficManifest: (candidate: TrafficManifest | null) => {
+      manifestAttempts += 1;
+      library.setManifest(candidate);
+    },
+    setTrafficState: (next: TrafficState | null) => {
+      renderedTraffic = next;
+      library.setState(next);
+    },
+    setLidarVisible: () => undefined,
+    setCollisionHullsVisible: () => undefined,
+    spawnAt: () => undefined,
+    setPose: (x: number) => (robotX = x),
+    setJointAngles: () => undefined,
+    setObjectPoses: () => undefined,
+  } as unknown as SimScene;
+  const replacement: TrafficManifest = {
+    ...manifest,
+    signal_materials: {
+      ...manifest.signal_materials,
+      east_west: { ...manifest.signal_materials.east_west, green: "Signal_EW_Green_V2" },
+    },
+  };
+  const { SimSession } = await import("../dist-lib/sim-session.js");
+  const session = new SimSession({ stateUrl: "ws://example.test/worldstate" });
+  const roster = (environment: string, extra: Record<string, unknown> = {}) => ({
+    environment: { id: environment, display_name: environment, viewer: {}, spawn: [0, 0, 0] },
+    environments: [],
+    switch: null,
+    props: [],
+    challenges: [],
+    ...extra,
+  });
+
+  try {
+    session.start();
+    const socket = SessionWebSocket.instances[0];
+    socket.open();
+    socket.message(roster("low-poly-town"));
+    socket.message(worldFrame(1, 0, state(-9)));
+    session.tick(scene, 0.016);
+    assert.equal(manifestAttempts, 1, "a roster without traffic applies as explicit no-traffic");
+    assert.equal(renderedCar(), undefined);
+
+    socket.message(roster("low-poly-town", { traffic_manifest: manifest }));
+    session.tick(scene, 0.016);
+    assert.equal(manifestAttempts, 2);
+    assert.equal(renderedCar()?.position.x, -9);
+    assert.deepEqual(library.visibleBounds[0], { minX: -10.8, maxX: -7.2, minY: -2.285, maxY: -0.735 });
+    const activeCar = renderedCar();
+
+    socket.message(roster("low-poly-town", { traffic_manifest: replacement }));
+    socket.message(worldFrame(2, 1, state(-7, 0, "green")));
+    session.tick(scene, 0.016);
+    assert.equal(manifestAttempts, 3);
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0][0]), /traffic roster rejected/);
+    assert.equal(renderedCar(), activeCar);
+    assert.equal(renderedCar()?.position.x, -9);
+    assert.ok(robotX > 0, "the rest of the scene must continue updating");
+
+    session.tick(scene, 0.016);
+    assert.equal(manifestAttempts, 3, "a rejected roster must not be retried every animation frame");
+    assert.equal(errors.length, 1, "a rejected roster is reported once per authoritative delivery");
+    assert.equal(renderedCar()?.position.x, -9);
+
+    const added = new THREE.Group();
+    addSignalMaterial(added, "Signal_EW_Green_V2");
+    library.registerEnvironment(added);
+    session.refreshTraffic(); // what the stage does once a pack's glb has streamed in
+    session.tick(scene, 0);
+    assert.equal(manifestAttempts, 4);
+    assert.equal(errors.length, 1);
+    assert.ok((renderedCar()?.position.x ?? -Infinity) > -9);
+    socket.message(worldFrame(2.1, 1.1, state(-6.8, 0, "green")));
+    session.tick(scene, 0.1);
+    assert.equal(renderedTraffic?.signals.north_south, "green");
+    assert.equal(signalMaterials.get("Signal_NS_Green")?.color.getHexString(), "5ee27a");
+
+    socket.message(roster("apartment", { traffic_manifest: null }));
+    socket.message(worldFrame(1, 0, null));
+    session.tick(scene, 0.016);
+    assert.equal(manifestAttempts, 5, "an explicit no-traffic roster must still be applied");
+    assert.equal(renderedCar(), undefined);
+    assert.equal(signalMaterials.get("Signal_NS_Red")?.color.getHexString(), "ff4b55");
+    assert.equal(signalMaterials.get("Signal_NS_Green")?.color.getHexString(), "171b1d");
+
+    socket.message(roster("low-poly-town", { traffic_manifest: {} }));
+    assert.match(String(errors.at(-1)?.[0]), /malformed traffic manifest/);
+    socket.message(worldFrame(1.5, 0.5, state(-5)));
+    session.tick(scene, 0.016);
+    assert.equal(renderedCar(), undefined, "a malformed roster reads as no traffic, never as stale cars");
+  } finally {
+    session.stop();
+    library.dispose();
+    hull.dispose();
+    console.error = previousConsoleError;
+    globalThis.WebSocket = previousWebSocket;
+    if (previousDocument) Object.defineProperty(globalThis, "document", previousDocument);
+    else Reflect.deleteProperty(globalThis, "document");
+    if (previousLocation) Object.defineProperty(globalThis, "location", previousLocation);
+    else Reflect.deleteProperty(globalThis, "location");
+  }
+});

--- a/sim/viewer/tsconfig.json
+++ b/sim/viewer/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/tests/test_sim_traffic.py
+++ b/tests/test_sim_traffic.py
@@ -1,0 +1,291 @@
+import fcntl
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import trimesh
+from sim.tools import build_low_poly_town as town_builder
+
+DRIVER_SOURCE = Path(__file__).resolve().parents[1] / "ros2_ws" / "src" / "mars_bot" / "mars_sim_driver"
+sys.path.insert(0, str(DRIVER_SOURCE))
+
+import mars_sim_driver.traffic as traffic_model  # noqa: E402
+
+
+def _car(traffic: traffic_model.TrafficController, lane_id: str):
+    return next(car for car in traffic.cars if car.lane.id == lane_id)
+
+
+def _advance(
+    traffic: traffic_model.TrafficController,
+    start: float,
+    duration: float,
+    robot_xy: tuple[float, float] | None = None,
+) -> None:
+    for step in range(round(duration / 0.01)):
+        traffic.advance(0.01, start + step * 0.01, robot_xy)
+
+
+def _files(root: Path) -> dict[Path, bytes]:
+    return {path.relative_to(root): path.read_bytes() for path in root.rglob("*") if path.is_file()}
+
+
+def test_town_build_is_grounded_phase_isolated_and_transactional(tmp_path, monkeypatch):
+    source = ["mtllib town.mtl", "o Decorative_Bush", "usemtl Red", "f 1 2 3"]
+    for name in town_builder.SIGNAL_OBJECT_PHASE:
+        source.append(f"o {name}")
+        for aspect in town_builder.SIGNAL_ASPECTS:
+            source.extend((f"usemtl {aspect}", "f 1 2 3"))
+    source_text = "\n".join(source) + "\n"
+    mtl = "newmtl Red\nKd 1 0 0\nnewmtl Yellow\nKd 1 1 0\nnewmtl Green\nKd 0 1 0\n"
+    obj, rewritten_mtl = town_builder.isolate_signal_materials(source_text, mtl)
+    assert "o Decorative_Bush\nusemtl Red" in obj
+    assert obj.count("usemtl Signal_NS_Red") == obj.count("usemtl Signal_EW_Green") == 6
+    assert "newmtl Signal_NS_Yellow\nKd 1 1 0" in rewritten_mtl
+    with pytest.raises(RuntimeError, match="unexpected traffic-light material assignments"):
+        town_builder.isolate_signal_materials(source_text.replace("usemtl Green", "usemtl Gray", 1), mtl)
+
+    sim = tmp_path / "sim"
+    assets = sim / "assets/local-environments/low-poly-town"
+    viewer = sim / "viewer/local-environments/low-poly-town"
+    manifest = sim / "environments.local/low-poly-town/manifest.json"
+    for target in (assets, viewer):
+        target.mkdir(parents=True)
+        (target / "last-working").write_text(target.as_posix(), encoding="utf-8")
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('{"last_working": true}\n', encoding="utf-8")
+    source_obj, source_mtl = tmp_path / "town.obj", tmp_path / "town.mtl"
+    source_obj.write_text("licensed source", encoding="utf-8")
+    source_mtl.write_text("licensed materials", encoding="utf-8")
+    monkeypatch.setattr(town_builder, "SIM", sim)
+
+    lock_path = sim / "environments.local/.low-poly-town.build.lock"
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(RuntimeError, match="already running"):
+            town_builder.build(source_obj, source_mtl)
+
+    with pytest.raises(FileNotFoundError, match="source is not installed"):
+        town_builder.build(tmp_path / "missing.obj", source_mtl)
+    assert (assets / "last-working").is_file() and (viewer / "last-working").is_file()
+    assert json.loads(manifest.read_text(encoding="utf-8")) == {"last_working": True}
+
+    generation = "first"
+    generated_scenes: list[trimesh.Scene] = []
+
+    def grounded_scene(*_args):
+        base_top = town_builder.BASE_SLAB_SOURCE_TOP_Y - town_builder.ROAD_SURFACE_Y
+        base = trimesh.creation.box(extents=(30.0, 0.1, 30.0))
+        base.apply_translation((0.0, base_top - 0.05, 0.0))
+        base.visual = trimesh.visual.TextureVisuals(material=trimesh.visual.material.SimpleMaterial(name="Gray"))
+        marking = trimesh.Trimesh(
+            vertices=((-1.0, 0.0, -1.0), (1.0, 0.0, -1.0), (1.0, 0.0, 1.0), (-1.0, 0.0, 1.0)),
+            faces=((0, 1, 2), (0, 2, 3)),
+            process=False,
+        )
+        marking.visual = trimesh.visual.TextureVisuals(material=trimesh.visual.material.SimpleMaterial(name="White"))
+        scene = trimesh.Scene({"base": base, "marking": marking})
+        generated_scenes.append(scene)
+        return scene
+
+    def write_browser(_scene, root):
+        (root / "scene.glb").write_text(generation, encoding="utf-8")
+
+    def write_visuals(_scene, root):
+        room = root / "road"
+        room.mkdir()
+        for name in ("road.obj", "road.png"):
+            (room / name).write_text(generation, encoding="utf-8")
+        return 1
+
+    def write_collisions(root, viewer_root):
+        room = root / "town"
+        room.mkdir()
+        (room / "town_collision_000.obj").write_text(generation, encoding="utf-8")
+        (viewer_root / "hulls.f32").write_text(generation, encoding="utf-8")
+        (viewer_root / "manifest.json").write_text("[]\n", encoding="utf-8")
+        return 1
+
+    def write_map(root):
+        (root / "town.pgm").write_text(generation, encoding="utf-8")
+        (root / "town.yaml").write_text("image: town.pgm\n", encoding="utf-8")
+        return 1, 1
+
+    monkeypatch.setattr(town_builder, "_load_authored_scene", grounded_scene)
+    monkeypatch.setattr(town_builder, "_apply_flat_shading", lambda _scene: None)
+    monkeypatch.setattr(town_builder, "_prepare_daylight_materials", lambda _scene: None)
+    monkeypatch.setattr(town_builder, "_write_browser_scene", write_browser)
+    monkeypatch.setattr(town_builder, "_write_mujoco_visuals", write_visuals)
+    monkeypatch.setattr(town_builder, "_write_collision_proxies", write_collisions)
+    monkeypatch.setattr(town_builder, "_write_navigation_map", write_map)
+
+    town_builder.build(source_obj, source_mtl)
+    assert (assets / "visual/road/road.obj").read_text(encoding="utf-8") == generation
+    assert (viewer / "scene.glb").read_text(encoding="utf-8") == generation
+    attribution = json.loads(manifest.read_text(encoding="utf-8"))["attribution"]
+    assert attribution["source_sha256"] == hashlib.sha256(source_obj.read_bytes()).hexdigest()
+    assert attribution["generated_assets_sha256"] == town_builder._tree_digest(assets, viewer)
+    scene = generated_scenes[-1]
+    assert scene.geometry["marking"].bounds[:, 1] == pytest.approx((0.002, 0.002))
+    assert scene.geometry["base"].bounds[1, 1] == pytest.approx(
+        town_builder.BASE_SLAB_SOURCE_TOP_Y - town_builder.ROAD_SURFACE_Y - town_builder.BASE_SLAB_CLEARANCE
+    )
+    assert town_builder._collision_proxies()[0][1].bounds[1, 1] == pytest.approx(0.10)
+
+    previous = (_files(assets), _files(viewer), manifest.read_bytes())
+    generation = "second"
+    real_replace = Path.replace
+
+    def fail_viewer_publish(path, target):
+        if path.name.startswith(".low-poly-town.build-") and Path(target) == viewer:
+            raise OSError("forced viewer publish failure")
+        return real_replace(path, target)
+
+    monkeypatch.setattr(Path, "replace", fail_viewer_publish)
+    with pytest.raises(OSError, match="forced viewer publish failure"):
+        town_builder.build(source_obj, source_mtl)
+    assert (_files(assets), _files(viewer), manifest.read_bytes()) == previous
+    assert not list(sim.rglob(".low-poly-town.build-*"))
+    assert not list(sim.rglob(".low-poly-town.backup-*"))
+
+
+def test_town_traffic_runs_safely_from_controller_through_mujoco():
+    boundaries = (0.0, 4.0, 16.0, 19.0, 23.0, 35.0, 38.0)
+    phases = (
+        "all_red_to_ns",
+        "ns_green",
+        "ns_yellow",
+        "all_red_to_ew",
+        "ew_green",
+        "ew_yellow",
+        "all_red_to_ns",
+    )
+    assert tuple(traffic_model.phase_at(t)[0] for t in boundaries) == phases
+    assert traffic_model.phase_at(traffic_model.CYCLE_S + 4.0) == traffic_model.phase_at(4.0)
+
+    traffic = traffic_model.TrafficController("low-poly-town")
+    seen: set[str] = set()
+    for step in range(round(4 * traffic_model.CYCLE_S / 0.01)):
+        sim_time = step * 0.01
+        traffic.advance(0.01, sim_time, (1.6, -9.0))
+        state = traffic.state(sim_time, 7)
+        assert state is not None
+        seen.add(state["phase"])
+        occupied = {
+            car.lane.signal_group
+            for car in traffic.cars
+            if car.active
+            and car.position + traffic_model.CAR_HALF_LENGTH_M > traffic_model.INTERSECTION_MIN_M
+            and car.position - traffic_model.CAR_HALF_LENGTH_M < traffic_model.INTERSECTION_MAX_M
+        }
+        assert len(occupied) <= 1
+        assert sum(aspect != traffic_model.RED for aspect in state["signals"].values()) <= 1
+        assert not (state["signals"][traffic_model.NS] == traffic_model.GREEN and traffic_model.EW in occupied)
+        assert not (state["signals"][traffic_model.EW] == traffic_model.GREEN and traffic_model.NS in occupied)
+    assert seen == set(phases)
+
+    # Late green still clears, while an occupied junction holds cross traffic.
+    traffic = traffic_model.TrafficController("low-poly-town")
+    eastbound = _car(traffic, "eastbound")
+    eastbound.position, eastbound.speed = eastbound.lane.stop - 2.0, 3.0
+    _advance(traffic, 20.0, 3.0)
+    traffic.advance(0.01, 34.99)
+    assert eastbound.committed
+    _advance(traffic, 35.0, 7.0)
+    assert eastbound.position - traffic_model.CAR_HALF_LENGTH_M > traffic_model.INTERSECTION_MAX_M
+
+    traffic = traffic_model.TrafficController("low-poly-town")
+    eastbound, southbound = _car(traffic, "eastbound"), _car(traffic, "southbound")
+    eastbound.position, eastbound.speed, eastbound.committed = 0.0, 0.0, True
+    southbound.position, southbound.speed = southbound.lane.stop, 0.0
+    traffic.advance(0.01, 5.0)
+    blocked = traffic.state(5.01, 0)
+    assert blocked is not None and blocked["phase"] == "ns_green_clearance_hold"
+    assert blocked["signals"] == {traffic_model.NS: traffic_model.RED, traffic_model.EW: traffic_model.RED}
+    assert (southbound.position, southbound.speed) == (southbound.lane.stop, 0.0)
+    eastbound.position, eastbound.committed = 9.0, False
+    traffic.advance(0.01, 5.01)
+    assert traffic.state(5.02, 0)["signals"][traffic_model.NS] == traffic_model.GREEN
+
+    # Robot obstruction cancels stale commitment, enforces a follow gap, and
+    # keeps a recycled actor off-map until its approach is clear.
+    traffic = traffic_model.TrafficController("low-poly-town")
+    eastbound = _car(traffic, "eastbound")
+    for car in traffic.cars:
+        if car.lane.signal_group == traffic_model.NS:
+            car.position = 10.0 if car.lane.direction > 0 else -10.0
+    eastbound.position, eastbound.speed = eastbound.lane.stop, 0.0
+    robot_block = (-6.10, eastbound.lane.fixed)
+    traffic.advance(0.01, 34.99, robot_block)
+    assert eastbound.committed and eastbound.position == eastbound.lane.stop
+    _advance(traffic, 35.0, 8.01, robot_block)
+    assert not eastbound.committed
+    _advance(traffic, 43.01, 1.0, (0.0, 8.0))
+    assert eastbound.position <= eastbound.lane.stop and eastbound.speed == 0.0
+
+    northbound = _car(traffic, "northbound")
+    northbound.position = northbound.lane.start
+    _advance(traffic, 3.0, 5.0, (1.6, -9.0))
+    gap = traffic_model.CAR_HALF_LENGTH_M + traffic_model.ROBOT_RADIUS_M + traffic_model.ROBOT_FOLLOW_GAP_M
+    assert northbound.position <= -9.0 - gap + 1e-6 and northbound.speed == 0.0
+    previous_spawn = northbound.spawn_seq
+    northbound.position, northbound.speed = northbound.lane.end - 0.01, 2.0
+    traffic.advance(0.02, 20.0, (1.6, -9.0))
+    assert not northbound.active and "northbound" not in traffic.state(20.02, 0)["cars"]
+    traffic.advance(0.02, 20.02, (8.0, -9.0))
+    assert northbound.active and northbound.position == northbound.lane.start
+    assert northbound.spawn_seq == previous_spawn + 1
+    traffic.reset()
+    assert (northbound.position, northbound.speed, northbound.spawn_seq) == (northbound.lane.initial_position, 0.0, 0)
+
+    manifest = traffic.manifest()
+    assert manifest is not None and [car["id"] for car in manifest["cars"]] == [car.lane.id for car in traffic.cars]
+    assert traffic.bodies_xml().count('mocap="true"') == 4
+    body = traffic_model.CAR_MODEL["parts"][0]
+    body_face = abs(body["position"][0]) + body["size"][0] / 2
+    lamps = [part for part in traffic_model.CAR_MODEL["parts"] if part["material"] in {"headlight", "taillight"}]
+    assert all(abs(part["position"][0]) + part["size"][0] / 2 > body_face + 0.01 for part in lamps)
+    apartment = traffic_model.TrafficController("apartment")
+    assert (apartment.bodies_xml(), apartment.manifest(), apartment.state(0.0, 0)) == ("", None, None)
+
+    mujoco = pytest.importorskip("mujoco")
+    if not callable(getattr(getattr(mujoco, "MjSpec", None), "from_string", None)):
+        pytest.skip("a test module installed a minimal fake mujoco without MjSpec")
+    materials = "\n".join(
+        f'<material name="mat_signal-{group}-{aspect}" rgba="1 1 1 1"/>'
+        for group in ("ns", "ew")
+        for aspect in ("red", "yellow", "green")
+    )
+    world = mujoco.MjSpec.from_string(
+        f"<mujoco><asset>{materials}</asset><worldbody>{traffic.bodies_xml()}</worldbody></mujoco>"
+    )
+    robot = mujoco.MjSpec.from_string(
+        '<mujoco><worldbody><body name="base" pos="0 0 0.3"><freejoint/>'
+        '<geom name="collision" type="box" size="0.3 0.3 0.3" contype="1" conaffinity="1"/>'
+        "</body></worldbody></mujoco>"
+    )
+    traffic.configure_robot_spec(robot)
+    world.attach(robot, frame=world.worldbody.add_frame(), prefix="robot_")
+    model = world.compile()
+    data = mujoco.MjData(model)
+    traffic.bind(model)
+    traffic.reset(data)
+    robot_geom, robot_body = model.geom("robot_collision").id, model.body("robot_base").id
+    assert model.nmocap == 4 and int(model.geom_conaffinity[robot_geom]) == 3
+    assert int(model.body_conaffinity[robot_body]) & traffic_model.CAR_COLLISION_BIT
+
+    eastbound = _car(traffic, "eastbound")
+    data.qpos[:3] = (eastbound.position, eastbound.lane.fixed, 0.3)
+    mujoco.mj_forward(model, data)
+    assert any(
+        robot_body in (int(model.geom_bodyid[contact.geom1]), int(model.geom_bodyid[contact.geom2]))
+        for contact in data.contact
+    )
+    ns_red, ns_green = model.mat("mat_signal-ns-red").id, model.mat("mat_signal-ns-green").id
+    assert tuple(model.mat_rgba[ns_red]) == (1.0, 1.0, 1.0, 1.0)
+    assert tuple(model.mat_rgba[ns_green]) == (0.1, 0.1, 0.1, 1.0)
+    traffic.advance(0.01, 5.0)
+    assert tuple(model.mat_rgba[ns_red]) == (0.1, 0.1, 0.1, 1.0)
+    assert tuple(model.mat_rgba[ns_green]) == (1.0, 1.0, 1.0, 1.0)

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -194,6 +194,9 @@ SIM_VIEWER_ROUTES = {
     "/robot/": ROOT.parent / "ros2_ws" / "src" / "mars_bot" / "mars_sim",
     # Collision hulls for the SimSession's "collisions" debug overlay.
     "/physics/": SIM_VIEWER_ROOT / "public" / "physics",
+    # Locally built environment packs (sim/environments.local): outside public,
+    # which the launcher replaces wholesale on every asset-image refresh.
+    "/local-environments/": SIM_VIEWER_ROOT / "local-environments",
 }
 
 


### PR DESCRIPTION
Ports #753 onto #756, stacked: merge #756 first, then retarget this PR to `main`.

## What carried over as is

- `traffic.py`: deterministic cars, interlocked signal phases, MARS yielding and collisions, mocap bodies; the `VirtualMars` hooks (`configure_robot_spec`, `bind`, `reset`, `step`, `traffic_manifest`/`traffic_state`); `traffic_bodies` in the MJCF; `traffic` on the state stream and `traffic_manifest` on the roster.
- `sim/tools/build_low_poly_town.py` and both of #753's test files (`tests/test_sim_traffic.py`, `sim/viewer/test/traffic.test.ts`), with the paths and the session half of the viewer test updated for this branch.
- `traffic.ts` / `trafficState.ts` in the viewer, plus one new method, `TrafficLibrary.resetEnvironment()`, for a hot swap inside one scene.

## What changed in the port

- **Viewer wiring.** #753 hung the traffic manifest on #751's `prepareScene` readiness barrier. Here the manifest rides the environment roster (`EnvironmentRoster.traffic`); the session applies it on the next tick, keeps the last complete frame when a scene rejects a roster whose lamp materials it lacks, and retries once the stage has streamed the pack's glb (`session.refreshTraffic()` after `scene.markEnvironmentReady()`). `unloadEnvironment()` resets the traffic library with the rest of the scene.
- **Local pack layout.** Generated files live under `local-environments/` roots in `sim/assets` and `sim/viewer`; the latter is served at `/local-environments/` and sits outside `sim/viewer/public`, which the launcher replaces wholesale on every asset-image refresh. The manifest is `sim/environments.local/low-poly-town/manifest.json`. The launch script seeds local packs' maps too.
- The traffic manifest is validated leniently on this branch: a malformed one logs and reads as no traffic, rather than closing the socket.

## Verified

- Host tests: 70 passed, including #753's builder and MuJoCo traffic tests. `ruff` clean.
- Viewer: typecheck, bundle build, and the traffic test (rewritten session half) pass.
- Runtime, against the ported world server on a **synthetic** town pack built through the real builder with a stand-in scene: apartment → town brought up the four-car roster, cars drove, signals cycled all-red → NS green, the challenge list narrowed to Victory Lap; town → apartment cleared the traffic with the epoch carried forward; an unknown pack was refused.
- Not verified: the licensed CGTrader source itself (not available here), and the browser rendering of cars over a real world beyond the node test's fake scene.

## Trying it

```bash
git checkout feat/town-traffic-on-hot-switch
sim/.venv/bin/python sim/tools/build_low_poly_town.py \
  --source-obj sim/viewer/assets/low_poly_town/town.obj \
  --source-mtl sim/viewer/assets/low_poly_town/town.mtl
./innate-sim down && ./innate-sim up          # the mode manager lists maps at startup
```

Then Scene setup → Environment → Town Intersection. The asset image for this branch's hash is not published (`sim/tools` changed), so run `up` with `INNATE_SIM_ASSETS_IMAGE` set to #756's image tag (`inputs-4fd325b5…`) until this merges.
