### PR TITLE
feat(brain): add provisional continuous visual navigation

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -33,7 +33,15 @@ from brain_client.brain import grounding
 from brain_client.brain.context import Decision, GeminiContext, ToolCall
 from brain_client.brain.loop import LoopThread
 from brain_client.brain.prompt import build_system_prompt, self_reference_turns
-from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
+from brain_client.brain.tools import (
+    END_CONTINUOUS_NAVIGATION,
+    GO_TO_POINT_IN_VIEW,
+    NAV_INSIGHT_CONTINUOUS,
+    STOP_SKILL,
+    WAIT,
+    assign_tool_names,
+    build_tools,
+)
 from brain_client.brain.transport import pick_transport
 from brain_client.brain.utils import (
     Event,
@@ -136,6 +144,11 @@ class BrainAgent:
         self._frame_at_capture: bytes | None = None
         self._pitch_at_capture = 0.0
         self._tool_map: dict[str, str] = {}  # gemini function name -> skill id
+        self._continuous_navigation_target: str | None = None
+        # A fresh visual decision can replace a still-running Nav2 step. Keep
+        # only the newest requested goal and start it after cancellation has
+        # released the one-skill slot.
+        self._continuous_navigation_pending_goal: dict | None = None
         self._error_streak = 0
         self._activated_at = 0.0
         self._turn_count = 0
@@ -200,6 +213,9 @@ class BrainAgent:
         if not unwound:
             self._logger.error("[Brain] Agent loop did not unwind within 5s")
         self._events.clear()
+        if unwound:
+            self._continuous_navigation_target = None
+            self._continuous_navigation_pending_goal = None
         return unwound
 
     def reset(self) -> None:
@@ -291,6 +307,10 @@ class BrainAgent:
 
     async def _think(self, context: GeminiContext, events: list[Event], speaker: SpeechStreamer) -> None:
         text, frames = self._look(events)
+        if self._continuous_navigation_target is not None:
+            # The target originates in user speech, so keep it in user-role
+            # observation text rather than promoting it into system guidance.
+            text += f"\n- Continuous navigation objective: {json.dumps(self._continuous_navigation_target)}"
         if self._frame_at_capture is None:
             return  # the feed died between the loop's freshness check and the look
         wrist_frames = [i for i, (label, _) in enumerate(frames) if label == FrameLabel.WRIST]
@@ -301,6 +321,7 @@ class BrainAgent:
             directive.get_prompt() if directive else None,
             identity=self._identity.current if self._identity is not None else None,
             running_guidance=self._running_guidance(self._state.primitive_running),
+            continuous_navigation_active=self._continuous_navigation_target is not None,
         )
         if self._state.log_everything:
             self._logger.info(f"[Brain] Turn input:\n{text}")
@@ -467,8 +488,18 @@ class BrainAgent:
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
         if running is not None:
-            return build_tools([], running.primitive_name, user_spoke=user_spoke)
-        return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
+            return build_tools(
+                [],
+                running.primitive_name,
+                continuous_navigation_active=self._continuous_navigation_target is not None,
+                user_spoke=user_spoke,
+            )
+        return build_tools(
+            named,
+            None,
+            can_go_to_point_in_view=_NAV_TO_POSITION in active_ids,
+            continuous_navigation_active=self._continuous_navigation_target is not None,
+        )
 
     # ================= act =================
     def _act(self, decision: Decision, speaker: SpeechStreamer, context: GeminiContext) -> list[tuple[ToolCall, str]]:
@@ -525,6 +556,17 @@ class BrainAgent:
             # (a goal that slips through anyway is cancelled by the runner's
             # generation bump, but this keeps the robot from twitching first).
             return "rejected — the brain is deactivating"
+        if call.name == NAV_INSIGHT_CONTINUOUS:
+            return self._start_continuous_navigation(call.args)
+        if call.name == END_CONTINUOUS_NAVIGATION:
+            return self._end_continuous_navigation(call.args)
+        if call.name == GO_TO_POINT_IN_VIEW:
+            running = self._state.primitive_running
+            if running is not None and (
+                self._continuous_navigation_target is None or running.primitive_name != "navigate_to_position"
+            ):
+                return "rejected — another skill is already running; stop it first"
+            return self._go_to_point_in_view(call.args)
         # Only names declared this turn resolve: falling back to the full
         # registry would let a hallucinated call bypass the active-skill allowlist.
         # The map is a turn old by now and the roster can change under it, so
@@ -532,8 +574,8 @@ class BrainAgent:
         skill_id = self._tool_map.get(call.name)
         if self._state.primitive_running is not None:
             return "rejected — another skill is already running; stop it first"
-        if call.name == GO_TO_POINT_IN_VIEW:
-            return self._go_to_point_in_view(call.args)
+        if self._continuous_navigation_target is not None:
+            return "rejected — end continuous navigation before starting a different skill"
         if skill_id is None:
             return f"unknown skill '{call.name}'"
         if skill_id not in self._roster.active_skill_ids():
@@ -542,16 +584,53 @@ class BrainAgent:
         return "started — you will get an event when it finishes"
 
     def _stop_skill(self) -> str:
-        if self._runner.has_active_goal:
+        was_continuous = self._continuous_navigation_target is not None
+        self._continuous_navigation_target = None
+        self._continuous_navigation_pending_goal = None
+        if getattr(self._runner, "has_active_goal", False):
             self._runner.cancel_active_goal()
-            return "stopping — you will get an event when it has stopped"
+            prefix = "continuous navigation canceled; " if was_continuous else ""
+            return prefix + "stopping — you will get an event when it has stopped"
         if self._state.primitive_running is None:
-            return "no skill is running"
+            return "continuous navigation canceled" if was_continuous else "no skill is running"
         # A run this client didn't start (webapp/CLI manual run): the skills
         # server's owner-agnostic cancel is the only handle.
         if self._runner.cancel_external():
-            return "stopping — you will get an event when it has stopped"
+            prefix = "continuous navigation canceled; " if was_continuous else ""
+            return prefix + "stopping — you will get an event when it has stopped"
         return "could not stop it — the skills server is unreachable"
+
+    def _start_continuous_navigation(self, args: dict) -> str:
+        if _NAV_TO_POSITION not in self._roster.active_skill_ids():
+            return "rejected — navigate_to_position is not available"
+        if self._state.primitive_running is not None:
+            return "rejected — another skill is already running; stop it first"
+        target = str(args.get("target_description") or "").strip()
+        if not target:
+            return "rejected — give a target_description"
+        if self._continuous_navigation_target is not None:
+            return f"rejected — already navigating continuously toward {self._continuous_navigation_target}"
+        self._continuous_navigation_target = target[:500]
+        self._continuous_navigation_pending_goal = None
+        return f"continuous navigation started toward {self._continuous_navigation_target}"
+
+    def _end_continuous_navigation(self, args: dict) -> str:
+        target = self._continuous_navigation_target
+        if target is None:
+            return "continuous navigation is not active"
+        status = args.get("status")
+        reason = str(args.get("reason") or "").strip()
+        if status not in ("reached", "cannot_proceed", "cancelled") or not reason:
+            return "rejected — give status reached, cannot_proceed, or cancelled and a reason"
+        self._continuous_navigation_target = None
+        self._continuous_navigation_pending_goal = None
+        if getattr(self._runner, "has_active_goal", False):
+            self._runner.cancel_active_goal()
+        if status == "reached":
+            return f"continuous navigation completed: reached {target} — {reason}"
+        if status == "cancelled":
+            return f"continuous navigation canceled — {reason}"
+        return f"continuous navigation ended before reaching {target} — {reason}"
 
     def _go_to_point_in_view(self, args: dict) -> str:
         """Project the pointed-at floor pixel into a local navigate_to_position goal."""
