### PR TITLE
fix(mars_cam): stop asserting depth memory where the camera cannot look

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
+++ b/ros2_ws/src/mars_bot/mars_cam/config/stereo_depth_estimator.yaml
@@ -191,6 +191,18 @@ arm_camera_driver:
     # 1m and 24cm at 2m. A far point should not carry a near point's authority.
     evidence.confidence_full_trust_m: 0.8
     evidence.confidence_no_trust_m: 2.0
+    # How far from base_link a REMEMBERED voxel may still be asserted.
+    #
+    # Confirmed voxels are republished every frame until their score decays, so
+    # an obstacle survives a maneuver that carries it out of the corridor. The
+    # cost is that memory is asserted where the camera is not looking, where
+    # odom drift moves it and nothing can correct it. Bounding by the corridor
+    # would delete the maneuver memory, so this bounds by range instead.
+    #
+    # 1.2m holds an obstacle the robot is steering around, and sits under STVL's
+    # obstacle_range of 1.5m — beyond that the point is discarded downstream
+    # anyway, so publishing it only invites drift.
+    evidence.publish_radius_m: 1.20
 
     # ── Online floor estimation ───────────────────────────────────────────
     #

--- a/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/stereo_depth_estimator.hpp
+++ b/ros2_ws/src/mars_bot/mars_cam/include/mars_cam/stereo_depth_estimator.hpp
@@ -239,6 +239,7 @@ class StereoDepthEstimator : public rclcpp::Node {
     bool evidence_enabled_{true};
     double confidence_full_trust_m_{0.8};
     double confidence_no_trust_m_{2.0};
+    double evidence_publish_radius_m_{1.20};
 
     std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
     std::shared_ptr<tf2_ros::TransformListener> tf_listener_;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/pointcloud.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/depth_estimator/pointcloud.cpp
@@ -345,23 +345,51 @@ void StereoDepthEstimator::publishPointCloudNav(const cv::Mat& disparity_lowres,
         last_evidence_stamp_ = ts;
         evidence_stats = evidence_.integrate(observations, dt);
         marks = evidence_.confirmed();
-        // Five stages that all fail by silently dropping points, so without a
-        // line in the log the only symptom is an empty topic and no clue which
-        // stage ate them. The stats topic carries the same funnel in machine
-        // form, but only while something subscribes — this is what the operator
-        // standing next to the robot sees in `innate view`.
-        RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
-                             "nav cloud: %zu in corridor -> %zu voxels -> %zu supported -> %zu confirmed "
-                             "(mean weight %.3f, %zu tracked)",
-                             evidence_stats.observations, evidence_stats.voxels_seen, evidence_stats.voxels_supported,
-                             evidence_stats.confirmed, evidence_stats.mean_weight, evidence_stats.tracked);
     } else {
         marks.reserve(observations.size());
         for (const auto& o : observations)
             marks.push_back({o.x, o.y, o.z});
+    }
+
+    // Confirmed cells live in the evidence frame and are republished every
+    // frame for as long as their score survives — that is what remembers an
+    // obstacle through a maneuver that carries it out of the corridor. The cost
+    // is that memory is asserted where the camera is not currently looking, so
+    // odom drift moves it and no observation can correct it.
+    //
+    // Bounding by the corridor would delete the maneuver memory outright, so
+    // the bound is a radius about base_link: far enough to hold an obstacle the
+    // robot is steering around, and no further than STVL's obstacle_range, past
+    // which the point is discarded downstream anyway. Range is taken in the
+    // ground plane, since a tall obstacle must not fall out of the bound for
+    // being tall.
+    const cv::Matx33f odom_to_base = R_odom.t();
+    const float radius_sq = static_cast<float>(evidence_publish_radius_m_ * evidence_publish_radius_m_);
+    std::vector<cv::Vec3f> published;
+    published.reserve(marks.size());
+    for (const auto& m : marks) {
+        const cv::Vec3f in_base = odom_to_base * (cv::Vec3f(m[0], m[1], m[2]) - t_odom);
+        if (in_base[0] * in_base[0] + in_base[1] * in_base[1] > radius_sq)
+            continue;
+        published.push_back(in_base);
+    }
+
+    // Six stages that all fail by silently dropping points, so without a line
+    // in the log the only symptom is an empty topic and no clue which stage ate
+    // them. The stats topic carries the same funnel in machine form, but only
+    // while something subscribes — this is what the operator standing next to
+    // the robot sees in `innate view`.
+    if (evidence_enabled_) {
+        RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+                             "nav cloud: %zu in corridor -> %zu voxels -> %zu supported -> %zu confirmed "
+                             "-> %zu published (mean weight %.3f, %zu tracked)",
+                             evidence_stats.observations, evidence_stats.voxels_seen, evidence_stats.voxels_supported,
+                             evidence_stats.confirmed, published.size(), evidence_stats.mean_weight,
+                             evidence_stats.tracked);
+    } else {
         RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
                              "nav cloud: %zu in corridor -> %zu published (evidence filter OFF)", observations.size(),
-                             marks.size());
+                             published.size());
     }
 
     if (pointcloud_nav_stats_pub_->get_subscription_count() > 0) {
@@ -391,7 +419,9 @@ void StereoDepthEstimator::publishPointCloudNav(const cv::Mat& disparity_lowres,
         append_size("voxels_supported", evidence_enabled_ ? evidence_stats.voxels_supported : 0);
         append_size("confirmed", evidence_enabled_ ? evidence_stats.confirmed : 0);
         append_size("tracked", evidence_enabled_ ? evidence_stats.tracked : 0);
-        append_size("published_points", marks.size());
+        append_size("published_points", published.size());
+        append_size("dropped_beyond_radius", marks.size() - published.size());
+        append_float("publish_radius_m", evidence_publish_radius_m_);
         append_float("mean_weight", weighted_points ? weight_sum / static_cast<double>(weighted_points) : 0.0);
         append_float("mean_match_confidence", weighted_points ? match_confidence_sum / static_cast<double>(weighted_points) : 0.0);
         append_float("min_match_confidence", weighted_points ? match_confidence_min : 0.0);
@@ -410,27 +440,25 @@ void StereoDepthEstimator::publishPointCloudNav(const cv::Mat& disparity_lowres,
     // observation's sensor origin from the cloud's frame, so an odom-stamped
     // cloud would put that origin at the odom origin — and obstacle_range would
     // then reject everything once the robot drove away from where odom started.
-    const cv::Matx33f odom_to_base = R_odom.t();
     auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
     cloud->header.stamp = ts;
     cloud->header.frame_id = nav_frame_;
     cloud->height = 1;
-    cloud->width = static_cast<uint32_t>(marks.size());
+    cloud->width = static_cast<uint32_t>(published.size());
     cloud->is_dense = true;
     cloud->is_bigendian = false;
 
     sensor_msgs::PointCloud2Modifier mod(*cloud);
     mod.setPointCloud2FieldsByString(1, "xyz");
-    mod.resize(marks.size());
+    mod.resize(published.size());
 
     sensor_msgs::PointCloud2Iterator<float> ix(*cloud, "x");
     sensor_msgs::PointCloud2Iterator<float> iy(*cloud, "y");
     sensor_msgs::PointCloud2Iterator<float> iz(*cloud, "z");
-    for (const auto& m : marks) {
-        const cv::Vec3f in_base = odom_to_base * (cv::Vec3f(m[0], m[1], m[2]) - t_odom);
-        *ix = in_base[0];
-        *iy = in_base[1];
-        *iz = in_base[2];
+    for (const auto& p : published) {
+        *ix = p[0];
+        *iy = p[1];
+        *iz = p[2];
         ++ix;
         ++iy;
         ++iz;

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_depth_estimator.cpp
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_depth_estimator.cpp
@@ -95,6 +95,7 @@ StereoDepthEstimator::StereoDepthEstimator(const rclcpp::NodeOptions& options)
     this->declare_parameter<double>("evidence.max_score", 10.0);
     this->declare_parameter<double>("evidence.confidence_full_trust_m", 0.8);
     this->declare_parameter<double>("evidence.confidence_no_trust_m", 2.0);
+    this->declare_parameter<double>("evidence.publish_radius_m", 1.20);
 
     // VPI creation parameters
     this->declare_parameter<int>("max_disparity", 64);
@@ -171,6 +172,7 @@ StereoDepthEstimator::StereoDepthEstimator(const rclcpp::NodeOptions& options)
     evidence_frame_ = this->get_parameter("evidence.frame").as_string();
     confidence_full_trust_m_ = this->get_parameter("evidence.confidence_full_trust_m").as_double();
     confidence_no_trust_m_ = this->get_parameter("evidence.confidence_no_trust_m").as_double();
+    evidence_publish_radius_m_ = this->get_parameter("evidence.publish_radius_m").as_double();
     {
         EvidenceParams ep;
         ep.voxel_size = this->get_parameter("evidence.voxel_size").as_double();


### PR DESCRIPTION
`EvidenceGrid::confirmed()` returns **every** believed voxel in the map with no spatial bound, and `publishPointCloudNav` republished all of them every frame until their score decayed.

Those cells accumulate in `odom`, so the ones outside the current view are carried by odom drift with no observation able to correct them. A mark that was right when it was made slides somewhere it never was, and is then re-asserted to STVL as fresh sensor data for as long as it survives — up to `(max_score - clear_threshold) / decay_per_second` = ~9.5 s. Because we re-assert every frame, STVL's own `voxel_decay: 2.0` never expires it either.

## Why a radius and not the corridor

Bounding by the corridor would undo `a2787ad2` (remember depth obstacles through a maneuver), which is the entire point of the memory — the robot steers around an obstacle, it leaves the corridor, and it must not be forgotten.

So the bound is range instead: **1.2 m about `base_link`**, taken in the ground plane so a tall obstacle cannot fall out of the bound for being tall.

- Far enough to hold an obstacle the robot is steering around. Passing alongside one puts it at ~0.45 m, and behind at ~0.64 m — both comfortably inside.
- No further than STVL's `obstacle_range` of 1.5 m, past which the point is discarded downstream regardless, so publishing it only invites drift.
- In-corridor observations reach at most `hypot(1.00, 0.22)` = **1.02 m**, so this only ever trims memory, never a live detection.

The case this gives up is a remembered obstacle more than 1.2 m behind the robot while reversing. The camera faces forward and had no recent evidence there anyway — that is lidar's job.

## Observability

The funnel log and the stats topic both gained the published count, plus `dropped_beyond_radius` and `publish_radius_m`, so the gap between `confirmed` and `published` is visible rather than inferred.

## Verification

Not compiled — `pointcloud.cpp` needs VPI, which is Jetson-only. The inverse transform `R_odomᵀ · (p − t_odom)` is unchanged from the existing code; only what it is applied to and when. Added lines are `clang-format` clean.

Base: `nikita/depth-nav-log-line`. Second of three stacked PRs.

https://claude.ai/code/session_01ShVeyid4YVPthaFuGXrX3m