### PR TITLE
feat(webapp): targeting overlay — what pick_any_object is doing, on the main camera

### DIFF
--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -451,9 +451,14 @@ class SkillsActionServer(Node):
         """
         previous_run_cancel = swap_run_cancel(skill._cancel_latch())
         try:
-            return self._run_code_skill_prepared(skill, entry, skill_type, inputs, goal_handle)
+            output = self._run_code_skill_prepared(skill, entry, skill_type, inputs, goal_handle)
+        except Exception as e:
+            skill.overlay.end(ok=False, cancelled=False, text=str(e))
+            raise
         finally:
             swap_run_cancel(previous_run_cancel)
+        skill.overlay.end(ok=output.ok, cancelled=output.status is SkillResult.CANCELLED, text=output.message)
+        return output
 
     def _run_code_skill_prepared(self, skill, entry, skill_type, inputs, goal_handle) -> SkillOutput:
         skill._begin_run(goal_handle)

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -32,6 +32,7 @@ from brain_client.robot.head import Head
 from brain_client.robot.manipulation import Manipulation
 from brain_client.robot.mobility import Mobility
 from brain_client.robot.spatial_memory import SpatialMemory
+from brain_client.skills import overlay
 from brain_client.skills.catalog import SkillRepository
 from brain_client.skills.cli_bridge import SkillCliBridge, SkillCliGoalHandle
 from brain_client.skills.invoker import SkillInvoker
@@ -450,15 +451,17 @@ class SkillsActionServer(Node):
         and unwind on cancel without any plumbing from the skill.
         """
         previous_run_cancel = swap_run_cancel(skill._cancel_latch())
+        overlay.start_run()
         try:
             output = self._run_code_skill_prepared(skill, entry, skill_type, inputs, goal_handle)
+            skill.overlay.end(ok=output.ok, cancelled=output.status is SkillResult.CANCELLED, text=output.message)
+            return output
         except Exception as e:
             skill.overlay.end(ok=False, cancelled=False, text=str(e))
             raise
         finally:
+            overlay.end_run()
             swap_run_cancel(previous_run_cancel)
-        skill.overlay.end(ok=output.ok, cancelled=output.status is SkillResult.CANCELLED, text=output.message)
-        return output
 
     def _run_code_skill_prepared(self, skill, entry, skill_type, inputs, goal_handle) -> SkillOutput:
         skill._begin_run(goal_handle)

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/skills_server.py
@@ -451,16 +451,19 @@ class SkillsActionServer(Node):
         and unwind on cancel without any plumbing from the skill.
         """
         previous_run_cancel = swap_run_cancel(skill._cancel_latch())
-        overlay.start_run()
+        root = overlay.enter_run()  # a nested code skill draws into its parent's run
         try:
             output = self._run_code_skill_prepared(skill, entry, skill_type, inputs, goal_handle)
-            skill.overlay.end(ok=output.ok, cancelled=output.status is SkillResult.CANCELLED, text=output.message)
+            if root:
+                skill.overlay.end(ok=output.ok, cancelled=output.status is SkillResult.CANCELLED, text=output.message)
             return output
         except Exception as e:
-            skill.overlay.end(ok=False, cancelled=False, text=str(e))
+            if root:
+                skill.overlay.end(ok=False, cancelled=False, text=str(e))
             raise
         finally:
-            overlay.end_run()
+            if root:
+                overlay.end_run()
             swap_run_cancel(previous_run_cancel)
 
     def _run_code_skill_prepared(self, skill, entry, skill_type, inputs, goal_handle) -> SkillOutput:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/overlay.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/overlay.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import time
+import uuid
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, Protocol
 
@@ -28,6 +29,27 @@ Publish = Callable[[str], None]
 
 class _Logger(Protocol):
     def warning(self, msg: str) -> None: ...
+
+
+# The run every overlay event belongs to, process-wide like the run cancel
+# latch: a sub-skill's overlay draws into its root's run, and the UI drops
+# stragglers from a run that has already ended.
+_run_id = ""
+_run_drew = False
+
+
+def start_run() -> str:
+    """Server hook: open a run for the root skill about to execute."""
+    global _run_id, _run_drew
+    _run_id = uuid.uuid4().hex[:8]
+    _run_drew = False
+    return _run_id
+
+
+def end_run() -> None:
+    global _run_id, _run_drew
+    _run_id = ""
+    _run_drew = False
 
 
 def _jsonable(value: Any) -> Any:
@@ -56,7 +78,6 @@ class Overlay:
         self._publish = publish
         self._logger = logger
         self._header: dict[str, Any] = {}
-        self._active = False
         self._last_mark: dict[str, tuple[float, dict[str, Any]]] = {}
         self._last_readout: tuple[str, bool, float | None] | None = None
 
@@ -119,11 +140,11 @@ class Overlay:
         self._emit("clear", ids=list(ids), view=view)
 
     def end(self, ok: bool, cancelled: bool, text: str) -> None:
-        """Close the run with its result. The server's call, made after execute() returns."""
-        if not self._active:
+        """Close the run with its result. The server's call on the root skill,
+        made after execute() returns; silent when nothing in the run drew."""
+        if not _run_drew:
             return
         self._emit("run", state="end", ok=ok, cancelled=cancelled, text=text)
-        self._active = False
         self._header = {}
         self._last_mark.clear()
         self._last_readout = None
@@ -142,10 +163,11 @@ class Overlay:
         self._emit("mark", id=id, **fields)
 
     def _emit(self, event: str, **fields: Any) -> None:
-        payload = {"skill": self._skill, "ev": event, "t": time.time(), **self._header, **fields}
+        global _run_drew
+        payload = {"skill": self._skill, "run": _run_id, "ev": event, "t": time.time(), **self._header, **fields}
         try:
             self._publish(json.dumps(_jsonable(payload)))
         except Exception as e:  # noqa: BLE001 — a side channel must never become the run's failure
             self._logger.warning(f"[{self._skill}] overlay '{event}' dropped: {e}")
             return
-        self._active = True
+        _run_drew = True

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/overlay.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/overlay.py
@@ -33,17 +33,21 @@ class _Logger(Protocol):
 
 # The run every overlay event belongs to, process-wide like the run cancel
 # latch: a sub-skill's overlay draws into its root's run, and the UI drops
-# stragglers from a run that has already ended.
+# stragglers from a run that has already ended. Nested code skills re-enter
+# the server's run body, so only the outermost entry owns the run.
 _run_id = ""
 _run_drew = False
 
 
-def start_run() -> str:
-    """Server hook: open a run for the root skill about to execute."""
+def enter_run() -> bool:
+    """Server hook around a code skill's execute(): opens a run when none is
+    open and returns whether this caller owns it (and so must end it)."""
     global _run_id, _run_drew
+    if _run_id:
+        return False
     _run_id = uuid.uuid4().hex[:8]
     _run_drew = False
-    return _run_id
+    return True
 
 
 def end_run() -> None:

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/overlay.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/overlay.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""What a running skill draws over the robot's cameras: a drawing vocabulary
+(brackets, boxes, points, lines) plus a HUD of stages and a readout, published
+as JSON events on /brain/skill_overlay for the webapp's targeting overlay.
+Nothing here knows what a pick is — the skill says what to draw where.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable, Sequence
+from typing import Any, Literal, Protocol
+
+OVERLAY_TOPIC = "/brain/skill_overlay"
+# A moving marker is coalesced to 10 Hz (the webapp glides its points between
+# updates; more only floods rosbridge); an unchanged one is repeated once a
+# second so a page opened mid-run still picks it up.
+MARK_MIN_INTERVAL_S = 0.1
+MARK_REFRESH_S = 1.0
+
+View = Literal["main", "arm"]
+Px = Sequence[float]
+Corners = Sequence[float]
+Publish = Callable[[str], None]
+
+
+class _Logger(Protocol):
+    def warning(self, msg: str) -> None: ...
+
+
+def _jsonable(value: Any) -> Any:
+    """Floats rounded to 3 dp, numpy scalars (bool_ included) unboxed, tuples listed."""
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if hasattr(value, "item"):
+        value = value.item()
+    return round(value, 3) if isinstance(value, float) else value
+
+
+class Overlay:
+    """One skill's drawing channel. Markers are keyed by id: sending an id
+    again moves it, ``clear`` removes it. ``begin`` is optional — the first
+    event opens the run on the UI — and the server closes the run with the
+    skill's result, so a skill never calls ``end``. Every event repeats the
+    run's header (prompt, stages, frame, current stage), so a page that opens
+    mid-run, or missed the start while the publisher was still matching,
+    rebuilds the HUD from whichever message reaches it first. Best effort: a
+    publish failure is logged, never raised into the run."""
+
+    def __init__(self, skill: str, publish: Publish, logger: _Logger) -> None:
+        self._skill = skill
+        self._publish = publish
+        self._logger = logger
+        self._header: dict[str, Any] = {}
+        self._active = False
+        self._last_mark: dict[str, tuple[float, dict[str, Any]]] = {}
+        self._last_readout: tuple[str, bool, float | None] | None = None
+
+    def begin(self, prompt: str = "", stages: Sequence[str] = (), frame: tuple[int, int] | None = None) -> None:
+        """Declare the run up front: what it is after, its stage ladder, and
+        the image size its pixels are in (the head camera's when omitted)."""
+        self._header = {"prompt": prompt, "stages": list(stages), "frame": frame, "stage": None}
+        self._emit("run", state="start")
+
+    def stage(self, name: str) -> None:
+        self._header["stage"] = name
+        self._emit("stage", name=name)
+
+    def readout(self, text: str, *, busy: bool = False, progress: float | None = None) -> None:
+        """The HUD's one live line; ``busy`` sweeps the picture (a frame is out
+        to a model), ``progress`` in 0..1 fills the bar beside it."""
+        if (text, busy, progress) == self._last_readout:
+            return
+        self._last_readout = (text, busy, progress)
+        self._emit("readout", text=text, busy=busy, progress=progress)
+
+    def bracket(self, id: str, corners: Corners, *, label: str = "", view: View = "main", locked: bool = False) -> None:
+        """Corner brackets on (x0, y0, x1, y1): the "seen HERE" shape."""
+        self._mark(id, "bracket", view, label, locked, corners=corners)
+
+    def box(
+        self,
+        id: str,
+        corners: Corners,
+        *,
+        inner: float | None = None,
+        label: str = "",
+        view: View = "main",
+        locked: bool = False,
+    ) -> None:
+        """A goal rectangle; ``inner`` draws the accept deadband as that fraction of it."""
+        self._mark(id, "box", view, label, locked, corners=corners, inner=inner)
+
+    def point(self, id: str, px: Px, *, label: str = "", view: View = "main", locked: bool = False) -> None:
+        self._mark(id, "point", view, label, locked, px=px)
+
+    def reticle(self, id: str, px: Px, *, label: str = "", view: View = "main") -> None:
+        self._mark(id, "reticle", view, label, False, px=px)
+
+    def vector(self, id: str, a: Px, b: Px, *, view: View = "main") -> None:
+        """A dashed steering line from a to b."""
+        self._mark(id, "vector", view, "", False, a=a, b=b)
+
+    def line(self, id: str, a: Px, b: Px, *, view: View = "main") -> None:
+        self._mark(id, "line", view, "", False, a=a, b=b)
+
+    def clear(self, *ids: str, view: View | None = None) -> None:
+        """Remove the named markers, every marker on ``view``, or everything."""
+        if ids and not any(id in self._last_mark for id in ids):
+            return
+        for id in ids:
+            self._last_mark.pop(id, None)
+        if not ids:
+            self._last_mark = {k: v for k, v in self._last_mark.items() if view is not None and v[1]["view"] != view}
+        self._emit("clear", ids=list(ids), view=view)
+
+    def end(self, ok: bool, cancelled: bool, text: str) -> None:
+        """Close the run with its result. The server's call, made after execute() returns."""
+        if not self._active:
+            return
+        self._emit("run", state="end", ok=ok, cancelled=cancelled, text=text)
+        self._active = False
+        self._header = {}
+        self._last_mark.clear()
+        self._last_readout = None
+
+    def _mark(self, id: str, kind: str, view: View, label: str, locked: bool, **geometry: Any) -> None:
+        fields = _jsonable({"kind": kind, "view": view, "label": label, "locked": locked, **geometry})
+        now = time.monotonic()
+        last = self._last_mark.get(id)
+        if last is not None:
+            age = now - last[0]
+            if last[1] == fields and age < MARK_REFRESH_S:
+                return
+            if last[1]["locked"] == locked and age < MARK_MIN_INTERVAL_S:
+                return
+        self._last_mark[id] = (now, fields)
+        self._emit("mark", id=id, **fields)
+
+    def _emit(self, event: str, **fields: Any) -> None:
+        payload = {"skill": self._skill, "ev": event, "t": time.time(), **self._header, **fields}
+        try:
+            self._publish(json.dumps(_jsonable(payload)))
+        except Exception as e:  # noqa: BLE001 — a side channel must never become the run's failure
+            self._logger.warning(f"[{self._skill}] overlay '{event}' dropped: {e}")
+            return
+        self._active = True

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2026 Innate Inc
 import inspect
 import json
-import numbers
 import os
 import sys
 import threading
@@ -44,16 +43,14 @@ TELEMETRY_TOPIC = "/brain/skill_telemetry"
 
 def _jsonable(value: Any) -> Any:
     """Telemetry payload -> JSON-safe: floats rounded to 3 dp, numpy scalars
-    coerced, tuples listed."""
-    if value is None or isinstance(value, (bool, int, str)):
-        return value
-    if isinstance(value, numbers.Real):
-        return round(float(value), 3)
+    (bool_ included) unboxed to their Python value, tuples listed."""
     if isinstance(value, dict):
         return {k: _jsonable(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_jsonable(v) for v in value]
-    return value
+    if hasattr(value, "item"):
+        value = value.item()
+    return round(value, 3) if isinstance(value, float) else value
 
 
 class SkillResult(Enum):
@@ -768,6 +765,7 @@ class Skill(ABC):
         self.skills: SkillInvoker | None = None
         self._say_publisher = None
         self._telemetry_publisher = None
+        self._telemetry_open = False
         self._tts_status_sub = None
         self._tts_playing = None  # last /tts/is_playing value
         self._storage = None
@@ -1021,14 +1019,24 @@ class Skill(ABC):
 
     def telemetry(self, event: str, **fields: Any) -> None:
         """Publish one ``{skill, ev, t, ...fields}`` JSON event on
