### PR TITLE
fix(tts): protect direct Cartesia keys and redact provider errors

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/transport/cartesia.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/cartesia.py
@@ -107,7 +107,7 @@ def proxy_tts(proxy: ProxyClient) -> TtsTransport:
     def warmup() -> None:
         # Any request to the proxy host warms httpx's connection pool.
         with _safe_errors("proxy"):
-            proxy.get_sync_client().head(proxy.proxy_url).raise_for_status()
+            proxy.get_sync_client().head(proxy.proxy_url)
 
     # close is a no-op: the node owns the ProxyClient and shares it with the
     # brain and STT, so closing it here would cut those off mid-run.
@@ -149,7 +149,8 @@ def direct_tts(api_key: str) -> TtsTransport:
     def warmup() -> None:
         _require_private_session()
         with _safe_errors("direct"):
-            client.head(DIRECT_URL).raise_for_status()
+            # The bytes endpoint can reject HEAD (405) after warming TLS.
+            client.head(DIRECT_URL)
 
     def close() -> None:
         with _safe_errors("direct"):

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/cartesia.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/cartesia.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -57,37 +58,41 @@ class TtsBackend(StrEnum):
     UNCONFIGURED = "unconfigured"
 
 
+def _public_demo_enabled() -> bool:
+    return os.environ.get("INNATE_PUBLIC_DEMO", "").strip().lower() in {"1", "true", "yes"}
+
+
 def pick_tts(proxy: ProxyClient | None) -> tuple[TtsTransport | None, TtsBackend]:
     """The way to reach Cartesia: the Innate proxy (managed) or CARTESIA_API_KEY (dev)."""
     if proxy is not None and proxy.is_available():
         return proxy_tts(proxy), TtsBackend.PROXY
+    if _public_demo_enabled():
+        return None, TtsBackend.UNCONFIGURED
     api_key = os.environ.get("CARTESIA_API_KEY", "").strip()
     if api_key:
         return direct_tts(api_key), TtsBackend.DIRECT
     return None, TtsBackend.UNCONFIGURED
 
 
+@contextmanager
+def _safe_errors(backend: str) -> Iterator[None]:
+    """Provider errors reach robot logs; expose only the route and HTTP status."""
+    try:
+        yield
+    except httpx.HTTPStatusError as exc:
+        raise RuntimeError(f"cartesia {backend}: HTTP {exc.response.status_code}") from None
+    except Exception:
+        raise RuntimeError(f"cartesia {backend}: request failed") from None
+
+
+def _require_private_session() -> None:
+    if _public_demo_enabled():
+        raise RuntimeError("Direct Cartesia credentials are disabled in public demo sessions")
+
+
 def proxy_tts(proxy: ProxyClient) -> TtsTransport:
     """Reach Cartesia through the Innate proxy (the proxy holds the upstream key)."""
     tts = proxy.cartesia.tts
-
-    def warmup() -> None:
-        # Any request to the proxy host warms httpx's connection pool.
-        proxy.get_sync_client().head(proxy.proxy_url)
-
-    # close is a no-op: the node owns the ProxyClient and shares it with the
-    # brain and STT, so closing it here would cut those off mid-run.
-    return TtsTransport(stream=tts.bytes_stream, warmup=warmup, close=lambda: None)
-
-
-def direct_tts(api_key: str) -> TtsTransport:
-    """Reach Cartesia directly with CARTESIA_API_KEY."""
-    # One client for the process: reuses the TLS connection across utterances.
-    # Single-threaded use by construction (one clip at a time on the speech worker).
-    client = httpx.Client(
-        headers={"Authorization": f"Bearer {api_key}", "Cartesia-Version": DIRECT_API_VERSION},
-        timeout=60.0,
-    )
 
     def stream(
         model_id: str,
@@ -96,6 +101,38 @@ def direct_tts(api_key: str) -> TtsTransport:
         output_format: dict[str, Any],
         generation_config: dict[str, Any] | None = None,
     ) -> Iterator[bytes]:
