### PR TITLE
perf(ci): stop rebaking the apartment for edits that do not touch it

### DIFF
--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -53,7 +53,9 @@ permissions:
 
 concurrency:
   group: publish-sim-images-${{ github.ref }}
-  cancel-in-progress: true
+  # Queue, never cancel: a cancelled run exports no build cache, so the next
+  # push after one re-bakes CoACD from cold.
+  cancel-in-progress: false
 
 jobs:
   tags:

--- a/sim/Dockerfile.assets
+++ b/sim/Dockerfile.assets
@@ -90,9 +90,11 @@ FROM --platform=$BUILDPLATFORM toolchain AS decomp
 # Off by default so a local build stays readable; CI sets it, because an
 # OOM-killed bake leaves nothing behind to explain itself.
 ARG SIM_RESOURCE_LOG=0
-# The only copy of the pipeline scripts, so editing a tool re-bakes CoACD --
-# and the reason nothing else may land above this line.
-COPY sim/tools ./tools
+# Only the apartment's own scripts: everything copied here is in the cache key
+# of the 17-minute bake below, so the pack tool and the export scripts enter
+# in the layers that run them instead.
+COPY sim/tools/split_apartment_obj.py sim/tools/decompose_rooms.py sim/tools/bake_all_rooms.sh \
+     sim/tools/decompose_objects.py sim/tools/log_resources.sh ./tools/
 COPY --from=raw /raw/apartment.obj ./viewer/assets/apartment_obj/apartment.obj
 COPY sim/assets ./assets
 # The sampler is backgrounded and never reaped: the RUN's shell exiting takes
@@ -103,8 +105,10 @@ RUN set -eux; \
     ./tools/bake_all_rooms.sh; \
     uv run tools/decompose_objects.py
 # Further packs bake in their own layers below the apartment's, so a new pack
-# never invalidates the 17-minute bake above. The backrooms are boxy; 10 cm
-# hulls follow their walls as closely as 5 cm ones and bake in half the time.
+# or a pack-tool edit never invalidates the 17-minute bake above. The backrooms
+# are boxy; 10 cm hulls follow their walls as closely as 5 cm ones and bake in
+# half the time.
+COPY sim/tools/build_environment_pack.py sim/tools/build_viewer_physics.py ./tools/
 COPY --from=raw /raw/backrooms_vr.glb ./viewer/assets/backrooms/backrooms_vr.glb
 RUN uv run tools/build_environment_pack.py decompose backrooms viewer/assets/backrooms/backrooms_vr.glb --threshold 0.1
 
@@ -112,6 +116,7 @@ RUN uv run tools/build_environment_pack.py decompose backrooms viewer/assets/bac
 # Light next to CoACD: GLB -> per-room OBJ+PNG and the nav map.
 FROM decomp AS derived
 ARG SIM_RESOURCE_LOG=0
+COPY sim/tools ./tools
 COPY --from=raw /raw/appartement.glb ./viewer/public/models/appartement.glb
 # HERE, not in a parent: export_nav_map.py instantiates VirtualMars() and
 # rasterises its lidar, so the driver package and robot URDF are inputs to

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -155,16 +155,22 @@ ASSETS_IMAGE_PATHSPECS = (
     "sim/environments",
     "sim/tools",
     "sim/viewer/tools",
-    "ros2_ws/src/mars_bot/mars_sim_driver",
     "ros2_ws/src/mars_bot/mars_sim",
+)
+# The driver modules the build imports to compile a world for the nav map --
+# exactly those, not the package: world_server.py, node.py and the bridges
+# never enter the build, and hashing them renamed the image on every edit.
+_DRIVER = "ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver"
+ASSETS_IMAGE_DRIVER_FILES = tuple(
+    f"{_DRIVER}/{name}.py"
+    for name in ("__init__", "constants", "core", "drive_limits", "environments", "props", "world")
 )
 # Geometry is carved out by EXCLUSION, so a pathspec added above joins the
 # geometry hash by default: wrongly excluded costs a needless refusal, wrongly
-# included reuses geometry that no longer matches.
-NON_GEOMETRY_PATHSPECS = (
-    "ros2_ws/src/mars_bot/mars_sim_driver",
-    "ros2_ws/src/mars_bot/mars_sim",
-)
+# included reuses geometry that no longer matches. The driver files above are
+# excluded the same way: a driver edit renames the image but must not
+# hard-stop `up` (compute_geometry_inputs_hash).
+NON_GEOMETRY_PATHSPECS = ("ros2_ws/src/mars_bot/mars_sim",)
 GEOMETRY_INPUT_PATHSPECS = tuple(p for p in ASSETS_IMAGE_PATHSPECS if p not in NON_GEOMETRY_PATHSPECS)
 # The SimSession bundle the webapp loads, as its own image
 # (sim/viewer/Dockerfile), addressed by inputs-<compute_viewer_inputs_hash over
@@ -550,7 +556,7 @@ def iter_assets_image_input_files(repo_root: Path) -> list[Path]:
     reason. tests/test_assets_image_inputs.py checks that publish-sim-images.yml
     actually rebuilds when one of these changes.
     """
-    return _collect_input_files(repo_root, ASSETS_IMAGE_INPUT_FILES, ASSETS_IMAGE_PATHSPECS)
+    return _collect_input_files(repo_root, ASSETS_IMAGE_INPUT_FILES + ASSETS_IMAGE_DRIVER_FILES, ASSETS_IMAGE_PATHSPECS)
 
 
 @functools.lru_cache


### PR DESCRIPTION
Most asset-image publishes this week were cold 45-minute CoACD bakes for changes that never touched the apartment. Three causes, three fixes:

- **The whole driver package was a hashed input.** The nav map really depends on the driver, but on the seven modules the export imports (`core`, `world`, `constants`, `environments`, `props`, `drive_limits`, `__init__`). Editing `world_server.py` or the map bridge renamed the image for nothing. Those seven are hashed now; the rest of the package is not. They stay out of the launcher's geometry hash, so a driver edit still never hard-stops `up`.
- **All of sim/tools sat above the apartment bake.** Its cache key covered every tool, so an edit to the pack tool re-baked the apartment. The bake stage now copies only the five scripts it runs; the pack bake copies its two; the derived stage copies everything.
- **A push cancelled the in-progress run**, which exports no build cache, so the next run started cold. Runs now queue.

After this, the apartment re-bakes only when its own scripts, its source OBJ, or the pinned toolchain change. Driver and pack-tool edits re-run only the derived stage, about ten minutes with the cache warm.

Verified: `docker build --check` on the Dockerfile, the launcher tests (68, including the hashed-inputs-are-published-paths check), and the input lists inspected: the image hash covers exactly the seven driver modules, the geometry hash none of them.

This PR's own publish is a full bake, since the Dockerfile and config.py are hashed inputs; every publish after it is cheaper.