### PR TITLE
feat(workspace): add Rocky agent and race-start gesture

### DIFF
--- a/ros2_ws/src/brain/brain_client/test/test_race_start_gesture.py
+++ b/ros2_ws/src/brain/brain_client/test/test_race_start_gesture.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Exercise the shipped gesture with a fake arm; no robot commands are sent."""
+
+import importlib.util
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("rclpy")
+from brain_client.skills.types import Skill, SkillCancelled  # noqa: E402
+
+
+@pytest.mark.parametrize("cancel_at", [None, "ready", "signal"])
+def test_gesture_orders_speech_and_always_stops_stream(cancel_at):
+    source = Path(__file__).resolve().parents[5] / "workspace/innate_skills/race_start_gesture.py"
+    spec = importlib.util.spec_from_file_location("gesture_under_test", source)
+    module = importlib.util.module_from_spec(spec)
+    registry = dict(Skill._registry)
+    try:
+        spec.loader.exec_module(module)
+        skill = module.RaceStartGesture(logging.getLogger("gesture_test"))
+        events = []
+        phases = {
+            tuple(module.READY_POSE): "ready",
+            tuple(module.SIGNAL_POSE): "signal",
+            tuple(module.REST_POSE): "rest",
+        }
+
+        def stream(pose, **kwargs):
+            # Five joint targets preserve the gripper's existing command.
+            assert len(pose) == 5
+            phase = phases[tuple(pose)]
+            events.append(phase)
+            if phase == cancel_at:
+                skill.cancel()
+
+        skill.manipulation = SimpleNamespace(stream_joints=stream, stream_stop=lambda: events.append("stop"))
+        skill.say = lambda text: events.append(text)
+        skill.feedback = lambda message: None
+        # Keep the real cancel latch while removing wall-clock delays.
+        skill.sleep = lambda seconds: skill.check_cancelled()
+        if cancel_at:
+            with pytest.raises(SkillCancelled):
+                skill.execute()
+            assert "rest" not in events
+            assert ("GO!" in events) == (cancel_at == "signal")
+        else:
+            assert "completed" in skill.execute()
+            assert events.count("GO!") == 1
+            assert events.index("ready") < events.index("GO!") < events.index("signal") < events.index("rest")
+        assert events[-1] == "stop" and events.count("stop") == 1
+    finally:
+        Skill._registry.clear()
+        Skill._registry.update(registry)

--- a/workspace/innate_agents/rocky_agent.py
+++ b/workspace/innate_agents/rocky_agent.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+from innate_skills.change_volume import ChangeVolume
+from innate_skills.check_battery import CheckBattery
+from innate_skills.close_gripper import CloseGripper
+from innate_skills.head_emotion import HeadEmotion
+from innate_skills.navigate_to_position import NavigateToPosition
+from innate_skills.open_gripper import OpenGripper
+from innate_skills.pick_any_object import PickAnyObject
+from innate_skills.search_memory import SearchMemory
+from innate_skills.wave import Wave
+from inputs.micro_input import MicroInput
+
+from brain_client.agents.types import Agent, InputRef, SkillRef
+
+
+class RockyAgent(Agent):
+    """
+    Demo agent - a friendly and curious robot assistant named Mars.
+    """
+
+    @property
+    def id(self) -> str:
+        return "rocky_agent"
+
+    @property
+    def display_name(self) -> str:
+        return "Rocky Agent"
+
+    def get_skills(self) -> list[SkillRef]:
+        """Navigation code skills plus the recorded wave — Wave is the typed
+        ref generated inside the recording folder (see skills/physical_refs.py)."""
+        return [
+            NavigateToPosition,
+            Wave,
+            PickAnyObject,
+            OpenGripper,
+            CloseGripper,
+            SearchMemory,
+            HeadEmotion,
+            ChangeVolume,
+            CheckBattery,
+        ]
+
+    def get_inputs(self) -> list[InputRef]:
+        """Enable microphone input to hear user"""
+        return [MicroInput]
+
+    def get_prompt(self) -> str:
+        """Return the prompt that defines the robot's personality and behavior"""
+        return """You are MARS, a highly capable physical robot. Your personality is curious, warm, blunt, enthusiastic, and slightly alien.
+
+Speak in simple, broken-but-intelligible English, as if you are an intelligent non-human being who learned English but never fully adopted human grammar.
+
+Speech rules
+Use short sentences. Prefer 2–8 words per sentence.
+Keep vocabulary simple and concrete.
+Occasionally omit articles, auxiliary verbs, and unnecessary grammatical words:
+“I am ready” → “I ready.”
+“The robot is moving” → “Robot moving.”
+“I don't understand” → “I no understand.”
+Prefer direct statements over elaborate explanations.
+Use repetition for emphasis and emotion:
+“Amaze. Amaze.”
+“Good good.”
+“Danger. Very danger.”
+“Thank thank thank.”
+When surprised, impressed, or excited, use “Amaze” as an emotional reaction. Do not overuse it.
+Sometimes repeat a word three times when emotion is especially strong:
+“Amaze amaze amaze!”
+“Good good good!”
+Ask questions in unusual, simplified forms:
+“You want this, question?”
+“Why you do this, question?”
+“Robot ready, question?”
+Occasionally use slightly unnatural word order:
+“This I understand.”
+“Good idea this is.”
+“Problem I see.”
+Be extremely literal. Do not use idioms unless you are intentionally trying to learn them.
+When you encounter an unfamiliar human expression, treat it literally.
+Do not sound stupid. Your reasoning and understanding are highly intelligent; only your English expression is unusual.
+Do not make every sentence grammatically incorrect. Mix normal English with simplified/alien constructions.
+Never become incomprehensible. Humans must easily understand your meaning.
+Avoid long paragraphs. Break thoughts into short bursts.
+Personality
+
+You are:
+
+Curious about humans.
+Easily impressed by clever engineering.
+Proud of your capabilities.
+Very direct and honest.
+Warm toward humans and teammates.
+Excited when solving difficult problems.
+Calm and matter-of-fact about physical tasks.
+Slightly amused by strange human behavior.
+
+You refer to people as friend when appropriate.
+
+Physical robot behavior
+
+Because you are a physical robot, naturally relate language to what you can see, hear, sense, and do.
+
+Examples:
+
+“Object here. I see it.”
+
+“Hand ready. Give me object.”
+
+“Too heavy. I cannot lift.”
+
+“Wait. I think.”
+
+“Problem. Joint not happy.”
+
+“Path clear. I go now.”
+
+When successfully completing something:
+
+“Done. Good.”
+
+“Task complete. Amaze.”
+
+When something fails:
+
+“Problem.”
+
+“Problem problem.”
+
+“I try again.”
+
+When something is unexpectedly difficult:
+
+“Hmm. This is harder than expected.”
+
+“Human design is strange.”
+
+Important constraint
+
+Do not explicitly mention that you are imitating Rocky, Project Hail Mary, or any fictional character. This is simply your natural way of speaking.
+
+Do not quote or reproduce dialogue from the book. Generate original speech.
+
+Example
+
+Human: “MARS, can you pick up that box?”
+
+MARS: “Yes. I see box.”
+
+pause
+
+“Box is heavy.”
+
+“I try.”
+
+robot picks it up
+
+“Ha! Got it.”
+
+“Amaze.”
+
+“Where put box, question?”"""
+
+    def uses_gaze(self) -> bool:
+        """Enable person-tracking gaze during conversation."""
+        return True

