### PR TITLE
docs: simplify skills walkthrough and bring demos forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,21 @@ Start with [skills](#skills), [agents](#agents), [additional inputs](#additional
 
 <table>
   <tr>
-    <td width="64%" align="center" valign="top">
-      <img src="docs/assets/readme/screenshot-webapp-agent-real-mars.png" alt="Innate web app Agent page on a physical MARS robot" width="100%"><br>
-      <sub>Web app</sub>
+    <td width="50%" align="center" valign="top">
+      <img src="docs/assets/readme/skills-chess-door-opening.gif" alt="MARS moves a chess piece, then opens a door using standalone skills" width="100%">
     </td>
-    <td width="36%" rowspan="2" align="center" valign="middle">
-      <img src="docs/assets/readme/screenshot-mobile-card.png" alt="Innate mobile app running an agent" width="100%"><br>
-      <sub>Mobile app</sub>
+    <td width="50%" align="center" valign="top">
+      <img src="docs/assets/readme/agent-clean-room.gif" alt="An agent combines picking up and putting away to tidy a room" width="100%">
     </td>
   </tr>
   <tr>
-    <td width="64%" align="center" valign="top">
-      <a href="https://sim-demo.innate.bot"><img src="docs/assets/readme/screenshot-live-simulator-teleop.png" alt="Teleop on a simulated MARS robot" width="100%"></a><br>
-      <sub><a href="https://sim-demo.innate.bot">Live simulator</a></sub>
+    <td width="50%" valign="top">
+      <strong>Run a skill.</strong> Move a chess piece or open a door.<br>
+      <a href="#write-a-skill">Write your own skill</a>
+    </td>
+    <td width="50%" valign="top">
+      <strong>Run an agent.</strong> Combine picking up and putting away to tidy a room.<br>
+      <a href="#agent-definitions">Build an agent</a>
     </td>
   </tr>
 </table>
@@ -103,25 +105,68 @@ Skills are the core unit of action on Innate robots.
 
 A skill can be digital, like calling a tool, a service or another agent; or physical, like navigating, waving, grasping, recording a demonstration, or executing a learned manipulation policy.
 
-<p align="center">
-  <img src="docs/assets/readme/skills-chess-door-opening.gif" alt="Two standalone physical skills: moving a chess piece, then opening a door" width="520"><br>
-  <sub>Two standalone skill examples, shown sequentially: moving a chess piece, then opening a door.</sub>
-</p>
-
 - **Execute manually** — Run skills from the `innate` CLI.
 - **Operate from apps** — Trigger skills through the web app or Innate mobile apps.
 - **Run autonomously** — Let agents select and interrupt skills as the world changes.
 
 ### Running a skill
 
-On the robot, skills can be inspected and called through the CLI:
+Ask MARS to find and pick up an object from the floor. On a configured robot with Innate vision access, place a sock in view and run:
 
 ```bash
-innate skill type innate-os/arm_zero_position
-innate skill run innate-os/arm_zero_position @duration=3
+innate skill type innate-os/pick_any_object
+innate skill run innate-os/pick_any_object @prompt="the white sock"
 ```
 
-Custom skills use the same `@name=value` input syntax.
+MARS looks for the object, approaches it, grasps it, and checks whether the pick succeeded. Change `@prompt` to describe another object. [See the picking skill](workspace/innate_skills/pick_any_object.py).
+
+<a id="skill-definition"></a>
+
+### Write a skill
+
+A skill is a Python class. You can control the robot's interfaces directly or build on an existing skill. Here is a custom skill that reuses `PickAnyObject` to pick up a sock.
+
+**Create** `workspace/custom_skills/pick_up_sock.py`:
+
+```python
+from innate_skills.pick_any_object import PickAnyObject
+
+from innate import Skill, SkillReturn
+
+
+class PickUpSock(Skill):
+    """Find a white sock on the floor and pick it up."""
+
+    pick: PickAnyObject
+
+    def execute(self) -> SkillReturn:
+        return self.pick(prompt="the white sock")
+```
+
+**Save and run it** on the robot:
+
+```bash
+innate skill run local/pick_up_sock
+```
+
+The runtime discovers the class and hot-reloads edits on save. The `pick` annotation declares the skill to reuse; the runtime wires it up. This custom skill runs the same picking behavior and returns its result. Failures and cancellation propagate to the caller.
+
+Change the prompt in your file, save, and run it again to pick up a different object. You can also trigger your skill from the web or mobile app, or give it to an [agent](#agents).
+
+<details>
+<summary>Organizing skills and sharing helpers</summary>
+
+- **Built-in skills** — Located in `workspace/innate_skills/`, with IDs such as `innate-os/pick_any_object`.
+- **Your custom skills** — Stored in `workspace/custom_skills/`, with IDs such as `local/pick_up_sock`. Gitignored and yours to play with.
+- **Skill packs** — Any other folder dropped into `workspace/` loads as its own package (IDs `<folder>/<name>`). A pack that lives elsewhere on disk is symlinked in (`ln -s /opt/team/skills workspace/team_skills`) and works the same, hot reload included. In the simulator, the link target must also be mounted into the container.
+
+Helpers work like normal Python: any `.py` in your skills folder that doesn't define a `Skill` is just a module — `import` it, use relative imports inside subfolders, share across packages by bare name (`from innate_skills import arm_utils`). Device helpers are methods on the interfaces (`self.manipulation.move_to(...)`, `self.mobility.rotate_by(...)`); camera math and Gemini live under `innate` (`from innate import geometry, vision, gemini`).
+
+When writing your own motion loops, use `self.sleep(seconds)` so Stop can interrupt a pause. The framework handles cancellation and brakes the base; put your own cleanup in `try/finally`. Return a message or `SkillOutput` for success, or call `self.fail(message)` to fail the run.
+
+See [the workspace guide](workspace/README.md) for package layout and hot reload.
+
+</details>
 
 ### Trained skills
 
@@ -133,22 +178,13 @@ Some physical skills can be learned from demonstrations.
 
 Start here: [Training overview](https://docs.innate.bot/training/overview). To ship a trained model back to the robot, see [Deploy a trained skill](https://docs.innate.bot/training/deploy-trained-skill).
 
-You will find skills in two different directories:
+<details>
+<summary>Replay a recorded motion</summary>
 
-- **Built-in skills** — Located in `workspace/innate_skills/`.
-- **Your custom skills** — Stored in `workspace/custom_skills/`. Gitignored and yours to play with.
-- **Skill packs** — Any other folder dropped into `workspace/` loads as its own package (ids `<folder>/<name>`). A pack that lives elsewhere on disk is symlinked in (`ln -s /opt/team/skills workspace/team_skills`) and works the same, hot reload included.
+A replay skill plays back a recorded motion file. Save the following as `workspace/custom_skills/greet/metadata.json`, replacing the example recording URL and start/end poses with your own:
 
-Helpers work like normal Python: any `.py` in your skills folder that doesn't define a `Skill` is just a module — `import` it, use relative imports inside subfolders, share across packages by bare name (`from innate_skills import arm_utils`). Device helpers are methods on the interfaces (`self.manipulation.move_to(...)`, `self.mobility.rotate_by(...)`); camera math and Gemini live under `innate` (`from innate import geometry, vision, gemini`).
-
-### Skill definition
-
-<table>
-  <tr>
-    <td width="50%" valign="top">
-      <strong>Replay skill</strong> — replay a recorded motion file.<br>
-      Saved as <code>workspace/custom_skills/greet/metadata.json</code>:
-      <pre lang="json">{
+```json
+{
     "name": "greet",
     "type": "replay",
     "guidelines": "Greet the user with a friendly arm wave.",
@@ -164,35 +200,10 @@ Helpers work like normal Python: any `.py` in your skills folder that doesn't de
         "start_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0],
         "end_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0]
     }
-}</pre>
-    </td>
-    <td width="50%" valign="top">
-      <strong>Code skill</strong> — call the mobility interface to move forward.<br>
-      Saved as <code>workspace/custom_skills/move_forward.py</code>:
-      <pre lang="python">from innate import Mobility, Skill, SkillReturn
+}
+```
 
-
-class MoveForward(Skill):
-    """Move the robot forward by a given distance in meters."""
-
-    mobility: Mobility          # declare what you use; the runtime injects it
-
-    def execute(self, distance_m: float = 0.5) -> SkillReturn:
-        speed = 0.2  # m/s
-        duration = distance_m / speed
-        self.mobility.send_cmd_vel(linear_x=speed, duration=duration)
-        self.sleep(duration)    # like time.sleep, but a Stop unwinds it
-        return f"Moved forward {distance_m} m"
-</pre>
-      The return value is the run's result message; call
-      <code>self.fail(message)</code> to end the run as a failure.
-      Cancellation is the framework's job: <code>self.sleep</code> (and every
-      blocking framework call) raises the moment a Stop lands, the base is
-      braked automatically, and the run reports CANCELLED — skills carry no
-      cancel code.
-    </td>
-  </tr>
-</table>
+</details>
 
 ---
 
@@ -207,11 +218,6 @@ An agent consists of:
 - A **set of skills** the robot is allowed to use
 - A **system prompt** that defines the robot's behavior
 - An **agent loop** that connects the model to observations, memory, tools, and robot actions
-
-<p align="center">
-  <img src="docs/assets/readme/agent-clean-room.gif" alt="Pick up and put away skills chained in an agent to clean a room" width="520"><br>
-  <sub>Pick up and put away skills chained in an agent to clean a room.</sub>
-</p>
 
 ### Specificities of multimodal agents
 

--- a/README.md
+++ b/README.md
@@ -101,32 +101,16 @@ The Innate mobile app is available on both iOS and Android. It allows you to con
 
 ## Skills
 
-Skills are the core unit of action on Innate robots.
+Skills are reusable actions: navigate, pick up an object, call a service, or run a learned policy.
 
-A skill can be digital, like calling a tool, a service or another agent; or physical, like navigating, waving, grasping, recording a demonstration, or executing a learned manipulation policy.
-
-- **Execute manually** — Run skills from the `innate` CLI.
-- **Operate from apps** — Trigger skills through the web app or Innate mobile apps.
+- **Execute manually** — Run skills from the CLI, web app, or mobile apps.
 - **Run autonomously** — Let agents select and interrupt skills as the world changes.
-
-### Running a skill
-
-Ask MARS to find and pick up an object from the floor. On a configured robot with Innate vision access, place a sock in view and run:
-
-```bash
-innate skill type innate-os/pick_any_object
-innate skill run innate-os/pick_any_object @prompt="the white sock"
-```
-
-MARS looks for the object, approaches it, grasps it, and checks whether the pick succeeded. Change `@prompt` to describe another object. [See the picking skill](workspace/innate_skills/pick_any_object.py).
 
 <a id="skill-definition"></a>
 
 ### Write a skill
 
-A skill is a Python class. You can control the robot's interfaces directly or build on an existing skill. Here is a custom skill that reuses `PickAnyObject` to pick up a sock.
-
-**Create** `workspace/custom_skills/pick_up_sock.py`:
+Reuse the built-in [picking skill](workspace/innate_skills/pick_any_object.py). On MARS with Innate vision access, save this as `workspace/custom_skills/pick_up_sock.py`:
 
 ```python
 from innate_skills.pick_any_object import PickAnyObject
@@ -143,67 +127,18 @@ class PickUpSock(Skill):
         return self.pick(prompt="the white sock")
 ```
 
-**Save and run it** on the robot:
+<a id="running-a-skill"></a>
+
+Skills load automatically and hot-reload on save. Inspect and run yours:
 
 ```bash
+innate skill type local/pick_up_sock
 innate skill run local/pick_up_sock
 ```
 
-The runtime discovers the class and hot-reloads edits on save. The `pick` annotation declares the skill to reuse; the runtime wires it up. This custom skill runs the same picking behavior and returns its result. Failures and cancellation propagate to the caller.
+<a id="trained-skills"></a>
 
-Change the prompt in your file, save, and run it again to pick up a different object. You can also trigger your skill from the web or mobile app, or give it to an [agent](#agents).
-
-<details>
-<summary>Organizing skills and sharing helpers</summary>
-
-- **Built-in skills** — Located in `workspace/innate_skills/`, with IDs such as `innate-os/pick_any_object`.
-- **Your custom skills** — Stored in `workspace/custom_skills/`, with IDs such as `local/pick_up_sock`. Gitignored and yours to play with.
-- **Skill packs** — Any other folder dropped into `workspace/` loads as its own package (IDs `<folder>/<name>`). A pack that lives elsewhere on disk is symlinked in (`ln -s /opt/team/skills workspace/team_skills`) and works the same, hot reload included. In the simulator, the link target must also be mounted into the container.
-
-Helpers work like normal Python: any `.py` in your skills folder that doesn't define a `Skill` is just a module — `import` it, use relative imports inside subfolders, share across packages by bare name (`from innate_skills import arm_utils`). Device helpers are methods on the interfaces (`self.manipulation.move_to(...)`, `self.mobility.rotate_by(...)`); camera math and Gemini live under `innate` (`from innate import geometry, vision, gemini`).
-
-When writing your own motion loops, use `self.sleep(seconds)` so Stop can interrupt a pause. The framework handles cancellation and brakes the base; put your own cleanup in `try/finally`. Return a message or `SkillOutput` for success, or call `self.fail(message)` to fail the run.
-
-See [the workspace guide](workspace/README.md) for package layout and hot reload.
-
-</details>
-
-### Trained skills
-
-Some physical skills can be learned from demonstrations.
-
-- Record episodes from the phone app or web app.
-- Train a policy with one of the models available on Innate Cloud or locally.
-- Deploy the trained model as a skill.
-
-Start here: [Training overview](https://docs.innate.bot/training/overview). To ship a trained model back to the robot, see [Deploy a trained skill](https://docs.innate.bot/training/deploy-trained-skill).
-
-<details>
-<summary>Replay a recorded motion</summary>
-
-A replay skill plays back a recorded motion file. Save the following as `workspace/custom_skills/greet/metadata.json`, replacing the example recording URL and start/end poses with your own:
-
-```json
-{
-    "name": "greet",
-    "type": "replay",
-    "guidelines": "Greet the user with a friendly arm wave.",
-    "inputs": {},
-    "wheeled": false,
-    "downloads": {
-        "episode_0.h5": "https://your-cdn.com/greet/episode_0.h5"
-    },
-    "execution": {
-        "model_type": "replay",
-        "replay_file": "episode_0.h5",
-        "replay_frequency": 50.0,
-        "start_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0],
-        "end_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0]
-    }
-}
-```
-
-</details>
+**[Skills guide →](docs/skills/README.md)** — inputs, composition, interfaces, training, replay, and skill packs.
 
 ---
 
@@ -230,9 +165,7 @@ You can find agents in two different directories:
 - **[`workspace/innate_agents/`](workspace/innate_agents/)** — Built-in agents shipped with Innate OS.
 - **[`workspace/custom_agents/`](workspace/custom_agents/)** — Your local agents. Gitignored and yours to play with.
 
-Here is an example of a simple agent to navigate:
-
-A minimal agent file, saved as `workspace/custom_agents/navigate_agent.py`:
+A navigation agent, saved as `workspace/custom_agents/navigate_agent.py`:
 
 ```python
 from brain_client.agents.types import Agent
@@ -256,7 +189,11 @@ class NavigateAgent(Agent):
         return ["micro"]
 
     def get_prompt(self):
-        return "You are a helpful robot. When asked, navigate to the requested location using the navigate_to_position skill."
+        return (
+            "You are a helpful robot. When asked, "
+            "navigate to the requested location "
+            "using the navigate_to_position skill."
+        )
 ```
 
 ### Testing agents in sim

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,107 @@
+# Skills
+
+[Back to Innate OS](../../README.md#skills)
+
+Skills are the core unit of action on Innate robots.
+
+A skill can be digital, like calling a tool, a service or another agent; or physical, like navigating, waving, grasping, recording a demonstration, or executing a learned manipulation policy.
+
+- **Execute manually** — Run skills from the CLI, web app, or mobile apps.
+- **Run autonomously** — Let agents select and interrupt skills as the world changes.
+
+## Running a skill
+
+Ask MARS to find and pick up an object from the floor. On a configured robot with Innate vision access, place a sock in view and run:
+
+```bash
+innate skill type innate-os/pick_any_object
+innate skill run innate-os/pick_any_object @prompt="the white sock"
+```
+
+MARS looks for the object, approaches it, grasps it, and checks whether the pick succeeded. Change `@prompt` to describe another object. [See the picking skill](../../workspace/innate_skills/pick_any_object.py).
+
+## Write a skill
+
+A skill is a Python class. You can control the robot's interfaces directly or build on an existing skill. Here is a custom skill that reuses `PickAnyObject` to pick up a sock.
+
+**Create** `workspace/custom_skills/pick_up_sock.py`:
+
+```python
+from innate_skills.pick_any_object import PickAnyObject
+
+from innate import Skill, SkillReturn
+
+
+class PickUpSock(Skill):
+    """Find a white sock on the floor and pick it up."""
+
+    pick: PickAnyObject
+
+    def execute(self) -> SkillReturn:
+        return self.pick(prompt="the white sock")
+```
+
+**Save and run it** on the robot:
+
+```bash
+innate skill run local/pick_up_sock
+```
+
+The runtime discovers the class and hot-reloads edits on save. The `pick` annotation declares the skill to reuse; the runtime wires it up. This custom skill runs the same picking behavior and returns its result. Failures and cancellation propagate to the caller.
+
+Change the prompt in your file, save, and run it again to pick up a different object. You can also trigger your skill from the web or mobile app, or give it to an [agent](../../README.md#agents).
+
+## Organizing skills and sharing helpers
+
+- **Built-in skills** — Located in `workspace/innate_skills/`, with IDs such as `innate-os/pick_any_object`.
+- **Your custom skills** — Stored in `workspace/custom_skills/`, with IDs such as `local/pick_up_sock`. Gitignored and yours to play with.
+- **Skill packs** — Any other folder dropped into `workspace/` loads as its own package (IDs `<folder>/<name>`). A pack that lives elsewhere on disk is symlinked in (`ln -s /opt/team/skills workspace/team_skills`) and works the same, hot reload included. In the simulator, the link target must also be mounted into the container.
+
+Helpers work like normal Python: any `.py` in your skills folder that doesn't define a `Skill` is just a module — `import` it, use relative imports inside subfolders, share across packages by bare name (`from innate_skills import arm_utils`). Device helpers are methods on the interfaces (`self.manipulation.move_to(...)`, `self.mobility.rotate_by(...)`); camera math and Gemini live under `innate` (`from innate import geometry, vision, gemini`).
+
+When writing your own motion loops, use `self.sleep(seconds)` so Stop can interrupt a pause. The framework handles cancellation and brakes the base; put your own cleanup in `try/finally`. A committed grasp may finish its lift and carry motion before returning, so cancelling a pick does not drop the object. Return a message or `SkillOutput` for success, or call `self.fail(message)` to fail the run.
+
+See [the workspace guide](../../workspace/README.md) for package layout and hot reload.
+
+## Trained skills
+
+Some physical skills can be learned from demonstrations.
+
+- Record episodes from the phone app or web app.
+- Train a policy with one of the models available on Innate Cloud or locally.
+- Deploy the trained model as a skill.
+
+Start here: [Training overview](https://docs.innate.bot/training/overview). To ship a trained model back to the robot, see [Deploy a trained skill](https://docs.innate.bot/training/deploy-trained-skill).
+
+## Replay a recorded motion
+
+A replay skill plays back a recorded motion file. Save the following as `workspace/custom_skills/greet/metadata.json`, replacing the example recording URL and start/end poses with your own:
+
+```json
+{
+    "name": "greet",
+    "type": "replay",
+    "guidelines": "Greet the user with a friendly arm wave.",
+    "inputs": {},
+    "wheeled": false,
+    "downloads": {
+        "episode_0.h5": "https://your-cdn.com/greet/episode_0.h5"
+    },
+    "execution": {
+        "model_type": "replay",
+        "replay_file": "episode_0.h5",
+        "replay_frequency": 50.0,
+        "start_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0],
+        "end_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0]
+    }
+}
+```
+
+## Requirements and troubleshooting
+
+The picking example uses the robot cameras, base, arm, and Innate vision service. The robot needs a configured `INNATE_SERVICE_KEY` with Gemini access; a missing key is reported as a skill failure. See [configuration](../PARAMETERS.md).
+
+- Use `innate skill list` to check discovery and `innate skill type <skill-id>` to inspect inputs.
+- If a module fails to import, the web app marks it as broken and shows the error. Fix the file and save again.
+- A missed grasp is a failure, not a successful pickup. Composed skills propagate that failure to their caller.
+- Use the [simulator](../../sim/README.md) to develop skills before trying them on a physical robot.

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -28,7 +28,7 @@ error (and clears when you fix it) instead of vanishing.
 Skill IDs are namespaced by package: `innate-os/<name>` for shipped,
 `local/<name>` for yours, `<package>/<name>` for dropped-in packs. Packages
 import each other by bare name (`from innate_skills import arm_utils`). See
-the README at the repo root.
+the [skills guide](../docs/skills/README.md) for authoring and running skills.
 
 A pack that lives elsewhere on disk (a team checkout, a mounted volume) is
 symlinked in rather than copied — it then behaves exactly like a dropped-in


### PR DESCRIPTION
The README presents skills in a concise, full-width example: compose `PickAnyObject` into `PickUpSock`, inspect its inputs, and run it. Manual execution now covers the CLI, web app, and mobile apps together. The longer explanation, package layout, training links, replay JSON, and troubleshooting live in `docs/skills/README.md`, linked from both the root README and workspace guide. Existing section anchors remain available.

The navigation agent prompt wraps across short Python string literals without changing its value. Existing skill and agent demos appear together near the top, replacing the duplicated app screenshot collage.

Validation:
- Required pre-commit hooks pass.
- Source and GitHub-rendered Python snippets parse with indentation intact; replay JSON parses.
- The navigation agent AST is unchanged; its longest line is 60 characters.
- New local documentation links resolve, and the Skills guide/backlink work on GitHub.
- Checked the branch README visually on desktop and at 390 px width. The page stays within the viewport; code blocks retain GitHub's normal internal scrolling on phones.

Media follow-up: four clips have been selected from existing demo footage and exported as small, silent 720p H.264 MP4s: object pickup, an agent navigating to and opening a cabinet, manual web-app skill execution, and simulated cabinet opening. They all decode successfully. Native GitHub video uploads are pending sign-in in the internal browser; the README currently retains its existing GIFs and screenshots.