@@ -584,6 +663,19 @@ class BrainAgent:
             f"goal ({inputs['x']:.2f}, {inputs['y']:.2f}, {inputs['theta_degrees']:.0f}°) "
             f"pitch={self._pitch_at_capture:.0f}°"
         )
+        if self._state.primitive_running is not None:
+            # The model made this decision from a newer frame while the prior
+            # bounded step was moving. Cancellation is asynchronous; queue the
+            # replacement and let the terminal event start it after the runner
+            # releases its slot. Newer frames overwrite this pending goal.
+            cancel_already_requested = self._continuous_navigation_pending_goal is not None
+            self._continuous_navigation_pending_goal = inputs
+            if cancel_already_requested:
+                return "updated the queued replan from the newest camera frame"
+            if self._runner.has_active_goal:
+                self._runner.cancel_active_goal()
+                return "replanning from the current camera frame — replacing the in-flight waypoint"
+            return "replanning queued — waiting for the in-flight waypoint handle"
         self._start_skill(_NAV_TO_POSITION, inputs)
         return (
             f"driving to the floor point {math.hypot(*floor):.1f}m away (stopping ~{grounding.STANDOFF_M}m short) "
@@ -632,10 +724,34 @@ class BrainAgent:
     def on_skill_event(
         self, status: str, skill_name: str, detail: str | None = None, image: bytes | None = None
     ) -> None:
+        if skill_name == "navigate_to_position" and status in (
+            "completed",
+            "failed",
+            "interrupted",
+            "canceled",
+            "cancelled",
+        ):
+            # This callback runs on the ROS executor. Keep mode mutation and a
+            # planned replacement on the agent loop, queued before the wake.
+            self._runtime.post(self._handle_continuous_navigation_terminal, status)
         line = f"Skill {skill_name} {status}"
         if detail:
             line += f": {detail}"
         self.add_event(line, image=image)
+
+    def _clear_continuous_navigation(self) -> None:
+        self._continuous_navigation_target = None
+        self._continuous_navigation_pending_goal = None
+
+    def _handle_continuous_navigation_terminal(self, status: str) -> None:
+        pending = self._continuous_navigation_pending_goal
+        if status == "completed" and pending is None:
+            return  # normal bounded-step completion; the event wakes a fresh visual decision
+        if status != "failed" and self._continuous_navigation_target and pending:
+            self._continuous_navigation_pending_goal = None
+            self._start_skill(_NAV_TO_POSITION, pending)
+            return
+        self._clear_continuous_navigation()
 
     def on_skill_feedback(self, skill_name: str, feedback: str, image: bytes | None = None) -> None:
         self.add_event(f"Update from running skill {skill_name}: {feedback}", image=image)
@@ -695,6 +811,7 @@ class BrainAgent:
             next_in=max(0.0, round(self._pause_until - time.monotonic(), 1)) if self._pause_until else 0.0,
             streak=self._error_streak,
             running=running.primitive_name if running else None,
+            continuous_navigation=self._continuous_navigation_target,
             history=self._context.history_len if self._context else 0,
             tokens=self._context.last_usage if self._context else {},
             uptime=round(time.monotonic() - self._activated_at, 0) if self._state.is_brain_active else 0,

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
@@ -100,14 +100,33 @@ A skill is running right now. Guidance while it runs:
 {guidance}
 """
 
+_CONTINUOUS_NAVIGATION_GUIDANCE = """
+Continuous visual navigation mode is active.
+
+Reassess the route from every fresh camera update, including while navigate_to_position is still moving. If the
+current waypoint no longer looks best, call go_to_point_in_view with the best safe floor point in the CURRENT frame;
+this replaces the in-flight waypoint. If the waypoint still looks correct, wait rather than replacing it needlessly.
+A completed navigate_to_position run is only one bounded step, not completion of the objective. If the objective is
+visibly reached, call end_continuous_navigation with status=reached. A failed or externally interrupted step ends
+this mode automatically. If the route is unsafe or ambiguous, or no progress can be made, call
+end_continuous_navigation with status=cannot_proceed. Do not invent a route through unseen obstacles, and do not
+claim arrival merely because one movement completed. If the user asks to stop or switch tasks, call
+end_continuous_navigation with status=cancelled before doing anything else.
+"""
+
 
 def build_system_prompt(
-    directive_prompt: str | None, identity: RobotIdentity | None = None, running_guidance: str = ""
+    directive_prompt: str | None,
+    identity: RobotIdentity | None = None,
+    running_guidance: str = "",
+    continuous_navigation_active: bool = False,
 ) -> str:
     directive = (directive_prompt or "").strip() or "Be a helpful home robot."
     prompt = _SYSTEM_PROMPT.format(directive=directive, identity=_identity_block(identity))
     if running_guidance:
         prompt += _RUNNING_GUIDANCE.format(guidance=running_guidance)
+    if continuous_navigation_active:
+        prompt += _CONTINUOUS_NAVIGATION_GUIDANCE
     return prompt
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -11,6 +11,8 @@ from brain_client.skills.registry import SkillMeta
 STOP_SKILL = "stop_current_skill"
 WAIT = "wait"
 GO_TO_POINT_IN_VIEW = "go_to_point_in_view"
+NAV_INSIGHT_CONTINUOUS = "nav_insight_continuous"
+END_CONTINUOUS_NAVIGATION = "end_continuous_navigation"
 
 # An explicit no-op keeps idle turns clean: without it, models tend to emit
 # placeholder text ("[]", "Empty response") rather than returning nothing.
@@ -29,7 +31,8 @@ _GO_TO_POINT_IN_VIEW_DECLARATION = {
         "coordinates (0-1000) of a point ON THE FLOOR: y from the top, x from the left. For an "
         "object, point at the floor at its base. The robot drives to about 0.35 m short of that "
         "spot and turns to face it. Prefer this over navigate_to_position for anything you can "
-        "see. Far targets are approached in capped steps — call it again after arriving."
+        "see. Far targets are approached in capped steps. During continuous navigation, call it "
+        "from a fresh camera frame whenever the current waypoint should be replaced; otherwise wait."
     ),
     "parameters": {
         "type": "OBJECT",
@@ -38,6 +41,47 @@ _GO_TO_POINT_IN_VIEW_DECLARATION = {
             "x": {"type": "INTEGER", "description": "0-1000 from image left"},
         },
         "required": ["y", "x"],
+    },
+}
+
+# Provisional compatibility with innate-cloud-agent's old continuous visual
+# navigation primitive. The local brain already owns the camera/model loop, so
+# these tools only manage the objective; each actual movement still goes
+# through the bounded, grounded go_to_point_in_view -> navigate_to_position path.
+_NAV_INSIGHT_CONTINUOUS_DECLARATION = {
+    "name": NAV_INSIGHT_CONTINUOUS,
+    "description": (
+        "Start autonomous continuous visual navigation toward a distant target. Use when the target "
+        "is far away, not yet visible, or requires several visual navigation steps. The mode keeps "
+        "using fresh camera frames and bounded navigation steps until the target is reached or cannot "
+        "be reached. Do not use for a nearby visible target; use go_to_point_in_view directly."
+    ),
+    "parameters": {
+        "type": "OBJECT",
+        "properties": {
+            "target_description": {
+                "type": "STRING",
+                "description": "What to navigate toward, such as 'the exit door at the end of the hallway'",
+            }
+        },
+        "required": ["target_description"],
+    },
+}
+
+_END_CONTINUOUS_NAVIGATION_DECLARATION = {
+    "name": END_CONTINUOUS_NAVIGATION,
+    "description": (
+        "End the active continuous navigation mode. Use status=reached only when the current camera "
+        "frame shows the objective has actually been reached; use cannot_proceed when blocked and "
+        "cancelled when the user asks to stop or switch tasks."
+    ),
+    "parameters": {
+        "type": "OBJECT",
+        "properties": {
+            "status": {"type": "STRING", "enum": ["reached", "cannot_proceed", "cancelled"]},
+            "reason": {"type": "STRING", "description": "Brief visual or navigation reason"},
+        },
+        "required": ["status", "reason"],
     },
 }
 
@@ -66,7 +110,13 @@ def assign_tool_names(skills: list[SkillMeta]) -> list[tuple[str, SkillMeta]]:
     shadow a built-in tool); colliding names get a numeric suffix so a call
     never silently dispatches to the wrong skill.
     """
-    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW}
+    taken = {
+        STOP_SKILL,
+        WAIT,
+        GO_TO_POINT_IN_VIEW,
+        NAV_INSIGHT_CONTINUOUS,
+        END_CONTINUOUS_NAVIGATION,
+    }
     named: list[tuple[str, SkillMeta]] = []
     for meta in skills:
         base = name = tool_name(meta["name"])
