### PR TITLE
sim: `up` asks the store what the world needs, not what built it

### DIFF
--- a/sim/README.md
+++ b/sim/README.md
@@ -616,6 +616,18 @@ tag moves, CI builds it once, and every later publish of the same tag is
 skipped outright. To change the geometry, edit the pipeline in `sim/tools/`
 (see [`sandbox/README.md`](sandbox/README.md)) and push; CI rebuilds it.
 
+**A moved tag does not stop `up`.** It cannot: our CI does not build for forks,
+so "push the branch" is not a remedy everyone has. What gates the launch is the
+environment's manifest — `physics`, `navigation` and the browser assets it names
+— against `sim/assets` and `sim/viewer/public`. A store that answers the manifest
+launches, whatever tag it came from, which is why a spawn-pose edit costs nothing
+(the driver reads manifests live) and a driver edit that renames the image reuses
+the geometry it did not change. With nothing installed and nothing published for
+the checkout, the launcher installs the published `main` geometry and says which
+of your changes are not in it. Only a world the store genuinely cannot load
+refuses, naming the paths it wanted. Regenerating those locally is
+[`sandbox/README.md`](sandbox/README.md).
+
 ### Credits
 
 The apartment environment is derived from ["Appartement"](https://sketchfab.com/3d-models/appartement-6a7a5fe208344b2e8123a88923dbd5b3) by [SrMonteiro](https://sketchfab.com/crispimrafael), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Changes were made: split per room, convex-decomposed for collision, re-exported for rendering (GLB/MuJoCo meshes), and rasterized into a navigation map.

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import ast
+import dataclasses
 import functools
 import hashlib
+import json
 import os
 import shutil
 import subprocess
@@ -221,6 +223,14 @@ SIM_ASSET_UNITS_AUTHORED = (
     "objects",
 )
 SIM_ASSET_UNITS = SIM_ASSET_UNITS_DERIVED + SIM_ASSET_UNITS_AUTHORED
+# The published geometry to install when nothing built this checkout's tag. A
+# fork cannot push a branch for our CI to build, so the alternative is refusing
+# to start over inputs that may not touch geometry at all.
+ASSETS_FALLBACK_TAG = "main"
+# The two roots mars_sim_driver.environments reads, `environments.local`
+# gitignored for licensed packs. Manifests are loaded LIVE from the checkout,
+# so a spawn pose or a display name is not something `up` can be missing.
+ENVIRONMENT_MANIFEST_ROOTS = ("environments", "environments.local")
 # This file is deliberately NOT in ASSETS_IMAGE_INPUT_FILES -- that would retag
 # the asset image on every unrelated launcher edit. Safe only because
 # tests/test_assets_image_inputs.py holds the dockerignore (which IS hashed)
@@ -583,6 +593,71 @@ def compute_assets_image_inputs_hash(repo_root: Path) -> str:
 
 def resolve_assets_image(repo_root: Path) -> str:
     return f"{DEFAULT_SIM_ASSETS_IMAGE}:inputs-{compute_assets_image_inputs_hash(repo_root)}"
+
+
+def resolve_fallback_assets_image() -> str:
+    return f"{DEFAULT_SIM_ASSETS_IMAGE}:{ASSETS_FALLBACK_TAG}"
+
+
+@dataclasses.dataclass(frozen=True)
+class EnvironmentAssets:
+    """What one environment needs on disk, per install root.
+
+    The contract `up` gates on. A content hash over sim/environments and
+    sim/tools answers a different question -- was this store built from these
+    bytes -- and answers it wrongly for the common cases: a manifest the driver
+    reads live, or an edit to a pipeline whose output the launched world never
+    loads.
+    """
+
+    assets: tuple[str, ...]  # under sim/assets
+    viewer: tuple[str, ...]  # under sim/viewer/public
+
+
+def environment_manifest_path(repo_root: Path, environment_id: str) -> Path:
+    candidates = [repo_root / "sim" / root / environment_id / "manifest.json" for root in ENVIRONMENT_MANIFEST_ROOTS]
+    return next((path for path in candidates if path.is_file()), candidates[0])
+
+
+def available_environment_ids(repo_root: Path) -> list[str]:
+    sim = repo_root / "sim"
+    return sorted(
+        {path.parent.name for root in ENVIRONMENT_MANIFEST_ROOTS for path in (sim / root).glob("*/manifest.json")}
+    )
+
+
+def _viewer_paths(viewer: dict[str, str]) -> tuple[str, ...]:
+    """The browser assets whose absence means this pack is not installed.
+
+    Not every path the manifest names: the apartment names a monolith glb that
+    sim/Dockerfile.assets deliberately does not ship, because scene.ts streams
+    per-room files from `manifest` and falls back to the monolith only when
+    that is absent. Requiring it would refuse a healthy install.
+    """
+    keys = ("collision_dir",) if "manifest" in viewer else ("collision_dir", "model")
+    return tuple(str(viewer[key]) for key in keys if key in viewer)
+
+
+def read_environment_assets(repo_root: Path, environment_id: str) -> EnvironmentAssets | None:
+    """None when no manifest describes `environment_id`, or it does not parse.
+
+    Not an error here: the driver reports a broken pack against the world it
+    was asked to load, with the available ids -- far better than a launcher
+    gate can, and refusing to start is the behaviour being removed.
+    """
+    try:
+        manifest = json.loads(environment_manifest_path(repo_root, environment_id).read_text(encoding="utf-8"))
+        physics, viewer = manifest["physics"], manifest["viewer"]
+        return EnvironmentAssets(
+            assets=(
+                str(physics["collision_dir"]),
+                str(physics["visual_dir"]),
+                str(manifest["navigation"]["map_yaml"]),
+            ),
+            viewer=_viewer_paths(viewer),
+        )
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return None
 
 
 @functools.lru_cache

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -629,12 +629,13 @@ def available_environment_ids(repo_root: Path) -> list[str]:
 def _viewer_paths(viewer: dict[str, str]) -> tuple[str, ...]:
     """The browser assets whose absence means this pack is not installed.
 
-    Not every path the manifest names: the apartment names a monolith glb that
-    sim/Dockerfile.assets deliberately does not ship, because scene.ts streams
-    per-room files from `manifest` and falls back to the monolith only when
-    that is absent. Requiring it would refuse a healthy install.
+    Every path the manifest names except the one the image does not ship: the
+    apartment's monolith glb is scene.ts's fallback for a missing room
+    manifest, and sim/Dockerfile.assets deliberately leaves it out, so
+    requiring it would refuse a healthy install. Where the rooms are streamed,
+    the manifest and the directory it streams from are what must be there.
     """
-    keys = ("collision_dir",) if "manifest" in viewer else ("collision_dir", "model")
+    keys = ("manifest", "base_dir", "collision_dir") if "manifest" in viewer else ("model", "collision_dir")
     return tuple(str(viewer[key]) for key in keys if key in viewer)
 
 

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -62,6 +62,7 @@ from runtime import (
     tail_file,
     wait_for_os_runtime_ready,
     wait_for_virtual_mars,
+    warn_unloadable_environments,
     world_server_running,
 )
 from setup_wizard import (
@@ -148,9 +149,10 @@ def cmd_up(
                     f"`{CLI_SIM} up --offline` to start with whatever is already downloaded."
                 ) from exc
         with live_step("viewer", "Downloading the 3D view assets", "3D view assets"):
-            ensure_viewer_public_assets(config)
+            ensure_viewer_public_assets(config, offline=offline)
         with live_step("bundle", "Fetching the 3D viewer bundle", "3D viewer bundle"):
             ensure_sim_viewer_bundle(config, offline=offline)
+        warn_unloadable_environments(config)
         started = True
         with live_step("world", "Starting the physics world", "physics world"):
             config["world_endpoint"] = ensure_world_server(config)

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -25,6 +25,7 @@ from urllib.request import Request, urlopen
 
 import oci
 from config import (
+    ASSETS_FALLBACK_TAG,
     ASSETS_IMAGE_LAYERS,
     BOOTSTRAP_LOG_PATH,
     CLI_SIM,
@@ -51,7 +52,6 @@ from config import (
     REPO_ROOT,
     ROS_INSTALL_STATE_PATH,
     SIM_ASSET_UNITS,
-    SIM_ASSET_UNITS_AUTHORED,
     SIM_ASSET_UNITS_DERIVED,
     SIM_DIR,
     SIM_FOXGLOVE_PORT,
@@ -70,13 +70,16 @@ from config import (
     WORLD_STATE_PORT,
     DockerUnresponsiveError,
     StackError,
+    available_environment_ids,
     compute_geometry_inputs_hash,
     compute_ros_install_validation_hash,
     ensure_state_dir,
     log,
+    read_environment_assets,
     resolve_assets_image,
     resolve_auto_os_image,
     resolve_deps_image,
+    resolve_fallback_assets_image,
     resolve_local_os_image,
     resolve_local_viewer_image,
     resolve_viewer_image,
@@ -1799,8 +1802,83 @@ def health_score(level: str) -> float:
 # (sim/docker-compose.dev.yml).
 
 
+def missing_geometry(repo_root: Path, assets_dir: Path, environment_id: str) -> tuple[str, ...]:
+    """What one world needs under sim/assets and does not have.
+
+    The manifest IS the contract, so a store that answers it can launch
+    whatever inputs hash the image it came from was named after. A manifest
+    with no readable geometry section asks nothing, so fall back to demanding
+    every derived unit -- mars_sim_driver.environments reports a broken pack
+    against the world it was asked to load, better than a gate here can.
+    """
+    required = read_environment_assets(repo_root, environment_id)
+    wanted = required.assets if required else SIM_ASSET_UNITS_DERIVED
+    return tuple(path for path in wanted if not (assets_dir / path).exists())
+
+
+def assets_fallback_refs() -> tuple[str, ...]:
+    """The published geometry to accept when nothing built this checkout's tag.
+
+    Empty under INNATE_SIM_ASSETS_IMAGE: naming an image means that image, and
+    quietly installing a different one would hide the typo.
+    """
+    if os.environ.get("INNATE_SIM_ASSETS_IMAGE", "").strip():
+        return ()
+    return (resolve_fallback_assets_image(),)
+
+
+def _serving_assets_manifest(image: str, fallbacks: tuple[str, ...]) -> tuple[str, dict]:
+    """(ref, manifest) for the first asset image the registry serves.
+
+    Falling back is a real degradation, since published geometry cannot know
+    about a local pipeline edit. It happens anyway because "push the branch so
+    CI publishes it" is not advice a fork can take, and every input that
+    renames this image can leave the launched world's geometry untouched.
+    """
+    try:
+        return image, oci.manifest_for_image(image)
+    except oci.OciError:
+        for fallback in fallbacks:
+            try:
+                manifest = oci.manifest_for_image(fallback)
+            except oci.OciError:
+                continue
+            warn(
+                f"No published asset image for this checkout ({shorten_docker_image_ref(image)}); "
+                f"installing the published {ASSETS_FALLBACK_TAG} geometry instead.\n"
+                f"  Your changes under {', '.join(GEOMETRY_INPUT_PATHSPECS)} are NOT in it."
+            )
+            return fallback, manifest
+        raise
+
+
+def _incomplete_store(image: str, environment_id: str, missing: tuple[str, ...]) -> StackError:
+    return StackError(
+        f"The sim geometry from {shorten_docker_image_ref(image)} has nothing for {environment_id!r}: "
+        f"{', '.join(missing)}.\n"
+        f"Bake it from the pipeline in sim/tools (see sim/sandbox/README.md), or point "
+        f"INNATE_SIM_ASSETS_IMAGE at an image that carries it. If you deleted it by hand, "
+        f"delete sim/assets/.assets-tag to re-fetch."
+    )
+
+
+def warn_unloadable_environments(config: dict[str, object]) -> None:
+    """Which other worlds the store cannot serve, since the webapp can switch
+    to any of them at runtime (mars_sim_driver.world_server.switch_environment)
+    and only the launched one is gated."""
+    os_repo: Path = config["os_repo"]  # type: ignore[assignment]
+    sim_repo: Path = config["sim_repo"]  # type: ignore[assignment]
+    unloadable = [
+        environment_id
+        for environment_id in available_environment_ids(os_repo)
+        if missing_geometry(os_repo, sim_repo / "assets", environment_id)
+    ]
+    if unloadable:
+        warn(f"No installed geometry for {', '.join(unloadable)}; switching to those in the webapp will fail.")
+
+
 def assets_image_ref(config: dict[str, object]) -> str:
-    """The asset image compose mounts the viewer subtree from.
+    """The asset image this checkout implies.
 
     COMPUTED, not looked up: the tag is content-addressed over the tracked
     inputs, so it names exactly the image this checkout implies -- the same way
@@ -1814,7 +1892,13 @@ def assets_image_ref(config: dict[str, object]) -> str:
     fails at the manifest probe.
     """
     override = os.environ.get("INNATE_SIM_ASSETS_IMAGE", "").strip()
-    return override or resolve_assets_image(config["os_repo"])  # type: ignore[arg-type]
+    if override:
+        return override
+    # Whatever the geometry step actually installed from, so the viewer's layer
+    # cannot come from a different image than the geometry it describes: only
+    # that step learns which ref the registry served (assets_fallback_refs).
+    recorded = config.get("assets_image")
+    return str(recorded) if recorded else resolve_assets_image(config["os_repo"])  # type: ignore[arg-type]
 
 
 def ensure_sim_assets(config: dict[str, object]) -> None:
@@ -1832,62 +1916,67 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
     Extracted in place under sim/assets/, idempotent via the .assets-tag marker.
     """
     sim_repo: Path = config["sim_repo"]  # type: ignore[assignment]
+    os_repo: Path = config["os_repo"]  # type: ignore[assignment]
     marker = sim_repo / "assets" / ".assets-tag"
     image = assets_image_ref(config)
+    override = os.environ.get("INNATE_SIM_ASSETS_IMAGE", "").strip()
+    fallbacks = assets_fallback_refs()
+    environment_id = str(config["environment_id"])
 
     # The marker holds "<digest> <image ref> <geometry inputs hash>". Keyed on
     # the geometry layer's
     # digest, not the tag: the tag moves whenever any tracked input changes,
     # so re-extracting 168 MB for a viewer-source edit would be waste.
     #
-    # Checked against what is on disk too, since the digest only records what
-    # this host MEANT to install: a hand-deleted subtree reinstalls instead of
-    # being asserted complete forever.
-    #
-    # DERIVED only. The authored units are the ones a pinned layer may
-    # legitimately predate (see the warn below), so demanding them here would
-    # leave `installed` false forever and re-fetch the layer on every `up`.
-    # Recovering a hand-deleted authored unit means deleting .assets-tag.
+    # The narrow hash decides nothing here; it records which inputs produced
+    # the store, for a local bake to tell stale output from its own.
     parts = marker.read_text().split() if marker.exists() else []
-    installed = all((sim_repo / "assets" / unit).is_dir() for unit in SIM_ASSET_UNITS_DERIVED)
+    installed_ref = parts[1] if len(parts) > 1 else ""
 
     # Ref match => digest match, so the warm path stays off the network: the
     # ref is content-addressed and ci/build_assets_image.sh never rebuilds an
-    # existing tag. NOT valid for an INNATE_SIM_ASSETS_IMAGE override, which
-    # may name a mutable tag -- those probe the manifest every time.
-    geometry_hash = compute_geometry_inputs_hash(config["os_repo"])  # type: ignore[arg-type]
-    if not os.environ.get("INNATE_SIM_ASSETS_IMAGE", "").strip() and parts[1:2] == [image] and installed:
+    # existing tag. Only the exact tag skips the probe -- a store installed
+    # from a fallback re-probes so it upgrades itself once CI publishes -- and
+    # never for an INNATE_SIM_ASSETS_IMAGE override, which may name a mutable
+    # tag whose content moved under the same ref.
+    geometry_hash = compute_geometry_inputs_hash(os_repo)
+    missing = missing_geometry(os_repo, sim_repo / "assets", environment_id)
+    if not override and installed_ref == image and not missing:
+        config["assets_image"] = installed_ref
         return
 
     try:
-        manifest = oci.manifest_for_image(image)
+        image, manifest = _serving_assets_manifest(image, fallbacks)
     except oci.OciError as exc:
-        # Two different mistakes: the checkout implies a tag nobody built, or
-        # the override names something the registry will not serve. Saying
-        # "set INNATE_SIM_ASSETS_IMAGE" to someone who just did is no help.
-        if os.environ.get("INNATE_SIM_ASSETS_IMAGE", "").strip():
+        # The override names something the registry will not serve. Saying "set
+        # INNATE_SIM_ASSETS_IMAGE" to someone who just did is no help.
+        if override:
             raise StackError(
                 f"The registry did not serve INNATE_SIM_ASSETS_IMAGE ({shorten_docker_image_ref(image)}): {exc}\n"
                 f"The geometry is fetched over the registry API, so an override has to name a pushed "
                 f"image -- one that exists only in the local Docker store cannot be read here."
             ) from exc
-        # The name also moves for inputs that cannot change geometry, and
-        # "push the branch" is not advice a fork can take.
-        if parts[2:3] == [geometry_hash] and installed:
-            log("Reusing the installed geometry (geometry inputs unchanged).")
+        if not missing:
+            log(f"Reusing the installed geometry (it has everything {environment_id} needs).")
+            config["assets_image"] = installed_ref
             return
         raise StackError(
-            f"No published sim asset image for this checkout ({shorten_docker_image_ref(image)}): {exc}\n"
-            f"The geometry inputs themselves changed ({', '.join(GEOMETRY_INPUT_PATHSPECS)}), so what is "
-            f"installed no longer describes this checkout. Push the branch so CI publishes it, or set "
-            f"INNATE_SIM_ASSETS_IMAGE to one that exists."
+            f"The installed sim geometry has nothing for {environment_id!r} ({', '.join(missing)}), and no "
+            f"published asset image serves this checkout: {exc}\n"
+            f"Bake it from the pipeline in sim/tools (see sim/sandbox/README.md), or point "
+            f"INNATE_SIM_ASSETS_IMAGE at an image that carries it."
         ) from exc
+    config["assets_image"] = image
     digest = manifest["layers"][ASSETS_IMAGE_LAYERS.index("work")]["digest"]
 
-    if parts[:1] == [digest] and installed:
+    if parts[:1] == [digest]:
         # Same geometry under a new ref (or an old digest-only marker):
-        # remember the ref so the next run skips the probe above.
+        # remember the ref so the next run skips the probe above. Never
+        # re-fetch this digest: what it carries is already here, so a world it
+        # cannot serve would download 85 MB to fail identically every `up`.
         marker.write_text(f"{digest} {image} {geometry_hash}\n")
+        if missing:
+            raise _incomplete_store(image, environment_id, missing)
         return
 
     log(f"Downloading sim assets {digest[7:19]} (~85 MB, one-time)...")
@@ -1902,20 +1991,13 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
             oci.fetch_layer(repo, digest, out, oci.anon_token(repo), label="sim assets")
         oci.safe_extract(blob, staging)
         work = staging / "work"
-        # Fatal before anything is installed, rather than writing a marker that
-        # claims success: a store without apartment_split_v2 has no collision
-        # hulls at all, and would silently short-circuit every later `up`.
-        missing = [unit for unit in SIM_ASSET_UNITS_DERIVED if not (work / unit).is_dir()]
-        if missing:
-            raise StackError(
-                f"The pinned geometry layer {digest[7:19]} is missing {missing}.\n"
-                "Refusing to install a partial store -- the world server cannot run without it."
-            )
-        # Authored props are additive: a checkout can legitimately expect ones
-        # the pinned layer predates, and a world without them still runs.
-        absent = [unit for unit in SIM_ASSET_UNITS_AUTHORED if not (work / unit).is_dir()]
+        # Every unit is additive, props and packs alike: a served layer may
+        # legitimately predate one (the published `main` geometry does), and a
+        # world that does not load it runs regardless. Whether the world being
+        # launched can load is judged against the manifest once installed.
+        absent = [unit for unit in SIM_ASSET_UNITS if not (work / unit).is_dir()]
         if absent:
-            warn(f"The pinned geometry predates {absent}; the world will load without them.")
+            warn(f"The geometry from {shorten_docker_image_ref(image)} predates {absent}.")
 
         # Stamp one install time so every file reads as arriving now (buildx
         # does not normalise layer mtimes without SOURCE_DATE_EPOCH). NOTE this
@@ -1947,24 +2029,46 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
         blob.unlink(missing_ok=True)
         shutil.rmtree(staging, ignore_errors=True)
 
+    still_missing = missing_geometry(os_repo, sim_repo / "assets", environment_id)
+    if still_missing:
+        raise _incomplete_store(image, environment_id, still_missing)
 
-def ensure_viewer_public_assets(config: dict[str, object]) -> None:
+
+def ensure_viewer_public_assets(config: dict[str, object], *, offline: bool = False) -> None:
     """Install the models and physics the webapp serves at /models and /physics.
 
     The same image as the geometry, a different layer -- and on disk rather
     than mounted from the image, for the reasons in install_layer_subtree.
     """
     sim_repo: Path = config["sim_repo"]  # type: ignore[assignment]
-    install_layer_subtree(
-        assets_image_ref(config),
-        ASSETS_IMAGE_LAYERS.index("viewer"),
-        "viewer",
-        sim_repo / "viewer" / "public",
-        sim_repo / "viewer" / "public" / ".installed-tag",
-        label="viewer assets",
-        geometry_hash=compute_geometry_inputs_hash(config["os_repo"]),  # type: ignore[arg-type]
-        preserve_subtrees=("local-environments",),
-    )
+    os_repo: Path = config["os_repo"]  # type: ignore[assignment]
+    image = assets_image_ref(config)
+    required = read_environment_assets(os_repo, str(config["environment_id"]))
+    try:
+        install_layer_subtree(
+            image,
+            ASSETS_IMAGE_LAYERS.index("viewer"),
+            "viewer",
+            sim_repo / "viewer" / "public",
+            sim_repo / "viewer" / "public" / ".installed-tag",
+            label="viewer assets",
+            geometry_hash=compute_geometry_inputs_hash(os_repo),
+            preserve_subtrees=("local-environments",),
+            required=required.viewer if required else (),
+            fallbacks=assets_fallback_refs(),
+        )
+    except oci.OciError as exc:
+        # This step is not inside `up`'s offline guard: a warm store needs no
+        # network, so it runs either way and only the cold path can fail here.
+        remedy = (
+            f"Re-run `{CLI_SIM} up` online once first."
+            if offline
+            else "Bake the geometry from sim/tools (see sim/sandbox/README.md), or point "
+            "INNATE_SIM_ASSETS_IMAGE at an image that carries it."
+        )
+        raise StackError(
+            f"No 3D view assets for this checkout ({shorten_docker_image_ref(image)}): {exc}\n{remedy}"
+        ) from exc
 
 
 def install_layer_subtree(
@@ -1977,6 +2081,8 @@ def install_layer_subtree(
     label: str,
     geometry_hash: str | None = None,
     preserve_subtrees: tuple[str, ...] = (),
+    required: tuple[str, ...] = (),
+    fallbacks: tuple[str, ...] = (),
 ) -> None:
     """Put one subtree of one image layer on disk, idempotently.
 
@@ -2000,17 +2106,31 @@ def install_layer_subtree(
     than the published layer. They are copied into the staged tree before the
     atomic replacement so refreshing viewer assets cannot delete licensed,
     gitignored environment packs.
+
+    `required` names the paths this destination has to hold, so "installed" can
+    mean "serves the world being launched" rather than "was built from these
+    bytes"; with none given, any non-empty directory counts. `fallbacks` are
+    refs to accept when the registry does not serve `image`.
     """
     parts = marker.read_text().split() if marker.exists() else []
-    populated = destination.is_dir() and any(destination.iterdir())
-    if parts[1:2] == [image] and populated:
+    installed_ref = parts[1] if len(parts) > 1 else ""
+    populated = destination.is_dir() and (
+        all((destination / path).exists() for path in required) if required else any(destination.iterdir())
+    )
+    if installed_ref == image and populated:
         return
 
+    # A `required` contract is the caller saying what "good enough" means, so
+    # meeting it beats any hash. Without one, only the narrow hash can tell an
+    # unpublished tag from a real change -- and the bundle, which passes
+    # neither, must fall through to its local build rather than serve a stale
+    # copy (ensure_sim_viewer_bundle catches this).
+    reusable = populated and (bool(required) or parts[2:3] == [geometry_hash])
     try:
-        manifest = oci.manifest_for_image(image)
+        image, manifest = _serving_assets_manifest(image, fallbacks)
     except oci.OciError:
-        if geometry_hash is not None and parts[2:3] == [geometry_hash] and populated:
-            log(f"Reusing the installed {label} (geometry inputs unchanged).")
+        if reusable:
+            log(f"Reusing the installed {label} (nothing published serves this checkout).")
             return
         raise
     digest = manifest["layers"][layer_index]["digest"]

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -2056,6 +2056,7 @@ def ensure_viewer_public_assets(config: dict[str, object], *, offline: bool = Fa
             preserve_subtrees=("local-environments",),
             required=required.viewer if required else (),
             fallbacks=assets_fallback_refs(),
+            offline=offline,
         )
     except oci.OciError as exc:
         # This step is not inside `up`'s offline guard: a warm store needs no
@@ -2083,6 +2084,7 @@ def install_layer_subtree(
     preserve_subtrees: tuple[str, ...] = (),
     required: tuple[str, ...] = (),
     fallbacks: tuple[str, ...] = (),
+    offline: bool = False,
 ) -> None:
     """Put one subtree of one image layer on disk, idempotently.
 
@@ -2126,6 +2128,11 @@ def install_layer_subtree(
     # neither, must fall through to its local build rather than serve a stale
     # copy (ensure_sim_viewer_bundle catches this).
     reusable = populated and (bool(required) or parts[2:3] == [geometry_hash])
+    # A store installed from a fallback records that ref, so the match above
+    # misses and a probe would follow -- offline, that is a connect timeout
+    # before reaching the same answer.
+    if offline and reusable:
+        return
     try:
         manifest = oci.manifest_for_image(image)
     except oci.OciError:

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -1827,29 +1827,26 @@ def assets_fallback_refs() -> tuple[str, ...]:
     return (resolve_fallback_assets_image(),)
 
 
-def _serving_assets_manifest(image: str, fallbacks: tuple[str, ...]) -> tuple[str, dict]:
-    """(ref, manifest) for the first asset image the registry serves.
+def _fallback_assets_manifest(image: str, fallbacks: tuple[str, ...]) -> tuple[str, dict] | None:
+    """(ref, manifest) for the first fallback the registry serves, or None.
 
-    Falling back is a real degradation, since published geometry cannot know
-    about a local pipeline edit. It happens anyway because "push the branch so
-    CI publishes it" is not advice a fork can take, and every input that
-    renames this image can leave the launched world's geometry untouched.
+    LAST resort, after reusing what is installed: the fallback is older
+    geometry by construction, so reaching for it while the store can already
+    serve the world would trade a working install for a downgrade. It exists
+    because "push the branch so CI publishes it" is not advice a fork can take.
     """
-    try:
-        return image, oci.manifest_for_image(image)
-    except oci.OciError:
-        for fallback in fallbacks:
-            try:
-                manifest = oci.manifest_for_image(fallback)
-            except oci.OciError:
-                continue
-            warn(
-                f"No published asset image for this checkout ({shorten_docker_image_ref(image)}); "
-                f"installing the published {ASSETS_FALLBACK_TAG} geometry instead.\n"
-                f"  Your changes under {', '.join(GEOMETRY_INPUT_PATHSPECS)} are NOT in it."
-            )
-            return fallback, manifest
-        raise
+    for fallback in fallbacks:
+        try:
+            manifest = oci.manifest_for_image(fallback)
+        except oci.OciError:
+            continue
+        warn(
+            f"No published asset image for this checkout ({shorten_docker_image_ref(image)}); "
+            f"installing the published {ASSETS_FALLBACK_TAG} geometry instead.\n"
+            f"  Your changes under {', '.join(GEOMETRY_INPUT_PATHSPECS)} are NOT in it."
+        )
+        return fallback, manifest
+    return None
 
 
 def _incomplete_store(image: str, environment_id: str, missing: tuple[str, ...]) -> StackError:
@@ -1946,7 +1943,7 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
         return
 
     try:
-        image, manifest = _serving_assets_manifest(image, fallbacks)
+        manifest = oci.manifest_for_image(image)
     except oci.OciError as exc:
         # The override names something the registry will not serve. Saying "set
         # INNATE_SIM_ASSETS_IMAGE" to someone who just did is no help.
@@ -1960,12 +1957,15 @@ def ensure_sim_assets(config: dict[str, object]) -> None:
             log(f"Reusing the installed geometry (it has everything {environment_id} needs).")
             config["assets_image"] = installed_ref
             return
-        raise StackError(
-            f"The installed sim geometry has nothing for {environment_id!r} ({', '.join(missing)}), and no "
-            f"published asset image serves this checkout: {exc}\n"
-            f"Bake it from the pipeline in sim/tools (see sim/sandbox/README.md), or point "
-            f"INNATE_SIM_ASSETS_IMAGE at an image that carries it."
-        ) from exc
+        served = _fallback_assets_manifest(image, fallbacks)
+        if served is None:
+            raise StackError(
+                f"The installed sim geometry has nothing for {environment_id!r} ({', '.join(missing)}), and no "
+                f"published asset image serves this checkout: {exc}\n"
+                f"Bake it from the pipeline in sim/tools (see sim/sandbox/README.md), or point "
+                f"INNATE_SIM_ASSETS_IMAGE at an image that carries it."
+            ) from exc
+        image, manifest = served
     config["assets_image"] = image
     digest = manifest["layers"][ASSETS_IMAGE_LAYERS.index("work")]["digest"]
 
@@ -2127,12 +2127,15 @@ def install_layer_subtree(
     # copy (ensure_sim_viewer_bundle catches this).
     reusable = populated and (bool(required) or parts[2:3] == [geometry_hash])
     try:
-        image, manifest = _serving_assets_manifest(image, fallbacks)
+        manifest = oci.manifest_for_image(image)
     except oci.OciError:
         if reusable:
             log(f"Reusing the installed {label} (nothing published serves this checkout).")
             return
-        raise
+        served = _fallback_assets_manifest(image, fallbacks)
+        if served is None:
+            raise
+        image, manifest = served
     digest = manifest["layers"][layer_index]["digest"]
     if parts[:1] == [digest] and populated:
         marker.parent.mkdir(parents=True, exist_ok=True)

--- a/sim/sandbox/README.md
+++ b/sim/sandbox/README.md
@@ -59,7 +59,9 @@ with `uv run sandbox/test_driver_core.py`.
 
 Apartment meshes come from sim/assets/ (gitignored): `./innate-sim up`
 extracts the geometry layer of the published asset image; to change the
-geometry, edit tools/ (see below) and push -- CI rebuilds the image.
+geometry, edit tools/ (see below) and push -- CI rebuilds the image. Editing
+them does not stop `up`, which gates on the launched environment's manifest
+rather than on the image tag (sim/README.md#assets).
 
 ## Asset pipeline
 

--- a/tests/test_assets_image_inputs.py
+++ b/tests/test_assets_image_inputs.py
@@ -63,6 +63,38 @@ def test_traffic_geometry_sources_are_asset_and_geometry_inputs():
         assert (path in config.GEOMETRY_DRIVER_FILES) == (name == "crossroads")
 
 
+def test_the_launcher_looks_for_packs_where_the_driver_does():
+    """Read out of the driver rather than imported: importing it pulls MuJoCo.
+    A root only the driver knows is a pack `up` cannot see, so it gates on the
+    whole derived store instead and refuses a checkout the driver would run."""
+    import ast
+
+    import config
+
+    source = (REPO_ROOT / "ros2_ws/src/mars_bot/mars_sim_driver/mars_sim_driver/environments.py").read_text()
+    roots = next(
+        ast.literal_eval(node.value)
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", "") == "MANIFEST_ROOTS"
+    )
+    assert roots == config.ENVIRONMENT_MANIFEST_ROOTS
+
+
+def test_every_environment_manifest_names_installable_geometry():
+    """`up` gates on these paths (runtime.missing_geometry), so a manifest the
+    launcher cannot read, or one naming geometry no asset unit carries, would
+    refuse to start with nothing able to satisfy it."""
+    import config
+
+    units = set(config.SIM_ASSET_UNITS)
+    for environment_id in config.available_environment_ids(REPO_ROOT):
+        required = config.read_environment_assets(REPO_ROOT, environment_id)
+        assert required is not None, f"{environment_id}: the launcher cannot read its requirements"
+        assert required.viewer, f"{environment_id}: names no browser assets to check"
+        named = {Path(path).parts[0] for path in required.assets}
+        assert named <= units, f"{environment_id} wants {named - units}, which no asset unit carries"
+
+
 def _dockerignore_allows(relative_path: str, rules: list[str]) -> bool:
     """Does any `!` rule re-admit `relative_path` after the leading `**`?"""
     for rule in rules:


### PR DESCRIPTION
## The problem

`./innate-sim up` refused to start whenever the asset image's content hash moved:

```
Error: No published sim asset image for this checkout (...inputs-74490a4e6418...): HTTP 404
The geometry inputs themselves changed (sim/environments, sim/tools, sim/viewer/tools) ...
Push the branch so CI publishes it, or set INNATE_SIM_ASSETS_IMAGE to one that exists.
```

Two things are wrong with that.

**The remedy is not available to everyone.** `publish-sim-images.yml` guards every job on `github.repository == 'innate-inc/innate-os'` and pushes to `ghcr.io/innate-inc`, so a fork's push builds nothing and could not push if it did. The other suggestion does not help either: the geometry is fetched over the registry API, so an image built locally is rejected at the manifest probe.

**The blast radius is much wider than "geometry".** That tag also covers the sim driver core, the `mars_sim` package, `Dockerfile.assets` and the lockfiles. On a machine with a store already installed, a narrow-hash rescue hid this. On a fresh clone there is no marker and no store, so it fell straight through to the refusal. Someone who forks, edits one line of the driver, and runs `up` on a clean machine was blocked by an edit that touches no geometry at all.

Three of the four things `up` installs already degrade properly: the ROS image falls back to a deps image and then a local build, and the viewer bundle builds itself from the same Dockerfile CI uses. Only the geometry refused.

## The change

Gate on the environment's manifest instead of on a content hash. `physics`, `navigation` and the browser assets a manifest names are what a world actually needs, so a store that answers them launches whatever tag it came from.

- **Manifest edits cost nothing.** `mars_sim_driver.environments` reads manifests live from the checkout, so a spawn pose, display name or traffic flag takes effect on restart with nothing rebuilt.
- **A tag that moved for an unrelated input reuses what is installed**, and says so.
- **Nothing published and nothing installed** falls back to the published `main` geometry, warning which local changes are not in it.
- **A world the store genuinely cannot load** still refuses, but names the paths it wanted and points at the pipeline instead of at a push nobody can do.
- **`--offline` now covers the 3D view assets.** That step runs outside the offline guard on purpose, because a warm store needs no network, but it was re-raising a bare registry error. That was the naked 404 people saw right after being told to re-run offline.
- **Switching worlds is reported.** The webapp can switch environments at runtime, so `up` warns which other packs the store cannot serve rather than leaving the switch to crash.

## Three traps worth knowing

**`viewer.model` is not a requirement when a pack has a streamed `manifest`.** The apartment names a monolith glb that `Dockerfile.assets` deliberately does not ship, because `scene.ts` streams per-room files and falls back to the monolith only when the room manifest is absent. Requiring every path a manifest names would have refused every healthy install. The requirement sets were checked against a real installed store for all three packs.

**`ghcr.io/innate-inc/innate-os-sim-assets:main` is stale.** `ci/build_assets_image.sh` exits early when the inputs tag already exists, and that exit happens before the buildx call carrying `--tag main`; branch builds never push main tags. So a pack first built on a branch never advances the alias, and today `:main` carries no intersection geometry. An absent unit is therefore a warning judged against the launched world rather than a fatal partial store. Retagging on the early-exit path is a separate fix, not in this PR.

**A digest already installed is never re-fetched.** Otherwise a world the layer cannot serve would download 85 MB and fail identically on every `up`. Recovering a hand-deleted subtree means deleting `.assets-tag`, which was already the documented recovery for the authored units.

## Verification

Lint, format and the 88 root tests pass. `basedpyright` on the launcher is unchanged from its baseline; it is not clean on `main` because the repo's own `config/` directory shadows `sim/launcher/config.py` for the type checker.

Exercised against the real registry with `./innate-sim assets`, not only mocks:

1. clean checkout installs the exact tag as before
2. a moved geometry hash with nothing published falls back to `:main`, warns about the fallback and about the packs that geometry predates, and starts
3. units absent from the fallback layer are left alone on disk, so an already-installed pack survives
4. reverting the edit re-installs the exact tag
5. a warm store is silent and touches no network
6. the two cold-store remedies differ correctly under `--offline`

## Not in this PR

A local bake, so a genuine geometry edit can produce its own geometry instead of running on the last published set. The build cache tag is anonymously readable and the Dockerfile already orders packs below the apartment bake, so a new pack should cost minutes rather than the seventeen the full decomposition takes.