### PR TITLE
pick_any_object: wrist box, axis lock, hop hysteresis, turn at height, yaw from the arm base, thin-object tracking

### DIFF
--- a/ros2_ws/src/brain/brain_client/innate/geometry.py
+++ b/ros2_ws/src/brain/brain_client/innate/geometry.py
@@ -9,6 +9,7 @@ import math
 
 HEAD_ORIGIN = (-0.040751, -0.0002, 0.25882)  # base_link -> head joint (URDF)
 CAM_IN_HEAD = (0.04327, 0.0297, -0.000275)  # head -> left camera optical
+ARM_ORIGIN = (0.086, -0.05285, 0.04025)  # base_link -> joint1 axis (URDF)
 IMG_W, IMG_H = 640, 480
 
 # Left-eye factory intrinsics (1280x720, fx~=fy~=400.8) through the driver's
@@ -16,6 +17,14 @@ IMG_W, IMG_H = 640, 480
 # 70 deg model read 0.156 m as 0.33. Tune FY first — it dominates range.
 FX, FY = 200.3, 267.3
 CX, CY = 319.1, 248.7
+
+
+def arm_bearing(x, y):
+    """Heading from the arm's own base to a base_link point. The whole arm
+    lies in the vertical plane through joint1's axis, so this IS the yaw a
+    grasp there must use; from the base_link origin it is ~18 deg off at
+    grasp range, which a vertical tool can only absorb in the wrist roll."""
+    return math.atan2(y - ARM_ORIGIN[1], x - ARM_ORIGIN[0])
 
 
 def _head_rot(tilt_rad):

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -187,11 +187,25 @@ def track_point(prev_gray, gray, grid):
 # Color seg for growing/deforming objects (LK slides off fabric during descent).
 _SEG_BINS = [16, 8, 8]
 _SEG_RANGES = [0, 180, 0, 256, 0, 256]
+# Hue is sensor noise below the first saturation bin. A white AirPods case is
+# S < 32 almost everywhere, and that noise scatters it over six hue bins, so
+# normalising the ratio to its peak left one shard — 16% of the case — above
+# _BLOB_MIN_LIKELIHOOD and the tracked centroid wandered over whichever shard
+# won. Folding every grey pixel into one hue bin puts 83% of the case there.
+# Saturated pixels keep their hue: the S index already separates them.
+_SEG_GREY_S = 256 // _SEG_BINS[1]
+
+
+def _fold_grey_hue(hsv: np.ndarray) -> np.ndarray:
+    folded = hsv.copy()
+    folded[:, :, 0][hsv[:, :, 1] < _SEG_GREY_S] = 0
+    return folded
 
 
 def seg_model(hsv, box):
     """Object/floor hist-ratio LUT for back-projection, or None."""
     x, y, w, h = box
