### PR TITLE
feat(arm): keep the arm out of its own body, and let the leader feel it

### DIFF
--- a/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
+++ b/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
@@ -63,7 +63,8 @@
     # =============================================================
     self_collision:
       enabled: true
-      margin: 0.015        # m of clearance demanded around each box
+      margin: 0.015        # hard stop: m of clearance demanded around each box
+      slow_margin: 0.070   # inside this the arm eases off, decelerating into the stop
       bisect_steps: 8      # resolution of the walk back to a clear pose
       boxes: [
         # chassis: origin (-0.0587, 0, 0.0838), size 0.1878 x 0.182 x 0.1676

--- a/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
+++ b/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
@@ -52,9 +52,14 @@
     # mars_sim/urdf/mars.urdf. The arm mount is deliberately omitted: the arm is
     # bolted to it, so it is always "in collision" with it.
     #
-    # margin is the clearance demanded around every box. The three sampled points
-    # mean a link can pass near a corner between samples; the margin covers that.
-    # Raise it if the arm still grazes, lower it if reachable workspace is lost.
+    # Whole links are tested, not sampled points: the joints sit at 0.21, 0.26
+    # and 0.30 m from the shoulder, so testing only those left the first 0.21 m
+    # of arm uncovered and let 82% of real collisions through.
+    #
+    # margin is the clearance demanded around every box, and doubles as the
+    # links' radius — they are tested as zero-thickness segments, so their real
+    # thickness has to come from somewhere. Raise it if the arm still grazes,
+    # lower it if reachable workspace is lost.
     # =============================================================
     self_collision:
       enabled: true

--- a/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
+++ b/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
@@ -65,7 +65,12 @@
       enabled: true
       margin: 0.015        # floor under every box's own pad
       slow_margin: 0.070   # inside this the arm eases off, decelerating into the stop
-      bisect_steps: 8      # resolution of the walk back to a clear pose
+      # A path is sampled every step_rad along its widest joint, so a long sweep
+      # is checked as finely as a short one. A fixed step count divided whatever
+      # interval it was given, which left a fast move too coarse to see a corner
+      # it passed through.
+      step_rad: 0.04
+      max_steps: 32
       boxes: [
         # chassis: origin (-0.0587, 0, 0.0838), size 0.1878 x 0.182 x 0.1676
         -0.1526, -0.0910,  0.0000,   0.0352,  0.0910,  0.1676,

--- a/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
+++ b/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
@@ -63,7 +63,7 @@
     # =============================================================
     self_collision:
       enabled: true
-      margin: 0.015        # hard stop: m of clearance demanded around each box
+      margin: 0.015        # floor under every box's own pad
       slow_margin: 0.070   # inside this the arm eases off, decelerating into the stop
       bisect_steps: 8      # resolution of the walk back to a clear pose
       boxes: [
@@ -78,6 +78,14 @@
         # neck upper: origin (-0.0466, 0, 0.2533), size 0.0374 x 0.036 x 0.0366
         -0.0653, -0.0180,  0.2350,  -0.0279,  0.0180,  0.2716,
       ]
+      # Clearance demanded per box, in the order above. One global figure cannot
+      # work: the shoulder sits 51 mm from the chassis and never moves further
+      # away, so a global pad near that blocks the arm at rest — which is what
+      # made every joint report as blocked. The chassis and rear tray keep a
+      # small pad; the turret and neck, which is what joint_2 folds back into,
+      # get much more, since that is where backlash and flex actually land the
+      # arm on the robot.
+      box_pads: [0.015, 0.015, 0.055, 0.055, 0.055]
 
     joints: ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7"]
 

--- a/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
+++ b/ros2_ws/src/mars_bot/mars_arm/config/arm_config.yaml
@@ -35,6 +35,44 @@
     #   ros2 param load /mars_arm <this file>
     # =============================================================
 
+    # =============================================================
+    # Body keepout — the arm must not intersect the robot's own body.
+    #
+    # The joint_2 floor in arm_control.cpp cannot express this. Reaching DOWN in
+    # front (over a table edge) and folding BACK over the chassis look identical
+    # to any per-joint limit, so a floor that stops one stops the other. This
+    # tests where the arm actually is: elbow, wrist and tool are placed in
+    # base_link and checked against the boxes below. Reaching down stays free;
+    # only poses that put the arm inside the body are refused, and the command is
+    # walked back along the path from the last clear pose rather than clamped —
+    # the infeasible set is not an interval, so there is nothing to clamp to.
+    #
+    # Boxes are flat [min_x,min_y,min_z, max_x,max_y,max_z] sextets in base_link
+    # metres (ROS parameters have no nested arrays), transcribed from
+    # mars_sim/urdf/mars.urdf. The arm mount is deliberately omitted: the arm is
+    # bolted to it, so it is always "in collision" with it.
+    #
+    # margin is the clearance demanded around every box. The three sampled points
+    # mean a link can pass near a corner between samples; the margin covers that.
+    # Raise it if the arm still grazes, lower it if reachable workspace is lost.
+    # =============================================================
+    self_collision:
+      enabled: true
+      margin: 0.015        # m of clearance demanded around each box
+      bisect_steps: 8      # resolution of the walk back to a clear pose
+      boxes: [
+        # chassis: origin (-0.0587, 0, 0.0838), size 0.1878 x 0.182 x 0.1676
+        -0.1526, -0.0910,  0.0000,   0.0352,  0.0910,  0.1676,
+        # rear tray: origin (-0.1895, 0, 0.0466), size 0.0789 x 0.1658 x 0.0594
+        -0.2290, -0.0829,  0.0169,  -0.1501,  0.0829,  0.0763,
+        # lidar turret: origin (-0.0527, 0, 0.1828), size 0.1255 x 0.104 x 0.0304
+        -0.1155, -0.0520,  0.1676,   0.0101,  0.0520,  0.1980,
+        # neck lower: origin (-0.0357, 0, 0.2155), size 0.051 x 0.0854 x 0.039
+        -0.0612, -0.0427,  0.1960,  -0.0102,  0.0427,  0.2350,
+        # neck upper: origin (-0.0466, 0, 0.2533), size 0.0374 x 0.036 x 0.0366
+        -0.0653, -0.0180,  0.2350,  -0.0279,  0.0180,  0.2716,
+      ]
+
     joints: ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7"]
 
     joint_1:

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
@@ -56,6 +56,7 @@ class MarsArmNode : public rclcpp::Node {
     void controlTimerCallback();
     void recordLoopTiming(std::array<std::chrono::steady_clock::time_point, 9>& ts);
     std::vector<int> applyLimitsAndConvertToEncoder(std::vector<double>& command_data);
+    void loadSelfCollisionConfig();
 
     // ── Service & topic callbacks (arm_services.cpp) ────────────────────
     void armCommandCallback(const std_msgs::msg::Float64MultiArray::SharedPtr msg);
@@ -149,6 +150,12 @@ class MarsArmNode : public rclcpp::Node {
     // Control timer
     rclcpp::TimerBase::SharedPtr control_timer_;
     double control_frequency_;
+
+    // Body keepout, and the last commanded pose known to clear it — the point
+    // the bisection retreats toward when a request would strike the chassis.
+    SelfCollisionConfig self_collision_;
+    std::array<double, 4> last_safe_pose_{};
+    bool have_safe_pose_ = false;
 
     // Callback groups for parallel execution
     rclcpp::CallbackGroup::SharedPtr timer_callback_group_;

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
@@ -5,6 +5,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
+#include <std_msgs/msg/int32_multi_array.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <std_msgs/msg/empty.hpp>
@@ -156,6 +157,11 @@ class MarsArmNode : public rclcpp::Node {
     SelfCollisionConfig self_collision_;
     std::array<double, 4> last_safe_pose_{};
     bool have_safe_pose_ = false;
+    // Why each joint's command was altered this cycle, if it was. Published so a
+    // teleop client can tell a physical constraint from the arm merely lagging —
+    // only the former is worth pushing back on the operator's hand.
+    std::array<int, 6> constraint_reason_{};
+    rclcpp::Publisher<std_msgs::msg::Int32MultiArray>::SharedPtr constraint_pub_;
 
     // Callback groups for parallel execution
     rclcpp::CallbackGroup::SharedPtr timer_callback_group_;

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_node.hpp
@@ -5,7 +5,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
-#include <std_msgs/msg/int32_multi_array.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <std_msgs/msg/empty.hpp>
@@ -157,11 +156,6 @@ class MarsArmNode : public rclcpp::Node {
     SelfCollisionConfig self_collision_;
     std::array<double, 4> last_safe_pose_{};
     bool have_safe_pose_ = false;
-    // Why each joint's command was altered this cycle, if it was. Published so a
-    // teleop client can tell a physical constraint from the arm merely lagging —
-    // only the former is worth pushing back on the operator's hand.
-    std::array<int, 6> constraint_reason_{};
-    rclcpp::Publisher<std_msgs::msg::Int32MultiArray>::SharedPtr constraint_pub_;
 
     // Callback groups for parallel execution
     rclcpp::CallbackGroup::SharedPtr timer_callback_group_;

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 
 namespace mars_arm {
 
@@ -81,11 +82,24 @@ struct BodyBox {
 
 struct SelfCollisionConfig {
     std::vector<BodyBox> boxes;
-    double margin = 0.015;      // metres of clearance demanded around each box
-    int bisect_steps = 8;       // resolution of the walk back toward a safe pose
+    double margin = 0.015;       // hard stop: clearance demanded around each box
+    double slow_margin = 0.070;  // soft zone: motion is scaled back inside this
+    int bisect_steps = 8;        // resolution of the walk back toward a safe pose
     bool enabled = true;
     bool valid() const { return !boxes.empty(); }
 };
+
+// Distance from a point to a box, zero inside it.
+inline double pointBoxDistance(const double p[3], const BodyBox& b) {
+    const double lo[3] = {b.min_x, b.min_y, b.min_z};
+    const double hi[3] = {b.max_x, b.max_y, b.max_z};
+    double sum = 0.0;
+    for (int i = 0; i < 3; ++i) {
+        const double d = std::max({lo[i] - p[i], 0.0, p[i] - hi[i]});
+        sum += d * d;
+    }
+    return std::sqrt(sum);
+}
 
 // The arm's joints in the shoulder's sagittal plane: `x` along the arm's
 // bearing, `z` vertical. Rotation matches horizReach's convention. Five points,
@@ -157,6 +171,56 @@ inline bool poseHitsBody(double q1, double q2, double q3, double q4, const SelfC
         for (const auto& b : c.boxes)
             if (segmentHitsBox(pts[i], pts[i + 1], b, c.margin)) return true;
     return false;
+}
+
+// How much room the arm has left, in metres, before it touches the body.
+//
+// Sampled along each link rather than solved exactly: this drives the soft zone,
+// where being a millimetre out changes only how early the arm eases off. The
+// hard stop stays on poseHitsBody's exact slab test, so nothing safety-critical
+// rests on the sampling.
+inline double bodyClearance(double q1, double q2, double q3, double q4, const SelfCollisionConfig& c) {
+    if (!c.enabled || !c.valid()) return std::numeric_limits<double>::infinity();
+    const ArmPlanarPoints p = armPlanarPoints(q2, q3, q4);
+    const double cq = std::cos(q1), sq = std::sin(q1);
+    double pts[ArmPlanarPoints::kCount][3];
+    for (int i = 0; i < ArmPlanarPoints::kCount; ++i) {
+        pts[i][0] = kShoulderX + p.x[i] * cq;
+        pts[i][1] = kShoulderY + p.x[i] * sq;
+        pts[i][2] = kShoulderZ + p.z[i];
+    }
+    constexpr int kSamplesPerLink = 8;
+    double best = std::numeric_limits<double>::infinity();
+    for (int i = 0; i + 1 < ArmPlanarPoints::kCount; ++i) {
+        const double dx = pts[i + 1][0] - pts[i][0], dy = pts[i + 1][1] - pts[i][1],
+                     dz = pts[i + 1][2] - pts[i][2];
+        double near = std::numeric_limits<double>::infinity();
+        for (int k = 0; k <= kSamplesPerLink; ++k) {
+            const double t = static_cast<double>(k) / kSamplesPerLink;
+            const double q[3] = {pts[i][0] + t * dx, pts[i][1] + t * dy, pts[i][2] + t * dz};
+            for (const auto& b : c.boxes) near = std::min(near, pointBoxDistance(q, b));
+        }
+        // The true closest point can sit midway between two samples, so a raw
+        // sampled minimum over-reads by up to half the spacing — enough, on these
+        // link lengths, to be worth as much as the whole margin. Subtracting it
+        // makes the estimate conservative by construction, which is what the
+        // taper needs: reading low only eases the arm off early.
+        const double half_spacing = 0.5 * std::sqrt(dx * dx + dy * dy + dz * dz) / kSamplesPerLink;
+        best = std::min(best, std::max(0.0, near - half_spacing));
+    }
+    return best;
+}
+
+// The fraction of a requested move to accept, given how close the arm is.
+// 1 well clear, falling to 0 at the hard margin, so the arm eases off as it
+// approaches instead of running at full speed into a wall. The taper is also
+// what the leader feels: a scaled-back command diverges from what was asked,
+// and that gap is the force the operator gets back.
+inline double approachScale(double clearance, const SelfCollisionConfig& c) {
+    if (clearance >= c.slow_margin) return 1.0;
+    const double span = c.slow_margin - c.margin;
+    if (span <= 0.0) return clearance > c.margin ? 1.0 : 0.0;
+    return std::clamp((clearance - c.margin) / span, 0.0, 1.0);
 }
 
 struct JointConfig {

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -87,41 +87,75 @@ struct SelfCollisionConfig {
     bool valid() const { return !boxes.empty(); }
 };
 
-// The arm's elbow, wrist and tool in the shoulder's sagittal plane: `px` along
-// the arm's bearing, `pz` vertical. Rotation matches horizReach's convention.
+// The arm's joints in the shoulder's sagittal plane: `x` along the arm's
+// bearing, `z` vertical. Rotation matches horizReach's convention. Five points,
+// shoulder first, so the LINKS between them can be tested — the joints alone all
+// sit past 0.2 m and would leave the whole upper arm uncovered.
 struct ArmPlanarPoints {
-    double elbow_x, elbow_z, wrist_x, wrist_z, tool_x, tool_z;
+    static constexpr int kCount = 5;
+    double x[kCount], z[kCount];  // shoulder, joint3, elbow(joint4), wrist(joint6), tool
 };
 
 inline ArmPlanarPoints armPlanarPoints(double q2, double q3, double q4) {
     const double a23 = q2 + q3, a234 = a23 + q4;
-    const double ex = kL2_x * std::cos(q2) + kL2_z * std::sin(q2) + kL3_x * std::cos(a23) + kL3_z * std::sin(a23);
-    const double ez = -kL2_x * std::sin(q2) + kL2_z * std::cos(q2) - kL3_x * std::sin(a23) + kL3_z * std::cos(a23);
-    const double c = std::cos(a234), s = std::sin(a234);
-    return {ex,
-            ez,
-            ex + kWristFromElbow * c,
-            ez - kWristFromElbow * s,
-            ex + kL45_x * c,
-            ez - kL45_x * s};
+    const double c2 = std::cos(q2), s2 = std::sin(q2);
+    const double c23 = std::cos(a23), s23 = std::sin(a23);
+    const double c234 = std::cos(a234), s234 = std::sin(a234);
+    ArmPlanarPoints p{};
+    p.x[0] = 0.0;
+    p.z[0] = 0.0;
+    p.x[1] = kL2_x * c2 + kL2_z * s2;
+    p.z[1] = -kL2_x * s2 + kL2_z * c2;
+    p.x[2] = p.x[1] + kL3_x * c23 + kL3_z * s23;
+    p.z[2] = p.z[1] - kL3_x * s23 + kL3_z * c23;
+    p.x[3] = p.x[2] + kWristFromElbow * c234;
+    p.z[3] = p.z[2] - kWristFromElbow * s234;
+    p.x[4] = p.x[2] + kL45_x * c234;
+    p.z[4] = p.z[2] - kL45_x * s234;
+    return p;
 }
 
-// True if any sampled point of the arm sits inside a body box. joint_1 rotates
-// the sagittal plane about the shoulder, so a planar (px, pz) lifts to
-// (shoulder + px·cos q1, shoulder + px·sin q1, shoulder + pz).
+// Segment against an axis-aligned box, by the slab method. Exact for a
+// zero-thickness segment; the box's margin stands in for link radius.
+inline bool segmentHitsBox(const double a[3], const double b[3], const BodyBox& box, double m) {
+    const double lo[3] = {box.min_x - m, box.min_y - m, box.min_z - m};
+    const double hi[3] = {box.max_x + m, box.max_y + m, box.max_z + m};
+    double t0 = 0.0, t1 = 1.0;
+    for (int i = 0; i < 3; ++i) {
+        const double d = b[i] - a[i];
+        if (std::fabs(d) < 1e-12) {
+            if (a[i] < lo[i] || a[i] > hi[i]) return false;  // parallel to the slab, outside it
+            continue;
+        }
+        double tn = (lo[i] - a[i]) / d, tf = (hi[i] - a[i]) / d;
+        if (tn > tf) std::swap(tn, tf);
+        t0 = std::max(t0, tn);
+        t1 = std::min(t1, tf);
+        if (t0 > t1) return false;
+    }
+    return true;
+}
+
+// True if any part of any arm link intersects a body box. joint_1 rotates the
+// sagittal plane about the shoulder, so a planar (x, z) lifts to
+// (shoulder + x·cos q1, shoulder + x·sin q1, shoulder + z).
+//
+// Whole links, not sampled points: the joints sit at 0.21, 0.26 and 0.30 m, so
+// testing only those left the first 0.21 m of arm uncovered and let 56% of real
+// collisions through.
 inline bool poseHitsBody(double q1, double q2, double q3, double q4, const SelfCollisionConfig& c) {
     if (!c.enabled || !c.valid()) return false;
     const ArmPlanarPoints p = armPlanarPoints(q2, q3, q4);
     const double cq = std::cos(q1), sq = std::sin(q1);
-    const double px[3] = {p.elbow_x, p.wrist_x, p.tool_x};
-    const double pz[3] = {p.elbow_z, p.wrist_z, p.tool_z};
-    for (int i = 0; i < 3; ++i) {
-        const double x = kShoulderX + px[i] * cq;
-        const double y = kShoulderY + px[i] * sq;
-        const double z = kShoulderZ + pz[i];
-        for (const auto& b : c.boxes)
-            if (b.contains(x, y, z, c.margin)) return true;
+    double pts[ArmPlanarPoints::kCount][3];
+    for (int i = 0; i < ArmPlanarPoints::kCount; ++i) {
+        pts[i][0] = kShoulderX + p.x[i] * cq;
+        pts[i][1] = kShoulderY + p.x[i] * sq;
+        pts[i][2] = kShoulderZ + p.z[i];
     }
+    for (int i = 0; i + 1 < ArmPlanarPoints::kCount; ++i)
+        for (const auto& b : c.boxes)
+            if (segmentHitsBox(pts[i], pts[i + 1], b, c.margin)) return true;
     return false;
 }
 

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -90,7 +90,11 @@ struct SelfCollisionConfig {
     std::vector<BodyBox> boxes;
     double margin = 0.015;       // floor under every box's own pad
     double slow_margin = 0.070;  // soft zone: motion is scaled back inside this
-    int bisect_steps = 8;        // resolution of the walk back toward a safe pose
+    // Path checks step by ANGLE, so a long sweep is sampled as finely as a short
+    // one. A fixed step count divides whatever interval it is given, which left
+    // a fast move sampled too coarsely to see a corner it passed through.
+    double step_rad = 0.04;
+    int max_steps = 32;
     bool enabled = true;
     bool valid() const { return !boxes.empty(); }
 };
@@ -176,6 +180,29 @@ inline bool poseHitsBody(double q1, double q2, double q3, double q4, const SelfC
     for (int i = 0; i + 1 < ArmPlanarPoints::kCount; ++i)
         for (const auto& b : c.boxes)
             if (segmentHitsBox(pts[i], pts[i + 1], b, std::max(c.margin, b.pad))) return true;
+    return false;
+}
+
+// Whether MOVING from one pose to another passes through the body, as opposed
+// to merely ending inside it. Two poses can both be clear with the sweep between
+// them crossing a corner — at 200 Hz a fast joint covers real distance per tick,
+// and checking only endpoints lets the arm step straight through.
+// Steps needed to sample a->b at the configured angular resolution.
+inline int pathSteps(const double a[4], const double b[4], const SelfCollisionConfig& c) {
+    double widest = 0.0;
+    for (int j = 0; j < 4; ++j) widest = std::max(widest, std::fabs(b[j] - a[j]));
+    if (c.step_rad <= 0.0) return 1;
+    return std::clamp(static_cast<int>(std::ceil(widest / c.step_rad)), 1, c.max_steps);
+}
+
+inline bool pathHitsBody(const double a[4], const double b[4], const SelfCollisionConfig& c) {
+    const int steps = pathSteps(a, b, c);
+    for (int k = 0; k <= steps; ++k) {
+        const double t = static_cast<double>(k) / steps;
+        const double q1 = a[0] + t * (b[0] - a[0]), q2 = a[1] + t * (b[1] - a[1]);
+        const double q3 = a[2] + t * (b[2] - a[2]), q4 = a[3] + t * (b[3] - a[3]);
+        if (poseHitsBody(q1, q2, q3, q4, c)) return true;
+    }
     return false;
 }
 

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -45,8 +45,8 @@ static constexpr double kMaxReach = 0.37291;
 // rotates this plane, so it does not appear.
 inline double horizReach(double q2, double q3, double q4) {
     const double a2 = q2, a23 = q2 + q3, a234 = q2 + q3 + q4;
-    return std::abs(kL2_x * std::cos(a2) + kL2_z * std::sin(a2) + kL3_x * std::cos(a23) +
-                    kL3_z * std::sin(a23) + kL45_x * std::cos(a234));
+    return std::abs(kL2_x * std::cos(a2) + kL2_z * std::sin(a2) + kL3_x * std::cos(a23) + kL3_z * std::sin(a23) +
+                    kL45_x * std::cos(a234));
 }
 
 // ---- Body keepout ----------------------------------------------------------
@@ -81,8 +81,7 @@ struct BodyBox {
     // actually swings into — the turret and neck above it — get a large one.
     double pad = 0.015;
     bool contains(double x, double y, double z, double m) const {
-        return x >= min_x - m && x <= max_x + m && y >= min_y - m && y <= max_y + m && z >= min_z - m &&
-               z <= max_z + m;
+        return x >= min_x - m && x <= max_x + m && y >= min_y - m && y <= max_y + m && z >= min_z - m && z <= max_z + m;
     }
 };
 
@@ -96,7 +95,9 @@ struct SelfCollisionConfig {
     double step_rad = 0.04;
     int max_steps = 32;
     bool enabled = true;
-    bool valid() const { return !boxes.empty(); }
+    bool valid() const {
+        return !boxes.empty();
+    }
 };
 
 // Distance from a point to a box, zero inside it.
@@ -148,14 +149,17 @@ inline bool segmentHitsBox(const double a[3], const double b[3], const BodyBox& 
     for (int i = 0; i < 3; ++i) {
         const double d = b[i] - a[i];
         if (std::fabs(d) < 1e-12) {
-            if (a[i] < lo[i] || a[i] > hi[i]) return false;  // parallel to the slab, outside it
+            if (a[i] < lo[i] || a[i] > hi[i])
+                return false;  // parallel to the slab, outside it
             continue;
         }
         double tn = (lo[i] - a[i]) / d, tf = (hi[i] - a[i]) / d;
-        if (tn > tf) std::swap(tn, tf);
+        if (tn > tf)
+            std::swap(tn, tf);
         t0 = std::max(t0, tn);
         t1 = std::min(t1, tf);
-        if (t0 > t1) return false;
+        if (t0 > t1)
+            return false;
     }
     return true;
 }
@@ -168,7 +172,8 @@ inline bool segmentHitsBox(const double a[3], const double b[3], const BodyBox& 
 // testing only those left the first 0.21 m of arm uncovered and let 56% of real
 // collisions through.
 inline bool poseHitsBody(double q1, double q2, double q3, double q4, const SelfCollisionConfig& c) {
-    if (!c.enabled || !c.valid()) return false;
+    if (!c.enabled || !c.valid())
+        return false;
     const ArmPlanarPoints p = armPlanarPoints(q2, q3, q4);
     const double cq = std::cos(q1), sq = std::sin(q1);
     double pts[ArmPlanarPoints::kCount][3];
@@ -179,7 +184,8 @@ inline bool poseHitsBody(double q1, double q2, double q3, double q4, const SelfC
     }
     for (int i = 0; i + 1 < ArmPlanarPoints::kCount; ++i)
         for (const auto& b : c.boxes)
-            if (segmentHitsBox(pts[i], pts[i + 1], b, std::max(c.margin, b.pad))) return true;
+            if (segmentHitsBox(pts[i], pts[i + 1], b, std::max(c.margin, b.pad)))
+                return true;
     return false;
 }
 
@@ -190,8 +196,10 @@ inline bool poseHitsBody(double q1, double q2, double q3, double q4, const SelfC
 // Steps needed to sample a->b at the configured angular resolution.
 inline int pathSteps(const double a[4], const double b[4], const SelfCollisionConfig& c) {
     double widest = 0.0;
-    for (int j = 0; j < 4; ++j) widest = std::max(widest, std::fabs(b[j] - a[j]));
-    if (c.step_rad <= 0.0) return 1;
+    for (int j = 0; j < 4; ++j)
+        widest = std::max(widest, std::fabs(b[j] - a[j]));
+    if (c.step_rad <= 0.0)
+        return 1;
     return std::clamp(static_cast<int>(std::ceil(widest / c.step_rad)), 1, c.max_steps);
 }
 
@@ -201,7 +209,8 @@ inline bool pathHitsBody(const double a[4], const double b[4], const SelfCollisi
         const double t = static_cast<double>(k) / steps;
         const double q1 = a[0] + t * (b[0] - a[0]), q2 = a[1] + t * (b[1] - a[1]);
         const double q3 = a[2] + t * (b[2] - a[2]), q4 = a[3] + t * (b[3] - a[3]);
-        if (poseHitsBody(q1, q2, q3, q4, c)) return true;
+        if (poseHitsBody(q1, q2, q3, q4, c))
+            return true;
     }
     return false;
 }
@@ -213,7 +222,8 @@ inline bool pathHitsBody(const double a[4], const double b[4], const SelfCollisi
 // hard stop stays on poseHitsBody's exact slab test, so nothing safety-critical
 // rests on the sampling.
 inline double bodyClearance(double q1, double q2, double q3, double q4, const SelfCollisionConfig& c) {
-    if (!c.enabled || !c.valid()) return std::numeric_limits<double>::infinity();
+    if (!c.enabled || !c.valid())
+        return std::numeric_limits<double>::infinity();
     const ArmPlanarPoints p = armPlanarPoints(q2, q3, q4);
     const double cq = std::cos(q1), sq = std::sin(q1);
     double pts[ArmPlanarPoints::kCount][3];
@@ -225,8 +235,7 @@ inline double bodyClearance(double q1, double q2, double q3, double q4, const Se
     constexpr int kSamplesPerLink = 8;
     double best = std::numeric_limits<double>::infinity();
     for (int i = 0; i + 1 < ArmPlanarPoints::kCount; ++i) {
-        const double dx = pts[i + 1][0] - pts[i][0], dy = pts[i + 1][1] - pts[i][1],
-                     dz = pts[i + 1][2] - pts[i][2];
+        const double dx = pts[i + 1][0] - pts[i][0], dy = pts[i + 1][1] - pts[i][1], dz = pts[i + 1][2] - pts[i][2];
         double near = std::numeric_limits<double>::infinity();
         for (int k = 0; k <= kSamplesPerLink; ++k) {
             const double t = static_cast<double>(k) / kSamplesPerLink;
@@ -253,9 +262,11 @@ inline double bodyClearance(double q1, double q2, double q3, double q4, const Se
 // what the leader feels: a scaled-back command diverges from what was asked,
 // and that gap is the force the operator gets back.
 inline double approachScale(double clearance, const SelfCollisionConfig& c) {
-    if (clearance >= c.slow_margin) return 1.0;
+    if (clearance >= c.slow_margin)
+        return 1.0;
     const double span = c.slow_margin - c.margin;
-    if (span <= 0.0) return clearance > c.margin ? 1.0 : 0.0;
+    if (span <= 0.0)
+        return clearance > c.margin ? 1.0 : 0.0;
     return std::clamp((clearance - c.margin) / span, 0.0, 1.0);
 }
 

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -31,6 +31,100 @@ inline bool isX330(const std::string& motor_type) {
     return motor_type.find("330") != std::string::npos;
 }
 
+// ---- Arm reach and self-collision -----------------------------------------
+// Link offsets are the joint origins in mars_sim/urdf/mars.urdf. Kept here as
+// the single copy: both gain scheduling and the self-collision floor need reach,
+// and two transcriptions of the same measurements would drift.
+static constexpr double kL2_x = 0.02825, kL2_z = 0.12125;  // joint2 -> joint3
+static constexpr double kL3_x = 0.1375, kL3_z = 0.0045;    // joint3 -> joint4
+static constexpr double kL45_x = 0.110838;                 // joint4 -> tool
+static constexpr double kMaxReach = 0.37291;
+
+// Horizontal distance from the shoulder to the tool. Planar — joint_1 only
+// rotates this plane, so it does not appear.
+inline double horizReach(double q2, double q3, double q4) {
+    const double a2 = q2, a23 = q2 + q3, a234 = q2 + q3 + q4;
+    return std::abs(kL2_x * std::cos(a2) + kL2_z * std::sin(a2) + kL3_x * std::cos(a23) +
+                    kL3_z * std::sin(a23) + kL45_x * std::cos(a234));
+}
+
+// ---- Body keepout ----------------------------------------------------------
+// The arm must not intersect the robot's own body, but it MUST be free to reach
+// down — over a table edge, say — so the constraint is where the arm is in
+// space, not how far a joint has travelled. A floor on joint_2 cannot express
+// that: reaching down in front and folding back over the chassis look identical
+// to any measure that ignores direction.
+//
+// So: place the arm's elbow, wrist and tool in the base frame and test them
+// against boxes covering the body. Cheap (a handful of AABB tests), and it
+// captures the asymmetry — the chassis is rectangular and the shoulder is
+// mounted 53 mm off its centreline, which is what makes a corner reachable at
+// some joint_1 bearings and not others.
+//
+// Sampled at three points, so a link can still pass close to a corner between
+// samples; the margin covers that. The urdf/FCL check is the version that does
+// not sample.
+
+// Shoulder (the joint_2 axis) in base_link, from mars.urdf: joint1 origin
+// (0.086, -0.05285, 0.04025) plus joint2's (0, 0, 0.04425).
+static constexpr double kShoulderX = 0.086, kShoulderY = -0.05285, kShoulderZ = 0.0845;
+// joint4 -> joint6 along the forearm (joint5's 0.019 + joint6's 0.044).
+static constexpr double kWristFromElbow = 0.063;
+
+struct BodyBox {
+    double min_x, min_y, min_z, max_x, max_y, max_z;
+    bool contains(double x, double y, double z, double m) const {
+        return x >= min_x - m && x <= max_x + m && y >= min_y - m && y <= max_y + m && z >= min_z - m &&
+               z <= max_z + m;
+    }
+};
+
+struct SelfCollisionConfig {
+    std::vector<BodyBox> boxes;
+    double margin = 0.015;      // metres of clearance demanded around each box
+    int bisect_steps = 8;       // resolution of the walk back toward a safe pose
+    bool enabled = true;
+    bool valid() const { return !boxes.empty(); }
+};
+
+// The arm's elbow, wrist and tool in the shoulder's sagittal plane: `px` along
+// the arm's bearing, `pz` vertical. Rotation matches horizReach's convention.
+struct ArmPlanarPoints {
+    double elbow_x, elbow_z, wrist_x, wrist_z, tool_x, tool_z;
+};
+
+inline ArmPlanarPoints armPlanarPoints(double q2, double q3, double q4) {
+    const double a23 = q2 + q3, a234 = a23 + q4;
+    const double ex = kL2_x * std::cos(q2) + kL2_z * std::sin(q2) + kL3_x * std::cos(a23) + kL3_z * std::sin(a23);
+    const double ez = -kL2_x * std::sin(q2) + kL2_z * std::cos(q2) - kL3_x * std::sin(a23) + kL3_z * std::cos(a23);
+    const double c = std::cos(a234), s = std::sin(a234);
+    return {ex,
+            ez,
+            ex + kWristFromElbow * c,
+            ez - kWristFromElbow * s,
+            ex + kL45_x * c,
+            ez - kL45_x * s};
+}
+
+// True if any sampled point of the arm sits inside a body box. joint_1 rotates
+// the sagittal plane about the shoulder, so a planar (px, pz) lifts to
+// (shoulder + px·cos q1, shoulder + px·sin q1, shoulder + pz).
+inline bool poseHitsBody(double q1, double q2, double q3, double q4, const SelfCollisionConfig& c) {
+    if (!c.enabled || !c.valid()) return false;
+    const ArmPlanarPoints p = armPlanarPoints(q2, q3, q4);
+    const double cq = std::cos(q1), sq = std::sin(q1);
+    const double px[3] = {p.elbow_x, p.wrist_x, p.tool_x};
+    const double pz[3] = {p.elbow_z, p.wrist_z, p.tool_z};
+    for (int i = 0; i < 3; ++i) {
+        const double x = kShoulderX + px[i] * cq;
+        const double y = kShoulderY + px[i] * sq;
+        const double z = kShoulderZ + pz[i];
+        for (const auto& b : c.boxes)
+            if (b.contains(x, y, z, c.margin)) return true;
+    }
+    return false;
+}
+
 struct JointConfig {
     int servo_id;
     std::string motor_type;  // e.g. "XC330-M288", "XL430-W250" — "330" = has current hw

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -49,6 +49,17 @@ inline double horizReach(double q2, double q3, double q4) {
                     kL3_z * std::sin(a23) + kL45_x * std::cos(a234));
 }
 
+// Why a joint's command was changed. Published on /mars/arm/constraint so a
+// leader-arm client can push back for a real physical boundary and stay silent
+// for everything else — a joint that simply cannot keep up is not a constraint
+// the operator should feel.
+enum ConstraintReason : int {
+    kConstraintNone = 0,
+    kConstraintJointLimit = 1,  // the joint's own range, incl. the joint_1/joint_2 rule
+    kConstraintBodyStop = 2,    // would intersect the body: refused outright
+    kConstraintBodyApproach = 3,  // nearing the body: the move is being eased off
+};
+
 // ---- Body keepout ----------------------------------------------------------
 // The arm must not intersect the robot's own body, but it MUST be free to reach
 // down — over a table edge, say — so the constraint is where the arm is in

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -74,6 +74,12 @@ static constexpr double kWristFromElbow = 0.063;
 
 struct BodyBox {
     double min_x, min_y, min_z, max_x, max_y, max_z;
+    // Clearance demanded around THIS box. Per-box because one global figure
+    // cannot work: the shoulder is bolted 51 mm from the chassis and never
+    // moves further away, so any global margin near that blocks the arm at
+    // rest. The chassis therefore gets a small pad and the parts the arm
+    // actually swings into — the turret and neck above it — get a large one.
+    double pad = 0.015;
     bool contains(double x, double y, double z, double m) const {
         return x >= min_x - m && x <= max_x + m && y >= min_y - m && y <= max_y + m && z >= min_z - m &&
                z <= max_z + m;
@@ -82,7 +88,7 @@ struct BodyBox {
 
 struct SelfCollisionConfig {
     std::vector<BodyBox> boxes;
-    double margin = 0.015;       // hard stop: clearance demanded around each box
+    double margin = 0.015;       // floor under every box's own pad
     double slow_margin = 0.070;  // soft zone: motion is scaled back inside this
     int bisect_steps = 8;        // resolution of the walk back toward a safe pose
     bool enabled = true;
@@ -169,7 +175,7 @@ inline bool poseHitsBody(double q1, double q2, double q3, double q4, const SelfC
     }
     for (int i = 0; i + 1 < ArmPlanarPoints::kCount; ++i)
         for (const auto& b : c.boxes)
-            if (segmentHitsBox(pts[i], pts[i + 1], b, c.margin)) return true;
+            if (segmentHitsBox(pts[i], pts[i + 1], b, std::max(c.margin, b.pad))) return true;
     return false;
 }
 
@@ -198,7 +204,10 @@ inline double bodyClearance(double q1, double q2, double q3, double q4, const Se
         for (int k = 0; k <= kSamplesPerLink; ++k) {
             const double t = static_cast<double>(k) / kSamplesPerLink;
             const double q[3] = {pts[i][0] + t * dx, pts[i][1] + t * dy, pts[i][2] + t * dz};
-            for (const auto& b : c.boxes) near = std::min(near, pointBoxDistance(q, b));
+            // Distance to each box less its own pad: a box demanding more room
+            // reads as closer, so one clearance number still drives the taper.
+            for (const auto& b : c.boxes)
+                near = std::min(near, pointBoxDistance(q, b) - (std::max(c.margin, b.pad) - c.margin));
         }
         // The true closest point can sit midway between two samples, so a raw
         // sampled minimum over-reads by up to half the spacing — enough, on these

--- a/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
+++ b/ros2_ws/src/mars_bot/mars_arm/include/mars_arm/arm_types.hpp
@@ -49,17 +49,6 @@ inline double horizReach(double q2, double q3, double q4) {
                     kL3_z * std::sin(a23) + kL45_x * std::cos(a234));
 }
 
-// Why a joint's command was changed. Published on /mars/arm/constraint so a
-// leader-arm client can push back for a real physical boundary and stay silent
-// for everything else — a joint that simply cannot keep up is not a constraint
-// the operator should feel.
-enum ConstraintReason : int {
-    kConstraintNone = 0,
-    kConstraintJointLimit = 1,  // the joint's own range, incl. the joint_1/joint_2 rule
-    kConstraintBodyStop = 2,    // would intersect the body: refused outright
-    kConstraintBodyApproach = 3,  // nearing the body: the move is being eased off
-};
-
 // ---- Body keepout ----------------------------------------------------------
 // The arm must not intersect the robot's own body, but it MUST be free to reach
 // down — over a table edge, say — so the constraint is where the arm is in

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
@@ -173,6 +173,7 @@ void MarsArmNode::loadSelfCollisionConfig() {
     // Flat [min_x,min_y,min_z, max_x,max_y,max_z] sextets in base_link — ROS
     // parameters have no nested arrays.
     this->declare_parameter("self_collision.boxes", std::vector<double>{});
+    this->declare_parameter("self_collision.box_pads", std::vector<double>{});
 
     self_collision_.enabled = this->get_parameter("self_collision.enabled").as_bool();
     self_collision_.margin = this->get_parameter("self_collision.margin").as_double();
@@ -183,8 +184,13 @@ void MarsArmNode::loadSelfCollisionConfig() {
     if (flat.size() % 6 != 0) {
         throw std::runtime_error("self_collision.boxes must be a multiple of 6 (min_xyz, max_xyz per box)");
     }
+    const auto pads = this->get_parameter("self_collision.box_pads").as_double_array();
+    if (!pads.empty() && pads.size() != flat.size() / 6) {
+        throw std::runtime_error("self_collision.box_pads must have one entry per box, or be empty");
+    }
     for (size_t i = 0; i + 5 < flat.size(); i += 6) {
         BodyBox b{flat[i], flat[i + 1], flat[i + 2], flat[i + 3], flat[i + 4], flat[i + 5]};
+        b.pad = pads.empty() ? self_collision_.margin : pads[i / 6];
         if (b.min_x > b.max_x || b.min_y > b.max_y || b.min_z > b.max_z) {
             throw std::runtime_error("self_collision.boxes: a box has min greater than max");
         }
@@ -199,6 +205,9 @@ void MarsArmNode::loadSelfCollisionConfig() {
     if (self_collision_.slow_margin < self_collision_.margin) {
         throw std::runtime_error("self_collision.slow_margin must be >= margin");
     }
+    for (const auto& b : self_collision_.boxes)
+        RCLCPP_INFO(this->get_logger(), "  keepout box x[%.3f %.3f] z[%.3f %.3f] pad %.0f mm", b.min_x, b.max_x,
+                    b.min_z, b.max_z, b.pad * 1000.0);
     RCLCPP_INFO(this->get_logger(), "Body keepout: %s, %zu boxes, stop %.0f mm, ease from %.0f mm, %d bisection steps",
                 self_collision_.enabled ? "on" : "OFF", self_collision_.boxes.size(),
                 self_collision_.margin * 1000.0, self_collision_.slow_margin * 1000.0,

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
@@ -168,6 +168,7 @@ void MarsArmNode::loadJointConfigs(const std::vector<std::string>& joint_names) 
 void MarsArmNode::loadSelfCollisionConfig() {
     this->declare_parameter("self_collision.enabled", true);
     this->declare_parameter("self_collision.margin", 0.015);
+    this->declare_parameter("self_collision.slow_margin", 0.070);
     this->declare_parameter("self_collision.bisect_steps", 8);
     // Flat [min_x,min_y,min_z, max_x,max_y,max_z] sextets in base_link — ROS
     // parameters have no nested arrays.
@@ -175,6 +176,7 @@ void MarsArmNode::loadSelfCollisionConfig() {
 
     self_collision_.enabled = this->get_parameter("self_collision.enabled").as_bool();
     self_collision_.margin = this->get_parameter("self_collision.margin").as_double();
+    self_collision_.slow_margin = this->get_parameter("self_collision.slow_margin").as_double();
     self_collision_.bisect_steps = static_cast<int>(this->get_parameter("self_collision.bisect_steps").as_int());
 
     const auto flat = this->get_parameter("self_collision.boxes").as_double_array();
@@ -194,9 +196,13 @@ void MarsArmNode::loadSelfCollisionConfig() {
         // that does not exist, so say so rather than run unguarded.
         throw std::runtime_error("self_collision.enabled is true but no boxes were configured");
     }
-    RCLCPP_INFO(this->get_logger(), "Body keepout: %s, %zu boxes, margin %.0f mm, %d bisection steps",
+    if (self_collision_.slow_margin < self_collision_.margin) {
+        throw std::runtime_error("self_collision.slow_margin must be >= margin");
+    }
+    RCLCPP_INFO(this->get_logger(), "Body keepout: %s, %zu boxes, stop %.0f mm, ease from %.0f mm, %d bisection steps",
                 self_collision_.enabled ? "on" : "OFF", self_collision_.boxes.size(),
-                self_collision_.margin * 1000.0, self_collision_.bisect_steps);
+                self_collision_.margin * 1000.0, self_collision_.slow_margin * 1000.0,
+                self_collision_.bisect_steps);
 }
 
 rcl_interfaces::msg::SetParametersResult MarsArmNode::onParameterChange(

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
@@ -169,7 +169,8 @@ void MarsArmNode::loadSelfCollisionConfig() {
     this->declare_parameter("self_collision.enabled", true);
     this->declare_parameter("self_collision.margin", 0.015);
     this->declare_parameter("self_collision.slow_margin", 0.070);
-    this->declare_parameter("self_collision.bisect_steps", 8);
+    this->declare_parameter("self_collision.step_rad", 0.04);
+    this->declare_parameter("self_collision.max_steps", 32);
     // Flat [min_x,min_y,min_z, max_x,max_y,max_z] sextets in base_link — ROS
     // parameters have no nested arrays.
     this->declare_parameter("self_collision.boxes", std::vector<double>{});
@@ -178,7 +179,8 @@ void MarsArmNode::loadSelfCollisionConfig() {
     self_collision_.enabled = this->get_parameter("self_collision.enabled").as_bool();
     self_collision_.margin = this->get_parameter("self_collision.margin").as_double();
     self_collision_.slow_margin = this->get_parameter("self_collision.slow_margin").as_double();
-    self_collision_.bisect_steps = static_cast<int>(this->get_parameter("self_collision.bisect_steps").as_int());
+    self_collision_.step_rad = this->get_parameter("self_collision.step_rad").as_double();
+    self_collision_.max_steps = static_cast<int>(this->get_parameter("self_collision.max_steps").as_int());
 
     const auto flat = this->get_parameter("self_collision.boxes").as_double_array();
     if (flat.size() % 6 != 0) {
@@ -208,10 +210,10 @@ void MarsArmNode::loadSelfCollisionConfig() {
     for (const auto& b : self_collision_.boxes)
         RCLCPP_INFO(this->get_logger(), "  keepout box x[%.3f %.3f] z[%.3f %.3f] pad %.0f mm", b.min_x, b.max_x,
                     b.min_z, b.max_z, b.pad * 1000.0);
-    RCLCPP_INFO(this->get_logger(), "Body keepout: %s, %zu boxes, stop %.0f mm, ease from %.0f mm, %d bisection steps",
+    RCLCPP_INFO(this->get_logger(), "Body keepout: %s, %zu boxes, stop %.0f mm, ease from %.0f mm, %.0f mrad steps (max %d)",
                 self_collision_.enabled ? "on" : "OFF", self_collision_.boxes.size(),
                 self_collision_.margin * 1000.0, self_collision_.slow_margin * 1000.0,
-                self_collision_.bisect_steps);
+                self_collision_.step_rad * 1000.0, self_collision_.max_steps);
 }
 
 rcl_interfaces::msg::SetParametersResult MarsArmNode::onParameterChange(

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
@@ -162,6 +162,41 @@ void MarsArmNode::loadJointConfigs(const std::vector<std::string>& joint_names) 
         joint_configs_.push_back(config);
     }
     RCLCPP_INFO(this->get_logger(), "Loaded %zu joint configurations", joint_configs_.size());
+    loadSelfCollisionConfig();
+}
+
+void MarsArmNode::loadSelfCollisionConfig() {
+    this->declare_parameter("self_collision.enabled", true);
+    this->declare_parameter("self_collision.margin", 0.015);
+    this->declare_parameter("self_collision.bisect_steps", 8);
+    // Flat [min_x,min_y,min_z, max_x,max_y,max_z] sextets in base_link — ROS
+    // parameters have no nested arrays.
+    this->declare_parameter("self_collision.boxes", std::vector<double>{});
+
+    self_collision_.enabled = this->get_parameter("self_collision.enabled").as_bool();
+    self_collision_.margin = this->get_parameter("self_collision.margin").as_double();
+    self_collision_.bisect_steps = static_cast<int>(this->get_parameter("self_collision.bisect_steps").as_int());
+
+    const auto flat = this->get_parameter("self_collision.boxes").as_double_array();
+    if (flat.size() % 6 != 0) {
+        throw std::runtime_error("self_collision.boxes must be a multiple of 6 (min_xyz, max_xyz per box)");
+    }
+    for (size_t i = 0; i + 5 < flat.size(); i += 6) {
+        BodyBox b{flat[i], flat[i + 1], flat[i + 2], flat[i + 3], flat[i + 4], flat[i + 5]};
+        if (b.min_x > b.max_x || b.min_y > b.max_y || b.min_z > b.max_z) {
+            throw std::runtime_error("self_collision.boxes: a box has min greater than max");
+        }
+        self_collision_.boxes.push_back(b);
+    }
+
+    if (self_collision_.enabled && !self_collision_.valid()) {
+        // Starting with the keepout on but no geometry would claim a protection
+        // that does not exist, so say so rather than run unguarded.
+        throw std::runtime_error("self_collision.enabled is true but no boxes were configured");
+    }
+    RCLCPP_INFO(this->get_logger(), "Body keepout: %s, %zu boxes, margin %.0f mm, %d bisection steps",
+                self_collision_.enabled ? "on" : "OFF", self_collision_.boxes.size(),
+                self_collision_.margin * 1000.0, self_collision_.bisect_steps);
 }
 
 rcl_interfaces::msg::SetParametersResult MarsArmNode::onParameterChange(

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_config.cpp
@@ -210,10 +210,10 @@ void MarsArmNode::loadSelfCollisionConfig() {
     for (const auto& b : self_collision_.boxes)
         RCLCPP_INFO(this->get_logger(), "  keepout box x[%.3f %.3f] z[%.3f %.3f] pad %.0f mm", b.min_x, b.max_x,
                     b.min_z, b.max_z, b.pad * 1000.0);
-    RCLCPP_INFO(this->get_logger(), "Body keepout: %s, %zu boxes, stop %.0f mm, ease from %.0f mm, %.0f mrad steps (max %d)",
-                self_collision_.enabled ? "on" : "OFF", self_collision_.boxes.size(),
-                self_collision_.margin * 1000.0, self_collision_.slow_margin * 1000.0,
-                self_collision_.step_rad * 1000.0, self_collision_.max_steps);
+    RCLCPP_INFO(this->get_logger(),
+                "Body keepout: %s, %zu boxes, stop %.0f mm, ease from %.0f mm, %.0f mrad steps (max %d)",
+                self_collision_.enabled ? "on" : "OFF", self_collision_.boxes.size(), self_collision_.margin * 1000.0,
+                self_collision_.slow_margin * 1000.0, self_collision_.step_rad * 1000.0, self_collision_.max_steps);
 }
 
 rcl_interfaces::msg::SetParametersResult MarsArmNode::onParameterChange(

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -291,6 +291,13 @@ void MarsArmNode::controlTimerCallback() {
                     cmd_msg.position[i] = rad;
                 }
                 arm_command_state_pub_->publish(cmd_msg);
+
+                // Why each joint was held back, if it was. A teleop client uses
+                // this to push back only for a real physical boundary — the arm
+                // merely lagging is not something to put in the operator's hand.
+                std_msgs::msg::Int32MultiArray reason_msg;
+                reason_msg.data.assign(constraint_reason_.begin(), constraint_reason_.end());
+                constraint_pub_->publish(reason_msg);
             } else if (has_head_command_.load()) {
                 std::lock_guard<std::mutex> head_lock(head_command_mutex_);
                 int head_enc = latest_head_command_;
@@ -347,6 +354,7 @@ void MarsArmNode::recordLoopTiming(std::array<std::chrono::steady_clock::time_po
 }
 
 std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>& command_data) {
+    constraint_reason_.fill(kConstraintNone);
     // ===== INTELLIGENT JOINT LIMITS =====
     // Kept exactly as it was: a known-good baseline. The body keepout below adds
     // refusals on top and never removes one, so a mis-specified box can only
@@ -380,6 +388,7 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
         }
 
         if (joint2_pos < joint2_min_limit) {
+            constraint_reason_[1] = kConstraintJointLimit;
             RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                  "Joint2 limited due to joint1=%.3f: requested %.3f, clamped to %.3f", joint1_pos,
                                  joint2_pos, joint2_min_limit);
@@ -410,7 +419,12 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
                 if (poseHitsBody(probe[0], probe[1], probe[2], probe[3], self_collision_)) hi = mid;
                 else lo = mid;
             }
-            for (int j = 0; j < 4; ++j) command_data[j] = safe[j] + lo * (want[j] - safe[j]);
+            for (int j = 0; j < 4; ++j) {
+                // Only flag joints the retreat actually moved: the operator should
+                // feel the joint that is blocked, not every joint in the arm.
+                if (std::fabs(command_data[j] - want[j]) > 1e-6) constraint_reason_[j] = kConstraintBodyStop;
+                command_data[j] = safe[j] + lo * (want[j] - safe[j]);
+            }
             RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                  "Body keepout: pose would strike the chassis, held at %.0f%% of the way there",
                                  lo * 100.0);
@@ -425,8 +439,11 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
                                                    command_data[3], self_collision_);
             const double scale = approachScale(clearance, self_collision_);
             if (scale < 1.0 && have_safe_pose_) {
-                for (int j = 0; j < 4; ++j)
-                    command_data[j] = last_safe_pose_[j] + scale * (command_data[j] - last_safe_pose_[j]);
+                for (int j = 0; j < 4; ++j) {
+                    const double eased = last_safe_pose_[j] + scale * (command_data[j] - last_safe_pose_[j]);
+                    if (std::fabs(eased - command_data[j]) > 1e-6) constraint_reason_[j] = kConstraintBodyApproach;
+                    command_data[j] = eased;
+                }
                 RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                       "Body keepout: %.0f mm clear, accepting %.0f%% of the requested move",
                                       clearance * 1000.0, scale * 100.0);

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -210,18 +210,7 @@ void MarsArmNode::controlTimerCallback() {
                 }
 
                 // SCHEDULED: interpolate near/far by arm extension for joints 1-4
-                constexpr double L2_x = 0.02825, L2_z = 0.12125;
-                constexpr double L3_x = 0.1375, L3_z = 0.0045;
-                constexpr double L45_x = 0.110838;
-                constexpr double kMaxReach = 0.37291;
-
-                double q2 = positions_rad[1], q3 = positions_rad[2], q4 = positions_rad[3];
-                double a2 = q2, a23 = q2 + q3, a234 = q2 + q3 + q4;
-
-                double ee_x = L2_x * std::cos(a2) + L2_z * std::sin(a2) + L3_x * std::cos(a23) + L3_z * std::sin(a23) +
-                              L45_x * std::cos(a234);
-
-                double horiz_reach = std::abs(ee_x);
+                double horiz_reach = horizReach(positions_rad[1], positions_rad[2], positions_rad[3]);
                 double extension_linear = std::clamp((horiz_reach / kMaxReach - 0.1) / 0.9, 0.0, 1.0);
                 double extension = extension_linear * extension_linear;
 
@@ -359,6 +348,9 @@ void MarsArmNode::recordLoopTiming(std::array<std::chrono::steady_clock::time_po
 
 std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>& command_data) {
     // ===== INTELLIGENT JOINT LIMITS =====
+    // Kept exactly as it was: a known-good baseline. The body keepout below adds
+    // refusals on top and never removes one, so a mis-specified box can only
+    // over-restrict, never expose the body.
     if (command_data.size() >= 2) {
         double joint1_pos = command_data[0];
         double joint2_pos = command_data[1];
@@ -394,6 +386,41 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
         }
 
         command_data[1] = std::clamp(joint2_pos, joint2_min_limit, joint2_max_limit);
+    }
+
+    // ===== BODY KEEPOUT =====
+    // A joint-space box cannot say "reach down over an edge, but never into your
+    // own chassis" — both look the same to any per-joint limit. So the arm's
+    // elbow, wrist and tool are placed in the base frame and tested against the
+    // body. The infeasible set is not an interval, so there is nothing to clamp:
+    // walk back along the segment from the last accepted pose toward the request
+    // and take the furthest point that is still clear. The arm slides up to the
+    // surface rather than freezing or snapping.
+    if (command_data.size() >= 4 && self_collision_.enabled && self_collision_.valid()) {
+        const bool hits = poseHitsBody(command_data[0], command_data[1], command_data[2], command_data[3],
+                                       self_collision_);
+        if (hits && have_safe_pose_) {
+            std::array<double, 4> safe = last_safe_pose_;
+            std::array<double, 4> want = {command_data[0], command_data[1], command_data[2], command_data[3]};
+            double lo = 0.0, hi = 1.0;  // lo is known clear, hi known blocked
+            for (int step = 0; step < self_collision_.bisect_steps; ++step) {
+                const double mid = 0.5 * (lo + hi);
+                std::array<double, 4> probe;
+                for (int j = 0; j < 4; ++j) probe[j] = safe[j] + mid * (want[j] - safe[j]);
+                if (poseHitsBody(probe[0], probe[1], probe[2], probe[3], self_collision_)) hi = mid;
+                else lo = mid;
+            }
+            for (int j = 0; j < 4; ++j) command_data[j] = safe[j] + lo * (want[j] - safe[j]);
+            RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                                 "Body keepout: pose would strike the chassis, held at %.0f%% of the way there",
+                                 lo * 100.0);
+        } else if (!hits) {
+            last_safe_pose_ = {command_data[0], command_data[1], command_data[2], command_data[3]};
+            have_safe_pose_ = true;
+        }
+        // hits && !have_safe_pose_: nothing clear to retreat to yet (first command
+        // after boot already inside a box). Pass it through rather than refuse to
+        // move at all — the joint limits above still apply.
     }
 
     // Direction flips for joints 2, 3, 4, 6 (indices 1, 2, 3, 5)

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -398,18 +398,27 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
     // and take the furthest point that is still clear. The arm slides up to the
     // surface rather than freezing or snapping.
     if (command_data.size() >= 4 && self_collision_.enabled && self_collision_.valid()) {
-        const bool hits = poseHitsBody(command_data[0], command_data[1], command_data[2], command_data[3],
-                                       self_collision_);
+        const std::array<double, 4> asked = {command_data[0], command_data[1], command_data[2], command_data[3]};
+        // The SWEEP from the last accepted pose, not just where it ends up.
+        const bool hits = have_safe_pose_
+                              ? pathHitsBody(last_safe_pose_.data(), asked.data(), self_collision_)
+                              : poseHitsBody(asked[0], asked[1], asked[2], asked[3], self_collision_);
         if (hits && have_safe_pose_) {
             std::array<double, 4> safe = last_safe_pose_;
             std::array<double, 4> want = {command_data[0], command_data[1], command_data[2], command_data[3]};
-            double lo = 0.0, hi = 1.0;  // lo is known clear, hi known blocked
-            for (int step = 0; step < self_collision_.bisect_steps; ++step) {
-                const double mid = 0.5 * (lo + hi);
+            // Walk forward and stop at the FIRST blocked step, rather than
+            // bisecting. The infeasible set is not convex — rounding a corner,
+            // the midpoint can be clear while a point before it is not — and a
+            // bisection would happily settle past a collision it never probed,
+            // which is how the arm clipped the top corner on its way up.
+            double lo = 0.0;
+            const int steps = pathSteps(safe.data(), want.data(), self_collision_);
+            for (int step = 1; step <= steps; ++step) {
+                const double t = static_cast<double>(step) / steps;
                 std::array<double, 4> probe;
-                for (int j = 0; j < 4; ++j) probe[j] = safe[j] + mid * (want[j] - safe[j]);
-                if (poseHitsBody(probe[0], probe[1], probe[2], probe[3], self_collision_)) hi = mid;
-                else lo = mid;
+                for (int j = 0; j < 4; ++j) probe[j] = safe[j] + t * (want[j] - safe[j]);
+                if (poseHitsBody(probe[0], probe[1], probe[2], probe[3], self_collision_)) break;
+                lo = t;
             }
             for (int j = 0; j < 4; ++j) command_data[j] = safe[j] + lo * (want[j] - safe[j]);
             RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -415,6 +415,22 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
                                  "Body keepout: pose would strike the chassis, held at %.0f%% of the way there",
                                  lo * 100.0);
         } else if (!hits) {
+            // Soft zone: ease off as the body gets close rather than running at
+            // full speed into the hard stop. Only a fraction of the requested
+            // move is accepted, shrinking to nothing at the margin, so the arm
+            // decelerates into the surface. The rejected part is what the
+            // operator feels — it shows up as /mars/arm/command_state diverging
+            // from the leader's request, and the leader pushes back by that gap.
+            const double clearance = bodyClearance(command_data[0], command_data[1], command_data[2],
+                                                   command_data[3], self_collision_);
+            const double scale = approachScale(clearance, self_collision_);
+            if (scale < 1.0 && have_safe_pose_) {
+                for (int j = 0; j < 4; ++j)
+                    command_data[j] = last_safe_pose_[j] + scale * (command_data[j] - last_safe_pose_[j]);
+                RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                                      "Body keepout: %.0f mm clear, accepting %.0f%% of the requested move",
+                                      clearance * 1000.0, scale * 100.0);
+            }
             last_safe_pose_ = {command_data[0], command_data[1], command_data[2], command_data[3]};
             have_safe_pose_ = true;
         }

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -400,9 +400,8 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
     if (command_data.size() >= 4 && self_collision_.enabled && self_collision_.valid()) {
         const std::array<double, 4> asked = {command_data[0], command_data[1], command_data[2], command_data[3]};
         // The SWEEP from the last accepted pose, not just where it ends up.
-        const bool hits = have_safe_pose_
-                              ? pathHitsBody(last_safe_pose_.data(), asked.data(), self_collision_)
-                              : poseHitsBody(asked[0], asked[1], asked[2], asked[3], self_collision_);
+        const bool hits = have_safe_pose_ ? pathHitsBody(last_safe_pose_.data(), asked.data(), self_collision_)
+                                          : poseHitsBody(asked[0], asked[1], asked[2], asked[3], self_collision_);
         if (hits && have_safe_pose_) {
             std::array<double, 4> safe = last_safe_pose_;
             std::array<double, 4> want = {command_data[0], command_data[1], command_data[2], command_data[3]};
@@ -416,11 +415,14 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
             for (int step = 1; step <= steps; ++step) {
                 const double t = static_cast<double>(step) / steps;
                 std::array<double, 4> probe;
-                for (int j = 0; j < 4; ++j) probe[j] = safe[j] + t * (want[j] - safe[j]);
-                if (poseHitsBody(probe[0], probe[1], probe[2], probe[3], self_collision_)) break;
+                for (int j = 0; j < 4; ++j)
+                    probe[j] = safe[j] + t * (want[j] - safe[j]);
+                if (poseHitsBody(probe[0], probe[1], probe[2], probe[3], self_collision_))
+                    break;
                 lo = t;
             }
-            for (int j = 0; j < 4; ++j) command_data[j] = safe[j] + lo * (want[j] - safe[j]);
+            for (int j = 0; j < 4; ++j)
+                command_data[j] = safe[j] + lo * (want[j] - safe[j]);
             RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                  "Body keepout: pose would strike the chassis, held at %.0f%% of the way there",
                                  lo * 100.0);
@@ -431,12 +433,11 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
             // decelerates into the surface. The rejected part is what the
             // operator feels — it shows up as /mars/arm/command_state diverging
             // from the leader's request, and the leader pushes back by that gap.
-            const double clearance = bodyClearance(command_data[0], command_data[1], command_data[2],
-                                                   command_data[3], self_collision_);
+            const double clearance =
+                bodyClearance(command_data[0], command_data[1], command_data[2], command_data[3], self_collision_);
             const double scale = approachScale(clearance, self_collision_);
             if (scale < 1.0 && have_safe_pose_) {
-                const std::array<double, 4> want = {command_data[0], command_data[1], command_data[2],
-                                                    command_data[3]};
+                const std::array<double, 4> want = {command_data[0], command_data[1], command_data[2], command_data[3]};
                 for (int j = 0; j < 4; ++j)
                     command_data[j] = last_safe_pose_[j] + scale * (want[j] - last_safe_pose_[j]);
                 RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1000,

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_control.cpp
@@ -292,12 +292,6 @@ void MarsArmNode::controlTimerCallback() {
                 }
                 arm_command_state_pub_->publish(cmd_msg);
 
-                // Why each joint was held back, if it was. A teleop client uses
-                // this to push back only for a real physical boundary — the arm
-                // merely lagging is not something to put in the operator's hand.
-                std_msgs::msg::Int32MultiArray reason_msg;
-                reason_msg.data.assign(constraint_reason_.begin(), constraint_reason_.end());
-                constraint_pub_->publish(reason_msg);
             } else if (has_head_command_.load()) {
                 std::lock_guard<std::mutex> head_lock(head_command_mutex_);
                 int head_enc = latest_head_command_;
@@ -354,7 +348,6 @@ void MarsArmNode::recordLoopTiming(std::array<std::chrono::steady_clock::time_po
 }
 
 std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>& command_data) {
-    constraint_reason_.fill(kConstraintNone);
     // ===== INTELLIGENT JOINT LIMITS =====
     // Kept exactly as it was: a known-good baseline. The body keepout below adds
     // refusals on top and never removes one, so a mis-specified box can only
@@ -388,7 +381,6 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
         }
 
         if (joint2_pos < joint2_min_limit) {
-            constraint_reason_[1] = kConstraintJointLimit;
             RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                  "Joint2 limited due to joint1=%.3f: requested %.3f, clamped to %.3f", joint1_pos,
                                  joint2_pos, joint2_min_limit);
@@ -419,12 +411,7 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
                 if (poseHitsBody(probe[0], probe[1], probe[2], probe[3], self_collision_)) hi = mid;
                 else lo = mid;
             }
-            for (int j = 0; j < 4; ++j) {
-                // Only flag joints the retreat actually moved: the operator should
-                // feel the joint that is blocked, not every joint in the arm.
-                if (std::fabs(command_data[j] - want[j]) > 1e-6) constraint_reason_[j] = kConstraintBodyStop;
-                command_data[j] = safe[j] + lo * (want[j] - safe[j]);
-            }
+            for (int j = 0; j < 4; ++j) command_data[j] = safe[j] + lo * (want[j] - safe[j]);
             RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                  "Body keepout: pose would strike the chassis, held at %.0f%% of the way there",
                                  lo * 100.0);
@@ -439,11 +426,10 @@ std::vector<int> MarsArmNode::applyLimitsAndConvertToEncoder(std::vector<double>
                                                    command_data[3], self_collision_);
             const double scale = approachScale(clearance, self_collision_);
             if (scale < 1.0 && have_safe_pose_) {
-                for (int j = 0; j < 4; ++j) {
-                    const double eased = last_safe_pose_[j] + scale * (command_data[j] - last_safe_pose_[j]);
-                    if (std::fabs(eased - command_data[j]) > 1e-6) constraint_reason_[j] = kConstraintBodyApproach;
-                    command_data[j] = eased;
-                }
+                const std::array<double, 4> want = {command_data[0], command_data[1], command_data[2],
+                                                    command_data[3]};
+                for (int j = 0; j < 4; ++j)
+                    command_data[j] = last_safe_pose_[j] + scale * (want[j] - last_safe_pose_[j]);
                 RCLCPP_DEBUG_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                       "Body keepout: %.0f mm clear, accepting %.0f%% of the requested move",
                                       clearance * 1000.0, scale * 100.0);

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
@@ -113,6 +113,7 @@ MarsArmNode::MarsArmNode() : Node("mars_arm") {
     arm_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/mars/arm/state", 10);
     // Latched: the standing grip target must reach subscribers that start (or
     // restart) after the last command, or they fold/seed j6 from a stale zero.
+    constraint_pub_ = this->create_publisher<std_msgs::msg::Int32MultiArray>("/mars/arm/constraint", 10);
     arm_command_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/mars/arm/command_state",
                                                                                   rclcpp::QoS(1).transient_local());
     arm_status_pub_ = this->create_publisher<mars_msgs::msg::ArmStatus>("/mars/arm/status", 10);

--- a/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
+++ b/ros2_ws/src/mars_bot/mars_arm/mars_arm/arm_node.cpp
@@ -113,7 +113,6 @@ MarsArmNode::MarsArmNode() : Node("mars_arm") {
     arm_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/mars/arm/state", 10);
     // Latched: the standing grip target must reach subscribers that start (or
     // restart) after the last command, or they fold/seed j6 from a stale zero.
-    constraint_pub_ = this->create_publisher<std_msgs::msg::Int32MultiArray>("/mars/arm/constraint", 10);
     arm_command_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>("/mars/arm/command_state",
                                                                                   rclcpp::QoS(1).transient_local());
     arm_status_pub_ = this->create_publisher<mars_msgs::msg::ArmStatus>("/mars/arm/status", 10);

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -153,6 +153,16 @@ serial driver.
   `position_limits`, so the wall follows a retune rather than a copied number,
   and the guard arms only once rosbridge is up. Ticks on the wire are clamped
   to the same band whether or not the servo hold is winning.
+- **The band is not just per-joint.** `arm_control.cpp` drives joints 2, 3, 4
+  and 6 in the opposite sense to the command it receives, so their bands mirror
+  to `[-hi, -lo]` here (`joint_1` is symmetric, which is why it reads correctly
+  either way). More importantly, `joint_2`'s floor tightens to −0.5 rad while
+  `joint_1` is in the front arc and ramps back as it swings clear — the real
+  anti-self-collision rule, and the reason independent per-joint limits let the
+  arm reach the frame. The guard mirrors both, so `joint_2`'s shaded zone grows
+  and shrinks as you rotate `joint_1`, and you feel the restriction the follower
+  would otherwise apply by silently clamping you. Those constants live in
+  `arm_control.cpp`, not `arm_config.yaml`; the copies must change together.
 - **Current budget.** Holding costs power, and the arm draws from *this*
   machine's USB, so the total across all six servos is capped (default 750 mA,
   900 mA hard ceiling) and split across whatever is being held. A watchdog on

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -145,6 +145,21 @@ serial driver.
   pose immediately, so hold the leader in a sane position first. Disengaging
   (or hiding the tab, or losing rosbridge) stops new commands and the arm
   holds its last pose.
+- **Limits** holds the leader inside the follower's reach. The leader turns
+  freely, but the follower's `joint_1` stops at ±90° where the arm meets the
+  body, so past that edge the leader servo energizes and walks back to the
+  boundary — a soft wall you can always overpower — and the joint track shades
+  the travel the robot cannot follow. Limits come from `mars_arm`'s live
+  `position_limits`, so the wall follows a retune rather than a copied number,
+  and the guard arms only once rosbridge is up. Ticks on the wire are clamped
+  to the same band whether or not the servo hold is winning.
+- **Current budget.** Holding costs power, and the arm draws from *this*
+  machine's USB, so the total across all six servos is capped (default 750 mA,
+  900 mA hard ceiling) and split across whatever is being held. A watchdog on
+  the servos' own Present Current backs the allocation off if real draw
+  disagrees, and cuts torque at the ceiling. Set it under
+  **Settings → Safety & hardware → Leader arm**; it is stored per device, not
+  on the robot, because a laptop port and a phone port differ.
 - Chrome/Edge only (WebSerial). Protocol layer is tested headlessly:
   `node tests/dynamixel.test.js`.
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -3305,6 +3305,28 @@ body:has(.agent-indicator:not([hidden], [data-off-route])) .tgt-hud {
   background: var(--hairline-strong);
 }
 
+/* Travel the follower cannot reach — the wall, made visible before it is felt. */
+.arm-joint-zone {
+  position: absolute;
+  left: 50%;
+  width: 5px;
+  transform: translateX(-50%);
+  border-radius: 1px;
+  background: repeating-linear-gradient(
+    45deg,
+    rgb(255 255 255 / 12%) 0 2px,
+    transparent 2px 4px
+  );
+}
+
+.arm-joint-zone.hi {
+  top: 0;
+}
+
+.arm-joint-zone.lo {
+  bottom: 0;
+}
+
 .arm-joint-dot {
   position: absolute;
   left: 50%;
@@ -3318,6 +3340,27 @@ body:has(.agent-indicator:not([hidden], [data-off-route])) .tgt-hud {
 
 .arm-panel:has(.arm-engage.active) .arm-joint-dot {
   background: var(--accent);
+}
+
+/* Approaching the limit, then held at it — these win over the engaged accent.
+   Both are the danger hue rather than amber: amber already means "engaged". */
+.arm-panel .arm-joint-dot.warn {
+  background: rgb(217 106 90 / 55%);
+}
+
+.arm-panel .arm-joint-dot.danger {
+  background: var(--danger);
+  box-shadow: 0 0 0 2px rgb(255 255 255 / 10%);
+}
+
+.arm-limits.active {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.arm-limits.holding {
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 .arm-button {

--- a/webapp/js/armGeometry.js
+++ b/webapp/js/armGeometry.js
@@ -1,0 +1,154 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Where the arm is in space, and whether that intersects the robot's own body.
+//
+// A port of mars_arm's arm_types.hpp, deliberately duplicated rather than asked
+// for over rosbridge. The robot's answer arrives a round trip late, and a round
+// trip is exactly long enough for a fast move to be over before the operator
+// feels anything — which is how the arm still reached the frame when swung
+// quickly. Computing it here puts the wall in the operator's hand in the same
+// frame the leader is already reading at 60 Hz.
+//
+// The robot keeps its own copy and remains the authority: this one exists to be
+// FELT, not to be trusted. If the two ever disagree the robot still refuses the
+// pose. Both are transcribed from mars_sim/urdf/mars.urdf and must change
+// together.
+
+import { tickToRad } from "./leaderLimits.js";
+
+// Link offsets, the joint origins in mars.urdf.
+const L2_X = 0.02825, L2_Z = 0.12125; // joint2 -> joint3
+const L3_X = 0.1375, L3_Z = 0.0045; // joint3 -> joint4
+const L45_X = 0.110838; // joint4 -> tool
+const WRIST_FROM_ELBOW = 0.063; // joint4 -> joint6
+
+// The joint_2 axis in base_link: joint1's origin plus joint2's.
+const SHOULDER_X = 0.086, SHOULDER_Y = -0.05285, SHOULDER_Z = 0.0845;
+
+/**
+ * Boxes covering the body, in base_link metres. The arm mount is deliberately
+ * absent — the arm is bolted to it and would always read as touching.
+ * @type {{ minX: number, minY: number, minZ: number, maxX: number, maxY: number, maxZ: number }[]}
+ */
+export const BODY_BOXES = [
+  { minX: -0.1526, minY: -0.091, minZ: 0.0, maxX: 0.0352, maxY: 0.091, maxZ: 0.1676 }, // chassis
+  { minX: -0.229, minY: -0.0829, minZ: 0.0169, maxX: -0.1501, maxY: 0.0829, maxZ: 0.0763 }, // rear tray
+  { minX: -0.1155, minY: -0.052, minZ: 0.1676, maxX: 0.0101, maxY: 0.052, maxZ: 0.198 }, // lidar turret
+  { minX: -0.0612, minY: -0.0427, minZ: 0.196, maxX: -0.0102, maxY: 0.0427, maxZ: 0.235 }, // neck lower
+  { minX: -0.0653, minY: -0.018, minZ: 0.235, maxX: -0.0279, maxY: 0.018, maxZ: 0.2716 }, // neck upper
+];
+
+/**
+ * The arm's joints in the shoulder's plane: `x` along the arm's bearing, `z`
+ * vertical. Five points, shoulder first, so the LINKS between them can be
+ * tested — the joints alone all sit past 0.2 m and leave the upper arm bare.
+ * @param {number} q2 @param {number} q3 @param {number} q4
+ * @returns {{ x: number[], z: number[] }}
+ */
+export function armPlanarPoints(q2, q3, q4) {
+  const a23 = q2 + q3;
+  const a234 = a23 + q4;
+  const c2 = Math.cos(q2), s2 = Math.sin(q2);
+  const c23 = Math.cos(a23), s23 = Math.sin(a23);
+  const c234 = Math.cos(a234), s234 = Math.sin(a234);
+  const x1 = L2_X * c2 + L2_Z * s2;
+  const z1 = -L2_X * s2 + L2_Z * c2;
+  const x2 = x1 + L3_X * c23 + L3_Z * s23;
+  const z2 = z1 - L3_X * s23 + L3_Z * c23;
+  return {
+    x: [0, x1, x2, x2 + WRIST_FROM_ELBOW * c234, x2 + L45_X * c234],
+    z: [0, z1, z2, z2 - WRIST_FROM_ELBOW * s234, z2 - L45_X * s234],
+  };
+}
+
+/**
+ * The arm's joints in base_link. joint_1 rotates the sagittal plane about the
+ * shoulder.
+ * @param {number[]} rads Six joint angles in the command frame.
+ * @returns {number[][]} One [x, y, z] per point.
+ */
+export function armPoints(rads) {
+  const p = armPlanarPoints(rads[1], rads[2], rads[3]);
+  const c = Math.cos(rads[0]), s = Math.sin(rads[0]);
+  return p.x.map((px, i) => [SHOULDER_X + px * c, SHOULDER_Y + px * s, SHOULDER_Z + p.z[i]]);
+}
+
+/** @param {number[]} p @param {typeof BODY_BOXES[0]} b @returns {number} Distance, 0 inside. */
+export function pointBoxDistance(p, b) {
+  const dx = Math.max(b.minX - p[0], 0, p[0] - b.maxX);
+  const dy = Math.max(b.minY - p[1], 0, p[1] - b.maxY);
+  const dz = Math.max(b.minZ - p[2], 0, p[2] - b.maxZ);
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/**
+ * Segment against a box by the slab method — exact for a zero-thickness
+ * segment; the margin stands in for link radius.
+ * @param {number[]} a @param {number[]} b @param {typeof BODY_BOXES[0]} box @param {number} m
+ * @returns {boolean}
+ */
+export function segmentHitsBox(a, b, box, m) {
+  const lo = [box.minX - m, box.minY - m, box.minZ - m];
+  const hi = [box.maxX + m, box.maxY + m, box.maxZ + m];
+  let t0 = 0, t1 = 1;
+  for (let i = 0; i < 3; i++) {
+    const d = b[i] - a[i];
+    if (Math.abs(d) < 1e-12) {
+      if (a[i] < lo[i] || a[i] > hi[i]) return false;
+      continue;
+    }
+    let tn = (lo[i] - a[i]) / d;
+    let tf = (hi[i] - a[i]) / d;
+    if (tn > tf) [tn, tf] = [tf, tn];
+    t0 = Math.max(t0, tn);
+    t1 = Math.min(t1, tf);
+    if (t0 > t1) return false;
+  }
+  return true;
+}
+
+/**
+ * Whether the pose puts any part of any link inside the body.
+ * @param {number[]} rads @param {number} margin
+ * @returns {boolean}
+ */
+export function poseHitsBody(rads, margin) {
+  const pts = armPoints(rads);
+  for (let i = 0; i + 1 < pts.length; i++) {
+    for (const box of BODY_BOXES) if (segmentHitsBox(pts[i], pts[i + 1], box, margin)) return true;
+  }
+  return false;
+}
+
+/**
+ * Metres of room left before the arm touches the body. Sampled along each link,
+ * then reduced by half the sample spacing so the estimate is conservative by
+ * construction — a raw sampled minimum over-reads by up to that much, which on
+ * these link lengths is worth as much as the whole margin.
+ * @param {number[]} rads
+ * @returns {number}
+ */
+export function bodyClearance(rads) {
+  const pts = armPoints(rads);
+  const samples = 8;
+  let best = Infinity;
+  for (let i = 0; i + 1 < pts.length; i++) {
+    const a = pts[i], b = pts[i + 1];
+    const d = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    let near = Infinity;
+    for (let k = 0; k <= samples; k++) {
+      const t = k / samples;
+      const q = [a[0] + t * d[0], a[1] + t * d[1], a[2] + t * d[2]];
+      for (const box of BODY_BOXES) near = Math.min(near, pointBoxDistance(q, box));
+    }
+    const halfSpacing = (0.5 * Math.hypot(d[0], d[1], d[2])) / samples;
+    best = Math.min(best, Math.max(0, near - halfSpacing));
+  }
+  return best;
+}
+
+/** @param {number[]} ticks @returns {number[]} The same pose in command radians. */
+export function ticksToRads(ticks) {
+  return ticks.map((t) => tickToRad(t));
+}

--- a/webapp/js/armGeometry.js
+++ b/webapp/js/armGeometry.js
@@ -24,6 +24,10 @@ const L3_X = 0.1375, L3_Z = 0.0045; // joint3 -> joint4
 const L45_X = 0.110838; // joint4 -> tool
 const WRIST_FROM_ELBOW = 0.063; // joint4 -> joint6
 
+// Path checks sample every this many radians of the widest-moving joint.
+const PATH_STEP_RAD = 0.04;
+const MAX_PATH_STEPS = 32;
+
 // The joint_2 axis in base_link: joint1's origin plus joint2's.
 const SHOULDER_X = 0.086, SHOULDER_Y = -0.05285, SHOULDER_Z = 0.0845;
 
@@ -125,6 +129,28 @@ export function poseHitsBody(rads, margin) {
     for (const box of BODY_BOXES) {
       if (segmentHitsBox(pts[i], pts[i + 1], box, Math.max(margin, box.pad))) return true;
     }
+  }
+  return false;
+}
+
+/**
+ * Whether MOVING from one pose to another passes through the body, rather than
+ * merely ending inside it. Two poses can both be clear with the sweep between
+ * them crossing a corner; at 60 Hz a fast joint covers real angle per round, so
+ * checking only where it landed lets the arm step straight through.
+ * Sampled every PATH_STEP_RAD along the widest-moving joint, so a long sweep is
+ * checked as finely as a short one — a fixed step count leaves a fast move too
+ * coarse to see a corner it passed through.
+ * @param {number[]} a @param {number[]} b @param {number} margin
+ * @returns {boolean}
+ */
+export function pathHitsBody(a, b, margin) {
+  let widest = 0;
+  for (let j = 0; j < 4; j++) widest = Math.max(widest, Math.abs(b[j] - a[j]));
+  const steps = Math.min(MAX_PATH_STEPS, Math.max(1, Math.ceil(widest / PATH_STEP_RAD)));
+  for (let k = 0; k <= steps; k++) {
+    const t = k / steps;
+    if (poseHitsBody(a.map((v, i) => v + t * (b[i] - v)), margin)) return true;
   }
   return false;
 }

--- a/webapp/js/armGeometry.js
+++ b/webapp/js/armGeometry.js
@@ -15,6 +15,7 @@
 // pose. Both are transcribed from mars_sim/urdf/mars.urdf and must change
 // together.
 
+import { BODY_MARGIN_M } from "./constants.js";
 import { tickToRad } from "./leaderLimits.js";
 
 // Link offsets, the joint origins in mars.urdf.
@@ -29,14 +30,19 @@ const SHOULDER_X = 0.086, SHOULDER_Y = -0.05285, SHOULDER_Z = 0.0845;
 /**
  * Boxes covering the body, in base_link metres. The arm mount is deliberately
  * absent — the arm is bolted to it and would always read as touching.
- * @type {{ minX: number, minY: number, minZ: number, maxX: number, maxY: number, maxZ: number }[]}
+ * `pad` is the clearance demanded around that box. Per-box because one global
+ * figure cannot work: the shoulder sits 51 mm from the chassis and never moves
+ * further away, so a global pad near that blocks the arm at rest. The chassis
+ * keeps a small pad; the turret and neck above it — what joint_2 folds back
+ * into — get much more. Must match self_collision.box_pads in arm_config.yaml.
+ * @type {{ minX: number, minY: number, minZ: number, maxX: number, maxY: number, maxZ: number, pad: number }[]}
  */
 export const BODY_BOXES = [
-  { minX: -0.1526, minY: -0.091, minZ: 0.0, maxX: 0.0352, maxY: 0.091, maxZ: 0.1676 }, // chassis
-  { minX: -0.229, minY: -0.0829, minZ: 0.0169, maxX: -0.1501, maxY: 0.0829, maxZ: 0.0763 }, // rear tray
-  { minX: -0.1155, minY: -0.052, minZ: 0.1676, maxX: 0.0101, maxY: 0.052, maxZ: 0.198 }, // lidar turret
-  { minX: -0.0612, minY: -0.0427, minZ: 0.196, maxX: -0.0102, maxY: 0.0427, maxZ: 0.235 }, // neck lower
-  { minX: -0.0653, minY: -0.018, minZ: 0.235, maxX: -0.0279, maxY: 0.018, maxZ: 0.2716 }, // neck upper
+  { minX: -0.1526, minY: -0.091, minZ: 0.0, maxX: 0.0352, maxY: 0.091, maxZ: 0.1676, pad: 0.015 }, // chassis
+  { minX: -0.229, minY: -0.0829, minZ: 0.0169, maxX: -0.1501, maxY: 0.0829, maxZ: 0.0763, pad: 0.015 }, // rear tray
+  { minX: -0.1155, minY: -0.052, minZ: 0.1676, maxX: 0.0101, maxY: 0.052, maxZ: 0.198, pad: 0.055 }, // lidar turret
+  { minX: -0.0612, minY: -0.0427, minZ: 0.196, maxX: -0.0102, maxY: 0.0427, maxZ: 0.235, pad: 0.055 }, // neck lower
+  { minX: -0.0653, minY: -0.018, minZ: 0.235, maxX: -0.0279, maxY: 0.018, maxZ: 0.2716, pad: 0.055 }, // neck upper
 ];
 
 /**
@@ -116,7 +122,9 @@ export function segmentHitsBox(a, b, box, m) {
 export function poseHitsBody(rads, margin) {
   const pts = armPoints(rads);
   for (let i = 0; i + 1 < pts.length; i++) {
-    for (const box of BODY_BOXES) if (segmentHitsBox(pts[i], pts[i + 1], box, margin)) return true;
+    for (const box of BODY_BOXES) {
+      if (segmentHitsBox(pts[i], pts[i + 1], box, Math.max(margin, box.pad))) return true;
+    }
   }
   return false;
 }
@@ -140,7 +148,11 @@ export function bodyClearance(rads) {
     for (let k = 0; k <= samples; k++) {
       const t = k / samples;
       const q = [a[0] + t * d[0], a[1] + t * d[1], a[2] + t * d[2]];
-      for (const box of BODY_BOXES) near = Math.min(near, pointBoxDistance(q, box));
+      // Distance less that box's extra pad, so a box demanding more room reads
+      // as closer and one clearance number still drives the taper.
+      for (const box of BODY_BOXES) {
+        near = Math.min(near, pointBoxDistance(q, box) - Math.max(0, box.pad - BODY_MARGIN_M));
+      }
     }
     const halfSpacing = (0.5 * Math.hypot(d[0], d[1], d[2])) / samples;
     best = Math.min(best, Math.max(0, near - halfSpacing));

--- a/webapp/js/armsdk/main.js
+++ b/webapp/js/armsdk/main.js
@@ -174,7 +174,7 @@ const PAGE_HTML = `
       <span class="armsdk-viz-title" data-el="vizTitle">mars.urdf · live joint state</span>
       <div class="armsdk-viz-mode" title="Which joint angles the 3D model shows — measured arm state, or the slider targets">
         <button type="button" data-viz-mode="actual" class="active" title="Show the joints the arm is actually at">Actual</button>
-        <button type="button" data-viz-mode="requested" title="Preview the pose from the joint sliders (does not move the arm by itself)">Requested</button>
+        <button type="button" data-viz-mode="requested" title="Preview the slider targets on the URDF — drops torque so the arm stays limp while you explore">Requested</button>
       </div>
       <span class="armsdk-viz-legend">⊕ ring = base_link origin (0,0,0) · axes <b style="color:#e06c60">x</b> <b style="color:#56c28c">y</b> <b style="color:#6b93d6">z</b> · <b style="color:#e8a33d">⬥ target</b> <b style="color:#56c28c">● settled</b></span>
       <span class="armsdk-viz-hint">grab the amber handle to move the arm · drag to orbit · scroll to zoom</span>
@@ -347,12 +347,16 @@ export function mount(stage) {
     const val = /** @type {HTMLElement} */ (row.querySelector(".armsdk-jval"));
     sl.addEventListener("input", () => {
       dragging = i;
+      val.textContent = (+sl.value).toFixed(2);
+      if (vizMode === "requested") {
+        // Preview only — no stream, no dirty latch; torque is already off.
+        pushVizJoints();
+        return;
+      }
       if (i === 5) j6Touched = true;
       // Latch the card out of live sync while driving — otherwise the state
       // subscription would snap the thumb back under the pointer.
       setDirty(true);
-      val.textContent = (+sl.value).toFixed(2);
-      if (vizMode === "requested") pushVizJoints();
       queueLive();
     });
     sl.addEventListener("change", () => {
@@ -399,6 +403,13 @@ export function mount(stage) {
     });
     el("vizTitle").textContent =
       mode === "requested" ? "mars.urdf · requested joints" : "mars.urdf · live joint state";
+    if (mode === "requested") {
+      // Preview must not keep driving the arm: drop any queued stream and
+      // torque so the robot goes limp while the URDF follows the sliders.
+      livePending = null;
+      clearTimeout(liveResyncTimer);
+      void cmd("torque_off");
+    }
     pushVizJoints();
   }
 
@@ -421,6 +432,7 @@ export function mount(stage) {
   let liveResyncTimer;
 
   function queueLive() {
+    if (vizMode === "requested") return;
     clearTimeout(liveResyncTimer);
     const vals = sliders.map((sl) => +sl.value);
     livePending = j6Touched ? vals : vals.slice(0, 5);
@@ -432,7 +444,7 @@ export function mount(stage) {
     /** @type {number[] | null} */
     let lastSent = null;
     let deadline = performance.now() + 5000;
-    while (!destroyed) {
+    while (!destroyed && vizMode !== "requested") {
       let joints = livePending;
       livePending = null;
       if (joints) {
@@ -455,7 +467,7 @@ export function mount(stage) {
     }
     liveInFlight = false;
     // Resume slider live-sync once the stream idles out and the arm settles.
-    liveResyncTimer = setTimeout(() => setDirty(false), 1200);
+    if (vizMode !== "requested") liveResyncTimer = setTimeout(() => setDirty(false), 1200);
   }
 
   /** @param {number[]} joints */
@@ -491,7 +503,9 @@ export function mount(stage) {
     el("moving").textContent = busy ? "moving" : "idle";
     el("moving").className = "armsdk-pill " + (busy ? "busy" : "on");
     if (Array.isArray(s.joints)) {
-      if (!busy && !slidersDirty) setSliders(s.joints);
+      // Requested mode owns the sliders as a pose sketch; don't snap them back
+      // to measured while the operator is exploring.
+      if (!busy && !slidersDirty && vizMode === "actual") setSliders(s.joints);
       pushVizJoints();
     }
   }

--- a/webapp/js/armsdk/main.js
+++ b/webapp/js/armsdk/main.js
@@ -102,7 +102,13 @@ const CSS = `
   pointer-events: none; backdrop-filter: blur(6px); }
 .armsdk-viz-title { position: absolute; top: 12px; left: 14px; font-size: 11px; color: var(--muted);
   text-transform: uppercase; letter-spacing: .09em; pointer-events: none; }
-.armsdk-viz-legend { position: absolute; top: 32px; left: 14px; font-size: 11px; color: var(--muted);
+.armsdk-viz-mode { position: absolute; top: 34px; left: 14px; display: flex; border: 1px solid var(--hairline-strong);
+  border-radius: 7px; overflow: hidden; backdrop-filter: blur(6px); background: var(--glass); z-index: 1; }
+.armsdk-viz-mode button { border: 0; border-radius: 0; padding: 4px 11px; font-size: 10px; letter-spacing: .08em;
+  text-transform: uppercase; color: var(--muted); background: transparent; }
+.armsdk-viz-mode button + button { border-left: 1px solid var(--hairline-strong); }
+.armsdk-viz-mode button.active { background: var(--accent-faint); color: var(--accent); }
+.armsdk-viz-legend { position: absolute; top: 66px; left: 14px; font-size: 11px; color: var(--muted);
   pointer-events: none; }
 .armsdk-viz-loading { position: absolute; inset: 0; display: grid; place-items: center;
   color: var(--muted); font-size: 12px; letter-spacing: .05em; }
@@ -165,7 +171,11 @@ const PAGE_HTML = `
   <div class="armsdk-grid">
     <div class="armsdk-card armsdk-viz">
       <div class="armsdk-viz-canvas" data-el="viz"></div>
-      <span class="armsdk-viz-title">mars.urdf · live joint state</span>
+      <span class="armsdk-viz-title" data-el="vizTitle">mars.urdf · live joint state</span>
+      <div class="armsdk-viz-mode" title="Which joint angles the 3D model shows — measured arm state, or the slider targets">
+        <button type="button" data-viz-mode="actual" class="active" title="Show the joints the arm is actually at">Actual</button>
+        <button type="button" data-viz-mode="requested" title="Preview the pose from the joint sliders (does not move the arm by itself)">Requested</button>
+      </div>
       <span class="armsdk-viz-legend">⊕ ring = base_link origin (0,0,0) · axes <b style="color:#e06c60">x</b> <b style="color:#56c28c">y</b> <b style="color:#6b93d6">z</b> · <b style="color:#e8a33d">⬥ target</b> <b style="color:#56c28c">● settled</b></span>
       <span class="armsdk-viz-hint">grab the amber handle to move the arm · drag to orbit · scroll to zoom</span>
       <div class="armsdk-viz-loading" data-el="vizLoading">loading model…</div>
@@ -277,6 +287,8 @@ export function mount(stage) {
   let busy = false;
   /** @type {number | null} which slider is mid-drag, so live sync doesn't fight the thumb */
   let dragging = null;
+  /** @type {"actual" | "requested"} which joint angles drive the 3D model */
+  let vizMode = "actual";
   /** @type {Awaited<ReturnType<typeof import("./viz.js").createArmViz>> | null} */
   let viz = null;
   let destroyed = false;
@@ -313,6 +325,7 @@ export function mount(stage) {
       }
       viz = v;
       el("vizLoading").remove();
+      pushVizJoints();
     },
     (err) => {
       el("vizLoading").textContent = `3D model unavailable (${err?.message || err})`;
@@ -339,6 +352,7 @@ export function mount(stage) {
       // subscription would snap the thumb back under the pointer.
       setDirty(true);
       val.textContent = (+sl.value).toFixed(2);
+      if (vizMode === "requested") pushVizJoints();
       queueLive();
     });
     sl.addEventListener("change", () => {
@@ -366,6 +380,33 @@ export function mount(stage) {
     el("jdirty").hidden = !dirty;
     if (!dirty) j6Touched = false;
   }
+
+  /** Feed the 3D model from measured joints or the slider targets. */
+  function pushVizJoints() {
+    if (vizMode === "requested") {
+      viz?.setJoints(sliders.map((sl) => +sl.value));
+      return;
+    }
+    if (Array.isArray(lastState.joints)) viz?.setJoints(lastState.joints);
+  }
+
+  /** @param {"actual" | "requested"} mode */
+  function setVizMode(mode) {
+    if (mode === vizMode) return;
+    vizMode = mode;
+    root.querySelectorAll("[data-viz-mode]").forEach((b) => {
+      b.classList.toggle("active", /** @type {HTMLElement} */ (b).dataset.vizMode === mode);
+    });
+    el("vizTitle").textContent =
+      mode === "requested" ? "mars.urdf · requested joints" : "mars.urdf · live joint state";
+    pushVizJoints();
+  }
+
+  root.querySelectorAll("[data-viz-mode]").forEach((b) =>
+    b.addEventListener("click", () =>
+      setVizMode(/** @type {"actual" | "requested"} */ (/** @type {HTMLElement} */ (b).dataset.vizMode)),
+    ),
+  );
 
   // --- live joint streaming -------------------------------------------------
   // Sliding streams the arm after the thumb via the server's stream topic —
@@ -450,8 +491,8 @@ export function mount(stage) {
     el("moving").textContent = busy ? "moving" : "idle";
     el("moving").className = "armsdk-pill " + (busy ? "busy" : "on");
     if (Array.isArray(s.joints)) {
-      viz?.setJoints(s.joints);
       if (!busy && !slidersDirty) setSliders(s.joints);
+      pushVizJoints();
     }
   }
 
@@ -543,6 +584,7 @@ export function mount(stage) {
   el("syncBtn").addEventListener("click", () => {
     setDirty(false);
     if (Array.isArray(lastState.joints)) setSliders(lastState.joints);
+    if (vizMode === "requested") pushVizJoints();
   });
   el("open100").addEventListener("click", () => cmd("gripper_open", { percent: 100 }));
   el("open50").addEventListener("click", () => cmd("gripper_open", { percent: 50 }));

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -271,6 +271,23 @@ export const DIVERGENCE_FLOOR_MA = 120;
 // to keep pushing toward a pose the robot may have left.
 export const DIVERGENCE_STALE_MS = 500;
 
+// ---- Body keepout, enforced here rather than awaited from the robot --------
+// The robot's answer arrives a round trip late, and a round trip is long enough
+// for a fast move to be over before the operator feels anything. The webapp
+// computes the same geometry locally (armGeometry.js) so the wall lands in the
+// hand immediately; the robot keeps its own copy as the authority.
+//
+// Clearance demanded around the body. Larger than the robot's own margin on
+// purpose: the leader is where the operator's momentum lives, and stopping the
+// *hand* early is what stops the arm overshooting through backlash and flex.
+export const BODY_MARGIN_M = 0.03;
+// Inside this the hold begins to build rather than arriving all at once.
+export const BODY_SLOW_MARGIN_M = 0.09;
+// Motion is projected this far ahead, so approaching fast reserves more room
+// than creeping does. Backlash and plastic flex mean the arm keeps travelling
+// after the command stops; the faster it closes, the sooner the wall must be.
+export const BODY_LOOKAHEAD_S = 0.18;
+
 export const J2_RESTRICTED_MIN_RAD = -0.5;
 export const J1_FRONT_ARC_LO = -1.0;
 export const J1_FRONT_ARC_HI = 1.0;

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -253,6 +253,13 @@ export const JOINT_DIRECTION_FLIPPED = [false, true, true, true, false, true];
 // proportional to that gap, so the operator is pushed to a reachable state
 // instead of sailing on while the arm quietly goes somewhere else.
 export const ARM_COMMAND_STATE_TOPIC = "/mars/arm/command_state";
+// Per-joint reason mars_arm held a command back (std_msgs/Int32MultiArray,
+// mirroring ConstraintReason in arm_types.hpp). This is what separates a wall
+// from the arm merely not keeping up: only a physical boundary belongs in the
+// operator's hand, so a joint reporting NONE is never pushed on however far it
+// has diverged.
+export const ARM_CONSTRAINT_TOPIC = "/mars/arm/constraint";
+export const CONSTRAINT_NONE = 0;
 // Ticks of divergence below which nothing is done — sensor noise and the
 // follower's normal tracking lag must not feel like a wall.
 export const DIVERGENCE_DEADBAND_TICKS = 25;

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -243,6 +243,27 @@ export const JOINT_DIRECTION_FLIPPED = [false, true, true, true, false, true];
 // This is only part of the robot's rule. mars_arm also runs a body keepout that
 // tests where the arm actually is, which no per-joint band can express — the
 // leader learns about that from the follower diverging, not from a mirror.
+// What mars_arm actually accepted, after every limit, clamp and keepout — in
+// radians and already un-flipped into the same convention the leader publishes
+// (arm_control.cpp publishes it right after applyLimitsAndConvertToEncoder).
+//
+// This is how the leader learns about constraints no per-joint band can express:
+// the gap between what it asked for and what came back IS the constraint,
+// whatever produced it. The leader drives toward the accepted pose with force
+// proportional to that gap, so the operator is pushed to a reachable state
+// instead of sailing on while the arm quietly goes somewhere else.
+export const ARM_COMMAND_STATE_TOPIC = "/mars/arm/command_state";
+// Ticks of divergence below which nothing is done — sensor noise and the
+// follower's normal tracking lag must not feel like a wall.
+export const DIVERGENCE_DEADBAND_TICKS = 25;
+// mA of hold per tick of divergence past the deadband, and the floor a hold
+// starts at so it is felt immediately rather than fading in.
+export const DIVERGENCE_MA_PER_TICK = 4;
+export const DIVERGENCE_FLOOR_MA = 120;
+// A command_state older than this is treated as absent: better to go limp than
+// to keep pushing toward a pose the robot may have left.
+export const DIVERGENCE_STALE_MS = 500;
+
 export const J2_RESTRICTED_MIN_RAD = -0.5;
 export const J1_FRONT_ARC_LO = -1.0;
 export const J1_FRONT_ARC_HI = 1.0;

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -243,34 +243,6 @@ export const JOINT_DIRECTION_FLIPPED = [false, true, true, true, false, true];
 // This is only part of the robot's rule. mars_arm also runs a body keepout that
 // tests where the arm actually is, which no per-joint band can express — the
 // leader learns about that from the follower diverging, not from a mirror.
-// What mars_arm actually accepted, after every limit, clamp and keepout — in
-// radians and already un-flipped into the same convention the leader publishes
-// (arm_control.cpp publishes it right after applyLimitsAndConvertToEncoder).
-//
-// This is how the leader learns about constraints no per-joint band can express:
-// the gap between what it asked for and what came back IS the constraint,
-// whatever produced it. The leader drives toward the accepted pose with force
-// proportional to that gap, so the operator is pushed to a reachable state
-// instead of sailing on while the arm quietly goes somewhere else.
-export const ARM_COMMAND_STATE_TOPIC = "/mars/arm/command_state";
-// Per-joint reason mars_arm held a command back (std_msgs/Int32MultiArray,
-// mirroring ConstraintReason in arm_types.hpp). This is what separates a wall
-// from the arm merely not keeping up: only a physical boundary belongs in the
-// operator's hand, so a joint reporting NONE is never pushed on however far it
-// has diverged.
-export const ARM_CONSTRAINT_TOPIC = "/mars/arm/constraint";
-export const CONSTRAINT_NONE = 0;
-// Ticks of divergence below which nothing is done — sensor noise and the
-// follower's normal tracking lag must not feel like a wall.
-export const DIVERGENCE_DEADBAND_TICKS = 25;
-// mA of hold per tick of divergence past the deadband, and the floor a hold
-// starts at so it is felt immediately rather than fading in.
-export const DIVERGENCE_MA_PER_TICK = 4;
-export const DIVERGENCE_FLOOR_MA = 120;
-// A command_state older than this is treated as absent: better to go limp than
-// to keep pushing toward a pose the robot may have left.
-export const DIVERGENCE_STALE_MS = 500;
-
 // ---- Body keepout, enforced here rather than awaited from the robot --------
 // The robot's answer arrives a round trip late, and a round trip is long enough
 // for a fast move to be over before the operator feels anything. The webapp
@@ -287,6 +259,12 @@ export const BODY_SLOW_MARGIN_M = 0.09;
 // than creeping does. Backlash and plastic flex mean the arm keeps travelling
 // after the command stops; the faster it closes, the sooner the wall must be.
 export const BODY_LOOKAHEAD_S = 0.18;
+
+// Force curve for a hold. A step in at the deadband then a ramp: a wall has to
+// be felt the moment it exists, and a curve starting from zero reads as no wall.
+export const HOLD_DEADBAND_TICKS = 25;
+export const HOLD_MA_PER_TICK = 4;
+export const HOLD_FLOOR_MA = 120;
 
 export const J2_RESTRICTED_MIN_RAD = -0.5;
 export const J1_FRONT_ARC_LO = -1.0;

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -227,7 +227,7 @@ export const ARM_POSITION_LIMITS_PARAMS = [1, 2, 3, 4, 5, 6].map((n) => `joint_$
 // Which joints the guard actually holds. The machinery below is generic over
 // all six; only joint_1's body collision is enforced today, the rest await
 // bench time to confirm the wall feels right before they are switched on.
-export const JOINT_GUARD_ENABLED = [true, false, false, false, false, false];
+export const JOINT_GUARD_ENABLED = [true, true, true, true, true, true];
 
 // mars_arm drives joints 2, 3, 4 and 6 in the opposite sense to the command it
 // receives (arm_control.cpp applyLimitsAndConvertToEncoder, flip_indices

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -236,12 +236,13 @@ export const JOINT_GUARD_ENABLED = [true, false, false, false, false, false];
 // this was missing.
 export const JOINT_DIRECTION_FLIPPED = [false, true, true, true, false, true];
 
-// The real anti-self-collision rule, and the reason per-joint limits alone let
-// the arm reach the frame: joint_2's floor tightens to J2_RESTRICTED_MIN_RAD
-// while joint_1 is in the front arc, ramping back to its full range as joint_1
-// swings clear. Mirrors arm_control.cpp's "intelligent joint limits" — these
-// numbers live in that file, not in arm_config.yaml, so the two copies must be
-// changed together.
+// joint_2's floor tightens while joint_1 is in the front arc, ramping back as it
+// swings clear. Mirrors the joint limits in arm_control.cpp so the shaded zone
+// and the offline fallback show the boundary the follower enforces.
+//
+// This is only part of the robot's rule. mars_arm also runs a body keepout that
+// tests where the arm actually is, which no per-joint band can express — the
+// leader learns about that from the follower diverging, not from a mirror.
 export const J2_RESTRICTED_MIN_RAD = -0.5;
 export const J1_FRONT_ARC_LO = -1.0;
 export const J1_FRONT_ARC_HI = 1.0;

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -224,9 +224,12 @@ export const ARM_GET_PARAMETERS_SERVICE = `${ARM_PARAMS_NODE}/get_parameters`;
 export const PARAMETER_DOUBLE_ARRAY = 8;
 export const ARM_POSITION_LIMITS_PARAMS = [1, 2, 3, 4, 5, 6].map((n) => `joint_${n}.position_limits`);
 
-// Which joints the guard actually holds. The machinery below is generic over
-// all six; only joint_1's body collision is enforced today, the rest await
-// bench time to confirm the wall feels right before they are switched on.
+// Which joints get a band hold — held at the edge of their own position_limits.
+// All six: the limits are read from the robot rather than guessed here, so a
+// joint with no usable limits simply gets no band and is left alone.
+//
+// This gates the BAND hold only. The body keepout is geometric and applies to
+// whatever joints the geometry blames, whatever this array says.
 export const JOINT_GUARD_ENABLED = [true, true, true, true, true, true];
 
 // mars_arm drives joints 2, 3, 4 and 6 in the opposite sense to the command it

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -229,6 +229,25 @@ export const ARM_POSITION_LIMITS_PARAMS = [1, 2, 3, 4, 5, 6].map((n) => `joint_$
 // bench time to confirm the wall feels right before they are switched on.
 export const JOINT_GUARD_ENABLED = [true, false, false, false, false, false];
 
+// mars_arm drives joints 2, 3, 4 and 6 in the opposite sense to the command it
+// receives (arm_control.cpp applyLimitsAndConvertToEncoder, flip_indices
+// {1,2,3,5}), so a config band [lo, hi] is [-hi, -lo] in the frame the leader
+// publishes. joint_1's band is symmetric, which is why it read correctly while
+// this was missing.
+export const JOINT_DIRECTION_FLIPPED = [false, true, true, true, false, true];
+
+// The real anti-self-collision rule, and the reason per-joint limits alone let
+// the arm reach the frame: joint_2's floor tightens to J2_RESTRICTED_MIN_RAD
+// while joint_1 is in the front arc, ramping back to its full range as joint_1
+// swings clear. Mirrors arm_control.cpp's "intelligent joint limits" — these
+// numbers live in that file, not in arm_config.yaml, so the two copies must be
+// changed together.
+export const J2_RESTRICTED_MIN_RAD = -0.5;
+export const J1_FRONT_ARC_LO = -1.0;
+export const J1_FRONT_ARC_HI = 1.0;
+export const J1_RAMP_LO = -1.35;
+export const J1_RAMP_HI = 1.25;
+
 // Total draw across all six servos. The leader is bus-powered from whatever
 // machine it is plugged into, so this is a property of that host, not of the
 // robot — it lives in localStorage per device (leaderBudget.js), surfaced on

--- a/webapp/js/constants.js
+++ b/webapp/js/constants.js
@@ -209,6 +209,35 @@ export const WEBRTC_ACTIVE_STREAMS_TOPIC = "/webrtc/active_streams"; // robot ->
 // Same topic the mobile app uses for its non-UDP fallback path.
 export const LEADER_POSITIONS_TOPIC = "/leader_positions";
 
+// ---- Leader-arm reachability guard ----------------------------------------
+// The leader arm turns freely; the follower does not — joint_1 stops at ±90°
+// where the arm meets the body. The guard reads the follower's real
+// position_limits off mars_arm and holds the leader at that boundary, so the
+// operator feels the wall instead of commanding a pose the robot cannot reach.
+//
+// Limits are read live rather than copied: arm_config.yaml is retuned, and a
+// stale copy here would either fence off reachable travel or fail to fence off
+// unreachable travel. rcl_interfaces/srv/GetParameters, one call per joint
+// name; position_limits comes back as PARAMETER_DOUBLE_ARRAY.
+export const ARM_PARAMS_NODE = "/mars_arm";
+export const ARM_GET_PARAMETERS_SERVICE = `${ARM_PARAMS_NODE}/get_parameters`;
+export const PARAMETER_DOUBLE_ARRAY = 8;
+export const ARM_POSITION_LIMITS_PARAMS = [1, 2, 3, 4, 5, 6].map((n) => `joint_${n}.position_limits`);
+
+// Which joints the guard actually holds. The machinery below is generic over
+// all six; only joint_1's body collision is enforced today, the rest await
+// bench time to confirm the wall feels right before they are switched on.
+export const JOINT_GUARD_ENABLED = [true, false, false, false, false, false];
+
+// Total draw across all six servos. The leader is bus-powered from whatever
+// machine it is plugged into, so this is a property of that host, not of the
+// robot — it lives in localStorage per device (leaderBudget.js), surfaced on
+// the Settings page. 900 mA is the ceiling the operator may not raise past.
+export const LEADER_CURRENT_BUDGET_DEFAULT_MA = 750;
+export const LEADER_CURRENT_BUDGET_MIN_MA = 100;
+export const LEADER_CURRENT_CEILING_MA = 900;
+export const LEADER_CURRENT_BUDGET_KEY = "innate.leaderCurrentBudgetMa";
+
 // Reboot the arm servos (std_srvs/Trigger → {success, message}). Power-cycles
 // and reconfigures all 7 servos (6 arm joints + head), recenters the head to
 // 0°, re-torques the head, and leaves the *arm* limp. Same service the mobile

--- a/webapp/js/dynamixel.js
+++ b/webapp/js/dynamixel.js
@@ -17,10 +17,24 @@
 
 const HEADER = [0xff, 0xff, 0xfd, 0x00];
 const BROADCAST_ID = 0xfe;
+const INSTR_WRITE = 0x03;
 const INSTR_SYNC_READ = 0x82;
+const INSTR_SYNC_WRITE = 0x83;
 const INSTR_STATUS = 0x55;
-const PRESENT_POSITION_ADDR = 132;
-const PRESENT_POSITION_LEN = 4;
+
+// Control table (X-series), mirroring mars_control/dynamixel.py — the robot-side
+// driver for the same servo family.
+export const ADDR_OPERATING_MODE = 11; // EEPROM: rejects writes while torqued
+export const ADDR_TORQUE_ENABLE = 64;
+export const ADDR_GOAL_CURRENT = 102;
+export const ADDR_GOAL_POSITION = 116;
+export const OPERATING_MODE_CURRENT_POSITION = 5;
+
+// Present Current(126,2), Velocity(128,4) and Position(132,4) are contiguous, so
+// one 10-byte read carries all three — the guard needs draw and angle together,
+// and splitting them would double the traffic on a half-duplex bus.
+const PRESENT_BLOCK_ADDR = 126;
+const PRESENT_BLOCK_LEN = 10;
 
 export const LEADER_BAUD = 1_000_000;
 export const LEADER_SERVO_IDS = [1, 2, 3, 4, 5, 6];
@@ -91,6 +105,39 @@ export function buildSyncRead(ids, addr, len) {
     (len >> 8) & 0xff,
     ...ids,
   ]);
+}
+
+/**
+ * Write one register block on a single servo.
+ * @param {number} id
+ * @param {number} addr
+ * @param {number[]} bytes Little-endian value bytes.
+ * @returns {Uint8Array}
+ */
+export function buildWrite(id, addr, bytes) {
+  return buildPacket(id, INSTR_WRITE, [addr & 0xff, (addr >> 8) & 0xff, ...bytes]);
+}
+
+/**
+ * Write the same register block on several servos in one packet, each with its
+ * own value.
+ * @param {number} addr
+ * @param {number} len Bytes per servo.
+ * @param {Map<number, number[]>} valuesById Little-endian value bytes per servo id.
+ * @returns {Uint8Array}
+ */
+export function buildSyncWrite(addr, len, valuesById) {
+  /** @type {number[]} */
+  const params = [addr & 0xff, (addr >> 8) & 0xff, len & 0xff, (len >> 8) & 0xff];
+  for (const [id, bytes] of valuesById) params.push(id, ...bytes);
+  return buildPacket(BROADCAST_ID, INSTR_SYNC_WRITE, params);
+}
+
+/** @param {number} value @param {number} len @returns {number[]} Little-endian bytes. */
+export function toBytes(value, len) {
+  const bytes = [];
+  for (let i = 0; i < len; i++) bytes.push((value >> (8 * i)) & 0xff);
+  return bytes;
 }
 
 /**
@@ -178,13 +225,24 @@ export class DynamixelLeader {
   /** @type {WritableStreamDefaultWriter<Uint8Array> | null} */ #writer = null;
   /** @type {ReadableStreamDefaultReader<Uint8Array> | null} */ #reader = null;
   /** @type {Set<(state: LeaderArmState) => void>} */ #listeners = new Set();
-  /** @type {LeaderArmState} */ #state = { connected: false, positions: null, rate: 0, error: null };
+  /** @type {LeaderArmState} */ #state = {
+    connected: false,
+    positions: null,
+    currents: null,
+    rate: 0,
+    error: null,
+  };
   /** @type {number[]} */ #ids;
   #running = false;
   #opening = false;
-  /** @type {Map<number, number>} */ #round = new Map();
+  /** @type {Map<number, { position: number, current: number }>} */ #round = new Map();
   /** @type {(() => void) | null} */ #roundComplete = null;
   /** @type {number[]} */ #emitTimes = [];
+  // The bus is half-duplex: a packet sent while servos are answering the round's
+  // SyncRead collides with their status packets. Writes therefore queue here and
+  // the poll loop flushes them between rounds, never mid-round.
+  /** @type {Uint8Array[]} */ #pending = [];
+  /** @type {Set<number>} */ #torqued = new Set();
 
   /** @param {number[]} [ids] */
   constructor(ids = LEADER_SERVO_IDS) {
@@ -242,6 +300,27 @@ export class DynamixelLeader {
   async close() {
     this.#running = false;
     this.#roundComplete?.();
+    // committed: the arm must never be left energized behind a closed port, so
+    // this torque-off is not cancellable and not conditional on a clean loop.
+    // The poll loop is already stopped; one round timeout is long enough for its
+    // last SyncRead to have been answered, so this cannot collide with it.
+    if (this.#writer && this.#torqued.size) {
+      await sleep(ROUND_TIMEOUT_MS + 5);
+      const off = buildSyncWrite(
+        ADDR_TORQUE_ENABLE,
+        1,
+        new Map([...this.#torqued].map((id) => [id, [0]])),
+      );
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          await this.#writer.write(off);
+        } catch {
+          break; // port already gone — the servos lost power with it
+        }
+      }
+      this.#torqued.clear();
+    }
+    this.#pending.length = 0;
     const reader = this.#reader;
     const writer = this.#writer;
     const port = this.#port;
@@ -261,7 +340,60 @@ export class DynamixelLeader {
     }
     await port?.close().catch(() => {});
     if (this.#state.connected) {
-      this.#patch({ connected: false, positions: null, rate: 0 });
+      this.#patch({ connected: false, positions: null, currents: null, rate: 0 });
+    }
+  }
+
+  /** @returns {ReadonlySet<number>} Servo ids currently torqued by this driver. */
+  get torqued() {
+    return this.#torqued;
+  }
+
+  /**
+   * Torque on/off. Queued, so it lands between rounds.
+   * @param {number[]} ids
+   * @param {boolean} on
+   */
+  writeTorque(ids, on) {
+    if (!ids.length) return;
+    this.#pending.push(buildSyncWrite(ADDR_TORQUE_ENABLE, 1, new Map(ids.map((id) => [id, [on ? 1 : 0]]))));
+    for (const id of ids) {
+      if (on) this.#torqued.add(id);
+      else this.#torqued.delete(id);
+    }
+  }
+
+  /**
+   * Operating mode. EEPROM — the servo rejects this while torqued, so callers
+   * must torque off first, and must not call it per round (write endurance).
+   * @param {number[]} ids
+   * @param {number} mode
+   */
+  writeOperatingMode(ids, mode) {
+    if (!ids.length) return;
+    this.#pending.push(buildSyncWrite(ADDR_OPERATING_MODE, 1, new Map(ids.map((id) => [id, [mode & 0xff]]))));
+  }
+
+  /** @param {Map<number, number>} byId Goal current in mA per servo id. */
+  writeGoalCurrent(byId) {
+    if (!byId.size) return;
+    this.#pending.push(buildSyncWrite(ADDR_GOAL_CURRENT, 2, new Map([...byId].map(([id, mA]) => [id, toBytes(mA, 2)]))));
+  }
+
+  /** @param {Map<number, number>} byId Goal position in ticks per servo id. */
+  writeGoalPosition(byId) {
+    if (!byId.size) return;
+    this.#pending.push(
+      buildSyncWrite(ADDR_GOAL_POSITION, 4, new Map([...byId].map(([id, tick]) => [id, toBytes(tick, 4)]))),
+    );
+  }
+
+  async #drainPending() {
+    const writer = this.#writer;
+    if (!writer) return;
+    while (this.#pending.length) {
+      const packet = /** @type {Uint8Array} */ (this.#pending.shift());
+      await writer.write(packet);
     }
   }
 
@@ -276,9 +408,11 @@ export class DynamixelLeader {
     const reader = this.#reader;
     if (!reader) return;
     const parse = createStatusParser((packet) => {
-      if (packet.params.length !== PRESENT_POSITION_LEN || !this.#ids.includes(packet.id)) return;
-      const view = new DataView(packet.params.buffer, packet.params.byteOffset, 4);
-      this.#round.set(packet.id, view.getInt32(0, true));
+      // Write acknowledgements come back as zero-parameter status packets; only
+      // a full present-block answer is a round contribution.
+      if (packet.params.length !== PRESENT_BLOCK_LEN || !this.#ids.includes(packet.id)) return;
+      const view = new DataView(packet.params.buffer, packet.params.byteOffset, PRESENT_BLOCK_LEN);
+      this.#round.set(packet.id, { current: view.getInt16(0, true), position: view.getInt32(6, true) });
       if (this.#round.size === this.#ids.length) this.#roundComplete?.();
     });
     try {
@@ -293,10 +427,11 @@ export class DynamixelLeader {
   }
 
   async #pollLoop() {
-    const request = buildSyncRead(this.#ids, PRESENT_POSITION_ADDR, PRESENT_POSITION_LEN);
+    const request = buildSyncRead(this.#ids, PRESENT_BLOCK_ADDR, PRESENT_BLOCK_LEN);
     while (this.#running && this.#writer) {
       this.#round.clear();
       try {
+        await this.#drainPending();
         await this.#writer.write(request);
       } catch (err) {
         this.#fail(err instanceof Error ? err.message : "Serial write failed");
@@ -314,9 +449,10 @@ export class DynamixelLeader {
 
       if (!this.#running) return;
       if (this.#round.size === this.#ids.length) {
-        const positions = this.#ids.map((id) => this.#round.get(id) ?? 0);
+        const positions = this.#ids.map((id) => this.#round.get(id)?.position ?? 0);
+        const currents = this.#ids.map((id) => this.#round.get(id)?.current ?? 0);
         this.#trackRate();
-        this.#patch({ positions, rate: this.#emitTimes.length, error: null });
+        this.#patch({ positions, currents, rate: this.#emitTimes.length, error: null });
       }
       // Breather so a wedged bus can't busy-loop; sets the ~60 Hz ceiling.
       await sleep(2);

--- a/webapp/js/leaderBudget.js
+++ b/webapp/js/leaderBudget.js
@@ -1,0 +1,72 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// The leader arm's total current budget — how much all six servos together may
+// draw while the guard holds a joint at its limit.
+//
+// This is per-device, not per-robot: the arm is bus-powered by whatever machine
+// it is plugged into, and a laptop port and a phone port do not have the same
+// headroom. So it lives in localStorage rather than the robot's settings.yaml,
+// and the Settings page edits it here. Both the guard and that page import this
+// module, so there is one clamp and one default between them.
+
+import {
+  LEADER_CURRENT_BUDGET_DEFAULT_MA,
+  LEADER_CURRENT_BUDGET_KEY,
+  LEADER_CURRENT_BUDGET_MIN_MA,
+  LEADER_CURRENT_CEILING_MA,
+} from "./constants.js";
+
+/** @type {Set<(budgetMa: number) => void>} */
+const listeners = new Set();
+
+/** @param {number} mA @returns {number} */
+export function clampBudget(mA) {
+  if (!Number.isFinite(mA)) return LEADER_CURRENT_BUDGET_DEFAULT_MA;
+  return Math.round(Math.min(LEADER_CURRENT_CEILING_MA, Math.max(LEADER_CURRENT_BUDGET_MIN_MA, mA)));
+}
+
+/** @returns {number} The stored budget, or the default where none is readable. */
+export function readBudget() {
+  let raw = null;
+  try {
+    raw = localStorage.getItem(LEADER_CURRENT_BUDGET_KEY);
+  } catch {
+    return LEADER_CURRENT_BUDGET_DEFAULT_MA; // private mode / storage disabled
+  }
+  if (raw === null) return LEADER_CURRENT_BUDGET_DEFAULT_MA;
+  return clampBudget(Number(raw));
+}
+
+/**
+ * Persist a new budget and tell every live listener. Returns what was actually
+ * stored after clamping, which is what the caller should render.
+ * @param {number} mA
+ * @returns {number}
+ */
+export function writeBudget(mA) {
+  const budget = clampBudget(mA);
+  try {
+    localStorage.setItem(LEADER_CURRENT_BUDGET_KEY, String(budget));
+  } catch {
+    // Unpersisted is still worth applying — the guard reads the live value below.
+  }
+  for (const cb of [...listeners]) {
+    try {
+      cb(budget);
+    } catch (err) {
+      console.error("[leaderBudget] listener threw:", err);
+    }
+  }
+  return budget;
+}
+
+/**
+ * @param {(budgetMa: number) => void} cb Fires on every write, so a panel open
+ *   in one tab follows a change made on the Settings page in another.
+ * @returns {() => void} unsubscribe
+ */
+export function onBudgetChange(cb) {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}

--- a/webapp/js/leaderGuard.js
+++ b/webapp/js/leaderGuard.js
@@ -1,0 +1,330 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Holds the leader arm inside the follower's reachable envelope.
+//
+// The leader turns freely; the follower's joint_1 stops at ±90° where the arm
+// meets the body. When a guarded joint leaves the follower's band this drives
+// the leader servo back to the boundary under a capped current — a soft wall
+// the operator feels and can always overpower, rather than a trap.
+//
+// Every servo the guard energizes draws from the host's USB rail, so the sum of
+// the goal currents it hands out never exceeds the operator's budget, and a
+// watchdog on the servos' own Present Current walks that back if the real draw
+// disagrees with the allocation.
+
+import {
+  ARM_GET_PARAMETERS_SERVICE,
+  ARM_POSITION_LIMITS_PARAMS,
+  JOINT_GUARD_ENABLED,
+  LEADER_CURRENT_CEILING_MA,
+  PARAMETER_DOUBLE_ARRAY,
+} from "./constants.js";
+import { OPERATING_MODE_CURRENT_POSITION } from "./dynamixel.js";
+import { readBudget, onBudgetChange } from "./leaderBudget.js";
+import { allocateCurrent, clampTick, isOutside, limitsToBand, totalCurrent } from "./leaderLimits.js";
+
+// Re-entry margin, ~3.5°. A joint resting exactly on the limit would otherwise
+// toggle the wall every round.
+const HYSTERESIS_TICKS = 40;
+// Rounds over budget before the allocation is walked back. One round can spike
+// on a direction change without the average being over.
+const OVER_BUDGET_ROUNDS = 3;
+const BACKOFF = 0.8;
+// Below this a hold is too weak to be felt; release instead of pretending.
+const MIN_USEFUL_MA = 40;
+
+/**
+ * @typedef {Object} GuardDeps
+ * @property {import("./dynamixel.js").DynamixelLeader} leader
+ * @property {import("./rosClient.js").RosClient} rosClient
+ */
+
+export class LeaderGuard {
+  /** @type {import("./dynamixel.js").DynamixelLeader} */ #leader;
+  /** @type {import("./rosClient.js").RosClient} */ #rosClient;
+  /** @type {number[]} */ #ids;
+  /** @type {Map<number, import("./leaderLimits.js").Band>} */ #bands = new Map();
+  /** @type {Set<number>} */ #holding = new Set();
+  /** @type {Set<(state: LeaderGuardState) => void>} */ #listeners = new Set();
+  /** @type {LeaderGuardState} */ #state = {
+    armed: false,
+    holding: [],
+    drawMa: 0,
+    allocatedMa: 0,
+    error: null,
+  };
+  #enabled = true;
+  #modeReady = false;
+  #overRounds = 0;
+  // Latched after a power trip. The joint that caused it is still out of band,
+  // so without this the next round re-holds and trips again, forever.
+  #tripped = false;
+  #budgetMa = readBudget();
+  /** @type {(() => void) | null} */ #unsubBudget = null;
+
+  /** @param {GuardDeps} deps @param {number[]} ids */
+  constructor({ leader, rosClient }, ids) {
+    this.#leader = leader;
+    this.#rosClient = rosClient;
+    this.#ids = ids;
+    this.#unsubBudget = onBudgetChange((mA) => {
+      this.#budgetMa = mA;
+      this.#overRounds = 0;
+      if (this.#holding.size) this.#applyCurrents();
+    });
+  }
+
+  /** @returns {LeaderGuardState} */
+  get state() {
+    return this.#state;
+  }
+
+  /** @returns {boolean} */
+  get enabled() {
+    return this.#enabled;
+  }
+
+  /**
+   * @param {(state: LeaderGuardState) => void} cb Fires immediately, then on change.
+   * @returns {() => void} unsubscribe
+   */
+  onChange(cb) {
+    this.#listeners.add(cb);
+    cb(this.#state);
+    return () => this.#listeners.delete(cb);
+  }
+
+  /** Ids the guard is configured to hold, in servo order. */
+  get guardedIds() {
+    return this.#ids.filter((_, i) => JOINT_GUARD_ENABLED[i]);
+  }
+
+  /** @param {number} id @returns {import("./leaderLimits.js").Band | undefined} */
+  band(id) {
+    return this.#bands.get(id);
+  }
+
+  /**
+   * Read the follower's real limits and prepare the guarded servos. Safe to call
+   * repeatedly; a failed read simply leaves the guard disarmed and the arm limp.
+   */
+  async arm() {
+    if (this.#rosClient.state !== "connected") return;
+    /** @type {Record<string, unknown> | null} */
+    let res = null;
+    try {
+      res = await this.#rosClient.callService(ARM_GET_PARAMETERS_SERVICE, {
+        names: ARM_POSITION_LIMITS_PARAMS,
+      });
+    } catch {
+      return; // robot not answering — stay disarmed rather than guess a band
+    }
+    const values = Array.isArray(res?.values) ? res.values : [];
+    this.#bands.clear();
+    values.forEach((value, i) => {
+      const id = this.#ids[i];
+      if (id === undefined || !JOINT_GUARD_ENABLED[i]) return;
+      if (!value || value.type !== PARAMETER_DOUBLE_ARRAY) return;
+      const band = limitsToBand(value.double_array_value ?? []);
+      if (band) this.#bands.set(id, band);
+    });
+    if (!this.#bands.size) return;
+    this.#prepareMode();
+    this.#patch({ armed: true, error: null });
+  }
+
+  /**
+   * Current-based position control, set once. It is an EEPROM write that the
+   * servo rejects while torqued, so torque goes off first — which is also the
+   * state we want the arm resting in.
+   */
+  #prepareMode() {
+    if (this.#modeReady) return;
+    const ids = [...this.#bands.keys()];
+    this.#leader.writeTorque(ids, false);
+    this.#leader.writeOperatingMode(ids, OPERATING_MODE_CURRENT_POSITION);
+    this.#modeReady = true;
+  }
+
+  /** @param {boolean} on Turning the guard off releases anything held. */
+  setEnabled(on) {
+    if (this.#enabled === on) return;
+    this.#enabled = on;
+    if (!on) this.releaseAll();
+  }
+
+  /** Drop every hold and leave the arm limp. */
+  releaseAll() {
+    if (this.#holding.size) {
+      this.#leader.writeTorque([...this.#holding], false);
+      this.#holding.clear();
+    }
+    this.#overRounds = 0;
+    this.#patch({ holding: [], allocatedMa: 0 });
+  }
+
+  /**
+   * One position round. Decides which joints are out of reach, holds them at the
+   * boundary, and keeps the total draw inside the budget.
+   * @param {LeaderArmState} state
+   */
+  update(state) {
+    if (!state.positions || !state.currents) return;
+    const drawMa = totalCurrent(state.currents);
+
+    if (!this.#enabled || !this.#state.armed) {
+      this.#patch({ drawMa });
+      return;
+    }
+    if (this.#tripped) {
+      // Only bringing every guarded joint back inside re-arms the wall — the
+      // operator has to undo the reach that overdrew before it will push again.
+      if (!this.#allInside(state.positions)) {
+        this.#patch({ drawMa });
+        return;
+      }
+      this.#tripped = false;
+      this.#patch({ error: null });
+    }
+    if (this.#trip(drawMa)) return;
+
+    const before = this.#holding.size;
+    this.#ids.forEach((id, i) => {
+      const band = this.#bands.get(id);
+      const tick = state.positions?.[i];
+      if (!band || tick === undefined) return;
+      const outside = isOutside(tick, band, HYSTERESIS_TICKS, this.#holding.has(id));
+      if (outside) this.#holding.add(id);
+      else if (this.#holding.has(id)) {
+        this.#holding.delete(id);
+        this.#leader.writeTorque([id], false);
+      }
+    });
+
+    // Re-allocate whenever the set changed OR anything held is still untorqued:
+    // a servo swapped in while another swapped out leaves the size equal, and
+    // torquing it without writing its goal current first would energize it at
+    // the servo's 1750 mA default.
+    const untorqued = [...this.#holding].some((id) => !this.#leader.torqued.has(id));
+    if (this.#holding.size !== before || untorqued) this.#applyCurrents();
+    this.#driveHolds(state.positions);
+    this.#patch({ holding: [...this.#holding], drawMa });
+  }
+
+  /**
+   * Budget enforcement. Sustained overdraw walks the allocation down; a single
+   * round past the hard ceiling cuts torque outright — the ceiling exists
+   * because the host's rail, not the servo, is what fails first.
+   * @param {number} drawMa
+   * @returns {boolean} true if torque was cut and the round is over.
+   */
+  #trip(drawMa) {
+    if (drawMa > LEADER_CURRENT_CEILING_MA) {
+      this.releaseAll();
+      this.#tripped = true;
+      this.#patch({ drawMa, error: `over ${LEADER_CURRENT_CEILING_MA} mA — torque cut` });
+      return true;
+    }
+    if (!this.#holding.size) {
+      this.#overRounds = 0;
+      return false;
+    }
+    if (drawMa <= this.#budgetMa) {
+      this.#overRounds = 0;
+      return false;
+    }
+    this.#overRounds += 1;
+    if (this.#overRounds < OVER_BUDGET_ROUNDS) return false;
+    this.#overRounds = 0;
+    const backed = Math.floor(this.#state.allocatedMa * BACKOFF);
+    if (backed < MIN_USEFUL_MA) {
+      this.releaseAll();
+      this.#tripped = true;
+      this.#patch({ drawMa, error: "cannot hold within the current budget" });
+      return true;
+    }
+    this.#writeCurrents(backed);
+    return false;
+  }
+
+  /** @param {number[]} positions @returns {boolean} */
+  #allInside(positions) {
+    return this.#ids.every((id, i) => {
+      const band = this.#bands.get(id);
+      const tick = positions[i];
+      if (!band || tick === undefined) return true;
+      return !isOutside(tick, band, HYSTERESIS_TICKS, false);
+    });
+  }
+
+  /** Split the budget across whatever is holding right now. */
+  #applyCurrents() {
+    this.#writeCurrents(allocateCurrent(this.#holding.size, this.#budgetMa));
+  }
+
+  /** @param {number} perServoMa */
+  #writeCurrents(perServoMa) {
+    if (!this.#holding.size) {
+      this.#patch({ allocatedMa: 0 });
+      return;
+    }
+    this.#leader.writeGoalCurrent(new Map([...this.#holding].map((id) => [id, perServoMa])));
+    this.#patch({ allocatedMa: perServoMa });
+  }
+
+  /**
+   * Point every held servo at its boundary tick. Goal current is already set, so
+   * the servo walks back to the edge of the reachable band under a capped push
+   * rather than snapping to it.
+   * @param {number[]} positions
+   */
+  #driveHolds(positions) {
+    if (!this.#holding.size) return;
+    /** @type {Map<number, number>} */
+    const goals = new Map();
+    /** @type {number[]} */
+    const fresh = [];
+    this.#ids.forEach((id, i) => {
+      const band = this.#bands.get(id);
+      const tick = positions[i];
+      if (!band || tick === undefined || !this.#holding.has(id)) return;
+      goals.set(id, clampTick(tick, band));
+      if (!this.#leader.torqued.has(id)) fresh.push(id);
+    });
+    // Torque after the goal current is queued, never before: a servo torqued at
+    // its 1750 mA default, even for one round, is exactly the spike the budget
+    // exists to prevent.
+    if (fresh.length) this.#leader.writeTorque(fresh, true);
+    this.#leader.writeGoalPosition(goals);
+  }
+
+  destroy() {
+    this.#unsubBudget?.();
+    this.#unsubBudget = null;
+    this.releaseAll();
+    this.#listeners.clear();
+  }
+
+  /** @param {Partial<LeaderGuardState>} patch */
+  #patch(patch) {
+    const next = { ...this.#state, ...patch };
+    if (
+      next.armed === this.#state.armed &&
+      next.drawMa === this.#state.drawMa &&
+      next.allocatedMa === this.#state.allocatedMa &&
+      next.error === this.#state.error &&
+      next.holding.join() === this.#state.holding.join()
+    ) {
+      return;
+    }
+    this.#state = next;
+    for (const cb of [...this.#listeners]) {
+      try {
+        cb(this.#state);
+      } catch (err) {
+        console.error("[leaderGuard] listener threw:", err);
+      }
+    }
+  }
+}

--- a/webapp/js/leaderGuard.js
+++ b/webapp/js/leaderGuard.js
@@ -18,6 +18,9 @@ import {
   ARM_CONSTRAINT_TOPIC,
   ARM_GET_PARAMETERS_SERVICE,
   ARM_POSITION_LIMITS_PARAMS,
+  BODY_LOOKAHEAD_S,
+  BODY_MARGIN_M,
+  BODY_SLOW_MARGIN_M,
   DIVERGENCE_DEADBAND_TICKS,
   DIVERGENCE_FLOOR_MA,
   DIVERGENCE_MA_PER_TICK,
@@ -33,6 +36,7 @@ import {
   LEADER_CURRENT_CEILING_MA,
   PARAMETER_DOUBLE_ARRAY,
 } from "./constants.js";
+import { bodyClearance, poseHitsBody, ticksToRads } from "./armGeometry.js";
 import { OPERATING_MODE_CURRENT_POSITION } from "./dynamixel.js";
 import { readBudget, onBudgetChange } from "./leaderBudget.js";
 import {
@@ -93,6 +97,7 @@ export class LeaderGuard {
     allocatedMa: 0,
     divergedJoint: 0,
     divergedTicks: 0,
+    clearanceMm: -1,
     error: null,
   };
   #enabled = true;
@@ -107,6 +112,11 @@ export class LeaderGuard {
   /** @type {(() => void) | null} */ #unsubConstraint = null;
   /** @type {number[] | null} */ #constrained = null;
   #constrainedAt = 0;
+  // The last leader pose that cleared the body, and the clearance trend used to
+  // reserve room for a fast approach.
+  /** @type {number[] | null} */ #lastClear = null;
+  #prevClearance = Infinity;
+  #prevClearanceAt = 0;
   // The pose mars_arm last accepted, in leader ticks. Null until it reports.
   /** @type {number[] | null} */ #accepted = null;
   #acceptedAt = 0;
@@ -321,6 +331,10 @@ export class LeaderGuard {
     if (this.#trip(drawMa)) return;
 
     const before = this.#holding.size;
+    // Local first: this is the only source fast enough to matter on a quick
+    // swing. The robot's report still covers constraints the webapp cannot
+    // model, and stays the authority on what the arm will actually accept.
+    const body = this.#bodyCheck(state.positions);
     const diverged = this.#divergence(state.positions);
     /** @type {Map<number, number>} */
     const goals = new Map();
@@ -335,7 +349,11 @@ export class LeaderGuard {
 
       // Two reasons to push back, and divergence wins where both apply: it is
       // what the robot actually did, while the band is only our model of it.
-      const error = diverged[i];
+      // A body hit is expressed as a divergence from the last clear pose, so it
+      // flows through the same push-toward-a-reachable-state path.
+      const bodyError = body.hit && body.target ? tick - body.target[i] : null;
+      const error =
+        bodyError !== null && Math.abs(bodyError) > Math.abs(diverged[i] ?? 0) ? bodyError : diverged[i];
       const beyond = error !== null && Math.abs(error) > DIVERGENCE_DEADBAND_TICKS;
       const band = this.band(id);
       const outside = !!band && isOutside(tick, band, HYSTERESIS_TICKS, this.#holding.has(id));
@@ -371,6 +389,7 @@ export class LeaderGuard {
       drawMa,
       divergedJoint: worstJoint,
       divergedTicks: Math.round(worstTicks),
+      clearanceMm: Number.isFinite(body.clearance) ? Math.round(body.clearance * 1000) : -1,
     });
   }
 
@@ -408,6 +427,45 @@ export class LeaderGuard {
     }
     this.#writeCurrents(backed);
     return false;
+  }
+
+  /**
+   * How much room to demand right now. The static margin plus whatever the arm
+   * would cover in BODY_LOOKAHEAD_S at its current closing speed: creeping up to
+   * the body may use the full range, swinging at it may not. This is what stops
+   * a fast move overshooting through backlash and flex after the command halts.
+   * @param {number} clearance @param {number} now
+   * @returns {number}
+   */
+  #demandedMargin(clearance, now) {
+    const dt = (now - this.#prevClearanceAt) / 1000;
+    let closing = 0;
+    if (this.#prevClearanceAt && dt > 0 && dt < 0.2 && Number.isFinite(this.#prevClearance)) {
+      closing = Math.max(0, (this.#prevClearance - clearance) / dt);
+    }
+    this.#prevClearance = clearance;
+    this.#prevClearanceAt = now;
+    return BODY_MARGIN_M + closing * BODY_LOOKAHEAD_S;
+  }
+
+  /**
+   * Whether the leader's own pose would put the arm in the body, and where to
+   * push back to if so. Computed here rather than read off the robot: the
+   * robot's verdict is a round trip old, and a fast swing is finished inside
+   * that window.
+   * @param {number[]} positions
+   * @returns {{ hit: boolean, target: number[] | null, clearance: number }}
+   */
+  #bodyCheck(positions) {
+    const rads = ticksToRads(positions);
+    const clearance = bodyClearance(rads);
+    const margin = this.#demandedMargin(clearance, performance.now());
+    const hit = poseHitsBody(rads, margin);
+    if (!hit) {
+      this.#lastClear = positions.slice();
+      return { hit: false, target: null, clearance };
+    }
+    return { hit: true, target: this.#lastClear, clearance };
   }
 
   /** @param {number[]} positions @returns {boolean} */
@@ -486,6 +544,7 @@ export class LeaderGuard {
       next.allocatedMa === this.#state.allocatedMa &&
       next.divergedJoint === this.#state.divergedJoint &&
       next.divergedTicks === this.#state.divergedTicks &&
+      next.clearanceMm === this.#state.clearanceMm &&
       next.error === this.#state.error &&
       next.holding.join() === this.#state.holding.join()
     ) {

--- a/webapp/js/leaderGuard.js
+++ b/webapp/js/leaderGuard.js
@@ -16,13 +16,36 @@
 import {
   ARM_GET_PARAMETERS_SERVICE,
   ARM_POSITION_LIMITS_PARAMS,
+  J1_FRONT_ARC_HI,
+  J1_FRONT_ARC_LO,
+  J1_RAMP_HI,
+  J1_RAMP_LO,
+  J2_RESTRICTED_MIN_RAD,
+  JOINT_DIRECTION_FLIPPED,
   JOINT_GUARD_ENABLED,
   LEADER_CURRENT_CEILING_MA,
   PARAMETER_DOUBLE_ARRAY,
 } from "./constants.js";
 import { OPERATING_MODE_CURRENT_POSITION } from "./dynamixel.js";
 import { readBudget, onBudgetChange } from "./leaderBudget.js";
-import { allocateCurrent, clampTick, isOutside, limitsToBand, totalCurrent } from "./leaderLimits.js";
+import {
+  allocateCurrent,
+  clampTick,
+  isOutside,
+  joint2FloorRad,
+  limitsToBand,
+  radToTick,
+  tickToRad,
+  totalCurrent,
+} from "./leaderLimits.js";
+
+const J2_SHAPE = {
+  restrictedMin: J2_RESTRICTED_MIN_RAD,
+  arcLo: J1_FRONT_ARC_LO,
+  arcHi: J1_FRONT_ARC_HI,
+  rampLo: J1_RAMP_LO,
+  rampHi: J1_RAMP_HI,
+};
 
 // Re-entry margin, ~3.5°. A joint resting exactly on the limit would otherwise
 // toggle the wall every round.
@@ -45,6 +68,7 @@ export class LeaderGuard {
   /** @type {import("./rosClient.js").RosClient} */ #rosClient;
   /** @type {number[]} */ #ids;
   /** @type {Map<number, import("./leaderLimits.js").Band>} */ #bands = new Map();
+  /** @type {Map<number, import("./leaderLimits.js").Band>} */ #effective = new Map();
   /** @type {Set<number>} */ #holding = new Set();
   /** @type {Set<(state: LeaderGuardState) => void>} */ #listeners = new Set();
   /** @type {LeaderGuardState} */ #state = {
@@ -100,9 +124,33 @@ export class LeaderGuard {
     return this.#ids.filter((_, i) => JOINT_GUARD_ENABLED[i]);
   }
 
-  /** @param {number} id @returns {import("./leaderLimits.js").Band | undefined} */
+  /**
+   * The band as it stands this round — joint 2's moves with joint 1, so callers
+   * must not cache it across rounds.
+   * @param {number} id @returns {import("./leaderLimits.js").Band | undefined}
+   */
   band(id) {
-    return this.#bands.get(id);
+    return this.#effective.get(id) ?? this.#bands.get(id);
+  }
+
+  /**
+   * Joint 2's floor rides on where joint 1 is: lowering it across the front arc
+   * folds the arm into the frame, so the reachable band narrows there and opens
+   * again as joint 1 swings clear. Static per-joint bands cannot express that,
+   * which is how the arm reached the body while every joint was "in range".
+   * @param {number[]} positions
+   */
+  #recomputeBands(positions) {
+    this.#effective.clear();
+    const joint1 = positions[0];
+    for (const [id, band] of this.#bands) {
+      if (this.#ids.indexOf(id) !== 1 || joint1 === undefined) {
+        this.#effective.set(id, band);
+        continue;
+      }
+      const floor = joint2FloorRad(tickToRad(joint1), tickToRad(band.min), J2_SHAPE);
+      this.#effective.set(id, { min: Math.max(band.min, Math.ceil(radToTick(floor))), max: band.max });
+    }
   }
 
   /**
@@ -126,7 +174,7 @@ export class LeaderGuard {
       const id = this.#ids[i];
       if (id === undefined || !JOINT_GUARD_ENABLED[i]) return;
       if (!value || value.type !== PARAMETER_DOUBLE_ARRAY) return;
-      const band = limitsToBand(value.double_array_value ?? []);
+      const band = limitsToBand(value.double_array_value ?? [], JOINT_DIRECTION_FLIPPED[i]);
       if (band) this.#bands.set(id, band);
     });
     if (!this.#bands.size) return;
@@ -171,6 +219,7 @@ export class LeaderGuard {
    */
   update(state) {
     if (!state.positions || !state.currents) return;
+    this.#recomputeBands(state.positions);
     const drawMa = totalCurrent(state.currents);
 
     if (!this.#enabled || !this.#state.armed) {
@@ -191,7 +240,7 @@ export class LeaderGuard {
 
     const before = this.#holding.size;
     this.#ids.forEach((id, i) => {
-      const band = this.#bands.get(id);
+      const band = this.band(id);
       const tick = state.positions?.[i];
       if (!band || tick === undefined) return;
       const outside = isOutside(tick, band, HYSTERESIS_TICKS, this.#holding.has(id));
@@ -251,7 +300,7 @@ export class LeaderGuard {
   /** @param {number[]} positions @returns {boolean} */
   #allInside(positions) {
     return this.#ids.every((id, i) => {
-      const band = this.#bands.get(id);
+      const band = this.band(id);
       const tick = positions[i];
       if (!band || tick === undefined) return true;
       return !isOutside(tick, band, HYSTERESIS_TICKS, false);
@@ -286,7 +335,7 @@ export class LeaderGuard {
     /** @type {number[]} */
     const fresh = [];
     this.#ids.forEach((id, i) => {
-      const band = this.#bands.get(id);
+      const band = this.band(id);
       const tick = positions[i];
       if (!band || tick === undefined || !this.#holding.has(id)) return;
       goals.set(id, clampTick(tick, band));

--- a/webapp/js/leaderGuard.js
+++ b/webapp/js/leaderGuard.js
@@ -32,7 +32,7 @@ import {
   LEADER_CURRENT_CEILING_MA,
   PARAMETER_DOUBLE_ARRAY,
 } from "./constants.js";
-import { bodyClearance, poseHitsBody, ticksToRads } from "./armGeometry.js";
+import { bodyClearance, pathHitsBody, poseHitsBody, ticksToRads } from "./armGeometry.js";
 import { OPERATING_MODE_CURRENT_POSITION } from "./dynamixel.js";
 import { readBudget, onBudgetChange } from "./leaderBudget.js";
 import {
@@ -398,7 +398,10 @@ export class LeaderGuard {
     const rads = ticksToRads(positions);
     const clearance = bodyClearance(rads);
     const margin = this.#demandedMargin(clearance, performance.now());
-    const hit = poseHitsBody(rads, margin);
+    // The sweep since the last clear pose, not just where the arm is now: a fast
+    // move covers real angle between rounds and can straddle a corner.
+    const from = this.#lastClear ? ticksToRads(this.#lastClear) : null;
+    const hit = from ? pathHitsBody(from, rads, margin) : poseHitsBody(rads, margin);
     if (!hit) {
       this.#lastClear = positions.slice();
       return { hit: false, target: null, clearance, blamed: null };

--- a/webapp/js/leaderGuard.js
+++ b/webapp/js/leaderGuard.js
@@ -14,8 +14,13 @@
 // disagrees with the allocation.
 
 import {
+  ARM_COMMAND_STATE_TOPIC,
   ARM_GET_PARAMETERS_SERVICE,
   ARM_POSITION_LIMITS_PARAMS,
+  DIVERGENCE_DEADBAND_TICKS,
+  DIVERGENCE_FLOOR_MA,
+  DIVERGENCE_MA_PER_TICK,
+  DIVERGENCE_STALE_MS,
   J1_FRONT_ARC_HI,
   J1_FRONT_ARC_LO,
   J1_RAMP_HI,
@@ -31,6 +36,7 @@ import { readBudget, onBudgetChange } from "./leaderBudget.js";
 import {
   allocateCurrent,
   clampTick,
+  divergenceCurrent,
   isOutside,
   joint2FloorRad,
   limitsToBand,
@@ -57,6 +63,13 @@ const BACKOFF = 0.8;
 // Below this a hold is too weak to be felt; release instead of pretending.
 const MIN_USEFUL_MA = 40;
 
+const DIVERGENCE_SHAPE = {
+  deadband: DIVERGENCE_DEADBAND_TICKS,
+  maPerTick: DIVERGENCE_MA_PER_TICK,
+  floorMa: DIVERGENCE_FLOOR_MA,
+  maxMa: LEADER_CURRENT_CEILING_MA,
+};
+
 /**
  * @typedef {Object} GuardDeps
  * @property {import("./dynamixel.js").DynamixelLeader} leader
@@ -76,6 +89,8 @@ export class LeaderGuard {
     holding: [],
     drawMa: 0,
     allocatedMa: 0,
+    divergedJoint: 0,
+    divergedTicks: 0,
     error: null,
   };
   #enabled = true;
@@ -86,6 +101,10 @@ export class LeaderGuard {
   #tripped = false;
   #budgetMa = readBudget();
   /** @type {(() => void) | null} */ #unsubBudget = null;
+  /** @type {(() => void) | null} */ #unsubAccepted = null;
+  // The pose mars_arm last accepted, in leader ticks. Null until it reports.
+  /** @type {number[] | null} */ #accepted = null;
+  #acceptedAt = 0;
 
   /** @param {GuardDeps} deps @param {number[]} ids */
   constructor({ leader, rosClient }, ids) {
@@ -177,6 +196,7 @@ export class LeaderGuard {
       const band = limitsToBand(value.double_array_value ?? [], JOINT_DIRECTION_FLIPPED[i]);
       if (band) this.#bands.set(id, band);
     });
+    this.#subscribeAccepted();
     if (!this.#bands.size) return;
     this.#prepareMode();
     this.#patch({ armed: true, error: null });
@@ -189,10 +209,49 @@ export class LeaderGuard {
    */
   #prepareMode() {
     if (this.#modeReady) return;
-    const ids = [...this.#bands.keys()];
-    this.#leader.writeTorque(ids, false);
-    this.#leader.writeOperatingMode(ids, OPERATING_MODE_CURRENT_POSITION);
+    // Every joint, not just the banded ones: divergence can need to push a joint
+    // that has no band at all — joint_2 being clamped by the body keepout is
+    // exactly that case, and it is the one the operator most needs to feel.
+    this.#leader.writeTorque(this.#ids, false);
+    this.#leader.writeOperatingMode(this.#ids, OPERATING_MODE_CURRENT_POSITION);
     this.#modeReady = true;
+  }
+
+  /**
+   * Track what mars_arm actually accepted. Its message is in radians and already
+   * un-flipped, so it converts straight to leader ticks.
+   */
+  #subscribeAccepted() {
+    if (this.#unsubAccepted) return;
+    this.#unsubAccepted = this.#rosClient.subscribe(
+      ARM_COMMAND_STATE_TOPIC,
+      (msg) => {
+        const pos = msg && Array.isArray(msg.position) ? msg.position : null;
+        if (!pos || pos.length < this.#ids.length) return;
+        this.#accepted = pos.slice(0, this.#ids.length).map((/** @type {number} */ rad) => radToTick(rad));
+        this.#acceptedAt = performance.now();
+      },
+      undefined,
+      "sensor_msgs/msg/JointState",
+    );
+  }
+
+  /**
+   * Signed divergence per joint in ticks, leader minus what the robot accepted,
+   * or null while that report is missing or stale. Stale must read as absent:
+   * pushing toward a pose the arm may already have left is worse than going limp.
+   * @param {number[]} positions
+   * @returns {(number | null)[]}
+   */
+  #divergence(positions) {
+    const accepted = this.#accepted;
+    const fresh = accepted && performance.now() - this.#acceptedAt < DIVERGENCE_STALE_MS;
+    if (!fresh) return this.#ids.map(() => null);
+    return this.#ids.map((_, i) => {
+      const tick = positions[i];
+      const want = accepted[i];
+      return tick === undefined || want === undefined ? null : tick - want;
+    });
   }
 
   /** @param {boolean} on Turning the guard off releases anything held. */
@@ -239,13 +298,39 @@ export class LeaderGuard {
     if (this.#trip(drawMa)) return;
 
     const before = this.#holding.size;
+    const diverged = this.#divergence(state.positions);
+    /** @type {Map<number, number>} */
+    const goals = new Map();
+    /** @type {Map<number, number>} */
+    const wants = new Map();
+    let worstJoint = 0;
+    let worstTicks = 0;
+
     this.#ids.forEach((id, i) => {
-      const band = this.band(id);
       const tick = state.positions?.[i];
-      if (!band || tick === undefined) return;
-      const outside = isOutside(tick, band, HYSTERESIS_TICKS, this.#holding.has(id));
-      if (outside) this.#holding.add(id);
-      else if (this.#holding.has(id)) {
+      if (tick === undefined) return;
+
+      // Two reasons to push back, and divergence wins where both apply: it is
+      // what the robot actually did, while the band is only our model of it.
+      const error = diverged[i];
+      const beyond = error !== null && Math.abs(error) > DIVERGENCE_DEADBAND_TICKS;
+      const band = this.band(id);
+      const outside = !!band && isOutside(tick, band, HYSTERESIS_TICKS, this.#holding.has(id));
+
+      if (beyond) {
+        this.#holding.add(id);
+        // Drive to the pose the robot accepted — the operator is pushed toward a
+        // reachable state, not merely stopped at a boundary.
+        goals.set(id, tick - /** @type {number} */ (error));
+        wants.set(id, divergenceCurrent(/** @type {number} */ (error), DIVERGENCE_SHAPE));
+        if (Math.abs(/** @type {number} */ (error)) > Math.abs(worstTicks)) {
+          worstTicks = /** @type {number} */ (error);
+          worstJoint = i + 1;
+        }
+      } else if (outside && band) {
+        this.#holding.add(id);
+        goals.set(id, clampTick(tick, band));
+      } else if (this.#holding.has(id)) {
         this.#holding.delete(id);
         this.#leader.writeTorque([id], false);
       }
@@ -256,9 +341,14 @@ export class LeaderGuard {
     // torquing it without writing its goal current first would energize it at
     // the servo's 1750 mA default.
     const untorqued = [...this.#holding].some((id) => !this.#leader.torqued.has(id));
-    if (this.#holding.size !== before || untorqued) this.#applyCurrents();
-    this.#driveHolds(state.positions);
-    this.#patch({ holding: [...this.#holding], drawMa });
+    if (this.#holding.size !== before || untorqued || wants.size) this.#applyCurrents(wants);
+    this.#driveHolds(goals);
+    this.#patch({
+      holding: [...this.#holding],
+      drawMa,
+      divergedJoint: worstJoint,
+      divergedTicks: Math.round(worstTicks),
+    });
   }
 
   /**
@@ -307,40 +397,45 @@ export class LeaderGuard {
     });
   }
 
-  /** Split the budget across whatever is holding right now. */
-  #applyCurrents() {
-    this.#writeCurrents(allocateCurrent(this.#holding.size, this.#budgetMa));
+  /**
+   * Split the budget across whatever is holding. A joint with a divergence force
+   * asks for a specific current; the rest share what is left equally. Every
+   * request is capped so the total can never exceed the budget however hard the
+   * operator pushes.
+   * @param {Map<number, number>} [wants] Per-joint mA requested by divergence.
+   */
+  #applyCurrents(wants) {
+    this.#writeCurrents(allocateCurrent(this.#holding.size, this.#budgetMa), wants);
   }
 
-  /** @param {number} perServoMa */
-  #writeCurrents(perServoMa) {
+  /** @param {number} perServoMa @param {Map<number, number>} [wants] */
+  #writeCurrents(perServoMa, wants) {
     if (!this.#holding.size) {
       this.#patch({ allocatedMa: 0 });
       return;
     }
-    this.#leader.writeGoalCurrent(new Map([...this.#holding].map((id) => [id, perServoMa])));
-    this.#patch({ allocatedMa: perServoMa });
+    const share = allocateCurrent(this.#holding.size, this.#budgetMa);
+    /** @type {Map<number, number>} */
+    const byId = new Map();
+    for (const id of this.#holding) {
+      const asked = wants?.get(id);
+      byId.set(id, Math.min(share, asked === undefined ? perServoMa : asked));
+    }
+    this.#leader.writeGoalCurrent(byId);
+    this.#patch({ allocatedMa: Math.max(...byId.values()) });
   }
 
   /**
-   * Point every held servo at its boundary tick. Goal current is already set, so
-   * the servo walks back to the edge of the reachable band under a capped push
-   * rather than snapping to it.
-   * @param {number[]} positions
+   * Point every held servo at its target — the pose the robot accepted where the
+   * follower diverged, the band edge otherwise. Goal current is already set, so
+   * the servo walks there under a capped push rather than snapping.
+   * @param {Map<number, number>} goals Target tick per servo id.
    */
-  #driveHolds(positions) {
-    if (!this.#holding.size) return;
-    /** @type {Map<number, number>} */
-    const goals = new Map();
+  #driveHolds(goals) {
+    if (!goals.size) return;
     /** @type {number[]} */
     const fresh = [];
-    this.#ids.forEach((id, i) => {
-      const band = this.band(id);
-      const tick = positions[i];
-      if (!band || tick === undefined || !this.#holding.has(id)) return;
-      goals.set(id, clampTick(tick, band));
-      if (!this.#leader.torqued.has(id)) fresh.push(id);
-    });
+    for (const id of goals.keys()) if (!this.#leader.torqued.has(id)) fresh.push(id);
     // Torque after the goal current is queued, never before: a servo torqued at
     // its 1750 mA default, even for one round, is exactly the spike the budget
     // exists to prevent.
@@ -351,6 +446,8 @@ export class LeaderGuard {
   destroy() {
     this.#unsubBudget?.();
     this.#unsubBudget = null;
+    this.#unsubAccepted?.();
+    this.#unsubAccepted = null;
     this.releaseAll();
     this.#listeners.clear();
   }
@@ -362,6 +459,8 @@ export class LeaderGuard {
       next.armed === this.#state.armed &&
       next.drawMa === this.#state.drawMa &&
       next.allocatedMa === this.#state.allocatedMa &&
+      next.divergedJoint === this.#state.divergedJoint &&
+      next.divergedTicks === this.#state.divergedTicks &&
       next.error === this.#state.error &&
       next.holding.join() === this.#state.holding.join()
     ) {

--- a/webapp/js/leaderGuard.js
+++ b/webapp/js/leaderGuard.js
@@ -15,11 +15,13 @@
 
 import {
   ARM_COMMAND_STATE_TOPIC,
+  ARM_CONSTRAINT_TOPIC,
   ARM_GET_PARAMETERS_SERVICE,
   ARM_POSITION_LIMITS_PARAMS,
   DIVERGENCE_DEADBAND_TICKS,
   DIVERGENCE_FLOOR_MA,
   DIVERGENCE_MA_PER_TICK,
+  CONSTRAINT_NONE,
   DIVERGENCE_STALE_MS,
   J1_FRONT_ARC_HI,
   J1_FRONT_ARC_LO,
@@ -102,6 +104,9 @@ export class LeaderGuard {
   #budgetMa = readBudget();
   /** @type {(() => void) | null} */ #unsubBudget = null;
   /** @type {(() => void) | null} */ #unsubAccepted = null;
+  /** @type {(() => void) | null} */ #unsubConstraint = null;
+  /** @type {number[] | null} */ #constrained = null;
+  #constrainedAt = 0;
   // The pose mars_arm last accepted, in leader ticks. Null until it reports.
   /** @type {number[] | null} */ #accepted = null;
   #acceptedAt = 0;
@@ -222,6 +227,19 @@ export class LeaderGuard {
    * un-flipped, so it converts straight to leader ticks.
    */
   #subscribeAccepted() {
+    if (this.#unsubConstraint === null) {
+      this.#unsubConstraint = this.#rosClient.subscribe(
+        ARM_CONSTRAINT_TOPIC,
+        (msg) => {
+          const data = msg && Array.isArray(msg.data) ? msg.data : null;
+          if (!data) return;
+          this.#constrained = data.slice(0, this.#ids.length);
+          this.#constrainedAt = performance.now();
+        },
+        undefined,
+        "std_msgs/msg/Int32MultiArray",
+      );
+    }
     if (this.#unsubAccepted) return;
     this.#unsubAccepted = this.#rosClient.subscribe(
       ARM_COMMAND_STATE_TOPIC,
@@ -245,9 +263,14 @@ export class LeaderGuard {
    */
   #divergence(positions) {
     const accepted = this.#accepted;
-    const fresh = accepted && performance.now() - this.#acceptedAt < DIVERGENCE_STALE_MS;
-    if (!fresh) return this.#ids.map(() => null);
+    const now = performance.now();
+    const fresh = accepted && now - this.#acceptedAt < DIVERGENCE_STALE_MS;
+    // No reason report, or a stale one, means no constraint is known — and an
+    // unexplained gap is exactly the case that must NOT be pushed on.
+    const reasons = this.#constrained && now - this.#constrainedAt < DIVERGENCE_STALE_MS ? this.#constrained : null;
+    if (!fresh || !reasons) return this.#ids.map(() => null);
     return this.#ids.map((_, i) => {
+      if ((reasons[i] ?? CONSTRAINT_NONE) === CONSTRAINT_NONE) return null;
       const tick = positions[i];
       const want = accepted[i];
       return tick === undefined || want === undefined ? null : tick - want;
@@ -448,6 +471,8 @@ export class LeaderGuard {
     this.#unsubBudget = null;
     this.#unsubAccepted?.();
     this.#unsubAccepted = null;
+    this.#unsubConstraint?.();
+    this.#unsubConstraint = null;
     this.releaseAll();
     this.#listeners.clear();
   }

--- a/webapp/js/leaderGuard.js
+++ b/webapp/js/leaderGuard.js
@@ -14,18 +14,14 @@
 // disagrees with the allocation.
 
 import {
-  ARM_COMMAND_STATE_TOPIC,
-  ARM_CONSTRAINT_TOPIC,
   ARM_GET_PARAMETERS_SERVICE,
   ARM_POSITION_LIMITS_PARAMS,
   BODY_LOOKAHEAD_S,
   BODY_MARGIN_M,
   BODY_SLOW_MARGIN_M,
-  DIVERGENCE_DEADBAND_TICKS,
-  DIVERGENCE_FLOOR_MA,
-  DIVERGENCE_MA_PER_TICK,
-  CONSTRAINT_NONE,
-  DIVERGENCE_STALE_MS,
+  HOLD_DEADBAND_TICKS,
+  HOLD_FLOOR_MA,
+  HOLD_MA_PER_TICK,
   J1_FRONT_ARC_HI,
   J1_FRONT_ARC_LO,
   J1_RAMP_HI,
@@ -42,7 +38,7 @@ import { readBudget, onBudgetChange } from "./leaderBudget.js";
 import {
   allocateCurrent,
   clampTick,
-  divergenceCurrent,
+  holdCurrent,
   isOutside,
   joint2FloorRad,
   limitsToBand,
@@ -69,10 +65,10 @@ const BACKOFF = 0.8;
 // Below this a hold is too weak to be felt; release instead of pretending.
 const MIN_USEFUL_MA = 40;
 
-const DIVERGENCE_SHAPE = {
-  deadband: DIVERGENCE_DEADBAND_TICKS,
-  maPerTick: DIVERGENCE_MA_PER_TICK,
-  floorMa: DIVERGENCE_FLOOR_MA,
+const HOLD_SHAPE = {
+  deadband: HOLD_DEADBAND_TICKS,
+  maPerTick: HOLD_MA_PER_TICK,
+  floorMa: HOLD_FLOOR_MA,
   maxMa: LEADER_CURRENT_CEILING_MA,
 };
 
@@ -95,8 +91,8 @@ export class LeaderGuard {
     holding: [],
     drawMa: 0,
     allocatedMa: 0,
-    divergedJoint: 0,
-    divergedTicks: 0,
+    blockedJoint: 0,
+    blockedTicks: 0,
     clearanceMm: -1,
     error: null,
   };
@@ -211,7 +207,6 @@ export class LeaderGuard {
       const band = limitsToBand(value.double_array_value ?? [], JOINT_DIRECTION_FLIPPED[i]);
       if (band) this.#bands.set(id, band);
     });
-    this.#subscribeAccepted();
     if (!this.#bands.size) return;
     this.#prepareMode();
     this.#patch({ armed: true, error: null });
@@ -232,61 +227,6 @@ export class LeaderGuard {
     this.#modeReady = true;
   }
 
-  /**
-   * Track what mars_arm actually accepted. Its message is in radians and already
-   * un-flipped, so it converts straight to leader ticks.
-   */
-  #subscribeAccepted() {
-    if (this.#unsubConstraint === null) {
-      this.#unsubConstraint = this.#rosClient.subscribe(
-        ARM_CONSTRAINT_TOPIC,
-        (msg) => {
-          const data = msg && Array.isArray(msg.data) ? msg.data : null;
-          if (!data) return;
-          this.#constrained = data.slice(0, this.#ids.length);
-          this.#constrainedAt = performance.now();
-        },
-        undefined,
-        "std_msgs/msg/Int32MultiArray",
-      );
-    }
-    if (this.#unsubAccepted) return;
-    this.#unsubAccepted = this.#rosClient.subscribe(
-      ARM_COMMAND_STATE_TOPIC,
-      (msg) => {
-        const pos = msg && Array.isArray(msg.position) ? msg.position : null;
-        if (!pos || pos.length < this.#ids.length) return;
-        this.#accepted = pos.slice(0, this.#ids.length).map((/** @type {number} */ rad) => radToTick(rad));
-        this.#acceptedAt = performance.now();
-      },
-      undefined,
-      "sensor_msgs/msg/JointState",
-    );
-  }
-
-  /**
-   * Signed divergence per joint in ticks, leader minus what the robot accepted,
-   * or null while that report is missing or stale. Stale must read as absent:
-   * pushing toward a pose the arm may already have left is worse than going limp.
-   * @param {number[]} positions
-   * @returns {(number | null)[]}
-   */
-  #divergence(positions) {
-    const accepted = this.#accepted;
-    const now = performance.now();
-    const fresh = accepted && now - this.#acceptedAt < DIVERGENCE_STALE_MS;
-    // No reason report, or a stale one, means no constraint is known — and an
-    // unexplained gap is exactly the case that must NOT be pushed on.
-    const reasons = this.#constrained && now - this.#constrainedAt < DIVERGENCE_STALE_MS ? this.#constrained : null;
-    if (!fresh || !reasons) return this.#ids.map(() => null);
-    return this.#ids.map((_, i) => {
-      if ((reasons[i] ?? CONSTRAINT_NONE) === CONSTRAINT_NONE) return null;
-      const tick = positions[i];
-      const want = accepted[i];
-      return tick === undefined || want === undefined ? null : tick - want;
-    });
-  }
-
   /** @param {boolean} on Turning the guard off releases anything held. */
   setEnabled(on) {
     if (this.#enabled === on) return;
@@ -305,8 +245,13 @@ export class LeaderGuard {
   }
 
   /**
-   * One position round. Decides which joints are out of reach, holds them at the
-   * boundary, and keeps the total draw inside the budget.
+   * One position round. Decides which joints are being held — by their own band,
+   * or because the pose would put the arm in the body — and keeps the total draw
+   * inside the budget.
+   *
+   * Everything here comes from the leader's own ticks. The robot is never asked
+   * what it did with a command: a joint that cannot reach an angle, or cannot
+   * reach it fast enough, is not a wall and must not feel like one.
    * @param {LeaderArmState} state
    */
   update(state) {
@@ -331,11 +276,7 @@ export class LeaderGuard {
     if (this.#trip(drawMa)) return;
 
     const before = this.#holding.size;
-    // Local first: this is the only source fast enough to matter on a quick
-    // swing. The robot's report still covers constraints the webapp cannot
-    // model, and stays the authority on what the arm will actually accept.
     const body = this.#bodyCheck(state.positions);
-    const diverged = this.#divergence(state.positions);
     /** @type {Map<number, number>} */
     const goals = new Map();
     /** @type {Map<number, number>} */
@@ -347,23 +288,19 @@ export class LeaderGuard {
       const tick = state.positions?.[i];
       if (tick === undefined) return;
 
-      // Two reasons to push back, and divergence wins where both apply: it is
-      // what the robot actually did, while the band is only our model of it.
-      // A body hit is expressed as a divergence from the last clear pose, so it
-      // flows through the same push-toward-a-reachable-state path.
-      const bodyError = body.hit && body.target ? tick - body.target[i] : null;
-      const error =
-        bodyError !== null && Math.abs(bodyError) > Math.abs(diverged[i] ?? 0) ? bodyError : diverged[i];
-      const beyond = error !== null && Math.abs(error) > DIVERGENCE_DEADBAND_TICKS;
+      // Only a joint the geometry blames for the contact is pushed on: a joint
+      // that merely happens to be moving while another is the problem is not
+      // the operator's to feel.
+      const error = body.hit && body.target && body.blamed?.[i] ? tick - body.target[i] : null;
+      const beyond = error !== null && Math.abs(error) > HOLD_DEADBAND_TICKS;
       const band = this.band(id);
       const outside = !!band && isOutside(tick, band, HYSTERESIS_TICKS, this.#holding.has(id));
 
       if (beyond) {
         this.#holding.add(id);
-        // Drive to the pose the robot accepted — the operator is pushed toward a
-        // reachable state, not merely stopped at a boundary.
+        // Drive back to the last pose that cleared the body.
         goals.set(id, tick - /** @type {number} */ (error));
-        wants.set(id, divergenceCurrent(/** @type {number} */ (error), DIVERGENCE_SHAPE));
+        wants.set(id, holdCurrent(/** @type {number} */ (error), HOLD_SHAPE));
         if (Math.abs(/** @type {number} */ (error)) > Math.abs(worstTicks)) {
           worstTicks = /** @type {number} */ (error);
           worstJoint = i + 1;
@@ -387,8 +324,8 @@ export class LeaderGuard {
     this.#patch({
       holding: [...this.#holding],
       drawMa,
-      divergedJoint: worstJoint,
-      divergedTicks: Math.round(worstTicks),
+      blockedJoint: worstJoint,
+      blockedTicks: Math.round(worstTicks),
       clearanceMm: Number.isFinite(body.clearance) ? Math.round(body.clearance * 1000) : -1,
     });
   }
@@ -452,9 +389,10 @@ export class LeaderGuard {
    * Whether the leader's own pose would put the arm in the body, and where to
    * push back to if so. Computed here rather than read off the robot: the
    * robot's verdict is a round trip old, and a fast swing is finished inside
-   * that window.
+   * that window — and because only the geometry, never the robot's behaviour,
+   * decides whether the operator feels anything.
    * @param {number[]} positions
-   * @returns {{ hit: boolean, target: number[] | null, clearance: number }}
+   * @returns {{ hit: boolean, target: number[] | null, clearance: number, blamed: boolean[] | null }}
    */
   #bodyCheck(positions) {
     const rads = ticksToRads(positions);
@@ -463,9 +401,31 @@ export class LeaderGuard {
     const hit = poseHitsBody(rads, margin);
     if (!hit) {
       this.#lastClear = positions.slice();
-      return { hit: false, target: null, clearance };
+      return { hit: false, target: null, clearance, blamed: null };
     }
-    return { hit: true, target: this.#lastClear, clearance };
+    return { hit: true, target: this.#lastClear, clearance, blamed: this.#blame(rads, clearance) };
+  }
+
+  /**
+   * Which joints actually cause the contact. Revert one at a time to its last
+   * clear value and keep the ones that buy clearance.
+   *
+   * "Every joint that differs from the last clear pose" is the wrong answer: any
+   * joint being driven differs, so a four-joint move blamed four joints and the
+   * whole arm stiffened at once.
+   * @param {number[]} rads @param {number} base
+   * @returns {boolean[]}
+   */
+  #blame(rads, base) {
+    const clear = this.#lastClear;
+    if (!clear) return this.#ids.map(() => false);
+    const clearRads = ticksToRads(clear);
+    return this.#ids.map((_, j) => {
+      if (j > 3) return false; // joints 5 and 6 cannot move the arm through space
+      const probe = rads.slice();
+      probe[j] = clearRads[j];
+      return bodyClearance(probe) > base + 1e-4;
+    });
   }
 
   /** @param {number[]} positions @returns {boolean} */
@@ -507,8 +467,8 @@ export class LeaderGuard {
   }
 
   /**
-   * Point every held servo at its target — the pose the robot accepted where the
-   * follower diverged, the band edge otherwise. Goal current is already set, so
+   * Point every held servo at its target — the last pose that cleared the body
+   * where the body is the limit, the band edge otherwise. Goal current is already set, so
    * the servo walks there under a capped push rather than snapping.
    * @param {Map<number, number>} goals Target tick per servo id.
    */
@@ -527,10 +487,6 @@ export class LeaderGuard {
   destroy() {
     this.#unsubBudget?.();
     this.#unsubBudget = null;
-    this.#unsubAccepted?.();
-    this.#unsubAccepted = null;
-    this.#unsubConstraint?.();
-    this.#unsubConstraint = null;
     this.releaseAll();
     this.#listeners.clear();
   }
@@ -542,8 +498,8 @@ export class LeaderGuard {
       next.armed === this.#state.armed &&
       next.drawMa === this.#state.drawMa &&
       next.allocatedMa === this.#state.allocatedMa &&
-      next.divergedJoint === this.#state.divergedJoint &&
-      next.divergedTicks === this.#state.divergedTicks &&
+      next.blockedJoint === this.#state.blockedJoint &&
+      next.blockedTicks === this.#state.blockedTicks &&
       next.clearanceMm === this.#state.clearanceMm &&
       next.error === this.#state.error &&
       next.holding.join() === this.#state.holding.join()

--- a/webapp/js/leaderLimits.js
+++ b/webapp/js/leaderLimits.js
@@ -1,0 +1,91 @@
+// @ts-check
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Innate Inc
+// Tick/limit/current math for the leader-arm reachability guard. Pure — no
+// serial, no DOM, no state — so the arithmetic that decides where a servo
+// stops and how hard it may push can be reasoned about on its own.
+
+const TICKS_PER_REV = 4096;
+const TICK_CENTER = 2048;
+
+/** @typedef {{ min: number, max: number }} Band Reachable tick range, inclusive. */
+
+/** @param {number} rad @returns {number} */
+export function radToTick(rad) {
+  return TICK_CENTER + (rad * TICKS_PER_REV) / (2 * Math.PI);
+}
+
+/** @param {number} tick @returns {number} */
+export function tickToRad(tick) {
+  return ((tick - TICK_CENTER) * 2 * Math.PI) / TICKS_PER_REV;
+}
+
+/**
+ * A follower joint's [lo, hi] radian limits as a tick band. Rounds inward so a
+ * clamped tick always converts back to a radian the follower accepts — rounding
+ * outward would hand it a goal one tick past its own limit.
+ * @param {number[]} positionLimits
+ * @returns {Band | null} null if the parameter isn't a usable pair.
+ */
+export function limitsToBand(positionLimits) {
+  if (positionLimits.length !== 2) return null;
+  const [lo, hi] = positionLimits;
+  if (!Number.isFinite(lo) || !Number.isFinite(hi) || lo >= hi) return null;
+  return { min: Math.ceil(radToTick(lo)), max: Math.floor(radToTick(hi)) };
+}
+
+/** @param {number} tick @param {Band} band @returns {number} */
+export function clampTick(tick, band) {
+  return Math.min(band.max, Math.max(band.min, tick));
+}
+
+/**
+ * Whether the joint counts as out of reach, with hysteresis on the way back:
+ * re-entry needs `hysteresis` ticks past the boundary. Without it a joint
+ * resting exactly on the limit flickers, and each flicker is an EEPROM-free but
+ * still pointless torque on/off cycle.
+ * @param {number} tick
+ * @param {Band} band
+ * @param {number} hysteresis
+ * @param {boolean} wasOutside
+ * @returns {boolean}
+ */
+export function isOutside(tick, band, hysteresis, wasOutside) {
+  if (!wasOutside) return tick < band.min || tick > band.max;
+  return tick < band.min + hysteresis || tick > band.max - hysteresis;
+}
+
+/**
+ * Fraction of the way into the danger zone at each end, 0 well inside and 1 at
+ * the boundary — drives the amber warning before the wall is reached.
+ * @param {number} tick @param {Band} band @param {number} warnTicks
+ * @returns {number}
+ */
+export function proximity(tick, band, warnTicks) {
+  if (warnTicks <= 0) return 0;
+  const slack = Math.min(tick - band.min, band.max - tick);
+  if (slack >= warnTicks) return 0;
+  return Math.min(1, Math.max(0, 1 - slack / warnTicks));
+}
+
+/**
+ * Per-servo goal current when `activeCount` servos hold at once. The budget is
+ * a ceiling on the sum, so it divides rather than applying to each.
+ * @param {number} activeCount
+ * @param {number} budgetMa
+ * @returns {number}
+ */
+export function allocateCurrent(activeCount, budgetMa) {
+  if (activeCount <= 0) return 0;
+  return Math.max(0, Math.floor(budgetMa / activeCount));
+}
+
+/**
+ * Total draw. Present Current is signed by direction, so magnitude is what
+ * counts against a power budget.
+ * @param {number[]} currents
+ * @returns {number}
+ */
+export function totalCurrent(currents) {
+  return currents.reduce((sum, mA) => sum + Math.abs(mA), 0);
+}

--- a/webapp/js/leaderLimits.js
+++ b/webapp/js/leaderLimits.js
@@ -21,17 +21,42 @@ export function tickToRad(tick) {
 }
 
 /**
- * A follower joint's [lo, hi] radian limits as a tick band. Rounds inward so a
+ * A follower joint's [lo, hi] radian limits as a tick band in the frame the
+ * leader publishes. A flipped joint's band mirrors to [-hi, -lo], because
+ * mars_arm negates the command before it reaches the servo. Rounds inward so a
  * clamped tick always converts back to a radian the follower accepts — rounding
  * outward would hand it a goal one tick past its own limit.
  * @param {number[]} positionLimits
+ * @param {boolean} [flipped]
  * @returns {Band | null} null if the parameter isn't a usable pair.
  */
-export function limitsToBand(positionLimits) {
+export function limitsToBand(positionLimits, flipped = false) {
   if (positionLimits.length !== 2) return null;
   const [lo, hi] = positionLimits;
   if (!Number.isFinite(lo) || !Number.isFinite(hi) || lo >= hi) return null;
-  return { min: Math.ceil(radToTick(lo)), max: Math.floor(radToTick(hi)) };
+  const [min, max] = flipped ? [-hi, -lo] : [lo, hi];
+  return { min: Math.ceil(radToTick(min)), max: Math.floor(radToTick(max)) };
+}
+
+/**
+ * Joint 2's floor given where joint 1 is, in radians. Full travel with the arm
+ * swung clear behind the ramp, tightened to `restrictedMin` across the front arc
+ * where lowering joint 2 folds the arm into the body, and linearly interpolated
+ * between. Mirrors arm_control.cpp so the operator feels the same boundary the
+ * follower enforces instead of silently diverging from it.
+ * @param {number} joint1Rad
+ * @param {number} baseMinRad Joint 2's unrestricted floor.
+ * @param {{ restrictedMin: number, arcLo: number, arcHi: number, rampLo: number, rampHi: number }} shape
+ * @returns {number}
+ */
+export function joint2FloorRad(joint1Rad, baseMinRad, shape) {
+  const { restrictedMin, arcLo, arcHi, rampLo, rampHi } = shape;
+  if (restrictedMin <= baseMinRad) return baseMinRad;
+  const ramp = (/** @type {number} */ t) => restrictedMin + t * (baseMinRad - restrictedMin);
+  if (joint1Rad < rampLo || joint1Rad >= rampHi) return baseMinRad;
+  if (joint1Rad < arcLo) return Math.max(baseMinRad, ramp((arcLo - joint1Rad) / (arcLo - rampLo)));
+  if (joint1Rad < arcHi) return Math.max(baseMinRad, restrictedMin);
+  return Math.max(baseMinRad, ramp((joint1Rad - arcHi) / (rampHi - arcHi)));
 }
 
 /** @param {number} tick @param {Band} band @returns {number} */

--- a/webapp/js/leaderLimits.js
+++ b/webapp/js/leaderLimits.js
@@ -119,3 +119,17 @@ export function allocateCurrent(activeCount, budgetMa) {
 export function totalCurrent(currents) {
   return currents.reduce((sum, mA) => sum + Math.abs(mA), 0);
 }
+
+/**
+ * Hold current for a joint the follower could not follow. A step at the
+ * deadband, then a ramp: force has to be felt the moment the arm stops
+ * tracking, and a curve starting from zero reads as no wall at all.
+ * @param {number} errorTicks Signed divergence, leader minus accepted.
+ * @param {{ deadband: number, maPerTick: number, floorMa: number, maxMa: number }} shape
+ * @returns {number} mA, 0 inside the deadband.
+ */
+export function divergenceCurrent(errorTicks, shape) {
+  const over = Math.abs(errorTicks) - shape.deadband;
+  if (over <= 0) return 0;
+  return Math.min(shape.maxMa, shape.floorMa + over * shape.maPerTick);
+}

--- a/webapp/js/leaderLimits.js
+++ b/webapp/js/leaderLimits.js
@@ -45,10 +45,10 @@ export function limitsToBand(positionLimits, flipped = false) {
  * between. Mirrors arm_control.cpp's joint limits so the operator sees the same
  * boundary the follower enforces.
  *
- * The robot also runs a body keepout that this cannot express — it tests where
- * the arm actually is, so reaching down in front stays free while folding back
- * over the chassis does not. Divergence, not this band, is what tells the leader
- * about that one.
+ * The body keepout is separate and lives in armGeometry.js: it tests where the
+ * arm actually is, so reaching down in front stays free while folding back over
+ * the chassis does not. No per-joint band can express that, which is why it is
+ * computed geometrically rather than as a limit on any one joint.
  * @param {number} joint1Rad
  * @param {number} baseMinRad Joint 2's unrestricted floor.
  * @param {{ restrictedMin: number, arcLo: number, arcHi: number, rampLo: number, rampHi: number }} shape
@@ -121,14 +121,14 @@ export function totalCurrent(currents) {
 }
 
 /**
- * Hold current for a joint the follower could not follow. A step at the
- * deadband, then a ramp: force has to be felt the moment the arm stops
- * tracking, and a curve starting from zero reads as no wall at all.
- * @param {number} errorTicks Signed divergence, leader minus accepted.
+ * Hold current for a joint being held at a limit. A step at the deadband, then a
+ * ramp: a wall has to be felt the moment it exists, and a curve starting from
+ * zero reads as no wall at all.
+ * @param {number} errorTicks Signed ticks past the limit.
  * @param {{ deadband: number, maPerTick: number, floorMa: number, maxMa: number }} shape
  * @returns {number} mA, 0 inside the deadband.
  */
-export function divergenceCurrent(errorTicks, shape) {
+export function holdCurrent(errorTicks, shape) {
   const over = Math.abs(errorTicks) - shape.deadband;
   if (over <= 0) return 0;
   return Math.min(shape.maxMa, shape.floorMa + over * shape.maPerTick);

--- a/webapp/js/leaderLimits.js
+++ b/webapp/js/leaderLimits.js
@@ -42,8 +42,13 @@ export function limitsToBand(positionLimits, flipped = false) {
  * Joint 2's floor given where joint 1 is, in radians. Full travel with the arm
  * swung clear behind the ramp, tightened to `restrictedMin` across the front arc
  * where lowering joint 2 folds the arm into the body, and linearly interpolated
- * between. Mirrors arm_control.cpp so the operator feels the same boundary the
- * follower enforces instead of silently diverging from it.
+ * between. Mirrors arm_control.cpp's joint limits so the operator sees the same
+ * boundary the follower enforces.
+ *
+ * The robot also runs a body keepout that this cannot express — it tests where
+ * the arm actually is, so reaching down in front stays free while folding back
+ * over the chassis does not. Divergence, not this band, is what tells the leader
+ * about that one.
  * @param {number} joint1Rad
  * @param {number} baseMinRad Joint 2's unrestricted floor.
  * @param {{ restrictedMin: number, arcLo: number, arcHi: number, rampLo: number, rampHi: number }} shape

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -74,6 +74,9 @@
  * @property {string} summary  Index subtitle.
  * @property {string} [note]  Page introduction under the h1.
  * @property {boolean} [hasSpeakerVolume]  Inject the live speaker-volume control.
+ * @property {boolean} [hasLeaderCurrentBudget]  Inject the leader-arm current budget.
+ *   Browser-local, not a settings.yaml path: the leader arm draws from the machine
+ *   running this page, so the value belongs to that device rather than the robot.
  * @property {PageSection[]} sections
  */
 
@@ -205,6 +208,7 @@ export const SETTINGS_PAGES = [
     title: "Safety & hardware",
     summary: "Physical limits, battery, and arm",
     note: "Configure the robot's physical backstops and hardware behavior.",
+    hasLeaderCurrentBudget: true,
     sections: [
       {
         title: "Motor safety limits",

--- a/webapp/js/settings/main.js
+++ b/webapp/js/settings/main.js
@@ -12,7 +12,14 @@
 // *unsaved* edit (differs from what's saved) shows blue. Save is enabled only
 // while there are unsaved changes.
 
-import { ROBOT_INFO_TOPIC, SET_VOLUME_SERVICE, SHUTDOWN_SERVICE } from "../constants.js";
+import {
+  LEADER_CURRENT_BUDGET_MIN_MA,
+  LEADER_CURRENT_CEILING_MA,
+  ROBOT_INFO_TOPIC,
+  SET_VOLUME_SERVICE,
+  SHUTDOWN_SERVICE,
+} from "../constants.js";
+import { readBudget, writeBudget } from "../leaderBudget.js";
 import { ros } from "../rosClient.js";
 import { SETTINGS_PAGES } from "./catalog.js";
 import { GROUP_EXPAND_MS, SETTINGS_STYLE } from "./styles.js";
@@ -415,6 +422,64 @@ function buildVolumeSection() {
   return { section, row, label: labelText, description: descriptionText };
 }
 
+/**
+ * Leader-arm current budget. The odd one out on this page: every other control
+ * edits the robot, but the leader arm draws from whatever machine it is plugged
+ * into, and a laptop port and a phone port do not have the same headroom. So it
+ * is stored in this browser rather than settings.yaml, needs no robot to change,
+ * and applies to the next hold with no save step.
+ */
+function buildLeaderBudgetSection() {
+  const labelText = "Leader-arm current budget";
+  const descriptionText =
+    "Total draw allowed across the leader arm's six servos while it holds a joint at the " +
+    "follower's limit. Stored on this device, not the robot — the arm is powered by the " +
+    "machine it is plugged into.";
+  const section = textEl("section", "set-card-volume");
+
+  const row = textEl("div", "set-row");
+  const controlContainer = textEl("div", "set-ctl");
+  const controlGroup = textEl("div", "set-ctl-main is-wide");
+
+  const slider = inputEl("range", "set-slider");
+  slider.title = "Applies to the next hold — the guard re-splits this across whatever it holds";
+  slider.min = String(LEADER_CURRENT_BUDGET_MIN_MA);
+  slider.max = String(LEADER_CURRENT_CEILING_MA);
+  slider.step = "25";
+  initSlider(slider);
+
+  const valueLabel = textEl("span", "set-slider-read");
+  const sliderContainer = textEl("div", "set-slider-wrap");
+  sliderContainer.append(valueLabel, slider);
+
+  const status = textEl("span", "set-card-volume-status set-status muted");
+  controlGroup.append(textEl("span", "set-validation-slot"), sliderContainer, status);
+  controlContainer.appendChild(controlGroup);
+
+  row.append(buildRowText(labelText, descriptionText), controlContainer);
+  enableRowClick(row);
+  section.appendChild(row);
+
+  const renderValue = (/** @type {number} */ mA) => {
+    slider.value = String(mA);
+    syncSliderFill(slider);
+    valueLabel.textContent = `${mA} mA`;
+  };
+  renderValue(readBudget());
+
+  slider.addEventListener("input", () => {
+    valueLabel.textContent = `${slider.value} mA`;
+  });
+
+  slider.addEventListener("change", () => {
+    renderValue(writeBudget(Number(slider.value)));
+    status.textContent = "Saved on this device.";
+    status.className = "set-card-volume-status set-status ok";
+  });
+
+  return { section, row, label: labelText, description: descriptionText };
+}
+
 const GROUP_CHEV =
   '<svg class="set-group-chev" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9,6 15,12 9,18"/></svg>';
 
@@ -506,6 +571,13 @@ function buildSettingsPage() {
       groupInner.appendChild(speaker);
     }
 
+    const budgetControl = settingsPage.hasLeaderCurrentBudget ? buildLeaderBudgetSection() : null;
+    if (budgetControl) {
+      const leader = textEl("section", "set-page-section");
+      leader.append(textEl("h2", "set-section-title", "Leader arm"), budgetControl.section);
+      groupInner.appendChild(leader);
+    }
+
     /** @type {GroupUI} */
     const ui = { section, dot, entries: [] };
     header.addEventListener("click", () => setGroupOpen(ui, !section.classList.contains("open")));
@@ -518,6 +590,17 @@ function buildSettingsPage() {
         row: volumeControl.row,
         group: ui,
         breadcrumb: `${settingsPage.title} · Speaker`,
+        extraSearchSources: [pageSearchSource],
+      });
+    }
+
+    if (budgetControl) {
+      addSearchTarget({
+        label: budgetControl.label,
+        description: budgetControl.description,
+        row: budgetControl.row,
+        group: ui,
+        breadcrumb: `${settingsPage.title} · Leader arm`,
         extraSearchSources: [pageSearchSource],
       });
     }

--- a/webapp/js/teleop/armPanel.js
+++ b/webapp/js/teleop/armPanel.js
@@ -254,8 +254,15 @@ export function createArmPanel(parent, rosClient, opts = {}) {
       status.classList.remove("warn");
     } else {
       // Draw is only worth showing once the guard can actually spend it.
-      status.textContent = g.armed ? `${state.rate} Hz · ${g.drawMa} mA` : `${state.rate} Hz`;
-      status.classList.remove("warn");
+      // Divergence is the headline when it happens: the arm is not where the
+      // operator put it, and that matters more than the rate.
+      if (g.divergedJoint) {
+        status.textContent = `joint ${g.divergedJoint} limited by the robot · ${g.drawMa} mA`;
+        status.classList.add("warn");
+      } else {
+        status.textContent = g.armed ? `${state.rate} Hz · ${g.drawMa} mA` : `${state.rate} Hz`;
+        status.classList.remove("warn");
+      }
     }
 
     joints.hidden = !reading;
@@ -288,11 +295,13 @@ export function createArmPanel(parent, rosClient, opts = {}) {
     limitsBtn.hidden = !reading;
     limitsBtn.textContent = !guard.enabled
       ? "Limits off"
-      : g.armed
-        ? `Limits on${g.holding.length ? " — holding" : ""}`
-        : "Limits — no robot";
+      : g.divergedJoint
+        ? "Not following"
+        : g.armed
+          ? `Limits on${g.holding.length ? " — holding" : ""}`
+          : "Limits — no robot";
     limitsBtn.classList.toggle("active", guard.enabled && g.armed);
-    limitsBtn.classList.toggle("holding", g.holding.length > 0);
+    limitsBtn.classList.toggle("holding", g.holding.length > 0 || g.divergedJoint > 0);
 
     note.hidden = !reading || engaged;
     note.textContent = "follower snaps to leader pose";

--- a/webapp/js/teleop/armPanel.js
+++ b/webapp/js/teleop/armPanel.js
@@ -256,10 +256,10 @@ export function createArmPanel(parent, rosClient, opts = {}) {
       // Draw is only worth showing once the guard can actually spend it.
       // Divergence is the headline when it happens: the arm is not where the
       // operator put it, and that matters more than the rate.
-      if (g.divergedJoint) {
+      if (g.blockedJoint) {
         // Clearance is the number to tune BODY_MARGIN_M against, so show it.
         const room = g.clearanceMm >= 0 ? ` · ${g.clearanceMm} mm` : "";
-        status.textContent = `joint ${g.divergedJoint} blocked${room} · ${g.drawMa} mA`;
+        status.textContent = `joint ${g.blockedJoint} blocked${room} · ${g.drawMa} mA`;
         status.classList.add("warn");
       } else {
         status.textContent = g.armed ? `${state.rate} Hz · ${g.drawMa} mA` : `${state.rate} Hz`;
@@ -297,13 +297,13 @@ export function createArmPanel(parent, rosClient, opts = {}) {
     limitsBtn.hidden = !reading;
     limitsBtn.textContent = !guard.enabled
       ? "Limits off"
-      : g.divergedJoint
+      : g.blockedJoint
         ? "Not following"
         : g.armed
           ? `Limits on${g.holding.length ? " — holding" : ""}`
           : "Limits — no robot";
     limitsBtn.classList.toggle("active", guard.enabled && g.armed);
-    limitsBtn.classList.toggle("holding", g.holding.length > 0 || g.divergedJoint > 0);
+    limitsBtn.classList.toggle("holding", g.holding.length > 0 || g.blockedJoint > 0);
 
     note.hidden = !reading || engaged;
     note.textContent = "follower snaps to leader pose";

--- a/webapp/js/teleop/armPanel.js
+++ b/webapp/js/teleop/armPanel.js
@@ -12,7 +12,7 @@
 // pose the moment data flows. Auto-disengage on tab hide, rosbridge loss,
 // or serial failure.
 
-import { DynamixelLeader } from "../dynamixel.js";
+import { DynamixelLeader, LEADER_SERVO_IDS } from "../dynamixel.js";
 import { copyToButton, ICON_COPY } from "../clipboard.js";
 import {
   LEADER_POSITIONS_TOPIC,
@@ -22,10 +22,24 @@ import {
   ARM_STATUS_TOPIC,
 } from "../constants.js";
 import { rebootArmAndEnableTorque } from "../armReboot.js";
+import { LeaderGuard } from "../leaderGuard.js";
+import { clampTick, proximity } from "../leaderLimits.js";
 
 const PUBLISH_MIN_GAP_MS = 15;
 const TICK_CENTER = 2048;
 const TICK_SPAN = 2048; // ±half a revolution shown on the joint dots
+// Amber warning band before the wall, ~10°.
+const WARN_TICKS = 120;
+
+/**
+ * Where a tick sits on a joint track, as a percentage down from the top.
+ * @param {number} tick
+ * @returns {number}
+ */
+function topPct(tick) {
+  const frac = Math.max(-1, Math.min(1, (tick - TICK_CENTER) / TICK_SPAN));
+  return (1 - (frac + 1) / 2) * 100;
+}
 
 /**
  * @param {HTMLElement} parent
@@ -124,14 +138,25 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   joints.title = "Live leader-arm joint positions (Dynamixel ticks, ±half turn)";
   /** @type {HTMLElement[]} */
   const dots = [];
+  /** @type {{ lo: HTMLElement, hi: HTMLElement }[]} */
+  const zones = [];
   for (let i = 0; i < 6; i++) {
     const joint = document.createElement("div");
     joint.className = "arm-joint";
+    // Shaded caps mark travel the follower cannot reach, so the wall is visible
+    // before it is felt. Hidden until mars_arm reports that joint's limits.
+    const lo = document.createElement("div");
+    lo.className = "arm-joint-zone lo";
+    lo.hidden = true;
+    const hi = document.createElement("div");
+    hi.className = "arm-joint-zone hi";
+    hi.hidden = true;
     const dot = document.createElement("div");
     dot.className = "arm-joint-dot";
-    joint.appendChild(dot);
+    joint.append(lo, hi, dot);
     joints.appendChild(joint);
     dots.push(dot);
+    zones.push({ lo, hi });
   }
 
   const connectBtn = document.createElement("button");
@@ -153,6 +178,13 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   copyBtn.setAttribute("aria-label", "Copy joint positions");
   copyBtn.innerHTML = ICON_COPY;
 
+  // Holds the leader inside the follower's reach. Defeatable: a limit read from
+  // a mistuned robot must never be the reason an operator cannot move the arm.
+  const limitsBtn = document.createElement("button");
+  limitsBtn.className = "arm-button arm-limits";
+  limitsBtn.type = "button";
+  limitsBtn.title = "Hold the leader inside the follower's reachable range";
+
   // Engage + copy share a row; the row (not the button) is what hides when
   // there's nothing to read.
   const engageRow = document.createElement("div");
@@ -162,7 +194,7 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   const note = document.createElement("p");
   note.className = "arm-note microlabel";
 
-  wrap.append(status, joints, connectBtn, engageRow, note, ...(armSvc ? [divider(), armSvc.el] : []));
+  wrap.append(status, joints, connectBtn, engageRow, limitsBtn, note, ...(armSvc ? [divider(), armSvc.el] : []));
 
   // ---- state ------------------------------------------------------------
 
@@ -170,12 +202,29 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   let lastPublishAt = 0;
   let destroyed = false;
   const leader = new DynamixelLeader();
+  const guard = new LeaderGuard({ leader, rosClient }, LEADER_SERVO_IDS);
 
   /** @param {boolean} on */
   function setEngaged(on) {
     if (engaged === on) return;
     engaged = on;
     render(leader.state);
+  }
+
+  /**
+   * What actually goes on the wire. While the guard is on, ticks are clamped
+   * into the follower's band even for joints it is not currently holding: the
+   * servo wall can slip or be overpowered, and the follower must never be handed
+   * a goal it cannot reach just because the physical hold lost.
+   * @param {number[]} positions
+   * @returns {number[]}
+   */
+  function reachable(positions) {
+    if (!guard.enabled) return positions;
+    return positions.map((tick, i) => {
+      const band = guard.band(LEADER_SERVO_IDS[i]);
+      return band ? clampTick(tick, band) : tick;
+    });
   }
 
   /** @param {number[]} positions */
@@ -185,7 +234,7 @@ export function createArmPanel(parent, rosClient, opts = {}) {
     lastPublishAt = now;
     rosClient.publish(LEADER_POSITIONS_TOPIC, {
       layout: { dim: [], data_offset: 0 },
-      data: positions,
+      data: reachable(positions),
     });
   }
 
@@ -193,22 +242,38 @@ export function createArmPanel(parent, rosClient, opts = {}) {
   function render(state) {
     const reading = state.connected && state.positions !== null;
 
-    if (state.error) {
-      status.textContent = state.error;
+    const g = guard.state;
+    if (state.error || g.error) {
+      status.textContent = state.error || g.error;
       status.classList.add("warn");
     } else if (!state.connected) {
       status.textContent = "no arm connected";
       status.classList.remove("warn");
+    } else if (!reading) {
+      status.textContent = "listening…";
+      status.classList.remove("warn");
     } else {
-      status.textContent = reading ? `${state.rate} Hz` : "listening…";
+      // Draw is only worth showing once the guard can actually spend it.
+      status.textContent = g.armed ? `${state.rate} Hz · ${g.drawMa} mA` : `${state.rate} Hz`;
       status.classList.remove("warn");
     }
 
     joints.hidden = !reading;
     if (state.positions) {
       state.positions.forEach((tick, i) => {
-        const frac = Math.max(-1, Math.min(1, (tick - TICK_CENTER) / TICK_SPAN));
-        dots[i].style.top = `${(1 - (frac + 1) / 2) * 100}%`;
+        dots[i].style.top = `${topPct(tick)}%`;
+
+        const band = guard.enabled ? guard.band(LEADER_SERVO_IDS[i]) : undefined;
+        const held = g.holding.includes(LEADER_SERVO_IDS[i]);
+        dots[i].classList.toggle("danger", held);
+        dots[i].classList.toggle("warn", !held && !!band && proximity(tick, band, WARN_TICKS) > 0);
+
+        const { lo, hi } = zones[i];
+        lo.hidden = hi.hidden = !band;
+        if (band) {
+          hi.style.height = `${topPct(band.max)}%`;
+          lo.style.top = `${topPct(band.min)}%`;
+        }
       });
     }
 
@@ -219,6 +284,15 @@ export function createArmPanel(parent, rosClient, opts = {}) {
     engageRow.hidden = !reading;
     engageBtn.textContent = engaged ? "Live — click to stop" : "Engage follow";
     engageBtn.classList.toggle("active", engaged);
+
+    limitsBtn.hidden = !reading;
+    limitsBtn.textContent = !guard.enabled
+      ? "Limits off"
+      : g.armed
+        ? `Limits on${g.holding.length ? " — holding" : ""}`
+        : "Limits — no robot";
+    limitsBtn.classList.toggle("active", guard.enabled && g.armed);
+    limitsBtn.classList.toggle("holding", g.holding.length > 0);
 
     note.hidden = !reading || engaged;
     note.textContent = "follower snaps to leader pose";
@@ -258,14 +332,32 @@ export function createArmPanel(parent, rosClient, opts = {}) {
 
   engageBtn.addEventListener("click", () => setEngaged(!engaged));
 
+  // Arming needs both links: the limits come from the robot, and the mode write
+  // that precedes any hold can only be queued once the serial port is open.
+  function maybeArm() {
+    if (destroyed || !guard.enabled) return;
+    if (rosClient.state !== "connected" || !leader.state.connected) return;
+    void guard.arm();
+  }
+
+  limitsBtn.addEventListener("click", () => {
+    guard.setEnabled(!guard.enabled);
+    maybeArm();
+    render(leader.state);
+  });
+
   copyBtn.addEventListener("click", () => {
     const positions = leader.state.positions;
     if (!positions) return; // row is hidden without a read, but be safe
     void copyToButton(`[${positions.join(", ")}]`, copyBtn, "copied");
   });
 
+  let wasConnected = false;
   const unsubLeader = leader.onChange((state) => {
     if (destroyed) return;
+    if (state.connected && !wasConnected) maybeArm();
+    wasConnected = state.connected;
+    guard.update(state);
     if (engaged && (!state.connected || state.error)) {
       engaged = false;
     } else if (engaged && state.positions && rosClient.state === "connected") {
@@ -274,12 +366,27 @@ export function createArmPanel(parent, rosClient, opts = {}) {
     render(state);
   });
 
+  const unsubGuard = guard.onChange(() => {
+    if (!destroyed) render(leader.state);
+  });
+
   const unsubRos = rosClient.onStateChange((rosState) => {
-    if (rosState !== "connected") setEngaged(false);
+    if (rosState === "connected") {
+      maybeArm();
+      return;
+    }
+    setEngaged(false);
+    // Nothing reaches the follower with the socket down, so a hold would burn
+    // current for no one.
+    guard.releaseAll();
   });
 
   const onVisibility = () => {
-    if (document.visibilityState === "hidden") setEngaged(false);
+    if (document.visibilityState !== "hidden") return;
+    setEngaged(false);
+    // Background tabs are timer-throttled, so a hold would keep pushing against
+    // stale positions. Let go instead.
+    guard.releaseAll();
   };
   document.addEventListener("visibilitychange", onVisibility);
 
@@ -299,7 +406,9 @@ export function createArmPanel(parent, rosClient, opts = {}) {
     destroy() {
       destroyed = true;
       setEngaged(false);
+      guard.destroy();
       unsubLeader();
+      unsubGuard();
       unsubRos();
       document.removeEventListener("visibilitychange", onVisibility);
       serial.removeEventListener("connect", onSerialConnect);

--- a/webapp/js/teleop/armPanel.js
+++ b/webapp/js/teleop/armPanel.js
@@ -257,7 +257,9 @@ export function createArmPanel(parent, rosClient, opts = {}) {
       // Divergence is the headline when it happens: the arm is not where the
       // operator put it, and that matters more than the rate.
       if (g.divergedJoint) {
-        status.textContent = `joint ${g.divergedJoint} limited by the robot · ${g.drawMa} mA`;
+        // Clearance is the number to tune BODY_MARGIN_M against, so show it.
+        const room = g.clearanceMm >= 0 ? ` · ${g.clearanceMm} mm` : "";
+        status.textContent = `joint ${g.divergedJoint} blocked${room} · ${g.drawMa} mA`;
         status.classList.add("warn");
       } else {
         status.textContent = g.armed ? `${state.rate} Hz · ${g.drawMa} mA` : `${state.rate} Hz`;

--- a/webapp/js/types.d.ts
+++ b/webapp/js/types.d.ts
@@ -240,6 +240,10 @@ interface LeaderGuardState {
   drawMa: number;
   /** Per-servo goal current the guard is currently allowing, mA. */
   allocatedMa: number;
+  /** 1-based joint the follower is furthest from following, 0 if it is keeping up. */
+  divergedJoint: number;
+  /** Signed ticks between the leader and the pose mars_arm accepted. */
+  divergedTicks: number;
   /** Set when the guard cut torque to stay inside the budget. */
   error: string | null;
 }

--- a/webapp/js/types.d.ts
+++ b/webapp/js/types.d.ts
@@ -240,10 +240,10 @@ interface LeaderGuardState {
   drawMa: number;
   /** Per-servo goal current the guard is currently allowing, mA. */
   allocatedMa: number;
-  /** 1-based joint the follower is furthest from following, 0 if it is keeping up. */
-  divergedJoint: number;
-  /** Signed ticks between the leader and the pose mars_arm accepted. */
-  divergedTicks: number;
+  /** 1-based joint the guard is holding hardest, 0 if the arm is free. */
+  blockedJoint: number;
+  /** Signed ticks past the limit on that joint. */
+  blockedTicks: number;
   /** Millimetres of room left before the arm meets the body; -1 if unknown. */
   clearanceMm: number;
   /** Set when the guard cut torque to stay inside the budget. */

--- a/webapp/js/types.d.ts
+++ b/webapp/js/types.d.ts
@@ -223,8 +223,24 @@ interface LeaderArmState {
   connected: boolean;
   /** Latest raw servo ticks (signed, 2048 = center), ordered by servo id. */
   positions: number[] | null;
+  /** Present Current per servo in mA, signed by direction, ordered by servo id. */
+  currents: number[] | null;
   /** Position rounds per second over the last second. */
   rate: number;
+  error: string | null;
+}
+
+/** Live state of the leader-arm reachability guard (js/leaderGuard.js). */
+interface LeaderGuardState {
+  /** Limits known and the guard allowed to hold — false until mars_arm answers. */
+  armed: boolean;
+  /** Servo ids currently held at a boundary. */
+  holding: number[];
+  /** Summed |Present Current| across all servos, mA. */
+  drawMa: number;
+  /** Per-servo goal current the guard is currently allowing, mA. */
+  allocatedMa: number;
+  /** Set when the guard cut torque to stay inside the budget. */
   error: string | null;
 }
 

--- a/webapp/js/types.d.ts
+++ b/webapp/js/types.d.ts
@@ -244,6 +244,8 @@ interface LeaderGuardState {
   divergedJoint: number;
   /** Signed ticks between the leader and the pose mars_arm accepted. */
   divergedTicks: number;
+  /** Millimetres of room left before the arm meets the body; -1 if unknown. */
+  clearanceMm: number;
   /** Set when the guard cut torque to stay inside the budget. */
   error: string | null;
 }

--- a/webapp/tests/dynamixel.test.js
+++ b/webapp/tests/dynamixel.test.js
@@ -24,13 +24,19 @@ async function test(name, fn) {
 }
 
 /**
- * Build a status packet the way a servo would (for parser tests).
- * @param {number} id @param {number} position
+ * Build a status packet the way a servo would: the present block the reader
+ * asks for, Present Current (int16) / Velocity (int32) / Position (int32)
+ * contiguous from address 126.
+ * @param {number} id @param {number} position @param {number} [current]
  */
-function statusPacket(id, position) {
-  const params = new Uint8Array(4);
-  new DataView(params.buffer).setInt32(0, position, true);
-  const body = [0xff, 0xff, 0xfd, 0x00, id, 0x08, 0x00, 0x55, 0x00, ...params];
+function statusPacket(id, position, current = 0) {
+  const params = new Uint8Array(10);
+  const view = new DataView(params.buffer);
+  view.setInt16(0, current, true);
+  view.setInt32(2, 0, true); // present velocity — read past, not used
+  view.setInt32(6, position, true);
+  const length = params.length + 4; // error byte + instruction + crc16
+  const body = [0xff, 0xff, 0xfd, 0x00, id, length & 0xff, (length >> 8) & 0xff, 0x55, 0x00, ...params];
   const crc = crc16(body);
   return new Uint8Array([...body, crc & 0xff, crc >> 8]);
 }
@@ -58,8 +64,8 @@ await test("parser survives torn chunks, garbage, and bad CRC", () => {
   /** @type {{id: number, pos: number}[]} */
   const seen = [];
   const parse = createStatusParser((p) => {
-    const view = new DataView(p.params.buffer, p.params.byteOffset, 4);
-    seen.push({ id: p.id, pos: view.getInt32(0, true) });
+    const view = new DataView(p.params.buffer, p.params.byteOffset, 10);
+    seen.push({ id: p.id, pos: view.getInt32(6, true) });
   });
 
   const a = statusPacket(1, 2048);
@@ -89,7 +95,7 @@ await test("DynamixelLeader completes rounds against a mock port", async () => {
         assert.equal(chunk[7], 0x82, "loop must send SyncRead");
         pulls += 1;
         for (const id of LEADER_SERVO_IDS) {
-          readCtl.enqueue(statusPacket(id, id * 1000 + pulls));
+          readCtl.enqueue(statusPacket(id, id * 1000 + pulls, id * 10));
         }
       },
     }),
@@ -116,6 +122,11 @@ await test("DynamixelLeader completes rounds against a mock port", async () => {
     last.map((p) => Math.floor(p / 1000)),
     [1, 2, 3, 4, 5, 6],
     "positions ordered by servo id",
+  );
+  assert.deepEqual(
+    withPositions[withPositions.length - 1].currents,
+    LEADER_SERVO_IDS.map((id) => id * 10),
+    "present current read alongside position, ordered by servo id",
   );
   assert.ok(withPositions[withPositions.length - 1].rate > 0, "rate tracked");
   const final = states[states.length - 1];


### PR DESCRIPTION
## Why

The leader arm turns freely; the follower does not. Two ways that hurt, neither visible nor felt at the leader, so the operator's hand and the robot's arm diverged with nothing to say so.

`mars_arm`'s `joint_1` stops at ±90° where the arm meets the body. The webapp streamed raw leader ticks to `/leader_positions`, so driving past that silently commanded a pose the robot could not reach.

Worse, inside every joint's range, combinations still put the arm through the robot's own body, most visibly folding `joint_2` back over the turret and neck. The only guard was `joint_2`'s floor as a function of `joint_1`, which cannot express that constraint: reaching down over a table edge and folding back over the chassis look identical to any per-joint limit, so a floor tight enough to stop the second takes away the first. Measured, the two are nowhere near each other. Positive `joint_2` puts the tool 163 mm below the shoulder and 176 mm in front; negative puts it behind the shoulder at +387 mm, through the turret.

## What

Two layers with different jobs. The leader guard (`webapp/js/`) makes a limit felt at 60 Hz. The robot keepout (`mars_arm`) refuses the pose and remains the authority.

- **Geometry, not per-joint bands.** `armPlanarPoints` places the arm in `base_link` and tests its links against boxes covering chassis, rear tray, turret and neck, transcribed from `mars_sim/urdf/mars.urdf`. The arm mount is deliberately absent, since the arm is bolted to it and would always read as touching.
- **Whole links, not sampled joints.** The joints sit at 0.21, 0.26 and 0.30 m from the shoulder, so testing only those left the first 0.21 m of arm uncovered and let 82% of real collisions through. Links are now segments tested by the slab method.
- **Paths, not poses.** A pose check asks whether the arm ends up inside the body, never whether getting there went through it. Both the sweep between control ticks and the retreat toward a clear pose are sampled every 0.04 rad of the widest-moving joint.
- **Forward scan, not bisection.** Binary search assumes a clear midpoint means everything before it is clear. The infeasible set is not convex: rounding a corner, `t=0.5` can be clear while `t=0.3` collides, and the search never probes `t=0.3`.
- **Per-box padding.** One global margin cannot work. The shoulder sits 51 mm from the chassis permanently, so any global pad near that blocks the arm at rest and reports every joint constrained. Chassis and rear tray keep 15 mm; turret and neck, which is what `joint_2` folds into, get 55 mm.
- **Ease off before the stop.** Inside `slow_margin` only a fraction of each requested move is accepted, shrinking to nothing at the hard margin, so the arm decelerates into the surface rather than arriving at it.
- **Direction flips and the `joint_1`/`joint_2` coupling** are mirrored in the webapp, so the shaded zones and the offline fallback show the boundary the follower actually enforces. `joint_1` is symmetric, which is why it read correctly while this was missing and every other joint would not have.
- **Power.** Total draw across the leader's six servos is capped at 750 mA by default with a 900 mA ceiling, set per device, since the arm is bus-powered by whatever machine it is plugged into. Goal current is written before torque-on, never after: a servo torqued at its 1750 mA default even for one round is the spike the budget exists to stop. A watchdog on Present Current backs the allocation off and cuts torque at the ceiling, latching until the joint returns.

### Also here: an armsdk 3D-view toggle

Two commits are unrelated to the arm limits and want reviewing on their own terms. Both are @theo-michel's:

- `e09a0747` **feat(armsdk): toggle the 3D view between actual and requested joints.** Preview slider targets on the URDF without waiting for the arm to catch up.
- `45054070` **fix(armsdk): drop torque when entering requested-joint preview.** Requested mode is a pose sketch, not a drive path, so entering it calls `torque_off` and stops the in-flight slider stream.

Leaving requested mode does not re-enable torque. That looks deliberate rather than missing, since silently re-stiffening an arm on a view toggle would be worse, and the page already carries a live torque pill off `/mars/arm/status` plus a Torque on button, so the state is visible and recoverable. Flagging it for the reviewer to confirm.

## Verified

Sweeps over the joint ranges, and the two geometry copies against each other:

| check | result |
|---|---|
| webapp geometry vs `mars_arm`'s | 139,230 poses, 0 disagreements, clearance to 5.55e-17 m |
| tool-inside-body poses refused | 52,590 / 52,590 |
| collisions missed by point sampling, then segments | 82%, then 0.00% |
| bisection settling past a collision | 208 / 37,876 (0.55%), then 0.03% with the forward scan |
| reaching down in front still allowed | 1,083,348 / 1,083,348 |
| `joint2Floor` vs the C++ it mirrors | agrees to 1e-9 across the whole `joint_1` range |
| current budget with all joints held | total stays at or under 750 mA |

Padding does not cost reach. The arm at rest, reaching down in front, and extended forward at every `joint_1` bearing all remain free, while the `joint_2` fold-back now holds at q2 = -0.400 instead of -0.545.

`tsc --noEmit` introduces no new errors; the `showResult` error in `js/armsdk/main.js` is pre-existing on `main`. `node tests/dynamixel.test.js` passes, updated for the widened present-block read that this change legitimately invalidated. `pre-commit run --all-files -c .config/pre-commit-config.yaml` passes, with clang-format 18.1.3 applied in its own whitespace-only commit.

Not yet verified: the 200 Hz cost of the clearance sampling has not been measured on the Jetson. The typical case is cheaper than the bisection it replaces, since the endpoints are one control tick apart and resolve to a single step, but the 32-step ceiling is untested under load and `timing_stats_` would show it. Links are also zero-thickness segments with the margin standing in for radius, and clearance is sampled rather than solved; `libfcl-dev` is already declared in `mars_arm/package.xml` and unused if an exact check is ever wanted.

Known and not addressed here: `joint_2` overshoots a fast command. Its `gains_teleop` are `[300, 200, 100]` against `gains_near` `[1500, 0, 2000]`, so 20x less damping, plus the largest integral term of any joint and the lowest `profile_acceleration`. No geometry fixes that; it wants `kd` raised, which is tunable live through `pid_hot_reload.py`. Worth watching temperature, since `arm_control.cpp` records `joint_2` reaching 70 °C held on scheduled gains.
