### PR TITLE
fix(sim): robot cameras render like the viewer — lights, tone curve, shadows

### DIFF
--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -357,7 +357,6 @@ class VirtualMars:
         self.props.bind(self.model)
 
         self._renderer: mujoco.Renderer | None = None
-        self._foggy = self.environment.viewer.get("atmosphere") == "void"
         environment = self.model.body("apartment").id
         self._environment_geoms = {g for g in range(self.model.ngeom) if self.model.geom_bodyid[g] in (environment, 0)}
         self._encode_display_colours()
@@ -527,7 +526,7 @@ class VirtualMars:
         self._renderer.update_scene(self.data, camera=camera)
         scene.flags[mujoco.mjtRndFlag.mjRND_SHADOW] = int(SHADOWS)
         scene.flags[mujoco.mjtRndFlag.mjRND_REFLECTION] = 0
-        scene.flags[mujoco.mjtRndFlag.mjRND_FOG] = int(self._foggy)
+        scene.flags[mujoco.mjtRndFlag.mjRND_FOG] = 1
         if SHADOWS:
             self._exempt_environment_from_casting(scene)
 
@@ -539,9 +538,15 @@ class VirtualMars:
         self.model.geom_rgba[geoms, :3] = _linear_to_srgb(self.model.geom_rgba[geoms, :3])
 
     def _shadow_box(self) -> tuple[float, float, float]:
-        """(centre x, centre y, half-size) of the square around the robot and every prop in play."""
+        """(centre x, centre y, half-size) of the square around the robot and the props in
+        play near it; a prop the capped box cannot hold together with the robot is left out."""
         x, y, _yaw = self.pose()