+    hsv = _fold_grey_hue(hsv)
     obj = hsv[y : y + h, x : x + w]
     rx0, ry0 = max(0, x - w // 2), max(0, y - h // 2)
     ring = hsv[ry0 : y + h + h // 2, rx0 : x + w + w // 2]
@@ -276,7 +290,7 @@ def seg_track(
     hsv: np.ndarray, model: np.ndarray, window: Window, min_score: float = 25.0
 ) -> tuple[tuple[float, float] | None, Window, float, Axis | None]:
     """Back-project + CamShift -> (center|None, window, score, axis|None)."""
-    bp = _backproject(hsv, model)
+    bp = _backproject(_fold_grey_hue(hsv), model)
     crit = (cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 10, 1)
     rot, window = cv2.CamShift(bp, window, crit)
     x, y, w, h = window

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -210,23 +210,33 @@ Axis = tuple[float, float]
 Window = tuple[int, int, int, int]
 
 
-def _blob_axis(bp: np.ndarray, window: Window) -> Axis | None:
-    """Minimum-area rectangle of the thresholded blob under the window
-    centre. CamShift's own ellipse is not usable: its window hugs only part
-    of a blob that outgrows it, and the ellipse then follows the window."""
-    x, y, w, h = window
-    x0, y0 = max(0, x - w), max(0, y - h)
-    roi = bp[y0 : y + 2 * h, x0 : x + 2 * w]
-    _thr, mask = cv2.threshold(roi, 0, 255, cv2.THRESH_BINARY | cv2.THRESH_OTSU)
+# Back-projection level that counts as object: floor bins score 0, a colour
+# leaking from the floor into the seed box scores a few, and an object shade
+# at least an eighth as common as its dominant one scores 32 or more.
+_BLOB_MIN_LIKELIHOOD = 32
+
+
+def _blob_under(bp: np.ndarray, point: tuple[float, float]) -> tuple[tuple[float, float], Window, Axis] | None:
+    """The whole thresholded blob containing `point` (else the largest blob):
+    its centroid, bounding box and minimum-area-rectangle axis. CamShift's own
+    window and ellipse are not usable for any of these: the colour model
+    scores an object's dominant shade highest, so mean shift climbs onto the
+    lit face of a glossy object and the window hugs that patch, reporting a
+    point that drifts from the centre to an edge as the object grows."""
+    _thr, mask = cv2.threshold(bp, _BLOB_MIN_LIKELIHOOD - 1, 255, cv2.THRESH_BINARY)
     contours, _hier = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
     if not contours:
         return None
-    centre = (float(x + w // 2 - x0), float(y + h // 2 - y0))
-    under = [c for c in contours if cv2.pointPolygonTest(c, centre, False) >= 0]
+    under = [c for c in contours if cv2.pointPolygonTest(c, point, False) >= 0]
     blob = max(under or contours, key=cv2.contourArea)
+    m = cv2.moments(blob)
+    if m["m00"] <= 0:
+        return None
+    centroid = (m["m10"] / m["m00"], m["m01"] / m["m00"])
     _center, (rw, rh), angle_deg = cv2.minAreaRect(blob)
     major, minor, theta_deg = (rw, rh, angle_deg) if rw >= rh else (rh, rw, angle_deg + 90.0)
-    return math.radians(theta_deg) % math.pi, major / max(minor, 1.0)
+    axis = (math.radians(theta_deg) % math.pi, major / max(minor, 1.0))
+    return centroid, cv2.boundingRect(blob), axis
 
 
 def _backproject(hsv: np.ndarray, model: np.ndarray) -> np.ndarray:
@@ -264,4 +274,8 @@ def seg_track(
     score = _track_score(bp, rot, window)
     if score < min_score:
         return None, window, score, None
-    return (x + w / 2.0, y + h / 2.0), window, score, _blob_axis(bp, window)
+    blob = _blob_under(bp, (x + w / 2.0, y + h / 2.0))
+    if blob is None:
+        return (x + w / 2.0, y + h / 2.0), window, score, None
+    centroid, bbox, axis = blob
+    return centroid, bbox, score, axis

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -280,7 +280,11 @@ def seg_track(
     crit = (cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 10, 1)
     rot, window = cv2.CamShift(bp, window, crit)
     x, y, w, h = window
-    if w < 4 or h < 4 or w * h > 0.4 * IMG_W * IMG_H:
+    # A flooded model (matching the floor) fills the frame; a real object
+    # merely fills most of it — an AirPods case is ~40% of the real wrist
+    # camera's view at the 5 cm stop, and rejecting it there ends every
+    # descent with "lost track".
+    if w < 4 or h < 4 or w * h > 0.9 * IMG_W * IMG_H:
         return None, window, 0.0, None
     score = _track_score(bp, rot, window)
     if score < min_score:

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -238,17 +238,30 @@ def _backproject(hsv: np.ndarray, model: np.ndarray) -> np.ndarray:
     return model[np.clip(ih, 0, _SEG_BINS[0] - 1), i_s, iv]
 
 
+def _track_score(bp: np.ndarray, rot: Any, window: Window) -> float:
+    """Mean likelihood inside CamShift's rotated rectangle. Its axis-aligned
+    window is mostly floor around a thin diagonal object (a pen), and a mean
+    over that fails a track that is sitting on the object."""
+    x, y, w, h = window
+    roi = bp[y : y + h, x : x + w]
+    mask = np.zeros(roi.shape, np.uint8)
+    corners = np.round(cv2.boxPoints(rot) - (x, y)).astype(np.int32)
+    cv2.fillPoly(mask, [corners], 255)
+    inside = roi[mask > 0]
+    return float(inside.mean()) if inside.size else float(roi.mean())
+
+
 def seg_track(
     hsv: np.ndarray, model: np.ndarray, window: Window, min_score: float = 25.0
 ) -> tuple[tuple[float, float] | None, Window, float, Axis | None]:
     """Back-project + CamShift -> (center|None, window, score, axis|None)."""
     bp = _backproject(hsv, model)
     crit = (cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 10, 1)
-    _rot, window = cv2.CamShift(bp, window, crit)
+    rot, window = cv2.CamShift(bp, window, crit)
     x, y, w, h = window
     if w < 4 or h < 4 or w * h > 0.4 * IMG_W * IMG_H:
         return None, window, 0.0, None
-    score = float(bp[y : y + h, x : x + w].mean())
+    score = _track_score(bp, rot, window)
     if score < min_score:
         return None, window, score, None
     return (x + w / 2.0, y + h / 2.0), window, score, _blob_axis(bp, window)

--- a/ros2_ws/src/brain/brain_client/innate/vision.py
+++ b/ros2_ws/src/brain/brain_client/innate/vision.py
@@ -216,19 +216,30 @@ Window = tuple[int, int, int, int]
 _BLOB_MIN_LIKELIHOOD = 32
 
 
-def _blob_under(bp: np.ndarray, point: tuple[float, float]) -> tuple[tuple[float, float], Window, Axis] | None:
-    """The whole thresholded blob containing `point` (else the largest blob):
-    its centroid, bounding box and minimum-area-rectangle axis. CamShift's own
-    window and ellipse are not usable for any of these: the colour model
-    scores an object's dominant shade highest, so mean shift climbs onto the
-    lit face of a glossy object and the window hugs that patch, reporting a
-    point that drifts from the centre to an edge as the object grows."""
+def _overlaps(c: np.ndarray, window: Window) -> bool:
+    x, y, w, h = cv2.boundingRect(c)
+    wx, wy, ww, wh = window
+    return x < wx + ww and wx < x + w and y < wy + wh and wy < y + h
+
+
+def _blob_under(bp: np.ndarray, window: Window) -> tuple[tuple[float, float], Window, Axis] | None:
+    """The whole thresholded blob under the CamShift window's centre (else
+    the largest one overlapping the window; never one elsewhere in the frame,
+    which would hand the track to a same-coloured twin): its centroid,
+    bounding box and minimum-area-rectangle axis. CamShift's own window and
+    ellipse are not usable for any of these: the colour model scores an
+    object's dominant shade highest, so mean shift climbs onto the lit face
+    of a glossy object and the window hugs that patch, reporting a point that
+    drifts from the centre to an edge as the object grows."""
     _thr, mask = cv2.threshold(bp, _BLOB_MIN_LIKELIHOOD - 1, 255, cv2.THRESH_BINARY)
     contours, _hier = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-    if not contours:
+    x, y, w, h = window
+    centre = (x + w / 2.0, y + h / 2.0)
+    under = [c for c in contours if cv2.pointPolygonTest(c, centre, False) >= 0]
+    near = under or [c for c in contours if _overlaps(c, window)]
+    if not near:
         return None
-    under = [c for c in contours if cv2.pointPolygonTest(c, point, False) >= 0]
-    blob = max(under or contours, key=cv2.contourArea)
+    blob = max(near, key=cv2.contourArea)
     m = cv2.moments(blob)
     if m["m00"] <= 0:
         return None
@@ -274,7 +285,7 @@ def seg_track(
     score = _track_score(bp, rot, window)
     if score < min_score:
         return None, window, score, None
-    blob = _blob_under(bp, (x + w / 2.0, y + h / 2.0))
+    blob = _blob_under(bp, window)
     if blob is None:
         return (x + w / 2.0, y + h / 2.0), window, score, None
     centroid, bbox, axis = blob

--- a/workspace/innate_skills/drop_in_box.py
+++ b/workspace/innate_skills/drop_in_box.py
@@ -26,12 +26,12 @@ from innate import (
 )
 from innate import gemini as gemlib
 from innate.exceptions import ArmFailed, ArmUnhealthy, SkillFailed
-from innate.geometry import IMG_H, IMG_W, floor_to_pixel, pixel_to_floor, pixel_to_height
+from innate.geometry import ARM_ORIGIN, IMG_H, IMG_W, floor_to_pixel, pixel_to_floor, pixel_to_height
 
-# Arm reach as a sphere about the shoulder (URDF: joint2 at (0.086, 0.0845),
-# 0.326 m of link past it). It predicts a 0.407 m floor-height limit — where
-# Manipulation.REACH_X's 0.40 comes from.
-SHOULDER_X, SHOULDER_Z = 0.086, 0.0845
+# Arm reach as a sphere about the shoulder (joint2, one 0.04425 link above
+# joint1, with 0.326 m of link past it). It predicts a 0.407 m floor-height
+# limit — where Manipulation.REACH_X's 0.40 comes from.
+SHOULDER_X, SHOULDER_Z = ARM_ORIGIN[0], ARM_ORIGIN[2] + 0.04425
 ARM_REACH = 0.326
 
 # j6 band that PROVES a hold on its own, valid only after a fresh close.

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -101,6 +101,11 @@ PARAMS = {
 
 FOLLOW_TIMEOUT_S = 20.0
 WRIST_ALIGN_TIMEOUT_S = 60.0
+# A CamShift centre further than WRIST_JUMP_PX from the followed point is a
+# window hop until it repeats in place WRIST_JUMP_CONFIRM frames running;
+# beyond WRIST_MAX_JUMP_PX it is a miss, which after 3 frames re-seeds.
+WRIST_JUMP_PX = 40.0
+WRIST_JUMP_CONFIRM = 3
 WRIST_MAX_JUMP_PX = 80.0
 WRIST_SEG_MIN_SCORE = 25.0
 WRIST_CAM_ABOVE_EE = 0.07
@@ -139,6 +144,9 @@ class _BlobTracker:
         self.model = vision.seg_model(hsv, box)
         self.window = box
         self.guess = px
+        self.observed = False  # guess is an expectation until a frame confirms it
+        self.pending = None
+        self.hits = 0
         self.misses = 0
         self.axis: vision.Axis | None = None
 
@@ -146,19 +154,40 @@ class _BlobTracker:
     def ok(self):
         return self.model is not None
 
+    def expect(self, px):
+        """The arm moved: follow from px and forget any half-confirmed hop."""
+        self.guess, self.observed, self.pending, self.hits = px, False, None, 0
+
     def update(self, hsv):
-        """Blob center, or None on miss (keeps last window for retry)."""
+        """Followed blob center, or None on miss (keeps last window for
+        retry). A hop past WRIST_JUMP_PX returns the old center and keeps the
+        old window, so the next frame re-tests it from where the blob was;
+        the hop is followed only once it has repeated WRIST_JUMP_CONFIRM
+        frames running."""
         pt, window, _score, axis = vision.seg_track(hsv, self.model, self.window, min_score=WRIST_SEG_MIN_SCORE)
-        if pt is not None and math.hypot(pt[0] - self.guess[0], pt[1] - self.guess[1]) > WRIST_MAX_JUMP_PX:
-            pt = None
-        if pt is None:
+        if pt is None or _dist(pt, self.guess) > WRIST_MAX_JUMP_PX:
             self.misses += 1
             return None
         self.misses = 0
-        self.window = window
-        self.guess = pt
-        self.axis = axis
+        if self.observed and _dist(pt, self.guess) > WRIST_JUMP_PX and not self._hop_confirmed(pt):
+            return self.guess
+        self.window, self.guess, self.axis, self.observed = window, pt, axis, True
+        self.pending, self.hits = None, 0
         return pt
+
+    def _hop_confirmed(self, pt):
+        if self.pending is not None and _dist(pt, self.pending) <= WRIST_JUMP_PX:
+            self.hits += 1
+        else:
+            self.pending, self.hits = pt, 1
+        if self.hits < WRIST_JUMP_CONFIRM:
+            return False
+        self.pending, self.hits = None, 0
+        return True
+
+
+def _dist(a, b):
+    return math.hypot(a[0] - b[0], a[1] - b[1])
 
 
 class PickAnyObject(Skill):
@@ -365,7 +394,7 @@ class PickAnyObject(Skill):
         self.overlay.readout(f"wrist align: {reason}")
         return x, y, z, roll
 
-    def _draw_wrist(self, px, inside, z, top, blob):
+    def _draw_wrist(self, px, inside, z, top, blob, pending):
         """The servo box, the tracked blob with its long axis, and the descent."""
         p = self._p
         ui = self.overlay
@@ -373,6 +402,10 @@ class PickAnyObject(Skill):
         ui.clear("wrist-target")
         ui.box("wrist-box", (u - half, v - half, u + half, v + half), label="wrist box", view="arm", locked=inside)
         ui.point("blob", px, label="blob", view="arm", locked=inside)
+        if pending is None:
+            ui.clear("hop")
+        else:
+            ui.point("hop", pending, label="hop?", view="arm")
         if inside:
             ui.clear("wrist-steer")
         else:
@@ -490,7 +523,7 @@ class PickAnyObject(Skill):
             centered = centered + 1 if inside else 0
             if axis is None and centered >= 2:
                 axis = self._axis_lock(z, tracker.axis)
-            self._draw_wrist(px, inside, z, top, axis if axis is not None else tracker.axis)
+            self._draw_wrist(px, inside, z, top, axis if axis is not None else tracker.axis, tracker.pending)
             if streak < 2:
                 continue  # watch one more frame before trusting it
             if inside and centered < 2:
@@ -521,7 +554,7 @@ class PickAnyObject(Skill):
                     continue
                 stalled = 0
                 x, y = nx, ny
-                tracker.guess = (p["wrist_box_u"], p["wrist_box_v"])
+                tracker.expect((p["wrist_box_u"], p["wrist_box_v"]))
             self.manipulation.move_to(x, y, z, pitch=p["wrist_pitch"], duration=p["wrist_move_s"])
             if stepped_down:
                 # A pure z-hop barely shifts the view: one fresh confirming

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -70,7 +70,7 @@ PARAMS = {
     # Below image center: the wrist cam sits above the fingertips, so
     # mid-frame aims short of them. 350 is the hardware-tuned parallax bias.
     "wrist_box_v": 350.0,
-    "wrist_half_px": 60.0,
+    "wrist_half_px": 50.0,
     "wrist_kx": -0.04,
     "wrist_ky": -0.04,
     "wrist_step_max": 0.04,

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -29,7 +29,7 @@ from innate import (
 )
 from innate import gemini as gemlib
 from innate.exceptions import ArmFailed, ArmUnhealthy, SkillFailed
-from innate.geometry import IMG_H, IMG_W, floor_to_pixel, pixel_to_floor
+from innate.geometry import IMG_H, IMG_W, arm_bearing, floor_to_pixel, pixel_to_floor
 
 GRIPPER_EMPTY_J6 = -0.085
 VERIFY_BACKUP_M = 0.15
@@ -145,15 +145,6 @@ ROLLED_PITCH = math.pi / 2
 # "could not centre".
 MEM_COAST_LIMIT = 2
 WRIST_SEARCH_ARM = [0.1473, -0.0706, -0.4449, 1.3376, -0.0491]
-# joint1's axis in base_link (URDF). The whole arm lies in the vertical plane
-# through it, so a target's yaw IS its bearing from here — from the base_link
-# origin it is ~18 deg off at grasp range, and with the tool vertical the IK
-# can only put that error into the wrist roll, past its +-1.57 rad stop.
-ARM_BASE_X, ARM_BASE_Y = 0.086, -0.05285
-
-
-def _bearing(x: float, y: float) -> float:
-    return math.atan2(y - ARM_BASE_Y, x - ARM_BASE_X)
 
 
 class _BlobTracker:
@@ -633,7 +624,7 @@ class PickAnyObject(Skill):
         p = self._p
         if roll == 0.0:
             return 0.0, p["arm_pitch"], 0.0
-        yaw = _bearing(x, y)
+        yaw = arm_bearing(x, y)
         for z in (p["roll_z"], p["floor_z"]):
             if not self.manipulation.reachable(x, y, z, roll=roll, pitch=ROLLED_PITCH, yaw=yaw):
                 self.logger.warning(
@@ -795,7 +786,7 @@ class PickAnyObject(Skill):
         if p["wrist_steps"] >= 1:
             self.overlay.stage("align")
             self.overlay.readout("aligning the wrist camera")
-            self._goto_search_pose(_bearing(x, y))
+            self._goto_search_pose(arm_bearing(x, y))
             x, y, z, roll = self._wrist_descend(prompt, x, y)
             self.overlay.clear(view="arm")  # the arm moves on, the view with it
             self._aim(x, y)

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -207,15 +207,15 @@ def _dist(a, b):
     return math.hypot(a[0] - b[0], a[1] - b[1])
 
 
-def _fills_the_view(window) -> bool:
-    """The blob runs off two frame borders: its visible centroid is biased
-    toward the frame centre by an unknown amount, so the servo can only
-    steer it further out. Once the object has been centred whole, that xy
-    is the best estimate there is; before that, steering on the biased
-    centroid still beats a blind grasp."""
+def _clipped_axes(window) -> tuple[bool, bool]:
+    """Which of (u, v) the blob runs off the frame on. A centroid measured
+    across a border is pulled toward the frame centre by the part the camera
+    cannot see, so that axis carries no position: correcting it would only
+    trade the arm's last whole-object centring for the bias. The other axis
+    is unbiased and still worth steering; both clipped is the end of the
+    information there is."""
     x, y, w, h = window
-    edges = (x <= 1) + (y <= 1) + (x + w >= IMG_W - 1) + (y + h >= IMG_H - 1)
-    return edges >= 2
+    return (x <= 1 or x + w >= IMG_W - 1), (y <= 1 or y + h >= IMG_H - 1)
 
 
 class PickAnyObject(Skill):
@@ -428,11 +428,11 @@ class PickAnyObject(Skill):
         else:
             self.overlay.point("hop", pending, label="hop?", view="arm")
 
-    def _draw_wrist(self, px, inside, z, top, blob):
+    def _draw_wrist(self, px, aim, inside, z, top, blob):
         """The servo box, the tracked blob with its long axis, and the descent."""
         p = self._p
         ui = self.overlay
-        u, v, half = p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"]
+        u, v, half = aim[0], aim[1], p["wrist_half_px"]
         ui.clear("wrist-target")
         ui.box("wrist-box", (u - half, v - half, u + half, v + half), label="wrist box", view="arm", locked=inside)
         ui.point("blob", px, label="blob", view="arm", locked=inside)
@@ -547,18 +547,23 @@ class PickAnyObject(Skill):
                     reason = fail
                     break
                 px = tracker.guess
-            if descended and _fills_the_view(tracker.window):
+            # Until the first z-step nothing has been centred, so a biased
+            # centroid still beats a blind grasp.
+            clip_u, clip_v = _clipped_axes(tracker.window)
+            hold_u, hold_v = descended and clip_u, descended and clip_v
+            if hold_u and hold_v:
                 reason = "fills the view"
                 break
             streak += 1
 
-            err_u = px[0] - p["wrist_box_u"]
-            err_v = px[1] - p["wrist_box_v"]
-            inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
+            aim = (px[0] if hold_u else p["wrist_box_u"], px[1] if hold_v else p["wrist_box_v"])
+            err_u = px[0] - aim[0]
+            err_v = px[1] - aim[1]
+            inside = inside_box(px, aim[0], aim[1], p["wrist_half_px"])
             centered = centered + 1 if inside else 0
             if centered >= 2:
                 axis = self._trusted_axis(z, tracker.axis) or axis
-            self._draw_wrist(px, inside, z, top, axis if axis is not None else tracker.axis)
+            self._draw_wrist(px, aim, inside, z, top, axis if axis is not None else tracker.axis)
             if streak < 2:
                 continue  # watch one more frame before trusting it
             if inside and centered < 2:
@@ -590,7 +595,7 @@ class PickAnyObject(Skill):
                     continue
                 stalled = 0
                 x, y = nx, ny
-                tracker.expect((p["wrist_box_u"], p["wrist_box_v"]))
+                tracker.expect(aim)
             self.manipulation.move_to(x, y, z, pitch=p["wrist_pitch"], duration=p["wrist_move_s"])
             if stepped_down:
                 # A pure z-hop barely shifts the view: one fresh confirming

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -70,7 +70,7 @@ PARAMS = {
     # Below image center: the wrist cam sits above the fingertips, so
     # mid-frame aims short of them. 350 is the hardware-tuned parallax bias.
     "wrist_box_v": 350.0,
-    "wrist_half_px": 50.0,
+    "wrist_half_px": 40.0,
     "wrist_kx": -0.04,
     "wrist_ky": -0.04,
     "wrist_step_max": 0.04,

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -85,6 +85,11 @@ PARAMS = {
     # ee_link target, not fingertip height. 0.01 dug into carpet and aborted.
     "floor_z": 0.03,
     "descend_s": 1.2,
+    # A rolled grasp turns onto the object here, not at wrist_stop_z: the roll
+    # is about the tool axis, tilted for the camera, so mid-turn one open
+    # fingertip swings ~3 cm below the other — into an object it still
+    # clears from 10 cm. Higher and the vertical tool leaves the reach.
+    "roll_z": 0.10,
     "orient_s": 1.0,
     "descend_abort_z": 0.12,
     "arm_pitch": 1.30,
@@ -590,9 +595,12 @@ class PickAnyObject(Skill):
         if roll == 0.0:
             return 0.0, p["arm_pitch"], 0.0
         yaw = math.atan2(y, x)
-        if not self.manipulation.reachable(x, y, p["floor_z"], roll=roll, pitch=ROLLED_PITCH, yaw=yaw):
-            self.logger.warning(f"[PickAnyObject] rolled grasp unreachable at ({x:.2f}, {y:.2f}); grasping unrolled")
-            return 0.0, p["arm_pitch"], 0.0
+        for z in (p["roll_z"], p["floor_z"]):
+            if not self.manipulation.reachable(x, y, z, roll=roll, pitch=ROLLED_PITCH, yaw=yaw):
+                self.logger.warning(
+                    f"[PickAnyObject] rolled grasp unreachable at ({x:.2f}, {y:.2f}, {z:.2f}); grasping unrolled"
+                )
+                return 0.0, p["arm_pitch"], 0.0
         return roll, ROLLED_PITCH, yaw
 
     def _push_to_floor(self, x: float, y: float, z_from: float, roll: float, pitch: float, yaw: float) -> None:
@@ -602,16 +610,13 @@ class PickAnyObject(Skill):
         p = self._p
         self.check_cancelled()
         self.overlay.readout("reaching to the floor")
-        rungs = [z for z in (p["descend_z1"], p["descend_z2"], p["descend_z3"], p["floor_z"]) if z < z_from - 1e-6]
-        if rungs:
-            # grip=GRIPPER_OPEN re-asserts an open claw even if it drifted
-            # shut during the wrist descent (never re-seed from measured).
-            waypoints = [Waypoint(x, y, z, roll=roll, pitch=pitch, yaw=yaw, duration=p["descend_s"]) for z in rungs]
-            if roll != 0.0:
-                # The wrist stage stops at wrist_stop_z, so the rungs below it are
-                # millimetres: blended in, the fingers finish turning onto the object
-                # rather than above it. Turn at height first, then descend straight.
-                waypoints.insert(0, Waypoint(x, y, z_from, roll=roll, pitch=pitch, yaw=yaw, duration=p["orient_s"]))
+        waypoints = self._turn_at_height(x, y, z_from, roll, pitch, yaw) if roll != 0.0 else []
+        z_top = waypoints[-1].z if waypoints else z_from
+        rungs = [z for z in (p["descend_z1"], p["descend_z2"], p["descend_z3"], p["floor_z"]) if z < z_top - 1e-6]
+        # grip=GRIPPER_OPEN re-asserts an open claw even if it drifted
+        # shut during the wrist descent (never re-seed from measured).
+        waypoints += [Waypoint(x, y, z, roll=roll, pitch=pitch, yaw=yaw, duration=p["descend_s"]) for z in rungs]
+        if waypoints:
             try:
                 self.manipulation.follow(waypoints, grip=self.manipulation.GRIPPER_OPEN)
             except ArmFailed as e:
@@ -629,6 +634,19 @@ class PickAnyObject(Skill):
         if ee_z is not None and ee_z > p["descend_abort_z"]:
             self.manipulation.recover()
             raise ArmUnhealthy("arm would not descend")
+
+    def _turn_at_height(
+        self, x: float, y: float, z_from: float, roll: float, pitch: float, yaw: float
+    ) -> list[Waypoint]:
+        """Rise straight (still in the servo's unrolled pose) to roll_z, then
+        turn in place; the descent below is straight and already aligned."""
+        p = self._p
+        z = max(z_from, p["roll_z"])
+        wps: list[Waypoint] = []
+        if z > z_from + 1e-6:
+            wps.append(Waypoint(x, y, z, pitch=p["wrist_pitch"], duration=p["orient_s"]))
+        wps.append(Waypoint(x, y, z, roll=roll, pitch=pitch, yaw=yaw, duration=p["orient_s"]))
+        return wps
 
     def _arm_joints(self):
         """The 6 current joint positions; raises LookupError when joint

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -60,6 +60,10 @@ PARAMS = {
     # range, so a flat gate would reject the very object it is protecting.
     "mem_gate_m": 0.35,
     "mem_gate_frac": 0.4,
+    # Parking 3 cm short of the shared 0.285 puts the grasp at x=0.265 instead
+    # of 0.235, which sits 1.5 cm off REACH_X's near wall — close enough that a
+    # backward wrist nudge is eaten by the clamp and the servo stalls out.
+    "sweet_x": 0.315,
     # WRIST ALIGN (0 wrist_steps = blind grasp)
     "wrist_steps": 2.0,
     "wrist_stop_z": 0.05,

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -85,6 +85,7 @@ PARAMS = {
     # ee_link target, not fingertip height. 0.01 dug into carpet and aborted.
     "floor_z": 0.03,
     "descend_s": 1.2,
+    "orient_s": 1.0,
     "descend_abort_z": 0.12,
     "arm_pitch": 1.30,
     # close_strength is close depth, not force (servo 6 runs current-based
@@ -606,6 +607,11 @@ class PickAnyObject(Skill):
             # grip=GRIPPER_OPEN re-asserts an open claw even if it drifted
             # shut during the wrist descent (never re-seed from measured).
             waypoints = [Waypoint(x, y, z, roll=roll, pitch=pitch, yaw=yaw, duration=p["descend_s"]) for z in rungs]
+            if roll != 0.0:
+                # The wrist stage stops at wrist_stop_z, so the rungs below it are
+                # millimetres: blended in, the fingers finish turning onto the object
+                # rather than above it. Turn at height first, then descend straight.
+                waypoints.insert(0, Waypoint(x, y, z_from, roll=roll, pitch=pitch, yaw=yaw, duration=p["orient_s"]))
             try:
                 self.manipulation.follow(waypoints, grip=self.manipulation.GRIPPER_OPEN)
             except ArmFailed as e:

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -634,6 +634,10 @@ class PickAnyObject(Skill):
         if ee_z is not None and ee_z > p["descend_abort_z"]:
             self.manipulation.recover()
             raise ArmUnhealthy("arm would not descend")
+        settled = f"z={ee_z:.3f}" if ee_z is not None else "z=?"
+        self.logger.info(
+            f"[PickAnyObject] descent settled at {settled} (target {p['floor_z']:.3f}, roll={math.degrees(roll):+.0f} deg)"
+        )
 
     def _turn_at_height(
         self, x: float, y: float, z_from: float, roll: float, pitch: float, yaw: float

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -656,12 +656,14 @@ class PickAnyObject(Skill):
     def _turn_at_height(
         self, x: float, y: float, z_from: float, roll: float, pitch: float, yaw: float
     ) -> list[Waypoint]:
-        """Rise straight (still in the servo's unrolled pose) to roll_z, then
-        turn in place; the descent below is straight and already aligned."""
+        """Go straight (still in the servo's unrolled pose) to roll_z — the
+        one turn height _grasp_orientation reach-checked, whether the servo
+        stopped below it or bailed above — then turn in place; the descent
+        below is straight and already aligned."""
         p = self._p
-        z = max(z_from, p["roll_z"])
+        z = p["roll_z"]
         wps: list[Waypoint] = []
-        if z > z_from + 1e-6:
+        if abs(z - z_from) > 1e-6:
             wps.append(Waypoint(x, y, z, pitch=p["wrist_pitch"], duration=p["orient_s"]))
         wps.append(Waypoint(x, y, z, roll=roll, pitch=pitch, yaw=yaw, duration=p["orient_s"]))
         return wps

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -141,6 +141,15 @@ ROLLED_PITCH = math.pi / 2
 # "could not centre".
 MEM_COAST_LIMIT = 2
 WRIST_SEARCH_ARM = [0.1473, -0.0706, -0.4449, 1.3376, -0.0491]
+# joint1's axis in base_link (URDF). The whole arm lies in the vertical plane
+# through it, so a target's yaw IS its bearing from here — from the base_link
+# origin it is ~18 deg off at grasp range, and with the tool vertical the IK
+# can only put that error into the wrist roll, past its +-1.57 rad stop.
+ARM_BASE_X, ARM_BASE_Y = 0.086, -0.05285
+
+
+def _bearing(x: float, y: float) -> float:
+    return math.atan2(y - ARM_BASE_Y, x - ARM_BASE_X)
 
 
 class _BlobTracker:
@@ -594,7 +603,7 @@ class PickAnyObject(Skill):
         p = self._p
         if roll == 0.0:
             return 0.0, p["arm_pitch"], 0.0
-        yaw = math.atan2(y, x)
+        yaw = _bearing(x, y)
         for z in (p["roll_z"], p["floor_z"]):
             if not self.manipulation.reachable(x, y, z, roll=roll, pitch=ROLLED_PITCH, yaw=yaw):
                 self.logger.warning(
@@ -754,7 +763,7 @@ class PickAnyObject(Skill):
         if p["wrist_steps"] >= 1:
             self.overlay.stage("align")
             self.overlay.readout("aligning the wrist camera")
-            self._goto_search_pose(math.atan2(y, x))
+            self._goto_search_pose(_bearing(x, y))
             x, y, z, roll = self._wrist_descend(prompt, x, y)
             self.overlay.clear(view="arm")  # the arm moves on, the view with it
             self._aim(x, y)

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -207,6 +207,16 @@ def _dist(a, b):
     return math.hypot(a[0] - b[0], a[1] - b[1])
 
 
+def _fills_the_view(window) -> bool:
+    """The blob runs off two frame borders: its visible centroid is biased
+    toward the frame centre by an unknown amount, so the servo can only
+    steer it further out. The xy centred while it was whole is the best
+    estimate there is."""
+    x, y, w, h = window
+    edges = (x <= 1) + (y <= 1) + (x + w >= IMG_W - 1) + (y + h >= IMG_H - 1)
+    return edges >= 2
+
+
 class PickAnyObject(Skill):
     """Pick up an object lying on the floor, described in natural language
     (e.g. prompt='the white sock', 'a red cup'). The robot localizes the
@@ -535,6 +545,9 @@ class PickAnyObject(Skill):
                     reason = fail
                     break
                 px = tracker.guess
+            if _fills_the_view(tracker.window):
+                reason = "fills the view"
+                break
             streak += 1
 
             err_u = px[0] - p["wrist_box_u"]

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -119,8 +119,8 @@ WRIST_CAM_ABOVE_EE = 0.07
 AXIS_HALF_PX = 45
 # Wrist roll to the blob's minor axis (the gripper's 81 mm jaw is narrower
 # than most objects' long side). Blobs rounder than MIN_ELONGATION have no
-# axis worth chasing. The axis is locked from the first centred view at or
-# above AXIS_MIN_Z: lower, the blob fills the frame and the fingers clip its
+# axis worth chasing. The axis follows every centred view down to AXIS_MIN_Z
+# and freezes there: lower, the blob fills the frame and the fingers clip its
 # ends, and the minor axis of a clipped blob swings freely.
 MIN_ELONGATION = 1.3
 ROLL_MAX = 1.5
@@ -435,9 +435,9 @@ class PickAnyObject(Skill):
         ui.readout(f"{'descending' if inside else 'centring'} · {round(z * 100)} cm up", progress=progress)
 
     @staticmethod
-    def _axis_lock(z: float, blob: vision.Axis | None) -> vision.Axis | None:
+    def _trusted_axis(z: float, blob: vision.Axis | None) -> vision.Axis | None:
         """The blob axis if this centred view is high and elongated enough
-        to trust for the whole descent, else None to keep looking."""
+        to trust for the grasp, else None to keep what was read before."""
         if z < AXIS_MIN_Z or blob is None or blob[1] < MIN_ELONGATION:
             return None
         return blob
@@ -498,7 +498,7 @@ class PickAnyObject(Skill):
 
         deadline = time.monotonic() + WRIST_ALIGN_TIMEOUT_S
         top = z
-        axis = None  # locked from the first centred view high enough to trust
+        axis = None  # last centred view high enough to trust
         streak = 0  # verified matches since the arm last moved
         centered = 0  # consecutive matches INSIDE the box
         stalled = 0  # consecutive steps eaten by the reach clamp
@@ -536,8 +536,8 @@ class PickAnyObject(Skill):
             err_v = px[1] - p["wrist_box_v"]
             inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
             centered = centered + 1 if inside else 0
-            if axis is None and centered >= 2:
-                axis = self._axis_lock(z, tracker.axis)
+            if centered >= 2:
+                axis = self._trusted_axis(z, tracker.axis) or axis
             self._draw_wrist(px, inside, z, top, axis if axis is not None else tracker.axis, tracker.pending)
             if streak < 2:
                 continue  # watch one more frame before trusting it

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -210,8 +210,9 @@ def _dist(a, b):
 def _fills_the_view(window) -> bool:
     """The blob runs off two frame borders: its visible centroid is biased
     toward the frame centre by an unknown amount, so the servo can only
-    steer it further out. The xy centred while it was whole is the best
-    estimate there is."""
+    steer it further out. Once the object has been centred whole, that xy
+    is the best estimate there is; before that, steering on the biased
+    centroid still beats a blind grasp."""
     x, y, w, h = window
     edges = (x <= 1) + (y <= 1) + (x + w >= IMG_W - 1) + (y + h >= IMG_H - 1)
     return edges >= 2
@@ -516,6 +517,7 @@ class PickAnyObject(Skill):
         streak = 0  # verified matches since the arm last moved
         centered = 0  # consecutive matches INSIDE the box
         stalled = 0  # consecutive steps eaten by the reach clamp
+        descended = False  # a z-step has happened, so x, y were centred once
         reason = "reached stop z"
         while z > p["wrist_stop_z"] + 1e-6:
             # Explicit cancel point: with a fresh frame already buffered (the
@@ -545,7 +547,7 @@ class PickAnyObject(Skill):
                     reason = fail
                     break
                 px = tracker.guess
-            if _fills_the_view(tracker.window):
+            if descended and _fills_the_view(tracker.window):
                 reason = "fills the view"
                 break
             streak += 1
@@ -564,6 +566,7 @@ class PickAnyObject(Skill):
 
             stepped_down = centered >= 2
             if stepped_down:
+                descended = True
                 z = max(p["wrist_stop_z"], z - p["wrist_z_step"])
                 # Descending IS progress: only consecutive clamped nudges count
                 # as stalled, or three clamps spread across a long tracking

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -174,18 +174,20 @@ class _BlobTracker:
         self.guess, self.observed, self.pending, self.hits = px, False, None, 0
 
     def update(self, hsv):
-        """Followed blob center, or None on miss (keeps last window for
-        retry). A hop past WRIST_JUMP_PX returns the old center and keeps the
-        old window, so the next frame re-tests it from where the blob was;
-        the hop is followed only once it has repeated WRIST_JUMP_CONFIRM
-        frames running."""
+        """Followed blob center, or None when this frame gives no
+        observation: a miss (counted in `misses`, last window kept for retry)
+        or a held hop. A hop past WRIST_JUMP_PX is held — the old window
+        stays, so the next frame re-tests it from where the blob was — and
+        followed once it has repeated WRIST_JUMP_CONFIRM frames running; a
+        miss or a frame back home breaks the run."""
         pt, window, _score, axis = vision.seg_track(hsv, self.model, self.window, min_score=WRIST_SEG_MIN_SCORE)
         if pt is None or _dist(pt, self.guess) > WRIST_MAX_JUMP_PX:
             self.misses += 1
+            self.pending, self.hits = None, 0
             return None
         self.misses = 0
         if self.observed and _dist(pt, self.guess) > WRIST_JUMP_PX and not self._hop_confirmed(pt):
-            return self.guess
+            return None
         self.window, self.guess, self.axis, self.observed = window, pt, axis, True
         self.pending, self.hits = None, 0
         return pt
@@ -409,7 +411,13 @@ class PickAnyObject(Skill):
         self.overlay.readout(f"wrist align: {reason}")
         return x, y, z, roll
 
-    def _draw_wrist(self, px, inside, z, top, blob, pending):
+    def _draw_hop(self, pending):
+        if pending is None:
+            self.overlay.clear("hop")
+        else:
+            self.overlay.point("hop", pending, label="hop?", view="arm")
+
+    def _draw_wrist(self, px, inside, z, top, blob):
         """The servo box, the tracked blob with its long axis, and the descent."""
         p = self._p
         ui = self.overlay
@@ -417,10 +425,6 @@ class PickAnyObject(Skill):
         ui.clear("wrist-target")
         ui.box("wrist-box", (u - half, v - half, u + half, v + half), label="wrist box", view="arm", locked=inside)
         ui.point("blob", px, label="blob", view="arm", locked=inside)
-        if pending is None:
-            ui.clear("hop")
-        else:
-            ui.point("hop", pending, label="hop?", view="arm")
         if inside:
             ui.clear("wrist-steer")
         else:
@@ -517,10 +521,11 @@ class PickAnyObject(Skill):
                 break
 
             px = tracker.update(hsv)
+            self._draw_hop(tracker.pending)
             if px is None:
                 streak = centered = 0
                 if tracker.misses < 3:
-                    continue  # transient (blur / mid-move frame) — wait
+                    continue  # transient (blur / mid-move / held hop) — wait
                 if looks <= 0:
                     reason = "lost track"
                     break
@@ -538,7 +543,7 @@ class PickAnyObject(Skill):
             centered = centered + 1 if inside else 0
             if centered >= 2:
                 axis = self._trusted_axis(z, tracker.axis) or axis
-            self._draw_wrist(px, inside, z, top, axis if axis is not None else tracker.axis, tracker.pending)
+            self._draw_wrist(px, inside, z, top, axis if axis is not None else tracker.axis)
             if streak < 2:
                 continue  # watch one more frame before trusting it
             if inside and centered < 2:

--- a/workspace/innate_skills/pick_any_object.py
+++ b/workspace/innate_skills/pick_any_object.py
@@ -108,11 +108,12 @@ WRIST_CAM_ABOVE_EE = 0.07
 AXIS_HALF_PX = 45
 # Wrist roll to the blob's minor axis (the gripper's 81 mm jaw is narrower
 # than most objects' long side). Blobs rounder than MIN_ELONGATION have no
-# axis worth chasing; below AXIS_MIN_Z the fingers straddle the blob in the
-# wrist view and clip its ends, so the last trusted reading is kept.
+# axis worth chasing. The axis is locked from the first centred view at or
+# above AXIS_MIN_Z: lower, the blob fills the frame and the fingers clip its
+# ends, and the minor axis of a clipped blob swings freely.
 MIN_ELONGATION = 1.3
 ROLL_MAX = 1.5
-AXIS_MIN_Z = 0.07
+AXIS_MIN_Z = 0.10
 # Rolls under ROLL_MIN are not worth leaving the hardware-tuned unrolled
 # grasp for. ROLL_SIGN is verified in sim only: a mirrored wrist camera (as
 # the Gemini prompts below describe the real one) needs -1.
@@ -386,6 +387,14 @@ class PickAnyObject(Skill):
         ui.readout(f"{'descending' if inside else 'centring'} · {round(z * 100)} cm up", progress=progress)
 
     @staticmethod
+    def _axis_lock(z: float, blob: vision.Axis | None) -> vision.Axis | None:
+        """The blob axis if this centred view is high and elongated enough
+        to trust for the whole descent, else None to keep looking."""
+        if z < AXIS_MIN_Z or blob is None or blob[1] < MIN_ELONGATION:
+            return None
+        return blob
+
+    @staticmethod
     def _grasp_roll(axis: vision.Axis | None) -> float:
         """Wrist roll that turns the fingers onto the blob's minor axis, or
         0.0 for the tuned unrolled grasp. The wrist camera rolls with the
@@ -441,7 +450,7 @@ class PickAnyObject(Skill):
 
         deadline = time.monotonic() + WRIST_ALIGN_TIMEOUT_S
         top = z
-        axis = None  # last blob axis read high enough to trust
+        axis = None  # locked from the first centred view high enough to trust
         streak = 0  # verified matches since the arm last moved
         centered = 0  # consecutive matches INSIDE the box
         stalled = 0  # consecutive steps eaten by the reach clamp
@@ -460,8 +469,6 @@ class PickAnyObject(Skill):
                 break
 
             px = tracker.update(hsv)
-            if px is not None and z >= AXIS_MIN_Z and tracker.axis is not None:
-                axis = tracker.axis
             if px is None:
                 streak = centered = 0
                 if tracker.misses < 3:
@@ -480,8 +487,10 @@ class PickAnyObject(Skill):
             err_u = px[0] - p["wrist_box_u"]
             err_v = px[1] - p["wrist_box_v"]
             inside = inside_box(px, p["wrist_box_u"], p["wrist_box_v"], p["wrist_half_px"])
-            self._draw_wrist(px, inside, z, top, tracker.axis)
             centered = centered + 1 if inside else 0
+            if axis is None and centered >= 2:
+                axis = self._axis_lock(z, tracker.axis)
+            self._draw_wrist(px, inside, z, top, axis if axis is not None else tracker.axis)
             if streak < 2:
                 continue  # watch one more frame before trusting it
             if inside and centered < 2:


### PR DESCRIPTION
Tuning pass on `pick_any_object`'s wrist stage and rolled grasp, driven by runs on the robot and in sim. The skill changes are in `workspace/innate_skills/pick_any_object.py`; one SDK change in `innate/vision.py` fixes tracking thin objects.

## Wrist box 60 → 40 px

`wrist_half_px` tightens the servo's acceptance box from 60 to 40 px. In sim, the along-the-robot bar (the unrolled, "easy" case) missed twice at 50 px with the fingers landing beside it, and held at 40 px.

## The grasp axis is read from a clean, centred view

The wrist roll comes from the blob's long axis. Before, the axis was whatever the tracker last read above 7 cm, so the grasp used the lowest view, where the blob fills the frame and the fingers clip its ends. The minor axis of a clipped blob swings freely, which is the instability seen near the ground.

Now the axis refreshes on every frame where the blob has been confirmed inside the box and freezes when the descent passes `AXIS_MIN_Z` = 10 cm. The grasp uses the last centred, closest view with the fingers still clear. The overlay draws the axis it will actually use.

## Hysteresis on the wrist blob

On the real robot the tracked point sometimes hops between two places. CamShift hops of 40–80 px from the followed point are now held rather than chased: the tracker reports no observation for that frame and keeps its old search window, so the next frame re-tests the hop from where the blob was, and the descent loop waits rather than stepping down on a stale centre. Three consecutive frames at the new place accept it; a frame back home or a miss breaks the run. Hops past 80 px stay misses, so the Gemini re-seed path is untouched. The first frame after an arm move is adopted outright: right after a nudge the followed point is the box centre, an expectation rather than an observation. The wrist overlay shows a `hop?` marker while one is held.

## Turn onto the object at height, then descend

The roll cannot happen during the servo. The wrist camera hangs off the roll link 5 cm above the tool axis and pitched 25° toward the fingers, so it only looks down while the tool is tilted and unrolled; rolling about that tilted axis swings the camera ~40° off vertical. The one orientation where a roll keeps the camera down is the vertical tool, which is out of reach at grasp range for a 26 cm arm.

Rolling at `wrist_stop_z` (5 cm) hit the object instead: the open fingertips sit 4 cm either side of the tool axis, and turning through the roll swings one of them ~3 cm below the other, into the object. The descent now goes straight to a new `roll_z` (10 cm) in the servo's unrolled pose — rising from the servo's stop, or descending if the servo bailed higher — turns in place there, and descends the rungs already aligned. `roll_z` is the one turn height, and the rolled pose is reach-checked there as well as at the floor; unreachable falls back to the unrolled grasp as before.

Sim, orange bar at 45°: rolled 46°, the bar was untouched until the fingers closed, held.

## Yaw is the bearing from the arm's own base

Every -86° rolled grasp in the log held and the +86° one closed on air. The rolled grasp asks for a vertical tool with yaw equal to the target bearing, but the bearing was measured from the base_link origin while joint 1 pivots 8.6 cm forward and 5.3 cm to the right. At grasp range that is ~18° of error. With the tool vertical the only joint that can absorb a yaw error is the wrist roll, so +86° became a joint 5 target of 1.81 rad, past its 1.57 rad stop, and the servo clamped it; -86° came out at -1.19 rad and was fine. The IK node has no joint limits, which is why `reachable()` passed. The bearing is now taken from joint 1's axis, for the rolled grasp and the wrist search pose.

## Tracking thin objects (SDK: `innate/vision.py`)

On the robot a pen lost the wrist tracker on the first frames after the seed ("wrist stage: lost track (z=0.193)"), and the grasp fell back to the blind descent from the search pose. `seg_track` scored each CamShift result by the mean back-projection inside the window's axis-aligned bounding box, which is mostly floor around a thin diagonal object, so a track sitting on the pen still fell under the 25 threshold. The score is now the mean inside CamShift's rotated rectangle. Synthetic check, coloured bar on a noisy floor:

| bar | bounding-box score (old) | rotated-rect score (new) |
|---|---|---|
| 6 px wide, axis-aligned | 152 | 170 |
| 6 px wide, 45° | 23.5 | 189 |
| 10 px wide, 30° | 36 | 199 |
| 30 px wide, 45° | 91 | 207 |

Axis-aligned objects are barely affected. Needs a rebuild on the robot.

## Tracking featureless objects (SDK: `innate/vision.py`)

On the robot the tracked point on an AirPods case starts at Gemini's box centre and drifts to an edge as the case grows in the wrist view, so the servo centres the edge and the grasp misses. The colour model is a histogram ratio normalised so the object's dominant shade scores 255 and its other shades less; on a glossy object mean shift climbs onto the lit face and CamShift's window hugs that patch, and the window centre was the reported position. `seg_track` now returns the centroid of the whole thresholded blob under the window (the same blob the axis was already measured on), and that blob's bounding box becomes the next window. Synthetic glossy case growing from 120 to 300 px across five frames:

| frame | old CamShift-centre error | new centroid error |
|---|---|---|
| 0 | 5 px | 1 px |
| 2 | 25 px | 1 px |
| 4 | 63 px | 1 px |

## Large objects close up (SDK: `innate/vision.py`)

Near the bottom of the descent the AirPods track ended with "lost track" and the grasp ran from a stale xy. `seg_track` rejected any CamShift window above 40% of the frame as a flooded model. The real wrist camera's field of view is much narrower than the sim's 80° (a case spans ~60% of the frame width at grasp height), so a legitimately tracked case crosses 40% just before the 5 cm stop, every frame becomes a miss, and the re-seed's window is just as large. The guard now rejects only a window covering 90% of the frame, which a flooded model still hits.

Past that point the case runs off two frame borders, and the centroid of the visible part is biased toward the frame centre by an amount the camera cannot know, so steering on it only pushes the object further out. The servo now exits with "fills the view" when the blob touches two borders, and the grasp uses the xy that was centred while the object was still whole.

## Diagnostics

The descent logs where the end effector settled against the floor target and the roll used, so a "closed above the object" run shows whether the arm stopped short or reached the target height.

## Testing

Sim runs on the orange bar, blue can and pink cube; the rolled cases and the 40 px unrolled case held. The wrist hysteresis and the yaw fix were verified by reasoning and a standalone check of the tracker logic, not on hardware. The thin-object scoring was verified synthetically as above; the pen itself has not been re-tried on the robot with the rebuilt SDK yet.
