### PR TITLE
fix(sim): the hosted demo can build with, and switch to, the backrooms

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -46,5 +46,7 @@ sim/.venv/
 !sim/props/**
 !sim/challenges/
 !sim/challenges/**
+!sim/environments/
+!sim/environments/**
 __pycache__/
 *.pyc

--- a/.github/workflows/publish-sim-demo.yml
+++ b/.github/workflows/publish-sim-demo.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     paths:
       - .github/workflows/publish-sim-demo.yml
+      - .gcloudignore
       - ci/cloudbuild.sim-demo.yaml
       - sim/demo/**
       - sim/launcher/config.py


### PR DESCRIPTION
Two follow-ups to #756 for the hosted demo (sim.innate.bot):

- **Build:** the demo Dockerfile copies `sim/environments`, but Cloud Build works from a source tarball filtered by `.gcloudignore`, which never admitted that tree, so the build on main fails at that COPY. Admitted now, and `.gcloudignore` is in the demo workflow's trigger paths.
- **Switch:** the demo's launch script seeded only the apartment map into Nav2's maps folder, so switching to the backrooms on sim.innate.bot was refused with `Nav2 did not load backrooms.yaml`. It now seeds every pack's map, like the dev launch script.
- **Guard:** a host test checks that every tree the demo Dockerfile copies is admitted by both `.gcloudignore` and the demo dockerignore. It runs on every PR and flags exactly `sim/environments` against main today.