-        centers = [c for name in self.props.out if (c := self.props.center_xy(self.data, name)) is not None]
+        reach = 2 * (SHADOW_BOX_MAX_M - SHADOW_BOX_MARGIN_M)
+        centers = [
+            c
+            for name in self.props.out
+            if (c := self.props.center_xy(self.data, name)) is not None and math.dist(c, (x, y)) <= reach
+        ]
         xs, ys = [x, *(c[0] for c in centers)], [y, *(c[1] for c in centers)]
         half = max(max(xs) - min(xs), max(ys) - min(ys)) / 2 + SHADOW_BOX_MARGIN_M
         return (min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2, min(max(half, SHADOW_BOX_MIN_M), SHADOW_BOX_MAX_M)

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/core.py
@@ -45,9 +45,18 @@ CAMERAS = {
     "wrist": ("robot_arm_camera_link", (1, 0, 0), (0, 0, 1)),
 }
 JPEG_QUALITY = 80  # matches main_camera_driver.cpp
-# Post-render ACES tone map approximating sim/viewer's Three.js output
-# (ACESFilmicToneMapping); exposure calibrated visually against it.
-TONEMAP_EXPOSURE = 2.5
+TONEMAP_EXPOSURE = 1.5  # sim/viewer's renderer.toneMappingExposure
+# Shadow box half-size (m) around the robot and the props in play. Keep its texels
+# small: without ARB_clip_control (macOS) MuJoCo's caster pass offsets depth by
+# ~16 texels, which erases an object's base and leaves a detached shadow.
+SHADOW_BOX_MIN_M = 1.5
+SHADOW_BOX_MAX_M = 3.0
+SHADOW_BOX_MARGIN_M = 0.5
+# Shadows cost ~2x per frame on native GL and ~3x on software GL, where the
+# frame time already starves the stack; VIRTUAL_MARS_SHADOWS=0/1 overrides.
+SHADOWS = (
+    os.environ.get("VIRTUAL_MARS_SHADOWS", "0" if os.environ.get("MUJOCO_GL", "").lower() == "osmesa" else "1") == "1"
+)
 
 # Arm/head PD servo -- apartmentWorker.ts's tuned defaults (reactive feel),
 # torque-clamped; the URDF's per-joint damping=5 caps speed at LIMIT/5 rad/s.
@@ -93,19 +102,34 @@ def encode_jpeg(rgb: np.ndarray) -> bytes:
     return buf.getvalue()
 
 
-def _build_tonemap_lut() -> np.ndarray:
-    linear = (np.arange(256, dtype=np.float32) / 255.0) ** 2.2 * TONEMAP_EXPOSURE
-    mapped = np.clip(linear * (2.51 * linear + 0.03) / (linear * (2.43 * linear + 0.59) + 0.14), 0, 1)
-    return (mapped ** (1 / 2.2) * 255).astype(np.uint8)
+# three.js ACESFilmicToneMapping (Hill fit, colour matrices included): a baked
+# texture comes out of both renderers identical. Per-channel shortcuts shift hues.
+_ACES_INPUT = np.array(
+    [[0.59719, 0.35458, 0.04823], [0.07600, 0.90834, 0.01566], [0.02840, 0.13383, 0.83777]], dtype=np.float32
+)
+_ACES_OUTPUT = np.array(
+    [[1.60475, -0.53108, -0.07367], [-0.10208, 1.10813, -0.00605], [-0.00327, -0.07276, 1.07602]], dtype=np.float32
+)
+_SRGB_STEPS = 4096
 
 
-# The map is per-channel uint8 -> uint8, so a 256-entry LUT replaces two pow()
-# passes over every pixel of every frame.
-_TONEMAP_LUT = _build_tonemap_lut()
+def _srgb_to_linear(x: np.ndarray) -> np.ndarray:
+    return np.where(x <= 0.04045, x / 12.92, ((x + 0.055) / 1.055) ** 2.4)
+
+
+def _linear_to_srgb(x: np.ndarray) -> np.ndarray:
+    return np.where(x <= 0.0031308, x * 12.92, 1.055 * x ** (1 / 2.4) - 0.055)
+
+
+_LINEAR_LUT = (_srgb_to_linear(np.arange(256, dtype=np.float32) / 255.0) * (TONEMAP_EXPOSURE / 0.6)).astype(np.float32)
+_SRGB_LUT = (_linear_to_srgb(np.arange(_SRGB_STEPS + 1, dtype=np.float32) / _SRGB_STEPS) * 255 + 0.5).astype(np.uint8)
 
 
 def _tonemap(rgb: np.ndarray) -> np.ndarray:
-    return _TONEMAP_LUT[rgb]
+    v = _LINEAR_LUT[rgb] @ _ACES_INPUT.T
+    v = (v * (v + 0.0245786) - 0.000090537) / (v * (0.983729 * v + 0.4329510) + 0.238081)
+    v = np.clip(v @ _ACES_OUTPUT.T, 0.0, 1.0)
+    return _SRGB_LUT[(v * _SRGB_STEPS).astype(np.int32)]
 
 
 def _navigation_grid(base_grid: np.ndarray, seen_free: np.ndarray, seen_occ: np.ndarray) -> np.ndarray:
@@ -228,6 +252,7 @@ class VirtualMars:
             spawn_pose=self._spawn,
             traffic_bodies=self.traffic.bodies_xml(),
             traffic_assets=self.traffic.assets_xml(),
+            atmosphere=self.environment.viewer.get("atmosphere"),
         )
         # Lidar rays hit only the textured visual meshes (true surfaces, like
         # a real lidar) when available -- without them, fall back to all
@@ -303,10 +328,6 @@ class VirtualMars:
         # camera near plane) so the cameras clip their own housing shells
         # instead of rendering them.
         self.model.vis.map.znear = 0.03 / self.model.stat.extent
-        # The textured rooms carry baked lighting; brighten toward the
-        # Three.js render (ambient 1.2 + ACES exposure 1.5 there).
-        self.model.vis.headlight.ambient[:] = 0.5
-        self.model.vis.headlight.diffuse[:] = 0.5
         self.data = mujoco.MjData(self.model)
 
         self._base_id = self.model.body("robot_base_link").id
@@ -336,6 +357,10 @@ class VirtualMars:
         self.props.bind(self.model)
 
         self._renderer: mujoco.Renderer | None = None
+        self._foggy = self.environment.viewer.get("atmosphere") == "void"
+        environment = self.model.body("apartment").id
+        self._environment_geoms = {g for g in range(self.model.ngeom) if self.model.geom_bodyid[g] in (environment, 0)}
+        self._encode_display_colours()
         self._depth_renderer: mujoco.Renderer | None = None
         self._cmd_vx = 0.0
         self._cmd_wz = 0.0
