### PR TITLE
fix(mars_cam): the nav funnel must be visible without a subscriber

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/pointcloud.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/pointcloud.cpp
@@ -345,10 +345,23 @@ void StereoDepthEstimator::publishPointCloudNav(const cv::Mat& disparity_lowres,
         last_evidence_stamp_ = ts;
         evidence_stats = evidence_.integrate(observations, dt);
         marks = evidence_.confirmed();
+        // Five stages that all fail by silently dropping points, so without a
+        // line in the log the only symptom is an empty topic and no clue which
+        // stage ate them. The stats topic carries the same funnel in machine
+        // form, but only while something subscribes — this is what the operator
+        // standing next to the robot sees in `innate view`.
+        RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                             "nav cloud: %zu in corridor -> %zu voxels -> %zu supported -> %zu confirmed "
+                             "(mean weight %.3f, %zu tracked)",
+                             evidence_stats.observations, evidence_stats.voxels_seen, evidence_stats.voxels_supported,
+                             evidence_stats.confirmed, evidence_stats.mean_weight, evidence_stats.tracked);
     } else {
         marks.reserve(observations.size());
         for (const auto& o : observations)
             marks.push_back({o.x, o.y, o.z});
+        RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                             "nav cloud: %zu in corridor -> %zu published (evidence filter OFF)", observations.size(),
+                             marks.size());
     }
 
     if (pointcloud_nav_stats_pub_->get_subscription_count() > 0) {


### PR DESCRIPTION
The five-stage funnel log in `publishPointCloudNav` was replaced by a `DiagnosticArray` topic, which only publishes while something subscribes. In the ordinary case — an operator watching `innate view` next to the robot — that means **nothing at all** is reported about the nav path, and every stage in that path fails by silently dropping points.

Both now: the topic for machine consumption, a 2 s throttled line for the human.

The passthrough branch (`evidence.enabled: false`) gets its own line rather than reporting zeros through the evidence-shaped one, since "evidence filter OFF" and "evidence filter found nothing" are different problems that should not look identical in a log.

## Verification

Not compiled — this file needs VPI, which is Jetson-only. Format-string arity and types checked by hand against the `IntegrateStats` members; the added lines are `clang-format` clean against `ros2_ws/.clang-format`.

Base: `nikita/camera-depth-obstacle-avoidance`. First of three stacked PRs.

https://claude.ai/code/session_01ShVeyid4YVPthaFuGXrX3m