### PR TITLE
ci(sim): keep the asset bakes cached across branches

### DIFF
--- a/.github/workflows/cleanup-sim-images.yml
+++ b/.github/workflows/cleanup-sim-images.yml
@@ -33,7 +33,8 @@ jobs:
       # Retention policy (every branch tip publishes images):
       #   - main / buildcache / main's current inputs-<hash>: kept forever
       #   - head of a live branch: kept 30 days
-      #   - everything else (superseded mid-branch builds): kept 14 days
+      #   - everything else (superseded mid-branch builds, a branch's
+      #     cache-<branch> asset build cache): kept 14 days
       HEAD_OF_BRANCH_DAYS: "30"
       OTHER_DAYS: "14"
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}

--- a/.github/workflows/publish-sim-images.yml
+++ b/.github/workflows/publish-sim-images.yml
@@ -256,6 +256,7 @@ jobs:
           IMAGE_TAG: ${{ needs.tags.outputs.image_tag }}
           IMAGE_INPUTS_HASH: ${{ needs.tags.outputs.assets_inputs_hash }}
           PUSH_MAIN_TAGS: ${{ needs.tags.outputs.push_main_tags }}
+          CACHE_SCOPE: ${{ github.ref_name }}
           # Deliberately no COMMIT_SHA: ci/build_assets_image.sh sets no
           # image.revision label -- see its header.
           #

--- a/ci/build_assets_image.sh
+++ b/ci/build_assets_image.sh
@@ -13,6 +13,7 @@
 #   IMAGE_TAG           sha-<short12>
 #   IMAGE_INPUTS_HASH   config.compute_assets_image_inputs_hash of the checkout
 #   PUSH_MAIN_TAGS      "true" on main
+#   CACHE_SCOPE         the branch name; unset or "main" writes the shared cache
 #
 # Deliberately NO image.revision label, and so no COMMIT_SHA input: it varies
 # per commit, which changes the config blob and therefore the index digest, so
@@ -54,13 +55,25 @@ if [ "${PUSH_MAIN_TAGS:-false}" = "true" ]; then
   tags+=(--tag "${assets_image}:main")
 fi
 
+# A registry cache export REPLACES the ref's records rather than merging into
+# them, so a branch that wrote `buildcache` would evict main's bakes and cost
+# main's next publish the full 17 minutes. Branches read main's cache and their
+# own, and write only their own (cache-<branch>, aged out by
+# cleanup-sim-images.yml); main alone writes `buildcache`.
+cache_from=(--cache-from "type=registry,ref=${assets_image}:buildcache")
+cache_ref="buildcache"
+if [ -n "${CACHE_SCOPE:-}" ] && [ "${CACHE_SCOPE}" != "main" ]; then
+  cache_ref="cache-$(printf '%s' "${CACHE_SCOPE}" | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-100)"
+  cache_from+=(--cache-from "type=registry,ref=${assets_image}:${cache_ref}")
+fi
+
 DOCKER_BUILDKIT=1 docker buildx build \
   --platform linux/amd64,linux/arm64 \
   --file sim/Dockerfile.assets \
   --build-arg "SIM_RESOURCE_LOG=${SIM_RESOURCE_LOG:-0}" \
   --provenance=false --sbom=false \
-  --cache-from "type=registry,ref=${assets_image}:buildcache" \
-  --cache-to "type=registry,ref=${assets_image}:buildcache,mode=max" \
+  "${cache_from[@]}" \
+  --cache-to "type=registry,ref=${assets_image}:${cache_ref},mode=max" \
   --label "org.opencontainers.image.source=https://github.com/innate-inc/innate-os" \
   "${tags[@]}" \
   --push \

--- a/ci/build_assets_image.sh
+++ b/ci/build_assets_image.sh
@@ -13,7 +13,7 @@
 #   IMAGE_TAG           sha-<short12>
 #   IMAGE_INPUTS_HASH   config.compute_assets_image_inputs_hash of the checkout
 #   PUSH_MAIN_TAGS      "true" on main