@@ -85,6 +135,7 @@ def build_tools(
     running_skill_name: str | None,
     *,
     can_go_to_point_in_view: bool = False,
+    continuous_navigation_active: bool = False,
     user_spoke: bool = False,
 ) -> list[dict]:
     """One function declaration per available skill, in a native tools block.
@@ -111,10 +162,32 @@ def build_tools(
                 else "Use when it is clearly failing, no longer makes sense, or the user asks for something else."
             ),
         }
-        return [{"functionDeclarations": [stop] if user_spoke else [stop, _WAIT_DECLARATION]}]
+        if user_spoke:
+            return [{"functionDeclarations": [stop]}]
+        if continuous_navigation_active and running_skill_name == "navigate_to_position":
+            # A continuous visual-navigation turn must be able to revise the
+            # in-flight waypoint from its fresh frame instead of waiting for a
+            # long Nav2 goal to finish. Dispatch serializes cancel -> replace.
+            return [
+                {
+                    "functionDeclarations": [
+                        stop,
+                        _GO_TO_POINT_IN_VIEW_DECLARATION,
+                        _END_CONTINUOUS_NAVIGATION_DECLARATION,
+                        _WAIT_DECLARATION,
+                    ]
+                }
+            ]
+        return [{"functionDeclarations": [stop, _WAIT_DECLARATION]}]
     declarations = [_declaration(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)
+    if continuous_navigation_active:
+        # Keep the escape hatch even if navigate_to_position disappears from
+        # the live roster while a run is active.
+        declarations.append(_END_CONTINUOUS_NAVIGATION_DECLARATION)
+    elif can_go_to_point_in_view:
+        declarations.append(_NAV_INSIGHT_CONTINUOUS_DECLARATION)
     declarations.append(_WAIT_DECLARATION)
     return [{"functionDeclarations": declarations}]
 

--- a/ros2_ws/src/brain/brain_client/innate/gemini.py
+++ b/ros2_ws/src/brain/brain_client/innate/gemini.py
@@ -21,7 +21,7 @@ def make_client():
     return client if client.is_available() else None
 
 
-def ask_image(client, images_b64, question, logger=None, retries=3):
+def ask_image(client, images_b64, question, logger=None, retries=3, *, model=MODEL, reasoning_effort=None):
     """JPEG(s) + question -> reply text. None if no client / all retries fail.
     images_b64: one base64 string or a list of them — sent in order, so the
     question can refer to them as image 1, image 2, ... Frames go inline as
@@ -34,10 +34,12 @@ def ask_image(client, images_b64, question, logger=None, retries=3):
     content = [{"type": "text", "text": question}]
     content += [{"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b}"}} for b in images_b64]
     body = {
-        "model": MODEL,
+        "model": model,
         "temperature": 0.0,
         "messages": [{"role": "user", "content": content}],
     }
+    if reasoning_effort is not None:
+        body["reasoning_effort"] = reasoning_effort
     for attempt in range(retries):
         cancellable_sleep(0)
         try:

--- a/ros2_ws/src/brain/brain_client/test/test_continuous_navigation_skill.py
+++ b/ros2_ws/src/brain/brain_client/test/test_continuous_navigation_skill.py
@@ -7,7 +7,9 @@ _REPO_ROOT = Path(__file__).resolve().parents[5]
 sys.path.insert(0, str(_REPO_ROOT / "workspace"))
 
 from innate_agents.demo_agent import DemoAgent  # noqa: E402
