### PR TITLE
Keep public simulator credentials outside visitor runtimes

### DIFF
--- a/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/client.py
+++ b/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/client.py
@@ -29,7 +29,10 @@ from auth_client import AuthProvider
 from auth_client.httpx_auth import InnateBearerAuth
 from dotenv import load_dotenv
 
-load_dotenv()
+from innate_proxy.public_demo import demo_proxy_url, public_demo_enabled
+
+if not public_demo_enabled():
+    load_dotenv()
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +52,18 @@ class ProxyClient:
         auth_issuer_url: str | None = None,
         config: dict[str, Any] | None = None,
     ) -> None:
-        raw_url = (proxy_url or os.getenv("INNATE_PROXY_URL", "https://proxy-v1.svc.innate.bot")).rstrip("/")
+        self._public_demo = public_demo_enabled()
+        if self._public_demo:
+            if innate_service_key or auth_issuer_url or proxy_url:
+                raise RuntimeError("Public simulator proxy configuration must come from its credential-free relay")
+            raw_url = demo_proxy_url()
+        else:
+            raw_url = (proxy_url or os.getenv("INNATE_PROXY_URL", "https://proxy-v1.svc.innate.bot")).rstrip("/")
         if raw_url and not raw_url.startswith(("http://", "https://")):
             raw_url = f"https://{raw_url}"
         self.proxy_url: str = raw_url
 
-        self._service_key: str = innate_service_key or os.getenv("INNATE_SERVICE_KEY", "")
+        self._service_key: str = "" if self._public_demo else innate_service_key or os.getenv("INNATE_SERVICE_KEY", "")
         self.config: dict[str, Any] = config or {}
 
         issuer_url = auth_issuer_url or os.getenv("INNATE_AUTH_URL", "https://auth-v1.svc.innate.bot")
@@ -77,7 +86,7 @@ class ProxyClient:
 
     def is_available(self) -> bool:
         """Return True if proxy credentials are configured."""
-        return bool(self.proxy_url and self._service_key)
+        return bool(self.proxy_url and (self._public_demo or self._service_key))
 
     # -- Token helpers --------------------------------------------------------
 