+        with _safe_errors("proxy"):
+            yield from tts.bytes_stream(model_id, transcript, voice, output_format, generation_config)
+
+    def warmup() -> None:
+        # Any request to the proxy host warms httpx's connection pool.
+        with _safe_errors("proxy"):
+            proxy.get_sync_client().head(proxy.proxy_url).raise_for_status()
+
+    # close is a no-op: the node owns the ProxyClient and shares it with the
+    # brain and STT, so closing it here would cut those off mid-run.
+    return TtsTransport(stream=stream, warmup=warmup, close=lambda: None)
+
+
+def direct_tts(api_key: str) -> TtsTransport:
+    """Reach Cartesia directly with CARTESIA_API_KEY."""
+    _require_private_session()
+    # One client for the process: reuses the TLS connection across utterances.
+    # Single-threaded use by construction (one clip at a time on the speech worker).
+    with _safe_errors("direct"):
+        client = httpx.Client(
+            headers={"Authorization": f"Bearer {api_key}", "Cartesia-Version": DIRECT_API_VERSION},
+            timeout=60.0,
+        )
+
+    def stream(
+        model_id: str,
+        transcript: str,
+        voice: dict[str, Any],
+        output_format: dict[str, Any],
+        generation_config: dict[str, Any] | None = None,
+    ) -> Iterator[bytes]:
+        _require_private_session()
         body: dict[str, Any] = {
             "model_id": model_id,
             "transcript": transcript,
@@ -104,13 +141,18 @@ def direct_tts(api_key: str) -> TtsTransport:
         }
         if generation_config:
             body["generation_config"] = generation_config
-        with client.stream("POST", DIRECT_URL, json=body) as resp:
+        with _safe_errors("direct"), client.stream("POST", DIRECT_URL, json=body) as resp:
             if resp.status_code != 200:
-                resp.read()
-                raise RuntimeError(f"cartesia direct: HTTP {resp.status_code}: {resp.text[:200]}")
+                raise httpx.HTTPStatusError("TTS request failed", request=resp.request, response=resp)
             yield from resp.iter_bytes()
 
     def warmup() -> None:
-        client.head(DIRECT_URL)
+        _require_private_session()
+        with _safe_errors("direct"):
+            client.head(DIRECT_URL).raise_for_status()
 
-    return TtsTransport(stream=stream, warmup=warmup, close=client.close)
+    def close() -> None:
+        with _safe_errors("direct"):
+            client.close()
+
+    return TtsTransport(stream=stream, warmup=warmup, close=close)

