### PR TITLE
fix(sim): the hosted demo seeds every pack's map

### DIFF
--- a/sim/demo/launch_demo.zsh
+++ b/sim/demo/launch_demo.zsh
@@ -21,7 +21,8 @@ tmux new-window -t "$SESSION_NAME" -n sim-driver
 tmux send-keys -t "${SESSION_NAME}:sim-driver" "ros2 launch mars_sim_driver sim_driver.launch.py" C-m
 
 mkdir -p ~/innate-os/data/maps
-cp ~/innate-os/sim/assets/map/sim_apartment.* ~/innate-os/data/maps/ 2>/dev/null || true
+cp ~/innate-os/sim/assets/map/*.yaml ~/innate-os/sim/assets/map/*.pgm ~/innate-os/data/maps/ 2>/dev/null || true
+echo sim_apartment.yaml > ~/innate-os/data/.last_map
 
 tmux new-window -t "$SESSION_NAME" -n nav-brain
 tmux send-keys -t "${SESSION_NAME}:nav-brain" "ros2 launch mars_nav mode_manager.launch.py" C-m


### PR DESCRIPTION
The demo's launch script seeded only the apartment map into Nav2's maps folder, so switching to the backrooms on sim.innate.bot was refused with `Nav2 did not load backrooms.yaml`. It now seeds every pack's map, and writes Nav2's saved-map file so the mode manager boots on the apartment map (with two maps present it otherwise picks the alphabetically first, backrooms) while the demo's world starts in the apartment. The dev launcher does both already.