### PR TITLE
sim: clean a prebuilt-seeded install before the first local colcon build

### DIFF
--- a/scripts/validate_sim_ros_install.zsh
+++ b/scripts/validate_sim_ros_install.zsh
@@ -138,20 +138,26 @@ install_is_stale() {
 install_needs_clean_rebuild() {
     [[ ! -f install/setup.zsh ]] && return 0
     find install -xtype l -print -quit | grep -q . && return 0
+    # seeded copies are plain files; symlink-install cannot replace them
+    [[ -f install/.innate-prebuilt-source.sha256 ]] && return 0
 
     return 1
 }
 
-if [[ "${INNATE_OS_ALWAYS_BUILD:-0}" == "1" ]]; then
-    colcon_build_with_retry
-elif seed_prebuilt_install; then
-    :
-elif install_is_stale; then
+build_local_install() {
     if install_needs_clean_rebuild; then
-        echo "ROS install is unusable (missing or dangling); cleaning build/install/log before rebuild."
+        echo "ROS install cannot be built on; cleaning build/install/log before rebuild."
         clean_ros_build_artifacts
     fi
     colcon_build_with_retry
+}
+
+if [[ "${INNATE_OS_ALWAYS_BUILD:-0}" == "1" ]]; then
+    build_local_install
+elif seed_prebuilt_install; then
+    :
+elif install_is_stale; then
+    build_local_install
 else
     echo "ROS workspace install is current; skipping rebuild."
 fi


### PR DESCRIPTION
## Problem

`./innate-sim up` fails on every startup with

```
error: [Errno 17] File exists: '.../build/innate_uninavid/config/params.yaml' -> '.../install/innate_uninavid/share/innate_uninavid/config/params.yaml'
```

once a checkout that was seeded from the prebuilt image pulls a change to any `data_files` entry (here: #775 rewriting `innate_uninavid/config/params.yaml`).

The seeded install is `cp -a` of a non-symlink build, so it is plain files. Every local build runs `--symlink-install`. colcon's `symlink_data` only replaces an existing plain file when it passes `--force`, which it does only after finding its own `install.log` from a previous non-symlink build. The seed never produced one. Until a source file becomes newer than its seeded copy, distutils' update check silently skips it, which is why this stayed hidden for two weeks. The existing retry only matches the CMake variant of the same transition ("Is a directory"), not the Python one.

## Fix

Treat a seeded install as something that cannot be built on: when the validator falls through to a local colcon build and `install/.innate-prebuilt-source.sha256` is present, clean `build/install/log` first. `build/` is already empty on that path (the seed gate requires it), so the build was a full one anyway; this adds no compile time. The same step now also covers `INNATE_OS_ALWAYS_BUILD=1`.

Checkouts already in the mixed state heal with one clean rebuild on their next `up`.

## Verified

On a checkout in the broken state, `up` now logs `ROS install cannot be built on; cleaning build/install/log before rebuild.`, builds all 20 packages, and the install volume holds symlinks with only local markers. Runtime came up normally.

## No test

Per CLAUDE.md, tests ship only on request. The lesson worth keeping is that the dangerous state was silent, not the crash: for two weeks distutils' update check skipped every seeded data file, so the running sim kept the prebuilt copies while `up` reported success. The startup failure was the first visible symptom. The comment on the marker check in the script is the guard against reintroducing that.