--- a/ros2_ws/src/brain/brain_client/test/test_cartesia_transport.py
+++ b/ros2_ws/src/brain/brain_client/test/test_cartesia_transport.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Exercise real httpx requests and the TTS handler without provider credentials."""
+
+import json
+import threading
+import traceback
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from brain_client.core.config import _PARAM_DEFAULTS
+from brain_client.transport import cartesia
+from brain_client.transport.tts import TTSHandler
+from innate_proxy import ProxyClient
+
+CANARY = "controlled-private-credential-canary"
+VOICE = {"mode": "id", "id": _PARAM_DEFAULTS["cartesia_voice_id"]}
+FORMAT = {"container": "wav", "encoding": "pcm_s16le", "sample_rate": 44100}
+
+
+@pytest.fixture(autouse=True)
+def private_test_environment(monkeypatch):
+    monkeypatch.delenv("INNATE_PUBLIC_DEMO", raising=False)
+    monkeypatch.delenv("CARTESIA_API_KEY", raising=False)
+
+
+class AudioChunks(httpx.SyncByteStream):
+    def __init__(self, fail=False):
+        self.closed = False
+        self.fail = fail
+
+    def __iter__(self):
+        yield b"audio-first"
+        if self.fail:
+            raise httpx.ReadError(CANARY)
+        yield b"audio-second"
+
+    def close(self):
+        self.closed = True
+
+
+def direct_factory(monkeypatch, respond):
+    """Replace only the network; keep httpx's request/stream/client behavior."""
+    client_type = httpx.Client
+    clients = []
+
+    def create_client(**kwargs):
+        client = client_type(transport=httpx.MockTransport(respond), **kwargs)
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(cartesia.httpx, "Client", create_client)
+    return clients
+
+
+def proxy_client(respond):
+    proxy = ProxyClient(proxy_url="https://proxy.test", innate_service_key=CANARY)
+    # A controlled authenticated client replaces only OIDC/network access. The
+    # real proxy adapter still builds and routes every Cartesia request.
+    proxy._sync_client = httpx.Client(
+        headers={"Authorization": f"Bearer {CANARY}"}, transport=httpx.MockTransport(respond)
+    )
+    return proxy
+
+
+def handler_for(transport):
+    # Run the actual synchronous speech path without starting queue threads or
+    # publishing ROS messages. No physical audio device is involved.
+    handler = TTSHandler.__new__(TTSHandler)
+    handler._tts = transport
+    handler.backend = "test-backend"
+    handler.voice_id = _PARAM_DEFAULTS["cartesia_voice_id"]
+    handler._simulator_mode = True
+    handler.tts_audio_pub = object()
+    handler.play_lock = threading.Lock()
+    handler.is_playing = False
+    handler._closing = threading.Event()
+    messages = []
+    audio = []
+    handler.logger = SimpleNamespace(**{level: messages.append for level in ("info", "debug", "error")})
+    handler._publish_tts_status = lambda _status: None
+    handler._publish_audio = audio.append
+    return handler, messages, audio
+
+
+def test_direct_requests_forward_default_voice_and_reuse_then_close_client(monkeypatch):
+    requests = []
+    streams = []
+
+    def respond(request):
+        requests.append(request)
+        stream = AudioChunks()
+        streams.append(stream)
+        return httpx.Response(200, stream=stream)
+
+    clients = direct_factory(monkeypatch, respond)
+    assert cartesia.pick_tts(None) == (None, cartesia.TtsBackend.UNCONFIGURED)
+    monkeypatch.setenv("CARTESIA_API_KEY", CANARY)
+    transport, backend = cartesia.pick_tts(None)
+    assert backend == cartesia.TtsBackend.DIRECT
+    assert transport is not None
+    handler, _messages, audio = handler_for(transport)
+    try:
+        transport.warmup()
+        assert handler.speak_text("controlled transcript")
+        assert audio == [b"audio-firstaudio-second"]
+        assert list(handler._stream_tts_bytes("speaker transcript", VOICE, for_speaker=True)) == [
+            b"audio-first",
+            b"audio-second",
+        ]
+        assert len(clients) == 1
+        assert [request.method for request in requests] == ["HEAD", "POST", "POST"]
+        assert all(str(request.url) == cartesia.DIRECT_URL for request in requests)
+        assert all(request.headers["Authorization"] == f"Bearer {CANARY}" for request in requests)
+        assert all(request.headers["Cartesia-Version"] == cartesia.DIRECT_API_VERSION for request in requests)
+        assert json.loads(requests[1].content) == {
+            "model_id": "sonic-3.5",
+            "transcript": "controlled transcript",
+            "voice": VOICE,
+            "output_format": FORMAT,
+        }
+        speaker = json.loads(requests[2].content)
+        assert speaker["voice"] == VOICE
+        assert speaker["output_format"] == {"container": "raw", "encoding": "pcm_s16le", "sample_rate": 16000}
+        assert speaker["generation_config"] == {"speed": 1.5}
+        assert all(stream.closed for stream in streams)
+        assert not clients[0].is_closed
+    finally:
+        transport.close()
+    assert clients[0].is_closed
+
+
+@pytest.mark.parametrize("public_demo", ["", "1"])
+def test_proxy_precedes_direct_even_in_public_demo_and_retains_shared_client(monkeypatch, public_demo):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(200, stream=AudioChunks())
+
+    monkeypatch.setenv("CARTESIA_API_KEY", CANARY)
+    monkeypatch.setenv("INNATE_PUBLIC_DEMO", public_demo)
+    proxy = proxy_client(respond)
+    client = proxy.get_sync_client()
+
+    def forbidden_direct(_key):
+        pytest.fail("A configured proxy must never fall back to a direct key")
+
+    monkeypatch.setattr(cartesia, "direct_tts", forbidden_direct)
+    try:
+        transport, backend = cartesia.pick_tts(proxy)
+        assert transport is not None
+        assert backend == cartesia.TtsBackend.PROXY
+        transport.warmup()
+        assert list(transport.stream("sonic-3.5", "hello", VOICE, FORMAT)) == [b"audio-first", b"audio-second"]
+        assert [str(request.url) for request in requests] == [
+            "https://proxy.test",
+            "https://proxy.test/v1/services/cartesia/tts/bytes",
+        ]
+        assert json.loads(requests[1].content)["voice"] == VOICE
+        transport.close()
+        assert not client.is_closed
+    finally:
+        proxy.close()
+    assert client.is_closed
+
+
+@pytest.mark.parametrize("route", ["direct", "proxy"])
+@pytest.mark.parametrize("failure", ["unauthorized", "warmup_http", "partial_stream", "warmup_exception"])
+def test_failures_expose_only_status_or_generic_error_without_failover(monkeypatch, route, failure):
+    requests = []
+    streams = []
+
+    def respond(request):
+        requests.append(request)
+        if failure == "warmup_exception":
+            raise RuntimeError(CANARY)
+        if failure == "partial_stream":
+            stream = AudioChunks(fail=True)
+            streams.append(stream)
+            return httpx.Response(200, stream=stream)
+        return httpx.Response(401, text=CANARY, headers={"X-Provider-Details": CANARY})
+
+    monkeypatch.setenv("CARTESIA_API_KEY", CANARY)
+    proxy = None
+    if route == "direct":
+        clients = direct_factory(monkeypatch, respond)
+    else:
+        proxy = proxy_client(respond)
+
+        def forbidden_direct(_key):
+            pytest.fail("Provider errors must never trigger direct-key failover")
+
+        monkeypatch.setattr(cartesia, "direct_tts", forbidden_direct)
+    transport, _backend = cartesia.pick_tts(proxy)
+    assert transport is not None
+    handler, messages, _audio = handler_for(transport)
+    expected = f"cartesia {route}: " + ("HTTP 401" if failure in {"unauthorized", "warmup_http"} else "request failed")
+    try:
+        with pytest.raises(RuntimeError) as error:
+            if failure.startswith("warmup"):
+                transport.warmup()
+            else:
+                list(transport.stream("sonic-3.5", "hello", VOICE, FORMAT))
+        assert str(error.value) == expected
+        assert CANARY not in "".join(traceback.format_exception(error.value))
+        if failure.startswith("warmup"):
+            handler._warmup_connection()
+        else:
+            assert not handler.speak_text("controlled transcript")
+        assert any(expected in message for message in messages)
+        assert all(CANARY not in message for message in messages)
+        assert len(requests) == 2
+        assert all(stream.closed for stream in streams)
+    finally:
+        transport.close()
+        if proxy is not None:
+            proxy.close()
+        else:
+            assert clients[0].is_closed
+
+
+@pytest.mark.parametrize("flag", ["1", " true ", "YES"])
+def test_public_demo_blocks_selection_construction_and_existing_direct_calls(monkeypatch, flag):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(200, content=b"audio")
+
+    clients = direct_factory(monkeypatch, respond)
+    transport = cartesia.direct_tts(CANARY)
+    monkeypatch.setenv("CARTESIA_API_KEY", CANARY)
+    monkeypatch.setenv("INNATE_PUBLIC_DEMO", flag)
+    try:
+        assert cartesia.pick_tts(None) == (None, cartesia.TtsBackend.UNCONFIGURED)
+        with pytest.raises(RuntimeError, match="disabled in public demo"):
+            cartesia.direct_tts(CANARY)
+        with pytest.raises(RuntimeError, match="disabled in public demo"):
+            list(transport.stream("sonic-3.5", "hello", VOICE, FORMAT))
+        with pytest.raises(RuntimeError, match="disabled in public demo"):
+            transport.warmup()
+        assert requests == []
+        assert len(clients) == 1
+    finally:
+        transport.close()
+    assert clients[0].is_closed

