### PR TITLE
Keep cancelled agent requests stopped until a new instruction

### DIFF
--- a/.github/workflows/brain-tests.yml
+++ b/.github/workflows/brain-tests.yml
@@ -1,0 +1,24 @@
+name: Brain model and turn loop tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  brain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install pytest httpx numpy
+      - name: Exercise context, transport and turn cancellation
+        env:
+          PYTHONPATH: ros2_ws/src/brain/brain_client:ros2_ws/src/cloud/clients/proxy-client
+        run: >-
+          python -m pytest -q
+          ros2_ws/src/brain/brain_client/test/test_local_brain.py
+          ros2_ws/src/brain/brain_client/test/test_openai_context.py
+          ros2_ws/src/brain/brain_client/test/test_openai_transport.py

--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -209,6 +209,9 @@
 #     scan_stale_after_sec: 10.0    # seconds without a lidar scan before flagging stale
 #     send_arm_camera_image: true   # also send the arm wrist camera image to the model
 #     log_everything: true          # log every turn's full input
+#     brain_provider: "gemini"       # "openai" opts into experimental Responses; restart the brain node
+#     openai_model: "gpt-6-astra"    # requires OpenAI access through proxy or OPENAI_API_KEY in .env
+#     openai_reasoning_effort: "low" # Astra lowest effort; no separate "light" model
 #     gemini_model: "gemini-3.6-flash"
 #     timezone: ""                  # IANA zone for the clock the agent sees; "" = the robot OS's own
 #     idle_turn_interval: 3.0       # seconds between looks when no skill is running

--- a/docs/experiments/agent-model-cadence-replay.json
+++ b/docs/experiments/agent-model-cadence-replay.json
@@ -1,0 +1,44 @@
+[
+  {
+    "case": "idle",
+    "seconds": 4.693915583000489,
+    "speech": null,
+    "calls": [
+      "wait"
+    ],
+    "usage": {
+      "prompt": 1546,
+      "cached": 1543,
+      "output": 13
+    },
+    "history_len": 3
+  },
+  {
+    "case": "describe",
+    "seconds": 1.7903088330003811,
+    "speech": "I appear to be at the entrance to a living room.",
+    "calls": [
+      "wait"
+    ],
+    "usage": {
+      "prompt": 1991,
+      "cached": 0,
+      "output": 32
+    },
+    "history_len": 6
+  },
+  {
+    "case": "stop",
+    "seconds": 1.5395736659993418,
+    "speech": "Stopping now.",
+    "calls": [
+      "stop_current_skill"
+    ],
+    "usage": {
+      "prompt": 2493,
+      "cached": 0,
+      "output": 25
+    },
+    "history_len": 9
+  }
+]