--- a/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/public_demo.py
+++ b/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/public_demo.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Public sessions use an external credential relay, never owner credentials.
+
+This guard catches deployment mistakes. It is not a Python sandbox: visitors
+must be assumed able to inspect everything inside their session container.
+The relay's network and tenant isolation is enforced by the cloud deployment.
+"""
+
+import os
+import re
+from pathlib import Path
+from urllib.parse import urlsplit
+
+_CREDENTIAL_NAME = re.compile(
+    r"(?:^|_)(?:API_KEY|SERVICE_KEY|ACCESS_KEY|PRIVATE_KEY|SECRET(?:_KEY)?|TOKEN|PASSWORD|CREDENTIALS?|DATABASE_URL|DSN|CONNECTION_STRING)(?:$|_)"
+)
+
+
+def public_demo_enabled() -> bool:
+    return os.environ.get("INNATE_PUBLIC_DEMO", "").strip().lower() in {"1", "true", "yes"}
+
+
+def demo_proxy_url() -> str:
+    """Validate the credential-free public configuration without echoing values."""
+    if any(value and _CREDENTIAL_NAME.search(name.upper()) for name, value in os.environ.items()):
+        raise RuntimeError("Public simulator must not contain credential environment variables")
+    for value in os.environ.values():
+        if "://" not in value:
+            continue
+        try:
+            url = urlsplit(value)
+            if url.username or url.password:
+                raise RuntimeError("Public simulator must not contain credentials in environment URLs")
+        except ValueError:
+            pass  # Not a URL; never echo arbitrary environment text in diagnostics.
+    raw = os.environ.get("INNATE_DEMO_PROXY_URL", "").rstrip("/")
+    try:
+        parsed = urlsplit(raw)
+        valid = (
+            parsed.scheme in {"http", "https"}
+            and parsed.hostname
+            and not parsed.username
+            and not parsed.password
+            and not parsed.query
+            and not parsed.fragment
+            and parsed.path in {"", "/"}
+        )
+    except ValueError:
+        valid = False
+    if not valid:
+        raise RuntimeError("Public simulator requires an explicit credential-free relay URL")
+    return raw
+
+
+def check_runtime() -> None:
+    """Fail before any demo service starts if owner configuration was included."""
+    if not public_demo_enabled():
+        raise RuntimeError("Public simulator requires INNATE_PUBLIC_DEMO=1")
+    demo_proxy_url()
+    root = Path(os.environ.get("INNATE_OS_ROOT", str(Path.home() / "innate-os")))
+    # Refuse the whole files instead of parsing key names and missing an alias.
+    if any(p.exists() for p in (root / ".env", Path("/etc/innate.env"), root / "config" / "settings.yaml")):
+        raise RuntimeError("Public simulator must not contain owner environment or settings files")
+
+
+if __name__ == "__main__":
+    check_runtime()

--- a/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/ws.py
+++ b/ros2_ws/src/cloud/clients/proxy-client/innate_proxy/ws.py
@@ -46,7 +46,7 @@ class SyncRealtimeConnection:
 
     def __init__(
         self,
-        auth: AuthProvider,
+        auth: AuthProvider | None,
         ws_url: str,
         on_message: Callable | None = None,
         on_open: Callable | None = None,
@@ -122,7 +122,12 @@ class SyncRealtimeConnection:
 
     async def _run_ws(self) -> None:
         try:
-            self._ws = await self._auth.ws_connect(self._ws_url)
+            if self._auth is not None:
+                self._ws = await self._auth.ws_connect(self._ws_url)
+            else:
+                from websockets import connect
+
+                self._ws = await connect(self._ws_url)
             self._connected.set()
             if self._on_open:
                 self._on_open()

--- a/ros2_ws/src/cloud/innate_uninavid/innate_uninavid/node.py
+++ b/ros2_ws/src/cloud/innate_uninavid/innate_uninavid/node.py
@@ -37,6 +37,8 @@ from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import CompressedImage
 from std_msgs.msg import Int32MultiArray
 
+from innate_proxy.public_demo import demo_proxy_url, public_demo_enabled
+
 from .ws_client import Action, ClientState, UninavidWsClient
 
 DEFAULT_WS_URL = "wss://uninavid-v1.svc.innate.bot"
@@ -80,11 +82,19 @@ class UninavidNode(Node):
     def __init__(self) -> None:
         super().__init__("uninavid_node")
 
-        env_path = find_dotenv(usecwd=True)
-        if env_path:
-            load_dotenv(env_path)
+        self._public_demo = public_demo_enabled()
+        if not self._public_demo:
+            env_path = find_dotenv(usecwd=True)
+            if env_path:
+                load_dotenv(env_path)
 
-        self.declare_parameter("ws_url", os.getenv("UNINAVID_WS_URL", DEFAULT_WS_URL))
+        if self._public_demo:
+            relay = demo_proxy_url()
+            ws_url = relay.replace("https://", "wss://", 1).replace("http://", "ws://", 1) + "/uninavid/ws"
+        else:
+            ws_url = os.getenv("UNINAVID_WS_URL", DEFAULT_WS_URL)
+
+        self.declare_parameter("ws_url", ws_url)
         self.declare_parameter("auth_issuer_url", os.getenv("INNATE_AUTH_URL", DEFAULT_AUTH_ISSUER_URL))
         self.declare_parameter("cmd_duration_sec", 0.1)
         self.declare_parameter("cmd_publish_hz", 50.0)
@@ -104,7 +114,8 @@ class UninavidNode(Node):
             Action.RIGHT: (0.0, -turn_speed),
         }
 
-        self._ws_url = str(self.get_parameter("ws_url").value)
+        # Public sessions always use the fixed relay, never ROS URL overrides.
+        self._ws_url = ws_url if self._public_demo else str(self.get_parameter("ws_url").value)
         # ROS parameters and /parameter_events are readable through rosbridge.
         # Credentials stay in process configuration, never in the ROS graph.
         service_key = os.getenv("INNATE_SERVICE_KEY", "")
@@ -113,7 +124,7 @@ class UninavidNode(Node):
         self._service_key = service_key.strip()
 
         self._auth: AuthProvider | None = self._make_auth_provider(self._service_key)
-        if self._auth is None:
+        if self._auth is None and not self._public_demo:
             self.get_logger().warn(
                 "UniNavid service key is missing. "
                 "Vision navigation goals will fail until INNATE_SERVICE_KEY is "
@@ -202,7 +213,7 @@ class UninavidNode(Node):
             auth = self._auth
             ws_url = self._ws_url
 
-        if auth is None:
+        if auth is None and not self._public_demo:
             self._cmd.publish(_STOP)
             goal_handle.abort()
             return self._result(

--- a/ros2_ws/src/cloud/innate_uninavid/innate_uninavid/ws_client.py
+++ b/ros2_ws/src/cloud/innate_uninavid/innate_uninavid/ws_client.py
@@ -192,12 +192,10 @@ class UninavidWsClient:
     async def _session(self) -> None:
         """Single connection attempt with one 401 retry (via auth.ws_connect)."""
         try:
-            async with await self._auth.ws_connect(
-                self._url,
-                max_size=4 * 1024 * 1024,
-                ping_interval=20,
-                ping_timeout=20,
-            ) as ws:
+            # Public simulator sessions reach a private credential relay; owner
+            # runs keep AuthProvider's token injection and renewal behavior.
+            connect = self._auth.ws_connect if self._auth is not None else websockets.connect
+            async with await connect(self._url, max_size=4 * 1024 * 1024, ping_interval=20, ping_timeout=20) as ws:
                 with self._lock:
                     self._state = ClientState.CONNECTED
                 self._log.info("WS connected")

--- a/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/config_loader.py
+++ b/ros2_ws/src/mars_bot/mars_bringup/mars_bringup/config_loader.py
@@ -62,6 +62,9 @@ def load_env_file(env_path: Path | None = None) -> None:
     service key still resolves from /etc/innate.env after a repo reset. ``env_path``
     defaults to ``<root>/.env``.
     """
