### PR TITLE
fix(sim): make a retired world's GL context current before releasing it

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -360,8 +360,13 @@ class VirtualMars:
         """Release the offscreen GL renderers; must run on the thread that
         rendered with them (macOS GL is main-thread-sensitive)."""
         for renderer in (self._renderer, self._depth_renderer):
-            if renderer is not None:
-                renderer.close()
+            if renderer is None:
+                continue
+            # Renderer.close() destroys its GL context, then mjr_freeContext deletes
+            # textures/framebuffers by id on whatever context is *current* -- a newer
+            # world's, after a switch, whose every frame is then noise.
+            renderer._gl_context.make_current()
+            renderer.close()
         self._renderer = self._depth_renderer = None
 
     def set_cmd_vel(self, vx: float, wz: float) -> None:


### PR DESCRIPTION
## What

After an environment switch (apartment → backrooms, or back), the session's camera frames could come out as colour noise for **both** cameras and stay that way until the next switch. Reported from the hosted demo as "the camera feed is white / the robot says it doesn't see anything".

## Why

`mujoco.Renderer.close()` destroys its GL context first and *then* frees the `MjrContext`. `mjr_freeContext` deletes textures and framebuffers by id on whatever GL context is **current** at that moment. When the retired world is closed after the new world has already rendered, the current context is the new world's, so its framebuffer and textures are deleted by id and every frame it renders afterwards is garbage.

The fix makes the retired renderer's own context current before closing it, so the deletes land on the context that is being destroyed anyway.

## Verification

Reproduced on a GKE session pod (osmesa, `sha-fd5fd47`) by driving the real `WorldServer` with two client threads requesting `jpeg:main`, `jpeg:wrist` and `depth:main` while another thread switched environments 6 times:

| build | corrupted frames / run |
|---|---|
| unpatched | 53, 200, 166, 287 |
| this fix | 0, 0, 0, 0, 0 |

Closing the retired world *before* the new world's first render (an alternative ordering fix) did not help, which is what points at the teardown itself rather than the swap order.