### PR TITLE
feat(brain): a provider seam for the model backend, and an OpenAI one behind it

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,14 +9,21 @@
 # `./innate setup` / `./innate-sim setup` and seeded to /etc/innate.env on update —
 # it is never kept as a line in this template.
 #
-# The robot's brain (the local Gemini agent loop in brain_client) reaches
-# Gemini through the Innate proxy using INNATE_SERVICE_KEY — no Gemini key
-# needed. GEMINI_API_KEY is the standalone fallback (e.g. sim without a
-# service key), talking to Google directly.
+# The robot's brain (the local agent loop in brain_client) reaches its model
+# through the Innate proxy using INNATE_SERVICE_KEY — no vendor key needed,
+# whichever provider it thinks with. A vendor's own key is the standalone
+# fallback (e.g. sim without a service key), talking to that vendor directly;
+# set the one that matches BRAIN_BACKEND.
 # GEMINI_API_KEY=
+# OPENAI_API_KEY=
 
-# GEMINI_MODEL overrides the brain's model (default gemini-3.6-flash).
-# GEMINI_MODEL=
+# BRAIN_BACKEND picks the provider: gemini (default) or openai.
+# BRAIN_BACKEND=gemini
+
+# BRAIN_MODEL overrides the brain's model (default gemini-3.6-flash). It must
+# belong to BRAIN_BACKEND. GEMINI_MODEL is the name this had before the brain
+# could run on more than one provider, and still works.
+# BRAIN_MODEL=
 
 # --- Cloud endpoints (all read from the environment; set by default) ---
 # TELEMETRY_URL=https://logs.svc.innate.bot

--- a/config/settings.yaml.template
+++ b/config/settings.yaml.template
@@ -199,8 +199,9 @@
 #     auto_localize_timeout: 30.0   # seconds to keep trying auto-localization on startup
 
 # ── Brain runtime (local agent loop) ──────────────────────────────────
-# (Gemini credentials are connectivity and live in .env.) The TTS voice is global;
-# set it under /** above.
+# (Model credentials are connectivity and live in .env: INNATE_SERVICE_KEY for
+# the proxy, or GEMINI_API_KEY / OPENAI_API_KEY for the matching brain_backend.)
+# The TTS voice is global; set it under /** above.
 # brain_client_node:
 #   ros__parameters:
 #     vertical_fov: 80.0            # camera vertical field of view (degrees)
@@ -209,7 +210,10 @@
 #     scan_stale_after_sec: 10.0    # seconds without a lidar scan before flagging stale
 #     send_arm_camera_image: true   # also send the arm wrist camera image to the model
 #     log_everything: true          # log every turn's full input
-#     gemini_model: "gemini-3.6-flash"
+#     brain_backend: "gemini"        # which provider the brain thinks with: gemini | openai
+#     brain_model: "gemini-3.6-flash"  # must belong to brain_backend
+#     brain_thinking_level: "minimal"  # the provider's own vocabulary; "" = model default
+#     memory_model: "gemini-3.6-flash" # spatial memory search is Gemini-only
 #     timezone: ""                  # IANA zone for the clock the agent sees; "" = the robot OS's own
 #     idle_turn_interval: 3.0       # seconds between looks when no skill is running
 #     supervision_turn_interval: 5.0  # seconds between looks while a skill runs

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/agent.py
@@ -30,11 +30,11 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from brain_client.brain import grounding
-from brain_client.brain.context import Decision, GeminiContext, ToolCall
+from brain_client.brain.llm import key_hint, pick_conversation
+from brain_client.brain.llm.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
+from brain_client.brain.llm.types import Decision, ToolCall
 from brain_client.brain.loop import LoopThread