--- a/ros2_ws/src/brain/brain_client/test/test_cartesia_transport.py
+++ b/ros2_ws/src/brain/brain_client/test/test_cartesia_transport.py
@@ -168,7 +168,7 @@ def test_proxy_precedes_direct_even_in_public_demo_and_retains_shared_client(mon
 
 
 @pytest.mark.parametrize("route", ["direct", "proxy"])
-@pytest.mark.parametrize("failure", ["unauthorized", "warmup_http", "partial_stream", "warmup_exception"])
+@pytest.mark.parametrize("failure", ["unauthorized", "partial_stream", "warmup_exception"])
 def test_failures_expose_only_status_or_generic_error_without_failover(monkeypatch, route, failure):
     requests = []
     streams = []
@@ -197,7 +197,7 @@ def test_failures_expose_only_status_or_generic_error_without_failover(monkeypat
     transport, _backend = cartesia.pick_tts(proxy)
     assert transport is not None
     handler, messages, _audio = handler_for(transport)
-    expected = f"cartesia {route}: " + ("HTTP 401" if failure in {"unauthorized", "warmup_http"} else "request failed")
+    expected = f"cartesia {route}: " + ("HTTP 401" if failure == "unauthorized" else "request failed")
     try:
         with pytest.raises(RuntimeError) as error:
             if failure.startswith("warmup"):
@@ -220,6 +220,34 @@ def test_failures_expose_only_status_or_generic_error_without_failover(monkeypat
             proxy.close()
         else:
             assert clients[0].is_closed
+
+
+@pytest.mark.parametrize("route", ["direct", "proxy"])
+def test_warmup_ignores_http_status_without_logging_provider_details(monkeypatch, route):
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(405, text=CANARY, headers={"X-Provider-Details": CANARY})
+
+    proxy = None
+    if route == "direct":
+        direct_factory(monkeypatch, respond)
+        transport = cartesia.direct_tts(CANARY)
+    else:
+        proxy = proxy_client(respond)
+        transport = cartesia.proxy_tts(proxy)
+    handler, messages, _audio = handler_for(transport)
+    try:
+        transport.warmup()
+        handler._warmup_connection()
+        assert [request.method for request in requests] == ["HEAD", "HEAD"]
+        assert any("pre-warmed" in message for message in messages)
+        assert all(CANARY not in message and "failed" not in message for message in messages)
+    finally:
+        transport.close()
+        if proxy is not None:
+            proxy.close()
 
 
 @pytest.mark.parametrize("flag", ["1", " true ", "YES"])


### PR DESCRIPTION
Follow-up to David's #755, based on `feat/cartesia-api-key`. This changes only the Cartesia transport and its tests; it does not modify David's branch, select another voice, or resolve the Alfred voice-access blocker.

Direct and proxy failures can reach robot chat/logs through TTS handling. They now expose only HTTP status or a generic request failure, with no upstream body, headers, or exception chain. Public-demo sessions (`INNATE_PUBLIC_DEMO=1`, `true`, or `yes`) cannot select, construct, or use a direct Cartesia transport. The configured proxy still wins and never falls back to a different account after an error. Warmup remains status-agnostic because HEAD is only for connection reuse and may legitimately return 405.

21 tests passed using the actual TTS handler, real proxy adapter and httpx client with controlled network transport: exact Alfred/default voice forwarding, speech body and headers, optional generation config, client reuse/closure, proxy precedence, missing key, rejected credential/partial stream/warmup error redaction, and public-demo guard. Ruff and diff checks pass. No real provider key or physical audio device was used. A separate combined roundtrip with #773 and #772 successfully saved controlled keys through the CLI, loaded them with the real hardware launch loader, and exercised OpenAIContext plus the Cartesia TTSHandler against local HTTP provider doubles; 54 combined provider/TTS tests passed.

The original #755 must remain blocked until Alfred works consistently with the intended non-owning Cartesia key. Owner-local key configuration is separate draft #773; OpenAI Responses runtime is separate draft #772. No deployment or PR-status changes were made.

Keep this follow-up **draft** until Axel explicitly approves it.