+from innate_skills import continuous_navigation as continuous  # noqa: E402
 from innate_skills.continuous_navigation import (  # noqa: E402
+    ContinuousNavigation,
     NavigationStatus,
     VisualDecision,
     decision_odom_goal,
@@ -45,7 +47,7 @@ def test_visual_decision_contract_and_motion_compensated_goal():
     assert math.isclose(current[2] + theta, odom_goal[2], abs_tol=1e-9)
 
 
-def test_nav2_controller_cancels_an_inflight_goal_before_returning_replan():
+def test_visual_loop_advances_an_unfinished_goal_on_an_unchanged_route(monkeypatch):
     class FakeNavigator:
         cancelled = False
 
@@ -75,8 +77,38 @@ def test_nav2_controller_cancels_an_inflight_goal_before_returning_replan():
     controller._resolve_goal = lambda x, y, theta, _local: (x, y, theta, "odom")
     controller._pose_stamped = lambda x, y, theta, frame: (x, y, theta, frame)
 
-    replacement = object()
-    result = controller.go_to_position(1.0, 0.0, 0.0, True, reassess=lambda: replacement)
+    # The robot has moved since its previous assessment. The same clear
+    # floor pixel now represents a new absolute destination further ahead.
+    frame = MainImage("unused")
+    decision = VisualDecision(NavigationStatus.CONTINUE, "same clear corridor", x=500, y=800)
+    first_goal = decision_odom_goal(decision, frame, -20.0, (0.0, 0.0, 0.0))
+    skill = SimpleNamespace(
+        _target="end of the corridor", _iteration=1, _max_iterations=50,
+        _previous_image=frame, _consecutive_model_failures=0, _active_goal=first_goal,
+        main_image=frame, head_position=SimpleNamespace(pitch_degrees=-20.0),
+        odom=SimpleNamespace(x=1.0, y=0.0, theta=0.0), _proxy=object(),
+        logger=controller.logger, check_cancelled=lambda: None, feedback=lambda _message: None,
+    )
+    skill._prompt = lambda **kw: ContinuousNavigation._prompt(skill, **kw)
+    skill._decide = lambda **kw: ContinuousNavigation._decide(skill, **kw)
 
-    assert result is replacement
+    def model(_client, _images, prompt, **kwargs):
+        assert "on EVERY assessment, even when the route is unchanged" in prompt
+        assert "KEEP_CURRENT" not in prompt
+        assert kwargs["model"] == "gemini-3.8-flash"
+        assert kwargs["reasoning_effort"] == "low"
+        assert not navigator.isTaskComplete()
+        return '{"status":"CONTINUE","x":500,"y":800,"explanation":"same clear corridor"}'
+
+    monkeypatch.setattr(continuous.gemlib, "ask_image", model)
+    result = controller.go_to_position(
+        *first_goal, True, reassess=lambda: ContinuousNavigation._reassess_while_moving(skill)
+    )
+
+    assert result.odom_goal[0] == first_goal[0] + 1.0
     assert navigator.cancelled
+
+    # An identical absolute destination must not cause a cancel/restart loop.
+    skill._active_goal = result.odom_goal
+    skill._decide = lambda **_kw: result
+    assert ContinuousNavigation._reassess_while_moving(skill) is None

--- a/ros2_ws/src/brain/brain_client/test/test_continuous_navigation_skill.py
+++ b/ros2_ws/src/brain/brain_client/test/test_continuous_navigation_skill.py
@@ -1,0 +1,82 @@
+import math
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+sys.path.insert(0, str(_REPO_ROOT / "workspace"))
+
+from innate_agents.demo_agent import DemoAgent  # noqa: E402
+from innate_skills.continuous_navigation import (  # noqa: E402
+    NavigationStatus,
+    VisualDecision,
+    decision_odom_goal,
+    local_goal,
+    parse_visual_decision,
+)
+from innate_skills.navigate_to_position import Nav2Controller  # noqa: E402
+
+from innate import MainImage  # noqa: E402
+
+
+def test_demo_agent_exposes_the_standalone_continuous_navigation_skill():
+    assert "innate-os/continuous_navigation" in DemoAgent().skill_ids()
+
+
+def test_visual_decision_contract_and_motion_compensated_goal():
+    reply = """```json
+    {"status":"CONTINUE","x":500,"y":800,"explanation":"clear floor ahead","progress_description":"closer"}
+    ```"""
+    decision = parse_visual_decision(reply, allow_keep=False)
+    assert decision == VisualDecision(NavigationStatus.CONTINUE, "clear floor ahead", "closer", 500, 800)
+    assert parse_visual_decision('{"status":"KEEP_CURRENT","explanation":"same route"}', allow_keep=False) is None
+    assert parse_visual_decision('{"status":"CONTINUE","x":1001,"y":500,"explanation":"bad"}', allow_keep=True) is None
+
+    capture = (1.0, 2.0, 0.3)
+    odom_goal = decision_odom_goal(decision, MainImage("unused"), -20.0, capture)
+    assert odom_goal is not None
+    # Re-basing after the robot moves must preserve the same absolute odom
+    # destination instead of replaying a stale robot-relative command.
+    current = (1.2, 2.05, 0.4)
+    x, y, theta = local_goal(odom_goal, current)
+    c, s = math.cos(current[2]), math.sin(current[2])
+    assert math.isclose(current[0] + c * x - s * y, odom_goal[0], abs_tol=1e-9)
+    assert math.isclose(current[1] + s * x + c * y, odom_goal[1], abs_tol=1e-9)
+    assert math.isclose(current[2] + theta, odom_goal[2], abs_tol=1e-9)
+
+
+def test_nav2_controller_cancels_an_inflight_goal_before_returning_replan():
+    class FakeNavigator:
+        cancelled = False
+
+        def getPath(self, *_args, **_kwargs):
+            return object()
+
+        def goToPose(self, *_args, **_kwargs):
+            return None
+
+        def isTaskComplete(self):
+            return self.cancelled
+
+        def cancelTask(self):
+            self.cancelled = True
+
+        def getFeedback(self):
+            return None
+
+    navigator = FakeNavigator()
+    controller = Nav2Controller.__new__(Nav2Controller)
+    controller.skill = SimpleNamespace(sleep=lambda _seconds: None)
+    controller.logger = SimpleNamespace(info=lambda _message: None, warning=lambda _message: None)
+    controller.navigator = navigator
+    controller.navigator_mapfree = navigator
+    controller.navigator_navigation = navigator
+    controller._commanded_goal_pub = SimpleNamespace(publish=lambda _goal: None)
+    controller._resolve_goal = lambda x, y, theta, _local: (x, y, theta, "odom")
+    controller._pose_stamped = lambda x, y, theta, frame: (x, y, theta, frame)
+
+    replacement = object()
+    result = controller.go_to_position(1.0, 0.0, 0.0, True, reassess=lambda: replacement)
+
+    assert result is replacement
+    assert navigator.cancelled

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -16,6 +16,9 @@ import pytest
 from brain_client.brain.context import GeminiContext, _decision_from
 from brain_client.brain.prompt import build_system_prompt
 from brain_client.brain.tools import (
+    END_CONTINUOUS_NAVIGATION,
+    GO_TO_POINT_IN_VIEW,
+    NAV_INSIGHT_CONTINUOUS,
     STOP_SKILL,
     WAIT,
     assign_tool_names,
@@ -128,6 +131,30 @@ def test_build_tools_while_running_with_user_speech_offers_stop_alone():
 def test_build_tools_with_no_skills_still_offers_wait():
     declarations = build_tools([], None)[0]["functionDeclarations"]
     assert [d["name"] for d in declarations] == ["wait"]
+
+
+def test_continuous_navigation_tools_follow_visual_navigation_availability():
+    unavailable = build_tools([], None)[0]["functionDeclarations"]
+    assert NAV_INSIGHT_CONTINUOUS not in [d["name"] for d in unavailable]
+
+    idle = build_tools([], None, can_go_to_point_in_view=True)[0]["functionDeclarations"]
+    assert [d["name"] for d in idle] == [GO_TO_POINT_IN_VIEW, NAV_INSIGHT_CONTINUOUS, WAIT]
+
+    active = build_tools([], None, can_go_to_point_in_view=True, continuous_navigation_active=True)[0][
+        "functionDeclarations"
+    ]
+    assert [d["name"] for d in active] == [GO_TO_POINT_IN_VIEW, END_CONTINUOUS_NAVIGATION, WAIT]
+
+    actuator_removed = build_tools([], None, continuous_navigation_active=True)[0]["functionDeclarations"]
+    assert [d["name"] for d in actuator_removed] == [END_CONTINUOUS_NAVIGATION, WAIT]
+
+    moving = build_tools([], "navigate_to_position", continuous_navigation_active=True)[0]["functionDeclarations"]
+    assert [d["name"] for d in moving] == [
+        STOP_SKILL,
+        GO_TO_POINT_IN_VIEW,
+        END_CONTINUOUS_NAVIGATION,
+        WAIT,
+    ]
 
 
 def test_unknown_param_type_falls_back_to_annotated_string():
@@ -677,6 +704,114 @@ def test_go_to_point_rejects_out_of_range_coordinates(agent_factory):
     assert started == []
     outcome = agent._context._history[-1]["parts"][0]["functionResponse"]["response"]["outcome"]
     assert outcome == "rejected — y and x must be within 0-1000 image coordinates"
+
+
+def test_local_agent_runs_a_continuous_navigation_step_and_finishes(agent_factory):
+    """The real turn/dispatch path carries the objective across bounded Nav2 steps."""
+    from brain_client.skills.registry import SkillRegistry
+
+    agent, state = agent_factory()
+    state.registry = SkillRegistry.from_metadata([NAV_SKILL])
+    agent._roster.active_skill_ids = lambda: [NAV_SKILL["id"]]
+    agent._camera.fresh_image_jpeg = lambda max_age: FRAME
+    agent._camera.fresh_frame = lambda max_age: (FRAME, -10.0)
+    agent._config.vertical_fov = CAM["vertical_fov_deg"]
+    agent._config.height_cam = CAM["cam_height"]
+    agent._config.x_cam = CAM["cam_forward"]
+    started = []
+    agent._runner.start_task = lambda *a, **k: started.append(a)
+
+    responses = iter(
+        [
+            model_response(call_part(NAV_INSIGHT_CONTINUOUS, {"target_description": "the end of the hall"})),
+            model_response(call_part(GO_TO_POINT_IN_VIEW, {"y": 900, "x": 500})),
+            model_response(
+                call_part(
+                    END_CONTINUOUS_NAVIGATION,
+                    {"status": "reached", "reason": "the end wall is directly in front of me"},
+                )
+            ),
+        ]
+    )
+    request_bodies = []
+
+    def transport(model, body):
+        request_bodies.append(body)
+        return [next(responses)]
+
+    agent._context._transport = transport
+    run_turn(agent)
+    assert agent._continuous_navigation_target == "the end of the hall"
+
+    run_turn(agent)
+    assert len(started) == 1, agent._context._history[-1]
+    assert started[0][0] == NAV_SKILL["id"]
+    assert started[0][2]["local_frame"] is True
+    system = request_bodies[1]["systemInstruction"]["parts"][0]["text"]
+    assert "one bounded step" in system
+    observation = request_bodies[1]["contents"][-1]["parts"][0]["text"]
+    assert 'Continuous navigation objective: "the end of the hall"' in observation
+
+    run_turn(agent)
+    assert agent._continuous_navigation_target is None
+
+
+def test_continuous_navigation_replaces_a_running_waypoint_from_a_fresh_frame(agent_factory):
+    agent, state = agent_factory()
+    agent._roster.active_skill_ids = lambda: [NAV_SKILL["id"]]
+    agent._continuous_navigation_target = "the end of the hall"
+    agent._frame_at_capture = FRAME
+    agent._pitch_at_capture = -10.0
+    agent._config.vertical_fov = CAM["vertical_fov_deg"]
+    agent._config.height_cam = CAM["cam_height"]
+    agent._config.x_cam = CAM["cam_forward"]
+    state.primitive_running = RunningSkill(
+        primitive_name="navigate_to_position",
+        skill_id=NAV_SKILL["id"],
+        primitive_id="first-step",
+    )
+    cancelled = []
+    started = []
+    agent._runner.has_active_goal = True
+    agent._runner.cancel_active_goal = lambda: cancelled.append(True)
+    agent._runner.start_task = lambda *args: started.append(args)
+
+    outcome = agent._go_to_point_in_view({"y": 900, "x": 500})
+
+    assert "replacing" in outcome
+    assert cancelled == [True]
+    assert agent._continuous_navigation_pending_goal is not None
+    assert started == []
+
+    # A newer frame can revise the queued goal without issuing duplicate
+    # cancellation requests. Only the latest visual decision is executed.
+    first_pending = agent._continuous_navigation_pending_goal
+    outcome = agent._go_to_point_in_view({"y": 900, "x": 550})
+    assert "newest camera frame" in outcome
+    assert cancelled == [True]
+    assert agent._continuous_navigation_pending_goal != first_pending
+
+    # The cancellation result has released the runner slot before it reports
+    # the terminal event. The latest visual goal becomes the next Nav2 step.
+    state.primitive_running = None
+    agent.on_skill_event("interrupted", "navigate_to_position", "replanning")
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(0), agent._runtime.loop).result(timeout=2)
+
+    assert len(started) == 1
+    assert started[0][0] == NAV_SKILL["id"]
+    assert agent._continuous_navigation_target == "the end of the hall"
+    assert agent._continuous_navigation_pending_goal is None
+
+
+def test_external_navigation_interruption_clears_continuous_mode(agent_factory):
+    agent, _ = agent_factory()
+    agent._continuous_navigation_target = "the end of the hall"
+
+    agent.on_skill_event("interrupted", "navigate_to_position", "Stopped from the app")
+    # Barrier behind the callback posted by on_skill_event.
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(0), agent._runtime.loop).result(timeout=2)
+
+    assert agent._continuous_navigation_target is None
 
 
 def test_chat_failure_after_commit_still_answers_the_models_calls(agent_factory, monkeypatch):

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -52,6 +52,21 @@ class DemoAgent(Agent):
 
     def get_prompt(self) -> str:
         """Return the prompt that defines the robot's personality and behavior"""