+    if os.environ.get("INNATE_PUBLIC_DEMO", "").strip().lower() in {"1", "true", "yes"}:
+        # No owner .env fallback in a public session, even on a later restart.
+        return
     if env_path is None:
         env_path = innate_os_root() / ".env"
 

--- a/sim/demo/Dockerfile
+++ b/sim/demo/Dockerfile
@@ -88,6 +88,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache,sharing=locked \
     fi
 
 ENV INNATE_OS_ROOT=/root/innate-os \
+    INNATE_PUBLIC_DEMO=1 \
     VIRTUAL_MARS_ASSETS=/root/innate-os/sim/assets \
     VIRTUAL_MARS_REMOTE=127.0.0.1:8799 \
     INNATE_WORLD_STATE_PORT=8800 \

--- a/sim/demo/Dockerfile.dockerignore
+++ b/sim/demo/Dockerfile.dockerignore
@@ -13,8 +13,8 @@
 !sim/demo/**
 
 # Secrets and local state never enter a public image.
-.env
-**/.env
+.env*
+**/.env*
 **/.git
 **/.venv
 **/node_modules

--- a/sim/demo/README.md
+++ b/sim/demo/README.md
@@ -6,8 +6,22 @@ hands one to each visitor of sim.innate.bot and destroys it after the lease.
 
 ```bash
 sim/demo/build.sh          # -> us-central1-docker.pkg.dev/innate-managed-infra/sim/innate-os-sim-demo:<sha>
-docker run --rm -p 8080:80 us-central1-docker.pkg.dev/innate-managed-infra/sim/innate-os-sim-demo:latest
+docker run --rm -p 8080:80 --network sim-demo \
+  -e INNATE_DEMO_PROXY_URL=http://sim-credential-relay:8081 \
+  us-central1-docker.pkg.dev/innate-managed-infra/sim/innate-os-sim-demo:latest
 ```
+
+The `sim-demo` network above must already contain the trusted credential relay.
+In production the broker provisions that separately and restricts access with
+network policies. The relay holds the service/provider keys and authenticates
+upstream; the visitor container sends no bearer token. Do not publish the
+relay port or mount credentials into a session to bypass a failed startup.
+
+The image sets `INNATE_PUBLIC_DEMO=1`. Startup refuses credential environment
+variables, owner `.env` / `/etc/innate.env` files, and owner `settings.yaml`.
+Public configuration must provide `INNATE_DEMO_PROXY_URL`; owner direct-provider
+and authenticated-proxy configuration continues to work in the developer sim.
+Deploy this image with the matching credential-relay broker changes.
 
 Every push to main publishes `sha-<commit>` and moves `latest`
 (`.github/workflows/publish-sim-demo.yml`); the broker's `/admin` page picks
@@ -24,6 +38,7 @@ instance has no native GL either way, so the demo runs the world in-container
 | source, assets, viewer | bind-mounted from a checkout | baked in |
 | world server | host process (`uv`) | in-container |
 | `.env`, `~/.ssh`, `~/.gitconfig` | mounted | **absent** |
+| service/provider credentials | operator-owned | **absent**, external relay |
 | `POST /settings.json`, `/restart` | on | **off** (`INNATE_WEBAPP_READONLY=1`) |
 | foxglove, leader receiver | on | off |
 | lifetime | until `down` | `INNATE_DEMO_LEASE_SECONDS` (600) |

--- a/sim/demo/entrypoint.sh
+++ b/sim/demo/entrypoint.sh
@@ -8,6 +8,10 @@ source /opt/ros/humble/setup.bash
 source /root/innate-os/ros2_ws/install/setup.bash
 set -u
 
+# Fail closed before starting any visitor-reachable process. Credentials belong
+# only in the separately isolated cloud relay, never this container.
+python3 -m innate_proxy.public_demo
+
 : "${INNATE_DEMO_LEASE_SECONDS:=600}"
 : "${INNATE_SIM_RENDER_SCALE:=2}"
 : "${MUJOCO_GL:=osmesa}"