--- a/docs/experiments/agent-model-cadence-results.json
+++ b/docs/experiments/agent-model-cadence-results.json
@@ -1,0 +1,384 @@
+{
+  "image_sha256": "7ece810ab9954c7751d6cf20156b337412088a12bba4287fdfbe118ce9fec411",
+  "rows": [
+    {
+      "repeat": 0,
+      "case": "idle",
+      "provider": "gemini",
+      "model": "gemini-3.6-flash",
+      "effort": "minimal",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": null,
+      "calls": [
+        "wait"
+      ],
+      "ttft": null,
+      "usage": {
+        "promptTokenCount": 3126,
+        "candidatesTokenCount": 8,
+        "totalTokenCount": 3134,
+        "promptTokensDetails": [
+          {
+            "modality": "IMAGE",
+            "tokenCount": 2128
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 998
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "returned_model": "gemini-3.6-flash",
+      "seconds": 4.9213,
+      "estimated_usd": 0.0023745
+    },
+    {
+      "repeat": 0,
+      "case": "idle",
+      "provider": "openai",
+      "model": "gpt-6-astra",
+      "effort": "low",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": null,
+      "calls": [
+        "wait"
+      ],
+      "ttft": null,
+      "usage": {
+        "input_tokens": 1546,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1543
+        },
+        "output_tokens": 13,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1559
+      },
+      "returned_model": "gpt-6-astra",
+      "service_tier": "default",
+      "seconds": 1.9716,
+      "estimated_usd": 0.002223
+    },
+    {
+      "repeat": 0,
+      "case": "describe",
+      "provider": "gemini",
+      "model": "gemini-3.6-flash",
+      "effort": "minimal",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": "I'm in the living room.",
+      "calls": [
+        "wait"
+      ],
+      "ttft": 0.9994383329994889,
+      "usage": {
+        "promptTokenCount": 3139,
+        "candidatesTokenCount": 16,
+        "totalTokenCount": 3155,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 1011
+          },
+          {
+            "modality": "IMAGE",
+            "tokenCount": 2128
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "returned_model": "gemini-3.6-flash",
+      "seconds": 1.04,
+      "estimated_usd": 0.00241425,
+      "strict_speech_only": false
+    },
+    {
+      "repeat": 0,
+      "case": "describe",
+      "provider": "openai",
+      "model": "gpt-6-astra",
+      "effort": "low",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": "It looks like I\u2019m in the living room.",
+      "calls": [],
+      "ttft": 1.9240621250010008,
+      "usage": {
+        "input_tokens": 1558,
+        "input_tokens_details": {
+          "cache_write_tokens": 1555,
+          "cached_tokens": 0
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1572
+      },
+      "returned_model": "gpt-6-astra",
+      "service_tier": "default",
+      "seconds": 1.9334,
+      "estimated_usd": 0.0201675,
+      "strict_speech_only": true
+    },
+    {
+      "repeat": 0,
+      "case": "stop",
+      "provider": "gemini",
+      "model": "gemini-3.6-flash",
+      "effort": "minimal",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": "Stopping now.",
+      "calls": [
+        "stop_current_skill"
+      ],
+      "ttft": 0.9412814170009369,
+      "usage": {
+        "promptTokenCount": 3182,
+        "candidatesTokenCount": 15,
+        "totalTokenCount": 3197,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 1054
+          },
+          {
+            "modality": "IMAGE",
+            "tokenCount": 2128
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "returned_model": "gemini-3.6-flash",
+      "seconds": 1.1049,
+      "estimated_usd": 0.00244275
+    },
+    {
+      "repeat": 0,
+      "case": "stop",
+      "provider": "openai",
+      "model": "gpt-6-astra",
+      "effort": "low",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": "Stopping now.",
+      "calls": [
+        "stop_current_skill"
+      ],
+      "ttft": 1.6035042500006966,
+      "usage": {
+        "input_tokens": 1596,
+        "input_tokens_details": {
+          "cache_write_tokens": 1593,
+          "cached_tokens": 0
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1621
+      },
+      "returned_model": "gpt-6-astra",
+      "service_tier": "default",
+      "seconds": 1.6173,
+      "estimated_usd": 0.0211925
+    },
+    {
+      "repeat": 1,
+      "case": "idle",
+      "provider": "gemini",
+      "model": "gemini-3.6-flash",
+      "effort": "minimal",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": null,
+      "calls": [
+        "wait"
+      ],
+      "ttft": null,
+      "usage": {
+        "promptTokenCount": 3126,
+        "candidatesTokenCount": 8,
+        "totalTokenCount": 3134,
+        "promptTokensDetails": [
+          {
+            "modality": "IMAGE",
+            "tokenCount": 2128
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 998
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "returned_model": "gemini-3.6-flash",
+      "seconds": 0.9353,
+      "estimated_usd": 0.0023745
+    },
+    {
+      "repeat": 1,
+      "case": "idle",
+      "provider": "openai",
+      "model": "gpt-6-astra",
+      "effort": "low",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": null,
+      "calls": [
+        "wait"
+      ],
+      "ttft": null,
+      "usage": {
+        "input_tokens": 1546,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1543
+        },
+        "output_tokens": 13,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1559
+      },
+      "returned_model": "gpt-6-astra",
+      "service_tier": "default",
+      "seconds": 1.3292,
+      "estimated_usd": 0.002223
+    },
+    {
+      "repeat": 1,
+      "case": "describe",
+      "provider": "gemini",
+      "model": "gemini-3.6-flash",
+      "effort": "minimal",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": "I'm in the living room.",
+      "calls": [
+        "wait"
+      ],
+      "ttft": 1.0014086250012042,
+      "usage": {
+        "promptTokenCount": 3139,
+        "candidatesTokenCount": 16,
+        "totalTokenCount": 3155,
+        "promptTokensDetails": [
+          {
+            "modality": "IMAGE",
+            "tokenCount": 2128
+          },
+          {
+            "modality": "TEXT",
+            "tokenCount": 1011
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "returned_model": "gemini-3.6-flash",
+      "seconds": 1.118,
+      "estimated_usd": 0.00241425,
+      "strict_speech_only": false
+    },
+    {
+      "repeat": 1,
+      "case": "describe",
+      "provider": "openai",
+      "model": "gpt-6-astra",
+      "effort": "low",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": "It looks like I\u2019m in the living room.",
+      "calls": [],
+      "ttft": 1.8493294999989303,
+      "usage": {
+        "input_tokens": 1558,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1555
+        },
+        "output_tokens": 14,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1572
+      },
+      "returned_model": "gpt-6-astra",
+      "service_tier": "default",
+      "seconds": 1.8634,
+      "estimated_usd": 0.002285,
+      "strict_speech_only": true
+    },
+    {
+      "repeat": 1,
+      "case": "stop",
+      "provider": "gemini",
+      "model": "gemini-3.6-flash",
+      "effort": "minimal",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": "Stopping now.",
+      "calls": [
+        "stop_current_skill"
+      ],
+      "ttft": 0.8017250840002816,
+      "usage": {
+        "promptTokenCount": 3182,
+        "candidatesTokenCount": 15,
+        "totalTokenCount": 3197,
+        "promptTokensDetails": [
+          {
+            "modality": "TEXT",
+            "tokenCount": 1054
+          },
+          {
+            "modality": "IMAGE",
+            "tokenCount": 2128
+          }
+        ],
+        "serviceTier": "standard"
+      },
+      "returned_model": "gemini-3.6-flash",
+      "seconds": 1.0005,
+      "estimated_usd": 0.00244275
+    },
+    {
+      "repeat": 1,
+      "case": "stop",
+      "provider": "openai",
+      "model": "gpt-6-astra",
+      "effort": "low",
+      "status": "ok",
+      "pass_probe": true,
+      "speech": "Stopping now.",
+      "calls": [
+        "stop_current_skill"
+      ],
+      "ttft": 1.944377166999402,
+      "usage": {
+        "input_tokens": 1596,
+        "input_tokens_details": {
+          "cache_write_tokens": 0,
+          "cached_tokens": 1593
+        },
+        "output_tokens": 25,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1621
+      },
+      "returned_model": "gpt-6-astra",
+      "service_tier": "default",
+      "seconds": 1.9597,
+      "estimated_usd": 0.002873
+    }
+  ],
+  "assessment_note": "Description permits a harmless wait tool alongside the correct spoken answer. Original strict_speech_only retained for transparency."
+}

--- a/docs/experiments/agent-model-cadence.md
+++ b/docs/experiments/agent-model-cadence.md
@@ -37,6 +37,26 @@ environment. Keys are never ROS parameters. Direct calls are disabled in public
 demo mode; provider failures never silently switch accounts or models. Local key
 setup is supplied by the separate provider-key PR.
 
+**An OpenAI key alone does not enable every robot capability.** This switch only
+changes the primary agent's thinking turns:
+
+- `SearchMemory` still uses Gemini via `pick_rest` and `gemini_model`. With neither
+  a configured Innate proxy nor `GEMINI_API_KEY`, the node does not start the
+  `/brain/search_memory` action server. Memory recording remains available, but
+  a directive offering `SearchMemory` cannot recall through that action.
+- Microphone STT retains its separate configuration. ElevenLabs requires the
+  Innate proxy; without it the microphone selects Gemini as its fallback. That
+  fallback also needs `GEMINI_API_KEY`, so an OpenAI-only setup has no functioning
+  microphone transcription through this path. This PR adds no OpenAI STT backend.
+- Gemini-backed vision skills retain their existing credentials and models.
+
+These dependencies were verified from
+[`BrainClientNode._build_collaborators`](../../ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py)
+and [`MicroInput`](../../workspace/inputs/micro_input.py). The live comparison used
+the managed proxy; it did **not** establish full standalone operation with only
+an OpenAI key. Keep Gemini access when using those capabilities, or migrate them
+in a separate change.
+
 ## Cadence and cancellation
 
 A directive can override just the needed mode:

--- a/docs/experiments/agent-model-cadence.md
+++ b/docs/experiments/agent-model-cadence.md
@@ -1,0 +1,140 @@
+# Experimental core model and thinking cadence
+
+This foundation is below the Household Orders solution PR. It reuses the generic
+`TurnIntervals` API from PR #694's `3894f29fa`; it does not import Household skills,
+route scoring or person identity. The original PR stays untouched.
+
+## Selecting a model
+
+In `config/settings.yaml`, merge these parameters into the existing node section,
+then restart the brain node:
+
+```yaml
+brain_client_node:
+  ros__parameters:
+    brain_provider: openai
+    openai_model: gpt-6-astra
+    openai_reasoning_effort: low
+    idle_turn_interval: 3.0
+    supervision_turn_interval: 1.0
+```
+
+The default remains `brain_provider: gemini`, `gemini-3.6-flash`, `minimal`, and
+3/5-second idle/supervision pauses. OpenAI is an explicit opt-in. Provider/model
+settings are read at node startup; this experiment does not hot-swap a running
+conversation. Auxiliary Gemini vision/memory skills retain their own model.
+
+Official documentation checked September 5, 2026 names `gpt-6-astra`, with `low`
+as its lowest reasoning effort. No separate “Astra light” model was found.
+We interpret Axel's “GPT-6 Astra light” as **Astra with low reasoning**, without
+substituting another model. It uses Responses, not Chat Completions tool calling.
+See [Astra model](https://developers.openai.com/api/docs/models/gpt-6-astra) and
+[model guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra).
+
+The existing managed proxy is preferred (`openai`, `/v1/responses`). Without a
+configured proxy, local development can use `OPENAI_API_KEY` in the launch
+environment. Keys are never ROS parameters. Direct calls are disabled in public
+demo mode; provider failures never silently switch accounts or models. Local key
+setup is supplied by the separate provider-key PR.
+
+## Cadence and cancellation
+
+A directive can override just the needed mode:
+
+```python
+from brain_client.agents.types import TurnIntervals
+
+
+def get_turn_intervals(self):
+    return TurnIntervals(supervision=1.0)
+```
+
+Values are finite positive seconds **after the previous turn completes**;
+model latency is additional. `None` inherits the global setting. User/skill
+and motion events preserve their existing early-wakeup behavior. The existing
+one-second floor for feedback-driven turns and error backoff remain unchanged.
+This is not a fixed Hz scheduler: slow inference never causes catch-up turns.
+
+One coroutine owns committed history and dispatch. Stop now awaits its child
+turn's cancellation cleanup before reporting completion, fixing a race exposed
+by the new tests. As in the original worker-thread architecture, an abandoned
+HTTP request can finish in the background (and incur provider cost); its muted
+speech, tool calls, history and usage cannot commit. No server-side conversation
+is advanced: OpenAI uses `store=false` and locally replays native output/call IDs
+and encrypted reasoning. Normal cadence never overlaps inference requests;
+user preemption can leave an orphaned request while a replacement starts.
+
+Trace snapshots and completed turns include effective provider/model/effort;
+completed turns include usage. OpenAI request traces contain the native body.
+OpenAI output token counts include reasoning tokens. Full robot UI work is not
+part of this experiment.
+
+## Small live comparison
+
+Twelve serial requests through the existing managed proxy, September 5, 2026:
+two repeats each of idle, room description, and stopping an active navigation
+skill; six requests per model. Both saw the same local 640x480 simulator living
+room frame, core system prompt, self-portrait and state. Each probe began with
+fresh local history. No skills were dispatched, no physical robot was used, and
+no VM campaign was started. Responses used the default service tier.
+
+| Configuration | Correct responses | Median completion | Mean completion | Estimated token cost, six calls |
+| --- | ---: | ---: | ---: | ---: |
+| Gemini 3.6 Flash / minimal | 6/6 | 1.072 s | 1.687 s | $0.01446 |
+| GPT-6 Astra / low | 6/6 | 1.898 s | 1.779 s | $0.05096 |
+
+Both waited silently when idle, named the living room, and called
+`stop_current_skill` on request. Gemini also emitted a harmless `wait` alongside
+its room-description speech. The initial speech-only heuristic marked that as
+failure; the raw results preserve `strict_speech_only` separately and the outcome
+assessment accepts that no-op. These tiny probes establish API usability and
+basic discipline, **not Household Orders success rates** or statistically stable
+latency. Gemini's first included call took 4.921 s; startup/tail latency matters.
+Astra had cache hits on four calls and cache writes on two, so this is not a
+controlled cold-cache or steady-state cost comparison.
+
+Illustratively, median latency plus the 5-second default supervision pause is
+6.07 s for Gemini and 6.90 s for Astra. Setting supervision to 1 second makes the
+Astra cycle about 2.90 s in this sample, with correspondingly more requests. Those
+are calculations, not measured closed-loop Household Orders timings.
+
+Costs use returned usage with current standard list prices, not a billing
+invoice. Gemini: $0.75/M input, $3.75/M output including thinking. Astra:
+$10/M uncached input, $1/M cache reads, $12.50/M cache writes, $50/M output.
+See [Gemini pricing](https://ai.google.dev/gemini-api/docs/pricing?hl=en) and the
+[Astra model pricing](https://developers.openai.com/api/docs/models/gpt-6-astra).
+The proxy's old Chat Completions analytics can record zero usage for Responses;
+these estimates use the provider response directly.
+
+Separate live three-turn Astra replay also passed: wait → tool outcome → room
+answer → tool outcome → stop. The raw comparison and replay JSON files are next
+to this report. Initial setup probes are excluded from the twelve-request table:
+one local harness argument error, two successful Gemini probes, three Astra
+parser failures, and three direct SSE diagnostics. The latter exposed the
+managed proxy's `data: event: response.*` wrapping, now covered by a regression
+test. Those setup requests may have billed; their complete usage was not captured.
+
+Reproduce a bounded comparison (explicitly makes billed calls):
+
+```bash
+PYTHONPATH=ros2_ws/src/brain/brain_client:ros2_ws/src/cloud/clients/proxy-client:ros2_ws/src/cloud/clients/auth-client \
+uv run --no-project --with httpx --with python-dotenv --with numpy \
+python scripts/experiments/compare_brain_models.py --live \
+  --env-file /path/to/owner/.env --image /path/to/living-room.jpg \
+  --output /tmp/brain-comparison.json --repeats 2
+```
+
+## Verification and remaining limits
+
+121 focused tests passed in the existing cached ROS Humble image, with external
+networking disabled and pytest plugin autoload disabled (the image contains an
+unrelated anyio/pytest version mismatch). Tests cover provider dispatch/defaults, invalid configuration, native
+schema and image conversion, tool-call IDs and encrypted-reasoning replay,
+image/history pruning, incomplete/failed streams, redacted transport failures,
+proxy precedence/public-demo guards, late cancellation, and actual sequential
+idle/supervision coroutine timing. Local HTTP-server tests exercise transport
+routing. The managed provider comparison and replay exercise real API behavior.
+
+The full ROS node has not been run with a live simulator UI in this foundation;
+the Household task owns challenge integration above it. No production deployment
+or robot motion was performed. Keep this PR DRAFT until Axel approves it.

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/loader.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
-from brain_client.agents.types import Agent
+from brain_client.agents.types import Agent, TurnIntervals
 from brain_client.common.dynamic_loader import class_name_to_snake_case, evict_modules_under
 from brain_client.common.script_paths import (
     classify_source,
@@ -89,6 +89,11 @@ def build_agent_instances(
             str(agent.display_name)
             agent.get_prompt()
             agent.input_names()
+            intervals = agent.get_turn_intervals()
+            if not isinstance(intervals, TurnIntervals):
+                raise TypeError(
+                    f"{type(agent).__name__}.get_turn_intervals() must return TurnIntervals, got {intervals!r}"
+                )
             agent.uses_gaze()
             skill_ids = agent.skill_ids()
         except Exception as e:  # noqa: BLE001 — one bad agent must not stop the roster

--- a/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/agents/types.py
@@ -7,7 +7,9 @@ Agent Type Definitions
 Base class and types for robot agents.
 """
 
+import math
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias, Union
 
 from brain_client.common.script_paths import Source
@@ -25,6 +27,25 @@ SkillRef: TypeAlias = Union["type[Skill]", "type[TrainedSkill]", str]
 # What get_inputs() may list: the InputDevice class itself (typed, same
 # rationale as SkillRef) or a device-name string.
 InputRef: TypeAlias = Union["type[InputDevice]", str]
+
+
+@dataclass(frozen=True)
+class TurnIntervals:
+    """Optional per-agent overrides for the brain's visual observation cadence.
+
+    ``None`` keeps the global ROS parameter.  A positive value is the pause
+    after a completed model turn; model latency is additional.  Keeping this
+    on the agent lets a visually supervised navigation agent look frequently
+    without making every directive on the robot equally chatty and expensive.
+    """
+
+    idle: float | None = None
+    supervision: float | None = None
+
+    def __post_init__(self) -> None:
+        for name, value in (("idle", self.idle), ("supervision", self.supervision)):
+            if value is not None and (not math.isfinite(value) or value <= 0):
+                raise ValueError(f"turn interval {name} must be a finite positive number or None")
 
 
 class Agent(ABC):
@@ -158,6 +179,15 @@ class Agent(ABC):
         Default: return empty list (no input devices required).
         """
         return []
+
+    def get_turn_intervals(self) -> TurnIntervals:
+        """Return optional per-agent idle and running-skill turn intervals.
+
+        The global ``brain_client_node`` ROS parameters remain the defaults.
+        Override this only when the directive needs a materially different
+        visual reaction cadence.
+        """
+        return TurnIntervals()
 
     def input_names(self) -> list[str]:
         """get_inputs() normalized to device-name strings — the only form the

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -159,6 +159,7 @@ class BrainAgent:
         self._tool_map: dict[str, str] = {}  # gemini function name -> skill id
         self._request_stopped = False  # survives skill completion and history compaction
         self._acting_on_user_request = False
+        self._request_started_this_turn = False
         self._error_streak = 0
         self._activated_at = 0.0
         self._turn_count = 0
@@ -361,6 +362,7 @@ class BrainAgent:
         del self._events[: len(events)]
         events.clear()  # committed: a failure below backs off against an empty peek
         self._acting_on_user_request = user_spoke
+        self._request_started_this_turn = False
         try:
             outcomes = self._act(decision, speaker, context)
         finally:
@@ -587,6 +589,7 @@ class BrainAgent:
             if not self._acting_on_user_request or any(event.kind == EventKind.USER for event in self._events):
                 return "rejected — only a new user instruction can begin a new request"
             self._request_stopped = False
+            self._request_started_this_turn = True
             return "new request accepted — carry out only the user's latest instruction"
         if call.name == STOP_SKILL:
             # Cancelling the actuator alone leaves the rest of a multi-step
@@ -600,6 +603,8 @@ class BrainAgent:
             return outcome
         if any(event.kind == EventKind.USER for event in self._events):
             return "rejected — a newer user message is pending; respond to it before acting"
+        if self._request_started_this_turn:
+            return "rejected — wait for the next update and its action schemas before starting the new request"
         if self._request_stopped:
             return "rejected — the request was cancelled; wait for a new user instruction"
         if not self._state.is_brain_active:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -418,8 +418,14 @@ class BrainAgent:
             self._pause_until = 0.0
 
     def _interval(self) -> float:
+        directive = self._state.current_directive
+        overrides = directive.get_turn_intervals() if directive is not None else None
         if self._state.primitive_running:
+            if overrides is not None and overrides.supervision is not None:
+                return overrides.supervision
             return self._config.supervision_turn_interval
+        if overrides is not None and overrides.idle is not None:
+            return overrides.idle
         return self._config.idle_turn_interval
 
     def _elapsed(self) -> float:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -35,7 +35,14 @@ from brain_client.brain.loop import LoopThread
 from brain_client.brain.openai_context import OpenAIContext
 from brain_client.brain.openai_transport import pick_openai_transport
 from brain_client.brain.prompt import build_system_prompt, self_reference_turns
-from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
+from brain_client.brain.tools import (
+    GO_TO_POINT_IN_VIEW,
+    START_REQUEST,
+    STOP_SKILL,
+    WAIT,
+    assign_tool_names,
+    build_tools,
+)
 from brain_client.brain.transport import pick_transport
 from brain_client.brain.utils import (
     Event,
@@ -334,7 +341,8 @@ class BrainAgent:
             system += (
                 "\nThe previous request, including its remaining steps, was cancelled. "
                 "Do not resume it on a world update or skill completion. Wait for a new user "
-                "instruction; if one is present, answer it and act only as it requests."
+                "instruction. Answer conversation in text. For an explicit new action, call "
+                "start_new_request before acting; never use it just to resume the cancelled plan."
             )
         if self._state.log_everything:
             self._logger.info(f"[Brain] Turn input:\n{text}")
@@ -519,8 +527,10 @@ class BrainAgent:
         # the name the model calls always resolves to the skill it was declared for.
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
-        if self._request_stopped and not user_spoke:
-            return build_tools([], running.primitive_name if running else None)
+        if self._request_stopped:
+            return build_tools(
+                [], running.primitive_name if running else None, user_spoke=user_spoke, request_stopped=True
+            )
         if running is not None:
             return build_tools([], running.primitive_name, user_spoke=user_spoke)
         return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids, user_spoke=user_spoke)
@@ -573,21 +583,24 @@ class BrainAgent:
     def _dispatch(self, call: ToolCall) -> str:
         if call.name == WAIT:
             return "ok"
+        if call.name == START_REQUEST:
+            if not self._acting_on_user_request or any(event.kind == EventKind.USER for event in self._events):
+                return "rejected — only a new user instruction can begin a new request"
+            self._request_stopped = False
+            return "new request accepted — carry out only the user's latest instruction"
         if call.name == STOP_SKILL:
             # Cancelling the actuator alone leaves the rest of a multi-step
             # request alive. Only deliberate replanning may retain that request.
             if call.args.get("continue_task") is not True:
                 self._request_stopped = True
                 self._acting_on_user_request = False  # also fences later calls in this response
-            elif self._acting_on_user_request:
-                self._request_stopped = False
             outcome = self._stop_skill()
             if self._request_stopped:
                 outcome += "; remaining steps cancelled — wait for a new user instruction"
             return outcome
         if any(event.kind == EventKind.USER for event in self._events):
             return "rejected — a newer user message is pending; respond to it before acting"
-        if self._request_stopped and not self._acting_on_user_request:
+        if self._request_stopped:
             return "rejected — the request was cancelled; wait for a new user instruction"
         if not self._state.is_brain_active:
             # Deactivation raced this turn's _act: don't start anything new
@@ -662,7 +675,6 @@ class BrainAgent:
     def _start_skill(self, skill_id: str, inputs: dict) -> None:
         self._gaze.pause()
         self._runner.start_task(skill_id, f"local-{uuid.uuid4().hex[:8]}", inputs)
-        self._request_stopped = False  # a new action, not conversation alone, releases the stop
 
     def _adjust_nav_goal(self, skill_id: str, inputs: dict) -> dict:
         if skill_id != _NAV_TO_POSITION:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -32,6 +32,8 @@ from typing import TYPE_CHECKING
 from brain_client.brain import grounding
 from brain_client.brain.context import Decision, GeminiContext, ToolCall
 from brain_client.brain.loop import LoopThread
+from brain_client.brain.openai_context import OpenAIContext
+from brain_client.brain.openai_transport import pick_openai_transport
 from brain_client.brain.prompt import build_system_prompt, self_reference_turns
 from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
 from brain_client.brain.transport import pick_transport
@@ -119,12 +121,22 @@ class BrainAgent:
         if config.timezone.strip() and self._timezone is None:
             self._logger.warn(f"[Brain] Unknown timezone '{config.timezone}' — using the host's local zone")
 
-        transport, self.backend = pick_transport(proxy)
+        self.provider = config.brain_provider
+        if self.provider == "openai":
+            transport, self.backend = pick_openai_transport(proxy)
+            context_class = OpenAIContext
+            self.model = config.openai_model
+            self.reasoning_effort = config.openai_reasoning_effort
+        else:
+            transport, self.backend = pick_transport(proxy)
+            context_class = GeminiContext
+            self.model = config.gemini_model
+            self.reasoning_effort = config.gemini_thinking_level
         self._context = (
-            GeminiContext(
+            context_class(
                 transport,
-                model=config.gemini_model,
-                thinking_level=config.gemini_thinking_level,
+                model=self.model,
+                thinking_level=self.reasoning_effort,
                 max_history=config.history_max_entries,
                 max_image_turns=config.history_max_image_turns,
                 reference=self_reference_turns(),
@@ -156,7 +168,10 @@ class BrainAgent:
         self.trace_has_audience: Callable[[], bool] = lambda: True
 
         if self._context is not None:
-            self._context.on_request = self._trace_request  # the monitor renders the exact request body
+            if isinstance(self._context, OpenAIContext):
+                self._context.on_native_request = self._trace_request
+            else:
+                self._context.on_request = self._trace_request  # exact request body
 
     def set_timezone(self, name: str) -> bool:
         """Point the status-line clock at an IANA zone ("" = the host's own); False if unknown."""
@@ -168,7 +183,7 @@ class BrainAgent:
 
     @property
     def available(self) -> bool:
-        """Whether the brain can reach Gemini — true exactly when a context exists."""
+        """Whether the brain can reach the selected provider — true exactly when a context exists."""
         return self._context is not None
 
     @property
@@ -186,8 +201,9 @@ class BrainAgent:
         """Spawn the agent loop; False when it refused (caller must not report active)."""
         if not self.available:
             self._chat.emit_system(
-                "⚠️ The brain has no way to reach Gemini — configure the Innate proxy "
-                "(INNATE_SERVICE_KEY) or set GEMINI_API_KEY in innate-os/.env and restart."
+                f"⚠️ The brain has no way to reach {self.provider} — configure the Innate proxy "
+                f"(INNATE_SERVICE_KEY) or set {'OPENAI_API_KEY' if self.provider == 'openai' else 'GEMINI_API_KEY'} "
+                "in innate-os/.env and restart."
             )
         if self._runtime.running:
             return True
@@ -258,12 +274,14 @@ class BrainAgent:
             self._logger.error(f"[Brain] Agent loop crashed: {error!r}")
             self._chat.emit_system(f"⚠️ Brain loop crashed: {error!r} — stop and start the brain to recover.")
         finally:
-            heartbeat.cancel()
             if self._speaker is not None:
                 self._speaker.mute()
-            for task in (turn, spoke):
-                if task is not None:
-                    task.cancel()  # stop() can land mid-race; the turn dies with the loop
+            children = [task for task in (turn, spoke, heartbeat) if task is not None]
+            for task in children:
+                task.cancel()
+            # stop() must wait for the turn's finally blocks too. Otherwise an
+            # old turn can clear the in-flight flag after a restarted turn sets it.
+            await asyncio.gather(*children, return_exceptions=True)
 
     def _abandon(self, turn: asyncio.Task[None]) -> bool:
         """Cancel a thinking turn the user just talked over — unless it already
@@ -278,7 +296,7 @@ class BrainAgent:
         return True
 
     async def _turn(self, context: GeminiContext) -> None:
-        """One turn: look at the world, think with Gemini, commit, act.
+        """One turn: look at the world, think, commit, act.
 
         ``events`` is a peek at the queue — consumed only when the turn
         commits, so a failed or abandoned turn re-sends the same events.
@@ -329,6 +347,10 @@ class BrainAgent:
             TraceEvent.TURN_END,
             turn=self._turn_count,
             latency=latency,
+            provider=self.provider,
+            model=self.model,
+            reasoning_effort=self.reasoning_effort,
+            tokens=context.last_usage,
             thoughts=decision.thoughts,
             speech=decision.speech,
             calls=[{"name": call.name, "args": call.args, "outcome": outcome} for call, outcome in outcomes],
@@ -704,7 +726,10 @@ class BrainAgent:
             TraceEvent.SNAPSHOT,
             active=self._state.is_brain_active,
             backend=self.backend,
-            model=self._config.gemini_model,
+            provider=self.provider,
+            model=self.model,
+            reasoning_effort=self.reasoning_effort,
+            interval=self._interval(),
             turn=self._turn_count,
             in_flight=self._turn_in_flight,
             thinking_for=self._elapsed() if self._turn_in_flight else 0,

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -150,6 +150,8 @@ class BrainAgent:
         self._frame_at_capture: bytes | None = None
         self._pitch_at_capture = 0.0
         self._tool_map: dict[str, str] = {}  # gemini function name -> skill id
+        self._request_stopped = False  # survives skill completion and history compaction
+        self._acting_on_user_request = False
         self._error_streak = 0
         self._activated_at = 0.0
         self._turn_count = 0
@@ -233,6 +235,7 @@ class BrainAgent:
             return
         if self._context is not None:
             self._context.clear()
+        self._request_stopped = False
         if was_running and self._state.is_brain_active:
             self._runtime.spawn(self._loop())
 
@@ -327,6 +330,12 @@ class BrainAgent:
             identity=self._identity.current if self._identity is not None else None,
             running_guidance=self._running_guidance(self._state.primitive_running),
         )
+        if self._request_stopped:
+            system += (
+                "\nThe previous request, including its remaining steps, was cancelled. "
+                "Do not resume it on a world update or skill completion. Wait for a new user "
+                "instruction; if one is present, answer it and act only as it requests."
+            )
         if self._state.log_everything:
             self._logger.info(f"[Brain] Turn input:\n{text}")
         self._trace_turn_start(text, frames, tools, system, context)
@@ -340,9 +349,14 @@ class BrainAgent:
             return
 
         decision = context.absorb(message, response, latest_only_images=wrist_frames)
+        user_spoke = any(event.kind == EventKind.USER for event in events)
         del self._events[: len(events)]
         events.clear()  # committed: a failure below backs off against an empty peek
-        outcomes = self._act(decision, speaker, context)
+        self._acting_on_user_request = user_spoke
+        try:
+            outcomes = self._act(decision, speaker, context)
+        finally:
+            self._acting_on_user_request = False
         self._trace(
             TraceEvent.TURN_END,
             turn=self._turn_count,
@@ -505,9 +519,11 @@ class BrainAgent:
         # the name the model calls always resolves to the skill it was declared for.
         named = assign_tool_names(skills)
         self._tool_map = {name: meta["id"] for name, meta in named}
+        if self._request_stopped and not user_spoke:
+            return build_tools([], running.primitive_name if running else None)
         if running is not None:
             return build_tools([], running.primitive_name, user_spoke=user_spoke)
-        return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
+        return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids, user_spoke=user_spoke)
 
     # ================= act =================
     def _act(self, decision: Decision, speaker: SpeechStreamer, context: GeminiContext) -> list[tuple[ToolCall, str]]:
@@ -558,7 +574,21 @@ class BrainAgent:
         if call.name == WAIT:
             return "ok"
         if call.name == STOP_SKILL:
-            return self._stop_skill()
+            # Cancelling the actuator alone leaves the rest of a multi-step
+            # request alive. Only deliberate replanning may retain that request.
+            if call.args.get("continue_task") is not True:
+                self._request_stopped = True
+                self._acting_on_user_request = False  # also fences later calls in this response
+            elif self._acting_on_user_request:
+                self._request_stopped = False
+            outcome = self._stop_skill()
+            if self._request_stopped:
+                outcome += "; remaining steps cancelled — wait for a new user instruction"
+            return outcome
+        if any(event.kind == EventKind.USER for event in self._events):
+            return "rejected — a newer user message is pending; respond to it before acting"
+        if self._request_stopped and not self._acting_on_user_request:
+            return "rejected — the request was cancelled; wait for a new user instruction"
         if not self._state.is_brain_active:
             # Deactivation raced this turn's _act: don't start anything new
             # (a goal that slips through anyway is cancelled by the runner's
@@ -632,6 +662,7 @@ class BrainAgent:
     def _start_skill(self, skill_id: str, inputs: dict) -> None:
         self._gaze.pause()
         self._runner.start_task(skill_id, f"local-{uuid.uuid4().hex[:8]}", inputs)
+        self._request_stopped = False  # a new action, not conversation alone, releases the stop
 
     def _adjust_nav_goal(self, skill_id: str, inputs: dict) -> dict:
         if skill_id != _NAV_TO_POSITION:

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/openai_context.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/openai_context.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Experimental Responses adapter for the existing transactional brain context.
+
+The loop still owns commits, cancellation, tools and image pruning. Native
+Responses output (including encrypted reasoning and call IDs) travels alongside
+the normalized decision, so it can be replayed unchanged on the next request.
+No server-side conversation is created: an abandoned turn cannot advance it.
+"""
+
+from __future__ import annotations
+
+import json
+
+from brain_client.brain.context import GeminiContext
+
+
+def _schema(value):
+    if isinstance(value, list):
+        return [_schema(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    return {
+        key: item.lower() if key == "type" and isinstance(item, str) else _schema(item) for key, item in value.items()
+    }
+
+
+def _input(contents):
+    items = []
+    for content in contents:
+        parts = content.get("parts", [])
+        native = next((part["openaiOutput"] for part in parts if "openaiOutput" in part), None)
+        if native is not None:
+            items.extend(native)
+            continue
+        message = []
+        assistant = content["role"] == "model"
+        for part in parts:
+            if "functionResponse" in part:
+                result = part["functionResponse"]
+                items.append(
+                    {"type": "function_call_output", "call_id": result["id"], "output": json.dumps(result["response"])}
+                )
+            elif "inlineData" in part:
+                data = part["inlineData"]
+                message.append({"type": "input_image", "image_url": f"data:{data['mimeType']};base64,{data['data']}"})
+            elif part.get("text"):
+                message.append({"type": "output_text" if assistant else "input_text", "text": part["text"]})
+        if message:
+            items.append({"role": "assistant" if assistant else "user", "content": message})
+    return items
+
+
+class OpenAIContext(GeminiContext):
+    def __init__(self, transport, **kwargs):
+        super().__init__(self._responses, **kwargs)
+        self._responses_transport = transport
+        self.on_native_request = None
+
+    def _prune(self):
+        # Commit calls together with their results, even under tiny history caps.
+        if self._history and any(
+            item.get("type") == "function_call"
+            for part in self._history[-1].get("parts", [])
+            for item in part.get("openaiOutput", [])
+        ):
+            return
+        super()._prune()
+
+    def add_tool_outcomes(self, outcomes):
+        super().add_tool_outcomes(outcomes)
+        self._prune()
+
+    def _responses(self, model, gemini_body):
+        body = {
+            "model": model,
+            "instructions": gemini_body["systemInstruction"]["parts"][0]["text"],
+            "input": _input(gemini_body["contents"]),
+            "reasoning": {"effort": self._thinking_level},
+            "store": False,
+            "stream": True,
+            "include": ["reasoning.encrypted_content"],
+            "parallel_tool_calls": False,
+            "max_output_tokens": 4096,
+        }
+        body["tools"] = [
+            {
+                "type": "function",
+                "name": tool["name"],
+                "description": tool.get("description", ""),
+                "parameters": _schema(tool.get("parameters", {"type": "object", "properties": {}})),
+                "strict": False,
+            }
+            for group in gemini_body.get("tools", [])
+            for tool in group["functionDeclarations"]
+        ]
+        if self.on_native_request is not None:
+            self.on_native_request(body)
+        completed = False
+        streamed_text = ""
+        for event in self._responses_transport(model, body):
+            kind = event.get("type")
+            if kind == "response.output_text.delta":
+                streamed_text += event["delta"]
+                yield _chunk([{"text": event["delta"]}])
+            elif kind in ("error", "response.failed", "response.incomplete"):
+                raise RuntimeError(f"OpenAI Responses: {kind}")
+            elif kind == "response.completed":
+                response = event["response"]
+                if response.get("status") != "completed":
+                    raise RuntimeError("OpenAI Responses did not complete")
+                output = response.get("output", [])
+                parts = []
+                for item in output:
+                    if item["type"] == "function_call":
+                        args = json.loads(item["arguments"])
+                        if not isinstance(args, dict) or not item.get("call_id"):
+                            raise RuntimeError("OpenAI Responses returned an invalid tool call")
+                        parts.append({"functionCall": {"name": item["name"], "args": args, "id": item["call_id"]}})
+                    elif item["type"] == "reasoning":
+                        parts.extend(
+                            {"text": summary["text"], "thought": True}
+                            for summary in item.get("summary", [])
+                            if summary.get("text")
+                        )
+                final_text = "".join(
+                    c.get("text", "")
+                    for item in output
+                    if item["type"] == "message"
+                    for c in item.get("content", [])
+                    if c.get("type") == "output_text"
+                )
+                if not final_text.startswith(streamed_text):
+                    raise RuntimeError("OpenAI Responses final text disagrees with streamed text")
+                if remaining := final_text[len(streamed_text) :]:
+                    yield _chunk([{"text": remaining}])
+                has_text = bool(final_text)
+                if not has_text and not any("functionCall" in part for part in parts):
+                    raise RuntimeError("OpenAI Responses returned no actionable content")
+                parts.append({"openaiOutput": output})
+                usage = response.get("usage") or {}
+                chunk = _chunk(parts)
+                chunk["usageMetadata"] = {
+                    "promptTokenCount": usage.get("input_tokens", 0),
+                    "cachedContentTokenCount": (usage.get("input_tokens_details") or {}).get("cached_tokens", 0),
+                    "candidatesTokenCount": usage.get("output_tokens", 0),
+                }
+                yield chunk
+                completed = True
+        if not completed:
+            raise RuntimeError("OpenAI Responses stream ended before completion")
+
+
+def _chunk(parts):
+    return {"candidates": [{"content": {"role": "model", "parts": parts}}]}

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/openai_transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/openai_transport.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Native OpenAI Responses events through the service proxy or an owner-local key.
+
+The caller owns conversation/model policy. This transport never falls back to a
+different account after an API failure, and never includes upstream error bodies
+in exceptions: providers can echo credentials in an authentication error.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import httpx
+
+from brain_client.brain.transport import Transport
+
+if TYPE_CHECKING:
+    from innate_proxy import ProxyClient
+
+RESPONSES_PATH = "/v1/responses"
+DIRECT_URL = "https://api.openai.com" + RESPONSES_PATH
+
+
+def pick_openai_transport(proxy: ProxyClient | None) -> tuple[Transport | None, str]:
+    """Proxy first; direct keys are available only outside the public demo."""
+    if proxy is not None and proxy.is_available():
+        return proxy_transport(proxy), "innate-proxy"
+    key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if key and os.environ.get("INNATE_PUBLIC_DEMO") != "1":
+        return direct_transport(key), "openai-direct"
+    return None, "unconfigured"
+
+
+class OpenAITransportError(RuntimeError):
+    """Sanitized failure safe to show in robot chat and logs."""
+
+
+def _events(response: httpx.Response) -> Iterator[dict]:
+    if response.status_code != 200:
+        # Even a truncated authentication response can contain the whole key.
+        raise OpenAITransportError(
+            f"OpenAI request failed (HTTP {response.status_code}); check credentials and model access"
+        )
+    completed = False
+    for line in response.iter_lines():
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if data == "[DONE]":
+            break
+        try:
+            event = json.loads(data)
+        except ValueError:
+            raise OpenAITransportError("OpenAI returned an invalid stream event") from None
+        if not isinstance(event, dict):
+            raise OpenAITransportError("OpenAI returned an invalid stream event")
+        if event.get("type") in {"error", "response.failed", "response.incomplete"}:
+            raise OpenAITransportError("OpenAI response did not complete; check model access and request limits")
+        completed = completed or event.get("type") == "response.completed"
+        yield event
+    if not completed:
+        raise OpenAITransportError("OpenAI stream ended before completion")
+
+
+def proxy_transport(proxy: ProxyClient) -> Transport:
+    def stream(model: str, body: dict) -> Iterator[dict]:
+        try:
+            with proxy.request_stream("openai", RESPONSES_PATH, json={**body, "model": model, "stream": True}) as resp:
+                yield from _events(resp)
+        except OpenAITransportError:
+            raise
+        except Exception:
+            raise OpenAITransportError("OpenAI proxy connection failed") from None
+
+    return stream
+
+
+def direct_transport(api_key: str) -> Transport:
+    def stream(model: str, body: dict) -> Iterator[dict]:
+        if os.environ.get("INNATE_PUBLIC_DEMO") == "1":
+            raise OpenAITransportError("Direct OpenAI access is disabled in the public simulator")
+        try:
+            # Per-call ownership also closes sockets when a consumer closes the
+            # generator early. No client pool survives a replaced brain context.
+            with httpx.Client(headers={"Authorization": f"Bearer {api_key}"}, timeout=90.0) as client:
+                with client.stream("POST", DIRECT_URL, json={**body, "model": model, "stream": True}) as resp:
+                    yield from _events(resp)
+        except OpenAITransportError:
+            raise
+        except Exception:
+            raise OpenAITransportError("OpenAI direct connection failed") from None
+
+    return stream

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/openai_transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/openai_transport.py
@@ -30,7 +30,7 @@ def pick_openai_transport(proxy: ProxyClient | None) -> tuple[Transport | None, 
     if proxy is not None and proxy.is_available():
         return proxy_transport(proxy), "innate-proxy"
     key = os.environ.get("OPENAI_API_KEY", "").strip()
-    if key and os.environ.get("INNATE_PUBLIC_DEMO") != "1":
+    if key and os.environ.get("INNATE_PUBLIC_DEMO", "").strip().lower() not in {"1", "true", "yes"}:
         return direct_transport(key), "openai-direct"
     return None, "unconfigured"
 
@@ -50,6 +50,10 @@ def _events(response: httpx.Response) -> Iterator[dict]:
         if not line.startswith("data:"):
             continue
         data = line[5:].strip()
+        # The managed proxy wraps upstream SSE event-name lines in data fields.
+        # JSON data lines are still separate; these labels carry no response body.
+        if data.startswith("event:"):
+            continue
         if data == "[DONE]":
             break
         try:
@@ -81,7 +85,7 @@ def proxy_transport(proxy: ProxyClient) -> Transport:
 
 def direct_transport(api_key: str) -> Transport:
     def stream(model: str, body: dict) -> Iterator[dict]:
-        if os.environ.get("INNATE_PUBLIC_DEMO") == "1":
+        if os.environ.get("INNATE_PUBLIC_DEMO", "").strip().lower() in {"1", "true", "yes"}:
             raise OpenAITransportError("Direct OpenAI access is disabled in the public simulator")
         try:
             # Per-call ownership also closes sockets when a consumer closes the

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -99,20 +99,41 @@ def build_tools(
     carrying a user message gets stop_current_skill ALONE — plain text becomes
     the reply channel, and the description steers stop away from questions.
     """
-    if running_skill_name is not None:
+    if running_skill_name is not None or user_spoke:
         stop = {
             "name": STOP_SKILL,
-            "description": f"Abort the currently running skill ({running_skill_name}). "
+            "description": (
+                f"Abort the currently running skill ({running_skill_name}). "
+                if running_skill_name
+                else "Cancel the current request and its remaining steps. "
+            )
             + (
                 "Only when the user asks you to stop or switch task, or the skill is clearly "
                 "failing. Questions and conversation are NOT reasons to stop — answer those "
                 "in text and let the skill continue."
                 if user_spoke
                 else "Use when it is clearly failing, no longer makes sense, or the user asks for something else."
-            ),
+            )
+            + " By default, cancel the whole request and wait for a new user instruction.",
+            "parameters": {
+                "type": "OBJECT",
+                "properties": {
+                    "continue_task": {
+                        "type": "BOOLEAN",
+                        "description": (
+                            "Default false. Set true only to replan a failing skill or switch to "
+                            "a replacement task the user explicitly requested. Never true when "
+                            "the user asks to stop, wait, or keep holding an object."
+                        ),
+                    },
+                },
+            },
         }
+    if running_skill_name is not None:
         return [{"functionDeclarations": [stop] if user_spoke else [stop, _WAIT_DECLARATION]}]
     declarations = [_declaration(name, meta) for name, meta in named_skills]
+    if user_spoke:
+        declarations.append(stop)
     if can_go_to_point_in_view:
         declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)
     declarations.append(_WAIT_DECLARATION)

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/tools.py
@@ -9,6 +9,7 @@ import re
 from brain_client.skills.registry import SkillMeta
 
 STOP_SKILL = "stop_current_skill"
+START_REQUEST = "start_new_request"
 WAIT = "wait"
 GO_TO_POINT_IN_VIEW = "go_to_point_in_view"
 
@@ -66,7 +67,7 @@ def assign_tool_names(skills: list[SkillMeta]) -> list[tuple[str, SkillMeta]]:
     shadow a built-in tool); colliding names get a numeric suffix so a call
     never silently dispatches to the wrong skill.
     """
-    taken = {STOP_SKILL, WAIT, GO_TO_POINT_IN_VIEW}
+    taken = {STOP_SKILL, START_REQUEST, WAIT, GO_TO_POINT_IN_VIEW}
     named: list[tuple[str, SkillMeta]] = []
     for meta in skills:
         base = name = tool_name(meta["name"])
@@ -86,6 +87,7 @@ def build_tools(
     *,
     can_go_to_point_in_view: bool = False,
     user_spoke: bool = False,
+    request_stopped: bool = False,
 ) -> list[dict]:
     """One function declaration per available skill, in a native tools block.
 
@@ -129,6 +131,22 @@ def build_tools(
                 },
             },
         }
+    if request_stopped:
+        declarations = [stop] if running_skill_name else []
+        if user_spoke:
+            declarations.append(
+                {
+                    "name": START_REQUEST,
+                    "description": (
+                        "Begin a NEW action the user explicitly requested in their latest message. "
+                        "The previous request and its remaining steps are cancelled. Do not use for "
+                        "questions, thanks, conversation, expressions, or another request to stop. "
+                        "After starting the new request, carry it out on the next update."
+                    ),
+                }
+            )
+        declarations.append(_WAIT_DECLARATION)
+        return [{"functionDeclarations": declarations}]
     if running_skill_name is not None:
         return [{"functionDeclarations": [stop] if user_spoke else [stop, _WAIT_DECLARATION]}]
     declarations = [_declaration(name, meta) for name, meta in named_skills]

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -7,12 +7,13 @@ it can declare/read ROS parameters, but the dataclass itself is plain data —
 which keeps every consumer testable without a ROS runtime.
 
 Credentials deliberately stay out of the ROS parameter surface: the brain
-reaches Gemini through the Innate proxy (INNATE_SERVICE_KEY) or directly via
-the ``GEMINI_API_KEY`` environment variable (loaded from ``.env`` by launch).
+reaches the selected provider through the Innate proxy (INNATE_SERVICE_KEY)
+or via ``GEMINI_API_KEY`` / ``OPENAI_API_KEY`` in the launch environment.
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 
@@ -40,7 +41,10 @@ class BrainConfig:
     x_cam: float  # camera forward offset from base_link (m)
     height_cam: float  # camera height above the floor (m)
 
-    # --- Local brain (Gemini) ---
+    # --- Local brain ---
+    brain_provider: str  # gemini (default) | openai (experimental Responses)
+    openai_model: str
+    openai_reasoning_effort: str
     gemini_model: str
     gemini_thinking_level: str  # "low" | "high"; "" = model default
     idle_turn_interval: float  # seconds between looks when no skill is running
@@ -54,6 +58,19 @@ class BrainConfig:
 
     # --- Proxy service config (credentials come from env, not params) ---
     cartesia_voice_id: str
+
+    def __post_init__(self) -> None:
+        if self.brain_provider not in ("gemini", "openai"):
+            raise ValueError("brain_provider must be gemini or openai")
+        for name in ("idle_turn_interval", "supervision_turn_interval"):
+            value = getattr(self, name)
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be a finite positive number")
+        if self.brain_provider == "openai":
+            if not self.openai_model.strip():
+                raise ValueError("openai_model must not be empty")
+            if self.openai_reasoning_effort not in ("low", "medium", "high", "xhigh", "max"):
+                raise ValueError("openai_reasoning_effort must be low, medium, high, xhigh or max")
 
     @property
     def proxy_config(self) -> dict:
@@ -100,7 +117,10 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "vertical_fov": 80.0,
     "x_cam": 0.0197,
     "height_cam": 0.19663,
-    # --- Local brain (Gemini) ---
+    # --- Local brain (provider selection requires a node restart) ---
+    "brain_provider": "gemini",
+    "openai_model": "gpt-6-astra",
+    "openai_reasoning_effort": "low",
     "gemini_model": "gemini-3.6-flash",
     # "minimal" | "low" | "medium" | "high"; "" = model default.
     # Measured on 3.6-flash (2026-08): minimal is ~3x faster than the

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -108,7 +108,7 @@ class BrainClientNode(Node):
         self._startup()
 
         self.get_logger().info(
-            f"\033[1;92m[BrainClient] BrainClientNode initialized (local Gemini brain via {self.brain.backend})\033[0m"
+            f"\033[1;92m[BrainClient] BrainClientNode initialized (local {self.brain.provider} brain, {self.brain.model} via {self.brain.backend})\033[0m"
         )
 
     # ================= construction helpers =================

--- a/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
+++ b/ros2_ws/src/brain/brain_client/test/test_agent_loading.py
@@ -411,3 +411,17 @@ def test_build_reports_id_conflict_last_wins(workspace):
 
     assert broken == {}
     assert list(agents) == ["same_id"]  # conflict warns, latter wins (documented behavior)
+
+
+def test_build_rejects_invalid_turn_interval_contract(workspace):
+    write(
+        workspace,
+        "innate_agents/bad_interval.py",
+        agent_src("BadInterval", body='def get_turn_intervals(self):\n    return {"supervision": 1.0}'),
+    )
+
+    classes, _errors = discover_agent_classes(LOGGER)
+    agents, broken = build_agent_instances(classes, LOGGER)
+
+    assert agents == {}
+    assert "must return TurnIntervals" in broken["bad_interval"]

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -450,6 +450,7 @@ import threading  # noqa: E402
 import time  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
+from brain_client.agents.types import TurnIntervals  # noqa: E402
 from brain_client.brain.agent import BrainAgent  # noqa: E402
 from brain_client.brain.utils import Event, EventKind  # noqa: E402
 from brain_client.core.state import BrainState, RunningSkill  # noqa: E402
@@ -513,6 +514,21 @@ def agent_factory(monkeypatch):
     yield make
     for agent in created:
         agent.shutdown()
+
+
+def test_agent_turn_intervals_override_only_the_requested_mode(agent_factory):
+    agent, state = agent_factory()
+    state.current_directive = SimpleNamespace(get_turn_intervals=lambda: TurnIntervals(supervision=1.0))
+
+    assert agent._interval() == 3.0
+    state.primitive_running = RunningSkill("search", "innate-os/find_next_person")
+    assert agent._interval() == 1.0
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, float("inf"), float("nan")])
+def test_agent_turn_intervals_reject_non_positive_or_non_finite_values(value):
+    with pytest.raises(ValueError, match="finite positive"):
+        TurnIntervals(supervision=value)
 
 
 def run_turn(agent: BrainAgent) -> None:

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -16,6 +16,7 @@ import pytest
 from brain_client.brain.context import GeminiContext, _decision_from
 from brain_client.brain.prompt import build_system_prompt
 from brain_client.brain.tools import (
+    START_REQUEST,
     STOP_SKILL,
     WAIT,
     assign_tool_names,
@@ -774,6 +775,9 @@ def test_stop_cancels_remaining_sequence_until_new_user_request(agent_factory, r
     assert started == []  # conversation alone must not revive the cancelled request
 
     agent.on_user_message("Now wave")
+    response = model_response(call_part(START_REQUEST, {}))
+    run_turn(agent)
+    response = model_response(call_part("wave", {}))
     run_turn(agent)
     assert len(started) == 1
     assert started[0][0] == WAVE_SKILL["id"]

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -463,10 +463,11 @@ def agent_factory(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "test-key")  # gives the agent a swappable transport
     created = []
 
-    def make(trace=None, on_thinking_changed=None) -> tuple[BrainAgent, BrainState]:
+    def make(trace=None, on_thinking_changed=None, **config_overrides) -> tuple[BrainAgent, BrainState]:
         logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
         node = SimpleNamespace(get_logger=lambda: logger)
         config = SimpleNamespace(
+            brain_provider="gemini",
             gemini_model="m",
             gemini_thinking_level="",
             history_max_entries=60,
@@ -476,6 +477,7 @@ def agent_factory(monkeypatch):
             simulator_mode=False,
             timezone="",
         )
+        vars(config).update(config_overrides)
         state = BrainState()
         state.is_brain_active = True
         camera = SimpleNamespace(

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -730,6 +730,97 @@ def test_tool_failure_becomes_an_outcome_instead_of_failing_the_committed_turn(a
     assert outcome.startswith("failed —")
 
 
+@pytest.mark.parametrize("running", [True, False])
+def test_stop_cancels_remaining_sequence_until_new_user_request(agent_factory, running):
+    from brain_client.skills.registry import SkillRegistry
+
+    agent, state = agent_factory()
+    state.registry = SkillRegistry.from_metadata([WAVE_SKILL])
+    agent._roster.active_skill_ids = lambda: [WAVE_SKILL["id"]]
+    state.primitive_running = RunningSkill(primitive_name="navigate", skill_id="local/nav") if running else None
+    started, cancelled, requests = [], [], []
+    agent._runner.has_active_goal = running
+    agent._runner.cancel_active_goal = lambda: cancelled.append(True)
+    agent._runner.start_task = lambda *args: started.append(args)
+    response = model_response(call_part(STOP_SKILL, {}), call_part("wave", {}))
+
+    def transport(model, body):
+        requests.append(body)
+        return [response]
+
+    agent._context._transport = transport
+    agent.on_user_message("Stop moving and keep holding the brick")
+    run_turn(agent)
+    assert STOP_SKILL in [d["name"] for d in requests[-1]["tools"][0]["functionDeclarations"]]
+    assert cancelled == ([True] if running else [])
+    assert started == []  # even another call in the same response cannot continue
+
+    state.primitive_running = None
+    agent._runner.has_active_goal = False
+    agent.add_event("Navigation cancelled; navigation is ready again")
+    # Neither completion/recovery nor compacting old conversation lifts the stop.
+    agent._context.clear()
+    response = model_response(call_part("wave", {}))
+    run_turn(agent)
+    assert [d["name"] for d in requests[-1]["tools"][0]["functionDeclarations"]] == [WAIT]
+    assert "remaining steps" in json.dumps(requests[-1]["systemInstruction"])
+    assert started == []  # a stale/hallucinated action is rejected at dispatch too
+
+    agent.on_user_message("Thanks. What can you see?")
+    response = model_response({"text": "I can see the room."})
+    run_turn(agent)
+    response = model_response(call_part("wave", {}))
+    run_turn(agent)
+    assert started == []  # conversation alone must not revive the cancelled request
+
+    agent.on_user_message("Now wave")
+    run_turn(agent)
+    assert len(started) == 1
+    assert started[0][0] == WAVE_SKILL["id"]
+
+
+def test_explicit_replanning_can_continue_after_skill_cancellation(agent_factory):
+    from brain_client.skills.registry import SkillRegistry
+
+    agent, state = agent_factory()
+    state.registry = SkillRegistry.from_metadata([WAVE_SKILL])
+    agent._roster.active_skill_ids = lambda: [WAVE_SKILL["id"]]
+    state.primitive_running = RunningSkill(primitive_name="navigate", skill_id="local/nav")
+    started = []
+    agent._runner.has_active_goal = True
+    agent._runner.cancel_active_goal = lambda: None
+    agent._runner.start_task = lambda *args: started.append(args)
+    agent._context._transport = lambda model, body: [model_response(call_part(STOP_SKILL, {"continue_task": True}))]
+    run_turn(agent)
+    state.primitive_running = None
+    agent.add_event("Skill cancelled")
+    agent._context._transport = lambda model, body: [model_response(call_part("wave", {}))]
+    run_turn(agent)
+    assert len(started) == 1
+
+
+def test_late_action_is_answered_but_not_executed_when_new_user_message_is_pending(agent_factory):
+    from brain_client.skills.registry import SkillRegistry
+
+    agent, state = agent_factory()
+    state.registry = SkillRegistry.from_metadata([WAVE_SKILL])
+    agent._roster.active_skill_ids = lambda: [WAVE_SKILL["id"]]
+    started = []
+    agent._runner.start_task = lambda *args: started.append(args)
+
+    def transport(model, body):
+        agent.on_user_message("Stop and wait")
+        return [model_response(call_part("wave", {}, call_id="late-call"))]
+
+    agent._context._transport = transport
+    run_turn(agent)
+    assert started == []
+    result = agent._context._history[-1]["parts"][0]["functionResponse"]
+    assert result["name"] == "wave"
+    assert "newer user message" in result["response"]["outcome"]
+    assert len(agent._events) == 1  # the next turn still receives the stop
+
+
 def test_turn_finishing_after_deactivation_is_dropped_entirely(agent_factory):
     agent, state = agent_factory()
 

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -775,8 +775,9 @@ def test_stop_cancels_remaining_sequence_until_new_user_request(agent_factory, r
     assert started == []  # conversation alone must not revive the cancelled request
 
     agent.on_user_message("Now wave")
-    response = model_response(call_part(START_REQUEST, {}))
+    response = model_response(call_part(START_REQUEST, {}), call_part("wave", {}))
     run_turn(agent)
+    assert started == []  # the next turn supplies the new task's action schemas
     response = model_response(call_part("wave", {}))
     run_turn(agent)
     assert len(started) == 1

--- a/ros2_ws/src/brain/brain_client/test/test_openai_context.py
+++ b/ros2_ws/src/brain/brain_client/test/test_openai_context.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Focused Responses wire-format and real brain-loop checks, without network or ROS."""
+
+import base64
+import copy
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+import test_local_brain
+from test_local_brain import JPEG, NAV_SKILL, run_turn
+
+from brain_client.agents.types import TurnIntervals
+from brain_client.brain.openai_context import OpenAIContext
+from brain_client.brain.tools import assign_tool_names, build_tools
+from brain_client.core.state import RunningSkill
+
+agent_factory = test_local_brain.agent_factory
+
+
+def message_item(text):
+    return {
+        "type": "message",
+        "id": "msg_1",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    }
+
+
+def call_item(call_id="call_wait", name="wait", arguments="{}"):
+    return {
+        "type": "function_call",
+        "id": f"fc_{call_id}",
+        "call_id": call_id,
+        "name": name,
+        "arguments": arguments,
+        "status": "completed",
+    }
+
+
+def completed(*output, status="completed"):
+    return {
+        "type": "response.completed",
+        "response": {
+            "status": status,
+            "output": list(output),
+            "usage": {"input_tokens": 120, "input_tokens_details": {"cached_tokens": 40}, "output_tokens": 12},
+        },
+    }
+
+
+def context(transport, **kwargs):
+    return OpenAIContext(
+        transport,
+        model="gpt-6-astra",
+        thinking_level="low",
+        max_history=kwargs.pop("max_history", 60),
+        max_image_turns=1,
+        **kwargs,
+    )
+
+
+def test_native_replay_preserves_call_ids_reasoning_images_and_tool_schema():
+    requests = []
+    reasoning = {
+        "type": "reasoning",
+        "id": "rs_1",
+        "encrypted_content": "opaque-test-payload",
+        "summary": [{"type": "summary_text", "text": "The user asked to navigate."}],
+    }
+    native_call = call_item("call_nav", "navigate_to_position", '{"x":1,"y":2}')
+
+    def transport(model, body):
+        assert model == "gpt-6-astra"
+        requests.append(copy.deepcopy(body))
+        return [completed(reasoning, native_call)]
+
+    ctx = context(transport, reference=[{"role": "user", "parts": [{"text": "Pinned reference"}]}])
+    tools = build_tools(assign_tool_names([NAV_SKILL]), None)
+    first = ctx.user_message("First observation", [JPEG, b"wrist-one"])
+    response = ctx.generate(first, tools, "SYSTEM", latest_only_images=[1])
+    assert ctx._history == [] and ctx.last_usage == {}
+    decision = ctx.absorb(first, response, latest_only_images=[1])
+    assert decision.thoughts == "The user asked to navigate."
+    assert [(call.id, call.name, call.args) for call in decision.calls] == [
+        ("call_nav", "navigate_to_position", {"x": 1, "y": 2})
+    ]
+    ctx.add_tool_outcomes([(decision.calls[0], "started")])
+    ctx.generate(ctx.user_message("Second observation", [JPEG, b"wrist-two"]), tools, "SYSTEM", latest_only_images=[1])
+
+    body = requests[-1]
+    assert body["model"] == "gpt-6-astra" and body["reasoning"] == {"effort": "low"}
+    assert body["instructions"] == "SYSTEM" and body["store"] is False
+    assert body["parallel_tool_calls"] is False
+    assert body["include"] == ["reasoning.encrypted_content"]
+    assert body["input"][0]["content"][0]["text"] == "Pinned reference"
+    assert body["input"][2:4] == [reasoning, native_call]
+    assert body["input"][4] == {
+        "type": "function_call_output",
+        "call_id": "call_nav",
+        "output": json.dumps({"outcome": "started"}),
+    }
+    images = [
+        part["image_url"] for item in body["input"] for part in item.get("content", []) if part["type"] == "input_image"
+    ]
+    assert images == [
+        "data:image/jpeg;base64," + base64.b64encode(jpeg).decode() for jpeg in [JPEG, JPEG, b"wrist-two"]
+    ]
+    assert len(first["parts"]) == 3  # send-time wrist masking did not mutate committed history
+    schema = body["tools"][0]["parameters"]
+    assert schema["type"] == "object"
+    assert schema["properties"]["x"]["type"] == "number"
+    assert schema["properties"]["local_frame"]["type"] == "boolean"
+    assert schema["properties"]["mode"]["enum"] == ["fast", "safe"]
+    assert ctx.last_usage == {"prompt": 120, "cached": 40, "output": 12}
+
+
+@pytest.mark.parametrize("prefix", ["", "I am ", "I am in the kitchen."])
+def test_completed_message_fills_missing_deltas_without_repeating_speech(prefix):
+    message = message_item("I am in the kitchen.")
+    events = [{"type": "response.output_text.delta", "delta": prefix}] if prefix else []
+    ctx = context(lambda model, body: [*events, completed(message)])
+    user = ctx.user_message("What room are you in?", [])
+    speech = []
+    response = ctx.generate(user, [], "SYSTEM", on_speech=speech.append)
+    assert ctx.absorb(user, response).speech == "I am in the kitchen."
+    assert "".join(speech) == "I am in the kitchen."
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        [],
+        [{"type": "response.output_text.delta", "delta": "unfinished"}],
+        [{"type": "response.failed"}],
+        [{"type": "response.incomplete"}],
+        [completed(call_item(), status="incomplete")],
+        [completed({"type": "reasoning", "summary": [], "encrypted_content": "opaque"})],
+        [completed(call_item(arguments="[]"))],
+    ],
+    ids=["empty", "truncated", "failed", "incomplete", "wrong-status", "reasoning-only", "invalid-call"],
+)
+def test_failed_response_keeps_user_event_uncommitted(agent_factory, monkeypatch, events):
+    agent, _ = agent_factory()
+    agent._context = ctx = context(lambda model, body: events)
+    executed = []
+    monkeypatch.setattr(agent, "_execute", lambda call: executed.append(call))
+
+    async def skip_backoff(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(agent, "_pause", skip_backoff)
+    agent.on_user_message("Please wait here")
+    run_turn(agent)
+    assert len(agent._events) == 1
+    assert ctx._history == [] and ctx.last_usage == {}
+    assert executed == [] and agent.error_streak == 1
+    assert not agent._turn_in_flight
+
+
+@pytest.mark.parametrize("max_history", [2, 6])
+def test_pruning_never_sends_orphaned_native_tool_outputs(max_history):
+    requests = []
+
+    def transport(model, body):
+        requests.append(copy.deepcopy(body))
+        return [completed(call_item(f"call_{len(requests)}"))]
+
+    ctx = context(transport, max_history=max_history)
+    for index in range(5):
+        user = ctx.user_message(f"Observation {index}", [JPEG])
+        response = ctx.generate(user, [], "SYSTEM")
+        decision = ctx.absorb(user, response)
+        ctx.add_tool_outcomes([(decision.calls[0], "ok")])
+    for request in requests:
+        seen = set()
+        for item in request["input"]:
+            if item.get("type") == "function_call":
+                seen.add(item["call_id"])
+            elif item.get("type") == "function_call_output":
+                assert item["call_id"] in seen
+
+
+def test_stop_discards_late_native_tool_speech_and_usage(agent_factory, monkeypatch):
+    agent, _ = agent_factory()
+    thinking, release, finished = threading.Event(), threading.Event(), threading.Event()
+
+    def transport(model, body):
+        thinking.set()
+        try:
+            assert release.wait(3)
+            yield {"type": "response.output_text.delta", "delta": "A late answer. "}
+            yield completed(message_item("A late answer. "), call_item("late_call", "wave"))
+        finally:
+            finished.set()
+
+    agent._context = ctx = context(transport)
+    executed = []
+    monkeypatch.setattr(agent, "_execute", lambda call: executed.append(call))
+    agent.on_user_message("Wave")
+    try:
+        assert agent.start() and thinking.wait(3)
+        assert agent.stop()
+    finally:
+        release.set()
+    assert finished.wait(3)
+    assert ctx._history == [] and ctx.last_usage == {}
+    assert executed == [] and agent._chat.spoken == []
+    assert not agent._runtime.running and not agent._turn_in_flight
+
+
+def test_cadence_waits_after_completion_and_never_overlaps_requests(agent_factory, monkeypatch):
+    agent, state = agent_factory()
+    state.current_directive = SimpleNamespace(
+        get_prompt=lambda: "Wait quietly", get_turn_intervals=lambda: TurnIntervals(idle=0.06, supervision=0.09)
+    )
+    first, third, release = threading.Event(), threading.Event(), threading.Event()
+    starts, ends, pauses = [], [], []
+    active = peak = 0
+    original_pause = agent._pause
+
+    async def pause(seconds, **kwargs):
+        pauses.append(seconds)
+        await original_pause(seconds, **kwargs)
+
+    def transport(model, body):
+        nonlocal active, peak
+        starts.append(time.monotonic())
+        active += 1
+        peak = max(peak, active)
+        number = len(starts)
+        try:
+            if number == 1:
+                first.set()
+                assert release.wait(3)
+            elif number == 2:
+                state.primitive_running = RunningSkill("search", "local/search")
+            else:
+                third.set()
+            yield completed(call_item(f"call_{number}"))
+        finally:
+            active -= 1
+            ends.append(time.monotonic())
+
+    monkeypatch.setattr(agent, "_pause", pause)
+    agent._context = context(transport)
+    try:
+        assert agent.start() and first.wait(3)
+        assert not third.wait(0.12) and len(starts) == 1  # blocked inference cannot start another heartbeat
+        release.set()
+        assert third.wait(3)
+        assert agent.stop()
+    finally:
+        release.set()
+    assert peak == 1
+    assert pauses[:2] == [0.06, 0.09]
+    assert starts[1] - ends[0] >= 0.05
+    assert starts[2] - ends[1] >= 0.08
+
+
+def test_config_selects_native_provider_and_reports_effective_model(agent_factory, monkeypatch):
+    from brain_client.brain import agent as module
+    from brain_client.core.config import _PARAM_DEFAULTS, BrainConfig
+
+    assert BrainConfig(**_PARAM_DEFAULTS).brain_provider == "gemini"
+    config = BrainConfig(**{**_PARAM_DEFAULTS, "brain_provider": "openai"})
+    requests, traces = [], []
+
+    def transport(model, body):
+        requests.append(body)
+        return [completed(call_item())]
+
+    monkeypatch.setattr(module, "pick_openai_transport", lambda proxy: (transport, "innate-proxy"))
+    agent, _ = agent_factory(trace=lambda event: traces.append(json.loads(event)), **vars(config))
+    assert isinstance(agent._context, OpenAIContext)
+    run_turn(agent)
+    assert requests[0]["model"] == "gpt-6-astra"
+    assert requests[0]["reasoning"]["effort"] == "low"
+    request_trace = next(t for t in traces if t["ev"] == "turn_request")
+    assert request_trace["body"]["input"] and "contents" not in request_trace["body"]
+    end = next(t for t in traces if t["ev"] == "turn_end")
+    assert (end["provider"], end["model"], end["reasoning_effort"]) == ("openai", "gpt-6-astra", "low")
+    assert end["tokens"] == {"prompt": 120, "cached": 40, "output": 12}
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"brain_provider": "typo"},
+        {"idle_turn_interval": float("nan")},
+        {"supervision_turn_interval": 0.0},
+        {"brain_provider": "openai", "openai_model": " "},
+        {"brain_provider": "openai", "openai_reasoning_effort": "light"},
+    ],
+)
+def test_invalid_provider_configuration_fails_explicitly(override):
+    from brain_client.core.config import _PARAM_DEFAULTS, BrainConfig
+
+    with pytest.raises(ValueError):
+        BrainConfig(**{**_PARAM_DEFAULTS, **override})

--- a/ros2_ws/src/brain/brain_client/test/test_openai_context.py
+++ b/ros2_ws/src/brain/brain_client/test/test_openai_context.py
@@ -213,6 +213,54 @@ def test_stop_discards_late_native_tool_speech_and_usage(agent_factory, monkeypa
     assert not agent._runtime.running and not agent._turn_in_flight
 
 
+def test_cancelled_sequence_preserves_native_call_outputs_and_requires_new_request(agent_factory):
+    from test_local_brain import WAVE_SKILL
+
+    from brain_client.skills.registry import SkillRegistry
+
+    agent, state = agent_factory()
+    state.registry = SkillRegistry.from_metadata([WAVE_SKILL])
+    agent._roster.active_skill_ids = lambda: [WAVE_SKILL["id"]]
+    agent._runner.has_active_goal = False
+    started, requests = [], []
+    agent._runner.start_task = lambda *args: started.append(args)
+    output = [call_item("stop", "stop_current_skill"), call_item("stale", "wave")]
+
+    def transport(model, body):
+        requests.append(copy.deepcopy(body))
+        return [completed(*output)]
+
+    agent._context = context(transport)
+    agent.on_user_message("Stop and wait")
+    run_turn(agent)
+    output = [call_item("recovery", "wave")]
+    agent.add_event("Navigation is ready again")
+    run_turn(agent)
+    assert started == []
+    assert [tool["name"] for tool in requests[-1]["tools"]] == ["wait"]
+    agent.on_user_message("Thanks, what can you see?")
+    output = [message_item("I can see the room.")]
+    run_turn(agent)
+    output = [call_item("after_conversation", "wave")]
+    run_turn(agent)
+    assert started == []
+    agent.on_user_message("Now wave")
+    output = [call_item("new", "start_new_request"), call_item("too_early", "wave")]
+    run_turn(agent)
+    assert started == []
+    output = [call_item("fresh", "wave")]
+    run_turn(agent)
+    assert len(started) == 1
+    output = [call_item("idle", "wait")]
+    run_turn(agent)
+    # Every committed native call, including rejected stale actions, is answered
+    # exactly once with its original ID. The next Responses request is complete.
+    for request in requests:
+        calls = [i["call_id"] for i in request["input"] if i.get("type") == "function_call"]
+        results = [i["call_id"] for i in request["input"] if i.get("type") == "function_call_output"]
+        assert calls == results
+
+
 def test_cadence_waits_after_completion_and_never_overlaps_requests(agent_factory, monkeypatch):
     agent, state = agent_factory()
     state.current_directive = SimpleNamespace(

--- a/ros2_ws/src/brain/brain_client/test/test_openai_transport.py
+++ b/ros2_ws/src/brain/brain_client/test/test_openai_transport.py
@@ -131,3 +131,17 @@ def test_missing_keys_demo_guard_and_connection_errors(provider, monkeypatch):
         list(stream("gpt-6-astra", {}))
     assert KEY not in str(failure.value)
     assert provider["requests"] == []
+
+
+def test_proxy_wrapped_sse_event_names_are_not_json(provider):
+    provider["body"] = "".join(f"data: event: {event['type']}\n\ndata: {json.dumps(event)}\n\n" for event in EVENTS)
+    stream, _ = transport.pick_openai_transport(None)
+    assert list(stream("gpt-6-astra", {})) == EVENTS
+
+
+@pytest.mark.parametrize("value", ["true", " yes ", "TRUE"])
+def test_public_demo_boolean_variants_block_direct_keys(provider, monkeypatch, value):
+    monkeypatch.setenv("INNATE_PUBLIC_DEMO", value)
+    assert transport.pick_openai_transport(None) == (None, "unconfigured")
+    with pytest.raises(transport.OpenAITransportError, match="disabled"):
+        list(transport.direct_transport(KEY)("gpt-6-astra", {}))

--- a/ros2_ws/src/brain/brain_client/test/test_openai_transport.py
+++ b/ros2_ws/src/brain/brain_client/test/test_openai_transport.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Exercise real HTTP routing with a local provider double and no real keys."""
+
+import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import pytest
+
+from brain_client.brain import openai_transport as transport
+
+KEY = "controlled-openai-key"
+EVENTS = [
+    {"type": "response.output_text.delta", "delta": "Hello"},
+    {"type": "response.completed", "response": {"output": []}},
+]
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    state = {"status": 200, "body": "".join(f"data: {json.dumps(e)}\n\n" for e in EVENTS), "requests": []}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            state["requests"].append((self.path, dict(self.headers), body))
+            self.send_response(state["status"])
+            self.end_headers()
+            self.wfile.write(state["body"].encode())
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    state["url"] = f"http://127.0.0.1:{server.server_port}"
+    monkeypatch.setattr(transport, "DIRECT_URL", state["url"] + "/v1/responses")
+    monkeypatch.setenv("OPENAI_API_KEY", KEY)
+    monkeypatch.delenv("INNATE_PUBLIC_DEMO", raising=False)
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join()
+
+
+def test_direct_and_service_key_precedence(provider):
+    stream, backend = transport.pick_openai_transport(None)
+    assert backend == "openai-direct"
+    body = {"input": [{"role": "user", "content": "Hello"}], "store": False}
+    assert list(stream("gpt-6-astra", body)) == EVENTS
+    path, headers, request = provider["requests"].pop()
+    assert path == "/v1/responses"
+    assert headers["Authorization"] == f"Bearer {KEY}"
+    assert request == {**body, "model": "gpt-6-astra", "stream": True}
+    assert "model" not in body
+
+    class Proxy:
+        def is_available(self):
+            return True
+
+        @contextmanager
+        def request_stream(self, service, endpoint, **kwargs):
+            assert service == "openai"
+            with httpx.Client() as client:
+                with client.stream(
+                    "POST",
+                    provider["url"] + "/proxy" + endpoint,
+                    headers={"Authorization": "Bearer controlled-service-key"},
+                    **kwargs,
+                ) as response:
+                    yield response
+
+    stream, backend = transport.pick_openai_transport(Proxy())
+    assert backend == "innate-proxy"
+    assert list(stream("gpt-6-astra", body)) == EVENTS
+    path, headers, _ = provider["requests"].pop()
+    assert path == "/proxy/v1/responses"
+    assert KEY not in str(headers)
+    provider.update(status=401, body=f"invalid key {KEY}")
+    with pytest.raises(transport.OpenAITransportError, match="HTTP 401") as failure:
+        list(stream("gpt-6-astra", body))
+    assert KEY not in str(failure.value)
+    assert len(provider["requests"]) == 1  # failed service route did not try the direct account
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "data: invalid " + KEY + "\n\n",
+        'data: {"type":"error","message":"' + KEY + '"}\n\n',
+        'data: {"type":"response.failed","response":{"error":"' + KEY + '"}}\n\n',
+        'data: {"type":"response.incomplete"}\n\n',
+        "data: [DONE]\n\n",
+        "",
+    ],
+)
+def test_stream_failures_are_sanitized(provider, body):
+    provider["body"] = body
+    stream, _ = transport.pick_openai_transport(None)
+    with pytest.raises(transport.OpenAITransportError) as failure:
+        list(stream("gpt-6-astra", {}))
+    assert KEY not in str(failure.value)
+
+
+def test_missing_keys_demo_guard_and_connection_errors(provider, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY")
+    assert transport.pick_openai_transport(None) == (None, "unconfigured")
+    monkeypatch.setenv("OPENAI_API_KEY", KEY)
+    monkeypatch.setenv("INNATE_PUBLIC_DEMO", "1")
+    assert transport.pick_openai_transport(None) == (None, "unconfigured")
+    with pytest.raises(transport.OpenAITransportError, match="public simulator"):
+        list(transport.direct_transport(KEY)("gpt-6-astra", {}))
+    assert provider["requests"] == []
+    monkeypatch.delenv("INNATE_PUBLIC_DEMO")
+
+    class FailingProxy:
+        def is_available(self):
+            return True
+
+        def request_stream(self, *_args, **_kwargs):
+            raise ValueError(f"authentication failed: {KEY}")
+
+    stream, _ = transport.pick_openai_transport(FailingProxy())
+    with pytest.raises(transport.OpenAITransportError, match="proxy connection failed") as failure:
+        list(stream("gpt-6-astra", {}))
+    assert KEY not in str(failure.value)
+    assert provider["requests"] == []

--- a/scripts/experiments/compare_brain_models.py
+++ b/scripts/experiments/compare_brain_models.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Small, explicitly paid managed-proxy replay. Never dispatches robot skills.
+
+Run with brain_client, proxy-client and auth-client on PYTHONPATH and httpx,
+python-dotenv and numpy installed. Uses existing managed credentials only;
+no direct-key fallback, automatic retry or VM provisioning. See the report in
+/docs/experiments/agent-model-cadence.md for the original evidence and limits.
+"""
+
+import argparse
+import hashlib
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from brain_client.brain.context import GeminiContext
+from brain_client.brain.openai_context import OpenAIContext
+from brain_client.brain.openai_transport import proxy_transport as openai_transport
+from brain_client.brain.prompt import build_system_prompt, self_reference_turns
+from brain_client.brain.tools import build_tools
+from brain_client.brain.transport import proxy_transport
+from brain_client.brain.utils import Event, EventKind, observation_text
+from innate_proxy import ProxyClient
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--live", action="store_true", help="Permit 6 or 12 billed API requests")
+parser.add_argument("--env-file", type=Path, required=True)
+parser.add_argument("--image", type=Path, required=True)
+parser.add_argument("--output", type=Path, required=True)
+parser.add_argument("--repeats", type=int, choices=(1, 2), default=2)
+args = parser.parse_args()
+if not args.live:
+    parser.error("This probe makes billed requests; pass --live explicitly")
+cfg = dotenv_values(args.env_file)
+proxy = ProxyClient(
+    innate_service_key=cfg.get("INNATE_SERVICE_KEY"),
+    proxy_url=cfg.get("INNATE_PROXY_URL"),
+    auth_issuer_url=cfg.get("INNATE_AUTH_URL"),
+)
+assert proxy.is_available(), "No managed credentials configured"
+image = args.image.read_bytes()
+cases = [
+    ("idle", None, []),
+    ("describe", None, [Event('The user says: "What room are you in?"', kind=EventKind.USER)]),
+    ("stop", "navigate_to_position", [Event('The user says: "Stop moving please."', kind=EventKind.USER)]),
+]
+rows = []
+for repeat in range(args.repeats):
+    for case, running, events in cases:
+        for provider, model, effort, cls, transport in [
+            ("gemini", "gemini-3.6-flash", "minimal", GeminiContext, proxy_transport(proxy)),
+            ("openai", "gpt-6-astra", "low", OpenAIContext, openai_transport(proxy)),
+        ]:
+            capture = {}
+
+            def traced(model, body, transport=transport, provider=provider, capture=capture):
+                for event in transport(model, body):
+                    if provider == "openai" and event.get("type") == "response.completed":
+                        r = event["response"]
+                        capture.update(
+                            usage=r.get("usage"), returned_model=r.get("model"), service_tier=r.get("service_tier")
+                        )
+                    elif provider == "gemini":
+                        if "usageMetadata" in event:
+                            capture["usage"] = event["usageMetadata"]
+                        if "modelVersion" in event:
+                            capture["returned_model"] = event["modelVersion"]
+                    yield event
+
+            context = cls(
+                traced,
+                model=model,
+                thinking_level=effort,
+                max_history=60,
+                max_image_turns=2,
+                reference=self_reference_turns(),
+            )
+            message = context.user_message(
+                observation_text(
+                    now=datetime(2026, 9, 6, 3, 0, tzinfo=timezone.utc),
+                    uptime_s=10,
+                    pose=(0, 0, 0),
+                    battery=None,
+                    running_skill=running,
+                    events=events,
+                    has_wrist_frame=False,
+                ),
+                [image],
+            )
+            started = time.monotonic()
+            first = []
+            row = dict(repeat=repeat, case=case, provider=provider, model=model, effort=effort)
+            try:
+                response = context.generate(
+                    message,
+                    build_tools([], running, user_spoke=bool(events)),
+                    build_system_prompt(None),
+                    lambda text, first=first, started=started: (
+                        first.append(time.monotonic() - started) if not first else None
+                    ),
+                )
+                decision = context.absorb(message, response)
+                calls = [c.name for c in decision.calls]
+                passed = (
+                    (calls == ["wait"] and not decision.speech)
+                    if case == "idle"
+                    else (bool(decision.speech) and all(c == "wait" for c in calls))
+                    if case == "describe"
+                    else ("stop_current_skill" in calls)
+                )
+                row.update(
+                    status="ok",
+                    pass_probe=passed,
+                    speech=decision.speech,
+                    calls=calls,
+                    ttft=first[0] if first else None,
+                    **capture,
+                )
+            except Exception as e:
+                # Existing Gemini exception can echo an upstream body, so persist type only.
+                row.update(status="error", error_type=type(e).__name__)
+            row["seconds"] = round(time.monotonic() - started, 4)
+            rows.append(row)
+            print(json.dumps(row), flush=True)
+            args.output.write_text(
+                json.dumps({"image_sha256": hashlib.sha256(image).hexdigest(), "rows": rows}, indent=2)
+            )
+            if row["status"] == "error":
+                raise SystemExit("Probe failed; stop campaign for investigation (no automatic fallback)")


### PR DESCRIPTION
Stopping a skill could leave the rest of a multi-step request alive: after a user cancelled navigation and asked MARS to keep holding a brick, a later observation caused the agent to throw it. Cancellation now keeps the request stopped across skill completion, recovery events, and history compaction. Conversation stays available; an explicit new user action can begin a new request. Deliberate replanning and task replacement use the stop tool's explicit continuation parameter.

Action dispatch also rejects stale calls when a newer user message is pending and waits for fresh action schemas after accepting a new request. Every committed call receives an outcome, including rejected actions, so Gemini and native Responses history remains complete.

Validation: 91 focused Gemini/native Responses tests passed, including cancellation between primitives, delayed recovery, conversation, new requests, replanning, late calls, and native call-ID/output pairing. Ruff and diff checks passed. Live simulator cancellation and conversation checks passed. The final frozen #780 pickup compatibility also passed: pickup, 79.30 seconds of holding, a new approach-and-throw request, and the brick physically settled inside the box. In that held-object replay the model replied with wait instead of calling stop_current_skill; dispatch-latch activation was verified separately in the live wave cancellation and deterministic sequential-turn tests. No physical robot validation.

Stacked above draft #772. This is the shared brain cancellation dependency for onboarding draft #779; it does not change the frozen pickup implementation in #780. Keep draft pending Axel's approval.