+        return (
+            self._personality()
+            + """
+
+Navigation choice: when asked to drive continuously, follow a corridor to its end,
+or travel toward a distant visually described destination, prefer the standalone
+continuous_navigation(target_description=...) skill. Launch it once and let its
+own visual loop guide the journey. Use nav_insight_continuous only when the user
+specifically requests the local-agent-loop implementation. Nearby single moves
+still use go_to_point_in_view. While continuous_navigation runs, answer questions
+without interrupting it; stop it immediately if the user asks to stop or switch tasks.
+"""
+        )
+
+    def _personality(self) -> str:
         return """You are Mars, a friendly and curious robot assistant. Keep responses concise and conversational. You can see through a camera and use tools to wave, move, and interact. You have a long-term memory of what you've seen on this map — consult it via your skills before saying no. On the first user interaction in a new conversation, briefly say what you can do and invite one concrete next action: ask where you should navigate, whether you should wave, or what object you should pick up. Do this once, not on every reply. Greet people warmly when you see them! Whenever you say something, also use a head emotion, one of "happy", "very_happy", "sad", "excited", "angry", "agreeing", prefer "very_happy" for 12 syllables or more sentence. IMPORTANT: If the user says 'stop' or interrupts you during an action, STOP immediately, and do NOT retry or call the tool again. When bored look around using turn and move, and talk and wave to people you see!"""
 
     def uses_gaze(self) -> bool:

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -3,6 +3,7 @@
 from innate_skills.change_volume import ChangeVolume
 from innate_skills.check_battery import CheckBattery
 from innate_skills.close_gripper import CloseGripper
+from innate_skills.continuous_navigation import ContinuousNavigation
 from innate_skills.drop_in_box import DropInBox
 from innate_skills.head_emotion import HeadEmotion
 from innate_skills.navigate_to_position import NavigateToPosition
