### PR TITLE
docs(workspace): open with a hello world, and make the reference reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,8 +374,9 @@ class ThermometerInput(InputDevice):
 An agent can then request the input by class:
 
 ```python
-from innate import InputRef
 from inputs.thermometer_input import ThermometerInput
+
+from innate import InputRef
 
 
 def get_inputs(self) -> list[InputRef]:

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ class ThermometerInput(InputDevice):
 An agent can then request the input by class:
 
 ```python
+from innate import InputRef
 from inputs.thermometer_input import ThermometerInput
 
 

--- a/README.md
+++ b/README.md
@@ -233,29 +233,36 @@ Here is an example of a simple agent to navigate:
 A minimal agent file, saved as `workspace/custom_agents/navigate_agent.py`:
 
 ```python
-from brain_client.agents.types import Agent
+from innate_skills.navigate_to_position import NavigateToPosition
+from inputs.micro_input import MicroInput
+
+from innate import Agent, InputRef, SkillRef
 
 
 class NavigateAgent(Agent):
     """An agent that can navigate to requested positions."""
 
     @property
-    def id(self):
+    def id(self) -> str:
         return "navigate_agent"
 
     @property
-    def display_name(self):
+    def display_name(self) -> str:
         return "Navigate"
 
-    def get_skills(self):
-        return ["innate-os/navigate_to_position"]
+    def get_skills(self) -> list[SkillRef]:
+        return [NavigateToPosition]
 
-    def get_inputs(self):
-        return ["micro"]
+    def get_inputs(self) -> list[InputRef]:
+        return [MicroInput]
 
-    def get_prompt(self):
+    def get_prompt(self) -> str:
         return "You are a helpful robot. When asked, navigate to the requested location using the navigate_to_position skill."
 ```
+
+List skills and inputs as the classes themselves, so your editor catches a typo
+or a deleted skill before the robot does. Physical skills have no class, so
+those stay id strings (`"local/pick_socks"`).
 
 ### Testing agents in sim
 
@@ -364,11 +371,14 @@ class ThermometerInput(InputDevice):
             time.sleep(1.0)
 ```
 
-An agent or directive can then request the input by name:
+An agent can then request the input by class:
 
 ```python
-def get_inputs(self):
-    return ["thermometer"]
+from inputs.thermometer_input import ThermometerInput
+
+
+def get_inputs(self) -> list[InputRef]:
+    return [ThermometerInput]
 ```
 
 </details>

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,7 +1,75 @@
 # workspace
 
-Where agents and skills live on disk. Every skills directory is an ordinary
-Python package — imported, not scanned.
+Where your skills and agents live. This is the whole extension surface: write a
+class, drop it in, and the robot can do a new thing.
+
+## Your first skill
+
+Put this in `custom_skills/battery_level.py`:
+
+```python
+from innate import Battery, Skill, SkillReturn
+
+
+class BatteryLevel(Skill):
+    """Report how much charge the robot has left. Use this when the user asks
+    about the battery, or before starting anything long."""
+
+    battery: Battery
+
+    def execute(self) -> SkillReturn:
+        percent = round(self.battery.percentage * 100)
+        if self.battery.charging:
+            return f"Battery is at {percent}% and charging."
+        return f"Battery is at {percent}%."
+```
+
+Save it. The brain reloads on save, the web app lists it, and an agent can call
+it as `local/battery_level`.
+
+That file is the entire contract:
+
+- **The class is the skill.** Defining a `Skill` subclass *is* the
+  registration, and the class name is the identity: `BatteryLevel` →
+  `battery_level`. There is nothing to register, import or list anywhere else.
+- **The docstring is what the agent reads** when it decides whether to call
+  you. Write it for the model: what this does, and when to reach for it.
+- **A bare annotation asks for something.** `battery: Battery` means the
+  framework hands you a battery reading, and it is guaranteed to be there
+  inside `execute()` — no `None` checks. The same rule covers the cameras, the
+  arm, the base, the map and spatial memory. Annotate what you read.
+
+## Where to go next
+
+Three shipped skills worth copying, in order of size:
+
+| File | Lines | Shows |
+|---|---|---|
+| `innate_skills/arm/arm_rest_position.py` | 18 | The smallest useful shape: one feed, arguments with defaults, a message back |
+| `innate_skills/search_memory.py` | 28 | Waiting on a slow result, failing a run, returning a structured payload with an image |
+| `innate_skills/turn_in_place.py` | 55 | A cancellable loop, a deadline, and a typed payload for callers that chain |
+
+The full reference lives in the `innate` namespace itself — every feed you can
+annotate, what `execute()` may return, the camera overlay API, and the
+cancellation rules. Read it where `brain_client` is importable (on the robot, or
+`./innate-sim sh`):
+
+```bash
+python3 -c "import innate; help(innate)"
+```
+
+Guides and the wider API are on [docs.innate.bot](https://docs.innate.bot):
+[skills](https://docs.innate.bot/software/skills),
+[agents](https://docs.innate.bot/software/agents), and
+[inputs](https://docs.innate.bot/software/inputs).
+
+Agents are authored the same way, from the same namespace — `from innate import
+Agent`, with `SkillRef` and `InputRef` typing what `get_skills()` and
+`get_inputs()` may list. `innate_agents/basic_agent.py` is the short one.
+
+## How loading works
+
+Every skills directory is an ordinary Python package — imported, not scanned.
 
 ```
 innate_agents/   Shipped agents. Tracked in git, updated by `git pull`.
