### PR TITLE
feat(brain): configure per-agent thinking intervals

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
-from brain_client.agents.types import Agent
+from brain_client.agents.types import Agent, TurnIntervals
 from brain_client.common.dynamic_loader import class_name_to_snake_case, evict_modules_under
 from brain_client.common.script_paths import (
     classify_source,
@@ -89,6 +89,11 @@ def build_agent_instances(
             str(agent.display_name)
             agent.get_prompt()
             agent.input_names()
+            intervals = agent.get_turn_intervals()
+            if not isinstance(intervals, TurnIntervals):
+                raise TypeError(
+                    f"{type(agent).__name__}.get_turn_intervals() must return TurnIntervals, got {intervals!r}"
+                )
             agent.uses_gaze()
             skill_ids = agent.skill_ids()
         except Exception as e:  # noqa: BLE001 — one bad agent must not stop the roster

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
@@ -15,9 +15,10 @@ several agents per file.
 from __future__ import annotations
 
 import base64
+import math
 from pathlib import Path
 
-from brain_client.agents.types import Agent, TurnIntervals
+from brain_client.agents.types import Agent
 from brain_client.common.dynamic_loader import class_name_to_snake_case, evict_modules_under
 from brain_client.common.script_paths import (
     classify_source,
@@ -89,11 +90,16 @@ def build_agent_instances(
             str(agent.display_name)
             agent.get_prompt()
             agent.input_names()
-            intervals = agent.get_turn_intervals()
-            if not isinstance(intervals, TurnIntervals):
-                raise TypeError(
-                    f"{type(agent).__name__}.get_turn_intervals() must return TurnIntervals, got {intervals!r}"
-                )
+            intervals = (agent.idle_turn_interval, agent.supervision_turn_interval)
+            for name, value in zip(("idle_turn_interval", "supervision_turn_interval"), intervals, strict=True):
+                if value is not None and (
+                    isinstance(value, bool)
+                    or not isinstance(value, (int, float))
+                    or not math.isfinite(value)
+                    or value <= 0
+                ):
+                    raise ValueError(f"{name} must be a finite positive number or None")
+            agent._turn_intervals = intervals
             agent.uses_gaze()
             skill_ids = agent.skill_ids()
         except Exception as e:  # noqa: BLE001 — one bad agent must not stop the roster

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
@@ -7,9 +7,7 @@ Agent Type Definitions
 Base class and types for robot agents.
 """
 
-import math
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias, Union
 
 from brain_client.common.script_paths import Source
@@ -29,25 +27,6 @@ SkillRef: TypeAlias = Union["type[Skill]", "type[TrainedSkill]", str]
 InputRef: TypeAlias = Union["type[InputDevice]", str]
 
 
-@dataclass(frozen=True)
-class TurnIntervals:
-    """Optional per-agent overrides for the brain's visual observation cadence.
-
-    ``None`` keeps the global ROS parameter.  A positive value is the pause
-    after a completed model turn; model latency is additional.  Keeping this
-    on the agent lets a visually supervised navigation agent look frequently
-    without making every directive on the robot equally chatty and expensive.
-    """
-
-    idle: float | None = None
-    supervision: float | None = None
-
-    def __post_init__(self) -> None:
-        for name, value in (("idle", self.idle), ("supervision", self.supervision)):
-            if value is not None and (not math.isfinite(value) or value <= 0):
-                raise ValueError(f"turn interval {name} must be a finite positive number or None")
-
-
 class Agent(ABC):
     """
     Base class for all agents.
@@ -56,6 +35,14 @@ class Agent(ABC):
     along with the list of skills that should be available when this
     agent is active.
     """
+
+    # Pause after each completed model turn (seconds); None uses the global default.
+    # Set these on the subclass; edits take effect when the agent reloads.
+    idle_turn_interval: float | None = None
+    supervision_turn_interval: float | None = None
+
+    # Validated once by the loader; the brain never evaluates workspace getters.
+    _turn_intervals: tuple[float | None, float | None] = (None, None)
 
     # Stamped by the loader to "shipped" or "user" based on origin directory.
     # Subclasses must not set this themselves.
@@ -184,15 +171,6 @@ class Agent(ABC):
         Default: return empty list (no input devices required).
         """
         return []
-
-    def get_turn_intervals(self) -> TurnIntervals:
-        """Return optional per-agent idle and running-skill turn intervals.
-
-        The global ``brain_client_node`` ROS parameters remain the defaults.
-        Override this only when the directive needs a materially different
-        visual reaction cadence.
-        """
-        return TurnIntervals()
 
     def input_names(self) -> list[str]:
         """get_inputs() normalized to device-name strings — the only form the

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
@@ -7,7 +7,9 @@ Agent Type Definitions
 Base class and types for robot agents.
 """
 
+import math
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias, Union
 
 from brain_client.common.script_paths import Source
@@ -25,6 +27,25 @@ SkillRef: TypeAlias = Union["type[Skill]", "type[TrainedSkill]", str]
 # What get_inputs() may list: the InputDevice class itself (typed, same
 # rationale as SkillRef) or a device-name string.
 InputRef: TypeAlias = Union["type[InputDevice]", str]
+
+
+@dataclass(frozen=True)
+class TurnIntervals:
+    """Optional per-agent overrides for the brain's visual observation cadence.
+
+    ``None`` keeps the global ROS parameter.  A positive value is the pause
+    after a completed model turn; model latency is additional.  Keeping this
+    on the agent lets a visually supervised navigation agent look frequently
+    without making every directive on the robot equally chatty and expensive.
+    """
+
+    idle: float | None = None
+    supervision: float | None = None
+
+    def __post_init__(self) -> None:
+        for name, value in (("idle", self.idle), ("supervision", self.supervision)):
+            if value is not None and (not math.isfinite(value) or value <= 0):
+                raise ValueError(f"turn interval {name} must be a finite positive number or None")
 
 
 class Agent(ABC):
@@ -163,6 +184,15 @@ class Agent(ABC):
         Default: return empty list (no input devices required).
         """
         return []
+
+    def get_turn_intervals(self) -> TurnIntervals:
+        """Return optional per-agent idle and running-skill turn intervals.
+
+        The global ``brain_client_node`` ROS parameters remain the defaults.
+        Override this only when the directive needs a materially different
+        visual reaction cadence.
+        """
+        return TurnIntervals()
 
     def input_names(self) -> list[str]:
         """get_inputs() normalized to device-name strings — the only form the

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -418,8 +418,14 @@ class BrainAgent:
             self._pause_until = 0.0
 
     def _interval(self) -> float:
+        directive = self._state.current_directive
+        overrides = directive.get_turn_intervals() if directive is not None else None
         if self._state.primitive_running:
+            if overrides is not None and overrides.supervision is not None:
+                return overrides.supervision
             return self._config.supervision_turn_interval
+        if overrides is not None and overrides.idle is not None:
+            return overrides.idle
         return self._config.idle_turn_interval
 
     def _elapsed(self) -> float:
@@ -699,6 +705,7 @@ class BrainAgent:
             active=self._state.is_brain_active,
             backend=self.backend,
             model=self._config.gemini_model,
+            interval=self._interval(),
             turn=self._turn_count,
             in_flight=self._turn_in_flight,
             thinking_for=self._elapsed() if self._turn_in_flight else 0,

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -419,13 +419,13 @@ class BrainAgent:
 
     def _interval(self) -> float:
         directive = self._state.current_directive
-        overrides = directive.get_turn_intervals() if directive is not None else None
+        idle, supervision = directive._turn_intervals if directive is not None else (None, None)
         if self._state.primitive_running:
-            if overrides is not None and overrides.supervision is not None:
-                return overrides.supervision
+            if supervision is not None:
+                return supervision
             return self._config.supervision_turn_interval
-        if overrides is not None and overrides.idle is not None:
-            return overrides.idle
+        if idle is not None:
+            return idle
         return self._config.idle_turn_interval
 
     def _elapsed(self) -> float:

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -70,7 +70,7 @@ may list.
 
 from typing import TYPE_CHECKING
 
-from brain_client.agents.types import Agent, InputRef, SkillRef, TurnIntervals
+from brain_client.agents.types import Agent, InputRef, SkillRef
 from brain_client.robot.exceptions import ArmFailed, ArmUnhealthy
 from brain_client.skills.overlay import Overlay
 from brain_client.skills.types import (
@@ -99,7 +99,6 @@ CAMERAS: dict[str, type[Image]] = {"main": MainImage, "wrist": WristImage}
 
 __all__ = [
     "Agent",
-    "TurnIntervals",
     "Arm",
     "ArmFailed",
     "ArmUnhealthy",

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -70,7 +70,7 @@ may list.
 
 from typing import TYPE_CHECKING
 
-from brain_client.agents.types import Agent, InputRef, SkillRef
+from brain_client.agents.types import Agent, InputRef, SkillRef, TurnIntervals
 from brain_client.robot.exceptions import ArmFailed, ArmUnhealthy
 from brain_client.skills.overlay import Overlay
 from brain_client.skills.types import (
@@ -99,6 +99,7 @@ CAMERAS: dict[str, type[Image]] = {"main": MainImage, "wrist": WristImage}
 
 __all__ = [
     "Agent",
+    "TurnIntervals",
     "Arm",
     "ArmFailed",
     "ArmUnhealthy",

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -411,3 +411,30 @@ def test_build_reports_id_conflict_last_wins(workspace):
 
     assert broken == {}
     assert list(agents) == ["same_id"]  # conflict warns, latter wins (documented behavior)
+
+
+def test_build_loads_turn_intervals_from_public_namespace(workspace):
+    write(
+        workspace,
+        "innate_agents/fast.py",
+        "from innate import TurnIntervals\n"
+        + agent_src("Fast", body="def get_turn_intervals(self):\n    return TurnIntervals(0.01, 0.01)"),
+    )
+    agents, _default, broken = initialize_agents(LOGGER)
+    assert broken == {}
+    assert agents["fast"].get_turn_intervals().idle == 0.01
+    assert agents["fast"].get_turn_intervals().supervision == 0.01
+
+
+def test_build_rejects_invalid_turn_interval_contract(workspace):
+    write(
+        workspace,
+        "innate_agents/bad_interval.py",
+        agent_src("BadInterval", body='def get_turn_intervals(self):\n    return {"supervision": 1.0}'),
+    )
+
+    classes, _errors = discover_agent_classes(LOGGER)
+    agents, broken = build_agent_instances(classes, LOGGER)
+
+    assert agents == {}
+    assert "must return TurnIntervals" in broken["bad_interval"]

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -89,7 +89,7 @@ def write(workspace, relpath: str, content: str) -> None:
 
 
 def test_agents_load_with_source_stamping(workspace):
-    write(workspace, "innate_agents/alpha.py", agent_src("Alpha"))
+    write(workspace, "innate_agents/alpha.py", agent_src("Alpha", body="idle_turn_interval = 0.01"))
     write(workspace, "custom_agents/beta.py", agent_src("Beta"))
 
     agents, default_agent, broken = initialize_agents(LOGGER)
@@ -99,6 +99,9 @@ def test_agents_load_with_source_stamping(workspace):
     assert agents["alpha"].source == "shipped"
     assert agents["beta"].source == "user"
     assert default_agent is agents["alpha"]  # no intro_agent -> first loaded
+    assert agents["beta"]._turn_intervals == (None, None)
+    agents["alpha"].idle_turn_interval = float("nan")  # runtime reads the validated load-time snapshot
+    assert agents["alpha"]._turn_intervals == (0.01, None)
 
 
 def test_intro_agent_is_default(workspace):
@@ -210,12 +213,18 @@ def test_probe_failure_rosters_broken(workspace):
         "innate_agents/lazy.py",
         agent_src("Lazy", body='def get_inputs(self):\n    raise ValueError("no input device")'),
     )
+    write(
+        workspace,
+        "innate_agents/bad_cadence.py",
+        agent_src("BadCadence", body='supervision_turn_interval = float("nan")'),
+    )
 
     agents, _default, broken = initialize_agents(LOGGER)
 
     assert set(agents) == {"alpha"}
-    assert list(broken) == ["lazy"]
+    assert set(broken) == {"lazy", "bad_cadence"}
     assert "ValueError: no input device" in broken["lazy"]
+    assert "supervision_turn_interval must be a finite positive number or None" in broken["bad_cadence"]
 
 
 def test_function_local_agent_rosters_broken(workspace):

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -411,30 +411,3 @@ def test_build_reports_id_conflict_last_wins(workspace):
 
     assert broken == {}
     assert list(agents) == ["same_id"]  # conflict warns, latter wins (documented behavior)
-
-
-def test_build_loads_turn_intervals_from_public_namespace(workspace):
-    write(
-        workspace,
-        "innate_agents/fast.py",
-        "from innate import TurnIntervals\n"
-        + agent_src("Fast", body="def get_turn_intervals(self):\n    return TurnIntervals(0.01, 0.01)"),
-    )
-    agents, _default, broken = initialize_agents(LOGGER)
-    assert broken == {}
-    assert agents["fast"].get_turn_intervals().idle == 0.01
-    assert agents["fast"].get_turn_intervals().supervision == 0.01
-
-
-def test_build_rejects_invalid_turn_interval_contract(workspace):
-    write(
-        workspace,
-        "innate_agents/bad_interval.py",
-        agent_src("BadInterval", body='def get_turn_intervals(self):\n    return {"supervision": 1.0}'),
-    )
-
-    classes, _errors = discover_agent_classes(LOGGER)
-    agents, broken = build_agent_instances(classes, LOGGER)
-
-    assert agents == {}
-    assert "must return TurnIntervals" in broken["bad_interval"]

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -450,6 +450,7 @@ import threading  # noqa: E402
 import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
+from brain_client.agents.types import TurnIntervals  # noqa: E402
 from brain_client.brain.agent import BrainAgent  # noqa: E402
 from brain_client.brain.utils import Event, EventKind  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
@@ -513,6 +514,34 @@ def agent_factory(monkeypatch):
     yield make
     for agent in created:
         agent.shutdown()
+
+
+@pytest.mark.parametrize(
+    "overrides, idle, supervision",
+    [
+        (None, 3.0, 5.0),
+        (TurnIntervals(), 3.0, 5.0),
+        (TurnIntervals(idle=0.01), 0.01, 5.0),
+        (TurnIntervals(supervision=1.0), 3.0, 1.0),
+        (TurnIntervals(0.01, 0.01), 0.01, 0.01),
+    ],
+)
+def test_agent_turn_intervals_override_only_the_requested_mode(agent_factory, overrides, idle, supervision):
+    agent, state = agent_factory()
+    state.current_directive = SimpleNamespace(get_turn_intervals=lambda: overrides) if overrides is not None else None
+
+    assert agent._interval() == idle
+    state.primitive_running = RunningSkill("search", "innate-os/find_next_person")
+    assert agent._interval() == supervision
+    state.current_directive = None  # switching away must not retain the override
+    assert agent._interval() == 5.0
+
+
+@pytest.mark.parametrize("mode", ["idle", "supervision"])
+@pytest.mark.parametrize("value", [0.0, -1.0, float("inf"), float("nan")])
+def test_agent_turn_intervals_reject_non_positive_or_non_finite_values(mode, value):
+    with pytest.raises(ValueError, match="finite positive"):
+        TurnIntervals(**{mode: value})
 
 
 def run_turn(agent: BrainAgent) -> None:

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -450,7 +450,6 @@ import threading  # noqa: E402
 import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
-from brain_client.agents.types import TurnIntervals  # noqa: E402
 from brain_client.brain.agent import BrainAgent  # noqa: E402
 from brain_client.brain.utils import Event, EventKind  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
@@ -514,34 +513,6 @@ def agent_factory(monkeypatch):
     yield make
     for agent in created:
         agent.shutdown()
-
-
-@pytest.mark.parametrize(
-    "overrides, idle, supervision",
-    [
-        (None, 3.0, 5.0),
-        (TurnIntervals(), 3.0, 5.0),
-        (TurnIntervals(idle=0.01), 0.01, 5.0),
-        (TurnIntervals(supervision=1.0), 3.0, 1.0),
-        (TurnIntervals(0.01, 0.01), 0.01, 0.01),
-    ],
-)
-def test_agent_turn_intervals_override_only_the_requested_mode(agent_factory, overrides, idle, supervision):
-    agent, state = agent_factory()
-    state.current_directive = SimpleNamespace(get_turn_intervals=lambda: overrides) if overrides is not None else None
-
-    assert agent._interval() == idle
-    state.primitive_running = RunningSkill("search", "innate-os/find_next_person")
-    assert agent._interval() == supervision
-    state.current_directive = None  # switching away must not retain the override
-    assert agent._interval() == 5.0
-
-
-@pytest.mark.parametrize("mode", ["idle", "supervision"])
-@pytest.mark.parametrize("value", [0.0, -1.0, float("inf"), float("nan")])
-def test_agent_turn_intervals_reject_non_positive_or_non_finite_values(mode, value):
-    with pytest.raises(ValueError, match="finite positive"):
-        TurnIntervals(**{mode: value})
 
 
 def run_turn(agent: BrainAgent) -> None:

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -450,6 +450,7 @@ import threading  # noqa: E402
 import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
+from brain_client.agents.types import TurnIntervals  # noqa: E402
 from brain_client.brain.agent import BrainAgent  # noqa: E402
 from brain_client.brain.utils import Event, EventKind  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
@@ -1114,6 +1115,21 @@ def test_trace_reports_the_turn_lifecycle(agent_factory, monkeypatch):
     snapshot = traces[7]
     # History: the user turn, the model turn, and the wait call's functionResponse.
     assert snapshot["active"] is False and snapshot["backend"] == "gemini-direct" and snapshot["history"] == 3
+    assert snapshot["interval"] == 3.0
+
+    # The heartbeat follows the current agent and skill state, including unset overrides.
+    for intervals, expected in [
+        (TurnIntervals(idle=0.01), (0.01, 5.0)),
+        (TurnIntervals(supervision=0.02), (3.0, 0.02)),
+        (None, (3.0, 5.0)),
+    ]:
+        state.current_directive = (
+            SimpleNamespace(get_turn_intervals=lambda value=intervals: value) if intervals else None
+        )
+        for running, interval in zip((None, RunningSkill("wave", "innate-os/wave")), expected, strict=True):
+            state.primitive_running = running
+            agent._snapshot()
+            assert traces[-1]["interval"] == interval
 
 
 # ---------- skill events ----------

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -450,7 +450,6 @@ import threading  # noqa: E402
 import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
-from brain_client.agents.types import TurnIntervals  # noqa: E402
 from brain_client.brain.agent import BrainAgent  # noqa: E402
 from brain_client.brain.utils import Event, EventKind  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
@@ -1119,13 +1118,11 @@ def test_trace_reports_the_turn_lifecycle(agent_factory, monkeypatch):
 
     # The heartbeat follows the current agent and skill state, including unset overrides.
     for intervals, expected in [
-        (TurnIntervals(idle=0.01), (0.01, 5.0)),
-        (TurnIntervals(supervision=0.02), (3.0, 0.02)),
+        ((0.01, None), (0.01, 5.0)),
+        ((None, 0.02), (3.0, 0.02)),
         (None, (3.0, 5.0)),
     ]:
-        state.current_directive = (
-            SimpleNamespace(get_turn_intervals=lambda value=intervals: value) if intervals else None
-        )
+        state.current_directive = SimpleNamespace(_turn_intervals=intervals) if intervals else None
         for running, interval in zip((None, RunningSkill("wave", "innate-os/wave")), expected, strict=True):
             state.primitive_running = running
             agent._snapshot()


### PR DESCRIPTION
Agents can override the pause after each completed thought with two class attributes:

```python
idle_turn_interval = 0.5
supervision_turn_interval = 0.3
```

Both default to `None`, retaining the configured global intervals (3s/5s by default). The loader validates finite positive numbers and caches them once, so the turn loop and heartbeat read resolved values without calling workspace getters. Changes take effect on agent reload; the brain trace reports the effective interval.

Scoped to cadence; model/backend support is handled separately by #824. Existing tests cover overrides, defaults, cached values and invalid configuration; no new test functions. All 62 brain tests and 19 loader tests pass, along with Ruff and diff checks. The local onboarding trial's 0.01s override remains outside this PR.