@@ -33,6 +34,7 @@ class DemoAgent(Agent):
         ref generated inside the recording folder (see skills/physical_refs.py)."""
         return [
             NavigateToPosition,
+            ContinuousNavigation,
             Wave,
             PickAnyObject,
             OpenGripper,

--- a/workspace/innate_skills/continuous_navigation.py
+++ b/workspace/innate_skills/continuous_navigation.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Standalone continuous visual navigation.
+
+Unlike the local brain's built-in continuous-navigation mode, this is a real
+long-running skill. It owns its camera/model loop and keeps reassessing while
+its Nav2 action is still moving. A new visual waypoint replaces the in-flight
+goal; KEEP_CURRENT leaves Nav2 alone so the base does not brake and accelerate
+again on every model turn.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from enum import Enum
+
+from innate_skills.navigate_to_position import Nav2Controller
+
+from brain_client.perception.pose import compute_pose_delta
+from innate import HeadState, MainImage, Map, Odometry, Pose, Skill, SkillReturn, resource
+from innate import gemini as gemlib
+from innate.geometry import IMG_H, IMG_W, pixel_to_floor
+
+REASSESS_INTERVAL_S = 3.0
+MAX_VISUAL_RANGE_M = 3.5
+STANDOFF_M = 0.35
+SAME_GOAL_DISTANCE_M = 0.45
+SAME_GOAL_HEADING_RAD = math.radians(25.0)
+MAX_CONSECUTIVE_MODEL_FAILURES = 3
+
+
+class NavigationStatus(str, Enum):
+    CONTINUE = "CONTINUE"
+    KEEP_CURRENT = "KEEP_CURRENT"
+    OBJECTIVE_REACHED = "OBJECTIVE_REACHED"
+    CANNOT_PROCEED = "CANNOT_PROCEED"
+
+
+@dataclass(frozen=True)
+class VisualDecision:
+    status: NavigationStatus
+    explanation: str
+    progress_description: str = ""
+    x: int | None = None
+    y: int | None = None
+
+
+@dataclass(frozen=True)
+class NavigationDirective:
+    decision: VisualDecision
+    # Stable odom-frame destination. The model may take seconds to answer and
+    # Nav2 may need time to cancel, so retaining robot-relative coordinates
+    # here would make every replacement waypoint stale before it starts.
+    odom_goal: tuple[float, float, float] | None = None
+
+
+def parse_visual_decision(reply: str | None, *, allow_keep: bool) -> VisualDecision | None:
+    """Parse the model's bounded JSON contract; malformed output is no action."""
+    if not reply:
+        return None
+    start, end = reply.find("{"), reply.rfind("}")
+    if start < 0 or end < start:
+        return None
+    try:
+        payload = json.loads(reply[start : end + 1])
+        status = NavigationStatus(str(payload.get("status", "")).strip().upper())
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+    explanation = str(payload.get("explanation") or "").strip()[:500]
+    progress = str(payload.get("progress_description") or "").strip()[:500]
+    if not explanation:
+        return None
+    if status == NavigationStatus.KEEP_CURRENT:
+        return VisualDecision(status, explanation, progress) if allow_keep else None
+    if status != NavigationStatus.CONTINUE:
+        return VisualDecision(status, explanation, progress)
+
+    x, y = payload.get("x"), payload.get("y")
+    if isinstance(x, bool) or isinstance(y, bool) or not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+        return None
+    x, y = round(x), round(y)
+    if not (0 <= x <= 1000 and 0 <= y <= 1000):
+        return None
+    return VisualDecision(status, explanation, progress, x=x, y=y)
+
+
+def decision_odom_goal(
+    decision: VisualDecision,
+    frame: MainImage,
+    head_pitch_degrees: float,
+    capture_pose: tuple[float, float, float],
+) -> tuple[float, float, float] | None:
+    """Ground a model-selected floor pixel into a stable odom-frame goal."""
+    if decision.x is None or decision.y is None:
+        return None
+    u = decision.x / 1000.0 * (IMG_W - 1)
+    v = decision.y / 1000.0 * (IMG_H - 1)
+    floor = pixel_to_floor(u, v, head_pitch_degrees)
+    if floor is None:
+        return None
+
+    floor_x, floor_y = floor
+    distance = math.hypot(floor_x, floor_y)
+    if distance > MAX_VISUAL_RANGE_M:
+        scale = MAX_VISUAL_RANGE_M / distance
+        floor_x, floor_y, distance = floor_x * scale, floor_y * scale, MAX_VISUAL_RANGE_M
+    travel = max(0.0, distance - STANDOFF_M)
+    heading = math.atan2(floor_y, floor_x)
+    local_x = travel * math.cos(heading)
+    local_y = travel * math.sin(heading)
+
+    ox, oy, oth = capture_pose
+    c, s = math.cos(oth), math.sin(oth)
+    return (
+        ox + c * local_x - s * local_y,
+        oy + s * local_x + c * local_y,
+        math.atan2(math.sin(oth + heading), math.cos(oth + heading)),
+    )
+
+
+def local_goal(
+    odom_goal: tuple[float, float, float], current_pose: tuple[float, float, float]
+) -> tuple[float, float, float]:
+    """Re-express a stable odom destination in the robot's current frame."""
+    return compute_pose_delta(current_pose, odom_goal)
+
+
+def _same_goal(a: tuple[float, float, float], b: tuple[float, float, float]) -> bool:
+    heading_delta = abs(math.atan2(math.sin(a[2] - b[2]), math.cos(a[2] - b[2])))
+    return math.hypot(a[0] - b[0], a[1] - b[1]) <= SAME_GOAL_DISTANCE_M and heading_delta <= SAME_GOAL_HEADING_RAD
+
+
+class ContinuousNavigation(Skill):
+    """Continuously navigate toward a distant visually described target.
+
+    This is the separately launchable skill implementation. It uses fresh
+    head-camera frames while Nav2 is moving, keeps the current waypoint when
+    it remains appropriate, replaces it when the visual route changes, and
+    stops only when the target is visibly reached or progress is unsafe.
+    Requires target_description (for example, "the traffic lights at the
+    intersection"). Use the local agent's nav_insight_continuous mode instead
+    when you want the agent itself to retain control of the loop.
+    """
+
+    main_image: MainImage
+    head_position: HeadState
+    odom: Odometry
+    map: Map | None
+    pose: Pose | None
+
+    @resource
+    def _proxy(self):
+        return gemlib.make_client()
+
+    @resource
+    def controller(self) -> Iterator[Nav2Controller]:
+        controller = Nav2Controller(self)
+        yield controller
+        controller.destroy()
+
+    def execute(self, target_description: str, max_iterations: int = 50) -> SkillReturn:
+        target = target_description.strip()
+        if not target:
+            self.fail("target_description cannot be empty")
+        if self._proxy is None:
+            self.fail("Continuous navigation needs Innate Gemini access; check INNATE_SERVICE_KEY")
+
+        self._target = target[:500]
+        self._max_iterations = max(1, min(int(max_iterations), 100))
+        self._iteration = 0
+        self._previous_image: MainImage | None = None
+        self._next_assessment_at = 0.0
+        self._consecutive_model_failures = 0
+        self._active_goal: tuple[float, float, float] | None = None
+        self.on_cancel(self.controller.cancel_navigation)
+
+        self.feedback(f"Starting continuous visual navigation toward: {self._target}")
+        directive = self._decide(is_moving=False)
+        while True:
+            if directive.decision.status == NavigationStatus.OBJECTIVE_REACHED:
+                return f"Reached {self._target}: {directive.decision.explanation}"
+            if directive.decision.status == NavigationStatus.CANNOT_PROCEED:
+                self.fail(f"Could not reach {self._target}: {directive.decision.explanation}")
+            if directive.odom_goal is None:
+                self.fail("Continuous navigation did not produce a grounded waypoint")
+
+            self._active_goal = directive.odom_goal
+            current = self.odom
+            x, y, theta = local_goal(self._active_goal, (current.x, current.y, current.theta))
+            self._next_assessment_at = time.monotonic() + REASSESS_INTERVAL_S
+            replanned = self.controller.go_to_position(x, y, theta, True, reassess=self._reassess_while_moving)
+            if isinstance(replanned, NavigationDirective):
+                directive = replanned
+                continue
+
+            # A waypoint is only progress, never proof that the semantic target
+            # was reached. Look again and let vision make that determination.
+            self.feedback("Waypoint reached; reassessing the objective from the current view")
+            directive = self._decide(is_moving=False)
+
+    def _reassess_while_moving(self) -> NavigationDirective | None:
+        if time.monotonic() < self._next_assessment_at:
+            return None
+        self._next_assessment_at = time.monotonic() + REASSESS_INTERVAL_S
+        directive = self._decide(is_moving=True)
+        if directive.decision.status == NavigationStatus.KEEP_CURRENT:
+            return None
+        if (
+            directive.odom_goal is not None
+            and self._active_goal is not None
+            and _same_goal(directive.odom_goal, self._active_goal)
+        ):
+            self.feedback("Visual route is unchanged; keeping the current Nav2 waypoint")
+            return None
+        return directive
+
+    def _decide(self, *, is_moving: bool) -> NavigationDirective:
+        if self._iteration >= self._max_iterations:
+            return NavigationDirective(
+                VisualDecision(
+                    NavigationStatus.CANNOT_PROCEED,
+                    f"maximum of {self._max_iterations} visual reassessments reached",
+                )
+            )
+
+        frame = self.main_image
+        head = self.head_position
+        odom = self.odom
+        capture_pose = (odom.x, odom.y, odom.theta)
+        previous = self._previous_image
+        self._iteration += 1
+        prompt = self._prompt(is_moving=is_moving, has_previous=previous is not None)
+        images = [frame, previous] if previous is not None else frame
+        reply = gemlib.ask_image(self._proxy, images, prompt, logger=self.logger, retries=1 if is_moving else 2)
+        self.check_cancelled()
+        decision = parse_visual_decision(reply, allow_keep=is_moving)
+        self._previous_image = frame
+
+        if decision is None:
+            self._consecutive_model_failures += 1
+            if is_moving and self._consecutive_model_failures < MAX_CONSECUTIVE_MODEL_FAILURES:
+                self.feedback("Visual reassessment was invalid; keeping the current safe waypoint")
+                return NavigationDirective(
+                    VisualDecision(NavigationStatus.KEEP_CURRENT, "invalid visual response; keeping current waypoint")
+                )
+            return NavigationDirective(
+                VisualDecision(
+                    NavigationStatus.CANNOT_PROCEED, "visual navigation model did not return a valid decision"
+                )
+            )
+
+        self._consecutive_model_failures = 0
+        detail = decision.progress_description or decision.explanation
+        self.feedback(f"[{self._iteration}/{self._max_iterations}] {detail}")
+        if decision.status != NavigationStatus.CONTINUE:
+            return NavigationDirective(decision)
+
+        goal = decision_odom_goal(decision, frame, head.pitch_degrees, capture_pose)
+        if goal is None:
+            if is_moving:
+                self.feedback("Selected point was not on reachable floor; keeping the current waypoint")
+                return NavigationDirective(
+                    VisualDecision(NavigationStatus.KEEP_CURRENT, "selected point did not project onto the floor")
+                )
+            return NavigationDirective(
+                VisualDecision(NavigationStatus.CANNOT_PROCEED, "the selected point did not project onto the floor")
+            )
+        return NavigationDirective(decision, goal)
+
+    def _prompt(self, *, is_moving: bool, has_previous: bool) -> str:
+        moving = (
+            "The robot is CURRENTLY MOVING toward its previous safe waypoint. Return KEEP_CURRENT if that waypoint "
+            "still follows the best visible route; use CONTINUE only if it should be replaced."
+            if is_moving
+            else "The robot is stopped and needs a new waypoint; do not return KEEP_CURRENT."
+        )
+        previous = "Image 2 is the previous assessed view for progress comparison." if has_previous else ""
+        return f"""You are the visual navigation controller for a wheeled indoor robot.
+
+OBJECTIVE: {self._target}
+ASSESSMENT: {self._iteration}/{self._max_iterations}
+Image 1 is the fresh current head-camera view. {previous}
+{moving}
+
+Choose exactly one status:
+- CONTINUE: provide x and y from 0 to 1000 for a visibly clear point ON THE FLOOR in Image 1 that advances the objective.
+- KEEP_CURRENT: only while already moving and the existing waypoint remains appropriate.
+- OBJECTIVE_REACHED: only with current visual evidence that the robot has reached a useful stopping position.
+- CANNOT_PROCEED: the route is visibly blocked, unsafe, or the objective cannot be located after reasonable exploration.
+
+Do not point through objects, walls, vehicles, curbs, or people. For a visible target, point at clear floor leading toward
+it, not on the object itself. Return JSON only:
+{{"status":"CONTINUE|KEEP_CURRENT|OBJECTIVE_REACHED|CANNOT_PROCEED","x":0,"y":0,
+"explanation":"brief reason","progress_description":"change since the previous view"}}
+"""