-#   CACHE_SCOPE         the branch name; unset or "main" writes the shared cache
+#   CACHE_SCOPE         the ref name; a branch writes its own cache, main the shared one
 #
 # Deliberately NO image.revision label, and so no COMMIT_SHA input: it varies
 # per commit, which changes the config blob and therefore the index digest, so
@@ -60,10 +60,14 @@ fi
 # main's next publish the full 17 minutes. Branches read main's cache and their
 # own, and write only their own (cache-<branch>, aged out by
 # cleanup-sim-images.yml); main alone writes `buildcache`.
+# The hash suffix keeps refs that sanitise alike (feat/x, feat-x) or a tag
+# named main from sharing a cache; PUSH_MAIN_TAGS, not the name, says main.
 cache_from=(--cache-from "type=registry,ref=${assets_image}:buildcache")
 cache_ref="buildcache"
-if [ -n "${CACHE_SCOPE:-}" ] && [ "${CACHE_SCOPE}" != "main" ]; then
-  cache_ref="cache-$(printf '%s' "${CACHE_SCOPE}" | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-100)"
+if [ "${PUSH_MAIN_TAGS:-false}" != "true" ] && [ -n "${CACHE_SCOPE:-}" ]; then
+  scope_slug="$(printf '%s' "${CACHE_SCOPE}" | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-80)"
+  scope_hash="$(printf '%s' "${CACHE_SCOPE}" | git hash-object --stdin | cut -c1-8)"
+  cache_ref="cache-${scope_slug}-${scope_hash}"
   cache_from+=(--cache-from "type=registry,ref=${assets_image}:${cache_ref}")
 fi
 

--- a/ci/seed_asset_context.py
+++ b/ci/seed_asset_context.py
@@ -42,8 +42,9 @@ RAW_FILES = {
         f"{_RAW_RELEASE}/appartement.glb",
         "807ff2613f4b3aaf1fad39645fee19e10cd560296e1a2f59133daa46f8678c38",
     ),
