### PR TITLE
Expose simulator world switching to the demo header

### DIFF
--- a/sim/viewer/src/environmentBridge.ts
+++ b/sim/viewer/src/environmentBridge.ts
@@ -1,0 +1,74 @@
+import type { EnvironmentRoster } from "./physics/worldStateController";
+import type { SimSession } from "./simSession";
+
+// Versioned, deliberately small contract with sim-broker/public/environment.js.
+// The embedding document may select a public world, never issue arbitrary
+// simulator commands or receive raw errors, asset paths, or robot state.
+const CHANNEL = "innate:environment:v1";
+type ViewState = "loading" | "ready" | "failed";
+
+export function createEnvironmentBridge(session: SimSession, retryView: () => void) {
+  let parentOrigin: string | null = null;
+  if (window.parent !== window && document.referrer) {
+    const url = new URL(document.referrer);
+    if (["https:", "http:"].includes(url.protocol)) parentOrigin = url.origin;
+  }
+  let roster: EnvironmentRoster | null = null;
+  let view: { id: string; state: ViewState } | null = null;
+  let requested: { id: string; at: number } | null = null;
+  let requestFailed = false;
+
+  const publish = () => {
+    if (!parentOrigin) return;
+    // A lost command must not leave the control pending forever. A later
+    // server roster still wins, including a switch completed after reconnect.
+    if (requested && Date.now() - requested.at > 8000) {
+      requested = null;
+      requestFailed = true;
+    }
+    const connected = session.environmentConnected;
+    const pending = requested?.id ?? (roster?.switch?.state === "loading" ? roster.switch.id : null);
+    window.parent.postMessage({
+      channel: CHANNEL,
+      type: "state",
+      current: roster?.environment?.id ?? null,
+      environments: roster?.environments.map(({ id, display_name }) => ({ id, display_name })) ?? [],
+      pending,
+      state: !connected ? "disconnected" : pending ? "loading"
+        : requestFailed || roster?.switch?.state === "failed" ? "failed"
+        : view?.id === roster?.environment?.id ? view?.state : "loading",
+      retryView: connected && view?.state === "failed",
+    }, parentOrigin);
+  };
+  const unsubscribe = session.onEnvironment((next) => {
+    roster = next;
+    requested = null;
+    requestFailed = false;
+    publish();
+  });
+  const onMessage = (event: MessageEvent) => {
+    if (!parentOrigin || event.source !== window.parent || event.origin !== parentOrigin) return;
+    const data = event.data;
+    if (!data || data.channel !== CHANNEL) return;
+    if (data.type === "get-state") return publish();
+    if (data.type === "retry-view" && view?.state === "failed") return retryView();
+    if (data.type !== "switch" || typeof data.id !== "string") return;
+    if (!session.environmentConnected || requested || roster?.switch?.state === "loading" || view?.state === "loading") return;
+    if (data.id === roster?.environment?.id || !roster?.environments.some(({ id }) => id === data.id)) return;
+    requested = { id: data.id, at: Date.now() };
+    requestFailed = false;
+    session.switchEnvironment(data.id);
+    publish();
+  };
+  window.addEventListener("message", onMessage);
+  return {
+    updateView(id: string, state: ViewState) {
+      view = { id, state };
+      publish();
+    },
+    destroy() {
+      unsubscribe();
+      window.removeEventListener("message", onMessage);
+    },
+  };
+}

--- a/sim/viewer/src/scene.ts
+++ b/sim/viewer/src/scene.ts
@@ -565,8 +565,8 @@ export class SimScene {
   }
 
   /** Dispose environment assets; retain the robot and props for the next pose. */
