### PR TITLE
ci(sim): upload the demo's sources to Cloud Build, resolve tags on the runner

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -37,5 +37,14 @@ sim/.venv/
 !webapp/
 !webapp/proxy/
 !webapp/proxy/**
+# The demo image (sim/demo/Dockerfile) copies these whole.
+!webapp/**
+!scripts/**
+!sim/demo/
+!sim/demo/**
+!sim/props/
+!sim/props/**
+!sim/challenges/
+!sim/challenges/**
 __pycache__/
 *.pyc

--- a/.github/workflows/publish-sim-demo.yml
+++ b/.github/workflows/publish-sim-demo.yml
@@ -40,6 +40,24 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
+      # The asset and viewer tags are content-addressed via `git ls-files`, which
+      # Cloud Build's upload has no .git for. Resolve here, pass them in.
+      - name: Resolve base image tags
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          resolve() { python3 - "$1" <<'PY'
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, str(Path.cwd() / "sim" / "launcher"))
+          import config
+          print(getattr(config, f"resolve_{sys.argv[1]}_image")(Path.cwd()))
+          PY
+          }
+          echo "assets=$(resolve assets)" >> "$GITHUB_OUTPUT"
+          echo "viewer=$(resolve viewer)" >> "$GITHUB_OUTPUT"
+
       - name: Submit Cloud Build
         shell: bash
         run: |
@@ -57,6 +75,6 @@ jobs:
             --gcs-source-staging-dir="${{ vars.GCP_CLOUD_BUILD_SOURCE_STAGING_DIR }}" \
             --service-account="projects/${{ vars.GCP_PROJECT_ID }}/serviceAccounts/${{ vars.GCP_CLOUD_BUILD_SERVICE_ACCOUNT }}" \
             --config=ci/cloudbuild.sim-demo.yaml \
-            --substitutions="_IMAGE_TAG=sha-${short_sha},_LATEST_TAG=${latest_tag},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }}"
+            --substitutions="_IMAGE_TAG=sha-${short_sha},_LATEST_TAG=${latest_tag},_ASSETS_IMAGE=${{ steps.tags.outputs.assets }},_VIEWER_IMAGE=${{ steps.tags.outputs.viewer }},_GHCR_USERNAME_SECRET=${{ vars.GHCR_USERNAME_SECRET }},_GHCR_TOKEN_SECRET=${{ vars.GHCR_TOKEN_SECRET }}"
 
           echo "Published sha-${short_sha}${latest_tag:+ and }${latest_tag}" >> "$GITHUB_STEP_SUMMARY"

--- a/ci/cloudbuild.sim-demo.yaml
+++ b/ci/cloudbuild.sim-demo.yaml
@@ -5,6 +5,8 @@ timeout: 7200s
 substitutions:
   _IMAGE: us-central1-docker.pkg.dev/innate-managed-infra/sim/innate-os-sim-demo
   _IMAGE_TAG: manual
+  _ASSETS_IMAGE: manual
+  _VIEWER_IMAGE: manual
   _GHCR_USERNAME_SECRET: innate-os-sim-ghcr-username
   _GHCR_TOKEN_SECRET: innate-os-sim-ghcr-token
   # Only main moves it.
@@ -18,6 +20,8 @@ steps:
     env:
       - IMAGE=${_IMAGE}
       - TAG=${_IMAGE_TAG}
+      - ASSETS_IMAGE=${_ASSETS_IMAGE}
+      - VIEWER_IMAGE=${_VIEWER_IMAGE}
       - LATEST_TAG=${_LATEST_TAG}
     args:
       - -c


### PR DESCRIPTION
The first run of `publish-sim-demo.yml` (on the #745 merge) failed in three
minutes with exit 127 inside Cloud Build: `sim/demo/build.sh` was not in
`/workspace`.

## Why

`.gcloudignore` is an allowlist written for the simulator images. It admits
`sim/` but only `sim/Dockerfile*` beneath it, and only `webapp/proxy/` and one
script under `scripts/`. The demo Dockerfile copies `sim/demo`, `sim/props`,
`sim/challenges`, `webapp/` and `scripts/` whole. None of it was uploaded.

Fixing the upload exposes a second problem: `build.sh` resolves the
content-addressed asset/viewer tags via `git ls-files` and the launcher
package, and Cloud Build's upload has no `.git` (excluded by design) and no
`sim/launcher`. So the tags are resolved **on the runner**, where the checkout
is whole, and passed in as `_ASSETS_IMAGE` / `_VIEWER_IMAGE` — the same shape
`publish-sim-images.yml` already uses. `build.sh` honours those env vars and
skips its own resolve.

## Verified

- `gcloud meta list-files-for-upload` (gcloud's own matcher, no cloud calls)
  now lists `sim/demo/build.sh`, the Dockerfile, and 166 demo-relevant files
  that were previously excluded
- the resolve step, run exactly as the runner will, produces both tags; the
  resulting asset image exists on GHCR
- YAML and `actionlint` clean