@@ -11,15 +79,13 @@ custom_skills/   Your skills (code and physical). Gitignored.
 <anything>/      A skill package: someone's skills + helpers, installed by dropping the folder in.
 ```
 
-A skill is a class: define a `Skill` subclass anywhere in a package and the
-robot knows it — defining it is the registration (like a PyTorch `nn.Module`).
-The class name is the identity (`class PickSocks` → `pick_socks`), so files
-organize however you like: several skills in one file, a skill split across a
-subpackage with relative imports, helpers next to it. A `.py` that defines no
-`Skill` is just a module you import. Physical skills stay data: a directory
-with `metadata.json`. The catalog drops a generated `__init__.py` ref next to
-that metadata, so `from innate_skills.wave import Wave` imports a typed handle
-to the recording (the same class as `from physical_skills import Wave`).
+Because defining the class is the registration (like a PyTorch `nn.Module`),
+files organize however you like: several skills in one file, a skill split
+across a subpackage with relative imports, helpers next to it. A `.py` that
+defines no `Skill` is just a module you import. Physical skills stay data: a
+directory with `metadata.json`. The catalog drops a generated `__init__.py` ref
+next to that metadata, so `from innate_skills.wave import Wave` imports a typed
+handle to the recording (the same class as `from physical_skills import Wave`).
 
 Everything auto-loads on brain_client start, edits hot-reload on save, and a
 module that fails to import shows up in the web app marked broken with its
@@ -27,8 +93,7 @@ error (and clears when you fix it) instead of vanishing.
 
 Skill IDs are namespaced by package: `innate-os/<name>` for shipped,
 `local/<name>` for yours, `<package>/<name>` for dropped-in packs. Packages
-import each other by bare name (`from innate_skills import arm_utils`). See
-the README at the repo root.
+import each other by bare name (`from innate_skills import arm_utils`).
 
 A pack that lives elsewhere on disk (a team checkout, a mounted volume) is
 symlinked in rather than copied — it then behaves exactly like a dropped-in

--- a/workspace/innate_agents/basic_agent.py
+++ b/workspace/innate_agents/basic_agent.py
@@ -5,7 +5,7 @@ from innate_skills.navigate_with_vision import NavigateWithVision
 from innate_skills.search_memory import SearchMemory
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, InputRef, SkillRef
+from innate import Agent, InputRef, SkillRef
 
 
 class BasicAgent(Agent):

--- a/workspace/innate_agents/demo_agent.py
+++ b/workspace/innate_agents/demo_agent.py
@@ -11,7 +11,7 @@ from innate_skills.system.change_volume import ChangeVolume
 from innate_skills.wave import Wave
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, InputRef, SkillRef
+from innate import Agent, InputRef, SkillRef
 
 
 class DemoAgent(Agent):

--- a/workspace/innate_agents/intro_agent.py
+++ b/workspace/innate_agents/intro_agent.py
@@ -9,7 +9,7 @@ from innate_skills.search_memory import SearchMemory
 from innate_skills.wave import Wave
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, InputRef, SkillRef
+from innate import Agent, InputRef, SkillRef
 
 
 class IntroAgent(Agent):

--- a/workspace/innate_agents/j3so_directive.py
+++ b/workspace/innate_agents/j3so_directive.py
@@ -4,7 +4,7 @@ from innate_skills.head_emotion import HeadEmotion
 from innate_skills.navigate_to_position import NavigateToPosition
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, InputRef, SkillRef
+from innate import Agent, InputRef, SkillRef
 
 
 class J3SOAgent(Agent):

--- a/workspace/innate_agents/security_guard_agent.py
+++ b/workspace/innate_agents/security_guard_agent.py
@@ -3,7 +3,7 @@
 from innate_skills.navigate_to_position import NavigateToPosition
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, InputRef, SkillRef
+from innate import Agent, InputRef, SkillRef
 
 
 class SecurityGuardAgent(Agent):

--- a/workspace/innate_agents/void_agent.py
+++ b/workspace/innate_agents/void_agent.py
@@ -12,7 +12,7 @@ from innate_skills.turn_in_place import TurnInPlace
 from innate_skills.wave import Wave
 from inputs.micro_input import MicroInput
 
-from brain_client.agents.types import Agent, InputRef, SkillRef
+from innate import Agent, InputRef, SkillRef
 
 CONTEXT = Path(__file__).resolve().parents[1] / "challenge_context.json"
 


### PR DESCRIPTION
The workspace guide explained **how loading works** — packages, namespacing, hot reload, symlinked packs. That is the second thing you need. Nothing answered *how do I write one*. Meanwhile the complete API contract lives in the `innate` package's module docstring, which nothing links to and no newcomer would think to open.

Neither file was badly written. The reference is accurate and complete, and the mechanics section is good. The gap was a missing entry point.

## What changed

**A working hello world opens the guide** — 12 lines, reading the battery — followed by the three rules it demonstrates: the class *is* the registration, the docstring is what the agent reads, and a bare annotation is how you ask for a feed. Then where to go next. The loading mechanics keep every word and move below it.

**The reference is linked, not copied.** This mattered enough to call out: duplicating the feed catalogue into the guide is exactly how the four documents in `docs/` went stale. So the guide points at `help(innate)` and at docs.innate.bot for skills, agents and inputs, and stays the single source for the mechanics only.

**Three exemplars are named by size**, so nobody's first click is one of the two large vision-servoing files (915 and 485 lines):

| File | Lines | Shows |
|---|---|---|
| `innate_skills/arm/arm_rest_position.py` | 18 | The smallest useful shape |
| `innate_skills/search_memory.py` | 28 | Waiting, failing, structured payload |
| `innate_skills/turn_in_place.py` | 55 | A cancellable loop with a deadline |

**All six shipped agents now import from `innate`.** They were importing `Agent`, `InputRef` and `SkillRef` from `brain_client.agents.types` while the documented public API is `from innate import Agent`. Every example a reader copies contradicted the reference, and the public facade was used by zero shipped agents. The skills were already correct.

## Verified, not assumed

- The hello world parses, and each name it imports is in `innate.__all__`
- `Battery.percentage` and `Battery.charging` both exist on the dataclass
- All three exemplar paths exist and the line counts in the table are exact
- `ruff check` and `ruff format --check` clean across `workspace/`
- `tests/test_workspace_import_targets.py` passes (8 tests)

## One correction to the audit

It named `check_battery.py` (17 lines) as the de-facto hello world. Main deleted that skill, along with `move_straight`, in 87cca75b. So the entry point was slightly worse than the finding described, and the new example fills the same role.

## Note for whoever merges

Touches `security_guard_agent.py` (import line only). #818 touches the same file's prompt. Different lines, so it should merge cleanly either order.

## Not addressed here

Input devices still import `brain_client` internals — `InputDevice` is not part of the `innate` facade. That is a real gap in the public surface, but a bigger decision than this PR.

## Added: the README's third style is gone

The finding named three ways to import the API. Two are now one, and this commit removes the third.

README taught: import `Agent` from `brain_client.agents.types`, then list skills and inputs as **id strings** (`"innate-os/navigate_to_position"`, `"micro"`). Both agents worth copying, **Basic Navigation** (`BasicAgent`) and `DemoAgent`, use classes. The strings are legacy.

The README agent example now matches them: `from innate import Agent, InputRef, SkillRef`, skill and input imported as classes, `get_skills` / `get_inputs` annotated. I added the one caveat that keeps strings honest, since `BasicAgent`'s own docstring makes the same point: physical skills have no class, so those stay ids.

The input-device section had the same string form (`["thermometer"]`) and still said "an agent or directive". Both fixed. `directive` no longer appears anywhere in the README.

Verified: all three python blocks in the README parse, and `NavigateToPosition`, `MicroInput` and the three `innate` exports were each confirmed to exist.

**Merge note:** this touches README sections #818 does not (#818 changes the top requirements, the simulator section and the docs links). Different regions, should merge cleanly either order.
