### PR TITLE
Remove trajectory overlay button from camera views

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -1927,12 +1927,6 @@ body:has(.agent-indicator:not([hidden], [data-off-route])) .tgt-hud {
     display: grid;
   }
 
-  /* A driving aid for a stage you can see the floor in. Doubled up to
-     outrank .icon-toggle's own display, set further down. */
-  .icon-toggle.traj-toggle {
-    display: none;
-  }
-
   .cam-strip.collapsed {
     display: none;
   }

--- a/webapp/js/agent/main.js
+++ b/webapp/js/agent/main.js
@@ -251,13 +251,11 @@ function buildAgentView(root) {
       },
     },
   ];
-  // Watching the agent drive is where the projected route earns its keep. The
-  // agent panel owns the right edge here, so the toggle joins the top-left
-  // stack instead of a rail.
+  // Project the planned route onto the main camera while the agent drives.
   const ribbonStage = realVideo?.el ?? feedFrame.querySelector(".video-stage");
   if (ribbonStage instanceof HTMLElement) {
     parts.push(
-      createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, cornerStack, ros, session),
+      createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, ros, session),
       createTargetingOverlay(ribbonStage, realVideo?.videoEl ?? null, session),
     );
   }

--- a/webapp/js/teleop/main.js
+++ b/webapp/js/teleop/main.js
@@ -113,7 +113,7 @@ function buildCockpit(root) {
   const ribbonStage = realVideo?.el ?? root.querySelector(".video-stage");
   if (ribbonStage instanceof HTMLElement) {
     parts.push(
-      createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, rightRail, ros, session),
+      createTrajectoryOverlay(ribbonStage, realVideo?.videoEl ?? null, ros, session),
       createTargetingOverlay(ribbonStage, realVideo?.videoEl ?? null, session),
     );
   }

--- a/webapp/js/teleop/trajectoryOverlay.js
+++ b/webapp/js/teleop/trajectoryOverlay.js
@@ -75,7 +75,6 @@ const ANCHOR_NEAR_M = 0.4;
 // Nearer than this the ground point is level with or behind the lens and has no
 // image position at all — the one case that genuinely breaks the route.
 const NEAR_PLANE_M = 0.1;
-const STORE_KEY = "innate.trajOverlay";
 
 /** @param {number} pitchDeg @returns {number} height above the floor in metres */
 export function cameraHeight(pitchDeg) {
@@ -288,27 +287,15 @@ export function primaryCameraName(session) {
  * @param {HTMLVideoElement | null} video the stage's video element (frame size
  *   + fit) on hardware; null in sim, where a Three.js canvas renders the same
  *   head camera at the stage's own size
- * @param {HTMLElement} rail right-edge overlay that hosts the toggle
  * @param {import("../rosClient.js").RosClient} ros
  * @param {import("../webrtcSession.js").WebRtcSession} session
  * @returns {{ destroy: () => void }}
  */
-export function createTrajectoryOverlay(stage, video, rail, ros, session) {
+export function createTrajectoryOverlay(stage, video, ros, session) {
   const canvas = document.createElement("canvas");
   canvas.className = "traj-canvas";
   stage.appendChild(canvas);
   const ctx = canvas.getContext("2d");
-
-  const button = document.createElement("button");
-  button.className = "icon-toggle traj-toggle";
-  button.type = "button";
-  button.innerHTML =
-    '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
-    '<circle cx="6" cy="19" r="2.5"/>' +
-    '<path d="M8.5 19h8a3.5 3.5 0 0 0 0-7h-9a3.5 3.5 0 0 1 0-7H15"/>' +
-    '<circle cx="18" cy="5" r="2.5"/>' +
-    "</svg>";
-  rail.appendChild(button);
 
   /** @type {Array<{ x: number, y: number }> | null} plan points in their own frame */
   let plan = null;
@@ -489,46 +476,12 @@ export function createTrajectoryOverlay(stage, video, rail, ros, session) {
   video?.addEventListener("resize", schedule);
   const unsubSession = session.onChange(schedule);
 
-  /** @type {Array<() => void>} */
-  let unsubs = [];
-  let enabled = true;
-  try {
-    enabled = localStorage.getItem(STORE_KEY) !== "0";
-  } catch {
-    // Default on when storage is unavailable.
-  }
-
-  function apply() {
-    button.classList.toggle("active", enabled);
-    button.title = enabled
-      ? `Trajectory overlay on — planned route on the camera (${PLAN_TOPICS.join(" · ")})`
-      : "Trajectory overlay off — click to project the planned route onto the camera";
-    button.setAttribute("aria-pressed", String(enabled));
-    button.setAttribute("aria-label", "Trajectory overlay");
-    if (enabled && !unsubs.length) {
-      unsubs = [
-        ...PLAN_TOPICS.map((t) => ros.subscribe(t, (msg) => onPlan(t, msg), 250, "nav_msgs/msg/Path")),
-        ros.subscribe(ODOM_TOPIC, onOdom, 100, "nav_msgs/msg/Odometry"),
-        ros.subscribe(AMCL_POSE_TOPIC, onAmcl, 0, "geometry_msgs/msg/PoseWithCovarianceStamped"),
-        ros.subscribe(HEAD_CURRENT_POSITION_TOPIC, onHead, undefined, "std_msgs/msg/String"),
-      ];
-    } else if (!enabled) {
-      for (const unsub of unsubs) unsub();
-      unsubs = [];
-      clearPlan();
-    }
-  }
-  apply();
-
-  button.addEventListener("click", () => {
-    enabled = !enabled;
-    try {
-      localStorage.setItem(STORE_KEY, enabled ? "1" : "0");
-    } catch {
-      // The toggle still applies when storage is unavailable.
-    }
-    apply();
-  });
+  const unsubs = [
+    ...PLAN_TOPICS.map((t) => ros.subscribe(t, (msg) => onPlan(t, msg), 250, "nav_msgs/msg/Path")),
+    ros.subscribe(ODOM_TOPIC, onOdom, 100, "nav_msgs/msg/Odometry"),
+    ros.subscribe(AMCL_POSE_TOPIC, onAmcl, 0, "geometry_msgs/msg/PoseWithCovarianceStamped"),
+    ros.subscribe(HEAD_CURRENT_POSITION_TOPIC, onHead, undefined, "std_msgs/msg/String"),
+  ];
 
   return {
     destroy() {
@@ -539,7 +492,6 @@ export function createTrajectoryOverlay(stage, video, rail, ros, session) {
       clearTimeout(staleTimer);
       cancelAnimationFrame(raf);
       canvas.remove();
-      button.remove();
     },
   };
 }


### PR DESCRIPTION
## Summary

Remove the trajectory-overlay button shown beside the main camera from the Agent and Teleop views. Keep the planned-route overlay enabled automatically, and remove the obsolete toggle preference, button styling, and rail argument.

## Validation

- [x] JavaScript syntax checks for all three changed modules and `git diff --check` pass.
- [x] Ran `node --test webapp/tests/*.test.js`: six test files pass; the preload test fails for the same three missing entries on both this branch and `main` (`agentSheet.js`, `keyboardInset.js`, and `targetingOverlay.js`).
- [x] Ran the webapp TypeScript check and compared against `main`: diagnostics are identical; no new type errors.
- Simulator startup and asset publishing are not applicable: no simulator code, config, or assets changed. No live robot validation performed.