@@ -492,10 +517,42 @@ class VirtualMars:
         physics lock). The GL render itself (read_rgb) can then run outside."""
         if self._renderer is None:
             self._renderer = mujoco.Renderer(self.model, height=self._render_h, width=self._render_w)
+        if SHADOWS:
+            cx, cy, half = self._shadow_box()
+            key = (cx + world.KEY_LIGHT_OFFSET[0], cy + world.KEY_LIGHT_OFFSET[1], world.KEY_LIGHT_OFFSET[2])
+            self.model.light_pos[0] = key
+            self.data.light_xpos[0] = key  # what the scene reads; kinematics refresh it from light_pos
+            self._renderer._mjr_context.shadowClip = half  # mjr keeps the box size in its context, not the model
+        scene = self._renderer.scene
         self._renderer.update_scene(self.data, camera=camera)
-        # Shadows/reflections cost ~3x on software GL (242 -> 71 ms/frame).
-        self._renderer.scene.flags[mujoco.mjtRndFlag.mjRND_SHADOW] = 0
-        self._renderer.scene.flags[mujoco.mjtRndFlag.mjRND_REFLECTION] = 0
+        scene.flags[mujoco.mjtRndFlag.mjRND_SHADOW] = int(SHADOWS)
+        scene.flags[mujoco.mjtRndFlag.mjRND_REFLECTION] = 0
+        scene.flags[mujoco.mjtRndFlag.mjRND_FOG] = int(self._foggy)
+        if SHADOWS:
+            self._exempt_environment_from_casting(scene)
+
+    def _encode_display_colours(self) -> None:
+        """Prop rgba is linear light to the viewer's three.js and a display value to
+        MuJoCo; encoded once, the cameras show the colours the viewer shows."""
+        prop_bodies = {self.model.body(name).id for name in self.props.props}
+        geoms = [g for g in range(self.model.ngeom) if self.model.geom_bodyid[g] in prop_bodies]
+        self.model.geom_rgba[geoms, :3] = _linear_to_srgb(self.model.geom_rgba[geoms, :3])
+
+    def _shadow_box(self) -> tuple[float, float, float]:
+        """(centre x, centre y, half-size) of the square around the robot and every prop in play."""
+        x, y, _yaw = self.pose()
+        centers = [c for name in self.props.out if (c := self.props.center_xy(self.data, name)) is not None]
+        xs, ys = [x, *(c[0] for c in centers)], [y, *(c[1] for c in centers)]
+        half = max(max(xs) - min(xs), max(ys) - min(ys)) / 2 + SHADOW_BOX_MARGIN_M
+        return (min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2, min(max(half, SHADOW_BOX_MIN_M), SHADOW_BOX_MAX_M)
+
+    def _exempt_environment_from_casting(self, scene: mujoco.MjvScene) -> None:
+        """Baked geometry receives shadows but casts none (the viewer's castShadow=false),
+        or ceilings shadow whole rooms; the caster pass skips decor-category geoms."""
+        for i in range(scene.ngeom):
+            geom = scene.geoms[i]
+            if geom.objtype == mujoco.mjtObj.mjOBJ_GEOM and geom.objid in self._environment_geoms:
+                geom.category = mujoco.mjtCatBit.mjCAT_DECOR
 
     def read_rgb(self) -> np.ndarray:
         """Tone-mapped uint8 RGB of the last update_camera snapshot. Slow

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -98,9 +98,11 @@ ARM_HOME = {
 
 # sim/viewer's key light (scene.ts KEY_LIGHT_OFFSET); the renderer moves it with the robot.
 KEY_LIGHT_OFFSET = (2.0, -1.5, 3.0)
-# sim/viewer's background per atmosphere.
+# sim/viewer's background and FogExp2 density per atmosphere (scene.ts).
 SKY_RGB = {"daylight": (0.80, 0.86, 0.89), "void": (1.0, 1.0, 1.0)}
 SKY_RGB_DEFAULT = (0.08, 0.086, 0.10)
+FOG_DENSITY = {"daylight": 0.004, "void": 0.16}
+FOG_DENSITY_DEFAULT = 0.035
 
 # Visual conventions matching sim/viewer's Three.js render.
 ORANGE_LINKS = {"link1", "link3", "link5"}
@@ -286,6 +288,10 @@ def build_world_xml(
 
     lx, ly, lz, azimuth, elevation, extent = spawn_camera_view(*spawn_pose)
     sky = " ".join(f"{c:g}" for c in SKY_RGB.get(atmosphere or "", SKY_RGB_DEFAULT))
+    # MuJoCo fog is a linear ramp in units of extent; 0.3/d..1.5/d brackets the
+    # viewer's exp2 curve between ~9% and ~89%.
+    fog_density = FOG_DENSITY.get(atmosphere or "", FOG_DENSITY_DEFAULT)
+    fog_start, fog_end = 0.3 / fog_density / extent, 1.5 / fog_density / extent
     key_pos = " ".join(f"{spawn_pose[i] + KEY_LIGHT_OFFSET[i]:g}" for i in range(2)) + f" {KEY_LIGHT_OFFSET[2]:g}"
 
     return f"""
@@ -303,10 +309,9 @@ def build_world_xml(
          from every surface orientation. The headlight's diffuse/specular are
          view-dependent and washed lit faces white: ambient only. -->
     <headlight ambient="0.55 0.55 0.55" diffuse="0 0 0" specular="0 0 0"/>
-    <!-- Shadow box: core.py resizes it per frame. Fog: the void's haze, per atmosphere. -->
-    <map shadowclip="1.2" fogstart="2" fogend="10"/>
+    <map shadowclip="1.2" fogstart="{fog_start:g}" fogend="{fog_end:g}"/>
     <quality shadowsize="8192"/>
-    <rgba fog="1 1 1 1"/>
+    <rgba fog="{sky} 1"/>
   </visual>
   <statistic center="{lx} {ly} {lz}" extent="{extent}"/>
   <asset>

--- a/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
+++ b/ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/world.py
@@ -96,6 +96,12 @@ ARM_HOME = {
     "joint_head": 0.0,
 }
 
+# sim/viewer's key light (scene.ts KEY_LIGHT_OFFSET); the renderer moves it with the robot.
+KEY_LIGHT_OFFSET = (2.0, -1.5, 3.0)
+# sim/viewer's background per atmosphere.
+SKY_RGB = {"daylight": (0.80, 0.86, 0.89), "void": (1.0, 1.0, 1.0)}
+SKY_RGB_DEFAULT = (0.08, 0.086, 0.10)
+
 # Visual conventions matching sim/viewer's Three.js render.
 ORANGE_LINKS = {"link1", "link3", "link5"}
 BRIGHT_ORANGE = (1.0, 0.5, 0.0, 1.0)
@@ -224,6 +230,7 @@ def build_world_xml(
     spawn_pose: tuple[float, float, float] = (SPAWN_X, SPAWN_Y, SPAWN_YAW_DEG),
     traffic_bodies: str = "",
     traffic_assets: str = "",
+    atmosphere: str | None = None,
 ) -> str:
     """The apartment environment MJCF (floor plane + decomposed room hulls,
     optionally the textured visual rooms in their own geom group, plus every
@@ -278,6 +285,8 @@ def build_world_xml(
     )
 
     lx, ly, lz, azimuth, elevation, extent = spawn_camera_view(*spawn_pose)
+    sky = " ".join(f"{c:g}" for c in SKY_RGB.get(atmosphere or "", SKY_RGB_DEFAULT))
+    key_pos = " ".join(f"{spawn_pose[i] + KEY_LIGHT_OFFSET[i]:g}" for i in range(2)) + f" {KEY_LIGHT_OFFSET[2]:g}"
 
     return f"""
 <mujoco model="apartment">
@@ -289,19 +298,32 @@ def build_world_xml(
        claw no matter the friction (MuJoCo docs, "Preventing slip"). -->
   <visual>
     <global azimuth="{azimuth}" elevation="{elevation}" offwidth="1280" offheight="960"/>
+    <!-- Fixed-function lighting sums the lights and clips each channel at 1. The
+         environments are baked (unlit in the viewer), so the lights below sum to ~1
+         from every surface orientation. The headlight's diffuse/specular are
+         view-dependent and washed lit faces white: ambient only. -->
+    <headlight ambient="0.55 0.55 0.55" diffuse="0 0 0" specular="0 0 0"/>
+    <!-- Shadow box: core.py resizes it per frame. Fog: the void's haze, per atmosphere. -->
+    <map shadowclip="1.2" fogstart="2" fogend="10"/>
+    <quality shadowsize="8192"/>
+    <rgba fog="1 1 1 1"/>
   </visual>
   <statistic center="{lx} {ly} {lz}" extent="{extent}"/>
   <asset>
+    <texture type="skybox" builtin="flat" rgb1="{sky}" rgb2="{sky}" width="32" height="32"/>
 {chr(10).join(mesh_lines)}
 {chr(10).join(visual_mesh_lines)}{prop_assets}
 {traffic_assets}
   </asset>
   <worldbody>
-    <!-- MuJoCo defaults an untyped light to a narrow spotlight.  The viewer's
-         key and fill are directional, so make that contract explicit here to
-         avoid dark cones at the apartment perimeter. -->
-    <light type="directional" pos="4 -3 6" dir="-4 3 -6" diffuse="1 1 1"/>
-    <light type="directional" castshadow="false" pos="-4 3 3" dir="4 -3 -3" diffuse="0.67 0.8 1"/>
+    <!-- Key light casts the shadows; the up light lights ceilings; three horizontal
+         fills 120 degrees apart light walls near-uniformly (0.87-1x). Untyped lights
+         default to narrow spotlights, hence type="directional". -->
+    <light type="directional" pos="{key_pos}" dir="-2 1.5 -3" diffuse="0.58 0.58 0.58" specular="0 0 0"/>
+    <light type="directional" castshadow="false" pos="0 0 0" dir="0 0 1" diffuse="0.45 0.45 0.45" specular="0 0 0"/>
+    <light type="directional" castshadow="false" pos="0 0 3" dir="1 0 0" diffuse="0.45 0.45 0.45" specular="0 0 0"/>
+    <light type="directional" castshadow="false" pos="0 0 3" dir="-0.5 0.866 0" diffuse="0.45 0.45 0.45" specular="0 0 0"/>
+    <light type="directional" castshadow="false" pos="0 0 3" dir="-0.5 -0.866 0" diffuse="0.45 0.45 0.45" specular="0 0 0"/>
     <geom name="ground" type="plane" size="20 20 0.1" friction="0.9 0.01 0.001" margin="0.007"
           solref="0.01 1" rgba="0.35 0.35 0.35 1" group="{collision_group}"/>
     <body name="apartment" quat="0.7071068 0.7071068 0 0">


### PR DESCRIPTION
## What

The robot cameras (MuJoCo) now match sim/viewer (three.js): same brightness on the baked environments, same object colours, and real object shadows.

## Why

The apartment and Backrooms glbs are unlit in the viewer (baked lighting, ACES exposure 1.5). MuJoCo's fixed-function pipeline sums lights and clips each channel at 1 *before* the post tone map, so every brighter recipe desaturated colours and flattened shadows, while ceilings shadowed whole rooms whenever shadows were on. Indoors the cameras were markedly darker than the viewer.

## How

- **Light rig** (`world.py`): ambient-only headlight 0.55, one shadow-casting key 0.58 on the viewer's light offset, an up light 0.45 for ceilings, three horizontal fills 0.45 at 120°. Every surface orientation receives ~1.0. Checked against an ambient-only render (the exact unlit look): apartment and Backrooms frames match within 2% in every band.
- **Tone curve** (`core.py`): three.js's ACESFilmic (Hill fit, colour matrices included) at exposure 1.5, applied after sRGB decoding. A per-channel shortcut shifts saturated yellows by up to 90 levels, so it stays exact (~9 ms per 640×480 frame).
- **Shadows** (`core.py`, `world.py`): environment geoms are set to the decor category in the scene, which the caster pass skips, so they receive shadows but never cast (the viewer's `castShadow=false`). The shadow box is the bounding square of the robot and the props in play (1.5–3 m half-size) with an 8192 map: MuJoCo's caster pass uses `glPolygonOffset(-16, -512)` on GL without `ARB_clip_control` (macOS), which pushes casters ~16 texels away from the light; at 1.9 mm/texel only the top of a cube still cast. Shadows stay off under `MUJOCO_GL=osmesa` by default (they double the frame time there: 41→87 ms void, 28→62 ms apartment); `VIRTUAL_MARS_SHADOWS=0/1` overrides.
- **Prop colours**: the viewer reads prop rgba as linear light, MuJoCo as display values; rgba is encoded linear→sRGB once at load so the cameras show what the viewer shows. The robot is untouched.
- **Sky and fog**: skybox colour per atmosphere; linear white fog for the void, enabled per atmosphere.

## Verified

- Ambient-only parity oracle vs the rig: ≤2% per band, apartment and Backrooms.
- Cube/can/bar shadows attached to their bases at 0.8 m and 2.4 m; render 11–21 ms at 640×480 on the host's native GL, +~2 ms for the 8192 map.
- Tried live in the void and the apartment.
