### PR TITLE
feat(config): securely configure local Cartesia and OpenAI keys

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,6 +15,16 @@
 # service key), talking to Google directly.
 # GEMINI_API_KEY=
 
+# Owner-local API keys can be entered without putting them in shell history:
+#   innate keys set openai
+#   innate keys set cartesia
+#   innate keys status
+# Keys remain in .env (never config/settings.yaml or ROS parameters).
+# Restart the nodes/local simulator after changing a key. The selected agent
+# provider/model is configured separately; an Innate service route wins when set.
+# OPENAI_API_KEY=
+# CARTESIA_API_KEY=
+
 # GEMINI_MODEL overrides the brain's model (default gemini-3.6-flash).
 # GEMINI_MODEL=
 

--- a/.github/workflows/launcher-tests.yml
+++ b/.github/workflows/launcher-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run the host-side test suite
         run: |
-          pip install pytest pyyaml numpy trimesh pillow mujoco
+          pip install pytest pyyaml numpy trimesh pillow mujoco click
           python -m pytest tests/ -q
 
       - name: Set up Node.js

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ Thumbs.db
 
 # Environment files
 .env
+.env.lock
 config/os.toml
 config/settings.yaml
 sim/config.toml

--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ The terminal opens a live dashboard, and the robot webapp at [https://localhost]
 
 See [`sim/README.md`](sim/README.md) for everything else: the day-to-day workflow, the ROS-free VirtualMars Python API (with a walkthrough notebook), and the architecture.
 
+For owner-local OpenAI and Cartesia key entry, rotation, removal, and runtime
+requirements, see [provider keys](docs/provider-keys.md).
+
 ---
 
 ## Foxglove

--- a/docs/provider-keys.md
+++ b/docs/provider-keys.md
@@ -1,0 +1,53 @@
+# Owner-local provider keys
+
+Run these commands on your robot or in your own local simulator checkout:
+
+```sh
+innate keys set cartesia
+innate keys set openai
+innate keys status
+```
+
+`set` prompts with hidden input. In an uninstalled checkout, use
+`INNATE_OS_ROOT="$PWD" python3 scripts/innate keys set openai` (Python needs `click`).
+For automation, pipe a secret manager's output to `innate keys set openai --stdin`.
+There is deliberately no key-value command argument or browser/ROS credential API.
+
+The commands atomically save `.env` with mode `0600`, preserve unrelated settings,
+and remove older saved copies of the same key on replacement. `status` reports
+configuration presence, not whether the provider will accept the key. Restart
+robot nodes with `innate restart`, or stop and start the local simulator, to pick
+up a change. Existing processes retain their old environment until then.
+
+`innate keys remove openai` writes an explicit empty override and removes old
+commented copies, so the next launch cannot restore an inherited OpenAI key from
+the shell or `/etc/innate.env`. The same commands accept `cartesia`, `gemini`, and
+`innate`. These commands preserve the configured service route; adding a direct
+key never changes account routing or the selected model. A configured Innate
+service route takes precedence and errors do not silently switch accounts.
+
+## Runtime dependencies
+
+- Direct Cartesia speech is supplied by [PR #755](https://github.com/innate-inc/innate-os/pull/755).
+  It preserves Alfred (`9fdaae0b-f885-4813-b589-3c07cf9d5fea`). That PR is blocked
+  on Cartesia making the voice consistently available to non-owning accounts.
+  Saving a key cannot grant access to a private voice, and no substitute voice
+  is selected automatically.
+- The OpenAI agent and provider/model settings are supplied by
+  [PR #772](https://github.com/innate-inc/innate-os/pull/772). Select `brain_provider:
+  "openai"` using its documented settings. The verified model is `gpt-6-astra`,
+  using the Responses API with `low` reasoning. Key presence alone does not
+  select OpenAI. See [OpenAI's model guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra).
+
+Missing keys leave a direct provider unconfigured; rejected credentials or model/
+voice access fail that request. No live account access is proven by offline tests.
+Cartesia's [voice lookup](https://docs.cartesia.ai/api-reference/voices/get) reports
+whether a key can access a voice; synthesis must also succeed with the intended key.
+
+## Public simulator
+
+`INNATE_PUBLIC_DEMO=1` disables these credential commands and refuses generating
+a simulator environment containing provider/service keys. Public demo deployments
+must use the external credential relay supplied by the simulator security work.
+The flag is a deployment check; isolating credentials from visitor processes is
+the security boundary. Never configure a shared public session with an owner key.

--- a/scripts/innate
+++ b/scripts/innate
@@ -2673,6 +2673,45 @@ def cli(ctx):
 # -- service group ------------------------------------------------------------
 
 
+@cli.group("keys", invoke_without_command=True)
+@click.pass_context
+def keys_cli(ctx):
+    """Configure owner-local API keys (never exposed through robot settings)."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+def _key_commands():
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sim" / "launcher"))
+    import provider_keys
+
+    return provider_keys
+
+
+@keys_cli.command("set", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("provider", type=click.Choice(["openai", "cartesia", "gemini", "innate"]))
+@click.option("--stdin", "from_stdin", is_flag=True, help="Read one key from a pipe instead of the hidden prompt.")
+@click.pass_context
+def keys_set(ctx, provider, from_stdin):
+    """Save or replace a key. Key values are never command-line arguments."""
+    if ctx.args:
+        raise click.ClickException("Key values are not accepted as arguments. Use the hidden prompt or --stdin.")
+    _key_commands().set_key(INNATE_OS_ROOT, provider, from_stdin=from_stdin)
+
+
+@keys_cli.command("status")
+def keys_status():
+    """Show which keys are configured without revealing their values."""
+    _key_commands().status(INNATE_OS_ROOT)
+
+
+@keys_cli.command("remove")
+@click.argument("provider", type=click.Choice(["openai", "cartesia", "gemini", "innate"]))
+def keys_remove(provider):
+    """Clear a key, including saved copies from prior setup choices."""
+    _key_commands().remove_key(INNATE_OS_ROOT, provider)
+
+
 @cli.group(invoke_without_command=True)
 @click.pass_context
 def service(ctx):

--- a/scripts/innate
+++ b/scripts/innate
@@ -2682,6 +2682,7 @@ def keys_cli(ctx):
 
 
 def _key_commands():
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sim" / "launcher"))
     import provider_keys
 

--- a/scripts/provider_keys.py
+++ b/scripts/provider_keys.py
@@ -20,7 +20,7 @@ PROVIDERS = {
 
 
 def _require_owner_runtime() -> None:
-    if os.environ.get("INNATE_PUBLIC_DEMO") == "1":
+    if os.environ.get("INNATE_PUBLIC_DEMO", "").strip().lower() in {"1", "true", "yes"}:
         raise click.ClickException("API key configuration is disabled in the public simulator.")
 
 

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -238,7 +238,7 @@ LEGACY_SHARED_CONTAINER = "innate-dev"
 LEGACY_SHARED_PROJECT = "innate-os"
 LEGACY_CLOUD_AGENT_CONTAINER = "innate-cloud-agent"
 OS_CONTAINER_TMUX_CMD = "./scripts/launch_sim_in_tmux.zsh --detach"
-SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY)
+SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY, "OPENAI_API_KEY", "CARTESIA_API_KEY")
 LOG_TARGETS = {
     "bootstrap": BOOTSTRAP_LOG_PATH,
     "compose": COMPOSE_LOG_PATH,
@@ -702,7 +702,9 @@ def get_config() -> dict[str, object]:
     raw_env = dict(user_env)
     for key in SECRET_ENV_KEYS:
         value = os.environ.get(key, "").strip()
-        if is_configured_secret_value(key, value):
+        # An explicit local value (including a blank removal) wins over an old
+        # shell export, matching config_loader on the robot after restart.
+        if key not in user_env and is_configured_secret_value(key, value):
             raw_env[key] = value
     sim_config = parse_toml_file(SIM_CONFIG_PATH)
     if "cloud_agent" in sim_config:
@@ -747,13 +749,18 @@ def get_config() -> dict[str, object]:
 
 
 def write_env_file(path: Path, values: dict[str, str]) -> None:
-    lines = [f"{key}={value}" for key, value in sorted(values.items()) if value != ""]
-    path.write_text("\n".join(lines) + "\n")
+    from env_store import write_env_values
+
+    write_env_values(path, values)
 
 
 def build_os_env(config: dict[str, object]) -> Path:
     raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
     os_env: dict[str, str] = dict(raw_env)
+
+    if os.environ.get("INNATE_PUBLIC_DEMO") == "1" or os_env.get("INNATE_PUBLIC_DEMO") == "1":
+        if any(os_env.get(key, "").strip() for key in SECRET_ENV_KEYS):
+            raise StackError("Public simulator runtimes cannot contain API keys; use the external demo relay.")
 
     ensure_state_dir()
     write_env_file(GENERATED_OS_ENV_PATH, os_env)

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -758,7 +758,10 @@ def build_os_env(config: dict[str, object]) -> Path:
     raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
     os_env: dict[str, str] = dict(raw_env)
 
-    if os.environ.get("INNATE_PUBLIC_DEMO") == "1" or os_env.get("INNATE_PUBLIC_DEMO") == "1":
+    if any(
+        value.strip().lower() in {"1", "true", "yes"}
+        for value in (os.environ.get("INNATE_PUBLIC_DEMO", ""), os_env.get("INNATE_PUBLIC_DEMO", ""))
+    ):
         if any(os_env.get(key, "").strip() for key in SECRET_ENV_KEYS):
             raise StackError("Public simulator runtimes cannot contain API keys; use the external demo relay.")
 

--- a/sim/launcher/env_store.py
+++ b/sim/launcher/env_store.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Private, atomic updates to the local dotenv file shared by the CLI and wizard."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import re
+import stat
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+
+def _validate_env_key(key: str) -> None:
+    if not isinstance(key, str) or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key) is None:
+        raise ValueError("Invalid environment variable name")
+
+
+def _quote_env_value(value: str, *, allow_empty: bool = False) -> str:
+    # These files are also sourced by shell launchers. Never accept quoting or
+    # expansion syntax, even though our own assignments use literal quotes.
+    if not isinstance(value, str) or (not value.strip() and not (allow_empty and value == "")):
+        raise ValueError("Environment value must not be empty")
+    if any(not ch.isprintable() or ch in "\"'$`\\" for ch in value):
+        raise ValueError("Environment value contains unsupported characters")
+    return f"'{value}'"
+
+
+def _unquote_env_value(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _is_active_env_assignment(line: str, key: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return False
+    assignment_key, _ = stripped.split("=", 1)
+    return assignment_key.strip() == key
+
+
+def _is_commented_env_assignment(line: str, key: str) -> bool:
+    """Match commented assignments, never descriptive comments mentioning a key."""
+    stripped = line.strip()
+    return stripped.startswith("#") and _is_active_env_assignment(stripped.lstrip("#").strip(), key)
+
+
+def _check_regular_or_missing(path: Path) -> None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return
+    if not stat.S_ISREG(info.st_mode):
+        raise ValueError("Environment storage must be a regular file, not a symlink")
+
+
+@contextmanager
+def _locked_env(path: Path) -> Iterator[list[str] | None]:
+    """Hold a stable sidecar lock through the complete read/modify/replace."""
+    _check_regular_or_missing(path)
+    lock_path = path.with_name(path.name + ".lock")
+    _check_regular_or_missing(lock_path)
+    flags = os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_NONBLOCK
+    lock_fd = os.open(lock_path, flags, 0o600)
+    try:
+        lock_info = os.fstat(lock_fd)
+        if not stat.S_ISREG(lock_info.st_mode):
+            raise ValueError("Environment lock must be a regular file")
+        os.fchmod(lock_fd, 0o600)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        # Do not continue on a lock inode that was replaced while we waited.
+        current_lock = lock_path.lstat()
+        if (current_lock.st_dev, current_lock.st_ino) != (lock_info.st_dev, lock_info.st_ino):
+            raise ValueError("Environment lock changed during update")
+        _check_regular_or_missing(path)
+        try:
+            env_fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+        except FileNotFoundError:
+            lines = None
+        else:
+            with os.fdopen(env_fd, "r", encoding="utf-8") as source:
+                if not stat.S_ISREG(os.fstat(source.fileno()).st_mode):
+                    raise ValueError("Environment storage must be a regular file")
+                # Tighten permissions on old files as well as replacements.
+                os.fchmod(source.fileno(), 0o600)
+                try:
+                    lines = source.read().splitlines()
+                except UnicodeError:
+                    raise ValueError("Environment storage must contain valid UTF-8 text") from None
+        yield lines
+    finally:
+        os.close(lock_fd)
+
+
+def _atomic_write(path: Path, lines: list[str]) -> None:
+    fd, temporary = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as destination:
+            os.fchmod(destination.fileno(), 0o600)
+            destination.write("\n".join(lines) + "\n")
+            destination.flush()
+            os.fsync(destination.fileno())
+        _check_regular_or_missing(path)
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def write_env_value(path: Path, key: str, value: str, *, allow_empty: bool = False) -> None:
+    """Save one value, removing duplicate and stale commented assignments.
+
+    Empty values are rejected unless ``allow_empty=True`` explicitly requests a
+    blank tombstone. Errors never include the supplied key or value.
+    """
+    _validate_env_key(key)
+    replacement = f"{key}={_quote_env_value(value, allow_empty=allow_empty)}"
+    with _locked_env(path) as lines:
+        updated = False
+        output: list[str] = []
+        for line in lines or []:
+            if _is_active_env_assignment(line, key):
+                if not updated:
+                    output.append(replacement)
+                    updated = True
+            elif not _is_commented_env_assignment(line, key):
+                output.append(line)
+        if not updated:
+            if output and output[-1].strip():
+                output.append("")
+            output.append(replacement)
+        _atomic_write(path, output)
+
+
+def write_env_values(path: Path, values: dict[str, str]) -> None:
+    """Replace a generated Docker env file; values are literal, never shell sourced.
+
+    Docker's env-file syntax does not unquote values. Keep them unquoted, and
+    retain explicit empty values to mask credentials inherited from an image.
+    """
+    output = []
+    for key, value in sorted(values.items()):
+        _validate_env_key(key)
+        if not isinstance(value, str) or any(not ch.isprintable() for ch in value):
+            raise ValueError("Environment value contains unsupported characters")
+        output.append(f"{key}={value}")
+    with _locked_env(path):
+        _atomic_write(path, output)
+
+
+def comment_out_env_key(path: Path, key: str) -> bool:
+    """Disable an active assignment, retaining the effective value for switching.
+
+    Return whether an active assignment was found. Older commented copies are
+    removed so restoring a backend cannot resurrect an obsolete credential.
+    """
+    _validate_env_key(key)
+    with _locked_env(path) as lines:
+        lines = lines or []
+        active = [i for i, line in enumerate(lines) if _is_active_env_assignment(line, key)]
+        if not active:
+            return False
+        output = []
+        for i, line in enumerate(lines):
+            if i == active[-1]:
+                output.append(f"# {line}")
+            elif not _is_active_env_assignment(line, key) and not _is_commented_env_assignment(line, key):
+                output.append(line)
+        _atomic_write(path, output)
+        return True
+
+
+def uncomment_env_key(path: Path, key: str) -> str | None:
+    """Restore a saved backend key, skipping blank template placeholders.
+
+    An active assignment (including a blank tombstone) takes precedence. The
+    restored value is validated and quoted before becoming shell-readable.
+    """
+    _validate_env_key(key)
+    with _locked_env(path) as lines:
+        lines = lines or []
+        if any(_is_active_env_assignment(line, key) for line in lines):
+            return None
+        for i, line in enumerate(lines):
+            if not _is_commented_env_assignment(line, key):
+                continue
+            body = line.strip().lstrip("#").strip()
+            candidate = _unquote_env_value(body.split("=", 1)[1].strip())
+            if not candidate.strip():
+                continue
+            replacement = f"{key}={_quote_env_value(candidate)}"
+            output = [
+                replacement if j == i else current
+                for j, current in enumerate(lines)
+                if j == i or not _is_commented_env_assignment(current, key)
+            ]
+            _atomic_write(path, output)
+            return candidate
+        return None

--- a/sim/launcher/provider_keys.py
+++ b/sim/launcher/provider_keys.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Local CLI credential entry; deliberately has no HTTP or ROS interface."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import click
+from env_store import write_env_value
+
+PROVIDERS = {
+    "openai": "OPENAI_API_KEY",
+    "cartesia": "CARTESIA_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "innate": "INNATE_SERVICE_KEY",
+}
+
+
+def _require_owner_runtime() -> None:
+    if os.environ.get("INNATE_PUBLIC_DEMO") == "1":
+        raise click.ClickException("API key configuration is disabled in the public simulator.")
+
+
+def _write(root: Path, name: str, value: str) -> None:
+    try:
+        write_env_value(root / ".env", name, value, allow_empty=not value)
+    except (OSError, ValueError):
+        # Do not interpolate exceptions; callers can supply arbitrary input.
+        raise click.ClickException("Could not save key. Use a single API key and a writable local .env file.") from None
+
+
+def set_key(root: Path, provider: str, *, from_stdin: bool = False) -> None:
+    _require_owner_runtime()
+    name = PROVIDERS[provider]
+    if from_stdin:
+        value = sys.stdin.read(8193).removesuffix("\n").removesuffix("\r")
+    else:
+        # Click fails closed if hidden input is unavailable; never echo a key
+        # through getpass's fallback for an unattended command.
+        if not sys.stdin.isatty():
+            raise click.ClickException("Use --stdin with a secret-manager pipe, or run from a terminal.")
+        value = click.prompt(name, hide_input=True, err=True)
+    if not value.strip() or len(value) > 8192 or value != value.strip():
+        raise click.ClickException("Expected one nonempty API key without surrounding whitespace.")
+    _write(root, name, value)
+    click.echo(f"Saved {name}. Restart the robot nodes (innate restart) or restart your local simulator to apply.")
+    click.echo("A configured Innate service route takes precedence; adding a key does not change the selected model.")
+
+
+def remove_key(root: Path, provider: str) -> None:
+    _require_owner_runtime()
+    name = PROVIDERS[provider]
+    # Blank overrides inherited shell/system values on the next launch. Deleting
+    # the line would silently re-enable a key from /etc/innate.env.
+    _write(root, name, "")
+    click.echo(f"Cleared {name}. Restart the robot nodes or local simulator to apply.")
+
+
+def status(root: Path) -> None:
+    _require_owner_runtime()
+    from config import parse_env_file
+
+    try:
+        values = {**os.environ, **parse_env_file(Path("/etc/innate.env")), **parse_env_file(root / ".env")}
+    except OSError:
+        raise click.ClickException("Could not read local key configuration.") from None
+    for provider, name in PROVIDERS.items():
+        click.echo(f"{provider}: {'configured' if values.get(name, '').strip() else 'not configured'}")
+    click.echo("Configuration presence only; provider access is checked when used. Restart after changes.")

--- a/sim/launcher/setup_wizard.py
+++ b/sim/launcher/setup_wizard.py
@@ -6,7 +6,6 @@ import getpass
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 from config import (
     CLI_SIM,
@@ -19,6 +18,17 @@ from config import (
     warn,
 )
 from dashboard import BOLD, CYAN, DIM, GREEN, NC, YELLOW, confirm, menus_supported, select_one
+
+# Re-export the existing wizard helpers for callers importing them here.
+from env_store import (  # noqa: F401
+    _is_active_env_assignment,
+    _is_commented_env_assignment,
+    _quote_env_value,
+    _unquote_env_value,
+    comment_out_env_key,
+    uncomment_env_key,
+    write_env_value,
+)
 from runtime import UV_INSTALL_COMMAND, find_uv
 
 
@@ -38,14 +48,6 @@ def is_interactive_terminal() -> bool:
 
 def is_configured_secret(value: str | None) -> bool:
     return is_configured_secret_value(INNATE_SERVICE_KEY, value)
-
-
-def _is_active_env_assignment(line: str, key: str) -> bool:
-    stripped = line.strip()
-    if not stripped or stripped.startswith("#") or "=" not in stripped:
-        return False
-    assignment_key, _ = stripped.split("=", 1)
-    return assignment_key.strip() == key
 
 
 def _prompt_yes_no(question: str, *, default: bool = False) -> bool:
@@ -129,102 +131,6 @@ def _read_masked_secret(prompt: str) -> str | None:
         sys.stdout.write("\n")
         sys.stdout.flush()
     return "".join(chars).strip()
-
-
-def _quote_env_value(value: str) -> str:
-    if "'" in value:
-        raise ValueError("secret values saved to .env cannot contain single quotes")
-    return f"'{value}'"
-
-
-def _unquote_env_value(value: str) -> str:
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
-    return value
-
-
-def _is_commented_env_assignment(line: str, key: str) -> bool:
-    """True only for a commented-out assignment of ``key`` (``# KEY=value``).
-
-    A descriptive comment like ``# Filled by ./innate setup ...`` is not an
-    assignment, so it is never matched (and never toggled)."""
-    stripped = line.strip()
-    if not stripped.startswith("#"):
-        return False
-    return _is_active_env_assignment(stripped.lstrip("#").strip(), key)
-
-
-def write_env_value(path: Path, key: str, value: str) -> None:
-    if "\n" in value or "\r" in value:
-        raise ValueError(f"{key} cannot contain newlines")
-
-    replacement = f"{key}={_quote_env_value(value)}"
-    lines = path.read_text().splitlines() if path.exists() else []
-    updated = False
-    output: list[str] = []
-
-    for line in lines:
-        if _is_active_env_assignment(line, key):
-            if not updated:
-                output.append(replacement)
-                updated = True
-        else:
-            output.append(line)
-
-    if not updated:
-        if output and output[-1].strip():
-            output.append("")
-        output.append(replacement)
-
-    path.write_text("\n".join(output) + "\n")
-
-
-def comment_out_env_key(path: Path, key: str) -> bool:
-    """Comment out an active ``KEY=...`` assignment in the env file, if present.
-
-    Returns True when a line was actually commented out. Leaves unset keys and
-    already-commented lines untouched.
-    """
-    if not path.exists():
-        return False
-    lines = path.read_text().splitlines()
-    changed = False
-    output: list[str] = []
-    for line in lines:
-        if _is_active_env_assignment(line, key):
-            output.append(f"# {line}")
-            changed = True
-        else:
-            output.append(line)
-    if changed:
-        path.write_text("\n".join(output) + "\n")
-    return changed
-
-
-def uncomment_env_key(path: Path, key: str) -> str | None:
-    """Re-enable a previously commented-out ``# KEY=value`` assignment so the user
-    can switch a backend back on without re-pasting the key. Value-less
-    placeholders (the ``# KEY=`` lines shipped in .env.template) are left
-    commented — there is no key to restore, so the caller must prompt for one.
-    Returns the restored value, or None if there is nothing to restore."""
-    if not path.exists():
-        return None
-    lines = path.read_text().splitlines()
-    value: str | None = None
-    output: list[str] = []
-    for line in lines:
-        if value is None and _is_commented_env_assignment(line, key):
-            body = line.strip().lstrip("#").strip()
-            _, raw_value = body.split("=", 1)
-            candidate = _unquote_env_value(raw_value.strip())
-            if candidate:
-                output.append(body)
-                value = candidate
-                continue
-        output.append(line)
-    if value is not None:
-        path.write_text("\n".join(output) + "\n")
-    return value
 
 
 def _save_service_key(config: dict[str, object], service_key: str) -> None:

--- a/tests/test_env_store.py
+++ b/tests/test_env_store.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Secure persistence through the wizard API and the generated Docker env file."""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+LAUNCHER = Path(__file__).resolve().parents[1] / "sim" / "launcher"
+sys.path.insert(0, str(LAUNCHER))
+
+import env_store  # noqa: E402
+import setup_wizard  # noqa: E402
+from config import parse_env_file  # noqa: E402
+
+
+def test_wizard_rotation_and_backend_switch_preserve_only_current_key(tmp_path):
+    path = tmp_path / ".env"
+    path.write_text(
+        "# Describes TEST_KEY without assigning it\n"
+        "# TEST_KEY=\n"
+        "# TEST_KEY='revoked-value'\n"
+        "TEST_KEY='previous-value'\n"
+        "TEST_KEY='duplicate-value'\n"
+        "OTHER='leave-me-alone'\n"
+    )
+    path.chmod(0o644)
+    setup_wizard.write_env_value(path, "TEST_KEY", "new-value")
+    assert parse_env_file(path) == {"TEST_KEY": "new-value", "OTHER": "leave-me-alone"}
+    assert path.read_text().count("TEST_KEY=") == 1
+    assert "# Describes TEST_KEY without assigning it" in path.read_text()
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE((tmp_path / ".env.lock").stat().st_mode) == 0o600
+    assert setup_wizard.comment_out_env_key(path, "TEST_KEY")
+    assert "TEST_KEY" not in parse_env_file(path)
+    assert setup_wizard.uncomment_env_key(path, "TEST_KEY") == "new-value"
+    assert parse_env_file(path)["TEST_KEY"] == "new-value"
+    assert "revoked-value" not in path.read_text()
+    assert not setup_wizard.comment_out_env_key(path, "ABSENT_KEY")
+
+
+def test_switch_skips_placeholders_and_preserves_effective_duplicate_value(tmp_path):
+    path = tmp_path / ".env"
+    assert env_store.uncomment_env_key(path, "TEST_KEY") is None
+    assert not env_store.comment_out_env_key(path, "TEST_KEY")
+    assert not path.exists()
+    path.write_text('# TEST_KEY=\n# TEST_KEY=""\n# TEST_KEY="saved-value"\nOTHER=other\n')
+    assert env_store.uncomment_env_key(path, "TEST_KEY") == "saved-value"
+    path.write_text(path.read_text() + "TEST_KEY=effective-value\n")
+    assert env_store.comment_out_env_key(path, "TEST_KEY")
+    assert env_store.uncomment_env_key(path, "TEST_KEY") == "effective-value"
+    env_store.write_env_value(path, "TEST_KEY", "", allow_empty=True)
+    assert parse_env_file(path)["TEST_KEY"] == ""
+    assert env_store.uncomment_env_key(path, "TEST_KEY") is None
+    assert "effective-value" not in path.read_text()
+
+
+@pytest.mark.parametrize("invalid", ["", " ", "\n", "\r", "\x00", "\x1b", "\x7f", "\u2028", "'", '"', "$", "`", "\\"])
+def test_invalid_secret_leaves_storage_unchanged_and_error_does_not_echo_it(tmp_path, invalid):
+    path = tmp_path / ".env"
+    path.write_text("OTHER=untouched\n")
+    value = invalid if not invalid.strip() else "private-test-value" + invalid
+    with pytest.raises(ValueError) as error:
+        env_store.write_env_value(path, "TEST_KEY", value)
+    assert "private-test-value" not in str(error.value)
+    assert path.read_text() == "OTHER=untouched\n"
+    assert not (tmp_path / ".env.lock").exists()
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        env_store.write_env_value(path, "invalid-private-key;", "controlled-value")
+
+
+def test_literal_shell_roundtrip_and_unsafe_legacy_restore(tmp_path):
+    path = tmp_path / ".env"
+    # Shell punctuation is harmless inside our literal single-quoted value.
+    literal = "controlled-value; false & exit 9"
+    env_store.write_env_value(path, "TEST_KEY", literal)
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; test "$TEST_KEY" = "$2"', "env-test", str(path), literal],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    path.write_text('# TEST_KEY="$(private-test-command)"\n')
+    with pytest.raises(ValueError) as error:
+        env_store.uncomment_env_key(path, "TEST_KEY")
+    assert "private-test-command" not in str(error.value)
+    assert path.read_text() == '# TEST_KEY="$(private-test-command)"\n'
+
+
+@pytest.mark.parametrize("link_name", [".env", ".env.lock"])
+def test_refuses_symlink_storage_without_touching_target(tmp_path, link_name):
+    target = tmp_path / "target"
+    target.write_text("OTHER=untouched\n")
+    (tmp_path / link_name).symlink_to(target)
+    with pytest.raises(ValueError, match="not a symlink"):
+        env_store.write_env_value(tmp_path / ".env", "TEST_KEY", "controlled-value")
+    assert target.read_text() == "OTHER=untouched\n"
+    assert (tmp_path / link_name).is_symlink()
+
+
+def test_atomic_failure_keeps_original_and_cleans_private_temporary_file(tmp_path, monkeypatch):
+    path = tmp_path / ".env"
+    path.write_text("OTHER=original\n")
+
+    def fail_replace(source, destination):
+        assert Path(source).parent == path.parent
+        assert Path(destination) == path
+        assert stat.S_IMODE(Path(source).stat().st_mode) == 0o600
+        assert path.read_text() == "OTHER=original\n"
+        raise OSError("controlled replace failure")
+
+    monkeypatch.setattr(env_store.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="controlled replace failure"):
+        env_store.write_env_value(path, "TEST_KEY", "controlled-value")
+    assert path.read_text() == "OTHER=original\n"
+    assert sorted(p.name for p in tmp_path.iterdir()) == [".env", ".env.lock"]
+
+
+def test_concurrent_process_updates_do_not_clobber_each_other(tmp_path):
+    path = tmp_path / ".env"
+    path.write_text("OTHER=original\n")
+    gate = tmp_path / "start"
+    script = """
+import sys, time
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+import env_store
+original_write = env_store._atomic_write
+def delayed_write(path, lines):
+    # Widen the lost-update window: this delay must remain inside the lock.
+    time.sleep(0.02)
+    original_write(path, lines)
+env_store._atomic_write = delayed_write
+while not Path(sys.argv[3]).exists():
+    time.sleep(0.005)
+for index in range(4):
+    env_store.write_env_value(Path(sys.argv[2]), f"WORKER_{sys.argv[4]}_{index}", "controlled-value")
+"""
+    workers = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, str(LAUNCHER), str(path), str(gate), str(worker)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for worker in range(4)
+    ]
+    try:
+        gate.touch()
+        for worker in workers:
+            stdout, stderr = worker.communicate(timeout=15)
+            assert worker.returncode == 0, (stdout, stderr)
+    finally:
+        for worker in workers:
+            if worker.poll() is None:
+                worker.kill()
+                worker.wait()
+    expected = {f"WORKER_{worker}_{index}": "controlled-value" for worker in range(4) for index in range(4)}
+    assert parse_env_file(path) == {"OTHER": "original", **expected}
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_generated_docker_env_keeps_literal_values_and_blank_tombstones(tmp_path):
+    path = tmp_path / "innate-os.env"
+    path.write_text("OLD_KEY=obsolete\n")
+    path.chmod(0o644)
+    values = {"TEST_KEY": "controlled-value", "EMPTY_KEY": "", "URL": "https://example.test/?query=one&other=two"}
+    env_store.write_env_values(path, values)
+    assert path.read_text() == "".join(f"{key}={value}\n" for key, value in sorted(values.items()))
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(path.with_name(path.name + ".lock").stat().st_mode) == 0o600
+    with pytest.raises(ValueError):
+        env_store.write_env_values(path, {"TEST_KEY": "private-test-value\nOTHER=bad"})
+    assert parse_env_file(path) == values

--- a/tests/test_provider_keys.py
+++ b/tests/test_provider_keys.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Owner CLI -> persisted .env -> hardware loader / simulator launch environment."""
+
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "sim/launcher"))
+sys.path.insert(0, str(ROOT / "ros2_ws/src/mars_bot/mars_bringup"))
+
+import config as launcher  # noqa: E402
+from mars_bringup import config_loader  # noqa: E402
+
+CANARY = "controlled-provider-canary"
+
+
+def cli(root, *args, value=None, extra_env=None):
+    env = {**os.environ, "INNATE_OS_ROOT": str(root), **(extra_env or {})}
+    return subprocess.run(
+        [sys.executable, str(ROOT / "scripts/innate"), "keys", *args],
+        input=value,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def test_key_rotation_runtime_pickup_and_removal(tmp_path, monkeypatch):
+    for name in launcher.SECRET_ENV_KEYS:
+        monkeypatch.setenv(name, "")  # restore process environment after the real launch loader runs
+    root = tmp_path
+    path = root / ".env"
+    path.write_text("INNATE_SERVICE_KEY='controlled-service-key'\nOPENAI_API_KEY='old'\n# OPENAI_API_KEY='older'\n")
+    for provider, name in [("openai", "OPENAI_API_KEY"), ("cartesia", "CARTESIA_API_KEY")]:
+        result = cli(root, "set", provider, "--stdin", value=CANARY + "\n")
+        assert result.returncode == 0, result.stderr
+        assert CANARY not in result.stdout + result.stderr
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert "older" not in path.read_text()
+        monkeypatch.setattr(config_loader, "SYSTEM_ENV_PATH", root / "system.env")
+        config_loader.load_env_file(path)
+        assert os.environ[name] == CANARY
+
+    # Neither the settings overlay nor the service route is rewritten.
+    assert not (root / "config/settings.yaml").exists()
+    assert launcher.parse_env_file(path)["INNATE_SERVICE_KEY"] == "controlled-service-key"
+    status = cli(root, "status")
+    assert status.returncode == 0
+    assert "openai: configured" in status.stdout and "cartesia: configured" in status.stdout
+    assert CANARY not in status.stdout + status.stderr
+
+    result = cli(root, "remove", "openai")
+    assert result.returncode == 0
+    # Explicit blank overrides both system fallback and inherited shell value.
+    (root / "system.env").write_text("OPENAI_API_KEY='inherited-key'\n")
+    config_loader.load_env_file(path)
+    assert os.environ["OPENAI_API_KEY"] == ""
+    assert CANARY not in cli(root, "status").stdout
+    assert "openai: not configured" in cli(root, "status").stdout
+
+
+def test_rejected_input_and_public_demo_never_save_or_echo(tmp_path):
+    for value in ["", "\n", f"{CANARY}\nOTHER=value", CANARY + "\x00", CANARY + "\x1b[31m"]:
+        result = cli(tmp_path, "set", "openai", "--stdin", value=value)
+        assert result.returncode != 0
+        assert CANARY not in result.stdout + result.stderr
+        assert not (tmp_path / ".env").exists()
+    for args in [("set", "openai", "--stdin"), ("remove", "cartesia"), ("status",)]:
+        result = cli(tmp_path, *args, value=CANARY, extra_env={"INNATE_PUBLIC_DEMO": "1"})
+        assert result.returncode != 0
+        assert "public simulator" in result.stderr
+        assert CANARY not in result.stdout + result.stderr
+    assert not (tmp_path / ".env").exists()
+    result = cli(tmp_path, "set", "openai", value=CANARY)
+    assert result.returncode != 0
+    assert "--stdin" in result.stderr
+    result = cli(tmp_path, "set", "openai", CANARY)
+    assert result.returncode != 0
+    assert CANARY not in result.stdout + result.stderr
+
+
+def test_simulator_key_injection_and_explicit_local_precedence(tmp_path, monkeypatch):
+    for key in launcher.SECRET_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", CANARY)
+    monkeypatch.setenv("CARTESIA_API_KEY", CANARY)
+    monkeypatch.setattr(launcher, "ENV_PATH", tmp_path / ".env")
+    monkeypatch.setattr(launcher, "SETTINGS_PATH", tmp_path / "settings.yaml")
+    monkeypatch.setattr(launcher, "SIM_CONFIG_PATH", tmp_path / "sim.toml")
+    monkeypatch.setattr(launcher, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(launcher, "GENERATED_OS_ENV_PATH", tmp_path / "state/generated.env")
+    monkeypatch.setattr(launcher, "resolve_os_image_setting", lambda *_: ("controlled-image", False))
+    config = launcher.get_config()
+    generated = launcher.build_os_env(config)
+    assert generated.stat().st_mode & 0o777 == 0o600
+    assert launcher.parse_env_file(generated)["OPENAI_API_KEY"] == CANARY
+    assert launcher.parse_env_file(generated)["CARTESIA_API_KEY"] == CANARY
+    assert cli(tmp_path, "remove", "openai").returncode == 0
+    assert cli(tmp_path, "set", "cartesia", "--stdin", value="replacement").returncode == 0
+    generated = launcher.build_os_env(launcher.get_config())
+    assert launcher.parse_env_file(generated)["OPENAI_API_KEY"] == ""
+    assert launcher.parse_env_file(generated)["CARTESIA_API_KEY"] == "replacement"
+    monkeypatch.setenv("INNATE_PUBLIC_DEMO", "1")
+    with pytest.raises(launcher.StackError, match="cannot contain API keys") as failure:
+        launcher.build_os_env(config)
+    assert CANARY not in str(failure.value)
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+def test_real_terminal_prompt_hides_input_and_cancel_preserves_file(tmp_path, cancel):
+    path = tmp_path / ".env"
+    path.write_text("OTHER=original\n")
+    master, slave = pty.openpty()
+    process = subprocess.Popen(
+        [sys.executable, str(ROOT / "scripts/innate"), "keys", "set", "openai"],
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+        env={**os.environ, "INNATE_OS_ROOT": str(tmp_path)},
+        start_new_session=True,
+    )
+    os.close(slave)
+    transcript = b""
+
+    def read_until(marker):
+        nonlocal transcript
+        deadline = time.monotonic() + 10
+        while marker not in transcript and time.monotonic() < deadline:
+            if select.select([master], [], [], 0.1)[0]:
+                try:
+                    chunk = os.read(master, 8192)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                transcript += chunk
+        assert marker in transcript, transcript.decode(errors="replace")
+
+    try:
+        read_until(b"OPENAI_API_KEY:")
+        if cancel:
+            # Send SIGINT to the process itself (the test PTY has no controlling session).
+            import signal
+
+            process.send_signal(signal.SIGINT)
+            read_until(b"Aborted")
+        else:
+            os.write(master, (CANARY + "\n").encode())
+            read_until(b"Saved OPENAI_API_KEY")
+        process.wait(timeout=10)
+        assert CANARY.encode() not in transcript
+        if cancel:
+            assert process.returncode != 0
+            assert path.read_text() == "OTHER=original\n"
+        else:
+            assert process.returncode == 0
+            assert launcher.parse_env_file(path)["OPENAI_API_KEY"] == CANARY
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+        os.close(master)

--- a/tests/test_provider_keys.py
+++ b/tests/test_provider_keys.py
@@ -67,14 +67,15 @@ def test_key_rotation_runtime_pickup_and_removal(tmp_path, monkeypatch):
     assert "openai: not configured" in cli(root, "status").stdout
 
 
-def test_rejected_input_and_public_demo_never_save_or_echo(tmp_path):
+@pytest.mark.parametrize("public_flag", ["1", " true ", "YES"])
+def test_rejected_input_and_public_demo_never_save_or_echo(tmp_path, public_flag):
     for value in ["", "\n", f"{CANARY}\nOTHER=value", CANARY + "\x00", CANARY + "\x1b[31m"]:
         result = cli(tmp_path, "set", "openai", "--stdin", value=value)
         assert result.returncode != 0
         assert CANARY not in result.stdout + result.stderr
         assert not (tmp_path / ".env").exists()
     for args in [("set", "openai", "--stdin"), ("remove", "cartesia"), ("status",)]:
-        result = cli(tmp_path, *args, value=CANARY, extra_env={"INNATE_PUBLIC_DEMO": "1"})
+        result = cli(tmp_path, *args, value=CANARY, extra_env={"INNATE_PUBLIC_DEMO": public_flag})
         assert result.returncode != 0
         assert "public simulator" in result.stderr
         assert CANARY not in result.stdout + result.stderr
@@ -108,10 +109,11 @@ def test_simulator_key_injection_and_explicit_local_precedence(tmp_path, monkeyp
     generated = launcher.build_os_env(launcher.get_config())
     assert launcher.parse_env_file(generated)["OPENAI_API_KEY"] == ""
     assert launcher.parse_env_file(generated)["CARTESIA_API_KEY"] == "replacement"
-    monkeypatch.setenv("INNATE_PUBLIC_DEMO", "1")
-    with pytest.raises(launcher.StackError, match="cannot contain API keys") as failure:
-        launcher.build_os_env(config)
-    assert CANARY not in str(failure.value)
+    for flag in ["1", " true ", "YES"]:
+        monkeypatch.setenv("INNATE_PUBLIC_DEMO", flag)
+        with pytest.raises(launcher.StackError, match="cannot contain API keys") as failure:
+            launcher.build_os_env(config)
+        assert CANARY not in str(failure.value)
 
 
 @pytest.mark.parametrize("cancel", [False, True])


### PR DESCRIPTION
Owners can now enter Cartesia and OpenAI keys through `innate keys set cartesia` / `innate keys set openai`, inspect configuration presence with `innate keys status`, and remove keys without putting credentials into browser settings, ROS parameters, command arguments, or output. Entry uses a hidden terminal prompt or a secret-manager pipe via `--stdin`; changes take effect after a node/local-simulator restart.

The CLI reuses the simulator setup's `.env` persistence path. Updates are atomic, locked across processes, and mode 0600; replacing a key removes stale commented copies. Removal writes an empty override so old shell/system credentials do not silently return on restart. Generated simulator env files are also private and retain empty overrides. Local `.env` values now consistently take precedence over inherited shell keys, matching the robot launch loader. `INNATE_PUBLIC_DEMO=1` rejects key commands and credential-bearing generated environments.

### Runtime dependencies and boundaries

- Direct Cartesia TTS already belongs to David's #755. This PR does not duplicate its transport, change his branch/status, replace Alfred, or claim to resolve his external voice-access blocker.
- The complete OpenAI Responses agent/provider selection is in #772. The safe transport contributed from this work is included there, not duplicated in this diff. The official model ID is `gpt-6-astra`; entering a key does not select a model.
- Configured service-key routing is preserved. No deployed robot/public simulator was modified. The public-demo flag is a deployment guard; runtime credential isolation remains the separate security audit's relay work.

### Verification

50 focused tests passed: actual CLI subprocess save/rotate/status/remove, real PTY hidden input and cancellation, actual hardware `.env` loader and simulator generated environment, service-key preservation, shell override removal, public-demo rejection, concurrent process writes, atomic failure cleanup, permissions, symlink refusal, and launcher imports. Ruff and diff checks pass. Latest head `941d678f4` passes GitHub format and host pytest; ROS integration/image builds are still pending.

Combined verification against #755 plus #774 (`8e2d0d76a`) and #772 (`1cc44b47c`) also passed: actual CLI pipe → private `.env` → hardware launch loader → OpenAIContext two-turn native tool replay and Cartesia TTSHandler → local HTTP provider doubles, plus 54 provider/TTS tests. The integration needed two merge resolutions with #755: retain all four `SECRET_ENV_KEYS` in `sim/launcher/config.py`, and retain David's generic setup UX while importing the extracted env-store helpers in `setup_wizard.py`. No foundation conflict occurred.

The OpenAI transport's additional 8 real local HTTP tests passed before handoff to #772 (direct/proxy routing, no account failover, malformed/incomplete/error stream sanitization, missing key, public-demo guard). Live OpenAI account/model authorization and Cartesia synthesis with a non-owning key are not verified in this PR. Those require an owner-provided key through the local secret path; never paste credentials into a PR or chat.

Keep this PR **draft** until Axel explicitly approves it.
