### PR TITLE
fix(sim): seed the demo with every environment's map, not only the apartment

### DIFF
--- a/sim/demo/launch_demo.zsh
+++ b/sim/demo/launch_demo.zsh
@@ -21,7 +21,9 @@ tmux new-window -t "$SESSION_NAME" -n sim-driver
 tmux send-keys -t "${SESSION_NAME}:sim-driver" "ros2 launch mars_sim_driver sim_driver.launch.py" C-m
 
 mkdir -p ~/innate-os/data/maps
-cp ~/innate-os/sim/assets/map/sim_apartment.* ~/innate-os/data/maps/ 2>/dev/null || true
+# Every environment's map, as the dev launcher does: switching to one Nav2 has
+# no map for hangs the scene on "loading".
+cp ~/innate-os/sim/assets/map/*.yaml ~/innate-os/sim/assets/map/*.pgm ~/innate-os/data/maps/ 2>/dev/null || true
 
 tmux new-window -t "$SESSION_NAME" -n nav-brain
 tmux send-keys -t "${SESSION_NAME}:nav-brain" "ros2 launch mars_nav mode_manager.launch.py" C-m


### PR DESCRIPTION
Switching the public demo to the **backrooms** environment hangs on
"loading robot and backrooms…"; the console says
`RuntimeError('Nav2 did not load backrooms.yaml')`.

The map is in the assets image. The demo launcher copied only
`sim_apartment.*` into `data/maps/`; the dev launcher copies every
environment pack's `.yaml`/`.pgm`, and its comment explains why. The demo now
does the same.

Surfaced by the first CI-built demo image, whose asset layer is the first to
include the backrooms environment.