-        /brain/skill_telemetry for UIs that draw what the skill is doing
-        (the webapp's targeting overlay). No-op without a run node."""
+        /brain/skill_telemetry for UIs that draw what the skill is doing (the
+        webapp's targeting overlay). Events belong to a run: ``telemetry("run",
+        state="start", ...)`` opens one, ``state="end"`` closes it, and events
+        outside a run are dropped, so a collaborator shared with a skill that
+        never opened one stays silent. Best effort — never raises into the run."""
+        if event == "run":
+            self._telemetry_open = fields.get("state") == "start"
+        elif not self._telemetry_open:
+            return
         if self.node is None:
             return
-        if self._telemetry_publisher is None:
-            self._telemetry_publisher = self.node.create_publisher(String, TELEMETRY_TOPIC, 10)
-        payload = {"skill": self.name, "ev": event, "t": time.time(), **fields}
-        self._telemetry_publisher.publish(String(data=json.dumps(_jsonable(payload))))
+        try:
+            if self._telemetry_publisher is None:
+                self._telemetry_publisher = self.node.create_publisher(String, TELEMETRY_TOPIC, 10)
+            payload = {"skill": self.name, "ev": event, "t": time.time(), **fields}
+            self._telemetry_publisher.publish(String(data=json.dumps(_jsonable(payload))))
+        except Exception as e:  # noqa: BLE001 — a side channel must never become the run's failure
+            self.logger.warning(f"[{self.name}] telemetry '{event}' dropped: {e}")
 
     def _on_tts_status(self, msg: String) -> None:
         self._tts_playing = msg.data

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -23,6 +23,7 @@ from typing_extensions import Self
 from brain_client.common.dynamic_loader import class_name_to_snake_case
 from brain_client.common.logging import UniversalLogger
 from brain_client.common.script_paths import Source
+from brain_client.skills.overlay import OVERLAY_TOPIC, Overlay
 
 if TYPE_CHECKING:
     from brain_client.skills.invoker import SkillInvoker
@@ -38,19 +39,6 @@ SkillReturn = Union[None, str, "SkillOutput"]
 
 TTS_TOPIC = "/brain/tts"
 TTS_STATUS_TOPIC = "/tts/is_playing"
-TELEMETRY_TOPIC = "/brain/skill_telemetry"
-
-
-def _jsonable(value: Any) -> Any:
-    """Telemetry payload -> JSON-safe: floats rounded to 3 dp, numpy scalars
-    (bool_ included) unboxed to their Python value, tuples listed."""
-    if isinstance(value, dict):
-        return {k: _jsonable(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_jsonable(v) for v in value]
-    if hasattr(value, "item"):
-        value = value.item()
-    return round(value, 3) if isinstance(value, float) else value
 
 
 class SkillResult(Enum):
@@ -764,8 +752,8 @@ class Skill(ABC):
         # injected by the server before each run (see invoker.py)
         self.skills: SkillInvoker | None = None
         self._say_publisher = None
-        self._telemetry_publisher = None
-        self._telemetry_open = False
+        self._overlay: Overlay | None = None
+        self._overlay_publisher = None
         self._tts_status_sub = None
         self._tts_playing = None  # last /tts/is_playing value
         self._storage = None
@@ -1017,26 +1005,21 @@ class Skill(ABC):
         if wait:
             self._wait_for_speech_end(text)
 
-    def telemetry(self, event: str, **fields: Any) -> None:
-        """Publish one ``{skill, ev, t, ...fields}`` JSON event on
-        /brain/skill_telemetry for UIs that draw what the skill is doing (the
-        webapp's targeting overlay). Events belong to a run: ``telemetry("run",
-        state="start", ...)`` opens one, ``state="end"`` closes it, and events
-        outside a run are dropped, so a collaborator shared with a skill that
-        never opened one stays silent. Best effort — never raises into the run."""
-        if event == "run":
-            self._telemetry_open = fields.get("state") == "start"
-        elif not self._telemetry_open:
-            return
+    @property
+    def overlay(self) -> Overlay:
+        """What this skill draws over the cameras (see skills/overlay.py):
+        ``self.overlay.stage("approach")``, ``self.overlay.point("track", px)``,
+        ``self.overlay.readout("steering onto it")``."""
+        if self._overlay is None:
+            self._overlay = Overlay(self.name, self._publish_overlay, self.logger)
+        return self._overlay
+
+    def _publish_overlay(self, payload: str) -> None:
         if self.node is None:
             return
-        try:
-            if self._telemetry_publisher is None:
-                self._telemetry_publisher = self.node.create_publisher(String, TELEMETRY_TOPIC, 10)
-            payload = {"skill": self.name, "ev": event, "t": time.time(), **fields}
-            self._telemetry_publisher.publish(String(data=json.dumps(_jsonable(payload))))
-        except Exception as e:  # noqa: BLE001 — a side channel must never become the run's failure
-            self.logger.warning(f"[{self.name}] telemetry '{event}' dropped: {e}")
+        if self._overlay_publisher is None:
+            self._overlay_publisher = self.node.create_publisher(String, OVERLAY_TOPIC, 10)
+        self._overlay_publisher.publish(String(data=payload))
 
     def _on_tts_status(self, msg: String) -> None:
         self._tts_playing = msg.data

--- a/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/skills/types.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 Innate Inc
 import inspect
 import json
+import numbers
 import os
 import sys
 import threading
@@ -38,6 +39,21 @@ SkillReturn = Union[None, str, "SkillOutput"]
 
 TTS_TOPIC = "/brain/tts"
 TTS_STATUS_TOPIC = "/tts/is_playing"
+TELEMETRY_TOPIC = "/brain/skill_telemetry"
+
+
+def _jsonable(value: Any) -> Any:
+    """Telemetry payload -> JSON-safe: floats rounded to 3 dp, numpy scalars
+    coerced, tuples listed."""
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, numbers.Real):
+        return round(float(value), 3)
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    return value
 
 
 class SkillResult(Enum):
@@ -751,6 +767,7 @@ class Skill(ABC):
         # injected by the server before each run (see invoker.py)
         self.skills: SkillInvoker | None = None
         self._say_publisher = None
+        self._telemetry_publisher = None
         self._tts_status_sub = None
         self._tts_playing = None  # last /tts/is_playing value
         self._storage = None
@@ -1001,6 +1018,17 @@ class Skill(ABC):
         self._say_publisher.publish(String(data=text))
         if wait:
             self._wait_for_speech_end(text)
+
+    def telemetry(self, event: str, **fields: Any) -> None:
+        """Publish one ``{skill, ev, t, ...fields}`` JSON event on
+        /brain/skill_telemetry for UIs that draw what the skill is doing
+        (the webapp's targeting overlay). No-op without a run node."""
+        if self.node is None:
+            return
+        if self._telemetry_publisher is None:
+            self._telemetry_publisher = self.node.create_publisher(String, TELEMETRY_TOPIC, 10)
+        payload = {"skill": self.name, "ev": event, "t": time.time(), **fields}
+        self._telemetry_publisher.publish(String(data=json.dumps(_jsonable(payload))))
 
     def _on_tts_status(self, msg: String) -> None:
         self._tts_playing = msg.data

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -45,6 +45,11 @@ then ``out.message`` / ``out.data`` / ``out.ok``, with ``out.status`` a
 SkillResult enum, never a bare string. (Legacy ``(message, SkillResult)``
 tuple returns still work but are deprecated.)
 
+``self.telemetry(event, **fields)`` publishes one JSON event on
+/brain/skill_telemetry for UIs that draw what the skill is doing — the
+webapp's targeting overlay follows pick_any_object's stages and markers
+through it.
+
 Cancellation is the framework's job, not yours. Use ``self.sleep(seconds)``
 instead of ``time.sleep`` and write loops as if cancel didn't exist: every
 blocking framework call (``self.sleep``, ``self.wait_for``, sub-skill calls,

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -45,11 +45,13 @@ then ``out.message`` / ``out.data`` / ``out.ok``, with ``out.status`` a
 SkillResult enum, never a bare string. (Legacy ``(message, SkillResult)``
 tuple returns still work but are deprecated.)
 
-``self.telemetry(event, **fields)`` publishes one JSON event on
-/brain/skill_telemetry for UIs that draw what the skill is doing — the
-webapp's targeting overlay follows pick_any_object's stages and markers
-through it. Open a run with ``telemetry("run", state="start", ...)`` and
-close it with ``state="end"``; events outside a run are dropped.
+``self.overlay`` draws what the skill is doing over the robot's cameras in
+the webapp: ``overlay.begin(prompt, stages=[...])`` declares the run,
+``overlay.stage(name)`` and ``overlay.readout(text)`` drive the HUD, and
+``overlay.bracket`` / ``box`` / ``point`` / ``reticle`` / ``vector`` /
+``line`` place markers by id in image pixels (``view="arm"`` for the wrist
+camera); ``overlay.clear(*ids)`` removes them. The run closes by itself with
+the skill's result.
 
 Cancellation is the framework's job, not yours. Use ``self.sleep(seconds)``
 instead of ``time.sleep`` and write loops as if cancel didn't exist: every
@@ -70,6 +72,7 @@ from typing import TYPE_CHECKING
 
 from brain_client.agents.types import Agent, InputRef, SkillRef
 from brain_client.robot.exceptions import ArmFailed, ArmUnhealthy
+from brain_client.skills.overlay import Overlay
 from brain_client.skills.types import (
     PhysicalSkill,
     Skill,
@@ -114,6 +117,7 @@ __all__ = [
     "Map",
     "Mobility",
     "Odometry",
+    "Overlay",
     "Pose",
     "RecallVerdict",
     "Skill",

--- a/ros2_ws/src/brain/brain_client/innate/__init__.py
+++ b/ros2_ws/src/brain/brain_client/innate/__init__.py
@@ -48,7 +48,8 @@ tuple returns still work but are deprecated.)
 ``self.telemetry(event, **fields)`` publishes one JSON event on
 /brain/skill_telemetry for UIs that draw what the skill is doing — the
 webapp's targeting overlay follows pick_any_object's stages and markers
-through it.
+through it. Open a run with ``telemetry("run", state="start", ...)`` and
+close it with ``state="end"``; events outside a run are dropped.
 
 Cancellation is the framework's job, not yours. Use ``self.sleep(seconds)``
 instead of ``time.sleep`` and write loops as if cancel didn't exist: every

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -100,14 +100,15 @@ def _center_px(det):
 
 
 def parse_det_cands(text):
-    """All detections -> [(u, v, grip_strength | None)], best first.
-    (u, v) is the grasp_point when given, else the box center."""
+    """All detections -> [(u, v, grip_strength | None, box | None)], best
+    first. (u, v) is the grasp_point when given, else the box center; box is
+    the (x0, y0, x1, y1) px corners when the reply carried one."""
     cands = []
     for det in parse_dets(text):
         px = _grasp_px(det) or _center_px(det)
         if px is None:
             continue
-        cands.append((px[0], px[1], _grip(det)))
+        cands.append((px[0], px[1], _grip(det), _box_corners_px(det)))
     return cands
 
 

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -99,7 +99,7 @@ def _center_px(det):
     return ((c[0] + c[2]) / 2.0, (c[1] + c[3]) / 2.0) if c else None
 
 
-def parse_det_cands(text):
+def parse_det_cands_boxed(text):
     """All detections -> [(u, v, grip_strength | None, box | None)], best
     first. (u, v) is the grasp_point when given, else the box center; box is
     the (x0, y0, x1, y1) px corners when the reply carried one."""
@@ -110,6 +110,12 @@ def parse_det_cands(text):
             continue
         cands.append((px[0], px[1], _grip(det), _box_corners_px(det)))
     return cands
+
+
+def parse_det_cands(text):
+    """All detections -> [(u, v, grip_strength | None)], best first; see
+    parse_det_cands_boxed for the box corners as well."""
+    return [(u, v, grip) for u, v, grip, _box in parse_det_cands_boxed(text)]
 
 
 def parse_det_px(text):

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -987,6 +987,13 @@ select.skill-input {
   to { opacity: 1; transform: translate(-50%, 0); }
 }
 
+/* The Agent page's camera tiles sit along the top of the feed, so its HUD
+   takes the bottom edge, which only the challenge dock (far left) shares. */
+.agent-cockpit .tgt-hud {
+  top: auto;
+  bottom: 14px;
+}
+
 .tgt-hud.ok {
   border-color: rgb(86 194 140 / 60%);
 }

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -917,26 +917,37 @@ select.skill-input {
   right: calc(100% + 2px);
 }
 
-/* Steering vector: tracked point -> box centre, in frame coordinates. */
+/* Frame-coordinate lines: the steering vector (tracked point -> box centre)
+   and the blob's long axis on the wrist camera. */
 .tgt-vec {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   overflow: visible;
+}
+
+.tgt-vec-line,
+.tgt-axis-line {
+  stroke: var(--accent-dim);
+  stroke-width: 1.2;
+  vector-effect: non-scaling-stroke;
   opacity: 0;
   transition: opacity 200ms ease;
 }
 
-.tgt-vec.on {
-  opacity: 1;
+.tgt-vec-line {
+  stroke-dasharray: 4 5;
 }
 
-.tgt-vec-line {
-  stroke: var(--accent-dim);
-  stroke-width: 1.2;
-  stroke-dasharray: 4 5;
-  vector-effect: non-scaling-stroke;
+.tgt-axis-line {
+  stroke: var(--accent);
+  stroke-width: 1.5;
+}
+
+.tgt-vec-line.on,
+.tgt-axis-line.on {
+  opacity: 1;
 }
 
 /* While a frame is out to the model: one sweep across the picture. */

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -789,9 +789,9 @@ select.skill-input {
 }
 
 /* ---- targeting overlay (teleop/targetingOverlay.js) ----------------------
-   A skill's aim over the main camera. Every marker is a percentage of
-   .tgt-layer, which is the skill's image frame placed on the picture; the
-   markers themselves are hairline amber, greening as the skill locks on. */
+   What a running skill draws over the cameras. Every marker is a percentage
+   of .tgt-layer, which is the skill's image frame placed on the picture; the
+   markers themselves are hairline amber, greening when the skill locks them. */
 
 .tgt-clip {
   position: absolute;
@@ -812,17 +812,17 @@ select.skill-input {
   text-transform: uppercase;
   white-space: nowrap;
   color: inherit;
-  text-shadow: 0 0 3px rgb(0 0 0 / 80%);
+  text-shadow: 0 0 3px rgb(0 0 0 / 85%), 0 1px 2px rgb(0 0 0 / 70%);
 }
 
-/* Gemini's detection: four corner brackets, the "seen HERE" shape. */
-.tgt-seen {
+/* Corner brackets: the "seen HERE" shape. */
+.tgt-bracket {
   position: absolute;
   color: var(--accent);
   animation: tgt-lock 360ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
-.tgt-seen i {
+.tgt-bracket i {
   position: absolute;
   width: 12px;
   height: 12px;
@@ -832,12 +832,12 @@ select.skill-input {
   filter: drop-shadow(0 0 2px rgb(0 0 0 / 70%));
 }
 
-.tgt-seen i:nth-child(1) { top: 0; left: 0; border-width: 1.5px 0 0 1.5px; }
-.tgt-seen i:nth-child(2) { top: 0; right: 0; border-width: 1.5px 1.5px 0 0; }
-.tgt-seen i:nth-child(3) { bottom: 0; right: 0; border-width: 0 1.5px 1.5px 0; }
-.tgt-seen i:nth-child(4) { bottom: 0; left: 0; border-width: 0 0 1.5px 1.5px; }
+.tgt-bracket i:nth-child(1) { top: 0; left: 0; border-width: 1.5px 0 0 1.5px; }
+.tgt-bracket i:nth-child(2) { top: 0; right: 0; border-width: 1.5px 1.5px 0 0; }
+.tgt-bracket i:nth-child(3) { bottom: 0; right: 0; border-width: 0 1.5px 1.5px 0; }
+.tgt-bracket i:nth-child(4) { bottom: 0; left: 0; border-width: 0 0 1.5px 1.5px; }
 
-.tgt-seen .tgt-tag {
+.tgt-bracket .tgt-tag {
   bottom: calc(100% + 4px);
   left: 0;
 }
@@ -847,16 +847,17 @@ select.skill-input {
   to { transform: scale(1); opacity: 1; }
 }
 
-/* The pick box: get the tracked point inside the dashed square and the base
-   stops; the solid inner square is the servo's deadband, what "inside" tests. */
-.tgt-goal {
+/* A goal box: dashed outline, with an optional solid inner square for the
+   deadband the skill actually tests against. */
+.tgt-box {
   position: absolute;
   border: 1.5px dashed var(--accent-dim);
   border-radius: 2px;
+  filter: drop-shadow(0 0 2px rgb(0 0 0 / 70%));
   transition: border-color 200ms ease;
 }
 
-.tgt-accept {
+.tgt-inner {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -866,28 +867,28 @@ select.skill-input {
   transition: border-color 200ms ease, box-shadow 200ms ease;
 }
 
-.tgt-goal .tgt-tag {
+.tgt-box .tgt-tag {
   bottom: calc(100% + 3px);
   right: 0;
-  color: var(--accent-dim);
+  color: var(--accent);
 }
 
-.tgt-goal.inside {
+.tgt-box.locked {
   border-color: var(--ok);
 }
 
-.tgt-goal.inside .tgt-accept {
+.tgt-box.locked .tgt-inner {
   border-color: var(--ok);
   box-shadow: 0 0 10px rgb(86 194 140 / 45%);
 }
 
-.tgt-goal.inside .tgt-tag {
+.tgt-box.locked .tgt-tag {
   color: var(--ok);
 }
 
-/* Point markers are centred on their pixel; the tracked point glides between
-   ~10 Hz updates instead of stepping. */
-.tgt-track,
+/* Point markers are centred on their pixel; a point glides between ~10 Hz
+   updates instead of stepping. */
+.tgt-point,
 .tgt-reticle {
   position: absolute;
   transform: translate(-50%, -50%);
@@ -895,31 +896,30 @@ select.skill-input {
   filter: drop-shadow(0 0 2px rgb(0 0 0 / 70%));
 }
 
-.tgt-track {
+.tgt-point {
   transition: left 120ms linear, top 120ms linear;
 }
 
-.tgt-track.inside {
+.tgt-point.locked {
   color: var(--ok);
 }
 
-.tgt-track .tgt-tag,
+.tgt-point .tgt-tag,
 .tgt-reticle .tgt-tag {
   top: 50%;
   left: calc(100% + 2px);
   transform: translateY(-50%);
 }
 
-/* The tracked point ends up in the pick box, whose tag hangs top-right, so
-   this one hangs left. */
-.tgt-track .tgt-tag {
+/* A point usually ends up in a box, whose tag hangs top-right, so this one
+   hangs left. */
+.tgt-point .tgt-tag {
   left: auto;
   right: calc(100% + 2px);
 }
 
-/* Frame-coordinate lines: the steering vector (tracked point -> box centre)
-   and the blob's long axis on the wrist camera. */
-.tgt-vec {
+/* Frame-coordinate lines: a dashed steering vector, or a plain line. */
+.tgt-lines {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -927,30 +927,23 @@ select.skill-input {
   overflow: visible;
 }
 
-.tgt-vec-line,
-.tgt-axis-line {
+.tgt-vector,
+.tgt-line {
   stroke: var(--accent-dim);
   stroke-width: 1.2;
   vector-effect: non-scaling-stroke;
-  opacity: 0;
-  transition: opacity 200ms ease;
 }
 
-.tgt-vec-line {
+.tgt-vector {
   stroke-dasharray: 4 5;
 }
 
-.tgt-axis-line {
+.tgt-line {
   stroke: var(--accent);
   stroke-width: 1.5;
 }
 
-.tgt-vec-line.on,
-.tgt-axis-line.on {
-  opacity: 1;
-}
-
-/* While a frame is out to the model: one sweep across the picture. */
+/* While the skill is busy (a frame out to a model): one sweep across the picture. */
 .tgt-scan {
   position: absolute;
   top: 0;
@@ -962,7 +955,7 @@ select.skill-input {
   transition: opacity 200ms ease;
 }
 
-.tgt-layer.looking .tgt-scan {
+.tgt-layer.busy .tgt-scan {
   opacity: 1;
   animation: tgt-sweep 1.6s linear infinite;
 }
@@ -973,7 +966,9 @@ select.skill-input {
 }
 
 /* The HUD: skill + prompt, the stage ladder, one live readout. Top-centre is
-   the one stage edge nothing else claims on either cockpit. */
+   the one stage edge nothing else claims on either cockpit — except the
+   "<agent> is running" pill while the brain is active, which the HUD then
+   sits under. */
 .tgt-hud {
   top: 14px;
   left: 50%;
@@ -996,6 +991,10 @@ select.skill-input {
 @keyframes tgt-hud-in {
   from { opacity: 0; transform: translate(-50%, -6px); }
   to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+body:has(.agent-indicator:not([hidden], [data-off-route])) .tgt-hud {
+  top: 68px;
 }
 
 /* The Agent page's camera tiles sit along the top of the feed, so its HUD
@@ -1119,7 +1118,7 @@ select.skill-input {
   white-space: nowrap;
 }
 
-.tgt-hud.looking .tgt-readout-text::after {
+.tgt-hud.busy .tgt-readout-text::after {
   content: "…";
   animation: breathe 1.2s ease-in-out infinite;
 }
@@ -1132,7 +1131,7 @@ select.skill-input {
   color: var(--ctl-danger);
 }
 
-/* Wrist descent progress: hover height down to the stop height. */
+/* The readout's progress bar, when the skill reports one. */
 .tgt-bar {
   flex: 1;
   min-width: 48px;
@@ -1151,14 +1150,14 @@ select.skill-input {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .tgt-seen,
+  .tgt-bracket,
   .tgt-hud,
-  .tgt-layer.looking .tgt-scan,
+  .tgt-layer.busy .tgt-scan,
   .tgt-stage.active::before {
     animation: none;
   }
 
-  .tgt-track {
+  .tgt-point {
     transition: none;
   }
 }
@@ -10184,6 +10183,12 @@ select.skill-input {
   font-size: 13px;
   text-decoration: none;
   transition: border-color 150ms ease, background 150ms ease;
+}
+
+/* The Agent page has its own Start/Stop; the shell marks the pill off-route
+   there so styles that sit under it (the targeting HUD) can tell. */
+.agent-indicator[data-off-route] {
+  display: none;
 }
 
 /* The rule above shifts it by half the rail's column, which this layout has

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -788,6 +788,375 @@ select.skill-input {
   pointer-events: none;
 }
 
+/* ---- targeting overlay (teleop/targetingOverlay.js) ----------------------
+   A skill's aim over the main camera. Every marker is a percentage of
+   .tgt-layer, which is the skill's image frame placed on the picture; the
+   markers themselves are hairline amber, greening as the skill locks on. */
+
+.tgt-clip {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.tgt-layer {
+  position: absolute;
+}
+
+.tgt-tag {
+  position: absolute;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: inherit;
+  text-shadow: 0 0 3px rgb(0 0 0 / 80%);
+}
+
+/* Gemini's detection: four corner brackets, the "seen HERE" shape. */
+.tgt-seen {
+  position: absolute;
+  color: var(--accent);
+  animation: tgt-lock 360ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.tgt-seen i {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  max-width: 45%;
+  max-height: 45%;
+  border: 0 solid currentColor;
+  filter: drop-shadow(0 0 2px rgb(0 0 0 / 70%));
+}
+
+.tgt-seen i:nth-child(1) { top: 0; left: 0; border-width: 1.5px 0 0 1.5px; }
+.tgt-seen i:nth-child(2) { top: 0; right: 0; border-width: 1.5px 1.5px 0 0; }
+.tgt-seen i:nth-child(3) { bottom: 0; right: 0; border-width: 0 1.5px 1.5px 0; }
+.tgt-seen i:nth-child(4) { bottom: 0; left: 0; border-width: 0 0 1.5px 1.5px; }
+
+.tgt-seen .tgt-tag {
+  bottom: calc(100% + 4px);
+  left: 0;
+}
+
+@keyframes tgt-lock {
+  from { transform: scale(1.35); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+/* The pick box: get the tracked point inside the dashed square and the base
+   stops; the solid inner square is the servo's deadband, what "inside" tests. */
+.tgt-goal {
+  position: absolute;
+  border: 1.5px dashed var(--accent-dim);
+  border-radius: 2px;
+  transition: border-color 200ms ease;
+}
+
+.tgt-accept {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border: 1.5px solid var(--accent-dim);
+  border-radius: 2px;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.tgt-goal .tgt-tag {
+  bottom: calc(100% + 3px);
+  right: 0;
+  color: var(--accent-dim);
+}
+
+.tgt-goal.inside {
+  border-color: var(--ok);
+}
+
+.tgt-goal.inside .tgt-accept {
+  border-color: var(--ok);
+  box-shadow: 0 0 10px rgb(86 194 140 / 45%);
+}
+
+.tgt-goal.inside .tgt-tag {
+  color: var(--ok);
+}
+
+/* Point markers are centred on their pixel; the tracked point glides between
+   ~10 Hz updates instead of stepping. */
+.tgt-track,
+.tgt-reticle {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  color: var(--accent);
+  filter: drop-shadow(0 0 2px rgb(0 0 0 / 70%));
+}
+
+.tgt-track {
+  transition: left 120ms linear, top 120ms linear;
+}
+
+.tgt-track.inside {
+  color: var(--ok);
+}
+
+.tgt-track .tgt-tag,
+.tgt-reticle .tgt-tag {
+  top: 50%;
+  left: calc(100% + 2px);
+  transform: translateY(-50%);
+}
+
+/* The tracked point ends up in the pick box, whose tag hangs top-right, so
+   this one hangs left. */
+.tgt-track .tgt-tag {
+  left: auto;
+  right: calc(100% + 2px);
+}
+
+/* Steering vector: tracked point -> box centre, in frame coordinates. */
+.tgt-vec {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.tgt-vec.on {
+  opacity: 1;
+}
+
+.tgt-vec-line {
+  stroke: var(--accent-dim);
+  stroke-width: 1.2;
+  stroke-dasharray: 4 5;
+  vector-effect: non-scaling-stroke;
+}
+
+/* While a frame is out to the model: one sweep across the picture. */
+.tgt-scan {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 18%;
+  opacity: 0;
+  background: linear-gradient(90deg, transparent, rgb(232 163 61 / 14%) 85%, rgb(232 163 61 / 55%));
+  transition: opacity 200ms ease;
+}
+
+.tgt-layer.looking .tgt-scan {
+  opacity: 1;
+  animation: tgt-sweep 1.6s linear infinite;
+}
+
+@keyframes tgt-sweep {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(560%); }
+}
+
+/* The HUD: skill + prompt, the stage ladder, one live readout. Top-centre is
+   the one stage edge nothing else claims on either cockpit. */
+.tgt-hud {
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 7;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 10px 14px 9px;
+  max-width: min(440px, calc(100% - 28px));
+  background: rgb(0 0 0 / 66%);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-color: var(--ctl-edge-accent);
+  box-shadow: 0 10px 28px rgb(0 0 0 / 24%), inset 0 0 0 1px rgb(232 163 61 / 8%);
+  animation: tgt-hud-in 240ms ease both;
+  transition: border-color 300ms ease;
+}
+
+@keyframes tgt-hud-in {
+  from { opacity: 0; transform: translate(-50%, -6px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.tgt-hud.ok {
+  border-color: rgb(86 194 140 / 60%);
+}
+
+.tgt-hud.failed {
+  border-color: var(--ctl-edge-danger);
+}
+
+.tgt-hud-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+
+.tgt-hud-head .tgt-skill {
+  color: var(--accent);
+  flex: none;
+}
+
+.tgt-prompt {
+  font-size: 12px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tgt-stages {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tgt-stage {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ctl-text-off);
+  transition: color 200ms ease;
+}
+
+/* The dot before each stage; a hairline joins consecutive stages. */
+.tgt-stage::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  box-sizing: border-box;
+  flex: none;
+}
+
+.tgt-stage + .tgt-stage {
+  margin-left: 8px;
+  padding-left: 16px;
+}
+
+.tgt-stage + .tgt-stage::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 8px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.6;
+}
+
+.tgt-stage.done {
+  color: var(--ok);
+}
+
+.tgt-stage.done::before {
+  background: currentColor;
+}
+
+.tgt-stage.active {
+  color: var(--accent);
+}
+
+.tgt-stage.active::before {
+  background: currentColor;
+  box-shadow: 0 0 0 0 rgb(232 163 61 / 60%);
+  animation: tgt-pulse 1.4s ease-out infinite;
+}
+
+@keyframes tgt-pulse {
+  from { box-shadow: 0 0 0 0 rgb(232 163 61 / 60%); }
+  to { box-shadow: 0 0 0 7px rgb(232 163 61 / 0%); }
+}
+
+.tgt-readout {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 11px;
+  color: var(--ctl-text);
+  min-height: 14px;
+}
+
+.tgt-readout-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tgt-hud.looking .tgt-readout-text::after {
+  content: "…";
+  animation: breathe 1.2s ease-in-out infinite;
+}
+
+.tgt-hud.ok .tgt-readout {
+  color: var(--ok);
+}
+
+.tgt-hud.failed .tgt-readout {
+  color: var(--ctl-danger);
+}
+
+/* Wrist descent progress: hover height down to the stop height. */
+.tgt-bar {
+  flex: 1;
+  min-width: 48px;
+  height: 3px;
+  border-radius: 2px;
+  background: rgb(255 255 255 / 12%);
+  overflow: hidden;
+}
+
+.tgt-bar-fill {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  transition: width 250ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tgt-seen,
+  .tgt-hud,
+  .tgt-layer.looking .tgt-scan,
+  .tgt-stage.active::before {
+    animation: none;
+  }
+
+  .tgt-track {
+    transition: none;
+  }
+}
+
+@media (max-width: 780px) {
+  .tgt-hud {
+    top: 10px;
+    padding: 8px 12px 7px;
+    gap: 5px;
+  }
+
+  .tgt-prompt {
+    font-size: 11px;
+  }
+}
+
 .video-status {
   position: absolute;
   inset: 0;

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -23,6 +23,7 @@ import { getConfig } from "../config.js";
 import { robotSessionFactory } from "../robotSession.js";
 import { createVideoStage } from "../teleop/videoStage.js";
 import { createTrajectoryOverlay } from "../teleop/trajectoryOverlay.js";
+import { createTargetingOverlay } from "../teleop/targetingOverlay.js";
 import { createTelemetry } from "../teleop/telemetry.js";
 import { createCameraSwitch } from "../teleop/cameraSwitch.js";
 import { sharedAgentState } from "../teleop/agentState.js";
@@ -255,7 +256,10 @@ function buildAgentView(root) {
   // stack instead of a rail.
   const ribbonStage = realVideo?.el ?? feedFrame.querySelector(".video-stage");
   if (ribbonStage instanceof HTMLElement) {
-    parts.push(createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, cornerStack, ros, session));
+    parts.push(
+      createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, cornerStack, ros, session),
+      createTargetingOverlay(ribbonStage, realVideo?.videoEl ?? null, ros, session),
+    );
   }
 
   session.start();

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -258,7 +258,7 @@ function buildAgentView(root) {
   if (ribbonStage instanceof HTMLElement) {
     parts.push(
       createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, cornerStack, ros, session),
-      createTargetingOverlay(ribbonStage, realVideo?.videoEl ?? null, ros, session),
+      createTargetingOverlay(ribbonStage, realVideo?.videoEl ?? null, session),
     );
   }
 

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -162,15 +162,16 @@ export const MEMORY_SEARCH_TOPIC = "/brain/memory_search";
 // operators can see which skills the agent is executing.
 export const SKILL_STATUS_UPDATE_TOPIC = "/brain/skill_status_update";
 
-// What a running skill is looking at, for the targeting overlay drawn over the
-// main camera (std_msgs/String JSON: {skill, ev, t, ...} from Skill.telemetry()).
-// A run opens with {ev:"run", state:"start", prompt, stages:[...], frame:[w,h],
-// box, wrist_box} and closes with state:"end"; in between, markers arrive in
-// image pixels of that frame — look/track/grasp on the head camera, wrist
-// seed/track on the wrist camera — alongside stage changes and readouts. Stage
-// events repeat the prompt and track events their box, so a page that missed
-// the start still recovers them. The SDK drops events outside a run.
-export const SKILL_TELEMETRY_TOPIC = "/brain/skill_telemetry";
+// What a running skill draws over the cameras, for the targeting overlay
+// (std_msgs/String JSON: {skill, ev, t, ...} from Skill.overlay in the SDK).
+// {ev:"run", state:"start", prompt, stages:[...], frame:[w,h]} opens a run and
+// the server's {ev:"run", state:"end", ok, cancelled, text} closes it; between
+// them {ev:"stage", name}, {ev:"readout", text, busy, progress}, {ev:"mark", id,
+// kind, view, label, locked, corners|px|a,b} and {ev:"clear", ids|view} arrive,
+// every marker in image pixels of the run's frame. Every event repeats the
+// run's header (prompt, stages, frame, current stage) and unchanged markers
+// repeat once a second, so a page that missed the start still recovers them.
+export const SKILL_OVERLAY_TOPIC = "/brain/skill_overlay";
 
 // Per-step ACT inference timing breakdown (std_msgs/String carrying JSON), published
 // by the manipulation server while a learned behavior runs. Drives the Profiling page.

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -164,9 +164,11 @@ export const SKILL_STATUS_UPDATE_TOPIC = "/brain/skill_status_update";
 
 // What a running skill is looking at, for the targeting overlay drawn over the
 // main camera (std_msgs/String JSON: {skill, ev, t, ...} from Skill.telemetry()).
-// A run opens with {ev:"run", state:"start", stages:[...], frame:[w,h], box}
-// and closes with state:"end"; in between, markers arrive in image pixels of
-// that frame (look/track/grasp) alongside stage changes and readouts.
+// A run opens with {ev:"run", state:"start", prompt, stages:[...], frame:[w,h],
+// box} and closes with state:"end"; in between, markers arrive in image pixels
+// of that frame (look/track/grasp) alongside stage changes and readouts. Stage
+// events repeat the prompt and track events the box, so a page that missed the
+// start still recovers them. The SDK drops events outside a run.
 export const SKILL_TELEMETRY_TOPIC = "/brain/skill_telemetry";
 
 // Per-step ACT inference timing breakdown (std_msgs/String carrying JSON), published

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -162,6 +162,13 @@ export const MEMORY_SEARCH_TOPIC = "/brain/memory_search";
 // operators can see which skills the agent is executing.
 export const SKILL_STATUS_UPDATE_TOPIC = "/brain/skill_status_update";
 
+// What a running skill is looking at, for the targeting overlay drawn over the
+// main camera (std_msgs/String JSON: {skill, ev, t, ...} from Skill.telemetry()).
+// A run opens with {ev:"run", state:"start", stages:[...], frame:[w,h], box}
+// and closes with state:"end"; in between, markers arrive in image pixels of
+// that frame (look/track/grasp) alongside stage changes and readouts.
+export const SKILL_TELEMETRY_TOPIC = "/brain/skill_telemetry";
+
 // Per-step ACT inference timing breakdown (std_msgs/String carrying JSON), published
 // by the manipulation server while a learned behavior runs. Drives the Profiling page.
 export const INFERENCE_PROFILE_TOPIC = "/brain/manipulation/inference_profile";

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -165,10 +165,11 @@ export const SKILL_STATUS_UPDATE_TOPIC = "/brain/skill_status_update";
 // What a running skill is looking at, for the targeting overlay drawn over the
 // main camera (std_msgs/String JSON: {skill, ev, t, ...} from Skill.telemetry()).
 // A run opens with {ev:"run", state:"start", prompt, stages:[...], frame:[w,h],
-// box} and closes with state:"end"; in between, markers arrive in image pixels
-// of that frame (look/track/grasp) alongside stage changes and readouts. Stage
-// events repeat the prompt and track events the box, so a page that missed the
-// start still recovers them. The SDK drops events outside a run.
+// box, wrist_box} and closes with state:"end"; in between, markers arrive in
+// image pixels of that frame — look/track/grasp on the head camera, wrist
+// seed/track on the wrist camera — alongside stage changes and readouts. Stage
+// events repeat the prompt and track events their box, so a page that missed
+// the start still recovers them. The SDK drops events outside a run.
 export const SKILL_TELEMETRY_TOPIC = "/brain/skill_telemetry";
 
 // Per-step ACT inference timing breakdown (std_msgs/String carrying JSON), published

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -163,7 +163,8 @@ export const MEMORY_SEARCH_TOPIC = "/brain/memory_search";
 export const SKILL_STATUS_UPDATE_TOPIC = "/brain/skill_status_update";
 
 // What a running skill draws over the cameras, for the targeting overlay
-// (std_msgs/String JSON: {skill, ev, t, ...} from Skill.overlay in the SDK).
+// (std_msgs/String JSON: {skill, run, ev, t, ...} from Skill.overlay in the SDK;
+// `run` is the id the server stamps on every event of one root skill's run).
 // {ev:"run", state:"start", prompt, stages:[...], frame:[w,h]} opens a run and
 // the server's {ev:"run", state:"end", ok, cancelled, text} closes it; between
 // them {ev:"stage", name}, {ev:"readout", text, busy, progress}, {ev:"mark", id,

--- a/webapp/js/shell.js
+++ b/webapp/js/shell.js
@@ -194,7 +194,7 @@ export function initShell(navigate) {
     // Every navigation lands here, and none may leave the drawer over the
     // page it just opened -- a number key and Back produce no rail click.
     closeRailDrawer();
-    agentIndicator.el.style.display = key === "agent" ? "none" : "";
+    agentIndicator.el.toggleAttribute("data-off-route", key === "agent");
     const section = SECTIONS.find((s) => s.key === key);
     document.title = section ? `Innate · ${section.label}` : "Innate";
   }

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -18,6 +18,7 @@ import { robotSessionFactory } from "../robotSession.js";
 import { mountPage } from "../pageMount.js";
 import { createVideoStage, createAudioToggle } from "./videoStage.js";
 import { createTrajectoryOverlay } from "./trajectoryOverlay.js";
+import { createTargetingOverlay } from "./targetingOverlay.js";
 import { createJoystick } from "./joystick.js";
 import { createKeyboardDrive, createWasdChips } from "./keyboardDrive.js";
 import { createHeadTilt } from "./headTilt.js";
@@ -111,7 +112,10 @@ function buildCockpit(root) {
   // the .video-stage class, and both hide the ribbon off the main camera.
   const ribbonStage = realVideo?.el ?? root.querySelector(".video-stage");
   if (ribbonStage instanceof HTMLElement) {
-    parts.push(createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, rightRail, ros, session));
+    parts.push(
+      createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, rightRail, ros, session),
+      createTargetingOverlay(ribbonStage, realVideo?.videoEl ?? null, ros, session),
+    );
   }
 
   session.start();

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -114,7 +114,7 @@ function buildCockpit(root) {
   if (ribbonStage instanceof HTMLElement) {
     parts.push(
       createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, rightRail, ros, session),
-      createTargetingOverlay(ribbonStage, realVideo?.videoEl ?? null, ros, session),
+      createTargetingOverlay(ribbonStage, realVideo?.videoEl ?? null, session),
     );
   }
 

--- a/webapp/js/teleop/targetingOverlay.js
+++ b/webapp/js/teleop/targetingOverlay.js
@@ -1,16 +1,15 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// Targeting overlay — what a manipulation skill is doing, drawn over the robot's
-// cameras. On the head camera: the object it detected (corner brackets), the
-// pick box the base steers it into, the tracked point gliding toward that box
-// and the spot the fingers will close on. On the wrist camera: the servo's goal
-// square, Gemini's wrist detection and the colour blob the descent follows,
-// with its long axis. Plus a HUD of the run's stages on either. Driven entirely
-// by /brain/skill_telemetry: a run declares its stages up front and every
-// marker arrives in image pixels, so nothing here is specific to one skill.
+// Targeting overlay — what a running skill draws over the robot's cameras.
+// Driven entirely by /brain/skill_overlay (Skill.overlay in the SDK): a run
+// declares its stage ladder, keeps one readout line and a progress bar in a
+// HUD, and places markers by id — brackets, boxes, points, reticles, lines —
+// in image pixels of its frame, on the head ("main") or wrist ("arm") camera.
+// Nothing here is specific to one skill.
 
-import { SKILL_TELEMETRY_TOPIC } from "../constants.js";
+import { SKILL_OVERLAY_TOPIC } from "../constants.js";
+import { ros } from "../rosClient.js";
 import { primaryCameraName } from "./trajectoryOverlay.js";
 
 // The sim renders the head camera with the driver's lens
@@ -20,28 +19,46 @@ import { primaryCameraName } from "./trajectoryOverlay.js";
 // point rather than the frame's middle. The wrist camera is a plain fovy in
 // both (square pixels, centred), so its frame just fits by height.
 const SIM_HEAD_LENS = { fx: 200.3, fy: 267.3, cx: 319.1, cy: 248.7 };
-// Half-length of the blob's drawn long axis, in frame px.
-const AXIS_HALF_PX = 45;
 // How long the verdict stays up after the run ends.
 const RESULT_LINGER_MS = 4000;
-// A page opened mid-run missed the start event that carries the frame size and
-// the stage list: it draws in the head camera's native frame and learns the
-// stages, prompt and pick box from the events that repeat them, rather than
-// showing nothing until the next run.
+// A page opened mid-run missed the start event: it draws in the head camera's
+// native frame until the next event, every one of which repeats the run's
+// header, rather than showing nothing until the next run.
 const DEFAULT_FRAME = { w: 640, h: 480 };
 
 /** @typedef {{ w: number, h: number }} Size */
 /** @typedef {[number, number]} Px */
 /** @typedef {[number, number, number, number]} Corners x0, y0, x1, y1 */
-/** @typedef {{ cu: number, cv: number, hu: number, hv: number, au: number, av: number }} PickBox */
-/** @typedef {{ u: number, v: number, half: number }} WristBox */
 /** @typedef {{ left: number, top: number, width: number, height: number }} Rect */
 /** @typedef {"main" | "arm"} View the two robot cameras a run draws on */
+/** @typedef {"bracket" | "box" | "point" | "reticle" | "vector" | "line"} Kind */
+/**
+ * One marker, as the skill placed it: geometry in frame px, `locked` greens it.
+ * @typedef {{
+ *   id: string, kind: Kind, view: View, label: string, locked: boolean,
+ *   corners: Corners | null, inner: number | null, px: Px | null, a: Px | null, b: Px | null,
+ * }} Marker
+ */
 /**
  * The stream as laid out on the page: intrinsic size, the video element's
  * content box within the stage, and how object-fit / object-position place the
  * picture in that box (position as the computed "x y" string).
  * @typedef {{ w: number, h: number, box: Rect, fit: string, position: string }} VideoLayout
+ */
+/**
+ * One run of a skill, as the overlay understands it.
+ * @typedef {{
+ *   skill: string,
+ *   prompt: string,
+ *   stages: string[],
+ *   stage: string | null,
+ *   frame: Size,
+ *   readout: string,
+ *   busy: boolean,
+ *   progress: number | null,
+ *   result: { ok: boolean, text: string } | null,
+ *   markers: Map<string, Marker>,
+ * }} Run
  */
 
 /** One object-position component -> where the picture's slack goes.
@@ -51,40 +68,6 @@ function positionOffset(term, slack) {
   if (term.endsWith("px")) return parseFloat(term);
   return slack / 2;
 }
-/**
- * One run of a skill, as the overlay understands it.
- * @typedef {{
- *   skill: string,
- *   prompt: string,
- *   stages: string[],
- *   frame: Size,
- *   box: PickBox | null,
- *   wristBox: WristBox | null,
- *   stage: string | null,
- *   looking: boolean,
- *   seen: { px: Px | null, box: Corners | null } | null,
- *   track: { px: Px, inside: boolean } | null,
- *   grasp: Px | null,
- *   wristSeen: { px: Px | null, box: Corners | null } | null,
- *   wristTrack: { px: Px, inside: boolean, axis: number | null } | null,
- *   descent: { top: number, z: number, stop: number } | null,
- *   readout: string,
- *   result: { ok: boolean, text: string } | null,
- * }} Run
- */
-
-/**
- * What to draw for one camera: every geometry in frame px, null = not drawn.
- * @typedef {{
- *   seen: Corners | null,
- *   goal: { rect: Rect, accept: Size | null, inside: boolean } | null,
- *   track: { px: Px, inside: boolean } | null,
- *   vec: [Px, Px] | null,
- *   axis: { px: Px, angle: number } | null,
- *   reticle: Px | null,
- *   tags: { seen: string, goal: string, track: string },
- * }} Markers
- */
 
 /**
  * Where the skill's image frame lands on the stage. On hardware the skill sees
@@ -124,245 +107,155 @@ export function frameRect(frame, video, cw, ch, view = "main") {
   return { left: cw / 2 - lens.cx * sx, top: ch / 2 - lens.cy * sy, width: frame.w * sx, height: frame.h * sy };
 }
 
-/** @param {any} v @returns {v is Px} */
-function isPx(v) {
-  return Array.isArray(v) && v.length >= 2 && Number.isFinite(v[0]) && Number.isFinite(v[1]);
+/** @param {any} v @returns {Px | null} */
+function px(v) {
+  return Array.isArray(v) && v.length >= 2 && Number.isFinite(v[0]) && Number.isFinite(v[1]) ? [v[0], v[1]] : null;
 }
 
-/** @param {any} v @returns {v is Corners} */
-function isBox(v) {
-  return Array.isArray(v) && v.length >= 4 && v.slice(0, 4).every(Number.isFinite);
+/** @param {any} v @returns {Corners | null} */
+function corners(v) {
+  if (!Array.isArray(v) || v.length < 4 || !v.slice(0, 4).every(Number.isFinite)) return null;
+  return [Math.min(v[0], v[2]), Math.min(v[1], v[3]), Math.max(v[0], v[2]), Math.max(v[1], v[3])];
 }
 
-/** @param {any} v @returns {PickBox | null} */
-function pickBox(v) {
-  if (!v || typeof v !== "object") return null;
-  const b = { cu: v.cu, cv: v.cv, hu: v.hu, hv: v.hv, au: v.au, av: v.av };
-  return Object.values(b).every((n) => Number.isFinite(n) && n >= 0) && b.hu > 0 && b.hv > 0 ? b : null;
-}
-
-/** @param {any} v @returns {WristBox | null} */
-function wristBox(v) {
-  if (!v || typeof v !== "object") return null;
-  const b = { u: v.u, v: v.v, half: v.half };
-  return Object.values(b).every(Number.isFinite) && b.half > 0 ? b : null;
-}
-
-/** @param {any} v @returns {{ px: Px | null, box: Corners | null }} */
-function sighting(v) {
-  return { px: isPx(v.px) ? [v.px[0], v.px[1]] : null, box: isBox(v.box) ? [v.box[0], v.box[1], v.box[2], v.box[3]] : null };
-}
-
-/** @param {number} n */
-function metres(n) {
-  return n >= 1 ? `${n.toFixed(2)} m` : `${Math.round(n * 100)} cm`;
-}
-
-/** @type {Record<string, string>} what each stage reads as while nothing finer is known */
-const STAGE_READOUT = {
-  search: "scanning the floor",
-  approach: "steering onto it",
-  align: "aligning the wrist camera",
-  grasp: "reaching down",
-  verify: "backing up to check",
+/** @type {Record<Kind, (ev: any) => boolean>} what each kind needs to be drawable */
+const KIND_GEOMETRY = {
+  bracket: (ev) => corners(ev.corners) !== null,
+  box: (ev) => corners(ev.corners) !== null,
+  point: (ev) => px(ev.px) !== null,
+  reticle: (ev) => px(ev.px) !== null,
+  vector: (ev) => px(ev.a) !== null && px(ev.b) !== null,
+  line: (ev) => px(ev.a) !== null && px(ev.b) !== null,
 };
+
+/** @param {any} ev a mark event @returns {Marker | null} */
+function marker(ev) {
+  const kind = /** @type {Kind} */ (ev.kind);
+  if (typeof ev.id !== "string" || !ev.id || !(kind in KIND_GEOMETRY) || !KIND_GEOMETRY[kind](ev)) return null;
+  const inner = Number.isFinite(ev.inner) && ev.inner > 0 && ev.inner <= 1 ? ev.inner : null;
+  return {
+    id: ev.id,
+    kind,
+    view: ev.view === "arm" ? "arm" : "main",
+    label: typeof ev.label === "string" ? ev.label : "",
+    locked: ev.locked === true,
+    corners: corners(ev.corners),
+    inner,
+    px: px(ev.px),
+    a: px(ev.a),
+    b: px(ev.b),
+  };
+}
+
+/** @param {any} v @returns {Size | null} */
+function size(v) {
+  if (!Array.isArray(v) || !(Number(v[0]) > 0) || !(Number(v[1]) > 0)) return null;
+  return { w: Number(v[0]), h: Number(v[1]) };
+}
+
+/** @param {any} v @returns {string[]} */
+function stageList(v) {
+  return Array.isArray(v) ? v.filter((/** @type {unknown} */ s) => typeof s === "string") : [];
+}
 
 /** @param {any} ev a run-start event, or any first event of a run missed at its start
  * @returns {Run} */
 function startRun(ev) {
-  const frame = Array.isArray(ev.frame) ? { w: Number(ev.frame[0]), h: Number(ev.frame[1]) } : DEFAULT_FRAME;
   return {
-    skill: typeof ev.skill === "string" ? ev.skill : "skill",
+    skill: ev.skill,
     prompt: typeof ev.prompt === "string" ? ev.prompt : "",
-    stages: Array.isArray(ev.stages) ? ev.stages.filter((/** @type {unknown} */ s) => typeof s === "string") : [],
-    frame: frame.w > 0 && frame.h > 0 ? frame : DEFAULT_FRAME,
-    box: pickBox(ev.box),
-    wristBox: wristBox(ev.wrist_box),
+    stages: stageList(ev.stages),
     stage: null,
-    looking: false,
-    seen: null,
-    track: null,
-    grasp: null,
-    wristSeen: null,
-    wristTrack: null,
-    descent: null,
+    frame: size(ev.frame) ?? DEFAULT_FRAME,
     readout: "starting",
+    busy: false,
+    progress: null,
     result: null,
+    markers: new Map(),
   };
 }
 
 /**
- * Fold one telemetry event into the run. Returns the run to keep showing, or
+ * Every event repeats the run's header (prompt, stage list, frame, current
+ * stage); a run opened from whichever message came first catches up here.
+ * @param {Run} run @param {any} ev
+ */
+function adoptHeader(run, ev) {
+  const stages = stageList(ev.stages);
+  if (stages.length > run.stages.length) run.stages = stages;
+  if (!run.prompt && typeof ev.prompt === "string") run.prompt = ev.prompt;
+  run.frame = size(ev.frame) ?? run.frame;
+  const stage = ev.ev === "stage" ? ev.name : ev.stage;
+  if (typeof stage !== "string" || !stage || stage === run.stage) return;
+  if (!run.stages.includes(stage)) run.stages.push(stage);
+  run.stage = stage;
+}
+
+/** @param {Run} run @param {any} ev a run-end event */
+function endRun(run, ev) {
+  run.markers.clear();
+  run.busy = false;
+  run.progress = null;
+  const text = typeof ev.text === "string" && ev.text ? ev.text : "";
+  run.result = ev.cancelled
+    ? { ok: false, text: "stopped" }
+    : ev.ok === true
+      ? { ok: true, text: text || "done" }
+      : { ok: false, text: `failed · ${text || "no reason given"}` };
+  run.readout = run.result.text;
+}
+
+/**
+ * Fold one overlay event into the run. Returns the run to keep showing, or
  * null when there is none. A run ends with its result set; the caller decides
- * how long that lingers.
+ * how long that lingers. A finished run's own stray events never revive it,
+ * but another skill's first event opens a fresh run over the verdict.
  * @param {Run | null} run
  * @param {any} ev
  * @returns {Run | null}
  */
 export function applyEvent(run, ev) {
   if (!ev || typeof ev !== "object" || typeof ev.ev !== "string" || typeof ev.skill !== "string") return run;
-  if (ev.ev === "run" && ev.state === "start") return startRun(ev);
-  if (ev.ev === "run" && ev.state !== "end") return run;
-  if (run?.result || (run && ev.skill !== run.skill)) return run;
-  if (!run) {
-    if (ev.ev === "run") return null; // the end of a run never seen
-    run = startRun(ev);
+  if (ev.ev === "run") {
+    if (ev.state === "start") return startRun(ev);
+    if (ev.state === "end" && run && !run.result) endRun(run, ev);
+    return run;
   }
+  if (run?.result && ev.skill === run.skill) return run;
+  if (!run || run.result) run = startRun(ev);
+  adoptHeader(run, ev);
   switch (ev.ev) {
-    case "run":
-      if (ev.state !== "end") break;
-      run.seen = run.track = run.grasp = run.wristSeen = run.wristTrack = null;
-      run.looking = false;
-      run.result = ev.ok
-        ? { ok: true, text: "picked up" }
-        : { ok: false, text: ev.cancelled ? "stopped" : `failed · ${ev.reason || "no reason given"}` };
-      run.readout = run.result.text;
-      break;
     case "stage":
-      if (typeof ev.stage !== "string") break;
-      if (!run.stages.includes(ev.stage)) run.stages.push(ev.stage);
-      if (!run.prompt && typeof ev.prompt === "string") run.prompt = ev.prompt;
-      run.stage = ev.stage;
-      run.readout = STAGE_READOUT[ev.stage] ?? ev.stage;
-      if (ev.stage !== "approach") run.track = null;
-      if (ev.stage !== "align") run.wristSeen = run.wristTrack = run.descent = null; // the arm moves on, the view with it
-      if (ev.stage === "verify") run.grasp = null;
+      if (typeof ev.name !== "string") break;
+      run.readout = ev.name;
+      run.busy = false;
       break;
-    case "look":
-      run.looking = ev.state === "ask";
-      if (ev.state === "ask") {
-        run.readout = run.stage === "search" ? "looking for it" : "taking another look";
-      } else if (ev.state === "seen") {
-        run.seen = sighting(ev);
-        run.track = null;
-        const dist = Number.isFinite(ev.dist) ? ` · ${metres(ev.dist)} ahead` : "";
-        const more = Number.isFinite(ev.n) && ev.n > 1 ? ` · ${ev.n} matches` : "";
-        run.readout = `spotted${dist}${more}`;
-      } else {
-        run.seen = run.track = null;
-        run.readout = "not in view";
-      }
+    case "readout":
+      if (typeof ev.text !== "string") break;
+      run.readout = ev.text;
+      run.busy = ev.busy === true;
+      run.progress = Number.isFinite(ev.progress) ? Math.min(1, Math.max(0, ev.progress)) : null;
       break;
-    case "move": {
-      // The picture is about to change under every pixel marker.
-      run.seen = run.track = run.grasp = null;
-      const amount = Number(ev.amount) || 0;
-      if (ev.kind === "rotate") {
-        const deg = Math.round(Math.abs(amount) * (180 / Math.PI));
-        run.readout = `turning ${deg}° ${amount >= 0 ? "left" : "right"}`;
-      } else {
-        run.readout = `${amount >= 0 ? "driving" : "backing up"} ${metres(Math.abs(amount))}`;
-      }
+    case "mark": {
+      const m = marker(ev);
+      if (m) run.markers.set(m.id, m);
       break;
     }
-    case "track": {
-      if (!isPx(ev.px)) break;
-      run.box ??= pickBox(ev.box);
-      run.seen = null;
-      run.track = { px: [ev.px[0], ev.px[1]], inside: ev.inside === true };
-      const off = run.box ? Math.round(Math.hypot(ev.px[0] - run.box.cu, ev.px[1] - run.box.cv)) : null;
-      run.readout = run.track.inside ? "in the pick box" : off === null ? "tracking" : `steering · ${off} px off`;
+    case "clear": {
+      const ids = Array.isArray(ev.ids) ? ev.ids : [];
+      if (ids.length) ids.forEach((/** @type {unknown} */ id) => run?.markers.delete(String(id)));
+      else if (ev.view === "main" || ev.view === "arm") {
+        for (const [id, m] of run.markers) if (m.view === ev.view) run.markers.delete(id);
+      } else run.markers.clear();
       break;
     }
-    case "parked":
-      if (run.track) run.track.inside = true;
-      run.readout = "parked over it";
-      break;
-    case "grasp":
-      if (ev.step === "target") {
-        run.grasp = isPx(ev.px) ? [ev.px[0], ev.px[1]] : null;
-        run.readout = "grasp point set";
-      } else if (ev.step === "descend") run.readout = "reaching to the floor";
-      else if (ev.step === "close") run.readout = "closing the gripper";
-      else if (ev.step === "lift") run.readout = "lifting";
-      break;
-    case "wrist":
-      if (ev.state === "seed") {
-        run.wristSeen = isPx(ev.px) ? sighting(ev) : null;
-        run.wristTrack = null;
-        run.readout = run.wristSeen ? "wrist camera has it" : "wrist camera can't see it";
-      } else if (ev.state === "track" && Number.isFinite(ev.z)) {
-        const stop = Number.isFinite(ev.stop) ? ev.stop : 0;
-        run.descent = { top: run.descent?.top ?? ev.z, z: ev.z, stop };
-        run.wristBox ??= wristBox(ev.box);
-        if (isPx(ev.px)) {
-          run.wristSeen = null;
-          run.wristTrack = { px: [ev.px[0], ev.px[1]], inside: ev.inside === true, axis: Number.isFinite(ev.axis) ? ev.axis : null };
-        }
-        run.readout = `${ev.inside ? "descending" : "centring"} · ${Math.round(ev.z * 100)} cm up`;
-      } else if (ev.state === "done") {
-        run.readout = typeof ev.reason === "string" ? `wrist align: ${ev.reason}` : "wrist align done";
-      }
-      break;
-    case "verify":
-      run.readout = ev.held ? "holding it" : "missed it";
-      break;
     default:
       break;
   }
   return run;
 }
 
-/** @param {Corners} c @returns {Rect} */
-function cornersRect([x0, y0, x1, y1]) {
-  return { left: x0, top: y0, width: x1 - x0, height: y1 - y0 };
-}
-
-/** @param {Px} px @param {number} half @returns {Rect} */
-function squareAround(px, half) {
-  return { left: px[0] - half, top: px[1] - half, width: 2 * half, height: 2 * half };
-}
-
-/** A sighting's frame: its box, or a small square around its point.
- * @param {{ px: Px | null, box: Corners | null } | null} s @returns {Corners | null} */
-function seenCorners(s) {
-  if (s?.box) return s.box;
-  if (s?.px) return [s.px[0] - 20, s.px[1] - 20, s.px[0] + 20, s.px[1] + 20];
-  return null;
-}
-
-/** The head camera's markers: detection, pick box, flow track, grasp point.
- * @param {Run} run @returns {Markers} */
-export function headMarkers(run) {
-  const { box, track } = run;
-  const goal =
-    box && run.stage === "approach"
-      ? {
-          rect: { left: box.cu - box.hu, top: box.cv - box.hv, width: 2 * box.hu, height: 2 * box.hv },
-          accept: { w: box.au / box.hu, h: box.av / box.hv },
-          inside: !!track?.inside,
-        }
-      : null;
-  return {
-    seen: seenCorners(run.seen),
-    goal,
-    track,
-    vec: track && box && !track.inside ? [track.px, [box.cu, box.cv]] : null,
-    axis: null,
-    reticle: run.grasp,
-    tags: { seen: "target", goal: "pick box", track: "tracking" },
-  };
-}
-
-/** The wrist camera's markers: Gemini's seed, the servo box, the tracked blob.
- * @param {Run} run @returns {Markers} */
-export function wristMarkers(run) {
-  const { wristBox: box, wristTrack: track } = run;
-  const goal =
-    box && run.stage === "align"
-      ? { rect: squareAround([box.u, box.v], box.half), accept: null, inside: !!track?.inside }
-      : null;
-  return {
-    seen: seenCorners(run.wristSeen),
-    goal,
-    track: track && { px: track.px, inside: track.inside },
-    vec: track && box && !track.inside ? [track.px, [box.u, box.v]] : null,
-    axis: track && track.axis !== null ? { px: track.px, angle: track.axis } : null,
-    reticle: null,
-    tags: { seen: "wrist target", goal: "wrist box", track: "blob" },
-  };
-}
-
+const SVG_NS = "http://www.w3.org/2000/svg";
 const SVG_OPEN =
   '<svg viewBox="0 0 48 48" width="48" height="48" fill="none" stroke="currentColor" ' +
   'stroke-width="1.6" aria-hidden="true">';
@@ -372,18 +265,89 @@ const RETICLE_SVG =
   '<line x1="24" y1="3" x2="24" y2="14"/><line x1="24" y1="34" x2="24" y2="45"/>' +
   '<line x1="3" y1="24" x2="14" y2="24"/><line x1="34" y1="24" x2="45" y2="24"/>' +
   '<circle cx="24" cy="24" r="2.2" fill="currentColor" stroke="none"/>';
-// Small diamond: the point optical flow is holding on to.
-const TRACK_SVG = '<path d="M24 11 37 24 24 37 11 24Z"/><circle cx="24" cy="24" r="1.8" fill="currentColor" stroke="none"/>';
+// Small diamond: a point the skill is holding on to.
+const POINT_SVG = '<path d="M24 11 37 24 24 37 11 24Z"/><circle cx="24" cy="24" r="1.8" fill="currentColor" stroke="none"/>';
+const TAG = '<span class="tgt-tag mono"></span>';
+
+/** @type {Record<"bracket" | "box" | "point" | "reticle", string>} */
+const TEMPLATES = {
+  bracket: `<i></i><i></i><i></i><i></i>${TAG}`,
+  box: `${TAG}<div class="tgt-inner"></div>`,
+  point: `${SVG_OPEN}${POINT_SVG}</svg>${TAG}`,
+  reticle: `${SVG_OPEN}${RETICLE_SVG}</svg>${TAG}`,
+};
+
+/**
+ * The run as last heard on the topic, kept for the whole session so a page
+ * switch mid-run (Agent to Teleop) draws the run in full at once instead of
+ * waiting for events to trickle in. Built on first use; pages drop their own
+ * listeners on unmount and nothing destroys the store itself.
+ * @returns {{ run: () => Run | null, subscribe: (cb: () => void) => () => void }}
+ */
+export function sharedTargetingRun() {
+  return (_store ??= createRunStore());
+}
+
+/** @type {ReturnType<typeof createRunStore> | undefined} */
+let _store;
+
+function createRunStore() {
+  /** @type {Run | null} */
+  let run = null;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let lingerTimer;
+  /** @type {Set<() => void>} */
+  const listeners = new Set();
+
+  function notify() {
+    for (const cb of listeners) cb();
+  }
+
+  /** @param {any} msg std_msgs/String */
+  function onOverlay(msg) {
+    if (typeof msg?.data !== "string") return;
+    /** @type {any} */
+    let ev;
+    try {
+      ev = JSON.parse(msg.data);
+    } catch {
+      return;
+    }
+    const ended = !!run?.result;
+    const next = applyEvent(run, ev);
+    if (next !== run) clearTimeout(lingerTimer); // a new run replaces a lingering verdict
+    run = next;
+    // Only the transition into a verdict arms the linger: later events of a
+    // finished run (or a stray one) must not keep pushing it out.
+    if (run?.result && !ended) {
+      lingerTimer = setTimeout(() => {
+        run = null;
+        notify();
+      }, RESULT_LINGER_MS);
+    }
+    notify();
+  }
+
+  ros.subscribe(SKILL_OVERLAY_TOPIC, onOverlay, undefined, "std_msgs/msg/String");
+  return {
+    run: () => run,
+    /** @param {() => void} cb */
+    subscribe(cb) {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+  };
+}
 
 /**
  * @param {HTMLElement} stage the .video-stage the markers pin to
  * @param {HTMLVideoElement | null} video the stage's video on hardware; null in
  *   the sim, where a canvas renders the head camera at the stage's size
- * @param {import("../rosClient.js").RosClient} ros
  * @param {import("../webrtcSession.js").WebRtcSession} session
  * @returns {{ destroy: () => void }}
  */
-export function createTargetingOverlay(stage, video, ros, session) {
+export function createTargetingOverlay(stage, video, session) {
+  const store = sharedTargetingRun();
   const clip = document.createElement("div");
   clip.className = "tgt-clip";
   clip.hidden = true;
@@ -391,15 +355,9 @@ export function createTargetingOverlay(stage, video, ros, session) {
   // of it, so a resize only moves this one element.
   const layer = document.createElement("div");
   layer.className = "tgt-layer";
-  layer.innerHTML =
-    '<div class="tgt-scan"></div>' +
-    '<svg class="tgt-vec" preserveAspectRatio="none" aria-hidden="true">' +
-    '<line class="tgt-vec-line"/><line class="tgt-axis-line"/></svg>' +
-    '<div class="tgt-seen" hidden><i></i><i></i><i></i><i></i><span class="tgt-tag mono">target</span></div>' +
-    '<div class="tgt-goal" hidden><span class="tgt-tag mono">pick box</span><div class="tgt-accept"></div></div>' +
-    `<div class="tgt-track" hidden>${SVG_OPEN}${TRACK_SVG}</svg><span class="tgt-tag mono">tracking</span></div>` +
-    `<div class="tgt-reticle" hidden>${SVG_OPEN}${RETICLE_SVG}</svg><span class="tgt-tag mono">grasp</span></div>`;
+  layer.innerHTML = '<div class="tgt-scan"></div><svg class="tgt-lines" preserveAspectRatio="none" aria-hidden="true"></svg>';
   clip.appendChild(layer);
+  const lines = /** @type {SVGSVGElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-lines")));
 
   const hud = document.createElement("div");
   hud.className = "overlay tgt-hud";
@@ -410,18 +368,6 @@ export function createTargetingOverlay(stage, video, ros, session) {
     '<div class="tgt-readout mono"><span class="tgt-readout-text"></span><span class="tgt-bar" hidden><span class="tgt-bar-fill"></span></span></div>';
   stage.append(clip, hud);
 
-  const q = (/** @type {string} */ sel) => /** @type {HTMLElement} */ (layer.querySelector(sel));
-  const seenEl = q(".tgt-seen");
-  const goalEl = q(".tgt-goal");
-  const acceptEl = q(".tgt-accept");
-  const trackEl = q(".tgt-track");
-  const reticleEl = q(".tgt-reticle");
-  const vecEl = /** @type {SVGSVGElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-vec")));
-  const vecLine = /** @type {SVGLineElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-vec-line")));
-  const axisLine = /** @type {SVGLineElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-axis-line")));
-  const seenTag = /** @type {HTMLElement} */ (seenEl.querySelector(".tgt-tag"));
-  const goalTag = /** @type {HTMLElement} */ (goalEl.querySelector(".tgt-tag"));
-  const trackTag = /** @type {HTMLElement} */ (trackEl.querySelector(".tgt-tag"));
   const skillEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-skill"));
   const promptEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-prompt"));
   const stagesEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-stages"));
@@ -429,10 +375,10 @@ export function createTargetingOverlay(stage, video, ros, session) {
   const barEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-bar"));
   const barFill = /** @type {HTMLElement} */ (hud.querySelector(".tgt-bar-fill"));
 
-  /** @type {Run | null} */
-  let run = null;
-  /** @type {ReturnType<typeof setTimeout> | undefined} */
-  let lingerTimer;
+  /** The DOM for each marker on screen, by id; a marker keeps its element
+   * between updates so a point glides instead of stepping.
+   * @type {Map<string, HTMLElement | SVGLineElement>} */
+  const els = new Map();
 
   /** The robot camera on the stage, or null when another view (map, orbit) is up.
    * @returns {View | null} */
@@ -441,29 +387,67 @@ export function createTargetingOverlay(stage, video, ros, session) {
     return name === "main" || name === "arm" ? name : null;
   }
 
-  /** @param {HTMLElement} el @param {Px} px @param {Size} frame */
-  function pin(el, px, frame) {
-    el.style.left = `${(px[0] / frame.w) * 100}%`;
-    el.style.top = `${(px[1] / frame.h) * 100}%`;
-    el.hidden = false;
+  /** @param {Marker} m @returns {HTMLElement | SVGLineElement} */
+  function elementFor(m) {
+    let el = els.get(m.id);
+    if (el && el.dataset.kind !== m.kind) {
+      el.remove();
+      el = undefined;
+    }
+    if (el) return el;
+    if (m.kind === "vector" || m.kind === "line") {
+      el = document.createElementNS(SVG_NS, "line");
+      lines.appendChild(el);
+    } else {
+      el = document.createElement("div");
+      el.innerHTML = TEMPLATES[m.kind];
+      layer.appendChild(el);
+    }
+    el.setAttribute("class", `tgt-${m.kind}`);
+    el.dataset.kind = m.kind;
+    els.set(m.id, el);
+    return el;
   }
 
-  /** @param {HTMLElement} el @param {Rect} r @param {Size} frame */
-  function place(el, r, frame) {
-    el.style.left = `${(r.left / frame.w) * 100}%`;
-    el.style.top = `${(r.top / frame.h) * 100}%`;
-    el.style.width = `${(r.width / frame.w) * 100}%`;
-    el.style.height = `${(r.height / frame.h) * 100}%`;
-    el.hidden = false;
+  /** @param {Marker} m @param {Size} frame */
+  function draw(m, frame) {
+    const el = elementFor(m);
+    el.classList.toggle("locked", m.locked);
+    if (el instanceof SVGLineElement) {
+      const [a, b] = [/** @type {Px} */ (m.a), /** @type {Px} */ (m.b)];
+      el.setAttribute("x1", String(a[0]));
+      el.setAttribute("y1", String(a[1]));
+      el.setAttribute("x2", String(b[0]));
+      el.setAttribute("y2", String(b[1]));
+      return;
+    }
+    const tag = /** @type {HTMLElement} */ (el.querySelector(".tgt-tag"));
+    tag.textContent = m.label;
+    tag.hidden = !m.label;
+    if (m.corners) {
+      const [x0, y0, x1, y1] = m.corners;
+      el.style.left = `${(x0 / frame.w) * 100}%`;
+      el.style.top = `${(y0 / frame.h) * 100}%`;
+      el.style.width = `${((x1 - x0) / frame.w) * 100}%`;
+      el.style.height = `${((y1 - y0) / frame.h) * 100}%`;
+    } else if (m.px) {
+      el.style.left = `${(m.px[0] / frame.w) * 100}%`;
+      el.style.top = `${(m.px[1] / frame.h) * 100}%`;
+    }
+    const inner = /** @type {HTMLElement | null} */ (el.querySelector(".tgt-inner"));
+    if (inner) {
+      inner.hidden = m.inner === null;
+      if (m.inner !== null) inner.style.width = inner.style.height = `${m.inner * 100}%`;
+    }
   }
 
-  /** @param {SVGLineElement} line @param {Px} a @param {Px} b */
-  function segment(line, a, b) {
-    line.setAttribute("x1", String(a[0]));
-    line.setAttribute("y1", String(a[1]));
-    line.setAttribute("x2", String(b[0]));
-    line.setAttribute("y2", String(b[1]));
-    line.classList.add("on");
+  /** @param {Set<string>} keep marker ids drawn this pass */
+  function prune(keep) {
+    for (const [id, el] of els) {
+      if (keep.has(id)) continue;
+      el.remove();
+      els.delete(id);
+    }
   }
 
   /** @returns {VideoLayout | null} */
@@ -488,6 +472,7 @@ export function createTargetingOverlay(stage, video, ros, session) {
   }
 
   function placeLayer() {
+    const run = store.run();
     if (!run) return;
     const rect = frameRect(run.frame, videoLayout(), stage.clientWidth, stage.clientHeight, view() ?? "main");
     layer.hidden = !rect;
@@ -498,23 +483,24 @@ export function createTargetingOverlay(stage, video, ros, session) {
     layer.style.height = `${rect.height}px`;
   }
 
-  function renderStages() {
-    if (!run) return;
+  /** @param {Run} run */
+  function renderStages(run) {
     const doneUpTo = run.stage ? run.stages.indexOf(run.stage) : -1;
     stagesEl.replaceChildren(
       ...run.stages.map((name, i) => {
         const li = document.createElement("li");
         li.className = "tgt-stage";
         li.textContent = name;
-        const done = run?.result?.ok ? true : i < doneUpTo;
+        const done = run.result?.ok ? true : i < doneUpTo;
         li.classList.toggle("done", done);
-        li.classList.toggle("active", !run?.result && i === doneUpTo);
+        li.classList.toggle("active", !run.result && i === doneUpTo);
         return li;
       }),
     );
   }
 
   function render() {
+    const run = store.run();
     const cam = view();
     const show = !!run && cam !== null;
     clip.hidden = !show || !!run?.result;
@@ -524,108 +510,43 @@ export function createTargetingOverlay(stage, video, ros, session) {
 
     skillEl.textContent = run.skill.replace(/_/g, " ");
     promptEl.textContent = run.prompt ? `“${run.prompt}”` : "";
-    renderStages();
+    renderStages(run);
     readoutEl.textContent = run.readout;
     hud.classList.toggle("ok", !!run.result?.ok);
     hud.classList.toggle("failed", !!run.result && !run.result.ok);
-    hud.classList.toggle("looking", run.looking);
-    if (run.descent) {
-      const span = run.descent.top - run.descent.stop;
-      const done = span > 0 ? Math.min(1, Math.max(0, (run.descent.top - run.descent.z) / span)) : 1;
-      barFill.style.width = `${done * 100}%`;
-      barEl.hidden = false;
-    } else {
-      barEl.hidden = true;
-    }
-    if (run.result) return;
-
-    const { frame } = run;
-    // The sweep is a head-camera look; the wrist stage tracks continuously.
-    layer.classList.toggle("looking", run.looking && cam === "main");
-    const m = cam === "main" ? headMarkers(run) : wristMarkers(run);
-    seenTag.textContent = m.tags.seen;
-    goalTag.textContent = m.tags.goal;
-    trackTag.textContent = m.tags.track;
-
-    if (m.seen) place(seenEl, cornersRect(m.seen), frame);
-    else seenEl.hidden = true;
-
-    if (m.goal) {
-      place(goalEl, m.goal.rect, frame);
-      acceptEl.hidden = !m.goal.accept;
-      if (m.goal.accept) {
-        acceptEl.style.width = `${m.goal.accept.w * 100}%`;
-        acceptEl.style.height = `${m.goal.accept.h * 100}%`;
-      }
-      goalEl.classList.toggle("inside", m.goal.inside);
-    } else {
-      goalEl.hidden = true;
-    }
-
-    if (m.track) {
-      pin(trackEl, m.track.px, frame);
-      trackEl.classList.toggle("inside", m.track.inside);
-    } else {
-      trackEl.hidden = true;
-    }
-
-    vecEl.setAttribute("viewBox", `0 0 ${frame.w} ${frame.h}`);
-    // The steering vector: tracked point -> the box it is being driven into.
-    if (m.vec) segment(vecLine, m.vec[0], m.vec[1]);
-    else vecLine.classList.remove("on");
-    // The blob's long axis: the side the fingers will roll onto.
-    if (m.axis) {
-      const [u, v] = m.axis.px;
-      const du = Math.cos(m.axis.angle) * AXIS_HALF_PX;
-      const dv = Math.sin(m.axis.angle) * AXIS_HALF_PX;
-      segment(axisLine, [u - du, v - dv], [u + du, v + dv]);
-    } else {
-      axisLine.classList.remove("on");
-    }
-
-    if (m.reticle) pin(reticleEl, m.reticle, frame);
-    else reticleEl.hidden = true;
-  }
-
-  /** @param {any} msg std_msgs/String */
-  function onTelemetry(msg) {
-    if (typeof msg?.data !== "string") return;
-    /** @type {any} */
-    let ev;
-    try {
-      ev = JSON.parse(msg.data);
-    } catch {
+    hud.classList.toggle("busy", run.busy);
+    barEl.hidden = run.progress === null;
+    if (run.progress !== null) barFill.style.width = `${run.progress * 100}%`;
+    if (run.result) {
+      prune(new Set());
       return;
     }
-    const ended = !!run?.result;
-    const next = applyEvent(run, ev);
-    if (next !== run) clearTimeout(lingerTimer); // a new run replaces a lingering verdict
-    run = next;
-    // Only the transition into a verdict arms the linger: later events of a
-    // finished run (or a stray one) must not keep pushing it out.
-    if (run?.result && !ended) {
-      lingerTimer = setTimeout(() => {
-        run = null;
-        render();
-      }, RESULT_LINGER_MS);
+
+    layer.classList.toggle("busy", run.busy);
+    lines.setAttribute("viewBox", `0 0 ${run.frame.w} ${run.frame.h}`);
+    const drawn = new Set();
+    for (const m of run.markers.values()) {
+      if (m.view !== cam) continue;
+      draw(m, run.frame);
+      drawn.add(m.id);
     }
-    render();
+    prune(drawn);
   }
 
-  const unsub = ros.subscribe(SKILL_TELEMETRY_TOPIC, onTelemetry, undefined, "std_msgs/msg/String");
+  const unsubStore = store.subscribe(render);
   const resize = new ResizeObserver(placeLayer);
   resize.observe(stage);
   if (video) resize.observe(video); // its box moves with media queries the stage's size does not
   video?.addEventListener("resize", placeLayer);
   const unsubSession = session.onChange(render);
+  render(); // a run already under way draws at once
 
   return {
     destroy() {
-      unsub();
+      unsubStore();
       unsubSession();
       resize.disconnect();
       video?.removeEventListener("resize", placeLayer);
-      clearTimeout(lingerTimer);
       clip.remove();
       hud.remove();
     },

--- a/webapp/js/teleop/targetingOverlay.js
+++ b/webapp/js/teleop/targetingOverlay.js
@@ -1,0 +1,448 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Targeting overlay — what a manipulation skill is doing, drawn over the main
+// camera: the object it detected (corner brackets), the pick box the base
+// steers it into, the tracked point gliding toward that box, the spot the
+// fingers will close on, and a HUD of the run's stages. Driven entirely by
+// /brain/skill_telemetry: a run declares its stages up front and every marker
+// arrives in image pixels, so nothing here is specific to one skill.
+
+import { SKILL_TELEMETRY_TOPIC } from "../constants.js";
+import { primaryCameraName } from "./trajectoryOverlay.js";
+
+// The sim renders the head camera with the driver's lens
+// (mars_sim_driver/constants.py — keep in sync). The viewer's preview shares
+// its vertical field, so the skill's frame fits the stage by height, runs wider
+// sideways because that lens has fx < fy, and centres on the lens's principal
+// point rather than the frame's middle.
+const SIM_LENS = { fx: 200.3, fy: 267.3, cx: 319.1, cy: 248.7 };
+// How long the verdict stays up after the run ends.
+const RESULT_LINGER_MS = 4000;
+// A page opened mid-run missed the start event that carries the frame size and
+// the stage list: it draws in the head camera's native frame and learns the
+// stages as they come, rather than showing nothing until the next run.
+const DEFAULT_FRAME = { w: 640, h: 480 };
+
+/** @typedef {{ w: number, h: number }} Size */
+/** @typedef {[number, number]} Px */
+/** @typedef {{ cu: number, cv: number, hu: number, hv: number, au: number, av: number }} PickBox */
+/** @typedef {{ left: number, top: number, width: number, height: number }} Rect */
+/**
+ * One run of a skill, as the overlay understands it.
+ * @typedef {{
+ *   skill: string,
+ *   prompt: string,
+ *   stages: string[],
+ *   frame: Size,
+ *   box: PickBox | null,
+ *   stage: string | null,
+ *   looking: boolean,
+ *   seen: { px: Px | null, box: [number, number, number, number] | null } | null,
+ *   track: { px: Px, inside: boolean } | null,
+ *   grasp: Px | null,
+ *   descent: { top: number, z: number, stop: number } | null,
+ *   readout: string,
+ *   result: { ok: boolean, text: string } | null,
+ * }} Run
+ */
+
+/**
+ * Where the skill's image frame lands on the stage. Hardware letterboxes the
+ * stream (object-fit: contain) and the skill sees that same picture, so the
+ * frame is the video's rectangle; the sim has no stream, its canvas renders the
+ * head camera at the stage's own size (see SIM_LENS).
+ * @param {Size} frame the skill's image size
+ * @param {Size | null} video the stream's intrinsic size, null in the sim
+ * @param {number} cw @param {number} ch stage size
+ * @returns {Rect | null}
+ */
+export function frameRect(frame, video, cw, ch) {
+  if (!cw || !ch || !frame.w || !frame.h) return null;
+  if (video) {
+    if (!video.w || !video.h) return null;
+    const fit = Math.min(cw / video.w, ch / video.h);
+    const width = video.w * fit;
+    const height = video.h * fit;
+    return { left: (cw - width) / 2, top: (ch - height) / 2, width, height };
+  }
+  const sy = ch / frame.h;
+  const sx = sy * (SIM_LENS.fy / SIM_LENS.fx);
+  return { left: cw / 2 - SIM_LENS.cx * sx, top: ch / 2 - SIM_LENS.cy * sy, width: frame.w * sx, height: frame.h * sy };
+}
+
+/** @param {any} v @returns {v is Px} */
+function isPx(v) {
+  return Array.isArray(v) && v.length >= 2 && Number.isFinite(v[0]) && Number.isFinite(v[1]);
+}
+
+/** @param {any} v @returns {v is [number, number, number, number]} */
+function isBox(v) {
+  return Array.isArray(v) && v.length >= 4 && v.slice(0, 4).every(Number.isFinite);
+}
+
+/** @param {any} v @returns {PickBox | null} */
+function pickBox(v) {
+  if (!v || typeof v !== "object") return null;
+  const b = { cu: v.cu, cv: v.cv, hu: v.hu, hv: v.hv, au: v.au, av: v.av };
+  return Object.values(b).every((n) => Number.isFinite(n) && n >= 0) && b.hu > 0 && b.hv > 0 ? b : null;
+}
+
+/** @param {number} n */
+function metres(n) {
+  return n >= 1 ? `${n.toFixed(2)} m` : `${Math.round(n * 100)} cm`;
+}
+
+/** @type {Record<string, string>} what each stage reads as while nothing finer is known */
+const STAGE_READOUT = {
+  search: "scanning the floor",
+  approach: "steering onto it",
+  align: "aligning the wrist camera",
+  grasp: "reaching down",
+  verify: "backing up to check",
+};
+
+/** @param {any} ev a run-start event, or any first event of a run missed at its start
+ * @returns {Run} */
+function startRun(ev) {
+  const frame = Array.isArray(ev.frame) ? { w: Number(ev.frame[0]), h: Number(ev.frame[1]) } : DEFAULT_FRAME;
+  return {
+    skill: typeof ev.skill === "string" ? ev.skill : "skill",
+    prompt: typeof ev.prompt === "string" ? ev.prompt : "",
+    stages: Array.isArray(ev.stages) ? ev.stages.filter((/** @type {unknown} */ s) => typeof s === "string") : [],
+    frame: frame.w > 0 && frame.h > 0 ? frame : DEFAULT_FRAME,
+    box: pickBox(ev.box),
+    stage: null,
+    looking: false,
+    seen: null,
+    track: null,
+    grasp: null,
+    descent: null,
+    readout: "starting",
+    result: null,
+  };
+}
+
+/**
+ * Fold one telemetry event into the run. Returns the run to keep showing, or
+ * null when there is none. A run ends with its result set; the caller decides
+ * how long that lingers.
+ * @param {Run | null} run
+ * @param {any} ev
+ * @returns {Run | null}
+ */
+export function applyEvent(run, ev) {
+  if (!ev || typeof ev !== "object" || typeof ev.ev !== "string" || typeof ev.skill !== "string") return run;
+  if (ev.ev === "run" && ev.state === "start") return startRun(ev);
+  if (ev.ev === "run" && ev.state !== "end") return run;
+  if (run?.result || (run && ev.skill !== run.skill)) return run;
+  if (!run) {
+    if (ev.ev === "run") return null; // the end of a run never seen
+    run = startRun(ev);
+  }
+  switch (ev.ev) {
+    case "run":
+      if (ev.state !== "end") break;
+      run.seen = run.track = run.grasp = null;
+      run.looking = false;
+      run.result = ev.ok
+        ? { ok: true, text: "picked up" }
+        : { ok: false, text: ev.cancelled ? "stopped" : `failed · ${ev.reason || "no reason given"}` };
+      run.readout = run.result.text;
+      break;
+    case "stage":
+      if (typeof ev.stage !== "string") break;
+      if (!run.stages.includes(ev.stage)) run.stages.push(ev.stage);
+      run.stage = ev.stage;
+      run.readout = STAGE_READOUT[ev.stage] ?? ev.stage;
+      if (ev.stage !== "approach") run.track = null;
+      if (ev.stage === "verify") run.grasp = null;
+      break;
+    case "look":
+      run.looking = ev.state === "ask";
+      if (ev.state === "ask") {
+        run.readout = run.stage === "search" ? "looking for it" : "taking another look";
+      } else if (ev.state === "seen") {
+        run.seen = { px: isPx(ev.px) ? [ev.px[0], ev.px[1]] : null, box: isBox(ev.box) ? ev.box : null };
+        run.track = null;
+        const dist = Number.isFinite(ev.dist) ? ` · ${metres(ev.dist)} ahead` : "";
+        const more = Number.isFinite(ev.n) && ev.n > 1 ? ` · ${ev.n} matches` : "";
+        run.readout = `spotted${dist}${more}`;
+      } else {
+        run.seen = null;
+        run.readout = "not in view";
+      }
+      break;
+    case "move": {
+      // The picture is about to change under every pixel marker.
+      run.seen = run.track = run.grasp = null;
+      const amount = Number(ev.amount) || 0;
+      if (ev.kind === "rotate") {
+        const deg = Math.round(Math.abs(amount) * (180 / Math.PI));
+        run.readout = `turning ${deg}° ${amount >= 0 ? "left" : "right"}`;
+      } else {
+        run.readout = `${amount >= 0 ? "driving" : "backing up"} ${metres(Math.abs(amount))}`;
+      }
+      break;
+    }
+    case "track": {
+      if (!isPx(ev.px)) break;
+      run.seen = null;
+      run.track = { px: [ev.px[0], ev.px[1]], inside: ev.inside === true };
+      const off = run.box ? Math.round(Math.hypot(ev.px[0] - run.box.cu, ev.px[1] - run.box.cv)) : null;
+      run.readout = run.track.inside ? "in the pick box" : off === null ? "tracking" : `steering · ${off} px off`;
+      break;
+    }
+    case "parked":
+      if (run.track) run.track.inside = true;
+      run.readout = "parked over it";
+      break;
+    case "grasp":
+      if (ev.step === "target") {
+        run.grasp = isPx(ev.px) ? [ev.px[0], ev.px[1]] : null;
+        run.readout = "grasp point set";
+      } else if (ev.step === "descend") run.readout = "reaching to the floor";
+      else if (ev.step === "close") run.readout = "closing the gripper";
+      else if (ev.step === "lift") run.readout = "lifting";
+      break;
+    case "wrist":
+      if (ev.state === "seed") {
+        run.readout = isPx(ev.px) ? "wrist camera has it" : "wrist camera can't see it";
+      } else if (ev.state === "track" && Number.isFinite(ev.z)) {
+        const stop = Number.isFinite(ev.stop) ? ev.stop : 0;
+        run.descent = { top: run.descent?.top ?? ev.z, z: ev.z, stop };
+        run.readout = `${ev.inside ? "descending" : "centring"} · ${Math.round(ev.z * 100)} cm up`;
+      } else if (ev.state === "done") {
+        run.readout = typeof ev.reason === "string" ? `wrist align: ${ev.reason}` : "wrist align done";
+      }
+      break;
+    case "verify":
+      run.readout = ev.held ? "holding it" : "missed it";
+      break;
+    default:
+      break;
+  }
+  return run;
+}
+
+const SVG_OPEN =
+  '<svg viewBox="0 0 48 48" width="48" height="48" fill="none" stroke="currentColor" ' +
+  'stroke-width="1.6" aria-hidden="true">';
+// Crosshair: where the fingers close.
+const RETICLE_SVG =
+  '<circle cx="24" cy="24" r="13"/>' +
+  '<line x1="24" y1="3" x2="24" y2="14"/><line x1="24" y1="34" x2="24" y2="45"/>' +
+  '<line x1="3" y1="24" x2="14" y2="24"/><line x1="34" y1="24" x2="45" y2="24"/>' +
+  '<circle cx="24" cy="24" r="2.2" fill="currentColor" stroke="none"/>';
+// Small diamond: the point optical flow is holding on to.
+const TRACK_SVG = '<path d="M24 11 37 24 24 37 11 24Z"/><circle cx="24" cy="24" r="1.8" fill="currentColor" stroke="none"/>';
+
+/**
+ * @param {HTMLElement} stage the .video-stage the markers pin to
+ * @param {HTMLVideoElement | null} video the stage's video on hardware; null in
+ *   the sim, where a canvas renders the head camera at the stage's size
+ * @param {import("../rosClient.js").RosClient} ros
+ * @param {import("../webrtcSession.js").WebRtcSession} session
+ * @returns {{ destroy: () => void }}
+ */
+export function createTargetingOverlay(stage, video, ros, session) {
+  const clip = document.createElement("div");
+  clip.className = "tgt-clip";
+  clip.hidden = true;
+  // The skill's frame, placed over the picture; every marker is a percentage
+  // of it, so a resize only moves this one element.
+  const layer = document.createElement("div");
+  layer.className = "tgt-layer";
+  layer.innerHTML =
+    '<div class="tgt-scan"></div>' +
+    '<svg class="tgt-vec" preserveAspectRatio="none" aria-hidden="true"><line class="tgt-vec-line"/></svg>' +
+    '<div class="tgt-seen" hidden><i></i><i></i><i></i><i></i><span class="tgt-tag mono">target</span></div>' +
+    '<div class="tgt-goal" hidden><span class="tgt-tag mono">pick box</span><div class="tgt-accept"></div></div>' +
+    `<div class="tgt-track" hidden>${SVG_OPEN}${TRACK_SVG}</svg><span class="tgt-tag mono">tracking</span></div>` +
+    `<div class="tgt-reticle" hidden>${SVG_OPEN}${RETICLE_SVG}</svg><span class="tgt-tag mono">grasp</span></div>`;
+  clip.appendChild(layer);
+
+  const hud = document.createElement("div");
+  hud.className = "overlay tgt-hud";
+  hud.hidden = true;
+  hud.innerHTML =
+    '<div class="tgt-hud-head"><span class="microlabel tgt-skill"></span><span class="tgt-prompt mono"></span></div>' +
+    '<ol class="tgt-stages"></ol>' +
+    '<div class="tgt-readout mono"><span class="tgt-readout-text"></span><span class="tgt-bar" hidden><span class="tgt-bar-fill"></span></span></div>';
+  stage.append(clip, hud);
+
+  const q = (/** @type {string} */ sel) => /** @type {HTMLElement} */ (layer.querySelector(sel));
+  const seenEl = q(".tgt-seen");
+  const goalEl = q(".tgt-goal");
+  const acceptEl = q(".tgt-accept");
+  const trackEl = q(".tgt-track");
+  const reticleEl = q(".tgt-reticle");
+  const vecEl = /** @type {SVGSVGElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-vec")));
+  const vecLine = /** @type {SVGLineElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-vec-line")));
+  const skillEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-skill"));
+  const promptEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-prompt"));
+  const stagesEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-stages"));
+  const readoutEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-readout-text"));
+  const barEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-bar"));
+  const barFill = /** @type {HTMLElement} */ (hud.querySelector(".tgt-bar-fill"));
+
+  /** @type {Run | null} */
+  let run = null;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let lingerTimer;
+
+  /** @param {HTMLElement} el @param {Px} px @param {Size} frame */
+  function pin(el, px, frame) {
+    el.style.left = `${(px[0] / frame.w) * 100}%`;
+    el.style.top = `${(px[1] / frame.h) * 100}%`;
+    el.hidden = false;
+  }
+
+  function placeLayer() {
+    if (!run) return;
+    const size = video ? { w: video.videoWidth, h: video.videoHeight } : null;
+    const rect = frameRect(run.frame, size, stage.clientWidth, stage.clientHeight);
+    layer.hidden = !rect;
+    if (!rect) return;
+    layer.style.left = `${rect.left}px`;
+    layer.style.top = `${rect.top}px`;
+    layer.style.width = `${rect.width}px`;
+    layer.style.height = `${rect.height}px`;
+  }
+
+  function renderStages() {
+    if (!run) return;
+    const doneUpTo = run.stage ? run.stages.indexOf(run.stage) : -1;
+    stagesEl.replaceChildren(
+      ...run.stages.map((name, i) => {
+        const li = document.createElement("li");
+        li.className = "tgt-stage";
+        li.textContent = name;
+        const done = run?.result?.ok ? true : i < doneUpTo;
+        li.classList.toggle("done", done);
+        li.classList.toggle("active", !run?.result && i === doneUpTo);
+        return li;
+      }),
+    );
+  }
+
+  function render() {
+    const show = !!run && primaryCameraName(session) === "main";
+    clip.hidden = !show || !!run?.result;
+    hud.hidden = !show;
+    if (!run || !show) return;
+    placeLayer();
+
+    skillEl.textContent = run.skill.replace(/_/g, " ");
+    promptEl.textContent = run.prompt ? `“${run.prompt}”` : "";
+    renderStages();
+    readoutEl.textContent = run.readout;
+    hud.classList.toggle("ok", !!run.result?.ok);
+    hud.classList.toggle("failed", !!run.result && !run.result.ok);
+    hud.classList.toggle("looking", run.looking);
+    if (run.descent) {
+      const span = run.descent.top - run.descent.stop;
+      const done = span > 0 ? Math.min(1, Math.max(0, (run.descent.top - run.descent.z) / span)) : 1;
+      barFill.style.width = `${done * 100}%`;
+      barEl.hidden = false;
+    } else {
+      barEl.hidden = true;
+    }
+    if (run.result) return;
+
+    const { frame, box } = run;
+    layer.classList.toggle("looking", run.looking);
+    if (run.seen?.box) {
+      const [x0, y0, x1, y1] = run.seen.box;
+      seenEl.style.left = `${(x0 / frame.w) * 100}%`;
+      seenEl.style.top = `${(y0 / frame.h) * 100}%`;
+      seenEl.style.width = `${((x1 - x0) / frame.w) * 100}%`;
+      seenEl.style.height = `${((y1 - y0) / frame.h) * 100}%`;
+      seenEl.hidden = false;
+    } else if (run.seen?.px) {
+      // A grasp point without a box: a small square around it still says "here".
+      const [u, v] = run.seen.px;
+      seenEl.style.left = `${((u - 20) / frame.w) * 100}%`;
+      seenEl.style.top = `${((v - 20) / frame.h) * 100}%`;
+      seenEl.style.width = `${(40 / frame.w) * 100}%`;
+      seenEl.style.height = `${(40 / frame.h) * 100}%`;
+      seenEl.hidden = false;
+    } else {
+      seenEl.hidden = true;
+    }
+
+    if (box && run.stage === "approach") {
+      goalEl.style.left = `${((box.cu - box.hu) / frame.w) * 100}%`;
+      goalEl.style.top = `${((box.cv - box.hv) / frame.h) * 100}%`;
+      goalEl.style.width = `${((2 * box.hu) / frame.w) * 100}%`;
+      goalEl.style.height = `${((2 * box.hv) / frame.h) * 100}%`;
+      acceptEl.style.width = `${(box.au / box.hu) * 100}%`;
+      acceptEl.style.height = `${(box.av / box.hv) * 100}%`;
+      goalEl.classList.toggle("inside", !!run.track?.inside);
+      goalEl.hidden = false;
+    } else {
+      goalEl.hidden = true;
+    }
+
+    if (run.track) {
+      pin(trackEl, run.track.px, frame);
+      trackEl.classList.toggle("inside", run.track.inside);
+    } else {
+      trackEl.hidden = true;
+    }
+    // The steering vector: from the tracked point to the box centre.
+    const vec = run.track && box && !run.track.inside;
+    vecEl.setAttribute("viewBox", `0 0 ${frame.w} ${frame.h}`);
+    if (vec && run.track && box) {
+      vecLine.setAttribute("x1", String(run.track.px[0]));
+      vecLine.setAttribute("y1", String(run.track.px[1]));
+      vecLine.setAttribute("x2", String(box.cu));
+      vecLine.setAttribute("y2", String(box.cv));
+    }
+    vecEl.classList.toggle("on", !!vec);
+
+    if (run.grasp) pin(reticleEl, run.grasp, frame);
+    else reticleEl.hidden = true;
+  }
+
+  /** @param {any} msg std_msgs/String */
+  function onTelemetry(msg) {
+    if (typeof msg?.data !== "string") return;
+    /** @type {any} */
+    let ev;
+    try {
+      ev = JSON.parse(msg.data);
+    } catch {
+      return;
+    }
+    const next = applyEvent(run, ev);
+    if (next !== run) clearTimeout(lingerTimer);
+    run = next;
+    if (run?.result) {
+      clearTimeout(lingerTimer);
+      lingerTimer = setTimeout(() => {
+        run = null;
+        render();
+      }, RESULT_LINGER_MS);
+    }
+    render();
+  }
+
+  const unsub = ros.subscribe(SKILL_TELEMETRY_TOPIC, onTelemetry, undefined, "std_msgs/msg/String");
+  const resize = new ResizeObserver(placeLayer);
+  resize.observe(stage);
+  video?.addEventListener("resize", placeLayer);
+  const unsubSession = session.onChange(render);
+
+  return {
+    destroy() {
+      unsub();
+      unsubSession();
+      resize.disconnect();
+      video?.removeEventListener("resize", placeLayer);
+      clearTimeout(lingerTimer);
+      clip.remove();
+      hud.remove();
+    },
+  };
+}

--- a/webapp/js/teleop/targetingOverlay.js
+++ b/webapp/js/teleop/targetingOverlay.js
@@ -21,6 +21,13 @@ import { primaryCameraName } from "./trajectoryOverlay.js";
 const SIM_HEAD_LENS = { fx: 200.3, fy: 267.3, cx: 319.1, cy: 248.7 };
 // How long the verdict stays up after the run ends.
 const RESULT_LINGER_MS = 4000;
+// A run whose end never arrived (rosbridge dropped, the server died) must not
+// stay on screen: nothing heard for this long clears it.
+const IDLE_CLEAR_MS = 60000;
+// An event carrying another run's id replaces the shown run only when that
+// run is finished or has gone quiet; while it is live, such events are
+// stragglers from the run before and are dropped.
+const STALE_MS = 2000;
 // A page opened mid-run missed the start event: it draws in the head camera's
 // native frame until the next event, every one of which repeats the run's
 // header, rather than showing nothing until the next run.
@@ -48,6 +55,7 @@ const DEFAULT_FRAME = { w: 640, h: 480 };
 /**
  * One run of a skill, as the overlay understands it.
  * @typedef {{
+ *   id: string,
  *   skill: string,
  *   prompt: string,
  *   stages: string[],
@@ -58,6 +66,7 @@ const DEFAULT_FRAME = { w: 640, h: 480 };
  *   progress: number | null,
  *   result: { ok: boolean, text: string } | null,
  *   markers: Map<string, Marker>,
+ *   seen: number,
  * }} Run
  */
 
@@ -158,10 +167,16 @@ function stageList(v) {
   return Array.isArray(v) ? v.filter((/** @type {unknown} */ s) => typeof s === "string") : [];
 }
 
+/** @param {any} ev @returns {string} the run id the event carries, "" when none */
+function runId(ev) {
+  return typeof ev.run === "string" ? ev.run : "";
+}
+
 /** @param {any} ev a run-start event, or any first event of a run missed at its start
- * @returns {Run} */
-function startRun(ev) {
+ * @param {number} now @returns {Run} */
+function startRun(ev, now) {
   return {
+    id: runId(ev),
     skill: ev.skill,
     prompt: typeof ev.prompt === "string" ? ev.prompt : "",
     stages: stageList(ev.stages),
@@ -172,6 +187,7 @@ function startRun(ev) {
     progress: null,
     result: null,
     markers: new Map(),
+    seen: now,
   };
 }
 
@@ -208,21 +224,30 @@ function endRun(run, ev) {
 /**
  * Fold one overlay event into the run. Returns the run to keep showing, or
  * null when there is none. A run ends with its result set; the caller decides
- * how long that lingers. A finished run's own stray events never revive it,
- * but another skill's first event opens a fresh run over the verdict.
+ * how long that lingers. Events are matched to the run by the id the SDK
+ * stamps on them: a finished run's own stragglers never revive it, another
+ * run's end never closes it, and another run's first event opens a fresh run
+ * over a verdict or a run gone quiet.
  * @param {Run | null} run
  * @param {any} ev
+ * @param {number} [now]
  * @returns {Run | null}
  */
-export function applyEvent(run, ev) {
+export function applyEvent(run, ev, now = Date.now()) {
   if (!ev || typeof ev !== "object" || typeof ev.ev !== "string" || typeof ev.skill !== "string") return run;
+  const isEnd = ev.ev === "run" && ev.state === "end";
+  if (run && runId(ev) !== run.id) {
+    if (isEnd || (!run.result && now - run.seen < STALE_MS)) return run;
+    run = null;
+  }
   if (ev.ev === "run") {
-    if (ev.state === "start") return startRun(ev);
-    if (ev.state === "end" && run && !run.result) endRun(run, ev);
+    if (ev.state === "start") return startRun(ev, now);
+    if (isEnd && run && !run.result) endRun(run, ev);
     return run;
   }
-  if (run?.result && ev.skill === run.skill) return run;
-  if (!run || run.result) run = startRun(ev);
+  if (run?.result) return run;
+  run ??= startRun(ev, now);
+  run.seen = now;
   adoptHeader(run, ev);
   switch (ev.ev) {
     case "stage":
@@ -296,11 +321,20 @@ function createRunStore() {
   let run = null;
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let lingerTimer;
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let idleTimer;
   /** @type {Set<() => void>} */
   const listeners = new Set();
 
   function notify() {
     for (const cb of listeners) cb();
+  }
+
+  function clear() {
+    clearTimeout(lingerTimer);
+    clearTimeout(idleTimer);
+    run = null;
+    notify();
   }
 
   /** @param {any} msg std_msgs/String */
@@ -317,6 +351,8 @@ function createRunStore() {
     const next = applyEvent(run, ev);
     if (next !== run) clearTimeout(lingerTimer); // a new run replaces a lingering verdict
     run = next;
+    clearTimeout(idleTimer);
+    if (run && !run.result) idleTimer = setTimeout(clear, IDLE_CLEAR_MS);
     // Only the transition into a verdict arms the linger: later events of a
     // finished run (or a stray one) must not keep pushing it out.
     if (run?.result && !ended) {
@@ -329,6 +365,10 @@ function createRunStore() {
   }
 
   ros.subscribe(SKILL_OVERLAY_TOPIC, onOverlay, undefined, "std_msgs/msg/String");
+  // The end of a run published while the socket was down is gone for good.
+  ros.onStateChange((state) => {
+    if (state !== "connected" && run) clear();
+  });
   return {
     run: () => run,
     /** @param {() => void} cb */

--- a/webapp/js/teleop/targetingOverlay.js
+++ b/webapp/js/teleop/targetingOverlay.js
@@ -21,13 +21,19 @@ const SIM_LENS = { fx: 200.3, fy: 267.3, cx: 319.1, cy: 248.7 };
 const RESULT_LINGER_MS = 4000;
 // A page opened mid-run missed the start event that carries the frame size and
 // the stage list: it draws in the head camera's native frame and learns the
-// stages as they come, rather than showing nothing until the next run.
+// stages, prompt and pick box from the events that repeat them, rather than
+// showing nothing until the next run.
 const DEFAULT_FRAME = { w: 640, h: 480 };
 
 /** @typedef {{ w: number, h: number }} Size */
 /** @typedef {[number, number]} Px */
 /** @typedef {{ cu: number, cv: number, hu: number, hv: number, au: number, av: number }} PickBox */
 /** @typedef {{ left: number, top: number, width: number, height: number }} Rect */
+/**
+ * The stream as laid out on the page: intrinsic size, the video element's box
+ * within the stage, and how object-fit places the picture in that box.
+ * @typedef {{ w: number, h: number, box: Rect, fit: string }} VideoLayout
+ */
 /**
  * One run of a skill, as the overlay understands it.
  * @typedef {{
@@ -48,23 +54,29 @@ const DEFAULT_FRAME = { w: 640, h: 480 };
  */
 
 /**
- * Where the skill's image frame lands on the stage. Hardware letterboxes the
- * stream (object-fit: contain) and the skill sees that same picture, so the
- * frame is the video's rectangle; the sim has no stream, its canvas renders the
- * head camera at the stage's own size (see SIM_LENS).
+ * Where the skill's image frame lands on the stage. On hardware the skill sees
+ * the same picture the stream shows, so the frame is wherever object-fit put
+ * that picture inside the video element — the cockpits letterbox it (contain),
+ * the Agent page crops it (cover) at some widths. The sim has no stream: its
+ * canvas renders the head camera at the stage's own size (see SIM_LENS).
  * @param {Size} frame the skill's image size
- * @param {Size | null} video the stream's intrinsic size, null in the sim
+ * @param {VideoLayout | null} video the stream on the page, null in the sim
  * @param {number} cw @param {number} ch stage size
  * @returns {Rect | null}
  */
 export function frameRect(frame, video, cw, ch) {
   if (!cw || !ch || !frame.w || !frame.h) return null;
   if (video) {
-    if (!video.w || !video.h) return null;
-    const fit = Math.min(cw / video.w, ch / video.h);
-    const width = video.w * fit;
-    const height = video.h * fit;
-    return { left: (cw - width) / 2, top: (ch - height) / 2, width, height };
+    const { w, h, box, fit } = video;
+    if (!w || !h || !box.width || !box.height) return null;
+    let sx = box.width / w;
+    let sy = box.height / h;
+    if (fit === "cover") sx = sy = Math.max(sx, sy);
+    else if (fit === "none") sx = sy = 1;
+    else if (fit !== "fill") sx = sy = Math.min(sx, sy);
+    const width = w * sx;
+    const height = h * sy;
+    return { left: box.left + (box.width - width) / 2, top: box.top + (box.height - height) / 2, width, height };
   }
   const sy = ch / frame.h;
   const sx = sy * (SIM_LENS.fy / SIM_LENS.fx);
@@ -153,6 +165,7 @@ export function applyEvent(run, ev) {
     case "stage":
       if (typeof ev.stage !== "string") break;
       if (!run.stages.includes(ev.stage)) run.stages.push(ev.stage);
+      if (!run.prompt && typeof ev.prompt === "string") run.prompt = ev.prompt;
       run.stage = ev.stage;
       run.readout = STAGE_READOUT[ev.stage] ?? ev.stage;
       if (ev.stage !== "approach") run.track = null;
@@ -169,7 +182,7 @@ export function applyEvent(run, ev) {
         const more = Number.isFinite(ev.n) && ev.n > 1 ? ` · ${ev.n} matches` : "";
         run.readout = `spotted${dist}${more}`;
       } else {
-        run.seen = null;
+        run.seen = run.track = null;
         run.readout = "not in view";
       }
       break;
@@ -187,6 +200,7 @@ export function applyEvent(run, ev) {
     }
     case "track": {
       if (!isPx(ev.px)) break;
+      run.box ??= pickBox(ev.box);
       run.seen = null;
       run.track = { px: [ev.px[0], ev.px[1]], inside: ev.inside === true };
       const off = run.box ? Math.round(Math.hypot(ev.px[0] - run.box.cu, ev.px[1] - run.box.cv)) : null;
@@ -298,10 +312,22 @@ export function createTargetingOverlay(stage, video, ros, session) {
     el.hidden = false;
   }
 
+  /** @returns {VideoLayout | null} */
+  function videoLayout() {
+    if (!video) return null;
+    const s = stage.getBoundingClientRect();
+    const v = video.getBoundingClientRect();
+    return {
+      w: video.videoWidth,
+      h: video.videoHeight,
+      box: { left: v.left - s.left, top: v.top - s.top, width: v.width, height: v.height },
+      fit: getComputedStyle(video).objectFit || "contain",
+    };
+  }
+
   function placeLayer() {
     if (!run) return;
-    const size = video ? { w: video.videoWidth, h: video.videoHeight } : null;
-    const rect = frameRect(run.frame, size, stage.clientWidth, stage.clientHeight);
+    const rect = frameRect(run.frame, videoLayout(), stage.clientWidth, stage.clientHeight);
     layer.hidden = !rect;
     if (!rect) return;
     layer.style.left = `${rect.left}px`;
@@ -415,11 +441,13 @@ export function createTargetingOverlay(stage, video, ros, session) {
     } catch {
       return;
     }
+    const ended = !!run?.result;
     const next = applyEvent(run, ev);
-    if (next !== run) clearTimeout(lingerTimer);
+    if (next !== run) clearTimeout(lingerTimer); // a new run replaces a lingering verdict
     run = next;
-    if (run?.result) {
-      clearTimeout(lingerTimer);
+    // Only the transition into a verdict arms the linger: later events of a
+    // finished run (or a stray one) must not keep pushing it out.
+    if (run?.result && !ended) {
       lingerTimer = setTimeout(() => {
         run = null;
         render();
@@ -431,6 +459,7 @@ export function createTargetingOverlay(stage, video, ros, session) {
   const unsub = ros.subscribe(SKILL_TELEMETRY_TOPIC, onTelemetry, undefined, "std_msgs/msg/String");
   const resize = new ResizeObserver(placeLayer);
   resize.observe(stage);
+  if (video) resize.observe(video); // its box moves with media queries the stage's size does not
   video?.addEventListener("resize", placeLayer);
   const unsubSession = session.onChange(render);
 

--- a/webapp/js/teleop/targetingOverlay.js
+++ b/webapp/js/teleop/targetingOverlay.js
@@ -1,12 +1,14 @@
 // @ts-check
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Innate Inc
-// Targeting overlay — what a manipulation skill is doing, drawn over the main
-// camera: the object it detected (corner brackets), the pick box the base
-// steers it into, the tracked point gliding toward that box, the spot the
-// fingers will close on, and a HUD of the run's stages. Driven entirely by
-// /brain/skill_telemetry: a run declares its stages up front and every marker
-// arrives in image pixels, so nothing here is specific to one skill.
+// Targeting overlay — what a manipulation skill is doing, drawn over the robot's
+// cameras. On the head camera: the object it detected (corner brackets), the
+// pick box the base steers it into, the tracked point gliding toward that box
+// and the spot the fingers will close on. On the wrist camera: the servo's goal
+// square, Gemini's wrist detection and the colour blob the descent follows,
+// with its long axis. Plus a HUD of the run's stages on either. Driven entirely
+// by /brain/skill_telemetry: a run declares its stages up front and every
+// marker arrives in image pixels, so nothing here is specific to one skill.
 
 import { SKILL_TELEMETRY_TOPIC } from "../constants.js";
 import { primaryCameraName } from "./trajectoryOverlay.js";
@@ -15,8 +17,11 @@ import { primaryCameraName } from "./trajectoryOverlay.js";
 // (mars_sim_driver/constants.py — keep in sync). The viewer's preview shares
 // its vertical field, so the skill's frame fits the stage by height, runs wider
 // sideways because that lens has fx < fy, and centres on the lens's principal
-// point rather than the frame's middle.
-const SIM_LENS = { fx: 200.3, fy: 267.3, cx: 319.1, cy: 248.7 };
+// point rather than the frame's middle. The wrist camera is a plain fovy in
+// both (square pixels, centred), so its frame just fits by height.
+const SIM_HEAD_LENS = { fx: 200.3, fy: 267.3, cx: 319.1, cy: 248.7 };
+// Half-length of the blob's drawn long axis, in frame px.
+const AXIS_HALF_PX = 45;
 // How long the verdict stays up after the run ends.
 const RESULT_LINGER_MS = 4000;
 // A page opened mid-run missed the start event that carries the frame size and
@@ -27,8 +32,11 @@ const DEFAULT_FRAME = { w: 640, h: 480 };
 
 /** @typedef {{ w: number, h: number }} Size */
 /** @typedef {[number, number]} Px */
+/** @typedef {[number, number, number, number]} Corners x0, y0, x1, y1 */
 /** @typedef {{ cu: number, cv: number, hu: number, hv: number, au: number, av: number }} PickBox */
+/** @typedef {{ u: number, v: number, half: number }} WristBox */
 /** @typedef {{ left: number, top: number, width: number, height: number }} Rect */
+/** @typedef {"main" | "arm"} View the two robot cameras a run draws on */
 /**
  * The stream as laid out on the page: intrinsic size, the video element's
  * content box within the stage, and how object-fit / object-position place the
@@ -51,11 +59,14 @@ function positionOffset(term, slack) {
  *   stages: string[],
  *   frame: Size,
  *   box: PickBox | null,
+ *   wristBox: WristBox | null,
  *   stage: string | null,
  *   looking: boolean,
- *   seen: { px: Px | null, box: [number, number, number, number] | null } | null,
+ *   seen: { px: Px | null, box: Corners | null } | null,
  *   track: { px: Px, inside: boolean } | null,
  *   grasp: Px | null,
+ *   wristSeen: { px: Px | null, box: Corners | null } | null,
+ *   wristTrack: { px: Px, inside: boolean, axis: number | null } | null,
  *   descent: { top: number, z: number, stop: number } | null,
  *   readout: string,
  *   result: { ok: boolean, text: string } | null,
@@ -63,17 +74,31 @@ function positionOffset(term, slack) {
  */
 
 /**
+ * What to draw for one camera: every geometry in frame px, null = not drawn.
+ * @typedef {{
+ *   seen: Corners | null,
+ *   goal: { rect: Rect, accept: Size | null, inside: boolean } | null,
+ *   track: { px: Px, inside: boolean } | null,
+ *   vec: [Px, Px] | null,
+ *   axis: { px: Px, angle: number } | null,
+ *   reticle: Px | null,
+ *   tags: { seen: string, goal: string, track: string },
+ * }} Markers
+ */
+
+/**
  * Where the skill's image frame lands on the stage. On hardware the skill sees
  * the same picture the stream shows, so the frame is wherever object-fit put
  * that picture inside the video element — the cockpits letterbox it (contain),
  * the Agent page crops it (cover) at some widths. The sim has no stream: its
- * canvas renders the head camera at the stage's own size (see SIM_LENS).
+ * canvas renders the camera at the stage's own size (see SIM_HEAD_LENS).
  * @param {Size} frame the skill's image size
  * @param {VideoLayout | null} video the stream on the page, null in the sim
  * @param {number} cw @param {number} ch stage size
+ * @param {View} [view] which camera fills the stage (the sim's lens differs)
  * @returns {Rect | null}
  */
-export function frameRect(frame, video, cw, ch) {
+export function frameRect(frame, video, cw, ch, view = "main") {
   if (!cw || !ch || !frame.w || !frame.h) return null;
   if (video) {
     const { w, h, box, fit } = video;
@@ -93,9 +118,10 @@ export function frameRect(frame, video, cw, ch) {
       height,
     };
   }
+  const lens = view === "main" ? SIM_HEAD_LENS : { fx: 1, fy: 1, cx: frame.w / 2, cy: frame.h / 2 };
   const sy = ch / frame.h;
-  const sx = sy * (SIM_LENS.fy / SIM_LENS.fx);
-  return { left: cw / 2 - SIM_LENS.cx * sx, top: ch / 2 - SIM_LENS.cy * sy, width: frame.w * sx, height: frame.h * sy };
+  const sx = sy * (lens.fy / lens.fx);
+  return { left: cw / 2 - lens.cx * sx, top: ch / 2 - lens.cy * sy, width: frame.w * sx, height: frame.h * sy };
 }
 
 /** @param {any} v @returns {v is Px} */
@@ -103,7 +129,7 @@ function isPx(v) {
   return Array.isArray(v) && v.length >= 2 && Number.isFinite(v[0]) && Number.isFinite(v[1]);
 }
 
-/** @param {any} v @returns {v is [number, number, number, number]} */
+/** @param {any} v @returns {v is Corners} */
 function isBox(v) {
   return Array.isArray(v) && v.length >= 4 && v.slice(0, 4).every(Number.isFinite);
 }
@@ -113,6 +139,18 @@ function pickBox(v) {
   if (!v || typeof v !== "object") return null;
   const b = { cu: v.cu, cv: v.cv, hu: v.hu, hv: v.hv, au: v.au, av: v.av };
   return Object.values(b).every((n) => Number.isFinite(n) && n >= 0) && b.hu > 0 && b.hv > 0 ? b : null;
+}
+
+/** @param {any} v @returns {WristBox | null} */
+function wristBox(v) {
+  if (!v || typeof v !== "object") return null;
+  const b = { u: v.u, v: v.v, half: v.half };
+  return Object.values(b).every(Number.isFinite) && b.half > 0 ? b : null;
+}
+
+/** @param {any} v @returns {{ px: Px | null, box: Corners | null }} */
+function sighting(v) {
+  return { px: isPx(v.px) ? [v.px[0], v.px[1]] : null, box: isBox(v.box) ? [v.box[0], v.box[1], v.box[2], v.box[3]] : null };
 }
 
 /** @param {number} n */
@@ -139,11 +177,14 @@ function startRun(ev) {
     stages: Array.isArray(ev.stages) ? ev.stages.filter((/** @type {unknown} */ s) => typeof s === "string") : [],
     frame: frame.w > 0 && frame.h > 0 ? frame : DEFAULT_FRAME,
     box: pickBox(ev.box),
+    wristBox: wristBox(ev.wrist_box),
     stage: null,
     looking: false,
     seen: null,
     track: null,
     grasp: null,
+    wristSeen: null,
+    wristTrack: null,
     descent: null,
     readout: "starting",
     result: null,
@@ -170,7 +211,7 @@ export function applyEvent(run, ev) {
   switch (ev.ev) {
     case "run":
       if (ev.state !== "end") break;
-      run.seen = run.track = run.grasp = null;
+      run.seen = run.track = run.grasp = run.wristSeen = run.wristTrack = null;
       run.looking = false;
       run.result = ev.ok
         ? { ok: true, text: "picked up" }
@@ -184,6 +225,7 @@ export function applyEvent(run, ev) {
       run.stage = ev.stage;
       run.readout = STAGE_READOUT[ev.stage] ?? ev.stage;
       if (ev.stage !== "approach") run.track = null;
+      if (ev.stage !== "align") run.wristSeen = run.wristTrack = null; // the arm moves on, the view with it
       if (ev.stage === "verify") run.grasp = null;
       break;
     case "look":
@@ -191,7 +233,7 @@ export function applyEvent(run, ev) {
       if (ev.state === "ask") {
         run.readout = run.stage === "search" ? "looking for it" : "taking another look";
       } else if (ev.state === "seen") {
-        run.seen = { px: isPx(ev.px) ? [ev.px[0], ev.px[1]] : null, box: isBox(ev.box) ? ev.box : null };
+        run.seen = sighting(ev);
         run.track = null;
         const dist = Number.isFinite(ev.dist) ? ` · ${metres(ev.dist)} ahead` : "";
         const more = Number.isFinite(ev.n) && ev.n > 1 ? ` · ${ev.n} matches` : "";
@@ -236,10 +278,17 @@ export function applyEvent(run, ev) {
       break;
     case "wrist":
       if (ev.state === "seed") {
-        run.readout = isPx(ev.px) ? "wrist camera has it" : "wrist camera can't see it";
+        run.wristSeen = isPx(ev.px) ? sighting(ev) : null;
+        run.wristTrack = null;
+        run.readout = run.wristSeen ? "wrist camera has it" : "wrist camera can't see it";
       } else if (ev.state === "track" && Number.isFinite(ev.z)) {
         const stop = Number.isFinite(ev.stop) ? ev.stop : 0;
         run.descent = { top: run.descent?.top ?? ev.z, z: ev.z, stop };
+        run.wristBox ??= wristBox(ev.box);
+        if (isPx(ev.px)) {
+          run.wristSeen = null;
+          run.wristTrack = { px: [ev.px[0], ev.px[1]], inside: ev.inside === true, axis: Number.isFinite(ev.axis) ? ev.axis : null };
+        }
         run.readout = `${ev.inside ? "descending" : "centring"} · ${Math.round(ev.z * 100)} cm up`;
       } else if (ev.state === "done") {
         run.readout = typeof ev.reason === "string" ? `wrist align: ${ev.reason}` : "wrist align done";
@@ -252,6 +301,66 @@ export function applyEvent(run, ev) {
       break;
   }
   return run;
+}
+
+/** @param {Corners} c @returns {Rect} */
+function cornersRect([x0, y0, x1, y1]) {
+  return { left: x0, top: y0, width: x1 - x0, height: y1 - y0 };
+}
+
+/** @param {Px} px @param {number} half @returns {Rect} */
+function squareAround(px, half) {
+  return { left: px[0] - half, top: px[1] - half, width: 2 * half, height: 2 * half };
+}
+
+/** A sighting's frame: its box, or a small square around its point.
+ * @param {{ px: Px | null, box: Corners | null } | null} s @returns {Corners | null} */
+function seenCorners(s) {
+  if (s?.box) return s.box;
+  if (s?.px) return [s.px[0] - 20, s.px[1] - 20, s.px[0] + 20, s.px[1] + 20];
+  return null;
+}
+
+/** The head camera's markers: detection, pick box, flow track, grasp point.
+ * @param {Run} run @returns {Markers} */
+export function headMarkers(run) {
+  const { box, track } = run;
+  const goal =
+    box && run.stage === "approach"
+      ? {
+          rect: { left: box.cu - box.hu, top: box.cv - box.hv, width: 2 * box.hu, height: 2 * box.hv },
+          accept: { w: box.au / box.hu, h: box.av / box.hv },
+          inside: !!track?.inside,
+        }
+      : null;
+  return {
+    seen: seenCorners(run.seen),
+    goal,
+    track,
+    vec: track && box && !track.inside ? [track.px, [box.cu, box.cv]] : null,
+    axis: null,
+    reticle: run.grasp,
+    tags: { seen: "target", goal: "pick box", track: "tracking" },
+  };
+}
+
+/** The wrist camera's markers: Gemini's seed, the servo box, the tracked blob.
+ * @param {Run} run @returns {Markers} */
+export function wristMarkers(run) {
+  const { wristBox: box, wristTrack: track } = run;
+  const goal =
+    box && run.stage === "align"
+      ? { rect: squareAround([box.u, box.v], box.half), accept: null, inside: !!track?.inside }
+      : null;
+  return {
+    seen: seenCorners(run.wristSeen),
+    goal,
+    track: track && { px: track.px, inside: track.inside },
+    vec: track && box && !track.inside ? [track.px, [box.u, box.v]] : null,
+    axis: track && track.axis !== null ? { px: track.px, angle: track.axis } : null,
+    reticle: null,
+    tags: { seen: "wrist target", goal: "wrist box", track: "blob" },
+  };
 }
 
 const SVG_OPEN =
@@ -284,7 +393,8 @@ export function createTargetingOverlay(stage, video, ros, session) {
   layer.className = "tgt-layer";
   layer.innerHTML =
     '<div class="tgt-scan"></div>' +
-    '<svg class="tgt-vec" preserveAspectRatio="none" aria-hidden="true"><line class="tgt-vec-line"/></svg>' +
+    '<svg class="tgt-vec" preserveAspectRatio="none" aria-hidden="true">' +
+    '<line class="tgt-vec-line"/><line class="tgt-axis-line"/></svg>' +
     '<div class="tgt-seen" hidden><i></i><i></i><i></i><i></i><span class="tgt-tag mono">target</span></div>' +
     '<div class="tgt-goal" hidden><span class="tgt-tag mono">pick box</span><div class="tgt-accept"></div></div>' +
     `<div class="tgt-track" hidden>${SVG_OPEN}${TRACK_SVG}</svg><span class="tgt-tag mono">tracking</span></div>` +
@@ -308,6 +418,10 @@ export function createTargetingOverlay(stage, video, ros, session) {
   const reticleEl = q(".tgt-reticle");
   const vecEl = /** @type {SVGSVGElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-vec")));
   const vecLine = /** @type {SVGLineElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-vec-line")));
+  const axisLine = /** @type {SVGLineElement} */ (/** @type {unknown} */ (layer.querySelector(".tgt-axis-line")));
+  const seenTag = /** @type {HTMLElement} */ (seenEl.querySelector(".tgt-tag"));
+  const goalTag = /** @type {HTMLElement} */ (goalEl.querySelector(".tgt-tag"));
+  const trackTag = /** @type {HTMLElement} */ (trackEl.querySelector(".tgt-tag"));
   const skillEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-skill"));
   const promptEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-prompt"));
   const stagesEl = /** @type {HTMLElement} */ (hud.querySelector(".tgt-stages"));
@@ -320,11 +434,36 @@ export function createTargetingOverlay(stage, video, ros, session) {
   /** @type {ReturnType<typeof setTimeout> | undefined} */
   let lingerTimer;
 
+  /** The robot camera on the stage, or null when another view (map, orbit) is up.
+   * @returns {View | null} */
+  function view() {
+    const name = primaryCameraName(session);
+    return name === "main" || name === "arm" ? name : null;
+  }
+
   /** @param {HTMLElement} el @param {Px} px @param {Size} frame */
   function pin(el, px, frame) {
     el.style.left = `${(px[0] / frame.w) * 100}%`;
     el.style.top = `${(px[1] / frame.h) * 100}%`;
     el.hidden = false;
+  }
+
+  /** @param {HTMLElement} el @param {Rect} r @param {Size} frame */
+  function place(el, r, frame) {
+    el.style.left = `${(r.left / frame.w) * 100}%`;
+    el.style.top = `${(r.top / frame.h) * 100}%`;
+    el.style.width = `${(r.width / frame.w) * 100}%`;
+    el.style.height = `${(r.height / frame.h) * 100}%`;
+    el.hidden = false;
+  }
+
+  /** @param {SVGLineElement} line @param {Px} a @param {Px} b */
+  function segment(line, a, b) {
+    line.setAttribute("x1", String(a[0]));
+    line.setAttribute("y1", String(a[1]));
+    line.setAttribute("x2", String(b[0]));
+    line.setAttribute("y2", String(b[1]));
+    line.classList.add("on");
   }
 
   /** @returns {VideoLayout | null} */
@@ -350,7 +489,7 @@ export function createTargetingOverlay(stage, video, ros, session) {
 
   function placeLayer() {
     if (!run) return;
-    const rect = frameRect(run.frame, videoLayout(), stage.clientWidth, stage.clientHeight);
+    const rect = frameRect(run.frame, videoLayout(), stage.clientWidth, stage.clientHeight, view() ?? "main");
     layer.hidden = !rect;
     if (!rect) return;
     layer.style.left = `${rect.left}px`;
@@ -376,10 +515,11 @@ export function createTargetingOverlay(stage, video, ros, session) {
   }
 
   function render() {
-    const show = !!run && primaryCameraName(session) === "main";
+    const cam = view();
+    const show = !!run && cam !== null;
     clip.hidden = !show || !!run?.result;
     hud.hidden = !show;
-    if (!run || !show) return;
+    if (!run || !cam) return;
     placeLayer();
 
     skillEl.textContent = run.skill.replace(/_/g, " ");
@@ -399,58 +539,51 @@ export function createTargetingOverlay(stage, video, ros, session) {
     }
     if (run.result) return;
 
-    const { frame, box } = run;
-    layer.classList.toggle("looking", run.looking);
-    if (run.seen?.box) {
-      const [x0, y0, x1, y1] = run.seen.box;
-      seenEl.style.left = `${(x0 / frame.w) * 100}%`;
-      seenEl.style.top = `${(y0 / frame.h) * 100}%`;
-      seenEl.style.width = `${((x1 - x0) / frame.w) * 100}%`;
-      seenEl.style.height = `${((y1 - y0) / frame.h) * 100}%`;
-      seenEl.hidden = false;
-    } else if (run.seen?.px) {
-      // A grasp point without a box: a small square around it still says "here".
-      const [u, v] = run.seen.px;
-      seenEl.style.left = `${((u - 20) / frame.w) * 100}%`;
-      seenEl.style.top = `${((v - 20) / frame.h) * 100}%`;
-      seenEl.style.width = `${(40 / frame.w) * 100}%`;
-      seenEl.style.height = `${(40 / frame.h) * 100}%`;
-      seenEl.hidden = false;
-    } else {
-      seenEl.hidden = true;
-    }
+    const { frame } = run;
+    // The sweep is a head-camera look; the wrist stage tracks continuously.
+    layer.classList.toggle("looking", run.looking && cam === "main");
+    const m = cam === "main" ? headMarkers(run) : wristMarkers(run);
+    seenTag.textContent = m.tags.seen;
+    goalTag.textContent = m.tags.goal;
+    trackTag.textContent = m.tags.track;
 
-    if (box && run.stage === "approach") {
-      goalEl.style.left = `${((box.cu - box.hu) / frame.w) * 100}%`;
-      goalEl.style.top = `${((box.cv - box.hv) / frame.h) * 100}%`;
-      goalEl.style.width = `${((2 * box.hu) / frame.w) * 100}%`;
-      goalEl.style.height = `${((2 * box.hv) / frame.h) * 100}%`;
-      acceptEl.style.width = `${(box.au / box.hu) * 100}%`;
-      acceptEl.style.height = `${(box.av / box.hv) * 100}%`;
-      goalEl.classList.toggle("inside", !!run.track?.inside);
-      goalEl.hidden = false;
+    if (m.seen) place(seenEl, cornersRect(m.seen), frame);
+    else seenEl.hidden = true;
+
+    if (m.goal) {
+      place(goalEl, m.goal.rect, frame);
+      acceptEl.hidden = !m.goal.accept;
+      if (m.goal.accept) {
+        acceptEl.style.width = `${m.goal.accept.w * 100}%`;
+        acceptEl.style.height = `${m.goal.accept.h * 100}%`;
+      }
+      goalEl.classList.toggle("inside", m.goal.inside);
     } else {
       goalEl.hidden = true;
     }
 
-    if (run.track) {
-      pin(trackEl, run.track.px, frame);
-      trackEl.classList.toggle("inside", run.track.inside);
+    if (m.track) {
+      pin(trackEl, m.track.px, frame);
+      trackEl.classList.toggle("inside", m.track.inside);
     } else {
       trackEl.hidden = true;
     }
-    // The steering vector: from the tracked point to the box centre.
-    const vec = run.track && box && !run.track.inside;
-    vecEl.setAttribute("viewBox", `0 0 ${frame.w} ${frame.h}`);
-    if (vec && run.track && box) {
-      vecLine.setAttribute("x1", String(run.track.px[0]));
-      vecLine.setAttribute("y1", String(run.track.px[1]));
-      vecLine.setAttribute("x2", String(box.cu));
-      vecLine.setAttribute("y2", String(box.cv));
-    }
-    vecEl.classList.toggle("on", !!vec);
 
-    if (run.grasp) pin(reticleEl, run.grasp, frame);
+    vecEl.setAttribute("viewBox", `0 0 ${frame.w} ${frame.h}`);
+    // The steering vector: tracked point -> the box it is being driven into.
+    if (m.vec) segment(vecLine, m.vec[0], m.vec[1]);
+    else vecLine.classList.remove("on");
+    // The blob's long axis: the side the fingers will roll onto.
+    if (m.axis) {
+      const [u, v] = m.axis.px;
+      const du = Math.cos(m.axis.angle) * AXIS_HALF_PX;
+      const dv = Math.sin(m.axis.angle) * AXIS_HALF_PX;
+      segment(axisLine, [u - du, v - dv], [u + du, v + dv]);
+    } else {
+      axisLine.classList.remove("on");
+    }
+
+    if (m.reticle) pin(reticleEl, m.reticle, frame);
     else reticleEl.hidden = true;
   }
 

--- a/webapp/js/teleop/targetingOverlay.js
+++ b/webapp/js/teleop/targetingOverlay.js
@@ -225,7 +225,7 @@ export function applyEvent(run, ev) {
       run.stage = ev.stage;
       run.readout = STAGE_READOUT[ev.stage] ?? ev.stage;
       if (ev.stage !== "approach") run.track = null;
-      if (ev.stage !== "align") run.wristSeen = run.wristTrack = null; // the arm moves on, the view with it
+      if (ev.stage !== "align") run.wristSeen = run.wristTrack = run.descent = null; // the arm moves on, the view with it
       if (ev.stage === "verify") run.grasp = null;
       break;
     case "look":

--- a/webapp/js/teleop/targetingOverlay.js
+++ b/webapp/js/teleop/targetingOverlay.js
@@ -30,10 +30,19 @@ const DEFAULT_FRAME = { w: 640, h: 480 };
 /** @typedef {{ cu: number, cv: number, hu: number, hv: number, au: number, av: number }} PickBox */
 /** @typedef {{ left: number, top: number, width: number, height: number }} Rect */
 /**
- * The stream as laid out on the page: intrinsic size, the video element's box
- * within the stage, and how object-fit places the picture in that box.
- * @typedef {{ w: number, h: number, box: Rect, fit: string }} VideoLayout
+ * The stream as laid out on the page: intrinsic size, the video element's
+ * content box within the stage, and how object-fit / object-position place the
+ * picture in that box (position as the computed "x y" string).
+ * @typedef {{ w: number, h: number, box: Rect, fit: string, position: string }} VideoLayout
  */
+
+/** One object-position component -> where the picture's slack goes.
+ * @param {string} term "50%" or "12px" @param {number} slack box minus picture */
+function positionOffset(term, slack) {
+  if (term.endsWith("%")) return (slack * parseFloat(term)) / 100;
+  if (term.endsWith("px")) return parseFloat(term);
+  return slack / 2;
+}
 /**
  * One run of a skill, as the overlay understands it.
  * @typedef {{
@@ -76,7 +85,13 @@ export function frameRect(frame, video, cw, ch) {
     else if (fit !== "fill") sx = sy = Math.min(sx, sy);
     const width = w * sx;
     const height = h * sy;
-    return { left: box.left + (box.width - width) / 2, top: box.top + (box.height - height) / 2, width, height };
+    const [px = "50%", py = "50%"] = (video.position || "").split(/\s+/);
+    return {
+      left: box.left + positionOffset(px, box.width - width),
+      top: box.top + positionOffset(py, box.height - height),
+      width,
+      height,
+    };
   }
   const sy = ch / frame.h;
   const sx = sy * (SIM_LENS.fy / SIM_LENS.fx);
@@ -317,11 +332,19 @@ export function createTargetingOverlay(stage, video, ros, session) {
     if (!video) return null;
     const s = stage.getBoundingClientRect();
     const v = video.getBoundingClientRect();
+    const style = getComputedStyle(video);
+    // object-fit lays the picture out in the content box, inside any border.
     return {
       w: video.videoWidth,
       h: video.videoHeight,
-      box: { left: v.left - s.left, top: v.top - s.top, width: v.width, height: v.height },
-      fit: getComputedStyle(video).objectFit || "contain",
+      box: {
+        left: v.left - s.left + video.clientLeft,
+        top: v.top - s.top + video.clientTop,
+        width: video.clientWidth,
+        height: video.clientHeight,
+      },
+      fit: style.objectFit || "contain",
+      position: style.objectPosition || "50% 50%",
     };
   }
 

--- a/webapp/js/teleop/trajectoryOverlay.js
+++ b/webapp/js/teleop/trajectoryOverlay.js
@@ -278,7 +278,7 @@ export function ribbon(pts, vw, bottomY, anchorBottom = true) {
 /** SimSession names the primary camera with a bare string, WebRtcSession with
  * an {index, name} pair — both call the head camera "main".
  * @param {any} session @returns {string | undefined} */
-function primaryCameraName(session) {
+export function primaryCameraName(session) {
   const cam = session.primaryCamera;
   return typeof cam === "string" ? cam : cam?.name;
 }

--- a/workspace/innate_skills/approach.py
+++ b/workspace/innate_skills/approach.py
@@ -9,7 +9,7 @@ target touches the floor), so pick and drop share one hardware-tuned approach.
 import math
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from innate import gemini as gemlib
 from innate import vision
@@ -17,7 +17,7 @@ from innate.exceptions import SkillFailed
 from innate.geometry import FX, FY, HEAD_ORIGIN, IMG_H, IMG_W, floor_to_pixel, pixel_to_floor
 
 if TYPE_CHECKING:
-    from innate import MainImage, Mobility, Odometry
+    from innate import MainImage, Mobility, Odometry, Overlay
     from innate_proxy import ProxyClient
 
 Pixel = tuple[float, float]
@@ -45,7 +45,8 @@ class ApproachHost(Protocol):
     def name(self) -> str: ...
     def sleep(self, seconds: float) -> None: ...
     def say(self, text: str, wait: bool = False) -> None: ...
-    def telemetry(self, event: str, **fields: Any) -> None: ...
+    @property
+    def overlay(self) -> "Overlay": ...
 
 
 APPROACH_PARAMS = {
@@ -78,8 +79,6 @@ APPROACH_PARAMS = {
 }
 
 FOLLOW_TIMEOUT_S = 20.0
-# The webapp glides its tracking marker between events; more only floods rosbridge.
-TRACK_TELEMETRY_S = 0.1
 # How far past the park the dead-reckoned target may come before the drive
 # stops: a target filling the frame reads a stable "2 cm short" even with the
 # bumper against it, so only odometry can bound the endgame.
@@ -138,6 +137,10 @@ def inside_box(px, cu, cv, half_u, half_v=None):
     return abs(px[0] - cu) <= half_u and abs(px[1] - cv) <= (half_u if half_v is None else half_v)
 
 
+def metres(m: float) -> str:
+    return f"{m:.2f} m" if m >= 1 else f"{round(m * 100)} cm"
+
+
 class FloorApproach:
     """Head-camera localize + base servo for one run of a hosting skill."""
 
@@ -169,7 +172,7 @@ class FloorApproach:
 
     def search(self, prompt):
         """Scan: straight, right 30°, left 60°. First hit wins. (+yaw=left)"""
-        self.host.telemetry("stage", stage="search", prompt=prompt)
+        self.host.overlay.stage("search")
         for i, turn in enumerate((0.0, -math.radians(30), math.radians(60))):
             if turn:
                 if i == 1:
@@ -188,8 +191,13 @@ class FloorApproach:
     def odom_xyt(self):
         return self.host.mobility.odom_xyt(self.host.odom)
 
+    def _moving(self, what):
+        """The picture is about to change under every head-camera marker."""
+        self.host.overlay.clear(view="main")
+        self.host.overlay.readout(what)
+
     def rotate_by(self, angle):
-        self.host.telemetry("move", kind="rotate", amount=angle)
+        self._moving(f"turning {round(abs(math.degrees(angle)))}° {'left' if angle >= 0 else 'right'}")
         return self.host.mobility.rotate_by(
             self.odom_xyt,
             angle,
@@ -201,7 +209,7 @@ class FloorApproach:
         )
 
     def drive(self, dist):
-        self.host.telemetry("move", kind="drive", amount=dist)
+        self._moving(f"{'driving' if dist >= 0 else 'backing up'} {metres(abs(dist))}")
         return self.host.mobility.drive(
             self.odom_xyt,
             dist,
@@ -214,13 +222,6 @@ class FloorApproach:
 
     # --- position the base ---
 
-    def _box_centre(self):
-        """The park's head-camera pixel, or None when the tuning puts it off-image."""
-        c = floor_to_pixel(self.p["sweet_x"], self.p["box_y"], self.p["tilt_deg"])
-        if c is None or not (0 <= c[0] < IMG_W and 0 <= c[1] < IMG_H):
-            return None
-        return (c[0], c[1])
-
     def _sweet_box(self):
         """(centre, (hold_u, hold_v), (accept_u, accept_v)). Two boxes because
         two things measure the park: `accept` is the flow servo's deadband,
@@ -229,22 +230,30 @@ class FloorApproach:
         whose box edge jitters tens of pixels cannot resolve millimetres.
         Two axes as well: near the park one image row is ~cm of RANGE but
         sub-mm of bearing, so one tolerance cannot serve both."""
-        c = self._box_centre()
-        if c is None:
+        c = floor_to_pixel(self.p["sweet_x"], self.p["box_y"], self.p["tilt_deg"])
+        if c is None or not (0 <= c[0] < IMG_W and 0 <= c[1] < IMG_H):
             raise SkillFailed("approach box off-image — check tilt_deg/sweet_x")
         hu, hv = self.p["box_half_px"], self.p["box_half_v_px"]
         hold, accept = self.p["hold_frac"], self.p["accept_frac"]
-        return c, (hu * hold, hv * hold), (hu * accept, hv * accept)
+        return (c[0], c[1]), (hu * hold, hv * hold), (hu * accept, hv * accept)
 
-    def box(self):
-        """The pick box for a UI to draw: centre, outer half-extents and the
-        accept deadband, head-camera px; None when off-image."""
-        c = self._box_centre()
-        if c is None:
-            return None
+    def _draw_track(self, px, cu, cv, inside):
+        ui = self.host.overlay
         hu, hv = self.p["box_half_px"], self.p["box_half_v_px"]
-        accept = self.p["accept_frac"]
-        return {"cu": c[0], "cv": c[1], "hu": hu, "hv": hv, "au": hu * accept, "av": hv * accept}
+        ui.box(
+            "pick-box",
+            (cu - hu, cv - hv, cu + hu, cv + hv),
+            inner=self.p["accept_frac"],
+            label="pick box",
+            locked=inside,
+        )
+        ui.point("track", px, label="tracking", locked=inside)
+        if inside:
+            ui.clear("steer")
+            ui.readout("in the pick box")
+        else:
+            ui.vector("steer", px, (cu, cv))
+            ui.readout("steering onto it")
 
     def _follow_into_box(self, seed_px, max_forward=None):
         """Optical-flow base servo into the sweet box. No Gemini.
@@ -258,9 +267,8 @@ class FloorApproach:
         grid = vision.grid_pts(u, v)
         in_box = 0
         (cu, cv), _half, accept = self._sweet_box()
-        box = self.box()  # rides every track event so a UI joining mid-run gets the box too
+        self.host.overlay.clear("target")
         t0 = time.monotonic()
-        last_told = 0.0
         anchor, anchor_odo = (u, v), self.odom_xyt()
         seg_start = anchor_odo
         while time.monotonic() - t0 < FOLLOW_TIMEOUT_S:
@@ -290,9 +298,7 @@ class FloorApproach:
                 return "lost", None
 
             inside = inside_box((u, v), cu, cv, accept[0], accept[1])
-            if inside or time.monotonic() - last_told >= TRACK_TELEMETRY_S:
-                last_told = time.monotonic()
-                self.host.telemetry("track", px=(u, v), inside=inside, box=box)
+            self._draw_track((u, v), cu, cv, inside)
             if inside:
                 in_box += 1
                 self.host.mobility.stop()
@@ -342,7 +348,7 @@ class FloorApproach:
     def position_above(self, prompt, xy):
         """Flow-follow into the sweet box; Gemini reseed/confirm. Stepwise if
         no cam. Raises SkillFailed if the target cannot be centred."""
-        self.host.telemetry("stage", stage="approach", prompt=prompt)
+        self.host.overlay.stage("approach")
         if not self.host.main_image:
             return self._position_stepwise(prompt, xy)
 

--- a/workspace/innate_skills/approach.py
+++ b/workspace/innate_skills/approach.py
@@ -169,7 +169,7 @@ class FloorApproach:
 
     def search(self, prompt):
         """Scan: straight, right 30°, left 60°. First hit wins. (+yaw=left)"""
-        self.host.telemetry("stage", stage="search")
+        self.host.telemetry("stage", stage="search", prompt=prompt)
         for i, turn in enumerate((0.0, -math.radians(30), math.radians(60))):
             if turn:
                 if i == 1:
@@ -258,6 +258,7 @@ class FloorApproach:
         grid = vision.grid_pts(u, v)
         in_box = 0
         (cu, cv), _half, accept = self._sweet_box()
+        box = self.box()  # rides every track event so a UI joining mid-run gets the box too
         t0 = time.monotonic()
         last_told = 0.0
         anchor, anchor_odo = (u, v), self.odom_xyt()
@@ -291,7 +292,7 @@ class FloorApproach:
             inside = inside_box((u, v), cu, cv, accept[0], accept[1])
             if inside or time.monotonic() - last_told >= TRACK_TELEMETRY_S:
                 last_told = time.monotonic()
-                self.host.telemetry("track", px=(u, v), inside=inside)
+                self.host.telemetry("track", px=(u, v), inside=inside, box=box)
             if inside:
                 in_box += 1
                 self.host.mobility.stop()
@@ -341,7 +342,7 @@ class FloorApproach:
     def position_above(self, prompt, xy):
         """Flow-follow into the sweet box; Gemini reseed/confirm. Stepwise if
         no cam. Raises SkillFailed if the target cannot be centred."""
-        self.host.telemetry("stage", stage="approach")
+        self.host.telemetry("stage", stage="approach", prompt=prompt)
         if not self.host.main_image:
             return self._position_stepwise(prompt, xy)
 

--- a/workspace/innate_skills/approach.py
+++ b/workspace/innate_skills/approach.py
@@ -9,7 +9,7 @@ target touches the floor), so pick and drop share one hardware-tuned approach.
 import math
 import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from innate import gemini as gemlib
 from innate import vision
@@ -45,6 +45,7 @@ class ApproachHost(Protocol):
     def name(self) -> str: ...
     def sleep(self, seconds: float) -> None: ...
     def say(self, text: str, wait: bool = False) -> None: ...
+    def telemetry(self, event: str, **fields: Any) -> None: ...
 
 
 APPROACH_PARAMS = {
@@ -77,6 +78,8 @@ APPROACH_PARAMS = {
 }
 
 FOLLOW_TIMEOUT_S = 20.0
+# The webapp glides its tracking marker between events; more only floods rosbridge.
+TRACK_TELEMETRY_S = 0.1
 # How far past the park the dead-reckoned target may come before the drive
 # stops: a target filling the frame reads a stable "2 cm short" even with the
 # bumper against it, so only odometry can bound the endgame.
@@ -166,6 +169,7 @@ class FloorApproach:
 
     def search(self, prompt):
         """Scan: straight, right 30°, left 60°. First hit wins. (+yaw=left)"""
+        self.host.telemetry("stage", stage="search")
         for i, turn in enumerate((0.0, -math.radians(30), math.radians(60))):
             if turn:
                 if i == 1:
@@ -185,6 +189,7 @@ class FloorApproach:
         return self.host.mobility.odom_xyt(self.host.odom)
 
     def rotate_by(self, angle):
+        self.host.telemetry("move", kind="rotate", amount=angle)
         return self.host.mobility.rotate_by(
             self.odom_xyt,
             angle,
@@ -196,6 +201,7 @@ class FloorApproach:
         )
 
     def drive(self, dist):
+        self.host.telemetry("move", kind="drive", amount=dist)
         return self.host.mobility.drive(
             self.odom_xyt,
             dist,
@@ -208,6 +214,13 @@ class FloorApproach:
 
     # --- position the base ---
 
+    def _box_centre(self):
+        """The park's head-camera pixel, or None when the tuning puts it off-image."""
+        c = floor_to_pixel(self.p["sweet_x"], self.p["box_y"], self.p["tilt_deg"])
+        if c is None or not (0 <= c[0] < IMG_W and 0 <= c[1] < IMG_H):
+            return None
+        return (c[0], c[1])
+
     def _sweet_box(self):
         """(centre, (hold_u, hold_v), (accept_u, accept_v)). Two boxes because
         two things measure the park: `accept` is the flow servo's deadband,
@@ -216,12 +229,22 @@ class FloorApproach:
         whose box edge jitters tens of pixels cannot resolve millimetres.
         Two axes as well: near the park one image row is ~cm of RANGE but
         sub-mm of bearing, so one tolerance cannot serve both."""
-        c = floor_to_pixel(self.p["sweet_x"], self.p["box_y"], self.p["tilt_deg"])
-        if c is None or not (0 <= c[0] < IMG_W and 0 <= c[1] < IMG_H):
+        c = self._box_centre()
+        if c is None:
             raise SkillFailed("approach box off-image — check tilt_deg/sweet_x")
         hu, hv = self.p["box_half_px"], self.p["box_half_v_px"]
         hold, accept = self.p["hold_frac"], self.p["accept_frac"]
-        return (c[0], c[1]), (hu * hold, hv * hold), (hu * accept, hv * accept)
+        return c, (hu * hold, hv * hold), (hu * accept, hv * accept)
+
+    def box(self):
+        """The pick box for a UI to draw: centre, outer half-extents and the
+        accept deadband, head-camera px; None when off-image."""
+        c = self._box_centre()
+        if c is None:
+            return None
+        hu, hv = self.p["box_half_px"], self.p["box_half_v_px"]
+        accept = self.p["accept_frac"]
+        return {"cu": c[0], "cv": c[1], "hu": hu, "hv": hv, "au": hu * accept, "av": hv * accept}
 
     def _follow_into_box(self, seed_px, max_forward=None):
         """Optical-flow base servo into the sweet box. No Gemini.
@@ -236,6 +259,7 @@ class FloorApproach:
         in_box = 0
         (cu, cv), _half, accept = self._sweet_box()
         t0 = time.monotonic()
+        last_told = 0.0
         anchor, anchor_odo = (u, v), self.odom_xyt()
         seg_start = anchor_odo
         while time.monotonic() - t0 < FOLLOW_TIMEOUT_S:
@@ -264,7 +288,11 @@ class FloorApproach:
                 self.host.mobility.stop()
                 return "lost", None
 
-            if inside_box((u, v), cu, cv, accept[0], accept[1]):
+            inside = inside_box((u, v), cu, cv, accept[0], accept[1])
+            if inside or time.monotonic() - last_told >= TRACK_TELEMETRY_S:
+                last_told = time.monotonic()
+                self.host.telemetry("track", px=(u, v), inside=inside)
+            if inside:
                 in_box += 1
                 self.host.mobility.stop()
                 anchor, anchor_odo = (u, v), self.odom_xyt()
@@ -313,6 +341,7 @@ class FloorApproach:
     def position_above(self, prompt, xy):
         """Flow-follow into the sweet box; Gemini reseed/confirm. Stepwise if
         no cam. Raises SkillFailed if the target cannot be centred."""
+        self.host.telemetry("stage", stage="approach")
         if not self.host.main_image:
             return self._position_stepwise(prompt, xy)
 

--- a/workspace/innate_skills/drop_in_box.py
+++ b/workspace/innate_skills/drop_in_box.py
@@ -145,6 +145,7 @@ class DropInBox(Skill):
         """Head frame -> the container's near floor-contact pixel, or None.
         Bottom edge midpoint, NOT the centre: a point at rim height
         back-projects far past the box (a 0.15 m rim at 0.6 m reads 0.88)."""
+        self.overlay.readout("looking for it", busy=True)
         text, img = ask_head(
             self,
             self._proxy,
@@ -162,13 +163,27 @@ class DropInBox(Skill):
         self._near_rim_v = _near_rim_v(text)
         if box is None:
             self._box_u = self._box_top_v = None
+            self.overlay.clear("target", "rim")
+            self.overlay.readout("not in view")
             return None
         x, y, w, h = box
+        self._draw_container((x, y, x + w, y + h))
         self._box_u = min(float(IMG_W - 1), x + w / 2.0)
         self._box_top_v = float(y)
         px = (self._box_u, min(float(IMG_H - 1), float(y + h)))
         self._measure_rim(px)
         return self._park_if_clipped(px, float(y + h))
+
+    def _draw_container(self, corners: tuple[float, float, float, float]) -> None:
+        """The container's box and the near rim the gripper will reach over."""
+        ui = self.overlay
+        ui.clear("track", "steer")
+        ui.bracket("target", corners, label="container")
+        if self._near_rim_v is None:
+            ui.clear("rim")
+        else:
+            ui.line("rim", (corners[0], self._near_rim_v), (corners[2], self._near_rim_v))
+        ui.readout("spotted")
 
     def _park_if_clipped(self, px: tuple[float, float], contact_v: float) -> tuple[float, float]:
         """A floor-contact row at or past the frame bottom means the container
@@ -300,6 +315,8 @@ class DropInBox(Skill):
         z = rim + p["release_clear_m"]
         x, y = self.manipulation.clamp_reach(self._release_x(near_x, z), near_y)
 
+        self.overlay.stage("release")
+        self.overlay.readout(f"reaching over the rim · {round(z * 100)} cm up")
         self.manipulation.torque_on()
         self._lift_clear(y)
         try:
@@ -317,9 +334,11 @@ class DropInBox(Skill):
         self._over_rim = True
 
         self.check_cancelled()  # last exit before the object leaves the claw
+        self.overlay.readout("opening the gripper")
         self.manipulation.gripper_open(duration=1.0)
         self._released = True
         self.sleep(p["release_settle_s"])
+        self.overlay.readout("lifting out")
         # Out of the container BEFORE anything drives: the verification backs
         # the base up 0.15 m, and doing that with the claw still hooked over
         # the rim drags the container along with it.
@@ -357,6 +376,7 @@ class DropInBox(Skill):
 
     def _landed(self, prompt: str, approach: FloorApproach) -> bool:
         """Back up, then look for evidence the object did NOT go in."""
+        self.overlay.stage("verify")
         approach.drive(-VERIFY_BACKUP_M)
         self.sleep(self._p["settle_s"])
         main_img, wrist_img = self.main_image, self.wrist_image
@@ -385,6 +405,7 @@ class DropInBox(Skill):
         )
         missed = _yes_no(text)
         self.logger.info(f"[DropInBox] landed: reply={text!r} -> {missed is not True}")
+        self.overlay.readout("still outside" if missed else "in the box")
         # No usable verdict is not a failure: the claw is open and the object
         # is no longer held, which is as much as this skill promised.
         return missed is not True
@@ -415,9 +436,11 @@ class DropInBox(Skill):
 
             self._carry_pose(self._p["travel_joints"])
             approach = FloorApproach(self, self._p, self._detect_px)
+            self.overlay.begin(prompt, stages=["search", "approach", "release", "verify"], frame=(IMG_W, IMG_H))
             self.say(f"Looking for {prompt}.")
             xy = approach.search(prompt)
             xy = approach.position_above(prompt, xy)
+            self.overlay.readout("parked at the rim")
             self.say("Dropping it in.")
             _x, _y, released_z = self._release_at(xy[0], xy[1])
 

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -9,6 +9,7 @@ No depth camera — URDF + pinhole model.
 
 import math
 import re
+import sys
 import time
 
 from innate_skills.approach import APPROACH_PARAMS, FloorApproach, ask_head, base_to_odom, inside_box
@@ -29,7 +30,7 @@ from innate import (
 )
 from innate import gemini as gemlib
 from innate.exceptions import ArmFailed, ArmUnhealthy, SkillFailed
-from innate.geometry import pixel_to_floor
+from innate.geometry import IMG_H, IMG_W, floor_to_pixel, pixel_to_floor
 
 GRIPPER_EMPTY_J6 = -0.085
 VERIFY_BACKUP_M = 0.15
@@ -104,6 +105,7 @@ WRIST_ALIGN_TIMEOUT_S = 60.0
 WRIST_MAX_JUMP_PX = 80.0
 WRIST_SEG_MIN_SCORE = 25.0
 WRIST_CAM_ABOVE_EE = 0.07
+WRIST_TELEMETRY_S = 0.1
 # Wrist roll to the blob's minor axis (the gripper's 81 mm jaw is narrower
 # than most objects' long side). Blobs rounder than MIN_ELONGATION have no
 # axis worth chasing; below AXIS_MIN_Z the fingers straddle the blob in the
@@ -244,6 +246,7 @@ class PickAnyObject(Skill):
     def _detect_px(self, prompt):
         """Head frame -> grasp pixel of the remembered target, or None. Also
         records Gemini's per-object grip_strength for the close."""
+        self.telemetry("look", state="ask")
         text, img = ask_head(
             self,
             self._proxy,
@@ -265,14 +268,16 @@ class PickAnyObject(Skill):
         cands = vision.parse_det_cands(text)
         cand = self._choose_cand(cands) if cands else None
         if cand is None:
+            self.telemetry("look", state="miss", n=len(cands))
             return None
-        u, v, grip = cand
+        u, v, grip, box = cand
         if grip is not None:
             lo, hi = GRIP_STRENGTH_RANGE
             self._grip_strength = max(lo, min(hi, grip))
         seen = self._sighting(cand)
         if seen is not None:
             self._last_seen = seen
+        self.telemetry("look", state="seen", px=(u, v), box=box, dist=seen[2] if seen else None, n=len(cands))
         return (u, v)
 
     def _rest_arm(self, keep_grip):
@@ -312,6 +317,7 @@ class PickAnyObject(Skill):
         # identical twins the box nearest the servo aim point is ours.
         box = min(boxes, key=self._wrist_aim_dist) if boxes else None
         px = (box[0] + box[2] / 2.0, box[1] + box[3] / 2.0) if box else None
+        self.telemetry("wrist", state="seed", px=px)
         return px, box
 
     def _wrist_aim_dist(self, box):
@@ -341,6 +347,7 @@ class PickAnyObject(Skill):
     ) -> tuple[float, float, float, float]:
         roll = self._grasp_roll(axis)
         self.logger.info(f"[PickAnyObject] wrist stage: {reason} (z={z:.3f}, roll={math.degrees(roll):+.0f} deg)")
+        self.telemetry("wrist", state="done", reason=reason, z=z, roll=roll)
         return x, y, z, roll
 
     @staticmethod
@@ -398,6 +405,7 @@ class PickAnyObject(Skill):
             return self._wrist_done(tx, ty, z, "not seen")
 
         deadline = time.monotonic() + WRIST_ALIGN_TIMEOUT_S
+        last_told = 0.0
         axis = None  # last blob axis read high enough to trust
         streak = 0  # verified matches since the arm last moved
         centered = 0  # consecutive matches INSIDE the box
@@ -437,6 +445,9 @@ class PickAnyObject(Skill):
             err_u = px[0] - p["wrist_box_u"]
             err_v = px[1] - p["wrist_box_v"]
             inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
+            if time.monotonic() - last_told >= WRIST_TELEMETRY_S:
+                last_told = time.monotonic()
+                self.telemetry("wrist", state="track", px=px, z=z, stop=p["wrist_stop_z"], inside=inside)
             centered = centered + 1 if inside else 0
             if streak < 2:
                 continue  # watch one more frame before trusting it
@@ -514,6 +525,7 @@ class PickAnyObject(Skill):
         Contact just stalls the final segments; abort if still high."""
         p = self._p
         self.check_cancelled()
+        self.telemetry("grasp", step="descend")
         rungs = [z for z in (p["descend_z1"], p["descend_z2"], p["descend_z3"], p["floor_z"]) if z < z_from - 1e-6]
         if rungs:
             # grip=GRIPPER_OPEN re-asserts an open claw even if it drifted
@@ -578,6 +590,7 @@ class PickAnyObject(Skill):
         # in the twist/lift below (e.g. ArmUnhealthy from the LookupError
         # fallback) must not release a just-grasped object on the way home.
         self._holding = True
+        self.telemetry("grasp", step="lift")
         time.sleep(p["close_settle_s"])
 
         grip = -p["close_strength"]
@@ -619,31 +632,41 @@ class PickAnyObject(Skill):
                 x, y, 0.22, roll=roll, pitch=p["arm_pitch"], yaw=yaw, duration=2.0, tolerance_xy=0.10
             )
 
+    def _aim(self, x: float, y: float) -> None:
+        """Tell the UI where the fingers will close: base xy and its head-camera pixel."""
+        self.telemetry("grasp", step="target", xy=(x, y), px=floor_to_pixel(x, y, self._p["tilt_deg"]))
+
     def _grasp_at(self, prompt, xy):
         """Full grasp at floor xy (base_link)."""
         p = self._p
         x, y = self.manipulation.clamp_reach(xy[0] - p["grasp_x_off"], xy[1])
+        self._aim(x, y)
 
         self.manipulation.torque_on()
         # gripper_open reboots + retries a tripped servo, raising ArmUnhealthy
         # if the claw stays shut.
         self.manipulation.gripper_open(duration=1.0)
         if p["wrist_steps"] >= 1:
+            self.telemetry("stage", stage="align")
             self._goto_search_pose(math.atan2(y, x))
             x, y, z, roll = self._wrist_descend(prompt, x, y)
+            self._aim(x, y)
         else:
             z, roll = p["hover_z"], 0.0
             self.manipulation.move_to(x, y, z, pitch=p["arm_pitch"], duration=p["hover_s"])
 
+        self.telemetry("stage", stage="grasp")
         roll, pitch, yaw = self._grasp_orientation(x, y, roll)
         self._push_to_floor(x, y, z, roll, pitch, yaw)
         self.check_cancelled()  # last exit before the fingers commit
+        self.telemetry("grasp", step="close")
         self._close_twist_lift(x, y, roll, pitch, yaw)
 
     def _grasp_verified(self, prompt, approach: FloorApproach):
         """Back up, then check floor clear + gripper not open. Gemini gets both
         cameras: the wrist view can show the object in the fingers, so a held
         object isn't mistaken for a dropped one."""
+        self.telemetry("stage", stage="verify")
         approach.drive(-VERIFY_BACKUP_M)
         self.sleep(self._p["settle_s"])
         js = self.joint_states
@@ -700,7 +723,12 @@ class PickAnyObject(Skill):
             f"[PickAnyObject] verify: floor={floor_text!r} j6={j6} "
             f"({len(images)} cams) -> {'HELD' if held else 'NOT HELD'}"
         )
+        self.telemetry("verify", held=held)
         return held
+
+    def _stages(self) -> list[str]:
+        align = ["align"] if self._p["wrist_steps"] >= 1 else []
+        return ["search", "approach", *align, "grasp", "verify"]
 
     def execute(self, prompt: str = "the sock") -> SkillReturn:
         """Pick up `prompt` from the floor."""
@@ -712,6 +740,7 @@ class PickAnyObject(Skill):
         self._holding = False
         self._last_seen = None
         self._coasts = 0
+        picked = False
         try:
             self.head.set_position(int(round(self._p["tilt_deg"])))
             # Fold clear of the head camera before searching
@@ -719,9 +748,13 @@ class PickAnyObject(Skill):
             self.manipulation.move_joints(NAV_ARM, duration=3.0)
 
             approach = FloorApproach(self, self._p, self._detect_px)
+            self.telemetry(
+                "run", state="start", prompt=prompt, frame=(IMG_W, IMG_H), box=approach.box(), stages=self._stages()
+            )
             self.say(f"Looking for {prompt}.")
             xy = approach.search(prompt)
             xy = approach.position_above(prompt, xy)
+            self.telemetry("parked", xy=xy)
             self.say("Picking it up.")
             self._grasp_at(prompt, xy)
             # _close_twist_lift latched self._holding the moment the fingers
@@ -731,6 +764,7 @@ class PickAnyObject(Skill):
                 self.say("I couldn't get a grip on it.")
                 raise SkillFailed(f"Grasp missed — '{prompt}' is still on the floor (verified after backing up)")
             self.say("Got it.")
+            picked = True
             return f"Picked up '{prompt}' (verified: floor clear after backing up)"
         except ArmFailed as e:
             # A clean arm give-up is a skill failure, not a crash. SkillFailed
@@ -743,3 +777,7 @@ class PickAnyObject(Skill):
             self.mobility.stop()
             self._rest_arm(keep_grip=self._holding)
             self.head.set_position(0)
+            # Inside finally the in-flight exception is still the handled one,
+            # so this reads the failure the run is ending on.
+            error = sys.exc_info()[1]
+            self.telemetry("run", state="end", ok=picked, cancelled=self.cancelled, reason=str(error or ""))

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -9,10 +9,9 @@ No depth camera — URDF + pinhole model.
 
 import math
 import re
-import sys
 import time
 
-from innate_skills.approach import APPROACH_PARAMS, FloorApproach, ask_head, base_to_odom, inside_box
+from innate_skills.approach import APPROACH_PARAMS, FloorApproach, ask_head, base_to_odom, inside_box, metres
 
 from innate import (
     Head,
@@ -105,7 +104,8 @@ WRIST_ALIGN_TIMEOUT_S = 60.0
 WRIST_MAX_JUMP_PX = 80.0
 WRIST_SEG_MIN_SCORE = 25.0
 WRIST_CAM_ABOVE_EE = 0.07
-WRIST_TELEMETRY_S = 0.1
+# Half-length of the blob's drawn long axis, wrist-image px.
+AXIS_HALF_PX = 45
 # Wrist roll to the blob's minor axis (the gripper's 81 mm jaw is narrower
 # than most objects' long side). Blobs rounder than MIN_ELONGATION have no
 # axis worth chasing; below AXIS_MIN_Z the fingers straddle the blob in the
@@ -246,7 +246,7 @@ class PickAnyObject(Skill):
     def _detect_px(self, prompt):
         """Head frame -> grasp pixel of the remembered target, or None. Also
         records Gemini's per-object grip_strength for the close."""
-        self.telemetry("look", state="ask")
+        self.overlay.readout("looking for it", busy=True)
         text, img = ask_head(
             self,
             self._proxy,
@@ -268,7 +268,8 @@ class PickAnyObject(Skill):
         cands = vision.parse_det_cands(text)
         cand = self._choose_cand(cands) if cands else None
         if cand is None:
-            self.telemetry("look", state="miss", n=len(cands))
+            self.overlay.clear("target")
+            self.overlay.readout("not in view")
             return None
         u, v, grip, box = cand
         if grip is not None:
@@ -277,8 +278,16 @@ class PickAnyObject(Skill):
         seen = self._sighting(cand)
         if seen is not None:
             self._last_seen = seen
-        self.telemetry("look", state="seen", px=(u, v), box=box, dist=seen[2] if seen else None, n=len(cands))
+        self._draw_sighting((u, v), box, seen[2] if seen else None, len(cands))
         return (u, v)
+
+    def _draw_sighting(self, px, box, dist, n):
+        ui = self.overlay
+        ui.clear("track", "steer")
+        ui.bracket("target", box or (px[0] - 20, px[1] - 20, px[0] + 20, px[1] + 20), label="target")
+        ahead = f" · {metres(dist)} ahead" if dist is not None else ""
+        matches = f" · {n} matches" if n > 1 else ""
+        ui.readout(f"spotted{ahead}{matches}")
 
     def _rest_arm(self, keep_grip):
         """Best-effort teardown: carry if holding, else fold to rest. Never
@@ -317,8 +326,12 @@ class PickAnyObject(Skill):
         # identical twins the box nearest the servo aim point is ours.
         box = min(boxes, key=self._wrist_aim_dist) if boxes else None
         px = (box[0] + box[2] / 2.0, box[1] + box[3] / 2.0) if box else None
-        corners = (box[0], box[1], box[0] + box[2], box[1] + box[3]) if box else None
-        self.telemetry("wrist", state="seed", px=px, box=corners)
+        if box:
+            corners = (box[0], box[1], box[0] + box[2], box[1] + box[3])
+            self.overlay.bracket("wrist-target", corners, label="wrist target", view="arm")
+            self.overlay.readout("wrist camera has it")
+        else:
+            self.overlay.readout("wrist camera can't see it")
         return px, box
 
     def _wrist_aim_dist(self, box):
@@ -348,8 +361,29 @@ class PickAnyObject(Skill):
     ) -> tuple[float, float, float, float]:
         roll = self._grasp_roll(axis)
         self.logger.info(f"[PickAnyObject] wrist stage: {reason} (z={z:.3f}, roll={math.degrees(roll):+.0f} deg)")
-        self.telemetry("wrist", state="done", reason=reason, z=z, roll=roll)
+        self.overlay.readout(f"wrist align: {reason}")
         return x, y, z, roll
+
+    def _draw_wrist(self, px, inside, z, top, blob):
+        """The servo box, the tracked blob with its long axis, and the descent."""
+        p = self._p
+        ui = self.overlay
+        u, v, half = p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"]
+        ui.clear("wrist-target")
+        ui.box("wrist-box", (u - half, v - half, u + half, v + half), label="wrist box", view="arm", locked=inside)
+        ui.point("blob", px, label="blob", view="arm", locked=inside)
+        if inside:
+            ui.clear("wrist-steer")
+        else:
+            ui.vector("wrist-steer", px, (u, v), view="arm")
+        if blob is not None and blob[1] >= MIN_ELONGATION:
+            du, dv = math.cos(blob[0]) * AXIS_HALF_PX, math.sin(blob[0]) * AXIS_HALF_PX
+            ui.line("axis", (px[0] - du, px[1] - dv), (px[0] + du, px[1] + dv), view="arm")
+        else:
+            ui.clear("axis")
+        span = top - p["wrist_stop_z"]
+        progress = min(1.0, max(0.0, (top - z) / span)) if span > 0 else 1.0
+        ui.readout(f"{'descending' if inside else 'centring'} · {round(z * 100)} cm up", progress=progress)
 
     @staticmethod
     def _grasp_roll(axis: vision.Axis | None) -> float:
@@ -406,7 +440,7 @@ class PickAnyObject(Skill):
             return self._wrist_done(tx, ty, z, "not seen")
 
         deadline = time.monotonic() + WRIST_ALIGN_TIMEOUT_S
-        last_told = 0.0
+        top = z
         axis = None  # last blob axis read high enough to trust
         streak = 0  # verified matches since the arm last moved
         centered = 0  # consecutive matches INSIDE the box
@@ -446,19 +480,7 @@ class PickAnyObject(Skill):
             err_u = px[0] - p["wrist_box_u"]
             err_v = px[1] - p["wrist_box_v"]
             inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
-            if time.monotonic() - last_told >= WRIST_TELEMETRY_S:
-                last_told = time.monotonic()
-                blob = tracker.axis
-                self.telemetry(
-                    "wrist",
-                    state="track",
-                    px=px,
-                    z=z,
-                    stop=p["wrist_stop_z"],
-                    inside=inside,
-                    box=self._wrist_box(),
-                    axis=blob[0] if blob is not None and blob[1] >= MIN_ELONGATION else None,
-                )
+            self._draw_wrist(px, inside, z, top, tracker.axis)
             centered = centered + 1 if inside else 0
             if streak < 2:
                 continue  # watch one more frame before trusting it
@@ -536,7 +558,7 @@ class PickAnyObject(Skill):
         Contact just stalls the final segments; abort if still high."""
         p = self._p
         self.check_cancelled()
-        self.telemetry("grasp", step="descend")
+        self.overlay.readout("reaching to the floor")
         rungs = [z for z in (p["descend_z1"], p["descend_z2"], p["descend_z3"], p["floor_z"]) if z < z_from - 1e-6]
         if rungs:
             # grip=GRIPPER_OPEN re-asserts an open claw even if it drifted
@@ -601,7 +623,7 @@ class PickAnyObject(Skill):
         # in the twist/lift below (e.g. ArmUnhealthy from the LookupError
         # fallback) must not release a just-grasped object on the way home.
         self._holding = True
-        self.telemetry("grasp", step="lift")
+        self.overlay.readout("lifting")
         time.sleep(p["close_settle_s"])
 
         grip = -p["close_strength"]
@@ -644,8 +666,10 @@ class PickAnyObject(Skill):
             )
 
     def _aim(self, x: float, y: float) -> None:
-        """Tell the UI where the fingers will close: base xy and its head-camera pixel."""
-        self.telemetry("grasp", step="target", xy=(x, y), px=floor_to_pixel(x, y, self._p["tilt_deg"]))
+        """Show where the fingers will close, on the head camera."""
+        px = floor_to_pixel(x, y, self._p["tilt_deg"])
+        if px is not None:
+            self.overlay.reticle("grasp", px, label="grasp")
 
     def _grasp_at(self, prompt, xy):
         """Full grasp at floor xy (base_link)."""
@@ -658,26 +682,29 @@ class PickAnyObject(Skill):
         # if the claw stays shut.
         self.manipulation.gripper_open(duration=1.0)
         if p["wrist_steps"] >= 1:
-            self.telemetry("stage", stage="align", prompt=prompt)
+            self.overlay.stage("align")
+            self.overlay.readout("aligning the wrist camera")
             self._goto_search_pose(math.atan2(y, x))
             x, y, z, roll = self._wrist_descend(prompt, x, y)
+            self.overlay.clear(view="arm")  # the arm moves on, the view with it
             self._aim(x, y)
         else:
             z, roll = p["hover_z"], 0.0
             self.manipulation.move_to(x, y, z, pitch=p["arm_pitch"], duration=p["hover_s"])
 
-        self.telemetry("stage", stage="grasp", prompt=prompt)
+        self.overlay.stage("grasp")
         roll, pitch, yaw = self._grasp_orientation(x, y, roll)
         self._push_to_floor(x, y, z, roll, pitch, yaw)
         self.check_cancelled()  # last exit before the fingers commit
-        self.telemetry("grasp", step="close")
+        self.overlay.readout("closing the gripper")
         self._close_twist_lift(x, y, roll, pitch, yaw)
 
     def _grasp_verified(self, prompt, approach: FloorApproach):
         """Back up, then check floor clear + gripper not open. Gemini gets both
         cameras: the wrist view can show the object in the fingers, so a held
         object isn't mistaken for a dropped one."""
-        self.telemetry("stage", stage="verify", prompt=prompt)
+        self.overlay.stage("verify")
+        self.overlay.clear("grasp")
         approach.drive(-VERIFY_BACKUP_M)
         self.sleep(self._p["settle_s"])
         js = self.joint_states
@@ -734,17 +761,12 @@ class PickAnyObject(Skill):
             f"[PickAnyObject] verify: floor={floor_text!r} j6={j6} "
             f"({len(images)} cams) -> {'HELD' if held else 'NOT HELD'}"
         )
-        self.telemetry("verify", held=held)
+        self.overlay.readout("holding it" if held else "missed it")
         return held
 
     def _stages(self) -> list[str]:
         align = ["align"] if self._p["wrist_steps"] >= 1 else []
         return ["search", "approach", *align, "grasp", "verify"]
-
-    def _wrist_box(self) -> dict[str, float]:
-        """The wrist servo's goal square for a UI, wrist-image px."""
-        p = self._p
-        return {"u": p["wrist_box_u"], "v": p["wrist_box_v"], "half": p["wrist_half_px"]}
 
     def execute(self, prompt: str = "the sock") -> SkillReturn:
         """Pick up `prompt` from the floor."""
@@ -756,7 +778,6 @@ class PickAnyObject(Skill):
         self._holding = False
         self._last_seen = None
         self._coasts = 0
-        picked = False
         try:
             self.head.set_position(int(round(self._p["tilt_deg"])))
             # Fold clear of the head camera before searching
@@ -764,19 +785,11 @@ class PickAnyObject(Skill):
             self.manipulation.move_joints(NAV_ARM, duration=3.0)
 
             approach = FloorApproach(self, self._p, self._detect_px)
-            self.telemetry(
-                "run",
-                state="start",
-                prompt=prompt,
-                frame=(IMG_W, IMG_H),
-                box=approach.box(),
-                wrist_box=self._wrist_box(),
-                stages=self._stages(),
-            )
+            self.overlay.begin(prompt, stages=self._stages(), frame=(IMG_W, IMG_H))
             self.say(f"Looking for {prompt}.")
             xy = approach.search(prompt)
             xy = approach.position_above(prompt, xy)
-            self.telemetry("parked", xy=xy)
+            self.overlay.readout("parked over it")
             self.say("Picking it up.")
             self._grasp_at(prompt, xy)
             # _close_twist_lift latched self._holding the moment the fingers
@@ -786,7 +799,6 @@ class PickAnyObject(Skill):
                 self.say("I couldn't get a grip on it.")
                 raise SkillFailed(f"Grasp missed — '{prompt}' is still on the floor (verified after backing up)")
             self.say("Got it.")
-            picked = True
             return f"Picked up '{prompt}' (verified: floor clear after backing up)"
         except ArmFailed as e:
             # A clean arm give-up is a skill failure, not a crash. SkillFailed
@@ -799,7 +811,3 @@ class PickAnyObject(Skill):
             self.mobility.stop()
             self._rest_arm(keep_grip=self._holding)
             self.head.set_position(0)
-            # Inside finally the in-flight exception is still the handled one,
-            # so this reads the failure the run is ending on.
-            error = sys.exc_info()[1]
-            self.telemetry("run", state="end", ok=picked, cancelled=self.cancelled, reason=str(error or ""))

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -265,7 +265,7 @@ class PickAnyObject(Skill):
             "Empty list if not present.",
             self._p["settle_s"],
         )
-        cands = vision.parse_det_cands(text)
+        cands = vision.parse_det_cands_boxed(text)
         cand = self._choose_cand(cands) if cands else None
         if cand is None:
             self.overlay.clear("target")

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -647,7 +647,7 @@ class PickAnyObject(Skill):
         # if the claw stays shut.
         self.manipulation.gripper_open(duration=1.0)
         if p["wrist_steps"] >= 1:
-            self.telemetry("stage", stage="align")
+            self.telemetry("stage", stage="align", prompt=prompt)
             self._goto_search_pose(math.atan2(y, x))
             x, y, z, roll = self._wrist_descend(prompt, x, y)
             self._aim(x, y)
@@ -655,7 +655,7 @@ class PickAnyObject(Skill):
             z, roll = p["hover_z"], 0.0
             self.manipulation.move_to(x, y, z, pitch=p["arm_pitch"], duration=p["hover_s"])
 
-        self.telemetry("stage", stage="grasp")
+        self.telemetry("stage", stage="grasp", prompt=prompt)
         roll, pitch, yaw = self._grasp_orientation(x, y, roll)
         self._push_to_floor(x, y, z, roll, pitch, yaw)
         self.check_cancelled()  # last exit before the fingers commit
@@ -666,7 +666,7 @@ class PickAnyObject(Skill):
         """Back up, then check floor clear + gripper not open. Gemini gets both
         cameras: the wrist view can show the object in the fingers, so a held
         object isn't mistaken for a dropped one."""
-        self.telemetry("stage", stage="verify")
+        self.telemetry("stage", stage="verify", prompt=prompt)
         approach.drive(-VERIFY_BACKUP_M)
         self.sleep(self._p["settle_s"])
         js = self.joint_states

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -317,7 +317,8 @@ class PickAnyObject(Skill):
         # identical twins the box nearest the servo aim point is ours.
         box = min(boxes, key=self._wrist_aim_dist) if boxes else None
         px = (box[0] + box[2] / 2.0, box[1] + box[3] / 2.0) if box else None
-        self.telemetry("wrist", state="seed", px=px)
+        corners = (box[0], box[1], box[0] + box[2], box[1] + box[3]) if box else None
+        self.telemetry("wrist", state="seed", px=px, box=corners)
         return px, box
 
     def _wrist_aim_dist(self, box):
@@ -447,7 +448,17 @@ class PickAnyObject(Skill):
             inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
             if time.monotonic() - last_told >= WRIST_TELEMETRY_S:
                 last_told = time.monotonic()
-                self.telemetry("wrist", state="track", px=px, z=z, stop=p["wrist_stop_z"], inside=inside)
+                blob = tracker.axis
+                self.telemetry(
+                    "wrist",
+                    state="track",
+                    px=px,
+                    z=z,
+                    stop=p["wrist_stop_z"],
+                    inside=inside,
+                    box=self._wrist_box(),
+                    axis=blob[0] if blob is not None and blob[1] >= MIN_ELONGATION else None,
+                )
             centered = centered + 1 if inside else 0
             if streak < 2:
                 continue  # watch one more frame before trusting it
@@ -730,6 +741,11 @@ class PickAnyObject(Skill):
         align = ["align"] if self._p["wrist_steps"] >= 1 else []
         return ["search", "approach", *align, "grasp", "verify"]
 
+    def _wrist_box(self) -> dict[str, float]:
+        """The wrist servo's goal square for a UI, wrist-image px."""
+        p = self._p
+        return {"u": p["wrist_box_u"], "v": p["wrist_box_v"], "half": p["wrist_half_px"]}
+
     def execute(self, prompt: str = "the sock") -> SkillReturn:
         """Pick up `prompt` from the floor."""
         if self._proxy is None:
@@ -749,7 +765,13 @@ class PickAnyObject(Skill):
 
             approach = FloorApproach(self, self._p, self._detect_px)
             self.telemetry(
-                "run", state="start", prompt=prompt, frame=(IMG_W, IMG_H), box=approach.box(), stages=self._stages()
+                "run",
+                state="start",
+                prompt=prompt,
+                frame=(IMG_W, IMG_H),
+                box=approach.box(),
+                wrist_box=self._wrist_box(),
+                stages=self._stages(),
             )
             self.say(f"Looking for {prompt}.")
             xy = approach.search(prompt)


### PR DESCRIPTION
## What

A targeting overlay on the robot's cameras that shows what `pick_any_object` is doing while it runs. On the **main camera**: a bracket on the object it spotted, the pick box the base steers it into (greens as the tracked point locks in), the steering vector, the grasp reticle and a sweep while a frame is out to the model. On the **wrist camera**: the servo's goal square, Gemini's wrist detection, the colour blob the descent follows with its long axis (the side the fingers roll onto) and the vector into the box. On either: a HUD with the stage ladder (search → approach → align → grasp → verify), a live readout and the wrist-descent bar. Hidden on the top view and map. Mounted on the Teleop and Agent pages.

This revives the pick overlay that lived on #542 (`pickOverlay.js`, never merged), generalised: instead of a per-skill `/pick_any_object/debug` topic mirroring the skill's tuning dict, the SDK now has `Skill.telemetry(event, **fields)` on one `/brain/skill_telemetry` topic, and the overlay knows nothing skill-specific — a run declares its stages up front and every marker arrives in image pixels.

## Interface

Captured in the sim during a real `pick_any_object` run (Teleop page, 1440×810). Images live on the `assets/pr-797-targeting-overlay` branch.

**Approach — steering.** Optical flow holds the can (diamond); the dashed vector leads to the pick box, which the base drives the can into. The HUD reads the pixel error.

![approach steering](https://raw.githubusercontent.com/innate-inc/innate-os/29e8f33f07640490aa17ed386dbf40d5df4d831b/targeting-overlay/1-approach-steering.png)

**Approach — locked.** The tracked point is inside the accept square, so the box and marker turn green and the base stops.

![approach locked](https://raw.githubusercontent.com/innate-inc/innate-os/29e8f33f07640490aa17ed386dbf40d5df4d831b/targeting-overlay/2-approach-locked.png)

**Align — wrist camera.** With the arm view primary: the servo's goal square, the CamShift blob on the can with its long axis (the side the fingers roll onto), and the descent bar in the HUD.

![align on the wrist camera](https://raw.githubusercontent.com/innate-inc/innate-os/29e8f33f07640490aa17ed386dbf40d5df4d831b/targeting-overlay/3-align-wrist-camera.png)

**Grasp.** Back on the main camera, the reticle marks where the fingers close; the last detection bracket stays as reference.

![grasp reticle](https://raw.githubusercontent.com/innate-inc/innate-os/29e8f33f07640490aa17ed386dbf40d5df4d831b/targeting-overlay/4-grasp-reticle.png)

**Verdict.** Every stage green, "picked up", then the HUD clears after four seconds.

![picked up](https://raw.githubusercontent.com/innate-inc/innate-os/29e8f33f07640490aa17ed386dbf40d5df4d831b/targeting-overlay/5-verdict-picked-up.png)

## How

- **SDK** — `Skill.telemetry()` publishes `{skill, ev, t, ...}` JSON through a lazily created publisher on the run node (same pattern as `say()`); floats rounded, numpy scalars (bool_ included) unboxed. Best effort: a failure is logged, never raised into the run. Events belong to a run (`run/start` opens, `run/end` closes) and are dropped outside one, so the `FloorApproach` events a `drop_in_box` run emits stay silent until that skill opens a run of its own.
- **Skill** — `pick_any_object` narrates: `run` start (prompt, frame, pick box, wrist box, stages) / end (ok, cancelled, reason); each Gemini `look` (ask → seen with the detection box, or miss); the flow `track` at ≤10 Hz with `inside`; base `move`s; `parked`; `grasp` target/descend/close/lift; `wrist` seed (with its box) / track (px, z, inside, the blob's axis when elongated enough to steer the roll) / done; `verify`. `FloorApproach` emits the shared `stage`/`move`/`track` events through its host, so `drop_in_box` gets the same channel for free (it does not open a run yet). `parse_det_cands` now carries Gemini's box corners.
- **Webapp** — `teleop/targetingOverlay.js`: a pure reducer (`applyEvent`), per-camera marker selection (`headMarkers` / `wristMarkers`) and one set of DOM markers that follows whichever robot camera is primary; markers are percentages of a layer placed where the skill's frame lands. Hardware: wherever `object-fit`/`object-position` put the picture inside the video's content box (the cockpits letterbox with `contain`, the Agent page crops with `cover` between 641 and 1400 px and anchors left-top on wide screens). Sim: the head camera is rendered at the stage's size with the driver's lens (same vertical FOV as the viewer), so the frame is height-fit, wider sideways (fx < fy), principal point at the canvas centre; the wrist camera is a plain fovy in both, so its frame is height-fit and centred. A page opened mid-run still follows: native frame, stages learned as they come, prompt recovered from the next stage event and the pick box from the next track event (both repeat them). The verdict lingers 4 s then clears.

## Review

Reviewed by Codex (GPT-6 Astra, xhigh) before opening: 1 P1 (telemetry could raise into the run and mask a `SkillCancelled`) and 6 P2s (Agent page `object-fit: cover`, mid-run metadata recovery, orphan `drop_in_box` events opening a run, the linger timer restarting on ignored events, numpy `bool_` in `json.dumps`, a look miss leaving a stale tracking marker). All seven are fixed in a0923bfe3 and e29fc2b53, each re-verified in the sim.

## Verified

- Sim, from this branch: scripted telemetry replays over rosbridge, then three real `innate skill run innate-os/pick_any_object @prompt="the can"` runs with a can dropped 1 m ahead — every stage drew as expected on a freshly loaded Teleop page with the main camera primary (bracket on the can, pick box greening, tracking marker + vector, sweep during the re-look, reticle, descent bar, "backing up 15 cm", verdict then clear), and with the arm camera primary (wrist box greening, blob diamond on the can with its axis, markers clearing at grasp); two of the runs picked the can up. No telemetry warnings in the skills server log. The Agent page shows the same HUD at the feed's bottom edge.
- `ruff check` / `ruff format --check` clean on `brain_client` and the skills; `pytest` 283 passed and `basedpyright` at its pre-existing baseline with no new diagnostics (both in the sim container); `tsc --noEmit` clean for the touched webapp files (the pre-existing `armsdk`/three.js errors are untouched).
- Not verified on hardware: that the WebRTC head stream shows the same field of view as the skill's 640×480 frame (the overlay maps by fractions of the video, so a different crop would offset the markers).

## Follow-ups

- Open `drop_in_box`'s run on the same channel (`run start` with its stages) so the overlay follows drops too.