--- a/tests/test_public_demo_proxy.py
+++ b/tests/test_public_demo_proxy.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Exercise the real HTTP and realtime adapters against a loopback relay.
+
+No provider call or credential is needed; the upstream asserts no auth is sent.
+"""
+
+import asyncio
+import os
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+ROOT = Path(__file__).resolve().parents[1]
+for package in ("proxy-client", "auth-client"):
+    sys.path.insert(0, str(ROOT / "ros2_ws/src/cloud/clients" / package))
+sys.path.insert(0, str(ROOT / "ros2_ws/src/mars_bot/mars_bringup"))
+sys.path.insert(0, str(ROOT / "ros2_ws/src/brain/brain_client"))
+sys.path.insert(0, str(ROOT / "ros2_ws/src/cloud/innate_uninavid"))
+
+from innate_uninavid.ws_client import UninavidWsClient  # noqa: E402
+from mars_bringup import config_loader  # noqa: E402
+
+from brain_client.brain.transport import proxy_transport  # noqa: E402
+from innate_proxy import ProxyClient  # noqa: E402
+from innate_proxy.public_demo import _CREDENTIAL_NAME, check_runtime  # noqa: E402
+
+
+@pytest.fixture
+def public_env(monkeypatch, tmp_path):
+    for name in os.environ:
+        if _CREDENTIAL_NAME.search(name.upper()):
+            monkeypatch.delenv(name)
+    monkeypatch.setenv("INNATE_PUBLIC_DEMO", "1")
+    monkeypatch.setenv("INNATE_DEMO_PROXY_URL", "http://127.0.0.1:8081")
+    monkeypatch.setenv("INNATE_OS_ROOT", str(tmp_path))
+
+
+def test_public_proxy_http_and_realtime(public_env, monkeypatch):
+    async def exercise():
+        seen = []
+
+        async def receive(request):
+            assert "Authorization" not in request.headers
+            assert "x-api-key" not in request.headers
+            seen.append(request.path)
+            if request.path.endswith("/realtime"):
+                ws = web.WebSocketResponse()
+                await ws.prepare(request)
+                await ws.send_str('{"message_type":"session_started"}')
+                async for message in ws:
+                    await ws.send_str(message.data)
+                return ws
+            if request.path == "/uninavid/ws":
+                ws = web.WebSocketResponse()
+                await ws.prepare(request)
+                assert (await ws.receive()).data == "look at the chair"
+                await ws.send_str("1,2,3")
+                await ws.close()
+                return ws
+            if request.path.endswith("/tts/bytes"):
+                assert (await request.json())["transcript"] == "Hello"
+                return web.Response(body=b"synthetic-pcm")
+            if request.path.endswith(":streamGenerateContent"):
+                assert request.query.get("alt") == "sse"
+                return web.Response(text='data: {"candidates": []}\n\n', content_type="text/event-stream")
+            return web.json_response({"ok": True})
+
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", receive)
+        server = TestServer(app)
+        await server.start_server()
+        monkeypatch.setenv("INNATE_DEMO_PROXY_URL", f"http://127.0.0.1:{server.port}")
+        proxy = ProxyClient()
+        assert proxy.is_available() and proxy.token == proxy.innate_service_key == ""
+        assert proxy._auth is None
+        conn = None
+        try:
+
+            def tts():
+                return b"".join(proxy.cartesia.tts.bytes_stream("sonic-3", "Hello", {}, {}))
+
+            assert await asyncio.to_thread(tts) == b"synthetic-pcm"
+            result = await proxy.request_async("gemini", "/v1beta/models/test:generateContent", json={})
+            assert result.json() == {"ok": True}
+            assert await asyncio.to_thread(lambda: list(proxy_transport(proxy)("test", {}))) == [{"candidates": []}]
+            received = threading.Event()
+            conn = proxy.elevenlabs.realtime.connect_sync(on_message=lambda _ws, _msg: received.set())
+            conn.start()
+            assert await asyncio.to_thread(conn.wait_until_connected, 3)
+            assert await asyncio.to_thread(received.wait, 3)
+            assert any(path.endswith("/realtime") for path in seen)
+            navigation = UninavidWsClient(f"ws://127.0.0.1:{server.port}/uninavid/ws")
+            navigation._instruction = "look at the chair"
+            await asyncio.wait_for(navigation._session(), timeout=3)
+            assert navigation.pop_action() == 3
+        finally:
+            if conn:
+                await asyncio.to_thread(conn.stop)
+            proxy.close()
+            await proxy.close_async()
+            await server.close()
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "INNATE_SERVICE_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+        "AWS_SESSION_TOKEN",
+        "AZURE_CLIENT_SECRET",
+        "DATABASE_URL",
+    ],
+)
+def test_public_credentials_fail_without_echo(public_env, monkeypatch, name):
+    canary = "synthetic-sensitive-canary"
+    monkeypatch.setenv(name, canary)
+    with pytest.raises(RuntimeError) as failure:
+        ProxyClient()
+    assert canary not in str(failure.value)
+
+
+def test_public_environment_urls_cannot_carry_credentials(public_env, monkeypatch):
+    monkeypatch.setenv("CUSTOM_ENDPOINT", "https://user:synthetic-url-canary@127.0.0.1")
+    with pytest.raises(RuntimeError) as failure:
+        ProxyClient()
+    assert "synthetic-url-canary" not in str(failure.value)
+
+
+def test_public_proxy_requires_explicit_relay_and_refuses_args(public_env, monkeypatch):
+    with pytest.raises(RuntimeError):
+        ProxyClient(innate_service_key="synthetic-sensitive-canary")
+    monkeypatch.delenv("INNATE_DEMO_PROXY_URL")
+    with pytest.raises(RuntimeError):
+        ProxyClient()
+    monkeypatch.setenv("INNATE_DEMO_PROXY_URL", "http://user:synthetic-sensitive-canary@127.0.0.1")
+    with pytest.raises(RuntimeError) as failure:
+        ProxyClient()
+    assert "synthetic-sensitive-canary" not in str(failure.value)
+
+
+def test_public_startup_and_restart_refuse_owner_files(public_env, monkeypatch, tmp_path):
+    owner_env = tmp_path / ".env"
+    owner_env.write_text("INNATE_SERVICE_KEY=synthetic-sensitive-canary\n")
+    monkeypatch.setattr(config_loader, "SYSTEM_ENV_PATH", tmp_path / "system.env")
+    with pytest.raises(RuntimeError):
+        check_runtime()
+    config_loader.load_env_file(owner_env)
+    assert "INNATE_SERVICE_KEY" not in os.environ
+    owner_env.unlink()
+    check_runtime()
+
+
+def test_owner_configuration_remains_available(monkeypatch, tmp_path):
+    monkeypatch.delenv("INNATE_PUBLIC_DEMO", raising=False)
+    owner_env = tmp_path / ".env"
+    owner_env.write_text("INNATE_SERVICE_KEY=synthetic-owner-canary\n")
+    monkeypatch.setattr(config_loader, "SYSTEM_ENV_PATH", tmp_path / "system.env")
+    monkeypatch.setenv("INNATE_SERVICE_KEY", "")
+    config_loader.load_env_file(owner_env)
+    proxy = ProxyClient()
+    assert proxy.is_available() and proxy.innate_service_key == "synthetic-owner-canary"
+    assert proxy._auth is not None

--- a/tests/test_ros_credential_parameters.py
+++ b/tests/test_ros_credential_parameters.py
@@ -141,3 +141,49 @@ def test_public_ws_cannot_retrieve_service_key(ros_node):
         frontdoor.ROSBRIDGE_URL = saved_url
         bridge.terminate()
         bridge.wait(timeout=10)
+
+
+def test_public_demo_navigation_uses_credential_free_relay(monkeypatch):
+    from types import SimpleNamespace
+
+    import innate_uninavid.node as navigation
+
+    from innate_proxy.public_demo import _CREDENTIAL_NAME
+
+    for name in os.environ:
+        if _CREDENTIAL_NAME.search(name.upper()):
+            monkeypatch.delenv(name)
+    monkeypatch.setenv("INNATE_PUBLIC_DEMO", "1")
+    monkeypatch.setenv("INNATE_DEMO_PROXY_URL", "http://127.0.0.1:8081")
+    rclpy.init()
+    node = UninavidNode()
+    try:
+        assert node._auth is None and node._service_key == ""
+        assert node._ws_url == "ws://127.0.0.1:8081/uninavid/ws"
+        seen = []
+
+        class CompletedClient:
+            state = navigation.ClientState.COMPLETED
+
+            def __init__(self, **kwargs):
+                assert kwargs["auth_provider"] is None
+                assert kwargs["url"] == node._ws_url
+
+            def connect(self, instruction):
+                seen.append(instruction)
+
+            def disconnect(self):
+                pass
+
+        monkeypatch.setattr(navigation, "UninavidWsClient", CompletedClient)
+        goal = SimpleNamespace(
+            request=SimpleNamespace(instruction="look at the chair"),
+            is_active=True,
+            is_cancel_requested=False,
+            succeed=lambda: seen.append("completed"),
+        )
+        assert node._execute(goal).success
+        assert seen == ["look at the chair", "completed"]
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/webapp/proxy/https_server.py
+++ b/webapp/proxy/https_server.py
@@ -329,32 +329,86 @@ async def _serve_static(path: Path, request: web.Request) -> web.StreamResponse:
 
 async def static_handler(request: web.Request) -> web.StreamResponse:
     clean = request.path
+    # Source/configuration files beside the zero-build app are not web assets.
+    # Deny hidden components before the SPA fallback (including encoded ones,
+    # which aiohttp has already decoded).
+    parts = Path(clean).parts[1:]
+    if any(part.startswith(".") for part in parts):
+        raise web.HTTPNotFound(text="not found")
     target = _safe_resolve(ROOT / clean.lstrip("/"))
     if target is None:
         raise web.HTTPNotFound(text="not found")
     if target.is_dir():
-        target = target / "index.html"
-    body_path = target if target.is_file() else None
+        target = _safe_resolve(target / "index.html")
+    body_path = target if target is not None and target.is_file() else None
     # SPA fallback: an extensionless route that maps to no file (e.g. /profiling,
     # /settings, or a deep link/refresh on any client-side route) is served the
     # app shell so the router can render it. Asset requests carry a suffix
     # (.js/.css/...), so a genuinely missing asset still 404s below. The
     # in-root guard keeps a traversal like /../secrets a 404, not the shell.
-    if body_path is None and target.is_relative_to(ROOT) and "." not in clean.rsplit("/", 1)[-1]:
-        body_path = ROOT / "index.html"
+    if body_path is None and target is not None and target.is_relative_to(ROOT) and "." not in clean.rsplit("/", 1)[-1]:
+        body_path = _safe_resolve(ROOT / "index.html")
     # Refuse anything that escapes the app root (or the TLS keys, defensively).
     if body_path is None or not body_path.is_relative_to(ROOT) or body_path.suffix == ".pem":
+        raise web.HTTPNotFound(text="not found")
+    relative = body_path.relative_to(ROOT)
+    if relative != Path("index.html") and (
+        relative.parts[0] not in {"js", "css", "public", "debug", "assets"}
+        or body_path.suffix.lower()
+        not in {
+            ".html",
+            ".js",
+            ".css",
+            ".json",
+            ".svg",
+            ".avif",
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".webp",
+            ".ico",
+            ".woff",
+            ".woff2",
+            ".ttf",
+            ".mp4",
+        }
+    ):
         raise web.HTTPNotFound(text="not found")
     return await _serve_static(body_path, request)
 
 
 async def sim_viewer_handler(request: web.Request) -> web.StreamResponse:
     clean = request.path
+    if any(part.startswith(".") for part in Path(clean).parts[1:]):
+        raise web.HTTPNotFound(text="not found")
     for prefix, base in SIM_VIEWER_ROUTES.items():
         if not clean.startswith(prefix):
             continue
         target = _safe_resolve(base / clean[len(prefix) :])
-        if target is None or not target.is_file() or not target.is_relative_to(base.resolve()):
+        if (
+            target is None
+            or not target.is_file()
+            or not target.is_relative_to(base.resolve())
+            or target.suffix.lower()
+            not in {
+                ".js",
+                ".json",
+                ".glb",
+                ".gltf",
+                ".bin",
+                ".obj",
+                ".mtl",
+                ".urdf",
+                ".stl",
+                ".png",
+                ".jpg",
+                ".jpeg",
+                ".webp",
+                ".avif",
+                ".wasm",
+            }
+        ):
             raise web.HTTPNotFound(text="not found")
         return await _serve_static(target, request)
     raise web.HTTPNotFound(text="not found")
@@ -409,26 +463,26 @@ async def restart_handler(request: web.Request) -> web.Response:
 # IK node solves against (the installed mars_sim share), read-only under
 # /armsdk/model/.
 MARS_MODEL_ROOT = ROOT.parent / "ros2_ws" / "install" / "mars_sim" / "share" / "mars_sim"
+MARS_MODEL_SOURCE_ROOT = ROOT.parent / "ros2_ws" / "src" / "mars_bot" / "mars_sim"
 
 
 def _model_target(tail: str) -> "Path | None":
-    """MARS_MODEL_ROOT / tail, with traversal blocked on the *requested* path.
+    """Serve models from the install or the explicit colcon source package.
 
-    Deliberately does not resolve() the result. The sim builds the workspace
-    with colcon --symlink-install (scripts/validate_sim_ros_install.zsh), which
-    installs every model file as a symlink into ros2_ws/src — so resolving and
-    then demanding containment 404s the whole model there. The robot installs
-    real files (plain colcon build) and never hit it.
-
-    Prefixing "/" before normpath collapses any leading "..", so the join
-    cannot escape the base and the symlinks we do follow are the build's own.
+    Symlink installs are expected; arbitrary symlink targets are not. Fence the
+    resolved path to both legitimate roots instead of trusting every symlink.
     """
     rel = posixpath.normpath("/" + tail).lstrip("/")
     if not rel:
         return None
     try:
-        target = MARS_MODEL_ROOT / rel
-        return target if target.is_file() else None
+        target = (MARS_MODEL_ROOT / rel).resolve()
+        allowed = any(target.is_relative_to(base.resolve()) for base in (MARS_MODEL_ROOT, MARS_MODEL_SOURCE_ROOT))
+        return (
+            target
+            if allowed and target.is_file() and target.suffix.lower() in {".urdf", ".stl", ".srdf", ".xml"}
+            else None
+        )
     except (OSError, ValueError):  # illegal path bytes (e.g. a decoded NUL)
         return None
 

--- a/webapp/proxy/media_routes.py
+++ b/webapp/proxy/media_routes.py
@@ -134,7 +134,9 @@ async def thumb_response(request: web.Request) -> web.Response:
     if mp4 is None or not _under_skills_root(mp4) or not mp4.is_file():
         return _plain(404, "Not Found", "no such episode video")
     # Cache beside data/ (not inside it) so thumbnails are never uploaded to the cloud.
-    cache = base / "thumbs" / f"episode_{eid}_{cam}.jpg"
+    cache = _safe_resolve(base / "thumbs" / f"episode_{eid}_{cam}.jpg")
+    if cache is None or not cache.is_relative_to(base):
+        return _plain(404, "Not Found", "no such thumbnail")
     try:
         if not cache.is_file():
             lock = _thumb_locks.setdefault(str(cache), asyncio.Lock())