-from brain_client.brain.prompt import build_system_prompt, self_reference_turns
-from brain_client.brain.tools import GO_TO_POINT_IN_VIEW, STOP_SKILL, WAIT, assign_tool_names, build_tools
-from brain_client.brain.transport import pick_transport
+from brain_client.brain.prompt import build_system_prompt
 from brain_client.brain.utils import (
     Event,
     EventKind,
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
 
     from rclpy.node import Node
 
+    from brain_client.brain.llm.types import Conversation, ToolSpec
     from brain_client.core.config import BrainConfig
     from brain_client.core.state import BrainState, RunningSkill
     from brain_client.perception.battery import BatteryMonitor
@@ -119,25 +120,13 @@ class BrainAgent:
         if config.timezone.strip() and self._timezone is None:
             self._logger.warn(f"[Brain] Unknown timezone '{config.timezone}' — using the host's local zone")
 
-        transport, self.backend = pick_transport(proxy)
-        self._context = (
-            GeminiContext(
-                transport,
-                model=config.gemini_model,
-                thinking_level=config.gemini_thinking_level,
-                max_history=config.history_max_entries,
-                max_image_turns=config.history_max_image_turns,
-                reference=self_reference_turns(),
-            )
-            if transport is not None
-            else None
-        )
+        self._context, self.backend = pick_conversation(config, proxy, self._logger)
 
         self._events: list[Event] = []
         self._pose_at_capture: Pose | None = None
         self._frame_at_capture: bytes | None = None
         self._pitch_at_capture = 0.0
-        self._tool_map: dict[str, str] = {}  # gemini function name -> skill id
+        self._tool_map: dict[str, str] = {}  # model function name -> skill id
         self._error_streak = 0
         self._activated_at = 0.0
         self._turn_count = 0
@@ -168,7 +157,7 @@ class BrainAgent:
 
     @property
     def available(self) -> bool:
-        """Whether the brain can reach Gemini — true exactly when a context exists."""
+        """Whether the brain can reach its model — true exactly when a context exists."""
         return self._context is not None
 
     @property
@@ -186,8 +175,8 @@ class BrainAgent:
         """Spawn the agent loop; False when it refused (caller must not report active)."""
         if not self.available:
             self._chat.emit_system(
-                "⚠️ The brain has no way to reach Gemini — configure the Innate proxy "
-                "(INNATE_SERVICE_KEY) or set GEMINI_API_KEY in innate-os/.env and restart."
+                f"⚠️ The brain has no way to reach {self._config.brain_backend} — configure the Innate proxy "
+                f"(INNATE_SERVICE_KEY) or set {key_hint(self._config.brain_backend)} in innate-os/.env and restart."
             )
         if self._runtime.running:
             return True
@@ -277,8 +266,8 @@ class BrainAgent:
         turn.cancel()
         return True
 
-    async def _turn(self, context: GeminiContext) -> None:
-        """One turn: look at the world, think with Gemini, commit, act.
+    async def _turn(self, context: Conversation) -> None:
+        """One turn: look at the world, think, commit, act.
 
         ``events`` is a peek at the queue — consumed only when the turn
         commits, so a failed or abandoned turn re-sends the same events.
@@ -296,12 +285,11 @@ class BrainAgent:
         except Exception as error:
             await self._back_off(error, seen=len(events))
 
-    async def _think(self, context: GeminiContext, events: list[Event], speaker: SpeechStreamer) -> None:
+    async def _think(self, context: Conversation, events: list[Event], speaker: SpeechStreamer) -> None:
         text, frames = self._look(events)
         if self._frame_at_capture is None:
             return  # the feed died between the loop's freshness check and the look
-        wrist_frames = [i for i, (label, _) in enumerate(frames) if label == FrameLabel.WRIST]
-        message = GeminiContext.user_message(text, [jpeg for _, jpeg in frames])
+        message = context.open_turn(text, frames)
         tools = self._build_tools(events)
         directive = self._state.current_directive
         system = build_system_prompt(
@@ -313,7 +301,7 @@ class BrainAgent:
             self._logger.info(f"[Brain] Turn input:\n{text}")
         self._trace_turn_start(text, frames, tools, system, context)
 
-        response = await self._generate(context, message, tools, system, speaker, wrist_frames)
+        response = await self._generate(context, message, tools, system, speaker)
         latency = self._elapsed()
         self._report_recovered()
         if not self._state.is_brain_active:
@@ -321,7 +309,7 @@ class BrainAgent:
             self._trace(TraceEvent.TURN_DROPPED, turn=self._turn_count, latency=latency)
             return
 
-        decision = context.absorb(message, response, latest_only_images=wrist_frames)
+        decision = context.commit(message, response)
         del self._events[: len(events)]
         events.clear()  # committed: a failure below backs off against an empty peek
         outcomes = self._act(decision, speaker, context)
@@ -338,12 +326,11 @@ class BrainAgent:
 
     async def _generate(
         self,
-        context: GeminiContext,
+        context: Conversation,
         message: dict,
-        tools: list[dict],
+        tools: list[ToolSpec],
         system: str,
         speaker: SpeechStreamer,
-        wrist_frames: list[int],
     ) -> dict:
         """The only blocking call, on a worker thread. Cancellation unwinds HERE —
         the orphaned HTTP call finishes and its result is dropped."""
@@ -351,9 +338,7 @@ class BrainAgent:
         try:
             if self._on_thinking_changed is not None:
                 self._on_thinking_changed()
-            return await asyncio.to_thread(
-                context.generate, message, tools, system, speaker.feed, latest_only_images=wrist_frames
-            )
+            return await asyncio.to_thread(context.generate, message, tools, system, speaker.feed)
         finally:
             self._turn_in_flight = False
             if self._on_thinking_changed is not None:
@@ -468,7 +453,7 @@ class BrainAgent:
         meta = self._state.registry.primitives.get(running.skill_id) or {}
         return (meta.get("guidelines_when_running") or "").strip()
 
-    def _build_tools(self, events: list[Event]) -> list[dict]:
+    def _build_tools(self, events: list[Event]) -> list[ToolSpec]:
         running = self._state.primitive_running
         user_spoke = any(event.kind == EventKind.USER for event in events)
         active_ids = set(self._roster.active_skill_ids())
@@ -482,8 +467,8 @@ class BrainAgent:
         return build_tools(named, None, can_go_to_point_in_view=_NAV_TO_POSITION in active_ids)
 
     # ================= act =================
-    def _act(self, decision: Decision, speaker: SpeechStreamer, context: GeminiContext) -> list[tuple[ToolCall, str]]:
-        # Execute and answer the calls before any chat I/O: a functionCall
+    def _act(self, decision: Decision, speaker: SpeechStreamer, context: Conversation) -> list[tuple[ToolCall, str]]:
+        # Execute and answer the calls before any chat I/O: a function call
         # left unanswered in history poisons every later request.
         outcomes = [(call, self._execute(call)) for call in decision.calls]
         context.add_tool_outcomes(outcomes)
@@ -666,7 +651,7 @@ class BrainAgent:
         self._trace(TraceEvent.TURN_REQUEST, heavy=True, turn=self._turn_count, body=body)
 
     def _trace_turn_start(
-        self, text: str, frames: list[Frame], tools: list[dict], system: str, context: GeminiContext
+        self, text: str, frames: list[Frame], tools: list[ToolSpec], system: str, context: Conversation
     ) -> None:
         if self._trace_sink is None or not self.trace_has_audience():
             return  # skip the base64 work entirely, not just the publish
@@ -676,7 +661,7 @@ class BrainAgent:
             turn=self._turn_count,
             input=text,
             images=len(frames),
-            tools=[d["name"] for d in tools[0]["functionDeclarations"]],
+            tools=[spec.name for spec in tools],
             history=context.history_len,
             history_images=context.image_turn_count,
             system=system,
@@ -698,7 +683,7 @@ class BrainAgent:
             TraceEvent.SNAPSHOT,
             active=self._state.is_brain_active,
             backend=self.backend,
-            model=self._config.gemini_model,
+            model=self._config.brain_model,
             turn=self._turn_count,
             in_flight=self._turn_in_flight,
             thinking_for=self._elapsed() if self._turn_in_flight else 0,

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/frame_files.py
@@ -25,14 +25,18 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from brain_client.brain.transport import FILES_UPLOAD_PATH, UNSUPPORTED_ENDPOINT_STATUSES, GeminiHttpError
+from brain_client.brain.llm.gemini.transport import (
+    FILES_UPLOAD_PATH,
+    UNSUPPORTED_ENDPOINT_STATUSES,
+    GeminiHttpError,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from rclpy.impl.rcutils_logger import RcutilsLogger
 
-    from brain_client.brain.transport import GeminiRest
+    from brain_client.brain.llm.gemini.transport import GeminiRest
     from brain_client.memory.store import Memory, MemoryStore
 
 _USABLE_FOR_SEC = 47 * 3600  # Gemini deletes uploads at 48 h; stop referencing an hour early

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/__init__.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/__init__.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Picking the model backend the brain thinks with.
+
+Adding a provider means adding a package beside these two and one line in
+:func:`pick_conversation`; nothing above this module knows which one is in use.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from brain_client.brain.llm import gemini, openai
+from brain_client.brain.llm.types import Backend, Provider
+
+if TYPE_CHECKING:
+    from rclpy.impl.rcutils_logger import RcutilsLogger
+
+    from brain_client.brain.llm.types import Conversation
+    from brain_client.core.config import BrainConfig
+    from innate_proxy import ProxyClient
+
+_BUILDERS = {Provider.GEMINI: gemini.build, Provider.OPENAI: openai.build}
+
+
+def pick_conversation(
+    config: BrainConfig, proxy: ProxyClient | None, logger: RcutilsLogger
+) -> tuple[Conversation | None, Backend]:
+    """The conversation the agent will think with, and how it reaches its provider.
+
+    None means no usable credential: the Innate service key covers every
+    provider, and each also accepts its own vendor key for development.
+    """
+    return _BUILDERS[provider(config.brain_backend, logger)](config, proxy, logger)
+
+
+def provider(name: str, logger: RcutilsLogger) -> Provider:
+    """The configured provider, falling back to Gemini for an unknown name."""
+    try:
+        return Provider(name.strip().lower())
+    except ValueError:
+        logger.warn(f"[Brain] Unknown brain_backend {name!r} — using {Provider.GEMINI} (one of {list(Provider)})")
+        return Provider.GEMINI
+
+
+def key_hint(name: str) -> str:
+    """Which vendor key would configure this provider without a service key."""
+    return "OPENAI_API_KEY" if name.strip().lower() == Provider.OPENAI else "GEMINI_API_KEY"

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/gemini/__init__.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/gemini/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The Gemini backend: native REST, thought summaries, implicit prefix caching."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from brain_client.brain.llm.gemini import wire
+from brain_client.brain.llm.gemini.context import GeminiConversation
+from brain_client.brain.llm.gemini.transport import pick_transport
+from brain_client.brain.llm.types import Backend
+
+if TYPE_CHECKING:
+    from rclpy.impl.rcutils_logger import RcutilsLogger
+
+    from brain_client.brain.llm.types import Conversation
+    from brain_client.core.config import BrainConfig
+    from innate_proxy import ProxyClient
+
+THINKING_LEVELS = ("minimal", "low", "medium", "high")
+
+
+def build(config: BrainConfig, proxy: ProxyClient | None, logger: RcutilsLogger) -> tuple[Conversation | None, Backend]:
+    transport, backend = pick_transport(proxy)
+    if transport is None:
+        return None, backend
+    conversation = GeminiConversation(
+        transport,
+        model=config.brain_model,
+        thinking_level=_thinking_level(config.brain_thinking_level, logger),
+        max_history=config.history_max_entries,
+        max_image_turns=config.history_max_image_turns,
+        reference=wire.reference_turns(),
+    )
+    return conversation, backend
+
+
+def _thinking_level(level: str, logger: RcutilsLogger) -> str:
+    """An unknown level would 400 every request; fall back to the model default."""
+    if not level or level in THINKING_LEVELS:
+        return level
+    logger.warn(f"[Brain] Unknown gemini thinking level {level!r} — using the model default (one of {THINKING_LEVELS})")
+    return ""

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/gemini/context.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/gemini/context.py
@@ -5,49 +5,32 @@
 The native API — unlike the OpenAI-compatible layer — returns *thought
 summaries* (parts flagged ``thought: true``), which the agent surfaces in the
 app chat as robot thoughts. A response is distilled into a plain
-:class:`Decision` the agent loop acts on, and the bounded content history is
-compacted in chunks — old camera frames masked, oldest turns evicted — so
-requests stay small while consecutive requests keep the shared byte prefix
-Gemini's implicit prompt cache needs (see :meth:`GeminiContext._prune`).
+:class:`~brain_client.brain.llm.types.Decision` the agent loop acts on, and the
+bounded content history is compacted in chunks — old camera frames masked,
+oldest turns evicted — so requests stay small while consecutive requests keep
+the shared byte prefix Gemini's implicit prompt cache needs (see
+:meth:`GeminiConversation._prune`).
 
-Threading contract: :meth:`GeminiContext.generate` is the only blocking network
-call and only *reads* the history, so the agent awaits it on a worker thread
-(``asyncio.to_thread``). All history mutation (:meth:`absorb`,
-:meth:`add_tool_outcomes`) happens in the agent's coroutine, strictly between
-generate calls, and :meth:`clear` only runs while the loop task is stopped —
-there is no concurrent access to a context by construction, not by lock.
+Threading contract: see :class:`~brain_client.brain.llm.types.Conversation`.
 """
 
 from __future__ import annotations
 
-import base64
-import re
-from collections.abc import Callable
-from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
-from brain_client.brain.transport import Transport
+from brain_client.brain.llm.gemini import wire
+from brain_client.brain.llm.types import Decision, ToolCall, Usage, clean_speech
+from brain_client.brain.utils import FrameLabel
 
-_FRAME_REMOVED = {"text": "[older camera frame removed]"}
-_WRIST_FRAME_REMOVED = {"text": "[older wrist camera frame removed]"}
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
-
-@dataclass
-class ToolCall:
-    name: str
-    args: dict
-    id: str = ""
+    from brain_client.brain.llm.gemini.transport import Transport
+    from brain_client.brain.llm.types import ToolSpec
+    from brain_client.brain.utils import Frame
 
 
-@dataclass
-class Decision:
-    """What the model wants the robot to do this turn."""
-
-    speech: str | None = None
-    thoughts: str | None = None
-    calls: list[ToolCall] = field(default_factory=list)
-
-
-class GeminiContext:
+class GeminiConversation:
     """Bounded model context for Gemini: one generate() per agent turn."""
 
     def __init__(
@@ -72,71 +55,54 @@ class GeminiContext:
         # The one history turn still carrying latest-only frames (wrist camera),
         # as (content, part indexes) — absorbing a newer set prunes these.
         self._latest_only_turn: tuple[dict, list[int]] | None = None
-        # Observability tap: called with the exact request body just before it
-        # goes on the wire (from generate's thread). The body must be treated
-        # as read-only — it shares structure with the live history.
+        # Image positions in the turn open_turn built last, read by generate and
+        # commit. Only the loop thread writes it, and generate reads it while
+        # serializing its body — the same window in which an abandoned turn's
+        # orphaned request is already immune to later history mutation.
+        self._pending_wrist: list[int] = []
+        self._last_usage: Usage = {}
         self.on_request: Callable[[dict], None] | None = None
-        # usageMetadata of the newest response — prompt/cached/output token
-        # counts, surfaced on the trace snapshot (cache-hit observability).
-        self.last_usage: dict[str, int] = {}
 
     def clear(self) -> None:
         self._history = []
         self._latest_only_turn = None
-        self.last_usage = {}
+        self._pending_wrist = []
+        self._last_usage = {}
 
     @property
     def history_len(self) -> int:
         return len(self._history)
 
     @property
-    def image_turn_count(self) -> int:
-        """History turns still carrying camera frames (pruning keeps the newest few)."""
-        return sum(
-            1 for c in self._history if c.get("role") == "user" and any("inlineData" in p for p in c.get("parts") or [])
-        )
+    def last_usage(self) -> Usage:
+        return self._last_usage
 
-    @staticmethod
-    def user_message(text: str, images: list[bytes]) -> dict:
-        parts: list[dict] = [{"text": text}]
-        for jpeg in images:
-            parts.append({"inlineData": {"mimeType": "image/jpeg", "data": base64.b64encode(jpeg).decode()}})
-        return {"role": "user", "parts": parts}
+    @property
+    def image_turn_count(self) -> int:
+        return sum(1 for c in self._history if c.get("role") == "user" and any(wire.is_image(p) for p in _parts(c)))
+
+    def open_turn(self, text: str, frames: list[Frame]) -> dict:
+        self._pending_wrist = [i for i, (label, _) in enumerate(frames) if label == FrameLabel.WRIST]
+        return wire.user_content(text, [jpeg for _, jpeg in frames])
 
     def generate(
         self,
-        user_message: dict,
-        tools: list[dict],
+        turn: dict,
+        tools: list[ToolSpec],
         system: str,
         on_speech: Callable[[str], None] | None = None,
-        *,
-        latest_only_images: list[int] | None = None,
     ) -> dict:
         """Blocking network call — safe on a worker thread (history is only read).
 
-        The reply streams in; every plain-text delta is handed to ``on_speech``
-        as it arrives, which is what lets the robot start talking at the first
-        sentence boundary. Returns the fully assembled response.
-
-        ``latest_only_images`` mirrors :meth:`absorb`'s: when this message
-        carries wrist frames, the previous turn's copies are masked out of the
-        request here — absorb's durable prune runs only after the response, so
-        without this every request would ship two wrist frames. The masking
-        HERE never mutates history — shallow copies only. Durable mutation
-        (absorb, _prune) runs on the loop thread strictly between generate
-        calls, by which point an abandoned turn's orphaned request has already
-        serialized its body.
+        When this turn carries wrist frames, the previous turn's copies are
+        masked out of the request here — commit's durable prune runs only after
+        the response, so without this every request would ship two wrist frames.
+        The masking HERE never mutates history: shallow copies only.
         """
-        contents = [*self._reference, *self._history, user_message]
-        if latest_only_images and self._latest_only_turn is not None:
+        contents = [*self._reference, *self._history, turn]
+        if self._pending_wrist and self._latest_only_turn is not None:
             stale, indexes = self._latest_only_turn
-            masked = {
-                **stale,
-                "parts": [
-                    dict(_WRIST_FRAME_REMOVED) if i in indexes and "inlineData" in p else p
-                    for i, p in enumerate(stale["parts"])
-                ],
-            }
+            masked = {**stale, "parts": _masked_parts(_parts(stale), indexes, wire.WRIST_FRAME_REMOVED)}
             contents = [masked if content is stale else content for content in contents]
         thinking: dict = {"includeThoughts": True}
         if self._thinking_level:
@@ -146,8 +112,9 @@ class GeminiContext:
             "contents": contents,
             "generationConfig": {"thinkingConfig": thinking},
         }
-        if tools:
-            body["tools"] = tools
+        tools_block = wire.tools_block(tools)
+        if tools_block:
+            body["tools"] = tools_block
         if self.on_request is not None:
             self.on_request(body)
         parts: list[dict] = []
@@ -168,47 +135,38 @@ class GeminiContext:
             # a silent, answerless exchange — raise instead, so the turn's
             # retry path keeps the events queued and the failure is visible.
             raise RuntimeError(f"gemini returned no content: {_empty_stream_reason(last_chunk)}")
-        # Usage rides the response and is committed by absorb, on the loop
-        # thread: writing self.last_usage here would let an abandoned turn's
+        # Usage rides the response and is committed by commit(), on the loop
+        # thread: writing self._last_usage here would let an abandoned turn's
         # orphaned request overwrite the committed turn's counts.
         return {
             "candidates": [{"content": {"role": "model", "parts": _merged(parts)}}],
             "usageMetadata": usage,
         }
 
-    def absorb(self, user_message: dict, response: dict, *, latest_only_images: list[int] | None = None) -> Decision:
-        """Commit the exchange to history and distill the model's Decision.
+    def commit(self, turn: dict, response: dict) -> Decision:
+        """Commit the exchange to history and distil the model's Decision.
 
         Thought-summary parts are dropped from the stored model turn (they are
         display-only); everything else — including any thoughtSignature the
         model attached to its parts — is kept verbatim for the next request.
 
-        ``latest_only_images`` names positions in this message's image list
-        (order given to :meth:`user_message`) that must only ever appear in the
-        newest turn — the wrist camera: a stale gripper close-up reads as
-        current grasp state and misleads the model, so absorbing a new one
-        prunes the previous turn's copy on the spot.
+        A stale wrist frame reads as current grasp state and misleads the model,
+        so committing a new one prunes the previous turn's copy on the spot.
         """
         decision = _decision_from(response)
         usage = response.get("usageMetadata") or {}
-        self.last_usage = {
+        self._last_usage = {
             "prompt": usage.get("promptTokenCount", 0),
             "cached": usage.get("cachedContentTokenCount", 0),
             "output": usage.get("candidatesTokenCount", 0),
         }
-        self._history.append(user_message)
-        if latest_only_images:
+        self._history.append(turn)
+        if self._pending_wrist:
             if self._latest_only_turn is not None:
                 content, indexes = self._latest_only_turn
-                content["parts"] = [
-                    dict(_WRIST_FRAME_REMOVED) if i in indexes and "inlineData" in p else p
-                    for i, p in enumerate(content["parts"])
-                ]
-            image_parts = [i for i, p in enumerate(user_message["parts"]) if "inlineData" in p]
-            self._latest_only_turn = (
-                user_message,
-                [image_parts[i] for i in latest_only_images if i < len(image_parts)],
-            )
+                content["parts"] = _masked_parts(_parts(content), indexes, wire.WRIST_FRAME_REMOVED)
+            image_parts = [i for i, p in enumerate(_parts(turn)) if wire.is_image(p)]
+            self._latest_only_turn = (turn, [image_parts[i] for i in self._pending_wrist if i < len(image_parts)])
         model_content = _model_content(response)
         if model_content is not None:
             kept = [p for p in model_content.get("parts") or [] if not p.get("thought")]
@@ -245,10 +203,10 @@ class GeminiContext:
             # The history must start with a plain user turn: a leading model turn or
             # an orphaned function response (whose call was just evicted) is rejected.
             while history and (
-                history[0].get("role") != "user" or any("functionResponse" in p for p in history[0].get("parts") or [])
+                history[0].get("role") != "user" or any("functionResponse" in p for p in _parts(history[0]))
             ):
                 history.pop(0)
-            # An evicted turn must not stay pinned as the latest-only holder: absorb
+            # An evicted turn must not stay pinned as the latest-only holder: commit
             # would "prune" an orphan dict nothing reads, and the reference would
             # keep its base64 wrist frame alive for as long as the arm feed is stale.
             if self._latest_only_turn is not None and not any(c is self._latest_only_turn[0] for c in history):
@@ -258,11 +216,17 @@ class GeminiContext:
         # Mask down to the newest few frame turns (none at all if the keep-count
         # is zero or nonsensical). Until a compaction, older frames ride the
         # cached prefix at a tenth of the input price — cheap to carry.
-        image_turns = [
-            c for c in history if c.get("role") == "user" and any("inlineData" in p for p in c.get("parts") or [])
-        ]
+        image_turns = [c for c in history if c.get("role") == "user" and any(wire.is_image(p) for p in _parts(c))]
         for content in image_turns[:-keep] if keep else image_turns:
-            content["parts"] = [dict(_FRAME_REMOVED) if "inlineData" in p else p for p in content["parts"]]
+            content["parts"] = [dict(wire.FRAME_REMOVED) if wire.is_image(p) else p for p in _parts(content)]
+
+
+def _parts(content: dict) -> list[dict]:
+    return content.get("parts") or []
+
+
+def _masked_parts(parts: list[dict], indexes: list[int], placeholder: dict) -> list[dict]:
+    return [dict(placeholder) if i in indexes and wire.is_image(p) else p for i, p in enumerate(parts)]
 
 
 def _merged(parts: list[dict]) -> list[dict]:
@@ -311,30 +275,5 @@ def _decision_from(response: dict) -> Decision:
                 decision.thoughts = f"{decision.thoughts or ''}{part['text']}".strip()
             else:
                 decision.speech = f"{decision.speech or ''}{part['text']}".strip()
-    decision.speech = _clean_speech(decision.speech)
+    decision.speech = clean_speech(decision.speech)
     return decision
-
-
-_TOOL_NARRATION = re.compile(r"Calling tool\b")
-
-
-def split_tool_narration(text: str) -> tuple[str, bool]:
-    """Cut leaked tool-call narration ("Calling tool ..." to end of text).
-
-    gemini-3 preview sometimes appends it to its reply, without a sentence
-    boundary. Returns ``(clean text, whether narration was found)`` — the one
-    scrub both the chat transcript (:func:`_clean_speech`) and the audio path
-    (``SpeechStreamer._say``) apply, so the two can never diverge.
-    """
-    match = _TOOL_NARRATION.search(text)
-    if match is None:
-        return text, False
-    return text[: match.start()].rstrip(), True
-
-
-def _clean_speech(speech: str | None) -> str | None:
-    """Drop unspeakable output: placeholders and leaked tool-call narration."""
-    if not speech:
-        return None
-    speech, _ = split_tool_narration(speech)
-    return speech if re.search(r"[a-zA-Z0-9]", speech) else None

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/gemini/transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/gemini/transport.py
@@ -7,6 +7,11 @@ stream and the memory search's blocking generate / context-cache management —
 through untouched (the robot authenticates with its service key); the direct
 path talks to ``generativelanguage.googleapis.com``. Both speak the same wire
 format — a transport only moves payloads and never interprets them.
+
+The blocking half (:class:`GeminiRest`) has no OpenAI counterpart and is not
+meant to grow one: spatial memory search and the frame-file tier are built on
+Gemini's context caching and Files API, so they stay on Gemini whichever
+provider the agent itself thinks with.
 """
 
 from __future__ import annotations
@@ -19,7 +24,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import httpx
 
-from brain_client.common.enums import StrEnum
+from brain_client.brain.llm.types import Backend
 
 if TYPE_CHECKING:
     from innate_proxy import ProxyClient
@@ -65,14 +70,6 @@ class GeminiRest:
     upload: Callable[[str, bytes, str], dict]  # (api path, raw bytes, mime type) -> parsed response
 
 
-class Backend(StrEnum):
-    """Which way the brain reaches Gemini (surfaced in health and telemetry)."""
-
-    PROXY = "innate-proxy"
-    DIRECT = "gemini-direct"
-    UNCONFIGURED = "unconfigured"
-
-
 def pick_transport(proxy: ProxyClient | None) -> tuple[Transport | None, Backend]:
     """The way to reach Gemini: the Innate proxy (managed) or GEMINI_API_KEY (dev).
 
@@ -84,7 +81,7 @@ def pick_transport(proxy: ProxyClient | None) -> tuple[Transport | None, Backend
         return proxy_transport(proxy), Backend.PROXY
     api_key = os.environ.get("GEMINI_API_KEY", "").strip()
     if api_key:
-        return direct_transport(api_key), Backend.DIRECT
+        return direct_transport(api_key), Backend.GEMINI_DIRECT
     return None, Backend.UNCONFIGURED
 
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/gemini/wire.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/gemini/wire.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Neutral types -> the native Gemini REST shapes."""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING
+
+from brain_client.brain.prompt import PORTRAIT_CAPTION, self_portrait
+
+if TYPE_CHECKING:
+    from brain_client.brain.llm.types import ToolSpec
+
+FRAME_REMOVED = {"text": "[older camera frame removed]"}
+WRIST_FRAME_REMOVED = {"text": "[older wrist camera frame removed]"}
+
+# Gemini's schema dialect is JSON Schema with the type names uppercased.
+_TYPES = {"object": "OBJECT", "string": "STRING", "integer": "INTEGER", "number": "NUMBER", "boolean": "BOOLEAN"}
+
+
+def tools_block(specs: list[ToolSpec]) -> list[dict]:
+    """The whole ``tools`` field: one functionDeclarations block."""
+    if not specs:
+        return []
+    return [{"functionDeclarations": [_declaration(spec) for spec in specs]}]
+
+
+def image_part(jpeg: bytes) -> dict:
+    return {"inlineData": {"mimeType": "image/jpeg", "data": base64.b64encode(jpeg).decode()}}
+
+
+def is_image(part: dict) -> bool:
+    return "inlineData" in part
+
+
+def user_content(text: str, images: list[bytes]) -> dict:
+    return {"role": "user", "parts": [{"text": text}, *(image_part(jpeg) for jpeg in images)]}
+
+
+def reference_turns() -> list[dict]:
+    """A pinned exchange showing the model its own body. Gemini's
+    systemInstruction is text-only, so the portrait rides at the front of every
+    request's contents instead."""
+    jpeg = self_portrait()
+    if jpeg is None:
+        return []
+    return [
+        {"role": "user", "parts": [{"text": PORTRAIT_CAPTION}, image_part(jpeg)]},
+        {"role": "model", "parts": [{"text": "Understood — that is what my model of robot looks like."}]},
+    ]
+
+
+def _declaration(spec: ToolSpec) -> dict:
+    declaration: dict = {"name": spec.name, "description": spec.description}
+    if spec.parameters is not None:
+        declaration["parameters"] = _schema(spec.parameters)
+    return declaration
+
+
+def _schema(schema: dict) -> dict:
+    converted = {key: value for key, value in schema.items() if key != "properties"}
+    if "type" in converted:
+        converted["type"] = _TYPES.get(str(converted["type"]), converted["type"])
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        converted["properties"] = {name: _schema(sub) for name, sub in properties.items()}
+    return converted

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/__init__.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/__init__.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The OpenAI backend: the Responses API, reasoning summaries, prefix caching."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from brain_client.brain.llm.openai import wire
+from brain_client.brain.llm.openai.context import OpenAIConversation
+from brain_client.brain.llm.openai.transport import pick_transport
+from brain_client.brain.llm.types import Backend
+
+if TYPE_CHECKING:
+    from rclpy.impl.rcutils_logger import RcutilsLogger
+
+    from brain_client.brain.llm.types import Conversation
+    from brain_client.core.config import BrainConfig
+    from innate_proxy import ProxyClient
+
+REASONING_EFFORTS = ("none", "low", "medium", "high", "xhigh", "max")
+
+
+def build(config: BrainConfig, proxy: ProxyClient | None, logger: RcutilsLogger) -> tuple[Conversation | None, Backend]:
+    transport = pick_transport(proxy)
+    if transport is None:
+        return None, Backend.UNCONFIGURED
+    backend = Backend.PROXY if proxy is not None and proxy.is_available() else Backend.OPENAI_DIRECT
+    conversation = OpenAIConversation(
+        transport,
+        model=config.brain_model,
+        effort=_effort(config.brain_thinking_level, logger),
+        max_history=config.history_max_entries,
+        max_image_turns=config.history_max_image_turns,
+        # New per conversation: the hint only has to be stable across the turns
+        # that share a prefix, and a restart starts from a cold cache anyway.
+        cache_key=f"innate-brain-{uuid.uuid4().hex[:16]}",
+        reference=wire.reference_turns(),
+    )
+    return conversation, backend
+
+
+def _effort(level: str, logger: RcutilsLogger) -> str:
+    """The thinking-level setting is written in the provider's own vocabulary,
+    so a value carried over from Gemini ("minimal") is not one of these and
+    would 400 every request. Fall back to the model default."""
+    if not level or level in REASONING_EFFORTS:
+        return level
+    logger.warn(
+        f"[Brain] Unknown openai reasoning effort {level!r} — using the model default (one of {REASONING_EFFORTS})"
+    )
+    return ""

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/context.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/context.py
@@ -181,8 +181,12 @@ class OpenAIConversation:
                 response = event.get("response")
                 if not isinstance(response, dict):
                     raise RuntimeError(f"openai sent {kind} without a response body")
-                if kind == "response.failed":
-                    raise RuntimeError(f"openai response failed: {_empty_reason(response)}")
+                if kind != "response.completed":
+                    # A truncated or filtered generation is a failed turn, not a
+                    # short one: committing it would consume the queued events
+                    # and could dispatch a call whose arguments were cut
+                    # mid-JSON (and so parse as no arguments at all).
+                    raise RuntimeError(f"openai response did not complete: {_empty_reason(response)}")
                 return response
         raise RuntimeError("openai stream ended without a terminal event")
 

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/context.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/context.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The brain's bounded OpenAI conversation, over the Responses API.
+
+Responses rather than Chat Completions because Chat Completions is stateless
+and drops reasoning items, which OpenAI documents as costing both tool-call
+quality and extra reasoning tokens in loops like this one.
+
+OpenAI's headline advice for agent loops — ``store: true`` plus
+``previous_response_id`` — is deliberately NOT followed. Server-held state
+cannot be rewritten, and this conversation's whole job is rewriting its own
+history: masking old camera frames, evicting old turns. So the input list is
+managed here, which is the branch OpenAI supports for exactly this case, and
+``store: false`` keeps the robot's frames off their servers (reasoning items
+come back carrying ``encrypted_content``, which is what makes replay work).
+
+Threading contract: see :class:`~brain_client.brain.llm.types.Conversation`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from brain_client.brain.llm.openai import wire
+from brain_client.brain.llm.types import Decision, ToolCall, Usage, clean_speech
+from brain_client.brain.utils import FrameLabel
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from brain_client.brain.llm.openai.transport import Transport
+    from brain_client.brain.llm.types import ToolSpec
+    from brain_client.brain.utils import Frame
+
+_TERMINAL = {"response.completed", "response.failed", "response.incomplete"}
+
+
+class OpenAIConversation:
+    """Bounded model context for OpenAI: one generate() per agent turn."""
+
+    def __init__(
+        self,
+        transport: Transport,
+        *,
+        model: str,
+        effort: str,
+        max_history: int,
+        max_image_turns: int,
+        cache_key: str,
+        reference: list[dict] | None = None,
+    ):
+        self._transport = transport
+        self._model = model
+        self._effort = effort
+        self._max_history = max_history
+        self._max_image_turns = max_image_turns
+        # Routing hint: requests sharing it land on the same backend, which is
+        # what makes a prefix this large actually hit the cache.
+        self._cache_key = cache_key
+        # Pinned items (the robot's self-portrait) prepended to every request
+        # but never stored in history — immune to pruning and clear().
+        self._reference = reference or []
+        self._history: list[dict] = []
+        # The one history turn still carrying latest-only frames (wrist camera),
+        # as (item, content indexes) — committing a newer set prunes these.
+        self._latest_only_turn: tuple[dict, list[int]] | None = None
+        self._pending_wrist: list[int] = []
+        self._last_usage: Usage = {}
+        self.on_request: Callable[[dict], None] | None = None
+
+    def clear(self) -> None:
+        self._history = []
+        self._latest_only_turn = None
+        self._pending_wrist = []
+        self._last_usage = {}
+
+    @property
+    def history_len(self) -> int:
+        return len(self._history)
+
+    @property
+    def last_usage(self) -> Usage:
+        return self._last_usage
+
+    @property
+    def image_turn_count(self) -> int:
+        return sum(1 for item in self._history if any(wire.is_image(p) for p in _content(item)))
+
+    def open_turn(self, text: str, frames: list[Frame]) -> dict:
+        self._pending_wrist = [i for i, (label, _) in enumerate(frames) if label == FrameLabel.WRIST]
+        return wire.user_content(text, [jpeg for _, jpeg in frames])
+
+    def generate(
+        self,
+        turn: dict,
+        tools: list[ToolSpec],
+        system: str,
+        on_speech: Callable[[str], None] | None = None,
+    ) -> dict:
+        """Blocking network call — safe on a worker thread (history is only read).
+
+        When this turn carries wrist frames, the previous turn's copies are
+        masked out of the request here; the masking never mutates history.
+        """
+        items = [*self._reference, *self._history, turn]
+        if self._pending_wrist and self._latest_only_turn is not None:
+            stale, indexes = self._latest_only_turn
+            masked = {**stale, "content": _masked_content(_content(stale), indexes, wire.WRIST_FRAME_REMOVED)}
+            items = [masked if item is stale else item for item in items]
+        body: dict = {
+            "model": self._model,
+            "instructions": system,
+            "input": items,
+            "stream": True,
+            "store": False,
+            "prompt_cache_key": self._cache_key,
+        }
+        if tools:
+            body["tools"] = wire.function_tools(tools)
+        if self._effort:
+            # Summaries are opt-in and are what the app chat shows as thoughts.
+            body["reasoning"] = {"effort": self._effort, "summary": "auto"}
+        if self.on_request is not None:
+            self.on_request(body)
+        response = self._stream(body, on_speech)
+        if not (response.get("output") or []):
+            raise RuntimeError(f"openai returned no content: {_empty_reason(response)}")
+        # Usage rides the response and is committed by commit(), on the loop
+        # thread: writing self._last_usage here would let an abandoned turn's
+        # orphaned request overwrite the committed turn's counts.
+        return response
+
+    def commit(self, turn: dict, response: dict) -> Decision:
+        """Commit the exchange to history and distil the model's Decision.
+
+        Output items are stored verbatim — a reasoning item's encrypted content
+        and a function call's id both have to come back unchanged on the next
+        request. Stale reasoning items are NOT stripped per turn even though
+        only the newest ones earn their keep: rewriting the tail every turn
+        would forfeit the prompt-cache prefix on every request, which costs far
+        more than carrying them until the next compaction evicts them.
+        """
+        output = response.get("output") or []
+        decision = _decision_from(output)
+        usage = response.get("usage") or {}
+        self._last_usage = {
+            "prompt": usage.get("input_tokens", 0),
+            "cached": (usage.get("input_tokens_details") or {}).get("cached_tokens", 0),
+            "output": usage.get("output_tokens", 0),
+        }
+        self._history.append(turn)
+        if self._pending_wrist:
+            if self._latest_only_turn is not None:
+                item, indexes = self._latest_only_turn
+                item["content"] = _masked_content(_content(item), indexes, wire.WRIST_FRAME_REMOVED)
+            images = [i for i, part in enumerate(_content(turn)) if wire.is_image(part)]
+            self._latest_only_turn = (turn, [images[i] for i in self._pending_wrist if i < len(images)])
+        self._history.extend(output)
+        self._prune()
+        return decision
+
+    def add_tool_outcomes(self, outcomes: list[tuple[ToolCall, str]]) -> None:
+        """Answer the model's function calls (the API requires one response per call)."""
+        self._history.extend(wire.tool_outcome(call.id, outcome) for call, outcome in outcomes)
+
+    def _stream(self, body: dict, on_speech: Callable[[str], None] | None) -> dict:
+        """Consume the event stream, speaking text deltas as they land.
+
+        The terminal event carries the authoritative output items and usage, so
+        nothing is reassembled from deltas — they only drive the voice.
+        """
+        for event in self._transport(body):
+            kind = event.get("type")
+            if kind == "response.output_text.delta":
+                if on_speech and event.get("delta"):
+                    on_speech(str(event["delta"]))
+            elif kind == "error":
+                raise RuntimeError(f"openai stream error: {event.get('message') or event}")
+            elif kind in _TERMINAL:
+                response = event.get("response")
+                if not isinstance(response, dict):
+                    raise RuntimeError(f"openai sent {kind} without a response body")
+                if kind == "response.failed":
+                    raise RuntimeError(f"openai response failed: {_empty_reason(response)}")
+                return response
+        raise RuntimeError("openai stream ended without a terminal event")
+
+    def _prune(self) -> None:
+        """Compact the history in chunks, never one entry per turn.
+
+        OpenAI's prompt cache only hits on a shared prefix, so evicting or
+        masking anything every turn forfeits the cache on every request. The
+        history grows append-only until a budget trips, and one compaction then
+        evicts down to half the cap and masks old frames in the same step — a
+        single cache miss per window instead of one per turn.
+        """
+        history = self._history
+        keep = max(self._max_image_turns, 0)
+        if len(history) > self._max_history:
+            del history[: len(history) - self._max_history // 2]
+            # Cutting at a user message is what keeps every retained turn whole:
+            # a reasoning item, a function call, or a call output left without
+            # the items it belongs to is rejected on the next request.
+            while history and history[0].get("role") != "user":
+                history.pop(0)
+            # An evicted turn must not stay pinned as the latest-only holder: commit
+            # would "prune" an orphan dict nothing reads, and the reference would
+            # keep its base64 wrist frame alive for as long as the arm feed is stale.
+            if self._latest_only_turn is not None and not any(item is self._latest_only_turn[0] for item in history):
+                self._latest_only_turn = None
+        elif self.image_turn_count <= 2 * keep:
+            return  # under both budgets: stay append-only, the cache is warm
+        image_turns = [item for item in history if any(wire.is_image(p) for p in _content(item))]
+        for item in image_turns[:-keep] if keep else image_turns:
+            item["content"] = [dict(wire.FRAME_REMOVED) if wire.is_image(p) else p for p in _content(item)]
+
+
+def _content(item: dict) -> list[dict]:
+    """The content parts of an input message; empty for every other item kind
+    (and for the reference turn, whose assistant content is a plain string)."""
+    content = item.get("content")
+    return content if isinstance(content, list) else []
+
+
+def _masked_content(content: list[dict], indexes: list[int], placeholder: dict) -> list[dict]:
+    return [dict(placeholder) if i in indexes and wire.is_image(p) else p for i, p in enumerate(content)]
+
+
+def _empty_reason(response: dict) -> str:
+    """Why a response carried no output, from whatever the API did say."""
+    error = response.get("error") or {}
+    details = response.get("incomplete_details") or {}
+    reason = {"status": response.get("status"), "error": error.get("message"), "reason": details.get("reason")}
+    return ", ".join(f"{k}={v}" for k, v in reason.items() if v) or "empty response"
+
+
+def _decision_from(output: list[dict]) -> Decision:
+    decision = Decision()
+    speech: list[str] = []
+    thoughts: list[str] = []
+    for item in output:
+        kind = item.get("type")
+        if kind == "function_call":
+            decision.calls.append(
+                ToolCall(
+                    name=str(item.get("name") or ""),
+                    args=_arguments(item.get("arguments")),
+                    id=str(item.get("call_id") or ""),
+                )
+            )
+        elif kind == "reasoning":
+            thoughts += [str(part.get("text") or "") for part in item.get("summary") or []]
+        elif kind == "message":
+            speech += [str(part.get("text") or "") for part in _content(item) if part.get("type") == "output_text"]
+    decision.speech = clean_speech("".join(speech).strip())
+    decision.thoughts = "\n".join(t for t in thoughts if t).strip() or None
+    return decision
+
+
+def _arguments(raw: object) -> dict:
+    """Call arguments arrive as a JSON-encoded string, not an object."""
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(raw) if isinstance(raw, str) and raw else {}
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/transport.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""How the brain reaches OpenAI: the Innate proxy (managed) or OPENAI_API_KEY (dev).
+
+Both paths POST the same Responses body and read back the same SSE event
+stream; a transport only moves payloads and never interprets them.
+
+One asymmetry is worth knowing: the proxy's OpenAI adapter buffers the whole
+generation before it emits, so speech through the proxy starts only once the
+reply is complete, while the direct path streams sentence by sentence. Nothing
+here can work around that — it is fixed in the proxy adapter.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Iterable, Iterator
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from innate_proxy import ProxyClient
+
+PROXY_SERVICE = "openai"
+DIRECT_BASE_URL = "https://api.openai.com"
+RESPONSES_PATH = "/v1/responses"
+
+Transport = Callable[[dict], Iterator[dict]]
+"""request body -> streamed response events (the model rides in the body)."""
+
+
+def pick_transport(proxy: ProxyClient | None) -> Transport | None:
+    """The way to reach OpenAI, or None when neither credential is configured."""
+    if proxy is not None and proxy.is_available():
+        return proxy_transport(proxy)
+    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    return direct_transport(api_key) if api_key else None
+
+
+def proxy_transport(proxy: ProxyClient) -> Transport:
+    """Reach OpenAI through the Innate proxy (the proxy holds the upstream key)."""
+
+    def stream(body: dict) -> Iterator[dict]:
+        with proxy.request_stream(PROXY_SERVICE, RESPONSES_PATH, json=body) as resp:
+            if resp.status_code != 200:
+                raise RuntimeError(f"openai via proxy: HTTP {resp.status_code}: {resp.read()[:200]!r}")
+            yield from _sse_events(resp.iter_lines())
+
+    return stream
+
+
+def direct_transport(api_key: str) -> Transport:
+    """Reach OpenAI directly with OPENAI_API_KEY."""
+    # One client for the process: reuses the TLS connection across turns
+    # instead of a fresh handshake per generate call. Single-threaded use by
+    # construction (one turn at a time on the agent's worker thread).
+    client = httpx.Client(headers={"Authorization": f"Bearer {api_key}"}, timeout=90.0)
+
+    def stream(body: dict) -> Iterator[dict]:
+        with client.stream("POST", DIRECT_BASE_URL + RESPONSES_PATH, json=body) as resp:
+            if resp.status_code != 200:
+                resp.read()
+                raise RuntimeError(f"openai direct: HTTP {resp.status_code}: {resp.text[:200]}")
+            yield from _sse_events(resp.iter_lines())
+
+    return stream
+
+
+def _sse_events(lines: Iterable[str]) -> Iterator[dict]:
+    """Parse the data frames of an SSE stream.
+
+    Every event's own ``type`` is inside its JSON, so the ``event:`` lines carry
+    nothing we need. Skipping data that isn't JSON is not just defensive: the
+    proxy adapter re-serves upstream ``event:`` lines as ``data: event: ...``,
+    and that garbling must not abort the stream.
+    """
+    for line in lines:
+        if not line.startswith("data: "):
+            continue
+        try:
+            event = json.loads(line[len("data: ") :])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            yield event

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/wire.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/wire.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Neutral types -> the OpenAI Responses API shapes."""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING
+
+from brain_client.brain.prompt import PORTRAIT_CAPTION, self_portrait
+
+if TYPE_CHECKING:
+    from brain_client.brain.llm.types import ToolSpec
+
+FRAME_REMOVED = {"type": "input_text", "text": "[older camera frame removed]"}
+WRIST_FRAME_REMOVED = {"type": "input_text", "text": "[older wrist camera frame removed]"}
+
+
+def function_tools(specs: list[ToolSpec]) -> list[dict]:
+    """The ``tools`` field: Responses flattens a function tool, with no nesting."""
+    return [_function(spec) for spec in specs]
+
+
+def image_part(jpeg: bytes) -> dict:
+    return {"type": "input_image", "image_url": f"data:image/jpeg;base64,{base64.b64encode(jpeg).decode()}"}
+
+
+def is_image(part: dict) -> bool:
+    return part.get("type") == "input_image"
+
+
+def user_content(text: str, images: list[bytes]) -> dict:
+    content = [{"type": "input_text", "text": text}, *(image_part(jpeg) for jpeg in images)]
+    return {"role": "user", "content": content}
+
+
+def reference_turns() -> list[dict]:
+    """A pinned exchange showing the model its own body — ``instructions`` is
+    text-only, so the portrait rides at the front of the input instead."""
+    jpeg = self_portrait()
+    if jpeg is None:
+        return []
+    return [
+        user_content(PORTRAIT_CAPTION, [jpeg]),
+        {"role": "assistant", "content": "Understood — that is what my model of robot looks like."},
+    ]
+
+
+def tool_outcome(call_id: str, outcome: str) -> dict:
+    return {"type": "function_call_output", "call_id": call_id, "output": outcome}
+
+
+def _function(spec: ToolSpec) -> dict:
+    function: dict = {"type": "function", "name": spec.name, "description": spec.description}
+    # `strict` is left off deliberately: strict mode requires every property to
+    # be listed in `required`, and skill inputs are frequently optional.
+    function["parameters"] = spec.parameters or {"type": "object", "properties": {}, "required": []}
+    return function

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/tools.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/tools.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
-"""Skill metadata -> native Gemini tool declarations."""
+"""Skill metadata -> the tools offered to the model this turn.
+
+Provider-neutral: parameters come out as plain JSON Schema, and each provider's
+wire module renders that into its own declaration format.
+"""
 
 from __future__ import annotations
 
 import re
 
+from brain_client.brain.llm.types import ToolSpec
 from brain_client.skills.registry import SkillMeta
 
 STOP_SKILL = "stop_current_skill"
@@ -14,46 +19,47 @@ GO_TO_POINT_IN_VIEW = "go_to_point_in_view"
 
 # An explicit no-op keeps idle turns clean: without it, models tend to emit
 # placeholder text ("[]", "Empty response") rather than returning nothing.
-_WAIT_DECLARATION = {
-    "name": WAIT,
-    "description": "Do nothing until the next update. Use when there is nothing new to do or say.",
-}
+_WAIT_SPEC = ToolSpec(
+    name=WAIT,
+    description="Do nothing until the next update. Use when there is nothing new to do or say.",
+)
 
 # Visual navigation grounding: the model points at a floor pixel and the robot
 # projects it into a local navigation goal (brain/grounding.py). Declared only
 # when navigate_to_position is among the active skills — it is the actuator.
-_GO_TO_POINT_IN_VIEW_DECLARATION = {
-    "name": GO_TO_POINT_IN_VIEW,
-    "description": (
+_GO_TO_POINT_IN_VIEW_SPEC = ToolSpec(
+    name=GO_TO_POINT_IN_VIEW,
+    description=(
         "Drive toward a point you can see in the CURRENT camera frame. Give normalized image "
         "coordinates (0-1000) of a point ON THE FLOOR: y from the top, x from the left. For an "
         "object, point at the floor at its base. The robot drives to about 0.35 m short of that "
         "spot and turns to face it. Prefer this over navigate_to_position for anything you can "
         "see. Far targets are approached in capped steps — call it again after arriving."
     ),
-    "parameters": {
-        "type": "OBJECT",
+    parameters={
+        "type": "object",
         "properties": {
-            "y": {"type": "INTEGER", "description": "0-1000 from image top"},
-            "x": {"type": "INTEGER", "description": "0-1000 from image left"},
+            "y": {"type": "integer", "description": "0-1000 from image top"},
+            "x": {"type": "integer", "description": "0-1000 from image left"},
         },
         "required": ["y", "x"],
     },
-}
+)
 
 # Skill input "type" strings (python annotation names from skill introspection)
-# -> Gemini schema types. Anything else is passed as a string with the expected
+# -> JSON Schema types. Anything else is passed as a string with the expected
 # type noted in the description.
-_SCHEMA_TYPES = {"float": "NUMBER", "int": "INTEGER", "str": "STRING", "bool": "BOOLEAN"}
+_SCHEMA_TYPES = {"float": "number", "int": "integer", "str": "string", "bool": "boolean"}
 
 
 def tool_name(skill_name: str) -> str:
     """Skill name -> valid function name.
 
-    Gemini requires function names to start with a letter or underscore — a
-    digit-leading skill ("3d_scan") would 400 every request while active.
+    The intersection of what the providers accept: letters, digits, underscore
+    and dash, starting with a letter or underscore. A digit-leading skill
+    ("3d_scan") would 400 every request while it is active.
     """
-    name = re.sub(r"[^a-zA-Z0-9_.\-]", "_", skill_name) or "skill"
+    name = re.sub(r"[^a-zA-Z0-9_\-]", "_", skill_name) or "skill"
     if not re.match(r"[a-zA-Z_]", name):
         name = "_" + name
     return name[:64]
@@ -86,23 +92,23 @@ def build_tools(
     *,
     can_go_to_point_in_view: bool = False,
     user_spoke: bool = False,
-) -> list[dict]:
-    """One function declaration per available skill, in a native tools block.
+) -> list[ToolSpec]:
+    """One spec per available skill.
 
     ``named_skills`` is :func:`assign_tool_names`'s output — the caller derives
     its dispatch map from the same pairs, so the declared names and the
     dispatched names can never diverge.
 
-    While a skill runs, the robot's only action is stopping it, so the
-    declarations collapse. The shape depends on whether the user just spoke:
-    offered any no-op tool, the model calls it and goes silent, so a turn
-    carrying a user message gets stop_current_skill ALONE — plain text becomes
-    the reply channel, and the description steers stop away from questions.
+    While a skill runs, the robot's only action is stopping it, so the tools
+    collapse. The shape depends on whether the user just spoke: offered any
+    no-op tool, the model calls it and goes silent, so a turn carrying a user
+    message gets stop_current_skill ALONE — plain text becomes the reply
+    channel, and the description steers stop away from questions.
     """
     if running_skill_name is not None:
-        stop = {
-            "name": STOP_SKILL,
-            "description": f"Abort the currently running skill ({running_skill_name}). "
+        stop = ToolSpec(
+            name=STOP_SKILL,
+            description=f"Abort the currently running skill ({running_skill_name}). "
             + (
                 "Only when the user asks you to stop or switch task, or the skill is clearly "
                 "failing. Questions and conversation are NOT reasons to stop — answer those "
@@ -110,26 +116,27 @@ def build_tools(
                 if user_spoke
                 else "Use when it is clearly failing, no longer makes sense, or the user asks for something else."
             ),
-        }
-        return [{"functionDeclarations": [stop] if user_spoke else [stop, _WAIT_DECLARATION]}]
-    declarations = [_declaration(name, meta) for name, meta in named_skills]
+        )
+        return [stop] if user_spoke else [stop, _WAIT_SPEC]
+    specs = [_spec(name, meta) for name, meta in named_skills]
     if can_go_to_point_in_view:
-        declarations.append(_GO_TO_POINT_IN_VIEW_DECLARATION)
-    declarations.append(_WAIT_DECLARATION)
-    return [{"functionDeclarations": declarations}]
+        specs.append(_GO_TO_POINT_IN_VIEW_SPEC)
+    specs.append(_WAIT_SPEC)
+    return specs
 
 
-def _declaration(name: str, meta: SkillMeta) -> dict:
+def _spec(name: str, meta: SkillMeta) -> ToolSpec:
     properties: dict[str, dict] = {}
     required: list[str] = []
     for param_name, spec in (meta.get("inputs") or {}).items():
         properties[param_name] = _param_schema(spec if isinstance(spec, dict) else {})
         if isinstance(spec, dict) and spec.get("required"):
             required.append(param_name)
-    declaration: dict = {"name": name, "description": meta.get("guidelines") or meta["name"]}
-    if properties:
-        declaration["parameters"] = {"type": "OBJECT", "properties": properties, "required": required}
-    return declaration
+    description = meta.get("guidelines") or meta["name"]
+    if not properties:
+        return ToolSpec(name=name, description=description)
+    parameters = {"type": "object", "properties": properties, "required": required}
+    return ToolSpec(name=name, description=description, parameters=parameters)
 
 
 def _param_schema(spec: dict) -> dict:
@@ -138,13 +145,13 @@ def _param_schema(spec: dict) -> dict:
     notes = []
     if schema["type"] is None:
         notes.append(f"type: {declared_type}")
-        schema["type"] = "STRING"
+        schema["type"] = "string"
     if "default" in spec:
         notes.append(f"default: {spec['default']}")
 
     enum_values = spec.get("enum")
     if enum_values and all(isinstance(v, str) for v in enum_values):
-        schema["type"] = "STRING"
+        schema["type"] = "string"
         schema["enum"] = list(enum_values)
     elif enum_values:
         notes.append(f"one of: {enum_values}")

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/types.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The vocabulary between the agent loop and whichever model backend it runs on.
+
+The agent never builds or reads a request body: it hands a :class:`Conversation`
+an observation and gets a :class:`Decision` back. Which provider is underneath,
+and what its wire format looks like, stays behind this seam.
+
+Two values still cross it as opaque ``dict`` payloads — a pending turn and a raw
+response. Only the conversation that produced them may read them: a Gemini
+thought signature and an OpenAI reasoning item both have to be echoed back
+verbatim on the next request and cannot be rebuilt from a Decision.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+from brain_client.common.enums import StrEnum
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from brain_client.brain.utils import Frame
+
+Usage = dict[str, int]
+"""Token counts of the newest response, keyed ``prompt`` / ``cached`` /
+``output``. Wire-visible: the trace snapshot publishes it as ``tokens``."""
+
+
+class Provider(StrEnum):
+    """Which vendor's API the brain thinks with (the ``brain_backend`` setting)."""
+
+    GEMINI = "gemini"
+    OPENAI = "openai"
+
+
+class Backend(StrEnum):
+    """How the brain reaches its provider (surfaced in health and telemetry)."""
+
+    PROXY = "innate-proxy"
+    GEMINI_DIRECT = "gemini-direct"
+    OPENAI_DIRECT = "openai-direct"
+    UNCONFIGURED = "unconfigured"
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    name: str
+    args: dict
+    id: str = ""
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """One function the model may call this turn.
+
+    ``parameters`` is a JSON Schema object using the standard lowercase type
+    names, or None for a no-argument tool. Each provider's wire module renders
+    it — Gemini wants those type names uppercased, OpenAI takes them as they are.
+    """
+
+    name: str
+    description: str
+    parameters: dict | None = None
+
+
+@dataclass
+class Decision:
+    """What the model wants the robot to do this turn."""
+
+    speech: str | None = None
+    thoughts: str | None = None
+    calls: list[ToolCall] = field(default_factory=list)
+
+
+class Conversation(Protocol):
+    """A bounded model conversation: one :meth:`generate` per agent turn.
+
+    Threading contract, which every implementation must keep: ``generate`` is
+    the only blocking call and only *reads* history, so the agent awaits it on a
+    worker thread. Every mutation (:meth:`commit`, :meth:`add_tool_outcomes`)
+    runs on the agent's loop thread strictly between generate calls, and
+    :meth:`clear` only while that loop is stopped — no concurrent access by
+    construction, not by lock.
+    """
+
+    on_request: Callable[[dict], None] | None
+    """Observability tap: called with the exact request body just before it goes
+    on the wire, from generate's thread. The body must be treated as read-only —
+    it shares structure with the live history."""
+
+    @property
+    def history_len(self) -> int: ...
+
+    @property
+    def image_turn_count(self) -> int:
+        """History turns still carrying camera frames (pruning keeps the newest few)."""
+        ...
+
+    @property
+    def last_usage(self) -> Usage: ...
+
+    def open_turn(self, text: str, frames: list[Frame]) -> dict:
+        """Serialize one observation. The result is provider-shaped and opaque:
+        hand it back to :meth:`generate` and :meth:`commit`, never read it."""
+        ...
+
+    def generate(
+        self,
+        turn: dict,
+        tools: list[ToolSpec],
+        system: str,
+        on_speech: Callable[[str], None] | None = None,
+    ) -> dict:
+        """Blocking network call — safe on a worker thread. Every plain-text
+        delta is handed to ``on_speech`` as it arrives, which is what lets the
+        robot start talking at the first sentence boundary."""
+        ...
+
+    def commit(self, turn: dict, response: dict) -> Decision:
+        """Store the exchange in history and distil what the agent should act on."""
+        ...
+
+    def add_tool_outcomes(self, outcomes: list[tuple[ToolCall, str]]) -> None:
+        """Answer the model's calls (every provider requires one response per call)."""
+        ...
+
+    def clear(self) -> None: ...
+
+
+_TOOL_NARRATION = re.compile(r"Calling tool\b")
+
+
+def split_tool_narration(text: str) -> tuple[str, bool]:
+    """Cut leaked tool-call narration ("Calling tool ..." to end of text).
+
+    gemini-3 preview sometimes appends it to its reply, without a sentence
+    boundary. Returns ``(clean text, whether narration was found)`` — the one
+    scrub both the chat transcript (:func:`clean_speech`) and the audio path
+    (``SpeechStreamer._say``) apply, so the two can never diverge.
+    """
+    match = _TOOL_NARRATION.search(text)
+    if match is None:
+        return text, False
+    return text[: match.start()].rstrip(), True
+
+
+def clean_speech(speech: str | None) -> str | None:
+    """Drop unspeakable output: placeholders and leaked tool-call narration."""
+    if not speech:
+        return None
+    speech, _ = split_tool_narration(speech)
+    return speech if re.search(r"[a-zA-Z0-9]", speech) else None

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/memory_search.py
@@ -38,7 +38,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from brain_client.brain.frame_files import FrameFiles
-from brain_client.brain.transport import (
+from brain_client.brain.llm.gemini.transport import (
     CACHED_CONTENTS_PATH,
     GENERATE_PATH,
     UNSUPPORTED_ENDPOINT_STATUSES,
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
     from rclpy.impl.rcutils_logger import RcutilsLogger
 
-    from brain_client.brain.transport import GeminiRest
+    from brain_client.brain.llm.gemini.transport import GeminiRest
     from brain_client.memory.store import Memory, MemorySnapshot, MemoryStore
 
 _TTL_SEC = 12 * 3600  # ~20k-token cache: 12h of storage costs ~$0.24, cheap insurance against cold starts

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/prompt.py
@@ -4,31 +4,26 @@
 
 from __future__ import annotations
 
-import base64
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from brain_client.perception.identity import RobotIdentity
 
-# 384px on the long side on purpose: one Gemini tile (258 tokens) per request.
+# 384px on the long side on purpose: one image tile (~258 tokens) per request.
 _PORTRAIT = Path(__file__).parent.parent / "assets" / "self_portrait.jpg"
-_PORTRAIT_CAPTION = (
+PORTRAIT_CAPTION = (
     "For reference, this is how a black MARS looks. You are this model of robot; your own color may differ."
 )
 
 
-def self_reference_turns() -> list[dict]:
-    """A pinned exchange showing the model its own body. Gemini's
-    systemInstruction is text-only, so the portrait rides at the front of
-    every request's contents instead (GeminiContext's ``reference``)."""
-    if not _PORTRAIT.is_file():
-        return []
-    image = {"inlineData": {"mimeType": "image/jpeg", "data": base64.b64encode(_PORTRAIT.read_bytes()).decode()}}
-    return [
-        {"role": "user", "parts": [{"text": _PORTRAIT_CAPTION}, image]},
-        {"role": "model", "parts": [{"text": "Understood — that is what my model of robot looks like."}]},
-    ]
+def self_portrait() -> bytes | None:
+    """The JPEG the brain is shown of its own body, or None if it is missing.
+
+    Every provider's system instruction is text-only, so each wire module pins
+    this at the front of the request as a reference exchange instead.
+    """
+    return _PORTRAIT.read_bytes() if _PORTRAIT.is_file() else None
 
 
 _SYSTEM_PROMPT = """\

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/transport.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Deprecated: moved to brain_client.brain.llm.gemini.transport.
+
+Backward-compat shim for custom input devices that still import from the old
+path. ``workspace/`` lives on the robot and is user-editable, so a customized
+micro_input.py keeps its own import line across an update — moving the module
+out from under it would take the microphone down. Remove in a future release
+once external input files have migrated.
+"""
+
+from brain_client.brain.llm.gemini.transport import *  # noqa: F401, F403

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -7,8 +7,9 @@ it can declare/read ROS parameters, but the dataclass itself is plain data —
 which keeps every consumer testable without a ROS runtime.
 
 Credentials deliberately stay out of the ROS parameter surface: the brain
-reaches Gemini through the Innate proxy (INNATE_SERVICE_KEY) or directly via
-the ``GEMINI_API_KEY`` environment variable (loaded from ``.env`` by launch).
+reaches its provider through the Innate proxy (INNATE_SERVICE_KEY) or directly
+via that vendor's own key (``GEMINI_API_KEY`` / ``OPENAI_API_KEY``), loaded
+from ``.env`` by launch.
 """
 
 from __future__ import annotations
@@ -40,9 +41,11 @@ class BrainConfig:
     x_cam: float  # camera forward offset from base_link (m)
     height_cam: float  # camera height above the floor (m)
 
-    # --- Local brain (Gemini) ---
-    gemini_model: str
-    gemini_thinking_level: str  # "low" | "high"; "" = model default
+    # --- Local brain ---
+    brain_backend: str  # which provider it thinks with: "gemini" | "openai"
+    brain_model: str
+    brain_thinking_level: str  # written in the provider's vocabulary; "" = model default
+    memory_model: str  # spatial memory search is Gemini-only, whatever the brain runs on
     idle_turn_interval: float  # seconds between looks when no skill is running
     supervision_turn_interval: float  # seconds between looks while a skill runs
     history_max_entries: int  # conversation entries kept for the model
@@ -70,12 +73,11 @@ class BrainConfig:
         accessor = {str: "string_value", bool: "bool_value", int: "integer_value", float: "double_value"}
         for name, default in _PARAM_DEFAULTS.items():
             node.declare_parameter(name, default)
-        return cls(
-            **{
-                name: getattr(node.get_parameter(name).get_parameter_value(), accessor[type(default)])
-                for name, default in _PARAM_DEFAULTS.items()
-            }
-        )
+        values = {
+            name: getattr(node.get_parameter(name).get_parameter_value(), accessor[type(default)])
+            for name, default in _PARAM_DEFAULTS.items()
+        }
+        return cls(**_carry_renamed(node, values))
 
 
 # One default per BrainConfig field, in field order; a value's type must match
@@ -100,16 +102,25 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "vertical_fov": 80.0,
     "x_cam": 0.0197,
     "height_cam": 0.19663,
-    # --- Local brain (Gemini) ---
-    "gemini_model": "gemini-3.6-flash",
-    # "minimal" | "low" | "medium" | "high"; "" = model default.
-    # Measured on 3.6-flash (2026-08): minimal is ~3x faster than the
+    # --- Local brain ---
+    "brain_backend": "gemini",
+    "brain_model": "gemini-3.6-flash",
+    # Each provider names its own levels: gemini takes "minimal" | "low" |
+    # "medium" | "high", openai takes "none" | "low" | "medium" | "high" |
+    # "xhigh" | "max". "" = the model's default, and an unknown value falls
+    # back to that with a warning rather than 400ing every request.
+    # Measured on gemini-3.6-flash (2026-08): minimal is ~3x faster than the
     # default level (0.96s vs 3.08s median turn) and passed the same
     # single-turn discipline probes (wait on idle, ignore STT noise,
     # tool choice, go_to_point_in_view grounding). An earlier model's "low"
     # measurably hurt multi-turn instruction-following (skill re-runs,
-    # chatter) — if that resurfaces, revert to "" here.
-    "gemini_thinking_level": "minimal",
+    # chatter) — if that resurfaces, revert to "" here. The numbers are
+    # Gemini's; another provider's levels need their own measurement.
+    "brain_thinking_level": "minimal",
+    # Spatial memory search needs Gemini context caching and the Files API,
+    # which have no counterpart elsewhere, so it stays on Gemini even when the
+    # agent thinks with another provider.
+    "memory_model": "gemini-3.6-flash",
     "idle_turn_interval": 3.0,
     "supervision_turn_interval": 5.0,
     # Compaction evicts to half the cap, so depth rides 1000-2000 entries. A silent
@@ -129,3 +140,21 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     # --- Proxy service config ---
     "cartesia_voice_id": "9fdaae0b-f885-4813-b589-3c07cf9d5fea",
 }
+
+
+# Settings named before the brain could run on more than one provider. A robot's
+# settings.yaml still carries them, and ignoring one would silently revert that
+# robot to the default model.
+_RENAMED = {"gemini_model": "brain_model", "gemini_thinking_level": "brain_thinking_level"}
+
+
+def _carry_renamed(node, values: dict) -> dict:
+    """Let a retired parameter still set the one that replaced it, and say so."""
+    for old, new in _RENAMED.items():
+        node.declare_parameter(old, "")
+        legacy = node.get_parameter(old).get_parameter_value().string_value
+        if not legacy or values[new] != _PARAM_DEFAULTS[new]:
+            continue
+        node.get_logger().warn(f"[Brain] '{old}' is now '{new}' — using {legacy!r}; rename it in settings.yaml")
+        values[new] = legacy
+    return values

--- a/ros2_ws/src/brain/brain_client/brain_client/inputs/batch_stt.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/inputs/batch_stt.py
@@ -28,11 +28,11 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
 
-from brain_client.brain.transport import GENERATE_PATH
+from brain_client.brain.llm.gemini.transport import GENERATE_PATH
 from brain_client.inputs.vad import MIC_SAMPLE_RATE, pcm16_to_f32, resample_24k_to_16k
 
 if TYPE_CHECKING:
-    from brain_client.brain.transport import GeminiRest
+    from brain_client.brain.llm.gemini.transport import GeminiRest
     from brain_client.common.logging import UniversalLogger
     from innate_proxy import ProxyClient
 

--- a/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/nodes/brain_client_node.py
@@ -28,9 +28,9 @@ from std_srvs.srv import SetBool, Trigger
 
 from brain_client.agents.initializer import initialize_agents
 from brain_client.brain.agent import BrainAgent
+from brain_client.brain.llm.gemini.transport import pick_rest
 from brain_client.brain.memory_search import MemorySearch
 from brain_client.brain.search_server import MemorySearchServer
-from brain_client.brain.transport import pick_rest
 from brain_client.brain.utils import EventKind
 from brain_client.common.script_paths import get_innate_os_root
 from brain_client.core.config import BrainConfig
@@ -182,7 +182,7 @@ class BrainClientNode(Node):
         self.memory_store = MemoryStore(get_innate_os_root() / "data")
         rest = pick_rest(self._proxy)
         self.memory_search = (
-            MemorySearch(self.memory_store, rest, model=cfg.gemini_model, logger=self.get_logger())
+            MemorySearch(self.memory_store, rest, model=cfg.memory_model, logger=self.get_logger())
             if rest is not None
             else None
         )

--- a/ros2_ws/src/brain/brain_client/brain_client/transport/chat.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/transport/chat.py
@@ -15,7 +15,7 @@ import re
 import threading
 import time
 
-from brain_client.brain.context import split_tool_narration
+from brain_client.brain.llm.types import split_tool_narration
 from brain_client.common.enums import StrEnum
 
 _SENTENCE_END = re.compile(r"(?<=[.!?…])\s+")
@@ -167,7 +167,7 @@ class SpeechStreamer:
             return
         # Leaked tool narration, never speech — cut mid-sentence too (the model
         # appends it without a boundary) and mute the rest of the reply. Shared
-        # with context._clean_speech so the audio never carries text the chat
+        # with llm.types.clean_speech so the audio never carries text the chat
         # transcript scrubbed.
         sentence, truncated = split_tool_narration(sentence.strip())
         if truncated:

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
@@ -10,8 +10,8 @@ from brain_client.common.logging import get_logging_env_vars
 
 
 def generate_launch_description():
-    # Load environment variables from .env file (includes GEMINI_API_KEY for the
-    # local brain — read by the node from the environment, never a ROS param).
+    # Load environment variables from .env file (includes the brain's vendor keys
+    # — read by the node from the environment, never a ROS param).
     load_env_file()
 
     # Get logging environment variables
@@ -55,10 +55,17 @@ def generate_launch_description():
         default_value="True",
         description="Flag to enable full brain turn logging",
     )
-    gemini_model_arg = DeclareLaunchArgument(
-        "gemini_model",
-        default_value=get_env("GEMINI_MODEL", "gemini-3.6-flash"),
-        description="Gemini model powering the local brain",
+    brain_backend_arg = DeclareLaunchArgument(
+        "brain_backend",
+        default_value=get_env("BRAIN_BACKEND", "gemini"),
+        description="Which provider the local brain thinks with: gemini or openai",
+    )
+    brain_model_arg = DeclareLaunchArgument(
+        "brain_model",
+        # GEMINI_MODEL is the name this had before the brain could run on more
+        # than one provider; a robot's .env may still set it.
+        default_value=get_env("BRAIN_MODEL", get_env("GEMINI_MODEL", "gemini-3.6-flash")),
+        description="Model powering the local brain",
     )
 
     # --- Proxy service configuration ---
@@ -81,7 +88,8 @@ def generate_launch_description():
                 "simulator_mode": LaunchConfiguration("simulator_mode"),
                 "current_nav_mode_topic": LaunchConfiguration("current_nav_mode_topic"),
                 "log_everything": LaunchConfiguration("log_everything"),
-                "gemini_model": LaunchConfiguration("gemini_model"),
+                "brain_backend": LaunchConfiguration("brain_backend"),
+                "brain_model": LaunchConfiguration("brain_model"),
                 # Proxy service config
                 "cartesia_voice_id": LaunchConfiguration("cartesia_voice_id"),
             },
@@ -104,7 +112,8 @@ def generate_launch_description():
             simulator_mode_arg,
             current_nav_mode_topic_arg,
             log_everything_arg,
-            gemini_model_arg,
+            brain_backend_arg,
+            brain_model_arg,
             # Proxy service config args
             cartesia_voice_id_arg,
             brain_client_node,

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
@@ -10,8 +10,8 @@ from brain_client.common.logging import get_logging_env_vars
 
 
 def generate_launch_description():
-    # Load environment variables from .env file (includes GEMINI_API_KEY for the
-    # local brain — read by the node from the environment, never a ROS param).
+    # Load environment variables from .env file (includes the brain's vendor keys
+    # — read by the node from the environment, never a ROS param).
     load_env_file()
 
     # Get logging environment variables
@@ -46,10 +46,17 @@ def generate_launch_description():
         default_value="True",
         description="Flag to enable full brain turn logging",
     )
-    gemini_model_arg = DeclareLaunchArgument(
-        "gemini_model",
-        default_value=get_env("GEMINI_MODEL", "gemini-3.6-flash"),
-        description="Gemini model powering the local brain",
+    brain_backend_arg = DeclareLaunchArgument(
+        "brain_backend",
+        default_value=get_env("BRAIN_BACKEND", "gemini"),
+        description="Which provider the local brain thinks with: gemini or openai",
+    )
+    brain_model_arg = DeclareLaunchArgument(
+        "brain_model",
+        # GEMINI_MODEL is the name this had before the brain could run on more
+        # than one provider; a robot's .env may still set it.
+        default_value=get_env("BRAIN_MODEL", get_env("GEMINI_MODEL", "gemini-3.6-flash")),
+        description="Model powering the local brain",
     )
 
     brain_client_node = Node(
@@ -64,7 +71,8 @@ def generate_launch_description():
                 "simulator_mode": LaunchConfiguration("simulator_mode"),
                 "current_nav_mode_topic": LaunchConfiguration("current_nav_mode_topic"),
                 "log_everything": LaunchConfiguration("log_everything"),
-                "gemini_model": LaunchConfiguration("gemini_model"),
+                "brain_backend": LaunchConfiguration("brain_backend"),
+                "brain_model": LaunchConfiguration("brain_model"),
                 # Sim camera mount (the config.py defaults are the hardware's).
                 "x_cam": 0.0,
                 "height_cam": 0.2,
@@ -84,7 +92,8 @@ def generate_launch_description():
             simulator_mode_arg,
             current_nav_mode_topic_arg,
             log_everything_arg,
-            gemini_model_arg,
+            brain_backend_arg,
+            brain_model_arg,
             brain_client_node,
             Node(
                 package="brain_client",

--- a/ros2_ws/src/brain/brain_client/test/test_batch_stt.py
+++ b/ros2_ws/src/brain/brain_client/test/test_batch_stt.py
@@ -9,7 +9,7 @@ import json
 import httpx
 import pytest
 
-from brain_client.brain.transport import GeminiRest, proxy_rest
+from brain_client.brain.llm.gemini.transport import GeminiRest, proxy_rest
 from brain_client.inputs.batch_stt import (
     ELEVENLABS_PROXY_ENDPOINT,
     NO_SPEECH,

--- a/ros2_ws/src/brain/brain_client/test/test_compat_shims.py
+++ b/ros2_ws/src/brain/brain_client/test/test_compat_shims.py
@@ -30,6 +30,17 @@ def test_agent_types_shim_reexports_same_objects():
         assert getattr(agent_types, name) is getattr(agents_types, name)
 
 
+def test_brain_transport_shim_reexports_same_objects():
+    """workspace/inputs/micro_input.py imports pick_rest from the pre-#809 path,
+    and a robot's customized copy of it keeps that line across an update — the
+    shim is what stops a module move from taking the microphone down."""
+    from brain_client.brain import transport as transport_shim
+    from brain_client.brain.llm.gemini import transport as gemini_transport
+
+    for name in ("pick_rest", "pick_transport", "GeminiRest", "GeminiHttpError", "GENERATE_PATH"):
+        assert getattr(transport_shim, name) is getattr(gemini_transport, name)
+
+
 def test_skill_types_shim_reexports_same_objects():
     for name in (
         "Skill",

--- a/ros2_ws/src/brain/brain_client/test/test_local_brain.py
+++ b/ros2_ws/src/brain/brain_client/test/test_local_brain.py
@@ -2,28 +2,32 @@
 # Copyright (c) 2026 Innate Inc
 """Unit tests for the local brain's pure core (no ROS, no network).
 
-Covers the Gemini layer the agent loop depends on: skill metadata -> tool
-declarations, response -> Decision (speech / thoughts / calls), and the history
-pruning that keeps requests small (the "image cache"). GeminiContext only
-touches the network in generate(), so everything else is exercised directly
-with a None or capturing transport.
+Covers the model layer the agent loop depends on: skill metadata -> tool specs
+(and their Gemini rendering), response -> Decision (speech / thoughts / calls),
+and the history pruning that keeps requests small (the "image cache"). A
+conversation only touches the network in generate(), so everything else is
+exercised directly with a None or capturing transport.
 """
 
 import json
 
 import pytest
 
-from brain_client.brain.context import GeminiContext, _decision_from
-from brain_client.brain.prompt import build_system_prompt
-from brain_client.brain.tools import (
+from brain_client.brain.llm.gemini import wire
+from brain_client.brain.llm.gemini.context import GeminiConversation, _decision_from
+from brain_client.brain.llm.tools import (
     STOP_SKILL,
     WAIT,
     assign_tool_names,
     build_tools,
     tool_name,
 )
+from brain_client.brain.prompt import build_system_prompt
+from brain_client.brain.utils import FrameLabel
 
 JPEG = b"\xff\xd8\xff\xe0fakejpegbytes"
+HEAD = [(FrameLabel.HEAD, JPEG)]
+HEAD_AND_WRIST = [(FrameLabel.HEAD, JPEG), (FrameLabel.WRIST, JPEG)]
 
 NAV_SKILL = {
     "id": "innate-os/navigate_to_position",
@@ -39,8 +43,8 @@ NAV_SKILL = {
 WAVE_SKILL = {"id": "local/wave", "name": "wave", "guidelines": "Wave the arm.", "inputs": {}}
 
 
-def make_context(transport=None, max_history=60, max_image_turns=2) -> GeminiContext:
-    return GeminiContext(
+def make_context(transport=None, max_history=60, max_image_turns=2) -> GeminiConversation:
+    return GeminiConversation(
         transport, model="test-model", thinking_level="", max_history=max_history, max_image_turns=max_image_turns
     )
 
@@ -66,7 +70,7 @@ def test_tool_name_sanitizes_invalid_characters():
 
 
 def test_tool_name_never_starts_with_a_digit():
-    # Gemini requires function names to start with a letter or underscore; a
+    # Providers require function names to start with a letter or underscore; a
     # digit-leading skill would 400 every request while it is active.
     assert tool_name("3d_scan") == "_3d_scan"
     assert tool_name("-dash") == "_-dash"
@@ -88,54 +92,62 @@ def test_assign_tool_names_disambiguates_collisions_and_builtins():
     assert names[2] == "wait_2"
     assert len(names) == len(set(names)) and WAIT not in names
     assert all(len(name) <= 64 for name in names)
-    # The declarations use the same disambiguated names.
-    declared = [d["name"] for d in build_tools(named, None)[0]["functionDeclarations"]]
-    assert declared[:5] == names
+    # The specs use the same disambiguated names.
+    assert [spec.name for spec in build_tools(named, None)][:5] == names
 
 
 def test_build_tools_declares_one_function_per_skill_plus_wait():
-    tools = build_tools(assign_tool_names([NAV_SKILL, WAVE_SKILL]), None)
-    declarations = tools[0]["functionDeclarations"]
-    assert [d["name"] for d in declarations] == ["navigate_to_position", "wave", "wait"]
+    specs = build_tools(assign_tool_names([NAV_SKILL, WAVE_SKILL]), None)
+    assert [spec.name for spec in specs] == ["navigate_to_position", "wave", "wait"]
 
-    nav = declarations[0]
-    assert nav["description"] == NAV_SKILL["guidelines"]
-    params = nav["parameters"]
+    nav = specs[0]
+    assert nav.description == NAV_SKILL["guidelines"]
+    assert nav.parameters["type"] == "object"
+    assert set(nav.parameters["properties"]) == {"x", "y", "local_frame", "mode"}
+    assert nav.parameters["required"] == ["x", "y"]
+    assert nav.parameters["properties"]["x"]["type"] == "number"
+    assert nav.parameters["properties"]["local_frame"]["type"] == "boolean"
+    assert nav.parameters["properties"]["mode"]["enum"] == ["fast", "safe"]
+    # No-input skills must not carry an empty object schema.
+    assert specs[1].parameters is None
+
+
+def test_gemini_wire_uppercases_the_schema_types():
+    # Gemini's dialect is JSON Schema with the type names uppercased; sending
+    # them lowercase 400s the request.
+    declarations = wire.tools_block(build_tools(assign_tool_names([NAV_SKILL, WAVE_SKILL]), None))[0][
+        "functionDeclarations"
+    ]
+    params = declarations[0]["parameters"]
     assert params["type"] == "OBJECT"
-    assert set(params["properties"]) == {"x", "y", "local_frame", "mode"}
-    assert params["required"] == ["x", "y"]
     assert params["properties"]["x"]["type"] == "NUMBER"
     assert params["properties"]["local_frame"]["type"] == "BOOLEAN"
     assert params["properties"]["mode"]["enum"] == ["fast", "safe"]
-    # No-input skills must not carry an empty object schema.
     assert "parameters" not in declarations[1]
 
 
 def test_build_tools_while_running_offers_only_stop_and_wait():
-    declarations = build_tools([], "navigate_to_position")[0]["functionDeclarations"]
-    assert [d["name"] for d in declarations] == [STOP_SKILL, "wait"]
-    assert "navigate_to_position" in declarations[0]["description"]
+    specs = build_tools([], "navigate_to_position")
+    assert [spec.name for spec in specs] == [STOP_SKILL, "wait"]
+    assert "navigate_to_position" in specs[0].description
 
 
 def test_build_tools_while_running_with_user_speech_offers_stop_alone():
     # Offered any no-op tool the model calls it and goes silent, so a turn
     # carrying a user message gets stop alone — text becomes the reply channel.
-    declarations = build_tools([], "wave", user_spoke=True)[0]["functionDeclarations"]
-    assert [d["name"] for d in declarations] == [STOP_SKILL]
-    assert "NOT reasons to stop" in declarations[0]["description"]
+    specs = build_tools([], "wave", user_spoke=True)
+    assert [spec.name for spec in specs] == [STOP_SKILL]
+    assert "NOT reasons to stop" in specs[0].description
 
 
 def test_build_tools_with_no_skills_still_offers_wait():
-    declarations = build_tools([], None)[0]["functionDeclarations"]
-    assert [d["name"] for d in declarations] == ["wait"]
+    assert [spec.name for spec in build_tools([], None)] == ["wait"]
 
 
 def test_unknown_param_type_falls_back_to_annotated_string():
     skill = {"id": "s", "name": "s", "guidelines": "g", "inputs": {"blob": {"type": "list[str]", "required": True}}}
-    schema = build_tools(assign_tool_names([skill]), None)[0]["functionDeclarations"][0]["parameters"]["properties"][
-        "blob"
-    ]
-    assert schema["type"] == "STRING"
+    schema = build_tools(assign_tool_names([skill]), None)[0].parameters["properties"]["blob"]
+    assert schema["type"] == "string"
     assert "list[str]" in schema["description"]
 
 
@@ -164,8 +176,8 @@ def test_decision_tolerates_empty_or_malformed_response():
 # ---------- history / image pruning ----------
 
 
-def user_turn(text: str, with_image: bool) -> dict:
-    return GeminiContext.user_message(text, [JPEG] if with_image else [])
+def user_turn(context: GeminiConversation, text: str, with_image: bool) -> dict:
+    return context.open_turn(text, HEAD if with_image else [])
 
 
 def images_in(content: dict) -> int:
@@ -175,7 +187,7 @@ def images_in(content: dict) -> int:
 def test_prune_keeps_images_only_in_newest_turns():
     context = make_context(max_image_turns=2)
     for i in range(5):
-        context.absorb(user_turn(f"turn {i}", with_image=True), model_response({"text": "ok"}))
+        context.commit(user_turn(context, f"turn {i}", with_image=True), model_response({"text": "ok"}))
 
     user_turns = [c for c in context._history if c["role"] == "user"]
     assert [images_in(c) for c in user_turns] == [0, 0, 0, 1, 1]
@@ -184,13 +196,12 @@ def test_prune_keeps_images_only_in_newest_turns():
     assert any("removed" in p.get("text", "") for p in user_turns[0]["parts"])
 
 
-def test_absorb_keeps_only_the_newest_wrist_frame():
+def test_commit_keeps_only_the_newest_wrist_frame():
     # Head frames follow the image-turn window; wrist frames are latest-only —
     # a stale gripper close-up reads as current grasp state.
     context = make_context(max_image_turns=3)
     for i in range(3):
-        message = GeminiContext.user_message(f"turn {i}", [JPEG, JPEG])  # head + wrist
-        context.absorb(message, model_response({"text": "ok"}), latest_only_images=[1])
+        context.commit(context.open_turn(f"turn {i}", HEAD_AND_WRIST), model_response({"text": "ok"}))
 
     user_turns = [c for c in context._history if c["role"] == "user"]
     assert [images_in(c) for c in user_turns] == [1, 1, 2]
@@ -200,18 +211,14 @@ def test_absorb_keeps_only_the_newest_wrist_frame():
 def test_wrist_frame_survives_turns_without_one():
     # The arm camera going stale must not orphan-prune the one wrist frame left.
     context = make_context(max_image_turns=3)
-    context.absorb(
-        GeminiContext.user_message("with wrist", [JPEG, JPEG]),
-        model_response({"text": "ok"}),
-        latest_only_images=[1],
-    )
-    context.absorb(GeminiContext.user_message("head only", [JPEG]), model_response({"text": "ok"}))
+    context.commit(context.open_turn("with wrist", HEAD_AND_WRIST), model_response({"text": "ok"}))
+    context.commit(context.open_turn("head only", HEAD), model_response({"text": "ok"}))
     user_turns = [c for c in context._history if c["role"] == "user"]
     assert [images_in(c) for c in user_turns] == [2, 1]
 
 
 def test_generate_ships_exactly_one_wrist_frame():
-    # Absorb's prune runs only after the response, so without send-time masking
+    # Commit's prune runs only after the response, so without send-time masking
     # every request would carry the previous turn's wrist frame plus the new one.
     captured = {}
 
@@ -220,18 +227,14 @@ def test_generate_ships_exactly_one_wrist_frame():
         return [model_response({"text": "ok"})]
 
     context = make_context(transport, max_image_turns=3)
-    context.absorb(
-        GeminiContext.user_message("turn 1", [JPEG, JPEG]),
-        model_response({"text": "ok"}),
-        latest_only_images=[1],
-    )
-    context.generate(GeminiContext.user_message("turn 2", [JPEG, JPEG]), [], "S", latest_only_images=[1])
+    context.commit(context.open_turn("turn 1", HEAD_AND_WRIST), model_response({"text": "ok"}))
+    context.generate(context.open_turn("turn 2", HEAD_AND_WRIST), [], "S")
 
     contents = captured["contents"]
     assert images_in(contents[0]) == 1  # previous turn on the wire: head frame only
     assert any("wrist camera frame removed" in p.get("text", "") for p in contents[0]["parts"])
     assert images_in(contents[-1]) == 2  # the new message: head + wrist
-    # Stored history is untouched until absorb commits the exchange.
+    # Stored history is untouched until commit stores the exchange.
     assert images_in(context._history[0]) == 2
 
 
@@ -243,12 +246,8 @@ def test_generate_keeps_the_old_wrist_frame_when_this_turn_has_none():
         return [model_response({"text": "ok"})]
 
     context = make_context(transport, max_image_turns=3)
-    context.absorb(
-        GeminiContext.user_message("turn 1", [JPEG, JPEG]),
-        model_response({"text": "ok"}),
-        latest_only_images=[1],
-    )
-    context.generate(GeminiContext.user_message("turn 2", [JPEG]), [], "S", latest_only_images=[])
+    context.commit(context.open_turn("turn 1", HEAD_AND_WRIST), model_response({"text": "ok"}))
+    context.generate(context.open_turn("turn 2", HEAD), [], "S")
     assert images_in(captured["contents"][0]) == 2  # arm camera stale: last wrist frame still shown
 
 
@@ -258,8 +257,8 @@ def test_generate_taps_the_exact_request_body():
     context = make_context(lambda model, body: [model_response({"text": "ok"})])
     seen = []
     context.on_request = seen.append
-    context.absorb(user_turn("earlier", True), model_response({"text": "old"}))
-    context.generate(user_turn("now", True), tools=[{"functionDeclarations": []}], system="sys")
+    context.commit(user_turn(context, "earlier", True), model_response({"text": "old"}))
+    context.generate(user_turn(context, "now", True), tools=[], system="sys")
     (body,) = seen
     assert body["systemInstruction"]["parts"][0]["text"] == "sys"
     assert [c["role"] for c in body["contents"]] == ["user", "model", "user"]
@@ -269,7 +268,7 @@ def test_generate_taps_the_exact_request_body():
 def test_prune_with_zero_image_turns_strips_every_frame():
     context = make_context(max_image_turns=0)
     for i in range(3):
-        context.absorb(user_turn(f"turn {i}", with_image=True), model_response({"text": "ok"}))
+        context.commit(user_turn(context, f"turn {i}", with_image=True), model_response({"text": "ok"}))
     user_turns = [c for c in context._history if c["role"] == "user"]
     assert all(images_in(c) == 0 for c in user_turns)
 
@@ -277,7 +276,9 @@ def test_prune_with_zero_image_turns_strips_every_frame():
 def test_prune_caps_history_and_never_starts_on_orphaned_function_response():
     context = make_context(max_history=4)
     for i in range(6):
-        decision = context.absorb(user_turn(f"turn {i}", False), model_response(call_part("wave", {}, f"c{i}")))
+        decision = context.commit(
+            user_turn(context, f"turn {i}", False), model_response(call_part("wave", {}, f"c{i}"))
+        )
         context.add_tool_outcomes([(decision.calls[0], "started")])
 
     history = context._history
@@ -286,10 +287,10 @@ def test_prune_caps_history_and_never_starts_on_orphaned_function_response():
     assert not any("functionResponse" in p for p in history[0]["parts"])
 
 
-def test_absorb_drops_thought_parts_from_stored_history():
+def test_commit_drops_thought_parts_from_stored_history():
     context = make_context()
-    context.absorb(
-        user_turn("hi", False),
+    context.commit(
+        user_turn(context, "hi", False),
         model_response({"text": "planning...", "thought": True}, {"text": "Hello!"}),
     )
     model_turn = context._history[-1]
@@ -299,15 +300,15 @@ def test_absorb_drops_thought_parts_from_stored_history():
 
 def test_clear_empties_history():
     context = make_context()
-    context.absorb(user_turn("hi", False), model_response({"text": "hello"}))
+    context.commit(user_turn(context, "hi", False), model_response({"text": "hello"}))
     context.clear()
     assert context._history == []
 
 
 def test_tool_outcomes_are_recorded_as_function_responses():
     context = make_context()
-    decision = context.absorb(
-        user_turn("go", False), model_response(call_part("navigate_to_position", {"x": 1}, "abc"))
+    decision = context.commit(
+        user_turn(context, "go", False), model_response(call_part("navigate_to_position", {"x": 1}, "abc"))
     )
     context.add_tool_outcomes([(decision.calls[0], "started")])
     part = context._history[-1]["parts"][0]["functionResponse"]
@@ -326,10 +327,10 @@ def test_generate_builds_a_complete_native_request():
 
     context = make_context(transport=transport)
     tools = build_tools(assign_tool_names([WAVE_SKILL]), None)
-    context.generate(user_turn("hello", True), tools, "SYSTEM")
+    context.generate(user_turn(context, "hello", True), tools, "SYSTEM")
     assert captured["model"] == "test-model"
     assert captured["systemInstruction"] == {"parts": [{"text": "SYSTEM"}]}
-    assert captured["tools"] == tools
+    assert captured["tools"] == wire.tools_block(tools)
     assert captured["generationConfig"]["thinkingConfig"] == {"includeThoughts": True}
     assert images_in(captured["contents"][-1]) == 1
 
@@ -341,8 +342,8 @@ def test_generate_sets_thinking_level_when_configured():
         captured.update(body)
         return [model_response({"text": "ok"})]
 
-    context = GeminiContext(transport, model="m", thinking_level="high", max_history=10, max_image_turns=2)
-    context.generate(user_turn("hi", False), [], "S")
+    context = GeminiConversation(transport, model="m", thinking_level="high", max_history=10, max_image_turns=2)
+    context.generate(user_turn(context, "hi", False), [], "S")
     assert captured["generationConfig"]["thinkingConfig"] == {"includeThoughts": True, "thinkingLevel": "high"}
 
 
@@ -355,7 +356,7 @@ def test_generate_streams_speech_deltas_and_assembles_the_response():
     ]
     heard = []
     context = make_context(transport=lambda model, body: iter(chunks))
-    response = context.generate(user_turn("hi", False), [], "S", on_speech=heard.append)
+    response = context.generate(user_turn(context, "hi", False), [], "S", on_speech=heard.append)
 
     assert heard == ["One. ", "Two"]  # thoughts never reach the speech stream
     parts = response["candidates"][0]["content"]["parts"]
@@ -373,16 +374,16 @@ def test_generate_raises_on_an_empty_stream_instead_of_committing_silence():
     blocked = {"promptFeedback": {"blockReason": "SAFETY"}}
     context = make_context(transport=lambda model, body: iter([blocked]))
     with pytest.raises(RuntimeError, match="SAFETY"):
-        context.generate(user_turn("hi", False), [], "S")
+        context.generate(user_turn(context, "hi", False), [], "S")
 
     empty_candidate = {"candidates": [{"finishReason": "MALFORMED_FUNCTION_CALL"}]}
     context = make_context(transport=lambda model, body: iter([empty_candidate]))
     with pytest.raises(RuntimeError, match="MALFORMED_FUNCTION_CALL"):
-        context.generate(user_turn("hi", False), [], "S")
+        context.generate(user_turn(context, "hi", False), [], "S")
 
     context = make_context(transport=lambda model, body: iter([]))
     with pytest.raises(RuntimeError, match="empty stream"):
-        context.generate(user_turn("hi", False), [], "S")
+        context.generate(user_turn(context, "hi", False), [], "S")
 
 
 # ---------- visual grounding (pixel -> floor target) ----------
@@ -466,8 +467,9 @@ def agent_factory(monkeypatch):
         logger = SimpleNamespace(info=lambda *a: None, warn=lambda *a: None, error=lambda *a: None)
         node = SimpleNamespace(get_logger=lambda: logger)
         config = SimpleNamespace(
-            gemini_model="m",
-            gemini_thinking_level="",
+            brain_backend="gemini",
+            brain_model="m",
+            brain_thinking_level="",
             history_max_entries=60,
             history_max_image_turns=2,
             idle_turn_interval=3.0,
@@ -681,7 +683,7 @@ def test_go_to_point_rejects_out_of_range_coordinates(agent_factory):
 
 
 def test_chat_failure_after_commit_still_answers_the_models_calls(agent_factory, monkeypatch):
-    # emit_thoughts raising after absorb() must not leave the functionCall
+    # emit_thoughts raising after commit() must not leave the function call
     # unanswered in history — that would poison every later request.
     agent, state = agent_factory()
     no_pause(agent, monkeypatch)

--- a/ros2_ws/src/brain/brain_client/test/test_node_boot.launch.py
+++ b/ros2_ws/src/brain/brain_client/test/test_node_boot.launch.py
@@ -105,7 +105,7 @@ class TestNodesBoot(unittest.TestCase):
         self.assertIn("current_directive", status)
 
         health = json.loads(self._wait_for_message("/brain/websocket_status", String, timeout_sec=30.0).data)
-        # No Gemini credentials in CI: the local brain must say so truthfully
+        # No model credentials in CI: the local brain must say so truthfully
         # rather than crash or claim readiness.
-        self.assertIn(health.get("backend"), ("unconfigured", "innate-proxy", "gemini-direct"))
+        self.assertIn(health.get("backend"), ("unconfigured", "innate-proxy", "gemini-direct", "openai-direct"))
         self.assertIn("connected", health)

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -21,8 +21,8 @@ import numpy as np
 import pytest
 
 from brain_client.brain import memory_search as memory_search_module
+from brain_client.brain.llm.gemini.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
 from brain_client.brain.memory_search import MemorySearch, verdict_text
-from brain_client.brain.transport import CACHED_CONTENTS_PATH, GeminiHttpError, GeminiRest
 from brain_client.memory import recorder as recorder_module
 from brain_client.memory import selection as selection_module
 from brain_client.memory.coverage import Coverage, wedge_mask

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -86,12 +86,15 @@ PUBLISHED_PORT_ENV = {
     "SIM_UDP_PORT": str(SIM_UDP_PORT),
     "SIM_FOXGLOVE_PORT": str(SIM_FOXGLOVE_PORT),
 }
-# How brain_client reaches Gemini: through the Innate proxy with a service key,
-# straight at Google with a Gemini key, or not at all.
+# How brain_client reaches its model: through the Innate proxy with a service
+# key, straight at a vendor with that vendor's own key, or not at all.
 INNATE_BACKEND = "innate"
 GEMINI_BACKEND = "gemini"
+OPENAI_BACKEND = "openai"
 NO_BACKEND = "none"
 GEMINI_API_KEY = "GEMINI_API_KEY"
+OPENAI_API_KEY = "OPENAI_API_KEY"
+BRAIN_BACKEND = "BRAIN_BACKEND"  # which provider the robot's brain thinks with
 INNATE_SERVICE_KEY = "INNATE_SERVICE_KEY"
 AUTO_OS_IMAGE = "auto"
 LOCAL_OS_IMAGE = "local"
@@ -238,7 +241,7 @@ LEGACY_SHARED_CONTAINER = "innate-dev"
 LEGACY_SHARED_PROJECT = "innate-os"
 LEGACY_CLOUD_AGENT_CONTAINER = "innate-cloud-agent"
 OS_CONTAINER_TMUX_CMD = "./scripts/launch_sim_in_tmux.zsh --detach"
-SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY)
+SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY, OPENAI_API_KEY)
 LOG_TARGETS = {
     "bootstrap": BOOTSTRAP_LOG_PATH,
     "compose": COMPOSE_LOG_PATH,
@@ -461,17 +464,23 @@ def get_nested_bool(data: dict[str, object], *keys: str) -> bool | None:
 
 
 def resolve_brain_backend(env: dict[str, str]) -> str:
-    """Which key the in-process brain (brain_client) will use to reach Gemini.
+    """Which key the in-process brain (brain_client) will use to reach its model.
 
-    The service key wins: it also buys voice, which a Gemini key does not.
-    brain_client's `Backend` (brain/transport.py) makes the real choice and owns
-    this precedence; the launcher runs on the host and cannot import it, so this
-    restates the rule. Change one and change the other.
+    The service key wins: it also buys voice, and it covers every provider,
+    which a vendor key does not. Below it, the vendor key that matches
+    BRAIN_BACKEND is the one the brain will actually use — a key for the other
+    vendor leaves it unconfigured, which is what this reports.
+
+    brain_client's `pick_conversation` (brain/llm/__init__.py) makes the real
+    choice and owns this precedence; the launcher runs on the host and cannot
+    import it, so this restates the rule. Change one and change the other.
     """
     if is_configured_secret_value(INNATE_SERVICE_KEY, env.get(INNATE_SERVICE_KEY, "")):
         return INNATE_BACKEND
-    if is_configured_secret_value(GEMINI_API_KEY, env.get(GEMINI_API_KEY, "")):
-        return GEMINI_BACKEND
+    provider = (env.get(BRAIN_BACKEND, "") or GEMINI_BACKEND).strip().lower()
+    vendor_key = OPENAI_API_KEY if provider == OPENAI_BACKEND else GEMINI_API_KEY
+    if is_configured_secret_value(vendor_key, env.get(vendor_key, "")):
+        return OPENAI_BACKEND if provider == OPENAI_BACKEND else GEMINI_BACKEND
     return NO_BACKEND
 
 

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -201,7 +201,8 @@ def cmd_up(
         if config["brain_backend"] == NO_BACKEND:
             warn("No cloud LLM key configured — the sim is running WITHOUT an agent.")
             warn(
-                "Add GEMINI_API_KEY (your own Gemini key) or INNATE_SERVICE_KEY (Innate proxy) to "
+                "Add GEMINI_API_KEY or OPENAI_API_KEY (your own vendor key, matching the "
+                "brain_backend setting) or INNATE_SERVICE_KEY (Innate proxy) to "
                 f"{ENV_PATH}, or run `{CLI_SIM} setup`, then restart."
             )
         success("Innate sim runtime is up.")

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -2998,7 +2998,7 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
     elif config["brain_backend"] == INNATE_BACKEND:
         llm_level, llm_label = "healthy", "innate proxy"
     else:
-        llm_level, llm_label = "healthy", "gemini key"
+        llm_level, llm_label = "healthy", f"{config['brain_backend']} key"
 
     if all(level == "healthy" for level in (world_level, sim_level, transport_level, brain_level, llm_level)):
         stack_mood = ("healthy", "LIVE")

--- a/sim/launcher/setup_wizard.py
+++ b/sim/launcher/setup_wizard.py
@@ -20,6 +20,7 @@ from config import (
     OPENAI_API_KEY,
     OPENAI_BACKEND,
     SECRET_ENV_KEYS,
+    SETTINGS_PATH,
     is_configured_secret_value,
     success,
     warn,
@@ -404,7 +405,11 @@ def apply_brain_backend(config: dict[str, object], backend: str, key: str) -> No
     if backend in _VENDOR_KEYS:
         _save_vendor_key(config, _VENDOR_KEYS[backend], key)
         _select_provider(config, backend)
-        _disable_keys(config, [INNATE_SERVICE_KEY, *_other_vendor_keys(backend)])
+        # Only the service key is disabled. The other vendor's key is harmless
+        # now that brain_backend picks the provider, and leaving it is what
+        # keeps a brain_backend pinned in settings.yaml -- which is layered
+        # over BRAIN_BACKEND -- from landing on a provider with no key at all.
+        _disable_keys(config, [INNATE_SERVICE_KEY])
     elif backend == INNATE_BACKEND:
         # The proxy serves every provider, so the choice of provider is left
         # wherever it already stands.
@@ -419,18 +424,19 @@ def apply_brain_backend(config: dict[str, object], backend: str, key: str) -> No
 _VENDOR_KEYS = {GEMINI_BACKEND: GEMINI_API_KEY, OPENAI_BACKEND: OPENAI_API_KEY}
 
 
-def _other_vendor_keys(backend: str) -> list[str]:
-    return [key for name, key in _VENDOR_KEYS.items() if name != backend]
-
-
 def _select_provider(config: dict[str, object], backend: str) -> None:
     """Point the robot's brain at this vendor. A vendor key only works for its
-    own provider, so choosing the key has to choose the provider with it."""
+    own provider, so choosing the key has to choose the provider with it.
+
+    settings.yaml is layered over .env, so report what was written rather than
+    promising what the node will pick.
+    """
     write_env_value(ENV_PATH, BRAIN_BACKEND, backend)
     raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
     user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
     raw_env[BRAIN_BACKEND] = backend
     user_env[BRAIN_BACKEND] = backend
+    success(f"Set {BRAIN_BACKEND}={backend} in {ENV_PATH.name} (a brain_backend in {SETTINGS_PATH.name} wins over it).")
 
 
 def configure_brain_backend(config: dict[str, object]) -> None:
@@ -490,7 +496,7 @@ def configure_brain_backend(config: dict[str, object]) -> None:
         backend = GEMINI_BACKEND if choice == "1" else OPENAI_BACKEND
         _configure_vendor_key(config, _VENDOR_KEYS[backend])
         _select_provider(config, backend)
-        _disable_keys(config, [INNATE_SERVICE_KEY, *_other_vendor_keys(backend)])
+        _disable_keys(config, [INNATE_SERVICE_KEY])
     elif choice == "3":
         _configure_service_key(config)
         _disable_keys(config, list(_VENDOR_KEYS.values()))

--- a/sim/launcher/setup_wizard.py
+++ b/sim/launcher/setup_wizard.py
@@ -9,10 +9,16 @@ import sys
 from pathlib import Path
 
 from config import (
+    BRAIN_BACKEND,
     CLI_SIM,
     ENV_PATH,
     GEMINI_API_KEY,
+    GEMINI_BACKEND,
+    INNATE_BACKEND,
     INNATE_SERVICE_KEY,
+    NO_BACKEND,
+    OPENAI_API_KEY,
+    OPENAI_BACKEND,
     SECRET_ENV_KEYS,
     is_configured_secret_value,
     success,
@@ -271,42 +277,43 @@ def _prompt_choice(question: str, options: dict[str, str], *, default: str) -> s
         print(f"{YELLOW}Please choose one of: {', '.join(options)}.{NC}")
 
 
-def _save_gemini_key(config: dict[str, object], gemini_key: str) -> None:
-    write_env_value(ENV_PATH, GEMINI_API_KEY, gemini_key)
+def _save_vendor_key(config: dict[str, object], env_key: str, value: str) -> None:
+    write_env_value(ENV_PATH, env_key, value)
     raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
     user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
-    raw_env[GEMINI_API_KEY] = gemini_key
-    user_env[GEMINI_API_KEY] = gemini_key
-    success(f"Saved {GEMINI_API_KEY} to {ENV_PATH}.")
+    raw_env[env_key] = value
+    user_env[env_key] = value
+    success(f"Saved {env_key} to {ENV_PATH}.")
 
 
-def _configure_gemini_key(config: dict[str, object]) -> None:
+def _configure_vendor_key(config: dict[str, object], env_key: str) -> None:
+    """Collect one vendor's own API key (Gemini or OpenAI) into .env."""
     user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
-    if is_configured_secret_value(GEMINI_API_KEY, user_env.get(GEMINI_API_KEY)):
-        if not _prompt_yes_no(f"{GEMINI_API_KEY} is already set. Replace it?", default=False):
+    if is_configured_secret_value(env_key, user_env.get(env_key)):
+        if not _prompt_yes_no(f"{env_key} is already set. Replace it?", default=False):
             return
     else:
-        restored = uncomment_env_key(ENV_PATH, GEMINI_API_KEY)
+        restored = uncomment_env_key(ENV_PATH, env_key)
         if restored is not None:
             raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
-            raw_env[GEMINI_API_KEY] = restored
-            user_env[GEMINI_API_KEY] = restored
-            success(f"Re-enabled {GEMINI_API_KEY} in {ENV_PATH.name}.")
+            raw_env[env_key] = restored
+            user_env[env_key] = restored
+            success(f"Re-enabled {env_key} in {ENV_PATH.name}.")
             return
 
-        shell_value = os.environ.get(GEMINI_API_KEY, "").strip()
-        if is_configured_secret_value(GEMINI_API_KEY, shell_value) and _prompt_yes_no(
-            f"Found {GEMINI_API_KEY} in your shell. Save it to {ENV_PATH.name}?", default=True
+        shell_value = os.environ.get(env_key, "").strip()
+        if is_configured_secret_value(env_key, shell_value) and _prompt_yes_no(
+            f"Found {env_key} in your shell. Save it to {ENV_PATH.name}?", default=True
         ):
-            _save_gemini_key(config, shell_value)
+            _save_vendor_key(config, env_key, shell_value)
             return
 
     while True:
-        gemini_key = _prompt_secret(f"Paste {GEMINI_API_KEY}")
-        if is_configured_secret_value(GEMINI_API_KEY, gemini_key):
-            _save_gemini_key(config, gemini_key)
+        value = _prompt_secret(f"Paste {env_key}")
+        if is_configured_secret_value(env_key, value):
+            _save_vendor_key(config, env_key, value)
             return
-        warn("Gemini key cannot be empty. Press Ctrl+C to cancel.")
+        warn(f"{env_key} cannot be empty. Press Ctrl+C to cancel.")
 
 
 def _configure_service_key(config: dict[str, object]) -> None:
@@ -383,7 +390,7 @@ def report_configured_keys(config: dict[str, object]) -> None:
         warn(f"No brain keys set in {ENV_PATH.name}.")
 
 
-BRAIN_BACKENDS = ("gemini", "innate", "none")
+BRAIN_BACKENDS = (GEMINI_BACKEND, OPENAI_BACKEND, INNATE_BACKEND, NO_BACKEND)
 
 
 def apply_brain_backend(config: dict[str, object], backend: str, key: str) -> None:
@@ -394,29 +401,51 @@ def apply_brain_backend(config: dict[str, object], backend: str, key: str) -> No
     collects the answer only -- which key goes in .env, and which get commented
     out, stays here, so there is one implementation of that.
     """
-    if backend == "gemini":
-        _save_gemini_key(config, key)
-        _disable_keys(config, [INNATE_SERVICE_KEY])
-    elif backend == "innate":
+    if backend in _VENDOR_KEYS:
+        _save_vendor_key(config, _VENDOR_KEYS[backend], key)
+        _select_provider(config, backend)
+        _disable_keys(config, [INNATE_SERVICE_KEY, *_other_vendor_keys(backend)])
+    elif backend == INNATE_BACKEND:
+        # The proxy serves every provider, so the choice of provider is left
+        # wherever it already stands.
         _save_service_key(config, key)
-        _disable_keys(config, [GEMINI_API_KEY])
+        _disable_keys(config, list(_VENDOR_KEYS.values()))
     else:
-        _disable_keys(config, [GEMINI_API_KEY, INNATE_SERVICE_KEY])
+        _disable_keys(config, [*_VENDOR_KEYS.values(), INNATE_SERVICE_KEY])
         warn("No brain backend selected. The sim will run without an agent.")
     report_configured_keys(config)
 
 
+_VENDOR_KEYS = {GEMINI_BACKEND: GEMINI_API_KEY, OPENAI_BACKEND: OPENAI_API_KEY}
+
+
+def _other_vendor_keys(backend: str) -> list[str]:
+    return [key for name, key in _VENDOR_KEYS.items() if name != backend]
+
+
+def _select_provider(config: dict[str, object], backend: str) -> None:
+    """Point the robot's brain at this vendor. A vendor key only works for its
+    own provider, so choosing the key has to choose the provider with it."""
+    write_env_value(ENV_PATH, BRAIN_BACKEND, backend)
+    raw_env: dict[str, str] = config["raw_env"]  # type: ignore[assignment]
+    user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
+    raw_env[BRAIN_BACKEND] = backend
+    user_env[BRAIN_BACKEND] = backend
+
+
 def configure_brain_backend(config: dict[str, object]) -> None:
-    """Pick how the robot's brain reaches Gemini, and collect the matching key.
+    """Pick how the robot's brain reaches its model, and collect the matching key.
 
     The agent loop itself always runs on the robot (brain_client); the key only
-    decides which way out it takes -- straight to Google with a Gemini key, or
-    through the Innate proxy with a service key. Switching just uncomments the
-    relevant key and comments out the others, so you can toggle back and forth
-    without re-pasting. Non-interactively, just report what the robot will pick.
+    decides which way out it takes -- straight to a vendor with that vendor's
+    key, or through the Innate proxy with a service key. Switching just
+    uncomments the relevant key and comments out the others, so you can toggle
+    back and forth without re-pasting. Non-interactively, just report what the
+    robot will pick.
     """
     user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
     has_gemini = is_configured_secret_value(GEMINI_API_KEY, user_env.get(GEMINI_API_KEY))
+    has_openai = is_configured_secret_value(OPENAI_API_KEY, user_env.get(OPENAI_API_KEY))
     has_service_key = is_configured_secret(user_env.get(INNATE_SERVICE_KEY))
 
     if not is_interactive_terminal():
@@ -424,10 +453,12 @@ def configure_brain_backend(config: dict[str, object]) -> None:
             success("Innate proxy selected (INNATE_SERVICE_KEY detected).")
         elif has_gemini:
             success("Direct Gemini access selected (GEMINI_API_KEY detected).")
+        elif has_openai:
+            success("Direct OpenAI access selected (OPENAI_API_KEY detected).")
         else:
             warn(
-                f"No brain key configured. Add GEMINI_API_KEY (your own Gemini key) or "
-                f"INNATE_SERVICE_KEY (Innate proxy) to {ENV_PATH}."
+                f"No brain key configured. Add GEMINI_API_KEY or OPENAI_API_KEY (your own vendor "
+                f"key) or INNATE_SERVICE_KEY (Innate proxy) to {ENV_PATH}."
             )
         report_configured_keys(config)
         return
@@ -437,31 +468,34 @@ def configure_brain_backend(config: dict[str, object]) -> None:
     print(
         f"{DIM}The robot's agent runs on the robot, but thinks with a cloud LLM.\n"
         f"Choose how it reaches one:\n"
-        f"  - Your own Gemini key: the agent calls Google directly. Everything\n"
-        f"    works except voice.\n"
-        f"  - Innate service key (ships with a MARS robot): the agent calls Gemini\n"
+        f"  - Your own Gemini or OpenAI key: the agent calls that vendor directly.\n"
+        f"    Everything works except voice.\n"
+        f"  - Innate service key (ships with a MARS robot): the agent calls the model\n"
         f"    through Innate's proxy. Full experience, including the robot's voice.\n"
         f"  - None: drive, navigate, and trigger skills manually, with no agent.{NC}"
     )
     print()
-    default_choice = "2" if has_service_key else "1"
+    default_choice = "3" if has_service_key else "1"
     choice = _prompt_choice(
         "How would you like to access the cloud LLM?",
         {
             "1": "Your own Gemini key (get one at https://aistudio.google.com/api-keys)",
-            "2": "Innate service key (from your robot)",
-            "3": "None (run the sim without an agent)",
+            "2": "Your own OpenAI key (get one at https://platform.openai.com/api-keys)",
+            "3": "Innate service key (from your robot)",
+            "4": "None (run the sim without an agent)",
         },
         default=default_choice,
     )
-    if choice == "1":
-        _configure_gemini_key(config)
-        _disable_keys(config, [INNATE_SERVICE_KEY])
-    elif choice == "2":
+    if choice in ("1", "2"):
+        backend = GEMINI_BACKEND if choice == "1" else OPENAI_BACKEND
+        _configure_vendor_key(config, _VENDOR_KEYS[backend])
+        _select_provider(config, backend)
+        _disable_keys(config, [INNATE_SERVICE_KEY, *_other_vendor_keys(backend)])
+    elif choice == "3":
         _configure_service_key(config)
-        _disable_keys(config, [GEMINI_API_KEY])
+        _disable_keys(config, list(_VENDOR_KEYS.values()))
     else:
-        _disable_keys(config, [GEMINI_API_KEY, INNATE_SERVICE_KEY])
+        _disable_keys(config, [*_VENDOR_KEYS.values(), INNATE_SERVICE_KEY])
         warn("No brain backend selected. The sim will run without an agent.")
 
     report_configured_keys(config)

--- a/sim/launcher/setup_wizard.py
+++ b/sim/launcher/setup_wizard.py
@@ -22,6 +22,7 @@ from config import (
     SECRET_ENV_KEYS,
     SETTINGS_PATH,
     is_configured_secret_value,
+    resolve_brain_backend,
     success,
     warn,
 )
@@ -450,22 +451,22 @@ def configure_brain_backend(config: dict[str, object]) -> None:
     robot will pick.
     """
     user_env: dict[str, str] = config["user_env"]  # type: ignore[assignment]
-    has_gemini = is_configured_secret_value(GEMINI_API_KEY, user_env.get(GEMINI_API_KEY))
-    has_openai = is_configured_secret_value(OPENAI_API_KEY, user_env.get(OPENAI_API_KEY))
-    has_service_key = is_configured_secret(user_env.get(INNATE_SERVICE_KEY))
+    # Both vendor keys can be saved at once, so which one is live cannot be read
+    # off key presence. resolve_brain_backend owns that precedence; asking it is
+    # what keeps this report and the runtime dashboard from disagreeing.
+    backend = resolve_brain_backend(user_env)
 
     if not is_interactive_terminal():
-        if has_service_key:
+        if backend == INNATE_BACKEND:
             success("Innate proxy selected (INNATE_SERVICE_KEY detected).")
-        elif has_gemini:
-            success("Direct Gemini access selected (GEMINI_API_KEY detected).")
-        elif has_openai:
-            success("Direct OpenAI access selected (OPENAI_API_KEY detected).")
-        else:
+        elif backend == NO_BACKEND:
             warn(
-                f"No brain key configured. Add GEMINI_API_KEY or OPENAI_API_KEY (your own vendor "
-                f"key) or INNATE_SERVICE_KEY (Innate proxy) to {ENV_PATH}."
+                f"No brain key configured for {BRAIN_BACKEND}={user_env.get(BRAIN_BACKEND) or GEMINI_BACKEND}. "
+                f"Add GEMINI_API_KEY or OPENAI_API_KEY (your own vendor key) or INNATE_SERVICE_KEY "
+                f"(Innate proxy) to {ENV_PATH}."
             )
+        else:
+            success(f"Direct {backend} access selected ({_VENDOR_KEYS[backend]} detected).")
         report_configured_keys(config)
         return
 
@@ -481,7 +482,7 @@ def configure_brain_backend(config: dict[str, object]) -> None:
         f"  - None: drive, navigate, and trigger skills manually, with no agent.{NC}"
     )
     print()
-    default_choice = "3" if has_service_key else "1"
+    default_choice = {INNATE_BACKEND: "3", OPENAI_BACKEND: "2"}.get(backend, "1")
     choice = _prompt_choice(
         "How would you like to access the cloud LLM?",
         {

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -113,6 +113,11 @@ const TIMEZONE_OPTIONS = [
   { value: "UTC", label: "UTC" },
 ];
 
+const BRAIN_BACKEND_OPTIONS = [
+  { value: "gemini", label: "Gemini" },
+  { value: "openai", label: "OpenAI" },
+];
+
 const VAD_ENGINE_OPTIONS = [
   { value: "silero", label: "Silero (neural)" },
   { value: "energy", label: "Energy threshold" },
@@ -335,7 +340,10 @@ export const SETTINGS_PAGES = [
         title: "AI models",
         note: "The brain and the speech-to-text path use separate models. The transcribe backend picks which STT model knob applies.",
         knobs: [
-          { path: ["brain_client_node", P, "gemini_model"], label: "Brain model", default: "gemini-3.6-flash", type: "string", doc: "Gemini model powering the local brain", subsection: "Brain" },
+          { path: ["brain_client_node", P, "brain_backend"], label: "Brain provider", default: "gemini", type: "string", options: BRAIN_BACKEND_OPTIONS, doc: "Which provider the local brain thinks with. Without an Innate service key it needs that vendor's own key in .env", subsection: "Brain" },
+          { path: ["brain_client_node", P, "brain_model"], label: "Brain model", default: "gemini-3.6-flash", type: "string", doc: "Model powering the local brain. Must belong to the chosen provider", subsection: "Brain" },
+          { path: ["brain_client_node", P, "brain_thinking_level"], label: "Thinking level", default: "minimal", type: "string", doc: "Named in the provider's own vocabulary: gemini takes minimal/low/medium/high, openai none/low/medium/high/xhigh/max. Blank uses the model default", subsection: "Brain" },
+          { path: ["brain_client_node", P, "memory_model"], label: "Spatial memory model", default: "gemini-3.6-flash", type: "string", doc: "Memory search needs Gemini context caching, so it stays on Gemini whichever provider the brain uses", subsection: "Brain" },
           { path: ["input_manager_node", P, "stt_backend"], label: "Transcribe backend", default: "elevenlabs", type: "string", options: STT_BACKEND_OPTIONS, doc: "Which service transcribes the microphone", subsection: "Speech to text" },
           { path: ["input_manager_node", P, "stt_vad_engine"], label: "VAD engine", default: "silero", type: "string", options: VAD_ENGINE_OPTIONS, doc: "Local voice detector, every backend", subsection: "Speech to text" },
           { path: ["input_manager_node", P, "elevenlabs_batch_stt_model"], label: "Scribe batch model", default: "scribe_v2", type: "string", doc: "ElevenLabs model for the elevenlabs_batch backend", subsection: "Speech to text" },

--- a/workspace/inputs/micro_input.py
+++ b/workspace/inputs/micro_input.py
@@ -40,7 +40,7 @@ import time
 
 import numpy as np
 
-from brain_client.brain.transport import pick_rest
+from brain_client.brain.llm.gemini.transport import pick_rest
 from brain_client.common.logging import UniversalLogger
 from brain_client.inputs.batch_stt import (
     DEFAULT_KEYTERMS,


### PR DESCRIPTION
The brain could only think with Gemini. This puts a provider seam under the
agent loop and an OpenAI backend behind it, so `brain_backend: openai` with a
`gpt-6-astra`-class model is a setting rather than a fork.

## The seam

The loop now talks to a `Conversation`; everything vendor-shaped lives under
`brain/llm/`:

```
llm/types.py     the vocabulary: Conversation, Decision, ToolCall, ToolSpec
llm/tools.py     skill metadata -> tool specs, in plain JSON Schema
llm/gemini/      transport, wire, context (today's behaviour, moved)
llm/openai/      transport, wire, context (the Responses API)
```

Two of the four things that cross it are opaque `dict` payloads: a pending turn
and a raw response. Only the conversation that produced them may read them,
because a Gemini thought signature and an OpenAI reasoning item both have to be
echoed back verbatim and neither can be rebuilt from a `Decision`. They ride
back through the agent rather than being latched on the conversation, for the
reason the old `last_usage` comment already gave.

The agent got smaller: it no longer computes wrist-frame indexes and threads
them through generate and absorb, and it traces tool specs instead of indexing
into a `functionDeclarations` block.

## OpenAI specifics worth reviewing

- **Responses, not Chat Completions.** Chat Completions is stateless and drops
  reasoning items, which OpenAI documents as costing tool-call quality and
  extra reasoning tokens in loops like this one.
- **`store: false` and a self-managed input list.** OpenAI's headline advice is
  `store: true` with `previous_response_id`; that is deliberately declined,
  because server-held state cannot be masked or evicted and rewriting its own
  history is this conversation's whole job. The self-managed branch is the one
  they support for exactly this case, and `store: false` keeps camera frames
  off their servers while reasoning items come back with `encrypted_content`.
- **Stale reasoning items are not stripped per turn.** Rewriting the tail every
  turn would forfeit the prompt-cache prefix on every request, which costs more
  than carrying them until compaction. Compaction cuts at a user message so no
  turn is ever split.

## What stays on Gemini

Spatial memory search and the frame-file tier need context caching and the
Files API. `memory_model` is now its own setting and stays on Gemini whichever
provider the agent runs on.

## Settings migration

`gemini_model` / `gemini_thinking_level` become `brain_model` /
`brain_thinking_level`, beside a new `brain_backend`. A robot's settings.yaml
still carries the old names, so `load` reads them and warns rather than
silently reverting that robot to the default model. Same for `GEMINI_MODEL` in
.env.

The thinking level stays in each provider's own vocabulary rather than going
through a mapping table that would pretend the levels correspond. A value
carried across providers falls back to the model default with a warning. The
measured `minimal` default is Gemini's; OpenAI levels need their own
measurement before anyone should trust one on the 3 s loop.

The sim launcher recognises `OPENAI_API_KEY` and its wizard offers it. Picking
a vendor key also sets the provider, since a vendor key only works for its own.
Its two near-identical key flows became one parameterized function.

## Known gap, not fixed here

The proxy's OpenAI adapter buffers the whole generation before it emits, so
speech through the proxy arrives only once the reply finishes. A direct key
streams sentence by sentence. That belongs in innate-cloud's adapter; the
transport docstring says so.

## Verification

| check | result |
|---|---|
| `ruff check` + `format --check` | clean |
| ROS-free pytest suite | 101 passed |
| basedpyright vs the base commit | no new findings |

The five extra basedpyright lines are unresolved `httpx` / rclpy imports that a
clean worktree of the base commit reports the same way.

The OpenAI conversation was driven with a fake event stream, checking the
request body, streamed speech deltas, reasoning summary as thoughts,
JSON-string call arguments, the tool answer keyed by call id, and all three
pruning cases matching the Gemini conversation exactly.
