### PR TITLE
fix(sim): `up` straight after `down` -- the port probe asks listeners, `down` sweeps the checkout's world servers

### DIFF
--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -122,8 +122,10 @@ def cmd_up(
         # behind -- and one of them holds the ports this stack needs.
         remove_superseded_containers()
         if runtime_already_running(config):
-            # A code update can leave a stale world server running (frozen
-            # 3D view); ensure_world_server restarts it.
+            # ensure_world_server restarts a world left stale by a code update:
+            # it stops the old server and can spend minutes on the new one, so
+            # from here an `up` that does not finish must tear down, not strand it.
+            started = True
             ensure_world_server(config)
             log("Innate sim runtime is already running. Opening dashboard...")
             show_runtime_dashboard(config, watch=watch)
@@ -149,8 +151,6 @@ def cmd_up(
             ensure_viewer_public_assets(config)
         with live_step("bundle", "Fetching the 3D viewer bundle", "3D viewer bundle"):
             ensure_sim_viewer_bundle(config, offline=offline)
-        # From here an interrupt must tear down: the world step can run for
-        # minutes (uv sync, MuJoCo compile) with its server already spawned.
         started = True
         with live_step("world", "Starting the physics world", "physics world"):
             config["world_endpoint"] = ensure_world_server(config)

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -149,10 +149,12 @@ def cmd_up(
             ensure_viewer_public_assets(config)
         with live_step("bundle", "Fetching the 3D viewer bundle", "3D viewer bundle"):
             ensure_sim_viewer_bundle(config, offline=offline)
+        # From here an interrupt must tear down: the world step can run for
+        # minutes (uv sync, MuJoCo compile) with its server already spawned.
+        started = True
         with live_step("world", "Starting the physics world", "physics world"):
             config["world_endpoint"] = ensure_world_server(config)
 
-        started = True
         try:
             with live_step("os", "Starting the Innate OS container", "Innate OS container"):
                 ensure_os_container(config, os_env_file, offline=offline)

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -53,6 +53,7 @@ from config import (
     SIM_ASSET_UNITS,
     SIM_ASSET_UNITS_AUTHORED,
     SIM_ASSET_UNITS_DERIVED,
+    SIM_DIR,
     SIM_FOXGLOVE_PORT,
     SIM_HTTP_PORT,
     SIM_HTTPS_PORT,
@@ -1243,13 +1244,14 @@ def running_stack_from_another_checkout() -> tuple[str, str] | None:
     return None
 
 
-def _bind_refusal(port: int, *, udp: bool, reuse: bool = False) -> int | None:
+def _bind_refusal(port: int, *, udp: bool) -> int | None:
     """errno from claiming the port the way its consumer will, or None when the
-    bind succeeds. Docker publishes without SO_REUSEADDR; the host world server
-    sets it (socket.create_server), so its probe must too -- a just-stopped
-    server's TIME_WAIT remnants otherwise read as a live collision for ~30s."""
+    bind succeeds. Every TCP consumer binds with SO_REUSEADDR (Docker's Go
+    proxies and socket.create_server alike), so the probe must too: without it
+    the TIME_WAIT left by a Foxglove tab reconnecting through `down` reads as a
+    live collision for ~30s, while Docker itself would bind straight through."""
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM if udp else socket.SOCK_STREAM) as probe:
-        if reuse:
+        if not udp:
             probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             probe.bind(("0.0.0.0", port))
@@ -1264,17 +1266,17 @@ def _tcp_listener_answers(port: int) -> bool:
     return False
 
 
-def _host_port_free(port: int, *, udp: bool, reuse: bool = False) -> bool:
-    """Whether the port's consumer can still claim it (reuse: see
-    _bind_refusal). Only EADDRINUSE proves a collision: Linux refuses ports
-    below 1024 to a non-root binder while the daemon that publishes them runs
-    as root, so a free 443 refuses the probe."""
-    refusal = _bind_refusal(port, udp=udp, reuse=reuse)
-    if refusal is None:
-        return True
-    if refusal == errno.EACCES and not udp:
-        return not _tcp_listener_answers(port)
-    return refusal != errno.EADDRINUSE
+def _host_port_free(port: int, *, udp: bool) -> bool:
+    """Whether the port's consumer can still claim it. A TCP listener is asked
+    directly: macOS lets a SO_REUSEADDR bind on 0.0.0.0 coexist with a listener
+    on 127.0.0.1 -- every loopback publish and the world server -- so the bind
+    alone is blind to exactly the listeners that matter. The bind still counts,
+    for a listener on some other address; only EADDRINUSE proves a collision,
+    since Linux refuses ports below 1024 to a non-root binder while the daemon
+    that publishes them runs as root, so a free 443 refuses the probe."""
+    if not udp and _tcp_listener_answers(port):
+        return False
+    return _bind_refusal(port, udp=udp) != errno.EADDRINUSE
 
 
 def _container_published_ports(name: str) -> set[int]:
@@ -1305,7 +1307,7 @@ def _suggest_port_base() -> int | None:
     that just failed."""
     for base in range(8600, 9600, 10):
         if all(
-            _host_port_free(base + offset, udp=(spec or "").endswith("/udp"), reuse=spec is None)
+            _host_port_free(base + offset, udp=(spec or "").endswith("/udp"))
             for offset, (_, _, spec) in enumerate(_STACK_PORTS)
         ):
             return base
@@ -1330,7 +1332,7 @@ def refuse_if_ports_taken() -> None:
     taken = [
         (label, port)
         for label, port, spec in _STACK_PORTS
-        if port not in ours and not _host_port_free(port, udp=(spec or "").endswith("/udp"), reuse=spec is None)
+        if port not in ours and not _host_port_free(port, udp=(spec or "").endswith("/udp"))
     ]
     if not taken:
         return
@@ -2523,6 +2525,10 @@ def ensure_world_server(config: dict[str, object]) -> str:
                 f"wants {bind} -- restarting it..."
             )
         _stop_stale_world_server()
+    else:
+        # Silence on this block's port says nothing about the last run: a
+        # checkout moved to another block still has its server on the old one.
+        stop_world_server()
 
     ensure_state_dir()
     attempts: list[tuple[str, str, str]] = []  # (backend label, backend, that attempt's log output)
@@ -2794,13 +2800,75 @@ WORLD_PORTS_RECORD_GRACE_S = 5.0
 def _world_ports_free(ports: list[int], timeout_s: float) -> bool:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
-        if all(_host_port_free(port, udp=False, reuse=True) for port in ports):
+        if all(_host_port_free(port, udp=False) for port in ports):
             return True
         time.sleep(0.2)
     return False
 
 
+def _checkout_world_server_pids() -> set[int]:
+    """Every world server spawned for this checkout, whatever block it was given:
+    the uv parent by the --project it was handed, the python child by the venv
+    it runs from. Both are anchored on this checkout's own sim path, so another
+    clone's server cannot match, and both name the bootstrap module."""
+    parent_marker = f" --project {SIM_DIR} python "
+    child_prefix = f"{SIM_DIR}/.venv/bin/python"
+    listing = subprocess.run(["ps", "-ww", "-eo", "pid=,command="], capture_output=True, text=True, check=False)
+    pids: set[int] = set()
+    for line in listing.stdout.splitlines():
+        pid, _, command = line.strip().partition(" ")
+        if "mars_sim_driver.world_server" not in command:
+            continue
+        if parent_marker in command or command.startswith(child_prefix):
+            with contextlib.suppress(ValueError):
+                pids.add(int(pid))
+    pids.discard(os.getpid())
+    return pids
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _stop_checkout_world_servers() -> None:
+    """The ports record names one server; a checkout that changed block, or an
+    `up` killed mid-start, leaves another behind that no record points at."""
+    pids = _checkout_world_server_pids()
+    # A uv parent still exiting behind the child the recorded stop just ended
+    # is not a leftover.
+    settle = time.monotonic() + 2.0
+    while pids and time.monotonic() < settle:
+        time.sleep(0.2)
+        pids = {pid for pid in pids if _alive(pid)}
+    if not pids:
+        return
+    for pid in pids:
+        with contextlib.suppress(OSError):
+            os.kill(pid, signal.SIGTERM)
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline and any(_alive(pid) for pid in pids):
+        time.sleep(0.2)
+    for pid in pids:
+        if _alive(pid):
+            with contextlib.suppress(OSError):
+                os.kill(pid, signal.SIGKILL)
+    log(f"Stopped {len(pids)} leftover world server process(es) from an earlier run of this checkout.")
+
+
 def stop_world_server() -> None:
+    _stop_recorded_world_server()
+    _stop_checkout_world_servers()
+    with contextlib.suppress(OSError):  # read-only fs: the kill still counts
+        WORLD_SERVER_PID_PATH.unlink(missing_ok=True)
+        WORLD_SERVER_PORTS_PATH.unlink(missing_ok=True)
+        WORLD_SERVER_MODEL_DIGEST_PATH.unlink(missing_ok=True)
+
+
+def _stop_recorded_world_server() -> None:
     # Only the ports this checkout recorded when it started a server. The
     # configured ports are no evidence of ownership -- a checkout that never
     # started one would take them as licence to kill whoever holds the
@@ -2835,10 +2903,6 @@ def stop_world_server() -> None:
                 log("Stopped host world server (forced).")
             else:
                 warn(f"Something else holds the world ports (lsof -nP -iTCP:{ports[-1]}); `{CLI_SIM} up` may refuse.")
-    with contextlib.suppress(OSError):  # read-only fs: the kill still counts
-        WORLD_SERVER_PID_PATH.unlink(missing_ok=True)
-        WORLD_SERVER_PORTS_PATH.unlink(missing_ok=True)
-        WORLD_SERVER_MODEL_DIGEST_PATH.unlink(missing_ok=True)
 
 
 def ensure_skill_assets(config: dict[str, object]) -> None:


### PR DESCRIPTION
## Why

`./innate-sim down` followed immediately by `./innate-sim up` refused with `8765 foxglove bridge already in use` while nothing was listening. The Docker-published ports were probed with a plain bind on the premise that Docker publishes without `SO_REUSEADDR`. It does not: docker-proxy and the Desktop backend are Go listeners and bind straight through a TIME_WAIT (verified by publishing into a parked one). The remnant came from a Foxglove tab reconnecting through the teardown; the proxy's side of that socket sits in TIME_WAIT on 8765 for 30 s on macOS. Only the probe refused.

Along the way, two host world servers turned up running with no container behind them, one unreachable by any `down`: the ports record names a single server, and the fresh-start path of `ensure_world_server` only pinged the current block's port before spawning and overwriting the record. A checkout moved to another block left its server on the old one for good.

## What

- **Port probe asks listeners.** A TCP port is taken when a connect on 127.0.0.1 is answered, or when a `SO_REUSEADDR` bind on 0.0.0.0 fails with EADDRINUSE. A TIME_WAIT no longer reads as a collision. This also fixes a latent blind spot: macOS lets a reuse bind on 0.0.0.0 coexist with a listener on 127.0.0.1, so the old reuse probe for the world ports never saw a live world server. `down` reported "Stopped host world server" the moment it signalled, and a second checkout on the same block was never refused.
- **`down` sweeps the checkout's world servers.** After the record-based stop, every world server spawned for this checkout is stopped, matched by the `--project` it was handed (uv parent) or the venv it runs from (python child), both anchored on this checkout's own sim path. A 2 s settle keeps a parent still exiting behind the recorded stop from being reported as a leftover.
- **Fresh start stops the recorded server first**, whatever block it is on.
- **An interrupt during the world step tears down.** `started` is set before the world step, since the server is already spawned while uv syncs and MuJoCo compiles.

## Verified

Probe semantics per socket state on macOS 26 (plain bind is what shipped; connect is the new signal):

| state | reuse bind 0.0.0.0 | plain bind 0.0.0.0 | connect |
|---|---|---|---|
| LISTEN 127.0.0.1 (loopback publish, world server) | OK | EADDRINUSE | True |
| LISTEN 0.0.0.0 (wildcard publish) | EADDRINUSE | EADDRINUSE | True |
| FIN_WAIT_2 | OK | EADDRINUSE | False |
| TIME_WAIT | OK | EADDRINUSE | False |

Against a live stack, the new probe reports all seven ports taken, a parked TIME_WAIT free, and a free port free. The sweep matched exactly the two processes of each checkout's server and nothing for a checkout whose path is a prefix of another's. A fake orphan carrying the worktree's venv path was found and stopped by `stop_world_server()`. `ruff check` and `ruff format --check` are clean on `sim/launcher`.

Not yet exercised end to end: a real `down` then immediate `up` with a Foxglove tab connected, which needs a full stack cycle.