-    # The backrooms pack's one source: build_environment_pack.py derives its
-    # hulls, textured MuJoCo meshes, nav map and viewer copy in-image.
+    # The backrooms pack's one source: decompose_pack.py bakes its hulls and
+    # build_environment_pack.py derives its textured MuJoCo meshes, nav map
+    # and viewer copy, both in-image.
     SIM / "viewer" / "assets" / "backrooms" / "backrooms_vr.glb": (
         f"{_RAW_RELEASE}/backrooms_vr.glb",
         "f8f81dfa8a64a2afe51f0b2f31e6c596fcae196924beedc0f87258344a1ec7bf",

--- a/sim/Dockerfile.assets
+++ b/sim/Dockerfile.assets
@@ -105,12 +105,13 @@ RUN set -eux; \
     ./tools/bake_all_rooms.sh; \
     uv run tools/decompose_objects.py
 # Further packs bake in their own layers below the apartment's, so a new pack
-# or a pack-tool edit never invalidates the 17-minute bake above. The backrooms
-# are boxy; 10 cm hulls follow their walls as closely as 5 cm ones and bake in
-# half the time.
-COPY sim/tools/build_environment_pack.py sim/tools/build_viewer_physics.py ./tools/
+# never invalidates the 17-minute bake above; and only the bake script enters
+# here, so an edit to the rest of the pack tool never re-bakes a pack. The
+# backrooms are boxy; 10 cm hulls follow their walls as closely as 5 cm ones
+# and bake in half the time.
+COPY sim/tools/decompose_pack.py ./tools/
 COPY --from=raw /raw/backrooms_vr.glb ./viewer/assets/backrooms/backrooms_vr.glb
-RUN uv run tools/build_environment_pack.py decompose backrooms viewer/assets/backrooms/backrooms_vr.glb --threshold 0.1
+RUN uv run tools/decompose_pack.py backrooms viewer/assets/backrooms/backrooms_vr.glb --threshold 0.1
 
 # -------------------------------------------------------------- room splitting
 # Light next to CoACD: GLB -> per-room OBJ+PNG and the nav map.
@@ -137,7 +138,7 @@ RUN set -eux; \
 # rather than under physics/.
 RUN uv run tools/build_viewer_physics.py /out/physics /out/models
 # Each pack's textured MuJoCo meshes, lidar nav map, and browser glb + hull soup.
-RUN uv run tools/build_environment_pack.py finish backrooms viewer/assets/backrooms/backrooms_vr.glb /out
+RUN uv run tools/build_environment_pack.py backrooms viewer/assets/backrooms/backrooms_vr.glb /out
 # The compiled ~168 MB MJB and downscaled texture caches are host-local
 # derivations; shipping them would nearly double the image.
 COPY sim/ATTRIBUTION.md ./assets/ATTRIBUTION.md

--- a/sim/README.md
+++ b/sim/README.md
@@ -180,8 +180,9 @@ a directory under `sim/environments/` with a `manifest.json` naming its MuJoCo
 collision and visual meshes and Nav2 map (under `sim/assets/`), the browser glb
 or per-room manifest and collision hulls (under `sim/viewer/public/`), and the
 spawn pose -- `sim/environments/backrooms/manifest.json` is the template, and
-`sim/tools/build_environment_pack.py` derives every one of those files from a
-single glTF scene (the asset image runs it; see `sim/Dockerfile.assets`). Meshes are in
+`sim/tools/decompose_pack.py` then `sim/tools/build_environment_pack.py` derive
+every one of those files from a single glTF scene (the asset image runs them;
+see `sim/Dockerfile.assets`). Meshes are in
 meters, glTF Y-up, with the floor at y = 0: physics stands the robot on the
 MJCF ground plane there, and the 3D view's floor grid sits just below it.
 Licensed packs the repository must not ship go in `sim/environments.local/`

--- a/sim/tools/build_environment_pack.py
+++ b/sim/tools/build_environment_pack.py
@@ -1,72 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
-"""Derive an environment pack from one glTF scene: MuJoCo collision hulls and
-textured meshes under assets/, a lidar-consistent Nav2 map, and the browser's
-glb and hull soup. Two steps, in the asset image's stage order
-(sim/Dockerfile.assets) so the CoACD bake caches on its own:
+"""Derive an environment pack from one glTF scene, after decompose_pack.py has
+baked its hulls: textured MuJoCo meshes under assets/, a lidar-consistent Nav2
+map, and the browser's glb and hull soup.
 
-    uv run tools/build_environment_pack.py decompose <id> <scene.glb> [--threshold M]
-    uv run tools/build_environment_pack.py finish <id> <scene.glb> [viewer_out]
+    uv run tools/build_environment_pack.py <id> <scene.glb> [viewer_out]
 
-`finish` reads sim/environments/<id>/manifest.json: the nav map is rasterised
-from the compiled world like export_nav_map.py, and the manifest's spawn must
-land on known-free floor. The scene's floor -- the up-facing height carrying
-the most area -- is moved to y = 0 for physics and viewer alike.
+Reads sim/environments/<id>/manifest.json: the nav map is rasterised from the
+compiled world like export_nav_map.py, and the manifest's spawn must land on
+known-free floor. Physics and viewer share decompose_pack's floor at y = 0.
 """
 
 import argparse
 import json
 import struct
 import sys
-from collections import Counter
 from pathlib import Path
 
-import decompose_rooms
 import numpy as np
-import trimesh
 from build_viewer_physics import hull_soup
-from decompose_rooms import decompose_room
+from decompose_pack import ASSETS, SIM, Parts, load_parts
 from PIL import Image
 
-SIM = Path(__file__).resolve().parents[1]
-ASSETS = SIM / "assets"
 DEFAULT_VIEWER_OUT = SIM / "viewer" / "public"
-FLAT_SHEET_M = 0.02  # a part this thin in y is a floor plane; the MJCF ground plane stands in for it
-Parts = dict[str, trimesh.Trimesh]
-
-
-def load_parts(glb: Path) -> tuple[Parts, float]:
-    """Every mesh part in the scene's Y-up world frame, plus the floor height."""
-    scene = trimesh.load(glb, force="scene")
-    placements = [(node, *scene.graph[node]) for node in scene.graph.nodes_geometry]
-    uses = Counter(geometry for _node, _transform, geometry in placements)
-    parts: Parts = {}
-    for node, transform, geometry in placements:  # one part per placement: instanced geometry is several
-        part = scene.geometry[geometry].copy()
-        part.apply_transform(transform)
-        parts[geometry if uses[geometry] == 1 else f"{geometry}__{node}"] = part
-    whole = trimesh.util.concatenate(list(parts.values()))
-    up = whole.face_normals[:, 1] > 0.95
-    heights, index = np.unique(np.round(whole.triangles_center[up][:, 1], 3), return_inverse=True)
-    floor_y = float(heights[np.bincount(index, weights=whole.area_faces[up]).argmax()])
-    for geom in parts.values():
-        geom.apply_translation([0.0, -floor_y, 0.0])
-    return parts, floor_y
-
-
-def decompose(pack_id: str, glb: Path, threshold: float) -> None:
-    parts, floor_y = load_parts(glb)
-    print(f"{pack_id}: floor was at y={floor_y:+.3f}, now at 0")
-    decompose_rooms.THRESHOLD_M = threshold
-    split, hulls = ASSETS / f"{pack_id}_split", ASSETS / f"{pack_id}_split_v2"
-    split.mkdir(parents=True, exist_ok=True)
-    for name, geom in parts.items():
-        if geom.bounds[1][1] - geom.bounds[0][1] < FLAT_SHEET_M:
-            continue
-        obj = split / f"{name}.obj"
-        geom.export(obj)
-        print(f"{name}: {len(geom.faces)} faces")
-        print(f"    -> {decompose_room(obj, hulls / name)} hulls")
 
 
 def finish(pack_id: str, glb: Path, viewer_out: Path) -> None:
@@ -99,9 +55,6 @@ def write_visuals(pack_id: str, parts: Parts) -> None:
 
 
 def write_nav_map(pack_id: str) -> None:
-    # Imported here, not at the top: the decompose stage of the asset image
-    # carries no driver package, by design (its CoACD bake must not re-run on
-    # a driver edit), and only this step compiles a world.
     sys.path.insert(0, str(SIM / "sandbox"))
     import _driver_pkg  # noqa: F401
     import export_nav_map as nav
@@ -173,16 +126,11 @@ def write_shifted_glb(src: Path, dst: Path, dy: float) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("step", choices=("decompose", "finish"))
     parser.add_argument("pack_id")
     parser.add_argument("glb", type=Path)
     parser.add_argument("viewer_out", type=Path, nargs="?", default=DEFAULT_VIEWER_OUT)
-    parser.add_argument("--threshold", type=float, default=decompose_rooms.THRESHOLD_M, help="CoACD concavity, metres")
     args = parser.parse_args()
-    if args.step == "decompose":
-        decompose(args.pack_id, args.glb, args.threshold)
-    else:
-        finish(args.pack_id, args.glb, args.viewer_out)
+    finish(args.pack_id, args.glb, args.viewer_out)
 
 
 if __name__ == "__main__":

--- a/sim/tools/decompose_pack.py
+++ b/sim/tools/decompose_pack.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The CoACD bake of an environment pack: one OBJ and its convex hulls per mesh
+part of a glTF scene, under sim/assets/<id>_split and <id>_split_v2.
+
+    uv run tools/decompose_pack.py <id> <scene.glb> [--threshold M]
+
+The scene's floor -- the up-facing height carrying the most area -- is moved to
+y = 0, and flat floor sheets are skipped: the MJCF ground plane stands in for
+them. build_environment_pack.py derives everything else from the same scene.
+This file is the bake layer's whole cache key in sim/Dockerfile.assets, so it
+holds only what changes the hulls.
+"""
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+import decompose_rooms
+import numpy as np
+import trimesh
+from decompose_rooms import decompose_room
+
+SIM = Path(__file__).resolve().parents[1]
+ASSETS = SIM / "assets"
+FLAT_SHEET_M = 0.02
+Parts = dict[str, trimesh.Trimesh]
+
+
+def load_parts(glb: Path) -> tuple[Parts, float]:
+    """Every mesh part in the scene's Y-up world frame, plus the floor height."""
+    scene = trimesh.load(glb, force="scene")
+    placements = [(node, *scene.graph[node]) for node in scene.graph.nodes_geometry]
+    uses = Counter(geometry for _node, _transform, geometry in placements)
+    parts: Parts = {}
+    for node, transform, geometry in placements:  # one part per placement: instanced geometry is several
+        part = scene.geometry[geometry].copy()
+        part.apply_transform(transform)
+        parts[geometry if uses[geometry] == 1 else f"{geometry}__{node}"] = part
+    whole = trimesh.util.concatenate(list(parts.values()))
+    up = whole.face_normals[:, 1] > 0.95
+    heights, index = np.unique(np.round(whole.triangles_center[up][:, 1], 3), return_inverse=True)
+    floor_y = float(heights[np.bincount(index, weights=whole.area_faces[up]).argmax()])
+    for geom in parts.values():
+        geom.apply_translation([0.0, -floor_y, 0.0])
+    return parts, floor_y
+
+
+def decompose(pack_id: str, glb: Path, threshold: float) -> None:
+    parts, floor_y = load_parts(glb)
+    print(f"{pack_id}: floor was at y={floor_y:+.3f}, now at 0")
+    decompose_rooms.THRESHOLD_M = threshold
+    split, hulls = ASSETS / f"{pack_id}_split", ASSETS / f"{pack_id}_split_v2"
+    split.mkdir(parents=True, exist_ok=True)
+    for name, geom in parts.items():
+        if geom.bounds[1][1] - geom.bounds[0][1] < FLAT_SHEET_M:
+            continue
+        obj = split / f"{name}.obj"
+        geom.export(obj)
+        print(f"{name}: {len(geom.faces)} faces")
+        print(f"    -> {decompose_room(obj, hulls / name)} hulls")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("pack_id")
+    parser.add_argument("glb", type=Path)
+    parser.add_argument("--threshold", type=float, default=decompose_rooms.THRESHOLD_M, help="CoACD concavity, metres")
+    args = parser.parse_args()
+    decompose(args.pack_id, args.glb, args.threshold)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #767. #753's asset publish still re-baked the apartment (8 min) and the backrooms (12 min); two reasons, two fixes.

- **Bake script split out.** The CoACD step moves from `build_environment_pack.py` to `sim/tools/decompose_pack.py`, which is the only script the bake layer copies. Editing the finish step (visuals, nav map, viewer glb) no longer re-bakes a pack. `build_environment_pack.py` now runs the finish step alone.
- **Per-branch build cache.** A registry cache export replaces the ref's records, so every branch publish overwrote `buildcache` and evicted main's bakes. Branches now read main's `buildcache` plus their own `cache-<branch>` and write only their own. Main alone writes `buildcache`.
- Branch caches carry no `sha-` tag and are not in the keep-forever list, so `cleanup-sim-images.yml` ages them out after 14 days without a push.

This branch's own publish bakes the backrooms once (new bake-layer key); the apartment stays cached.

Verified: `ruff`, `tests/` (76 passed), `docker build --check -f sim/Dockerfile.assets`, both tools load the backrooms scene to the same 29 parts and floor as before.