--- a/workspace/innate_skills/continuous_navigation.py
+++ b/workspace/innate_skills/continuous_navigation.py
@@ -5,8 +5,8 @@
 Unlike the local brain's built-in continuous-navigation mode, this is a real
 long-running skill. It owns its camera/model loop and keeps reassessing while
 its Nav2 action is still moving. A new visual waypoint replaces the in-flight
-goal; KEEP_CURRENT leaves Nav2 alone so the base does not brake and accelerate
-again on every model turn.
+goal even when the route is unchanged. Only duplicate destinations or a
+transient invalid observation leave the current waypoint untouched.
 """
 
 from __future__ import annotations
@@ -137,8 +137,8 @@ class ContinuousNavigation(Skill):
     """Continuously navigate toward a distant visually described target.
 
     This is the separately launchable skill implementation. It uses fresh
-    head-camera frames while Nav2 is moving, keeps the current waypoint when
-    it remains appropriate, replaces it when the visual route changes, and
+    head-camera frames while Nav2 is moving, advances the waypoint along the
+    visible route without waiting to arrive at the previous waypoint, and
     stops only when the target is visibly reached or progress is unsafe.
     Requires target_description (for example, "the traffic lights at the
     intersection"). Use the local agent's nav_insight_continuous mode instead
@@ -210,8 +210,10 @@ class ContinuousNavigation(Skill):
             and self._active_goal is not None
             and _same_goal(directive.odom_goal, self._active_goal)
         ):
-            self.feedback("Visual route is unchanged; keeping the current Nav2 waypoint")
+            self.feedback("Selected destination duplicates the active waypoint; reassessing again while moving")
             return None
+        if directive.odom_goal is not None:
+            self.feedback("Advancing visual waypoint before the current navigation finishes")
         return directive
 
     def _decide(self, *, is_moving: bool) -> NavigationDirective:
@@ -241,7 +243,9 @@ class ContinuousNavigation(Skill):
             reasoning_effort="low",
         )
         self.check_cancelled()
-        decision = parse_visual_decision(reply, allow_keep=is_moving)
+        # KEEP_CURRENT is an internal fallback, not a model choice: a clear
+        # unchanged route still needs a fresh look-ahead point on every turn.
+        decision = parse_visual_decision(reply, allow_keep=False)
         self._previous_image = frame
 
         if decision is None:
@@ -259,7 +263,7 @@ class ContinuousNavigation(Skill):
 
         self._consecutive_model_failures = 0
         detail = decision.progress_description or decision.explanation
-        self.feedback(f"[{self._iteration}/{self._max_iterations}] {detail}")
+        self.feedback(f"[{self._iteration}/{self._max_iterations}] {decision.status.value}: {detail}")
         if decision.status != NavigationStatus.CONTINUE:
             return NavigationDirective(decision)
 
@@ -277,8 +281,11 @@ class ContinuousNavigation(Skill):
 
     def _prompt(self, *, is_moving: bool, has_previous: bool) -> str:
         moving = (
-            "The robot is CURRENTLY MOVING toward its previous safe waypoint. Return KEEP_CURRENT if that waypoint "
-            "still follows the best visible route; use CONTINUE only if it should be replaced."
+            "The robot is CURRENTLY MOVING. Select a NEW look-ahead floor point from the fresh current image "
+            "on EVERY assessment, even when the route is unchanged. Advance the destination along the clear "
+            "visible route as the robot moves; do not wait for arrival at the previous waypoint. "
+            "Choose far enough ahead to sustain progress, within visibly safe floor. "
+            "The previous waypoint is provisional, not a destination you must finish."
             if is_moving
             else "The robot is stopped and needs a new waypoint; do not return KEEP_CURRENT."
         )
@@ -292,12 +299,11 @@ Image 1 is the fresh current head-camera view. {previous}
 
 Choose exactly one status:
 - CONTINUE: provide x and y from 0 to 1000 for a visibly clear point ON THE FLOOR in Image 1 that advances the objective.
-- KEEP_CURRENT: only while already moving and the existing waypoint remains appropriate.
 - OBJECTIVE_REACHED: only with current visual evidence that the robot has reached a useful stopping position.
 - CANNOT_PROCEED: the route is visibly blocked, unsafe, or the objective cannot be located after reasonable exploration.
 
 Do not point through objects, walls, vehicles, curbs, or people. For a visible target, point at clear floor leading toward
 it, not on the object itself. Return JSON only:
-{{"status":"CONTINUE|KEEP_CURRENT|OBJECTIVE_REACHED|CANNOT_PROCEED","x":0,"y":0,
+{{"status":"CONTINUE|OBJECTIVE_REACHED|CANNOT_PROCEED","x":0,"y":0,
 "explanation":"brief reason","progress_description":"change since the previous view"}}
 """

--- a/workspace/innate_skills/continuous_navigation.py
+++ b/workspace/innate_skills/continuous_navigation.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import json
 import math
-import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
@@ -25,7 +24,6 @@ from innate import HeadState, MainImage, Map, Odometry, Pose, Skill, SkillReturn
 from innate import gemini as gemlib
 from innate.geometry import IMG_H, IMG_W, pixel_to_floor
 
-REASSESS_INTERVAL_S = 3.0
 MAX_VISUAL_RANGE_M = 3.5
 STANDOFF_M = 0.35
 SAME_GOAL_DISTANCE_M = 0.45
@@ -174,7 +172,6 @@ class ContinuousNavigation(Skill):
         self._max_iterations = max(1, min(int(max_iterations), 100))
         self._iteration = 0
         self._previous_image: MainImage | None = None
-        self._next_assessment_at = 0.0
         self._consecutive_model_failures = 0
         self._active_goal: tuple[float, float, float] | None = None
         self.on_cancel(self.controller.cancel_navigation)
@@ -192,7 +189,6 @@ class ContinuousNavigation(Skill):
             self._active_goal = directive.odom_goal
             current = self.odom
             x, y, theta = local_goal(self._active_goal, (current.x, current.y, current.theta))
-            self._next_assessment_at = time.monotonic() + REASSESS_INTERVAL_S
             replanned = self.controller.go_to_position(x, y, theta, True, reassess=self._reassess_while_moving)
             if isinstance(replanned, NavigationDirective):
                 directive = replanned
@@ -204,9 +200,8 @@ class ContinuousNavigation(Skill):
             directive = self._decide(is_moving=False)
 
     def _reassess_while_moving(self) -> NavigationDirective | None:
-        if time.monotonic() < self._next_assessment_at:
-            return None
-        self._next_assessment_at = time.monotonic() + REASSESS_INTERVAL_S
+        # Model calls are serial: start the next look on the next controller
+        # poll, with no extra timer after a decision or waypoint replacement.
         directive = self._decide(is_moving=True)
         if directive.decision.status == NavigationStatus.KEEP_CURRENT:
             return None

--- a/workspace/innate_skills/continuous_navigation.py
+++ b/workspace/innate_skills/continuous_navigation.py
@@ -236,7 +236,15 @@ class ContinuousNavigation(Skill):
         self._iteration += 1
         prompt = self._prompt(is_moving=is_moving, has_previous=previous is not None)
         images = [frame, previous] if previous is not None else frame
-        reply = gemlib.ask_image(self._proxy, images, prompt, logger=self.logger, retries=1 if is_moving else 2)
+        reply = gemlib.ask_image(
+            self._proxy,
+            images,
+            prompt,
+            logger=self.logger,
+            retries=1 if is_moving else 2,
+            model="gemini-3.8-flash",
+            reasoning_effort="low",
+        )
         self.check_cancelled()
         decision = parse_visual_decision(reply, allow_keep=is_moving)
         self._previous_image = frame

--- a/workspace/innate_skills/navigate_to_position.py
+++ b/workspace/innate_skills/navigate_to_position.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 Innate Inc
 import math
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 from geometry_msgs.msg import PoseStamped
 from nav2_simple_commander.robot_navigator import BasicNavigator, TaskResult
@@ -238,10 +238,39 @@ class Nav2Controller:
             )
         return detail
 
-    def go_to_position(self, x: float, y: float, theta: float, local_frame: bool) -> None:
+    def cancel_navigation(self) -> None:
+        """Best-effort stop for a skill cancel or an internal visual replan."""
+        try:
+            self.navigator.cancelTask()
+        except Exception as e:
+            self.logger.warning(f"Could not cancel Nav2 task: {e}")
+
+    def _cancel_for_replan(self) -> None:
+        """Cancel the current goal and wait until Nav2 releases it."""
+        self.navigator.cancelTask()
+        deadline = time.monotonic() + 3.0
+        while not self.navigator.isTaskComplete():
+            if time.monotonic() >= deadline:
+                raise SkillFailed("Nav2 did not stop the previous goal in time to replan safely")
+            self.skill.sleep(0.05)
+
+    def go_to_position(
+        self,
+        x: float,
+        y: float,
+        theta: float,
+        local_frame: bool,
+        reassess: Callable[[], object | None] | None = None,
+    ) -> object | None:
         """Navigate to the goal, blocking until Nav2 finishes. Raises
         SkillFailed with a human-readable reason; a skill cancel unwinds as
-        SkillCancelled with the Nav2 task cancelled."""
+        SkillCancelled with the Nav2 task cancelled.
+
+        ``reassess`` runs while the action is in flight. Returning a value
+        cancels this goal and hands that value back to the caller, which lets a
+        long-running visual-navigation skill replace or end a waypoint without
+        waiting for it to complete. Returning None leaves the goal untouched.
+        """
         goal_x, goal_y, goal_yaw, goal_frame = self._resolve_goal(x, y, theta, local_frame)
 
         goal_pose = self._pose_stamped(goal_x, goal_y, goal_yaw, goal_frame)
@@ -260,11 +289,18 @@ class Nav2Controller:
         said_close_to_goal = False
         last_pose = None
         while not self.navigator.isTaskComplete():
+            directive = None
             try:
                 self.skill.sleep(0.1)
+                directive = reassess() if reassess is not None else None
             except SkillCancelled:
-                self.navigator.cancelTask()
+                self.cancel_navigation()
                 raise
+
+            if directive is not None:
+                if not self.navigator.isTaskComplete():
+                    self._cancel_for_replan()
+                return directive
 
             feedback = self.navigator.getFeedback()
             if not feedback:
@@ -298,7 +334,7 @@ class Nav2Controller:
 
         result = self.navigator.getResult()
         if result == TaskResult.SUCCEEDED:
-            return
+            return None
         detail = f"Nav2 reported {getattr(result, 'name', result)}"
         if last_distance >= 0.0:
             detail += f" with {last_distance:.2f}m still to go"


### PR DESCRIPTION
## Summary
- keep `nav_insight_continuous(target_description)` as a built-in mode in the new local-agent loop
- add `innate-os/continuous_navigation` as a separately launchable, long-running skill with its own camera and Gemini decision loop
- reassess fresh camera frames while Nav2 is still moving; keep an unchanged waypoint without restarting the base, or cancel and replace an in-flight waypoint when the visual route changes
- ground model-selected floor pixels into stable odom-frame goals so model and cancellation latency do not stale the next command
- stop active motion on reached, blocked, user cancel, deactivation, navigation failure, or external interruption

## Two implementations
1. **Local agent mode**: the agent retains the objective and supervises bounded `go_to_point_in_view` -> `navigate_to_position` actions from its normal turn loop.
2. **Standalone skill**: `continuous_navigation` owns the full loop inside one skill run and can be launched directly from the skill surface.

Both use Nav2 for path planning and obstacle avoidance. Neither changes the configured drive-speed limits. Replans are only issued for a materially different visual goal so repeated reassessment does not continually reset acceleration.

## Verification
- focused local-brain plus standalone-skill tests: 67 passed
- standalone skill appears live as `innate-os/continuous_navigation` with no load error
- live Low Poly Town run: initial decision, in-motion reassessment, objective reached at the traffic lights
- `ruff check` and `ruff format --check` on all affected files
- `git diff --check`

This remains a draft because the standalone visual policy is intentionally a direct local port and still needs physical-robot validation.