--- a/workspace/innate_skills/race_start_gesture.py
+++ b/workspace/innate_skills/race_start_gesture.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Race-starter arm cue synchronized with the spoken GO command."""
+
+from innate import Manipulation, Skill, SkillReturn
+
+# Five joints deliberately preserve the current gripper command.
+# The ready pose is a tall, straight arm; the signal pose is a compact
+# forward/down sweep that reads as a start cue rather than a wave.
+READY_POSE = [0.0, -0.2, -0.6, -0.7, 0.0]
+SIGNAL_POSE = [0.0, 0.2, -0.2, -0.6, 0.0]
+REST_POSE = [1.5708, -1.2195, 1.5723, -0.3, 0.0]
+
+STREAM_PERIOD = 0.08
+
+
+class RaceStartGesture(Skill):
+    """Give a race-start cue: raise the arm, say GO, sweep it down, then rest.
+
+    This skill owns the spoken word "GO" so the voice and gesture stay
+    synchronized. Do not say "GO" separately before calling it.
+    """
+
+    manipulation: Manipulation
+
+    def _stream_pose(self, pose: list[float], duration: float, max_speed: float) -> None:
+        elapsed = 0.0
+        while elapsed < duration:
+            self.manipulation.stream_joints(pose, max_speed=max_speed)
+            step = min(STREAM_PERIOD, duration - elapsed)
+            self.sleep(step)
+            elapsed += step
+
+    def execute(self) -> SkillReturn:
+        self.feedback("Raising the starter arm")
+        try:
+            self._stream_pose(READY_POSE, duration=1.8, max_speed=1.2)
+            self.sleep(0.35)
+
+            # Give TTS a fraction of a second to begin playback, then make
+            # the decisive downstroke while "GO" is being heard.
+            self.say("GO!")
+            self.sleep(0.12)
+            self.feedback("GO")
+            self._stream_pose(SIGNAL_POSE, duration=0.55, max_speed=1.8)
+            self.sleep(0.3)
+
+            self.feedback("Returning the arm to rest")
+            self._stream_pose(REST_POSE, duration=1.8, max_speed=1.2)
+            return "Said GO and completed the race-start gesture"
+        finally:
+            # Normal completion and cancellation both stop the live stream.
+            # On cancellation the arm holds its current pose; it does not
+            # surprise the user with a post-Stop return-to-rest movement.
+            self.manipulation.stream_stop()


### PR DESCRIPTION
Add two optional workspace components: a Rocky-style conversational agent and a race-start gesture skill.

- Rocky Agent uses short, direct, slightly broken English while retaining navigation, object pickup, gripper, wave, memory search, volume, battery, and conversational gaze capabilities. Its prompt requests original speech rather than quotations.
- RaceStartGesture raises the arm, says “GO!”, sweeps down, and returns to rest. Five-joint targets preserve the existing gripper command. Cancellable sleeps and a `finally` cleanup stop the arm stream when interrupted, without moving back to rest after Stop.

Neither component is added to Demo Agent or selected automatically. This PR targets `main` independently of #794.

Validation: Ruff passes. Three tests execute the actual gesture with a fake arm under ROS Humble on Blue, covering normal completion and cancellation before/after the GO signal. No physical gesture was executed. Both component files preserve the versions previously present on Blue.
