### PR TITLE
Story: offer the custom character as a highlighted card

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -11639,6 +11639,16 @@ body.story-active { grid-template-columns: minmax(0, 1fr); }
   background: #fff; color: #3d2aa8; font-size: 12px; font-weight: 650;
 }
 .agent-offer-go svg { width: 14px; height: 14px; stroke-width: 2.4; }
+/* Write your own: across the deck under the characters, in the story's amber, so the typed
+   path reads as an option and not as a fallback. */
+.agent-offer-card.custom {
+  --offer-hue: var(--accent);
+  grid-column: 1 / -1; grid-template-columns: 36px minmax(0, 1fr) auto;
+  background: linear-gradient(135deg, rgb(232 163 61 / 22%), rgb(232 163 61 / 8%));
+  border: 1px dashed color-mix(in srgb, var(--accent) 70%, transparent);
+}
+.agent-offer-card.custom:hover { background: linear-gradient(135deg, rgb(232 163 61 / 32%), rgb(232 163 61 / 14%)); border-color: var(--accent); }
+.agent-offer-card.custom .agent-offer-go { background: var(--accent); color: #1a1206; }
 .agent-offers-row { display: flex; flex-wrap: wrap; gap: 6px; }
 .agent-offer-chip {
   display: inline-flex; align-items: center; gap: 6px;

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -11639,16 +11639,6 @@ body.story-active { grid-template-columns: minmax(0, 1fr); }
   background: #fff; color: #3d2aa8; font-size: 12px; font-weight: 650;
 }
 .agent-offer-go svg { width: 14px; height: 14px; stroke-width: 2.4; }
-/* Write your own: across the deck under the characters, in the story's amber, so the typed
-   path reads as an option and not as a fallback. */
-.agent-offer-card.custom {
-  --offer-hue: var(--accent);
-  grid-column: 1 / -1; grid-template-columns: 36px minmax(0, 1fr) auto;
-  background: linear-gradient(135deg, rgb(232 163 61 / 22%), rgb(232 163 61 / 8%));
-  border: 1px dashed color-mix(in srgb, var(--accent) 70%, transparent);
-}
-.agent-offer-card.custom:hover { background: linear-gradient(135deg, rgb(232 163 61 / 32%), rgb(232 163 61 / 14%)); border-color: var(--accent); }
-.agent-offer-card.custom .agent-offer-go { background: var(--accent); color: #1a1206; }
 .agent-offers-row { display: flex; flex-wrap: wrap; gap: 6px; }
 .agent-offer-chip {
   display: inline-flex; align-items: center; gap: 6px;

--- a/webapp/js/agent/agentStudio.js
+++ b/webapp/js/agent/agentStudio.js
@@ -188,7 +188,7 @@ export function createAgentStudio(root, agentState, session, panel, opts) {
   promptRow.innerHTML =
     '<span class="microlabel">Prompt</span>' +
     '<textarea rows="2" maxlength="240" aria-label="Robot personality prompt" placeholder="Who is this robot? e.g. a butler who has seen better days"></textarea>' +
-    '<button type="submit">Make it so</button>';
+    '<button type="submit">Become this</button>';
   const promptInput = /** @type {HTMLTextAreaElement} */ (promptRow.querySelector("textarea"));
 
   // The agent's prompt as its file holds it; editable when the file is the form's own.

--- a/webapp/js/agent/agentStudio.js
+++ b/webapp/js/agent/agentStudio.js
@@ -14,7 +14,7 @@
 
 import { closeIn, cue } from "./cue.js";
 import { createOfferDeck } from "./offerDeck.js";
-import { personaCard, skillCard } from "./storyCards.js";
+import { ICONS, personaCard, skillCard } from "./storyCards.js";
 
 // The left side of the stage holds one open panel at a time: the scene setup and the
 // challenges already trade places through this event (simStage.ts, challengePanel.js), and
@@ -559,6 +559,19 @@ export function createAgentStudio(root, agentState, session, panel, opts) {
     onSelect: () => void grant(skill),
   });
 
+  /** The custom character is typed where the persona lives: the panel's prompt, or the
+   *  composer where there is no panel. */
+  function focusPrompt() {
+    if (compact) {
+      panel.focusComposer();
+      return;
+    }
+    tab = "identity";
+    render(true);
+    promptInput.focus();
+    promptInput.scrollIntoView({ block: "nearest" });
+  }
+
   /** @param {string} persona */
   function choose(persona) {
     if (persona === lastChoice.text && Date.now() - lastChoice.at < 5000) return;
@@ -630,9 +643,14 @@ export function createAgentStudio(root, agentState, session, panel, opts) {
         title: `Who is ${name}?`,
         chips: [
           ...personas.map(pick),
+          {
+            text: "Write your own",
+            kind: /** @type {const} */ ("custom"),
+            icon: ICONS.pen,
+            detail: "Describe the character in your words",
+            onSelect: focusPrompt,
+          },
           { text: "Surprise me", kind: "random", onSelect: () => choose(personas[Math.floor(Math.random() * personas.length)]) },
-          // The panel has the prompt right there; only the chat's deck needs a way to the composer.
-          ...(compact ? [{ text: "Write your own", kind: /** @type {const} */ ("custom"), onSelect: () => panel.focusComposer() }] : []),
         ],
       };
     }
@@ -999,7 +1017,7 @@ export function createAgentStudio(root, agentState, session, panel, opts) {
     // the skills. The chat keeps the replies, and everything when there is no panel.
     const { chips, title: ask } = offers();
     panelEl.dataset.chips = chipReason;
-    const toPanel = compact ? [] : chips.filter((c) => c.kind === "persona" || c.kind === "grant" || c.kind === "random");
+    const toPanel = compact ? [] : chips.filter((c) => c.kind !== "reply");
     const askKey = toPanel.filter((c) => c.kind !== "random").map((c) => `${c.kind}:${c.text}`).join("|");
     if (askKey !== deckKey) {
       deckKey = askKey;

--- a/webapp/js/agent/agentStudio.js
+++ b/webapp/js/agent/agentStudio.js
@@ -188,7 +188,7 @@ export function createAgentStudio(root, agentState, session, panel, opts) {
   promptRow.innerHTML =
     '<span class="microlabel">Prompt</span>' +
     '<textarea rows="2" maxlength="240" aria-label="Robot personality prompt" placeholder="Who is this robot? e.g. a butler who has seen better days"></textarea>' +
-    '<button type="submit">Become this</button>';
+    '<button type="submit">Set character</button>';
   const promptInput = /** @type {HTMLTextAreaElement} */ (promptRow.querySelector("textarea"));
 
   // The agent's prompt as its file holds it; editable when the file is the form's own.

--- a/webapp/js/agent/agentStudio.js
+++ b/webapp/js/agent/agentStudio.js
@@ -562,14 +562,18 @@ export function createAgentStudio(root, agentState, session, panel, opts) {
   /** The custom character is typed where the persona lives: the panel's prompt, or the
    *  composer where there is no panel. */
   function focusPrompt() {
-    if (compact) {
-      panel.focusComposer();
-      return;
-    }
-    tab = "identity";
-    render(true);
-    promptInput.focus();
-    promptInput.scrollIntoView({ block: "nearest" });
+    // press-activate fires this on pointerdown, and the press then focuses the card itself:
+    // move the cursor a frame later, once that has happened.
+    requestAnimationFrame(() => {
+      if (compact) {
+        panel.focusComposer();
+        return;
+      }
+      tab = "identity";
+      render(true);
+      promptInput.focus();
+      promptInput.scrollIntoView({ block: "nearest" });
+    });
   }
 
   /** @param {string} persona */
@@ -647,7 +651,7 @@ export function createAgentStudio(root, agentState, session, panel, opts) {
             text: "Write your own",
             kind: /** @type {const} */ ("custom"),
             icon: ICONS.pen,
-            detail: "Describe the character in your words",
+            detail: "In your own words.",
             onSelect: focusPrompt,
           },
           { text: "Surprise me", kind: "random", onSelect: () => choose(personas[Math.floor(Math.random() * personas.length)]) },

--- a/webapp/js/agent/offerDeck.js
+++ b/webapp/js/agent/offerDeck.js
@@ -8,12 +8,12 @@
 import { cue } from "./cue.js";
 import { ICONS } from "./storyCards.js";
 
-/** persona and grant are cards; the rest are chips. @typedef {"persona" | "grant" | "reply" | "random" | "custom"} OfferKind */
+/** persona, custom and grant are cards; the rest are chips. @typedef {"persona" | "grant" | "reply" | "random" | "custom"} OfferKind */
 /** `text` is what selecting it means (and sends); `label` is what the card says instead, when shorter.
  * @typedef {{ text: string, kind: OfferKind, label?: string, detail?: string, icon?: string, hue?: string, onSelect: (text: string) => void }} Offer */
 
-const CARD_KINDS = new Set(["persona", "grant"]);
-const CHIP_ICONS = /** @type {Partial<Record<OfferKind, string>>} */ ({ random: ICONS.dice, custom: ICONS.pen });
+const CARD_KINDS = new Set(["persona", "custom", "grant"]);
+const CHIP_ICONS = /** @type {Partial<Record<OfferKind, string>>} */ ({ random: ICONS.dice });
 
 /** @returns {{ el: HTMLElement, set: (offers: Offer[], title?: string) => void }} */
 export function createOfferDeck() {
@@ -44,7 +44,8 @@ export function createOfferDeck() {
     button.innerHTML =
       `<span class="agent-offer-icon">${offer.icon ?? ICONS.sparkle}</span>` +
       '<span class="agent-offer-copy"><span class="agent-offer-name"></span><span class="agent-offer-detail"></span></span>' +
-      (offer.kind === "grant" ? `<span class="agent-offer-go">${ICONS.plus}<span>Grant</span></span>` : "");
+      (offer.kind === "grant" ? `<span class="agent-offer-go">${ICONS.plus}<span>Grant</span></span>` : "") +
+      (offer.kind === "custom" ? `<span class="agent-offer-go">${ICONS.pen}<span>Type</span></span>` : "");
     /** @type {HTMLElement} */ (button.querySelector(".agent-offer-name")).textContent = offer.label ?? offer.text;
     /** @type {HTMLElement} */ (button.querySelector(".agent-offer-detail")).textContent = offer.detail ?? "";
     button.addEventListener("click", () => offer.onSelect(offer.text));

--- a/webapp/js/agent/offerDeck.js
+++ b/webapp/js/agent/offerDeck.js
@@ -44,8 +44,7 @@ export function createOfferDeck() {
     button.innerHTML =
       `<span class="agent-offer-icon">${offer.icon ?? ICONS.sparkle}</span>` +
       '<span class="agent-offer-copy"><span class="agent-offer-name"></span><span class="agent-offer-detail"></span></span>' +
-      (offer.kind === "grant" ? `<span class="agent-offer-go">${ICONS.plus}<span>Grant</span></span>` : "") +
-      (offer.kind === "custom" ? `<span class="agent-offer-go">${ICONS.pen}<span>Type</span></span>` : "");
+      (offer.kind === "grant" ? `<span class="agent-offer-go">${ICONS.plus}<span>Grant</span></span>` : "");
     /** @type {HTMLElement} */ (button.querySelector(".agent-offer-name")).textContent = offer.label ?? offer.text;
     /** @type {HTMLElement} */ (button.querySelector(".agent-offer-detail")).textContent = offer.detail ?? "";
     button.addEventListener("click", () => offer.onSelect(offer.text));


### PR DESCRIPTION
## Why

In the intro's identity step, the four persona cards were the only thing that read as an option. On desktop, writing your own character meant noticing the unlabelled Prompt box under the deck; on phones a small "Write your own" chip sat next to "Surprise me".

## What

- "Write your own" is now a full-width card under the characters, in the story's amber with a dashed border and a **Type** button, on every layout.
- Selecting it puts the cursor in the panel's prompt textarea (desktop), or in the chat composer (compact/phone), where the existing "Make it so" / send path takes the typed prompt.
- `offerDeck` treats `custom` as a card kind; the pen icon moves from chip to card.

## Verified

- Live sim, `innate:play-intro`, desktop (1440 px): card renders under the persona grid; clicking it focuses the Prompt textarea, typed text lands there.
- Compact (600 px): card renders in the chat's deck; clicking it focuses the composer.
- `tsc --noEmit -p webapp/tsconfig.json`: no new errors in the touched files (same 4 pre-existing lines before and after).

| Desktop | Phone |
|---|---|
| card under the 2×2 persona grid, Prompt box below | card in the bottom sheet's deck, above "Surprise me" |