### PR TITLE
fix(vision): the wrist tracker's colour model must not collapse onto one face

### DIFF
--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -187,10 +187,18 @@ def track_point(prev_gray, gray, grid):
 # Color seg for growing/deforming objects (LK slides off fabric during descent).
 _SEG_BINS = [16, 8, 8]
 _SEG_RANGES = [0, 180, 0, 256, 0, 256]
+_SEG_MIN_SUPPORT_FRAC = 0.005
 
 
 def seg_model(hsv, box):
-    """Object/floor hist-ratio LUT for back-projection, or None."""
+    """Object/floor hist-ratio LUT for back-projection, or None.
+
+    A colour is fully object once it is more common inside the box than in
+    the ring around it. The ratio is capped there before scaling: scaled to
+    its maximum instead, one face that no floor colour shares (a saturated
+    side lit against a light floor) becomes the whole model and a paler face
+    of the same object drops to nothing, so the tracker follows a face rather
+    than the object."""
     x, y, w, h = box
     obj = hsv[y : y + h, x : x + w]
     rx0, ry0 = max(0, x - w // 2), max(0, y - h // 2)
@@ -198,9 +206,11 @@ def seg_model(hsv, box):
     h_obj = cv2.calcHist([obj], [0, 1, 2], None, _SEG_BINS, _SEG_RANGES)
     h_ring = cv2.calcHist([ring], [0, 1, 2], None, _SEG_BINS, _SEG_RANGES)
     ratio = h_obj / (np.maximum(h_ring - h_obj, 0.0) + 1.0)
-    if ratio.max() <= 0:
+    ratio[h_obj < _SEG_MIN_SUPPORT_FRAC * h_obj.sum()] = 0.0  # a few stray pixels are not a colour of the object
+    weight = np.minimum(ratio, 1.0)
+    if weight.max() <= 0:
         return None
-    return (255.0 * ratio / ratio.max()).astype(np.uint8)
+    return (255.0 * weight).astype(np.uint8)
 
 
 # Blob shape: major-axis angle in image coordinates (radians from +u toward


### PR DESCRIPTION
`seg_model` in `innate/vision.py` builds the object-versus-floor lookup table the wrist stage of PickAnyObject tracks with. It scaled the table to its maximum bin, so one colour absent from the floor (a saturated side face under the key light on a light floor) became 255 and every paler face of the same object fell to a few points. CamShift's centroid then sat on that face, the arm centred the face rather than the object, and on a cube the elongated blob also rolled the wrist. Result: 0 of 6 red-cube pickups on a white floor against 3 of 3 on the apartment's wood with the identical placement.

Change: cap each bin at ratio 1 ("more object than ring") before scaling, and drop bins carrying under 0.5% of the box's pixels so stray pixels cannot become an object colour.

Evidence: on wrist frames recorded during the failing runs, the share of cube pixels the model lights (≥128) goes from 65-70% to 96-97% once the cube fills the frame; at the seed height it goes from 7% to 20%, because most of the cube there is near-grey and only partially weighted. Live verification is next: three pickups in the white room and three in the apartment through the skills action server, before this leaves draft.

No behaviour change is expected where the object already contrasted with the floor on every face: those bins were at or above the cap already.