@@ -231,7 +233,10 @@ def memory_image_response(request: web.Request) -> web.Response:
     if (name != _MAPPING_SESSION and not _MAP_NAME_RE.match(name)) or not memory_id.isdigit():
         return _plain(404, "Not Found", "no such memory")
     try:
-        data = (MEMORY_DIR / name / f"{int(memory_id)}.jpg").read_bytes()
+        target = _safe_resolve(MEMORY_DIR / name / f"{int(memory_id)}.jpg")
+        if target is None or not target.is_relative_to(MEMORY_DIR):
+            return _plain(404, "Not Found", "no such memory")
+        data = target.read_bytes()
     except OSError:
         return _plain(404, "Not Found", "no such memory")
     return web.Response(
@@ -316,10 +321,11 @@ def _failure_excerpt(run_dir) -> str:
     excerpt = ""
     for name in ("process_output.jsonl", "daemon.log", "output.log"):
         path = run_dir / name
-        if not path.is_file():
+        resolved = _safe_resolve(path)
+        if resolved is None or not resolved.is_relative_to(run_dir) or not resolved.is_file():
             continue
         try:
-            with open(path, "rb") as fh:
+            with open(resolved, "rb") as fh:
                 size = fh.seek(0, os.SEEK_END)
                 fh.seek(max(0, size - _TAIL_BYTES))
                 tail = fh.read().decode("utf-8", errors="replace")

--- a/webapp/proxy/settings_routes.py
+++ b/webapp/proxy/settings_routes.py
@@ -7,6 +7,7 @@ page, so the API lives at /settings.json to leave it free.
 """
 
 import asyncio
+import os
 
 from aiohttp import ContentTypeError, web
 
@@ -16,6 +17,10 @@ async def settings_get(request: web.Request) -> web.Response:
     import settings_store
 
     def read():
+        if os.environ.get("INNATE_PUBLIC_DEMO", "").strip().lower() in {"1", "true", "yes"}:
+            # Public images use the committed defaults. Never serialize a
+            # misplaced owner settings file or arbitrary extra overrides.
+            return {"overrides": {}, "exists": False}
         return {"overrides": settings_store.read_overrides(), "exists": settings_store.settings_path().is_file()}
 
     return web.json_response(await asyncio.to_thread(read), headers={"Cache-Control": "no-cache"})

--- a/webapp/proxy/test/test_https_server.py
+++ b/webapp/proxy/test/test_https_server.py
@@ -143,6 +143,46 @@ async def test_path_guards(tmp_path):
 
 
 @sync
+async def test_private_static_files_and_directory_index_symlinks(tmp_path):
+    root = make_app_root(tmp_path)
+    canary = "synthetic-private-file-canary"
+    for name in (".env", "settings.yaml", "public/.env.local", "public/config.py", "proxy/error.log"):
+        target = root / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(canary)
+    outside = tmp_path / "outside.html"
+    outside.write_text(canary)
+    (root / "assets" / "page").mkdir()
+    (root / "assets" / "page" / "index.html").symlink_to(outside)
+    async with serve(ROOT=root) as (s, base):
+        for path in (
+            "/.env",
+            "/%2eenv",
+            "/settings.yaml",
+            "/public/.env.local",
+            "/public/config.py",
+            "/proxy/error.log",
+            "/assets/page/",
+        ):
+            response = await s.get(base + path)
+            assert response.status == 404, path
+            assert canary not in await response.text()
+
+
+@sync
+async def test_public_settings_do_not_serialize_owner_overrides(tmp_path, monkeypatch):
+    import settings_store
+
+    monkeypatch.setenv("INNATE_PUBLIC_DEMO", "1")
+    monkeypatch.setattr(settings_store, "read_overrides", lambda: {"brain": {"api_key": "synthetic-settings-canary"}})
+    root = make_app_root(tmp_path)
+    async with serve(ROOT=root, WEBAPP_READONLY=True) as (s, base):
+        response = await s.get(base + "/settings.json")
+        assert await response.json() == {"overrides": {}, "exists": False}
+        assert (await s.post(base + "/settings.json", json={})).status == 405
+
+
+@sync
 async def test_local_environment_assets_are_served(tmp_path):
     root = make_app_root(tmp_path)
     local_environments = tmp_path / "viewer-public" / "local-environments"
@@ -158,6 +198,25 @@ async def test_local_environment_assets_are_served(tmp_path):
         assert response.status == 200
         assert response.headers["Content-Type"] == "model/gltf-binary"
         assert await response.read() == b"custom glb"
+
+
+@sync
+async def test_model_symlinks_allow_colcon_source_only(tmp_path):
+    root = make_app_root(tmp_path)
+    installed = tmp_path / "model-install"
+    source = tmp_path / "model-source"
+    installed.mkdir()
+    source.mkdir()
+    (source / "mars.urdf").write_text("<robot/>")
+    (installed / "mars.urdf").symlink_to(source / "mars.urdf")
+    outside = tmp_path / "outside.urdf"
+    outside.write_text("synthetic-model-file-canary")
+    (installed / "outside.urdf").symlink_to(outside)
+    async with serve(ROOT=root, MARS_MODEL_ROOT=installed, MARS_MODEL_SOURCE_ROOT=source) as (s, base):
+        response = await s.get(base + "/armsdk/model/mars.urdf")
+        assert response.status == 200 and await response.text() == "<robot/>"
+        response = await s.get(base + "/armsdk/model/outside.urdf")
+        assert response.status == 404 and "synthetic-model-file-canary" not in await response.text()
 
 
 @sync

--- a/webapp/proxy/test/test_media_routes.py
+++ b/webapp/proxy/test/test_media_routes.py
@@ -90,6 +90,35 @@ async def test_run_log_serves_and_fences(tmp_path, monkeypatch):
 
 
 @sync
+async def test_media_symlinks_do_not_reveal_files_outside_their_roots(tmp_path, monkeypatch):
+    skill = _skill(tmp_path, monkeypatch)
+    root = make_app_root(tmp_path)
+    canary = "synthetic-private-media-canary"
+    outside = tmp_path / "private.txt"
+    outside.write_text("RuntimeError: " + canary)
+    memories = tmp_path / "memories"
+    (memories / "Home").mkdir(parents=True)
+    (memories / "Home" / "1.jpg").symlink_to(outside)
+    monkeypatch.setattr(media_routes, "MEMORY_DIR", memories)
+    (skill / "thumbs").mkdir()
+    (skill / "thumbs" / "episode_1_camera_1.jpg").symlink_to(outside)
+    (skill / "data" / "episode_1_camera_1.mp4").write_bytes(b"synthetic-video")
+    run = skill / "run"
+    run.mkdir()
+    (run / "output.log").symlink_to(outside)
+    async with serve(ROOT=root) as (s, base):
+        for route, params in (
+            ("/memory/image", {"map": "Home", "id": "1"}),
+            ("/episode/thumb", {"dir": str(skill), "id": "1", "camera": "camera_1"}),
+        ):
+            response = await s.get(base + route, params=params)
+            assert response.status == 404
+            assert canary not in await response.text()
+        info = await (await s.get(base + "/run/info", params={"dir": str(skill), "id": "run"})).json()
+        assert info["error_excerpt"] == ""
+
+
+@sync
 async def test_run_log_bounded_read(tmp_path, monkeypatch):
     skill = _skill(tmp_path, monkeypatch)
     run = skill / "run"


### PR DESCRIPTION
Public simulator containers currently receive a shared service key. This change adds a public runtime mode that fails before startup if credentials or owner configuration are present, and routes Gemini, Cartesia, ElevenLabs and UniNavid through the private credential relay with no client key, token or Authorization header. Owner-local authenticated clients remain supported.

The HTTP front door also stops serving hidden/config files, confines model/media/log symlink targets to their intended roots, and returns public settings defaults. Controlled canaries reproduced seven conditional file/config disclosures on the baseline and verified their denial after the change. The audit did not establish that these misplaced files existed in production.

Stacked on #775, the independently reviewable ROS credential-parameter fix. Requires innate-cloud [broker/relay #111](https://github.com/innate-inc/innate-cloud/pull/111) and [service-proxy #108](https://github.com/innate-inc/innate-cloud/pull/108). These changes must be staged together; the old broker's credential injection is intentionally rejected by this image. Nothing has been deployed. The standalone legacy demo also needs its own private relay or retirement; the Kubernetes manifest alone does not migrate it.

Validation: 43 HTTP/client/media integration tests and 3 tests in an isolated real ROS container passed. Actual UniNavid navigation exchanges work through a local credentialless WebSocket. The actual OS ProxyClient -> private relay -> service proxy chain passed synthetic Gemini SSE, Cartesia audio, forced key-echo error suppression and shared-storage denial. All 127 current/legacy browser asset paths returned 200, and Agent-to-Settings navigation rendered without browser console errors.

Release verification still required: build and boot the production simulator image, exercise full ROS/video/agent behavior and real inference in staging, verify Kubernetes policy enforcement, then drain old sessions and rotate the historical shared demo key. The browser smoke had no ROS/video backend. No real key values were retrieved during this audit. Keep this PR draft until Axel explicitly approves it.