-  unloadEnvironment(): void {
-    this.traffic.unloadEnvironment();
+  unloadEnvironment({ preserveWorldState = false }: { preserveWorldState?: boolean } = {}): void {
+    if (!preserveWorldState) this.traffic.unloadEnvironment();
     for (const group of [this.layoutGroup, this.hullsGroup]) {
       if (!group) continue;
       this.scene.remove(group);
@@ -578,15 +578,16 @@ export class SimScene {
     }
     this.layoutGroup = this.hullsGroup = this.hullsPromise = this.layoutBounds = undefined;
     this.environmentGeneration += 1;
-    this.robotRoot.visible = false;
-    this.spawned = false;
+    if (!preserveWorldState) {
+      this.robotRoot.visible = false;
+      this.spawned = false;
+    }
   }
 
   /**
    * Phase two: stream each room's glb through the queue and swap its
-   * placeholder box out on arrival. A room that fails is non-fatal (visual
-   * only): log it, drop its box, and let the rest of the apartment and the
-   * session carry on.
+   * placeholder box out on arrival. Finish the remaining rooms on failure,
+   * then let the stage offer a retry instead of claiming the world loaded.
    */
   async streamApartment(queue: LoadQueue, layout: ApartmentLayout): Promise<void> {
     const loader = new GLTFLoader();
@@ -595,22 +596,18 @@ export class SimScene {
     if (layout.monolith) {
       // Single-glb packs, and the dev fallback for a checkout that never ran
       // the apartment split (the published bundle always ships the manifest).
-      // Non-fatal: the sim just runs without the visual environment.
-      try {
-        if (!layout.modelUrl) throw new Error("the pack names no model");
-        const root = await queuedGLB(queue, loader, layout.modelUrl);
-        if (group !== this.layoutGroup) {
-          disposeObject(root); // the pack was unloaded while this streamed
-          return;
-        }
-        this.dressRoom(root);
-        group.add(root);
-      } catch (err) {
-        console.error("[sim-viewer] environment unavailable (no manifest, no monolith):", err);
+      if (!layout.modelUrl) throw new Error("the pack names no model");
+      const root = await queuedGLB(queue, loader, layout.modelUrl);
+      if (group !== this.layoutGroup) {
+        disposeObject(root); // the pack was unloaded while this streamed
+        return;
       }
+      this.dressRoom(root);
+      group.add(root);
       return;
     }
 
+    let failed = false;
     const loadRoom = ({ room, box }: ApartmentLayout["rooms"][number]) =>
       queuedGLB(queue, loader, `${layout.baseUrl}${room.file}`)
         .then((root) => {
@@ -621,7 +618,10 @@ export class SimScene {
           this.dressRoom(root);
           group.add(root);
         })
-        .catch((err) => console.error(`[sim-viewer] apartment room '${room.file}' failed to load:`, err))
+        .catch((err) => {
+          failed = true;
+          console.error(`[sim-viewer] apartment room '${room.file}' failed to load:`, err);
+        })
         .finally(() => {
           group.remove(box);
           box.geometry.dispose(); // material is shared -- disposed in dispose()
@@ -637,6 +637,7 @@ export class SimScene {
     const rest = ordered.slice(priority.length);
     for (const room of priority) await loadRoom(room);
     await Promise.all(rest.map(loadRoom));
+    if (failed) throw new Error("Some environment models failed to load");
   }
 
   /**

--- a/sim/viewer/src/simSession.ts
+++ b/sim/viewer/src/simSession.ts
@@ -370,6 +370,11 @@ export class SimSession {
     this.#controller?.send({ op: "switch_environment", id });
   }
 
+  /** A roster alone may be stale after the observer connection drops. */
+  get environmentConnected(): boolean {
+    return this.#started && this.#lastArrival > 0 && performance.now() / 1000 - this.#lastArrival < 5;
+  }
+
   /** Whether any manipulation prop is currently in the world. Read from
    * ground truth rather than from what this client last asked for, so the
    * stage's button still reads right after a sim reset or another viewer's

--- a/sim/viewer/src/simStage.ts
+++ b/sim/viewer/src/simStage.ts
@@ -14,6 +14,7 @@ import { APARTMENT_VIEWER, SimScene, type CameraMode, type CameraView } from "./
 import type { EnvironmentInfo } from "./physics/worldStateController";
 import type { PropInfo } from "./props";
 import { LoadQueue } from "./loadQueue";
+import { createEnvironmentBridge } from "./environmentBridge";
 import { THUMB_H, THUMB_W, type SimSession } from "./simSession";
 
 // One PiP tile refresh per N rendered frames, round-robin: ~30fps per tile
@@ -605,7 +606,9 @@ export function createSimStage(
   // The robot loads once; environments come and go around it.
   let robotDone: Promise<unknown> | null = null;
   let loadedEnvironmentId: string | null = null;
+  let currentEnvironment: EnvironmentInfo | null = null;
   let loadVersion = 0;
+  const environmentBridge = createEnvironmentBridge(session, () => void loadEnvironment(currentEnvironment));
   const loadEnvironment = async (environment: EnvironmentInfo | null) => {
     // Discard superseded loads after each await.
     const version = ++loadVersion;
@@ -615,9 +618,12 @@ export function createSimStage(
         if (version === loadVersion) setProgress(loaded, total);
       });
       queue.setEstimatedTotal(35e6);
-      scene.unloadEnvironment();
+      // Retrying geometry does not produce a new server epoch/pose. Keep
+      // the existing robot and traffic instead of waiting for a respawn.
+      scene.unloadEnvironment({ preserveWorldState: loadedEnvironmentId === environment?.id });
     }
     loadedEnvironmentId = environment?.id ?? "";
+    environmentBridge.updateView(loadedEnvironmentId, "loading");
     const name = environment?.display_name.toLowerCase() ?? "apartment";
     try {
       // Show layout placeholders while meshes download.
@@ -633,10 +639,12 @@ export function createSimStage(
       await Promise.all([robotDone, scene.streamApartment(queue, layout)]);
       if (disposed || version !== loadVersion) return;
       hideLoading();
+      environmentBridge.updateView(loadedEnvironmentId, "ready");
       // Prefetch props after the scene, outside its progress bar.
       if (firstLoad) scene.prefetchPropModels();
     } catch (err) {
       if (disposed || version !== loadVersion) return;
+      environmentBridge.updateView(environment?.id ?? "", "failed");
       if (robotDone === null) {
         session.stageError(err);
         return;
@@ -651,6 +659,7 @@ export function createSimStage(
   startLoop();
   let environmentOptionsKey = "";
   const unsubscribeEnvironment = session.onEnvironment(({ environment, environments, switch: pending }) => {
+    currentEnvironment = environment;
     environmentSection.hidden = environments.length < 2;
     const optionsKey = environments.map(({ id, display_name }) => `${id}\0${display_name}`).join("\n");
     if (optionsKey !== environmentOptionsKey) {
@@ -698,6 +707,7 @@ export function createSimStage(
       unsubscribe();
       unsubscribeProps();
       unsubscribeEnvironment();
+      environmentBridge.destroy();
       stopLoop();
       observer.disconnect();
       longTaskObserver?.disconnect();

--- a/sim/viewer/test/environmentBridge.test.ts
+++ b/sim/viewer/test/environmentBridge.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createEnvironmentBridge } from "../src/environmentBridge.ts";
+
+test("embedding bridge follows real roster and view transitions, rejects foreign commands, and recovers", () => {
+  const listeners = new Set<(event: any) => void>();
+  const messages: any[] = [];
+  const parent = { postMessage: (data: any, origin: string) => {
+    assert.equal(origin, "https://sim.innate.bot");
+    messages.push(data);
+  } };
+  const win = { parent, addEventListener: (_: string, cb: any) => listeners.add(cb),
+    removeEventListener: (_: string, cb: any) => listeners.delete(cb) };
+  const oldWindow = globalThis.window;
+  const oldDocument = globalThis.document;
+  const now = Date.now;
+  Object.assign(globalThis, { window: win, document: { referrer: "https://sim.innate.bot/session" } });
+  let rosterListener: any;
+  const sent: string[] = [];
+  const session = { environmentConnected: true, onEnvironment: (cb: any) => {
+    rosterListener = cb;
+    return () => { rosterListener = null; };
+  }, switchEnvironment: (id: string) => sent.push(id) };
+  let retries = 0;
+  const bridge = createEnvironmentBridge(session as any, () => retries++);
+  const environments = ["apartment", "backrooms", "intersection"].map(id => ({ id, display_name: id }));
+  const roster = (id: string, pending: any = null) => rosterListener({ environment: { id }, environments, switch: pending });
+  const command = (type: string, id?: string, origin = "https://sim.innate.bot", source: any = parent) => {
+    for (const cb of listeners) cb({ origin, source, data: { channel: "innate:environment:v1", type, id } });
+  };
+  const state = () => messages.at(-1);
+  try {
+    roster("apartment");
+    bridge.updateView("apartment", "ready");
+    command("switch", "backrooms", "https://evil.example");
+    command("switch", "backrooms", "https://sim.innate.bot", {});
+    command("switch", "unknown");
+    command("switch", "apartment");
+    assert.deepEqual(sent, []);
+    for (const id of ["backrooms", "intersection", "apartment"]) {
+      command("switch", id);
+      command("switch", "intersection");
+      assert.equal(sent.at(-1), id);
+      assert.equal(state().pending, id);
+      roster(state().current, { id, state: "loading" });
+      roster(id);
+      bridge.updateView(id, "loading");
+      assert.equal(state().state, "loading");
+      bridge.updateView(id, "ready");
+      assert.equal(state().current, id);
+      assert.equal(state().state, "ready");
+    }
+    assert.equal(sent.length, 3);
+    command("switch", "backrooms");
+    roster("apartment", { id: "backrooms", state: "failed", message: "private failure details" });
+    assert.equal(state().state, "failed");
+    assert.equal(JSON.stringify(state()).includes("private failure"), false);
+    command("switch", "backrooms");
+    roster("backrooms");
+    bridge.updateView("backrooms", "failed");
+    assert.equal(state().retryView, true);
+    command("retry-view");
+    assert.equal(retries, 1);
+    bridge.updateView("backrooms", "ready");
+    session.environmentConnected = false;
+    command("get-state");
+    assert.equal(state().state, "disconnected");
+    const count = sent.length;
+    command("switch", "apartment");
+    assert.equal(sent.length, count);
+    session.environmentConnected = true;
+    roster("intersection"); // another client changed the world while disconnected
+    bridge.updateView("intersection", "ready");
+    assert.equal(state().current, "intersection");
+    command("switch", "apartment");
+    const started = now();
+    Date.now = () => started + 9000;
+    command("get-state");
+    assert.equal(state().state, "failed");
+    assert.equal(state().pending, null);
+    command("switch", "apartment");
+    assert.equal(state().pending, "apartment");
+  } finally {
+    Date.now = now;
+    bridge.destroy();
+    assert.equal(listeners.size, 0);
+    Object.assign(globalThis, { window: oldWindow, document: oldDocument });
+  }
+});

--- a/webapp/js/robotSession.js
+++ b/webapp/js/robotSession.js
@@ -80,6 +80,10 @@ function releaseSimSession() {
   if (!simSession || simHolders === 0) return;
   simHolders -= 1;
   if (simHolders > 0) return;
+  // The demo shell still owns the environment control while this iframe is
+  // on Settings/Navigation. Keep its stage for the lease; removing the frame
+  // releases it. Standalone tabs retain the usual idle cleanup.
+  if (window.parent !== window) return;
   simLinger = setTimeout(() => {
     simLinger = null;
     simStage?.destroy();


### PR DESCRIPTION
The simulator page's outer header needs to select real worlds without restarting the visitor's session. Add a narrow `innate:environment:v1` iframe bridge to the existing SimSession environment command/roster, with source and origin checks, request serialization, connection freshness, and separate physics/model-loading outcomes.

Failed scene downloads now surface a retry. Retrying the same world's geometry preserves the robot and traffic state. Embedded sessions keep their stage during Settings/Navigation detours so the outer selector remains available after the standalone tab's idle cutoff.

Validation:
- Viewer library build and TypeScript check passed; focused environment protocol and existing traffic tests passed.
- Ran the actual local physics/ROS simulator with the companion cloud header: Home → Backrooms → Traffic Lights → Home → Backrooms, checking the loaded scene and authoritative server switch log.
- Exercised a real Nav2 switch failure, injected a missing Traffic Lights model, and verified Retry view restores the scene, robot and traffic without reloading the iframe.
- Checked keyboard selection/Escape, 320px and 390px layouts, a Settings detour beyond 60 seconds, and session-end UI cleanup.

The browser harness serves the real broker frontend with fixture lease/analytics endpoints around a real local simulator. No live broker lease, cloud deployment, or autonomous LLM agent run was tested. Keep this PR draft pending Axel's approval; pair it with [innate-cloud #110](https://github.com/innate-inc/innate-cloud/pull/110) before release.
