### PR TITLE
chore: rewrite the READMEs as intros, not manuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 **The lightweight agentic operating system for general-purpose robots**
 
 [Documentation](https://docs.innate.bot) ·
-[Try MARS](https://sim-demo.innate.bot) ·
+[Try MARS](https://sim.innate.bot) ·
 [Discord](https://discord.gg/innate) ·
 [Innate](https://innate.bot)
 
@@ -23,10 +23,10 @@
 ## Try it without a robot
 
 <p align="center">
-  <a href="https://sim-demo.innate.bot"><img src="docs/assets/readme/sim.png" alt="Driving the simulated MARS robot in the browser" width="85%"></a>
+  <a href="https://sim.innate.bot"><img src="docs/assets/readme/sim.png" alt="Driving the simulated MARS robot in the browser" width="85%"></a>
 </p>
 
-**[Try the live simulator →](https://sim-demo.innate.bot)** — no install, no robot.
+**[Try the live simulator →](https://sim.innate.bot)** — no install, no robot.
 
 Or run the same stack locally. One command on macOS, Linux, and WSL2:
 

--- a/README.md
+++ b/README.md
@@ -1,436 +1,158 @@
 <!-- markdownlint-disable MD033 MD046 -->
 <div align="center">
 
-<p>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/readme/innate-os-repo-intro-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="docs/assets/readme/innate-os-repo-intro.png">
-    <img src="docs/assets/readme/innate-os-repo-intro.png" alt="Innate OS" width="80%">
-  </picture>
-</p>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/readme/innate-os-repo-intro-dark.png">
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/readme/innate-os-repo-intro.png">
+  <img src="docs/assets/readme/innate-os-repo-intro.png" alt="Innate OS" width="70%">
+</picture>
 
 **The lightweight agentic operating system for general-purpose robots**
 
-[![Discord](https://img.shields.io/badge/Discord-Join%20our%20community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/innate)
-[![Documentation](https://img.shields.io/badge/Docs-Read%20the%20docs-blue?style=for-the-badge&logo=readthedocs&logoColor=white)](https://docs.innate.bot)
-[![Website](https://img.shields.io/badge/Website-Visit%20us-orange?style=for-the-badge&logo=safari&logoColor=white)](https://innate.bot)
-[![ROS 2](https://img.shields.io/badge/ROS%202-Humble-22314E?style=for-the-badge&logo=ros&logoColor=white)](https://docs.ros.org/en/humble/)
+[Documentation](https://docs.innate.bot) ·
+[Try MARS](https://sim-demo.innate.bot) ·
+[Discord](https://discord.gg/innate) ·
+[Innate](https://innate.bot)
+
+<img src="docs/assets/readme/mars-compatible.png" alt="MARS, a small agentic robot for your home" width="250px">
+
+<sub><strong>MARS</strong> is a small agentic robot for your home. Innate OS is the runtime for its skills, agents, inputs, simulation, and control.</sub>
 
 </div>
 
-<div align="center">
+## Try it without a robot
 
-<img src="docs/assets/readme/mars-compatible.png" alt="MARS robot, the first robot compatible with Innate OS" width="250px"><br>
-<sub><strong>MARS</strong>, a small agentic robot for your home.</sub>
+<p align="center">
+  <a href="https://sim-demo.innate.bot"><img src="docs/assets/readme/sim.png" alt="Driving the simulated MARS robot in the browser" width="85%"></a>
+</p>
 
-</div>
+**[Try the live simulator →](https://sim-demo.innate.bot)** — no install, no robot.
 
-Start with [skills](#skills), [agents](#agents), [additional inputs](#additional-inputs), the [simulator](#simulator), or the [ROS reference](#ros-reference).
+Or run the same stack locally. One command on macOS, Linux, and WSL2:
 
-> [!TIP]
-> Don't have a robot? [Try MARS live in your browser](https://sim-demo.innate.bot) or run the simulator locally.
+```bash
+curl -fsSL https://link.innate.bot/sim | sh
 
-<table>
-  <tr>
-    <td width="64%" align="center" valign="top">
-      <img src="docs/assets/readme/screenshot-webapp-agent-real-mars.png" alt="Innate web app Agent page on a physical MARS robot" width="100%"><br>
-      <sub>Web app</sub>
-    </td>
-    <td width="36%" rowspan="2" align="center" valign="middle">
-      <img src="docs/assets/readme/screenshot-mobile-card.png" alt="Innate mobile app running an agent" width="100%"><br>
-      <sub>Mobile app</sub>
-    </td>
-  </tr>
-  <tr>
-    <td width="64%" align="center" valign="top">
-      <a href="https://sim-demo.innate.bot"><img src="docs/assets/readme/screenshot-live-simulator-teleop.png" alt="Teleop on a simulated MARS robot" width="100%"></a><br>
-      <sub><a href="https://sim-demo.innate.bot">Live simulator</a></sub>
-    </td>
-  </tr>
-</table>
+cd innate-os
+./innate-sim up
+```
 
-_Innate OS is developed for MARS; if you want to port it to your robot, we are happy to feature it._
+The simulator runs the software that ships on MARS, with simulated hardware in place of the physical drivers. Open [https://localhost](https://localhost) to drive it, run skills, and talk to the agent.
 
----
+```bash
+./innate-sim status
+./innate-sim sh
+./innate-sim logs os-session
+./innate-sim down
+```
 
-## Table of Contents
+On a physical robot the web app is at `https://<robot-address>`. The same robot is on your phone via the [Android APK](https://cdn.innate.bot/innate-app-latest-1.4.0.apk) or [iOS TestFlight](https://testflight.apple.com/join/YeChe4A7).
 
-- [Control](#control)
-- [Skills](#skills)
-- [Agents](#agents)
-- [Simulator](#simulator)
-- [Foxglove](#foxglove)
-- [Additional Inputs](#additional-inputs)
-- [ROS Reference](#ros-reference)
-- [More Docs](#more-docs)
-- [Contribute](#contribute)
-
----
-
-## Control
-
-### Web app
-
-With the Innate web app, you can run agents, inspect what MARS sees, and control the robot in real time. The Agent page below is connected to a physical MARS.
-
-<img src="docs/assets/readme/screenshot-webapp-agent-real-mars.png" alt="Innate web app Agent page on a physical MARS robot" height="300">
-
-It is available at `https://<robot-address>` which can either be its IP or hostname.
-
-### Mobile app
-
-The Innate mobile app is available on both iOS and Android. It allows you to control the robot in real time, just like the web app, but with a more convenient interface.
-
-<table>
-  <tr>
-    <td width="45%" align="center" valign="top">
-      <img src="docs/assets/readme/screenshot-mobile-card.png" alt="Innate mobile app" height="340"><br>
-      <sub>Innate Controller app</sub>
-    </td>
-    <td width="55%" valign="middle">
-      <strong>Download the Innate Controller app</strong><br>
-      Connect to MARS, drive the robot, run agents and skills, record training data, and manage maps from your phone.<br><br>
-      <a href="https://cdn.innate.bot/innate-app-latest-1.4.0.apk"><strong>Android APK (1.4.0)</strong></a><br>
-      <sub>Direct APK download.</sub><br><br>
-      <a href="https://testflight.apple.com/join/YeChe4A7"><strong>iOS TestFlight</strong></a><br>
-      <sub>Join the iOS beta.</sub><br><br>
-      <a href="https://docs.innate.bot/robots/innate-controller-app">Controller app docs</a>
-    </td>
-  </tr>
-</table>
-
----
+See the [simulator docs](https://docs.innate.bot/simulator) or [`sim/README.md`](sim/README.md) for the full workflow.
 
 ## Skills
 
-Skills are the core unit of action on Innate robots.
-
-A skill can be digital, like calling a tool, a service or another agent; or physical, like navigating, waving, grasping, recording a demonstration, or executing a learned manipulation policy.
+Skills are the unit of action on an Innate robot — a software call, a motion, or a learned policy.
 
 <p align="center">
-  <img src="docs/assets/readme/skills-chess-door-opening.gif" alt="Two standalone physical skills: moving a chess piece, then opening a door" width="520"><br>
-  <sub>Two standalone skill examples, shown sequentially: moving a chess piece, then opening a door.</sub>
+  <img src="docs/assets/readme/skills-chess-door-opening.gif" alt="Two standalone skills: moving a chess piece, then opening a door" width="520">
 </p>
-
-- **Execute manually** — Run skills from the `innate` CLI.
-- **Operate from apps** — Trigger skills through the web app or Innate mobile apps.
-- **Run autonomously** — Let agents select and interrupt skills as the world changes.
-
-### Running a skill
-
-On the robot, skills can be inspected and called through the CLI:
 
 ```bash
 innate skill type innate-os/arm_zero_position
 innate skill run innate-os/arm_zero_position @duration=3
 ```
 
-Custom skills use the same `@name=value` input syntax.
+Write your own in `workspace/custom_skills/`:
 
-### Trained skills
-
-Some physical skills can be learned from demonstrations.
-
-- Record episodes from the phone app or web app.
-- Train a policy with one of the models available on Innate Cloud or locally.
-- Deploy the trained model as a skill.
-
-Start here: [Training overview](https://docs.innate.bot/training/overview). To ship a trained model back to the robot, see [Deploy a trained skill](https://docs.innate.bot/training/deploy-trained-skill).
-
-You will find skills in two different directories:
-
-- **Built-in skills** — Located in `workspace/innate_skills/`.
-- **Your custom skills** — Stored in `workspace/custom_skills/`. Gitignored and yours to play with.
-- **Skill packs** — Any other folder dropped into `workspace/` loads as its own package (ids `<folder>/<name>`). A pack that lives elsewhere on disk is symlinked in (`ln -s /opt/team/skills workspace/team_skills`) and works the same, hot reload included.
-
-Helpers work like normal Python: any `.py` in your skills folder that doesn't define a `Skill` is just a module — `import` it, use relative imports inside subfolders, share across packages by bare name (`from innate_skills import arm_utils`). Device helpers are methods on the interfaces (`self.manipulation.move_to(...)`, `self.mobility.rotate_by(...)`); camera math and Gemini live under `innate` (`from innate import geometry, vision, gemini`).
-
-### Skill definition
-
-<table>
-  <tr>
-    <td width="50%" valign="top">
-      <strong>Replay skill</strong> — replay a recorded motion file.<br>
-      Saved as <code>workspace/custom_skills/greet/metadata.json</code>:
-      <pre lang="json">{
-    "name": "greet",
-    "type": "replay",
-    "guidelines": "Greet the user with a friendly arm wave.",
-    "inputs": {},
-    "wheeled": false,
-    "downloads": {
-        "episode_0.h5": "https://your-cdn.com/greet/episode_0.h5"
-    },
-    "execution": {
-        "model_type": "replay",
-        "replay_file": "episode_0.h5",
-        "replay_frequency": 50.0,
-        "start_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0],
-        "end_pose": [1.57693225, -0.6, 1.4772235, -0.73784476, 0.0, 0.0]
-    }
-}</pre>
-    </td>
-    <td width="50%" valign="top">
-      <strong>Code skill</strong> — call the mobility interface to move forward.<br>
-      Saved as <code>workspace/custom_skills/move_forward.py</code>:
-      <pre lang="python">from innate import Mobility, Skill, SkillReturn
+```python
+from innate import Mobility, Skill, SkillReturn
 
 
 class MoveForward(Skill):
-    """Move the robot forward by a given distance in meters."""
+    """Move the robot forward by a given distance."""
 
-    mobility: Mobility          # declare what you use; the runtime injects it
+    mobility: Mobility
 
     def execute(self, distance_m: float = 0.5) -> SkillReturn:
-        speed = 0.2  # m/s
+        speed = 0.2
         duration = distance_m / speed
         self.mobility.send_cmd_vel(linear_x=speed, duration=duration)
-        self.sleep(duration)    # like time.sleep, but a Stop unwinds it
+        self.sleep(duration)
         return f"Moved forward {distance_m} m"
-</pre>
-      The return value is the run's result message; call
-      <code>self.fail(message)</code> to end the run as a failure.
-      Cancellation is the framework's job: <code>self.sleep</code> (and every
-      blocking framework call) raises the moment a Stop lands, the base is
-      braked automatically, and the run reports CANCELLED — skills carry no
-      cancel code.
-    </td>
-  </tr>
-</table>
+```
 
----
+Run them from the CLI, the apps, or an agent. Built-in skills live in `workspace/innate_skills/`. You can also [record a motion and train a policy](https://docs.innate.bot/training/overview), then deploy it as a skill.
+
+**[Skills documentation →](https://docs.innate.bot/software/skills)**
 
 ## Agents
 
-Agents allow Innate robots to run autonomously following your instructions.
-
-They make the robot think in a high-frequency loop using a multimodal model, for example a VLM that is constantly observing the world.
-
-An agent consists of:
-
-- A **set of skills** the robot is allowed to use
-- A **system prompt** that defines the robot's behavior
-- An **agent loop** that connects the model to observations, memory, tools, and robot actions
+Agents let the robot act on its own. One combines a set of skills, a prompt, inputs, and a loop that turns observations into actions.
 
 <p align="center">
-  <img src="docs/assets/readme/agent-clean-room.gif" alt="Pick up and put away skills chained in an agent to clean a room" width="520"><br>
-  <sub>Pick up and put away skills chained in an agent to clean a room.</sub>
+  <img src="docs/assets/readme/agent-clean-room.gif" alt="An agent chaining pick-up and put-away skills to clean a room" width="520">
 </p>
 
-### Specificities of multimodal agents
-
-Multimodal agents have different constraints than purely digital agents: they need to **observe continuously**, run at a **high frequency** to react, and to be able to **interrupt** a running skill when the world has changed.
-
-### Agent definitions
-
-You can find agents in two different directories:
-
-- **[`workspace/innate_agents/`](workspace/innate_agents/)** — Built-in agents shipped with Innate OS.
-- **[`workspace/custom_agents/`](workspace/custom_agents/)** — Your local agents. Gitignored and yours to play with.
-
-Here is an example of a simple agent to navigate:
-
-A minimal agent file, saved as `workspace/custom_agents/navigate_agent.py`:
-
 ```python
-from innate_skills.navigate_to_position import NavigateToPosition
-from inputs.micro_input import MicroInput
-
-from innate import Agent, InputRef, SkillRef
+from brain_client.agents.types import Agent
 
 
 class NavigateAgent(Agent):
-    """An agent that can navigate to requested positions."""
-
     @property
-    def id(self) -> str:
+    def id(self):
         return "navigate_agent"
 
     @property
-    def display_name(self) -> str:
+    def display_name(self):
         return "Navigate"
 
-    def get_skills(self) -> list[SkillRef]:
-        return [NavigateToPosition]
+    def get_skills(self):
+        return ["innate-os/navigate_to_position"]
 
-    def get_inputs(self) -> list[InputRef]:
-        return [MicroInput]
+    def get_inputs(self):
+        return ["micro"]
 
-    def get_prompt(self) -> str:
-        return "You are a helpful robot. When asked, navigate to the requested location using the navigate_to_position skill."
+    def get_prompt(self):
+        return (
+            "You are a helpful robot. When asked, navigate "
+            "to the requested location."
+        )
 ```
 
-List skills and inputs as the classes themselves, so your editor catches a typo
-or a deleted skill before the robot does. Physical skills have no class, so
-those stay id strings (`"local/pick_socks"`).
+Save it in `workspace/custom_agents/`. Because the robot lives in the physical world, agents observe continuously and can interrupt a running skill when the world changes.
 
-### Testing agents in sim
+**[Agents documentation →](https://docs.innate.bot/software/agents)**
 
-Use the [simulator](#simulator) to test custom agents before running them on a physical robot.
+## Inputs
 
----
-
-## Simulator
-
-**[Try MARS now at sim-demo.innate.bot](https://sim-demo.innate.bot)** -- no install or robot required.
-
-Innate OS includes a MuJoCo digital twin of MARS that runs the **real robot software** -- the same navigation stack, skills, brain client, and webapp as the physical robot, with only the hardware drivers swapped for a simulated equivalent. Use it to build and test skills, agents, and input devices before you have a robot on your desk.
-
-<p align="center">
-  <a href="https://sim-demo.innate.bot"><img src="docs/assets/readme/sim.png" alt="Driving the simulated MARS robot through its apartment in the browser" width="85%"></a>
-</p>
-
-```bash
-curl -fsSL https://link.innate.bot/sim | sh
-```
-
-One command on macOS, Linux and WSL2. It asks before installing anything missing (Docker, uv, git), clones this repository into `innate-os/` in the directory you run it from, asks how the agent should reach a cloud LLM, and downloads everything the simulator needs (simulation assets, the 3D viewer bundle, the Docker image). Already have a checkout? `./innate-sim setup` does the same from inside it.
-
-```bash
-cd innate-os && ./innate-sim up
-```
-
-The terminal opens a live dashboard, and the robot webapp at [https://localhost](https://localhost) is the sim UI -- drive and operate the simulated MARS exactly like a real one, with a live 3D view instead of camera streams.
-
-```bash
-./innate-sim status         # show current runtime state
-./innate-sim sh             # open a shell inside the ROS container
-./innate-sim logs os-session # inspect runtime logs (see `logs --help` for targets)
-./innate-sim down           # stop the runtime
-```
-
-See [`sim/README.md`](sim/README.md) for everything else: the day-to-day workflow, the ROS-free VirtualMars Python API (with a walkthrough notebook), and the architecture.
-
----
-
-## Foxglove
-
-[Foxglove Studio](https://foxglove.dev) gives you a live view of TF, `/scan`, camera images, point clouds, and `/cmd_vel` teleop for debugging. In the [simulator](#simulator) the bridge is always on; on a physical robot it is opt-in:
-
-```bash
-innate foxglove start   # start the bridge (ws://<robot-ip>:8765)
-innate foxglove stop    # stop it
-innate foxglove         # status
-```
-
-Then connect Foxglove Studio to the printed `ws://` URL.
-
-> **Over Wi-Fi, subscribe to the `/mars/main_camera/remote/*` topics, not the raw ones.** The raw camera images (~0.9 MB/frame) and point clouds (`/mars/main_camera/points`, ~10 MB/s) are far more than a Wi-Fi link can carry, so every panel — including `/cmd_vel` — falls seconds behind. The `remote/` namespace carries the same topics throttled to ~2 Hz (and images already compressed), which fits comfortably. Prefer `.../compressed` image topics and mono `remote/points` over `remote/points_color`.
-
----
-
-## Additional Inputs
-
-Innate OS provides an SDK for streaming new data into running agents. Innate robots are designed to be naturally expandable: add a new sensor, expose it as an input device, and let agents request it by name.
-
-Input devices live in [`workspace/inputs/`](workspace/inputs/) and are pure Python. They should not import ROS directly.
-
-<details>
-<summary>Thermometer input example</summary>
+Stream new data into a running agent — a custom sensor, a webhook, an API. Devices live in `workspace/inputs/` and are requested by name:
 
 ```python
-# workspace/inputs/thermometer_input.py
-
-import threading
-import time
-
-from brain_client.inputs.types import InputDevice
-
-
-def read_thermometer_celsius() -> float:
-    # Replace this with your hardware, websocket, serial, or API read.
-    return 21.5
-
-
-class ThermometerInput(InputDevice):
-    def __init__(self, logger=None):
-        super().__init__(logger)
-        self._stop_event = threading.Event()
-        self._thread = None
-
-    @property
-    def name(self) -> str:
-        return "thermometer"
-
-    def on_open(self):
-        self._stop_event.clear()
-        self._thread = threading.Thread(target=self._loop, daemon=True)
-        self._thread.start()
-
-    def on_close(self):
-        self._stop_event.set()
-        if self._thread:
-            self._thread.join(timeout=1.0)
-
-    def _loop(self):
-        while not self._stop_event.is_set():
-            self.send_data(
-                {"celsius": read_thermometer_celsius(), "timestamp": time.time()},
-                data_type="custom",
-            )
-            time.sleep(1.0)
+def get_inputs(self):
+    return ["thermometer"]
 ```
 
-An agent can then request the input by class:
+**[Input devices →](https://docs.innate.bot/software/inputs)**
 
-```python
-from inputs.thermometer_input import ThermometerInput
+## Documentation
 
-from innate import InputRef
+This README is an introduction. The rest lives in the docs:
 
+- [Getting started](https://docs.innate.bot/get-started/mars-quick-start)
+- [Simulator](https://docs.innate.bot/simulator)
+- [Skills](https://docs.innate.bot/software/skills)
+- [Agents](https://docs.innate.bot/software/agents)
+- [Input devices](https://docs.innate.bot/software/inputs)
+- [Training](https://docs.innate.bot/training/overview)
+- [Web app](https://docs.innate.bot/robots/web-app) and [controller app](https://docs.innate.bot/robots/innate-controller-app)
+- [CLI](https://docs.innate.bot/software/innate-cli)
+- [ROS 2](https://docs.innate.bot/software/ros2-core) and [system overview](docs/SYSTEM_OVERVIEW.md)
 
-def get_inputs(self) -> list[InputRef]:
-    return [ThermometerInput]
-```
+Most builders should start with skills, agents, inputs, and the simulator. Changing the ROS core is possible; it is not the usual path.
 
-</details>
+## Contributing
 
-See [`docs/INPUT_DEVICES.md`](docs/INPUT_DEVICES.md) for the full input-device lifecycle.
+Innate OS is open source under the [Apache 2.0](LICENSE) license. We welcome contributions, apps built on it, and ports to other robots — we will be happy to feature them.
 
----
-
-## ROS Reference
-
-Innate OS is currently based on ROS 2, the reference framework for robotics operating systems. Most builders should start with skills, agents, inputs, and the simulator. Changing the core OS is not recommended for normal usage, but it is possible.
-
-<table>
-  <tr>
-    <td width="20%" valign="top"><strong><a href="ros2_ws/">ros2_ws/</a></strong><br>Robot runtime workspace.</td>
-    <td width="20%" valign="top"><strong><a href="docs/SYSTEM_OVERVIEW.md">System Overview</a></strong><br>Architecture reference.</td>
-    <td width="20%" valign="top"><strong><a href="scripts/launch_ros_in_tmux.sh">Startup</a></strong><br>Robot node wiring.</td>
-    <td width="20%" valign="top"><strong><a href="scripts/update/README.md">Updates</a></strong><br>Services and CLI commands.</td>
-    <td width="20%" valign="top"><strong><a href="config/">config/</a></strong><br>DDS, systemd, udev, audio, Bluetooth, sounds, and shell setup.</td>
-  </tr>
-</table>
-
-<details>
-<summary>Main ROS 2 runtime packages</summary>
-
-- **[mars_control](ros2_ws/src/mars_bot/mars_control)** - top-level robot app node, rosbridge websocket server for the mobile/web app, and low-latency UDP receiver for leader-arm teleop.
-- **[mars_bringup](ros2_ws/src/mars_bot/mars_bringup)** - hardware bringup for motors, base, IMU, and LiDAR, plus `robot_state_publisher` for the TF tree.
-- **[mars_arm](ros2_ws/src/mars_bot/mars_arm)** - arm and head servo driver and KDL-based IK solver.
-- **[mars_cam](ros2_ws/src/mars_bot/mars_cam)** - stereo main camera, arm camera, VPI stereo depth estimator, WebRTC streamer, and stereo calibration action server.
-- **[mars_nav](ros2_ws/src/mars_bot/mars_nav)** - Nav2-based navigation, SLAM mapping, and the mode manager that switches between `mapfree`, `mapping`, and `navigation`.
-- **[brain_client](ros2_ws/src/brain/brain_client)** - bridge to the Innate cloud brain, websocket client, skills action server, and user input manager.
-- **[manipulation](ros2_ws/src/brain/manipulation)** - records and replays manipulation demonstrations and runs learned or scripted manipulation policies.
-- **[innate_logger](ros2_ws/src/cloud/innate_logger)** - uploads robot logs and telemetry to the Innate cloud.
-- **[innate_training_node](ros2_ws/src/cloud/innate_training_node)** - collects training episodes and pushes them to the training cloud.
-- **[innate_uninavid](ros2_ws/src/cloud/innate_uninavid)** - UniNaVid vision-language navigation client.
-
-</details>
-
----
-
-## More Docs
-
-- [Innate documentation](https://docs.innate.bot) - canonical docs for setup, simulator, skills, agents, training, and robot operation.
-
----
-
-## Contribute
-
-We welcome contributions to Innate OS and will be happy to feature applications written on top of it here–and robots using it.
-
-A huge thanks to all people in the community who helped by contributing, providing feedback, and building on Innate OS.
-
-If you want to help, feel free to reach out on [Discord](https://discord.gg/innate).
+**[Contributing guide](.github/CONTRIBUTING.md)** · **[Discord](https://discord.gg/innate)**

--- a/README.md
+++ b/README.md
@@ -58,12 +58,7 @@ Skills are the unit of action on an Innate robot — a software call, a motion, 
   <img src="docs/assets/readme/skills-chess-door-opening.gif" alt="Two standalone skills: moving a chess piece, then opening a door" width="520">
 </p>
 
-```bash
-innate skill type innate-os/arm_zero_position
-innate skill run innate-os/arm_zero_position @duration=3
-```
-
-Write your own in `workspace/custom_skills/`:
+Run them from the [web app](https://docs.innate.bot/robots/web-app), the [phone app](https://docs.innate.bot/robots/innate-controller-app), or an agent. Write your own in `workspace/custom_skills/`:
 
 ```python
 from innate import Mobility, Skill, SkillReturn
@@ -82,7 +77,7 @@ class MoveForward(Skill):
         return f"Moved forward {distance_m} m"
 ```
 
-Run them from the CLI, the apps, or an agent. Built-in skills live in `workspace/innate_skills/`. You can also [record a motion and train a policy](https://docs.innate.bot/training/overview), then deploy it as a skill.
+Built-in skills live in `workspace/innate_skills/`. You can also [record a motion and train a policy](https://docs.innate.bot/training/overview), then deploy it as a skill.
 
 **[Skills documentation →](https://docs.innate.bot/software/skills)**
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The simulator runs the software that ships on MARS, with simulated hardware in p
 ```bash
 ./innate-sim status
 ./innate-sim sh
-./innate-sim logs os-session
+./innate-sim logs startup
 ./innate-sim down
 ```
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ def get_inputs(self) -> list[InputRef]:
 
 This README is an introduction. The rest lives in the docs:
 
+- [Building with the simulator](https://docs.innate.bot/simulator/building-with-the-simulator)
 - [Getting started](https://docs.innate.bot/get-started/mars-quick-start)
 - [Simulator](https://docs.innate.bot/simulator)
 - [Skills](https://docs.innate.bot/software/skills)

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ Save it in `workspace/custom_agents/`. Because the robot lives in the physical w
 Stream new data into a running agent — a custom sensor, a webhook, an API. Devices live in `workspace/inputs/` and are requested by class:
 
 ```python
-from inputs.thermometer_input import ThermometerInput
+from inputs.arm_vitals_input import ArmVitalsInput
 
 from innate import InputRef
 
 
 def get_inputs(self) -> list[InputRef]:
-    return [ThermometerInput]
+    return [ArmVitalsInput]
 ```
 
 **[Input devices →](https://docs.innate.bot/software/inputs)**

--- a/README.md
+++ b/README.md
@@ -95,30 +95,35 @@ Agents let the robot act on its own. One combines a set of skills, a prompt, inp
 </p>
 
 ```python
-from brain_client.agents.types import Agent
+from innate_skills.navigate_to_position import NavigateToPosition
+from inputs.micro_input import MicroInput
+
+from innate import Agent, InputRef, SkillRef
 
 
 class NavigateAgent(Agent):
     @property
-    def id(self):
+    def id(self) -> str:
         return "navigate_agent"
 
     @property
-    def display_name(self):
+    def display_name(self) -> str:
         return "Navigate"
 
-    def get_skills(self):
-        return ["innate-os/navigate_to_position"]
+    def get_skills(self) -> list[SkillRef]:
+        return [NavigateToPosition]
 
-    def get_inputs(self):
-        return ["micro"]
+    def get_inputs(self) -> list[InputRef]:
+        return [MicroInput]
 
-    def get_prompt(self):
+    def get_prompt(self) -> str:
         return (
             "You are a helpful robot. When asked, navigate "
             "to the requested location."
         )
 ```
+
+List skills and inputs as the classes themselves. Physical skills have no class, so those stay id strings (`"local/pick_socks"`).
 
 Save it in `workspace/custom_agents/`. Because the robot lives in the physical world, agents observe continuously and can interrupt a running skill when the world changes.
 
@@ -126,11 +131,16 @@ Save it in `workspace/custom_agents/`. Because the robot lives in the physical w
 
 ## Inputs
 
-Stream new data into a running agent — a custom sensor, a webhook, an API. Devices live in `workspace/inputs/` and are requested by name:
+Stream new data into a running agent — a custom sensor, a webhook, an API. Devices live in `workspace/inputs/` and are requested by class:
 
 ```python
-def get_inputs(self):
-    return ["thermometer"]
+from inputs.thermometer_input import ThermometerInput
+
+from innate import InputRef
+
+
+def get_inputs(self) -> list[InputRef]:
+    return [ThermometerInput]
 ```
 
 **[Input devices →](https://docs.innate.bot/software/inputs)**

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ class NavigateAgent(Agent):
         )
 ```
 
-List skills and inputs as the classes themselves. Physical skills have no class, so those stay id strings (`"local/pick_socks"`).
+List skills and inputs as the classes themselves.
 
 Save it in `workspace/custom_agents/`. Because the robot lives in the physical world, agents observe continuously and can interrupt a running skill when the world changes.
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 **The lightweight agentic operating system for general-purpose robots**
 
-[Documentation](https://docs.innate.bot) ·
-[Try MARS](https://sim.innate.bot) ·
-[Discord](https://discord.gg/innate) ·
-[Innate](https://innate.bot)
+[![Discord](https://img.shields.io/badge/Discord-Join%20our%20community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/innate)
+[![Documentation](https://img.shields.io/badge/Docs-Read%20the%20docs-blue?style=for-the-badge&logo=readthedocs&logoColor=white)](https://docs.innate.bot)
+[![Website](https://img.shields.io/badge/Website-Visit%20us-orange?style=for-the-badge&logo=safari&logoColor=white)](https://innate.bot)
+[![ROS 2](https://img.shields.io/badge/ROS%202-Humble-22314E?style=for-the-badge&logo=ros&logoColor=white)](https://docs.ros.org/en/humble/)
 
 <img src="docs/assets/readme/mars-compatible.png" alt="MARS, a small agentic robot for your home" width="250px">
 
@@ -58,7 +58,7 @@ Skills are the unit of action on an Innate robot — a software call, a motion, 
   <img src="docs/assets/readme/skills-chess-door-opening.gif" alt="Two standalone skills: moving a chess piece, then opening a door" width="520">
 </p>
 
-Run them from the [web app](https://docs.innate.bot/robots/web-app), the [phone app](https://docs.innate.bot/robots/innate-controller-app), or an agent. Write your own in `workspace/custom_skills/`:
+Run them from the [web app](https://docs.innate.bot/robots/web-app), the [phone app](https://docs.innate.bot/robots/innate-controller-app), or an agent. Write your own in `workspace/custom_skills/` — the [workspace guide](workspace/README.md) is the hello world.
 
 ```python
 from innate import Mobility, Skill, SkillReturn
@@ -118,7 +118,7 @@ class NavigateAgent(Agent):
         )
 ```
 
-List skills and inputs as the classes themselves.
+List skills and inputs as the classes themselves, so your editor catches a typo before the robot does.
 
 Save it in `workspace/custom_agents/`. Because the robot lives in the physical world, agents observe continuously and can interrupt a running skill when the world changes.
 
@@ -145,6 +145,7 @@ def get_inputs(self) -> list[InputRef]:
 This README is an introduction. The rest lives in the docs:
 
 - [Building with the simulator](https://docs.innate.bot/simulator/building-with-the-simulator)
+- [Workspace guide](workspace/README.md)
 - [Getting started](https://docs.innate.bot/get-started/mars-quick-start)
 - [Simulator](https://docs.innate.bot/simulator)
 - [Skills](https://docs.innate.bot/software/skills)

--- a/sim/README.md
+++ b/sim/README.md
@@ -34,11 +34,11 @@ Already have this checkout? `sh scripts/install-sim.sh` from the repo root. OS-s
 
 ## Build against it
 
-The container mounts this repository, so `workspace/` is the same folder a real robot uses. Skills and agents [hot-reload on save](https://docs.innate.bot/simulator/building-with-the-simulator). Write them there, trigger them from the web app, then deploy the same files to hardware.
+The container mounts this repository, so `workspace/` is the same folder a real robot uses. Skills and agents hot-reload on save. Write them there, trigger them from the web app, then deploy the same files to hardware.
 
+- [Building with the simulator](https://docs.innate.bot/simulator/building-with-the-simulator)
 - [Skills](https://docs.innate.bot/software/skills)
 - [Agents](https://docs.innate.bot/software/agents)
-- [Building with the simulator](https://docs.innate.bot/simulator/building-with-the-simulator)
 
 | You edited | What to do |
 |---|---|

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,244 +1,58 @@
-# The Innate Simulator
+# Innate Simulator
 
 <p align="center">
-  <a href="https://sim-demo.innate.bot"><img src="../docs/assets/readme/sim.png" alt="Driving the simulated MARS robot through its apartment in the browser" width="85%"></a>
+  <a href="https://sim.innate.bot"><img src="../docs/assets/readme/sim.png" alt="Driving the simulated MARS robot through its apartment in the browser" width="85%"></a>
 </p>
 
-**[Try MARS now at sim-demo.innate.bot](https://sim-demo.innate.bot)** -- no install or robot required.
+**[Try MARS now at sim.innate.bot](https://sim.innate.bot)** — no install or robot required.
 
-A complete simulation of the [MARS](https://innate.bot) home robot that runs
-on your laptop — **no robot required**. It is a true digital twin: the same
-software that runs on a physical MARS (navigation, skills, the AI agent, the
-web app) runs here against a physics simulation of the robot in a furnished
-apartment. You drive it, run skills on it, and talk to its agent from your
-browser, exactly as you would with the real thing — which also means
-anything you build against the simulator works unchanged on a real MARS.
+A digital twin of [MARS](https://innate.bot) that runs on your laptop. The same navigation, skills, agent, and web app as the physical robot, against a MuJoCo apartment. Anything you build here runs unchanged on a real MARS.
 
-## Setup
+## Run it locally
+
+One command on macOS, Linux, and WSL2:
 
 ```bash
 curl -fsSL https://link.innate.bot/sim | sh
+
+cd innate-os
+./innate-sim up
 ```
 
-That is the whole install on Linux and WSL2: it asks before installing
-anything missing (Docker, uv, git, the rendering libraries), clones this
-repository into `innate-os/` in the directory you run it from, asks how the
-agent should reach a cloud LLM, and downloads the runtime — so the first
-`./innate-sim up` is a start, not a download.
+Open [https://localhost](https://localhost) (accept the self-signed certificate). Drive with the joystick or WASD, run skills from the web app, and talk to the agent.
 
-**On macOS, install [Docker
-Desktop](https://docs.docker.com/desktop/install/mac-install/) first** and open
-it once; the installer handles everything after that. Then:
+Already have this checkout? `sh scripts/install-sim.sh` from the repo root. OS-specific install, agent keys, and troubleshooting are in the [setup docs](https://docs.innate.bot/simulator/setup).
 
 ```bash
-cd innate-os && ./innate-sim up
+./innate-sim status
+./innate-sim sh
+./innate-sim logs startup
+./innate-sim down
 ```
 
-Set `INNATE_DIR` to put the checkout somewhere else.
+16 GB of RAM and 4 or more cores is comfortable. The first start downloads a few GB; later starts take seconds.
 
-**Already cloned this repository?** Run the same script from inside it — it
-skips the clone and sets up the checkout you have:
+## Build against it
 
-```bash
-sh scripts/install-sim.sh
-```
+The container mounts this repository, so `workspace/` is the same folder a real robot uses. Skills and agents [hot-reload on save](https://docs.innate.bot/simulator/building-with-the-simulator). Write them there, trigger them from the web app, then deploy the same files to hardware.
 
-`./innate-sim setup` does the same *last* step on its own, but installs no
-prerequisites: use it when Docker and uv are already in place.
+- [Skills](https://docs.innate.bot/software/skills)
+- [Agents](https://docs.innate.bot/software/agents)
+- [Building with the simulator](https://docs.innate.bot/simulator/building-with-the-simulator)
 
-Prefer to do it yourself? The rest of this section is the same setup by hand.
-
-You need two tools installed; everything else (world geometry, the Docker
-image, the ROS build) is provisioned automatically on first start:
-
-- **Docker** — runs the robot's software stack in a container.
-- **uv** — runs the physics world natively on your machine
-  (`./innate-sim setup` offers to install this one for you).
-
-16 GB of RAM and 4 or more CPU cores is comfortable; 8 GB runs it, but the
-physics and the robot's software compete for the machine. The first start
-downloads a few GB, so it takes a while; later starts take seconds.
-
-<details>
-<summary><b>macOS</b></summary>
-
-Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/)
-and open it once to accept its terms. macOS has no headless Docker: containers
-are Linux processes, so they run inside the VM Docker Desktop provides.
-
-The installer does not do this one for you — a desktop app with a licence to
-agree to and a first launch to sit through is not something a shell script can
-finish — so it checks, and says so if it is missing.
-
-</details>
-
-<details>
-<summary><b>Linux (Ubuntu / Debian / Raspberry Pi OS)</b></summary>
-
-Use Docker's own install script — it sets up the official apt repo and
-installs Docker the same way on every Debian-family distro:
-
-```bash
-curl -fsSL https://get.docker.com | sudo sh
-```
-
-Then let your user talk to Docker:
-
-```bash
-sudo usermod -aG docker $USER
-```
-
-Install the rendering libraries. On a headless server or VM these provide
-offscreen rendering; on a desktop with working OpenGL they're mostly already
-present, and the extra software-rendering library is harmless — so it's safe
-to run either way:
-
-```bash
-sudo apt install libegl1 libgl1 libopengl0 libosmesa6
-```
-
-</details>
-
-<details>
-<summary><b>Windows (WSL2)</b></summary>
-
-The sim runs inside WSL2. In PowerShell:
-
-```powershell
-wsl --install -d Ubuntu
-```
-
-then open the Ubuntu terminal and follow the **Linux** steps above. WSLg
-(included in current WSL) gives the sim GPU-accelerated rendering
-automatically.
-
-Install into your Linux home folder — run `cd ~` first if the prompt shows a
-path starting with `/mnt/`. That prefix is the Windows drive seen from Linux,
-and every file the container reads there crosses a bridge slow enough to turn
-a two-minute start into a coffee break.
-
-One caution: use exactly **one** Docker — either Docker Desktop (with WSL
-integration enabled) or `docker.io` installed inside WSL. Having both
-installed makes the `docker` command hang in confusing ways.
-
-</details>
-
-Then, from the repository root:
-
-```bash
-./innate-sim setup     # prerequisites + agent keys, then downloads the runtime
-./innate-sim up        # starts everything; leave the live dashboard open
-```
-
-`setup` downloads the images, the world geometry and the sim world's Python
-environment once it has your keys, which is the slow part; `up` then starts in
-a minute or two rather than after a multi-gigabyte download. `--no-prefetch`
-skips it and leaves the downloading to the first `up`.
-
-`setup` asks how the robot's AI agent reaches a cloud LLM. The agent loop
-itself always runs on the robot (`brain_client`); the choice is only about
-which key it thinks with:
-
-- **Your own Gemini key** — the choice for most people. Create a
-  [Gemini API key](https://aistudio.google.com/api-keys) and the agent calls
-  Google directly with it. Everything works except voice: the web app's speak
-  bar is disabled without a service key.
-- **Innate service key** — pick this if you already have one: it ships with a
-  MARS robot, and we hand them out to people building on the simulator. The
-  agent calls Gemini through Innate's proxy and the robot speaks. Ask on
-  [Discord](https://discord.gg/innate) if you would like one.
-- **None** — no agent; you can still drive, navigate, and trigger skills
-  manually.
-
-Rerun `./innate-sim setup` anytime to switch.
-
-**Open [https://localhost](https://localhost)** (accept the self-signed
-certificate; a different `INNATE_SIM_PORT_BASE` moves it — the dashboard
-prints the URL) — you are looking at the robot's web app. Drive with the
-joystick or WASD, switch between the 3D view, the robot's cameras, and the
-map, trigger skills, and chat with the agent. Add `?simperf` to the URL for
-a frame-time / latency HUD.
-
-Every error along the way is written to tell you exactly what to do next.
-If something stops you anyway, we want to hear about it —
-[join our Discord](https://discord.gg/innate).
-
-### Everyday commands
-
-```bash
-./innate-sim status      # startup checks + health snapshot
-./innate-sim logs startup   # startup logs; `logs brain` for the running stack
-./innate-sim sh          # shell into the container; `innate build` rebuilds ros2_ws
-./innate-sim down        # stop the container + world server (keeps data)
-./innate-sim clean       # remove containers/volumes (keeps .env + config)
-```
-
-### Environment packs
-
-The apartment is the default world and the backrooms ship beside it. A pack is
-a directory under `sim/environments/` with a `manifest.json` naming its MuJoCo
-collision and visual meshes and Nav2 map (under `sim/assets/`), the browser glb
-or per-room manifest and collision hulls (under `sim/viewer/public/`), and the
-spawn pose -- `sim/environments/backrooms/manifest.json` is the template, and
-`sim/tools/decompose_pack.py` then `sim/tools/build_environment_pack.py` derive
-every one of those files from a single glTF scene (the asset image runs them;
-see `sim/Dockerfile.assets`). Meshes are in
-meters, glTF Y-up, with the floor at y = 0: physics stands the robot on the
-MJCF ground plane there, and the 3D view's floor grid sits just below it.
-Licensed packs the repository must not ship go in `sim/environments.local/`
-(gitignored).
-
-Crossroads is generated from original geometry by `sim/tools/build_intersection.py`.
-Its manifest opts into the shared four-way traffic preset with `"traffic": true`
-(off when absent). Local packs can use the same preset without editing the driver;
-they must follow the layout in `mars_sim_driver/crossroads.py` and include the six
-`Signal_NS/EW_Red/Yellow/Green` materials. This flag is not an arbitrary route planner.
-
-Pick one at launch, or set `[simulation] environment` in `sim/config.toml`:
-
-```bash
-./innate-sim up --environment backrooms
-```
-
-A running simulator switches in place: **Scene setup → Environment** in the
-3D view, or `up --environment` again. The world server rebuilds its MuJoCo
-world for the pack and swaps it under the physics lock -- the robot respawns
-there, the viewer streams the pack's rooms, and Nav2 changes to its map over
-`/nav/change_navigation_map` -- with nothing restarted and the page still open.
-
-## Build skills and agents
-
-The simulator shares the repository's [`workspace/`](../workspace/) with the
-container, so the skills and agents you write for the sim are the ones a
-real robot runs — develop here, deploy there. Start with the docs:
-
-- [Skills](https://docs.innate.bot/software/skills) — teach the robot new
-  abilities in Python (or by demonstration on a real robot).
-- [Agents](https://docs.innate.bot/software/agents) — give the AI brain
-  goals, personality, and access to your skills.
+| You edited | What to do |
+|---|---|
+| skills or agents in `workspace/` | nothing — they hot-reload on save |
+| parameters in `config/` | inside the container: `innate restart` |
+| ROS code in `ros2_ws/src/` | inside the container: `innate build` |
+| the simulated world, challenges, or props | `./innate-sim down && ./innate-sim up` |
+| launcher / webapp files | rerun `./innate-sim up` / reload the browser |
 
 ### Challenges
 
-Scored tasks for what you build: find a collapsed person and stay with them,
-push a soccer ball to the dog, collect food orders from residents, or celebrate
-good news with the skill you wrote.
-Pick one from the panel at the top-left of the Agent page — it resets the
-world, drops the props the scenario needs, and ticks a goal checklist with a
-timer. Results (passed, attempts, best time) persist in
-`workspace/challenges.json`.
+Scored tasks in the web app's Agent page. Pick one — it resets the world, drops the props the scenario needs, and ticks a goal checklist. The **world server** judges from MuJoCo state, not from what the robot reports.
 
-The **world server** judges, not the robot: goals are read from MuJoCo's own
-state, and the robot stack is never told a challenge exists. Passing means
-the robot really did the thing, not that it reported doing it.
-
-A challenge defines the **environment and judge**, not the agent being tested.
-It may place props, create conversational residents, keep scenario facts
-hidden, and score resulting events; it does not install a directive or add
-robot skills. Select or build the agent separately, then run it against the
-challenge.
-
-A challenge is a sidecar in [`sim/challenges/`](challenges/) — the same shape
-as a prop's — exporting `CHALLENGE = Challenge(...)`:
+A challenge is a sidecar in [`sim/challenges/`](challenges/):
 
 ```python
 from mars_sim_driver.challenges import Challenge, Drop, Goal, Near
@@ -257,190 +71,82 @@ CHALLENGE = Challenge(
 )
 ```
 
-`environments` names the packs whose coordinates the drops and goals are
-written in; a challenge that places nothing (Victory Lap) leaves it out and
-is offered in every environment.
+Results persist in `workspace/challenges.json`. See `sim/challenges/40_household_orders/` for a challenge with its own runtime.
 
-`setup` drops props by name (the sidecars in [`sim/props/`](props/)). Goals
-are judged strictly in order and latch once true. The predicates are `Near`,
-`InCircle`, `InRect`, `Hold` (a dwell — true for N seconds without a break),
-`SkillDone` (optionally guarded by another predicate, so "wave WHILE next to
-the person" counts and a wave across the room does not), `EventSeen`, and
-`AllOf`/`AnyOf`.
+### Environments
 
-Simple challenges are one-file sidecars. A challenge with private stateful
-environment behavior may instead be a package whose `__init__.py` exports the
-same `CHALLENGE` value and attaches a `ChallengeRuntime`. The runtime receives
-world snapshots and external events, then returns trusted environment events
-and ordinary chat replies. Scenario concepts and private facts stay in that
-package rather than entering the generic challenge engine; see
-`sim/challenges/40_household_orders/`.
-
-Everything but robot lifecycle and speech events is read from the world. Those
-events arrive over rosbridge, so with rosbridge down the world-state goals
-still work while skill and resident-dialogue goals simply never fire.
-
-### When do changes take effect?
-
-| You edited | What to do |
-|---|---|
-| skills or agents in `workspace/` | **nothing** — they hot-reload on save (fallback: `ros2 service call /brain/reload std_srvs/srv/Trigger` in the container) |
-| parameters in `config/` | inside the container: `innate restart` |
-| ROS code in `ros2_ws/src/` | inside the container: `innate build` (it stops the nodes, builds, and restarts them) |
-| the simulated world (`mars_sim_driver/` world/server) | `./innate-sim down && ./innate-sim up` — this part runs on the host |
-| challenge or prop sidecars (`sim/challenges/`, `sim/props/`) | same restart — they are loaded by the host world server at startup |
-| launcher / webapp files | just rerun `./innate-sim up` / reload the browser |
-
-The container's ROS session lives in tmux (`./innate-sim sh`, then
-`tmux attach -t innate`): one window per subsystem (zenoh, rosbridge-app,
-sim-driver, nav-brain, behavior, arm-ik, vision-nav, console-webapp,
-foxglove).
-
----
-
-## Advanced
-
-### VirtualMars: the sim as a Python object
-
-For scripts, notebooks, and RL loops there is a second way in that needs no
-ROS and no Docker: the apartment, the robot, its cameras, lidar and arm as a
-single Python object — instantiate several in one process for parallel
-rollouts.
-
-▶ **Start with the walkthrough notebook:
-[`sandbox/virtual_mars_demo.ipynb`](sandbox/virtual_mars_demo.ipynb)** —
-camera/depth/lidar observations, driving, the arm, and the occupancy grid,
-with rendered outputs inline.
+The apartment is the default. Switch at launch or from **Scene setup → Environment** in the 3D view:
 
 ```bash
-./innate-sim assets          # one-time: fetch the world geometry (~100 MB, no Docker)
-cd sim && uv sync --group notebook   # then open the notebook on the sim/.venv kernel
+./innate-sim up --environment backrooms
 ```
 
-The API is shaped like a robot, not a physics engine:
+Packs live in `sim/environments/`. Licensed packs the repository must not ship go in `sim/environments.local/` (gitignored). How to build a pack is in [`sandbox/README.md`](sandbox/README.md).
+
+## VirtualMars
+
+For scripts, notebooks, and RL loops there is a second way in that needs no ROS and no Docker: the apartment, the robot, its cameras, lidar, and arm as a Python object.
+
+Start with [`sandbox/virtual_mars_demo.ipynb`](sandbox/virtual_mars_demo.ipynb):
+
+```bash
+./innate-sim assets
+cd sim && uv sync --group notebook
+```
 
 ```python
 from mars_sim_driver.core import VirtualMars
 
 sim = VirtualMars()
-sim.step(1.0)  # settle from spawn; step(dt) runs physics
-sim.set_cmd_vel(0.3, 0.5)  # vx m/s, wz rad/s (0.5s watchdog)
-sim.set_joint_target("joint2", -1.0)  # arm/head PD servo setpoints
-x, y, yaw = sim.pose()  # ground truth
-rgb = sim.render_rgb("main")  # 640x480 ("wrist" = arm camera)
-depth = sim.render_depth("main")  # meters; robot's own geoms excluded
-scan = sim.lidar_scan(360, 12.0)  # planar lidar off the visual surfaces
-grid, ox, oy = sim.occupancy_grid()  # rasterized nav map (-1/0/100)
-sim.reset()  # back to spawn, arm home
+sim.step(1.0)
+sim.set_cmd_vel(0.3, 0.5)
+sim.set_joint_target("joint2", -1.0)
+x, y, yaw = sim.pose()
+rgb = sim.render_rgb("main")
+depth = sim.render_depth("main")
+scan = sim.lidar_scan(360, 12.0)
+grid, ox, oy = sim.occupancy_grid()
+sim.reset()
 ```
 
-Rendering is lazy — pure physics is cheap. For a native MuJoCo viewer window
-(WASD driving, arm sliders in a browser control panel):
+For a native MuJoCo window: `cd sim && uv run sandbox/drive_mars.py`. More tooling is in [`sandbox/README.md`](sandbox/README.md).
+
+## Architecture
+
+Four layers in `ros2_ws/src/mars_bot/mars_sim_driver/`. Each works without the ones above it:
+
+```
+node.py          mars_sim_driver — ROS 2 client impersonating the hardware drivers
+world_server.py  world host      — owns the world + clock; driver RPC + observer stream
+core.py          VirtualMars     — physics + sensors, no ROS
+world.py         model building  — MJCF world + URDF robot, pure functions
+```
+
+The world always runs on the **host** (via `uv`), not in Docker: native GL is much faster, and physics does not compete with the ROS stack. The container's driver node is a pure RPC client. `./innate-sim logs world-server` is that process.
+
+Robot software sees the world only through the driver. Humans and tools see it only through the observer stream (`/worldstate`) — scenery, props, and challenge scoring, never robot control. That split is why a challenge can judge honestly: the robot stack is never told one exists.
+
+`node.py` publishes the same topics, types, rates, and frame names as the real drivers, so Nav2, the brain, the web app, and Foxglove run unmodified. The topic surface is in the `node.py` module docstring.
+
+## Foxglove and ROS
+
+The sim starts a Foxglove bridge for you. Connect [Foxglove Studio](https://foxglove.dev) to `ws://localhost:8765`. Because this is localhost, full-resolution cameras and point clouds are fine — unlike a physical robot on Wi-Fi, where you want the `/mars/main_camera/remote/*` topics. See the [Foxglove docs](https://docs.innate.bot/software/foxglove-setup).
+
+A rosbridge server is at `ws://localhost:9090`.
+
+## Working on the robot code
+
+`./innate-sim sh` drops you into the container. The checkout is bind-mounted, so host edits are visible immediately. `innate build` rebuilds `ros2_ws/` (a `colcon` install is a copy — editing a node and restarting is not enough). `innate view` attaches the tmux session, one window per subsystem.
+
+The trap is `mars_sim_driver`'s world server: it runs on the host and imports straight from the checkout. `innate build` does not reload it. Restart from the host: `./innate-sim down && ./innate-sim up`.
+
+**Two checkouts at once.** Each checkout already has its own container and volumes. Ports belong to the machine — move them with `INNATE_SIM_PORT_BASE`:
 
 ```bash
-cd sim && uv run sandbox/drive_mars.py
+INNATE_SIM_PORT_BASE=8600 ./innate-sim up   # web app at https://localhost:8600
 ```
 
-More dev tooling (physics stress gate, asset pipeline) is documented in
-[`sandbox/README.md`](sandbox/README.md).
-
-### ROS access
-
-[Foxglove Studio](https://foxglove.dev) is a free app for visualizing what the
-robot sees — camera images, the map and laser scan, coordinate frames, and the
-`/cmd_vel` velocity commands from teleop. It's the easiest way to look inside the
-running sim.
-
-You don't need to start anything: the sim launches a Foxglove bridge for you.
-To connect:
-
-1. Install and open [Foxglove Studio](https://foxglove.dev/download) (desktop or web).
-2. Choose **Open connection → Foxglove WebSocket**.
-3. Enter `ws://localhost:8765` and connect.
-4. Add panels (e.g. Image, 3D, Raw Messages) and pick the topics you want to see.
-
-> **Which port?** The sim's startup log always prints the exact address to use.
-> To force a specific port or network interface, set `SIM_FOXGLOVE_PORT` /
-> `SIM_FOXGLOVE_BIND` before starting the sim.
-
-Because the sim runs on your own machine, every topic is fast — feel free to view
-the full-resolution cameras and point clouds. This is different from a **physical
-robot on Wi-Fi**, where those topics are too large to stream smoothly; there you'd
-use the lighter `/mars/main_camera/remote/*` topics instead. See
-[Foxglove](../README.md#foxglove) in the main README for that case.
-
-### Working on the robot code
-
-`./innate-sim sh` drops you into the container, where the same `innate` CLI
-as on a real robot manages the ROS stack. Your checkout is bind-mounted into
-it (`ros2_ws/`, `workspace/`, `scripts/`, `config/`), so files you edit on
-the host are immediately visible inside — you only choose how to reload them:
-
-```bash
-innate                   # status: mode, node health, command hints
-innate view              # attach the tmux session running the stack (Ctrl-b d to detach)
-innate restart           # stop + relaunch all ROS nodes (no rebuild)
-innate build             # stop nodes, colcon-build ros2_ws, restart
-innate build <pkg…>      # same, but only the named packages (faster)
-innate build release     # optimized build (CMAKE_BUILD_TYPE=Release)
-innate skill list        # skills the brain currently offers
-innate skill run <id> @param=value   # trigger a skill from the shell
-```
-
-[When do changes take effect?](#when-do-changes-take-effect) above has the
-answer for each kind of edit. `ros2_ws/` is the one worth knowing by heart:
-`colcon` installs a *copy*, so editing a node and restarting is not enough —
-`innate build mars_nav` (naming the package keeps the cycle short) rebuilds
-and restarts in one step.
-
-The trap is the simulated world itself — `mars_sim_driver`'s `world.py`,
-`core.py` and `world_server.py`. That process runs on the **host**, outside
-the container, on every platform, importing straight from your checkout.
-`innate build` rebuilds the container's copy, but the world server never
-loads it. Restart that one from the host:
-`./innate-sim down && ./innate-sim up`.
-
-**Several clones at once.** Each checkout gets its own container, network and
-named volumes, so a branch clone beside your main one keeps its own compiled
-workspace. They still share the host's ports, so only one can be `up` at a
-time — starting a second stops with the name and path of the checkout holding
-them.
-
-`innate view` is the fastest way to see why a node is unhappy: the tmux
-session has one window per subsystem (zenoh, rosbridge-app, sim-driver,
-nav-brain, behavior, arm-ik, vision-nav, console-webapp, foxglove), each
-showing that process's live output.
-
-Prefer your own ROS tooling? A rosbridge server is also available at
-`ws://localhost:9090`.
-
-### Configuration
-
-- repo-root `.env` — secrets (`INNATE_SERVICE_KEY`, brain backend keys);
-  `./innate-sim setup` walks through them.
-- `config/settings.yaml` — optional non-secret ROS parameter tunables and
-  extra agent/skill dirs.
-- `sim/config.toml` — optional overrides (OS image, build behavior),
-  created from `config.toml.template` by setup.
-- `INNATE_SIM_RENDER_SCALE=N` — render the robot cameras at 1/N resolution
-  (the wire format stays 640×480). On machines stuck with software rendering
-  (`software-speed` in the dashboard's World field), `2` makes each frame
-  ~4× cheaper and noticeably lowers end-to-end latency.
-
-### Running two checkouts at once
-
-Each checkout already gets its own container, its own compose project and its
-own workspace build (all keyed to the checkout's path), but the ports a stack
-publishes belong to the machine. `INNATE_SIM_PORT_BASE` moves all seven at
-once, so a second checkout runs alongside the first:
-
-```bash
-cd ~/dev/innate-os-2
-INNATE_SIM_PORT_BASE=8600 ./innate-sim up   # webapp at https://localhost:8600
-```
-
-The block is laid out in a fixed order, and every port also takes an
-individual override that wins over the base:
+Export it for every `./innate-sim` command in that checkout (`down`, `status`, and `logs` look for the same ports).
 
 | Offset | Service | Override | Default |
 |---|---|---|---|
@@ -452,170 +158,13 @@ individual override that wins over the base:
 | +5 | world server RPC | `SIM_WORLD_PORT` | 8799 |
 | +6 | world state stream | `SIM_WORLD_STATE_PORT` | 8800 |
 
-Set nothing and you get exactly the ports above. The variable has to be set for
-every `./innate-sim` command in that checkout, not just `up` — `down`, `status`
-and `logs` look for the same ports — so export it or put it in an `.envrc`.
+## Configuration
 
-Any number of checkouts can run at once this way; each is a full ROS fleet plus
-a MuJoCo world server rendering on the host, so the limit is your RAM and GPU.
-`./innate-sim up` refuses with the list of conflicting ports if anything already
-holds one, and names a free block to move to.
+- repo-root `.env` — secrets; `./innate-sim setup` walks through them
+- `config/settings.yaml` — optional ROS tunables
+- `sim/config.toml` — optional overrides, created from `config.toml.template`
+- `INNATE_SIM_RENDER_SCALE=N` — render cameras at 1/N (helps software rendering)
 
----
+## Credits
 
-## How it works
-
-The sim is a stack of four layers inside
-`ros2_ws/src/mars_bot/mars_sim_driver/`; each is usable without the ones
-above it:
-
-```
-node.py          mars_sim_driver -- thin ROS 2 client impersonating the hardware drivers
-world_server.py  world host      -- owns the world + clock; driver RPC + observer stream
-core.py          VirtualMars     -- the simulation itself (physics + sensors), no ROS
-world.py         model building  -- MJCF world + URDF robot, pure functions
-```
-
-### world.py — the model
-
-Builds the MuJoCo model: apartment collision hulls + textured visual rooms
-(from `sim/assets`), the real `mars.urdf` attached on a planar base (x/y/yaw
-— a wheeled robot can't pitch), drive gains and contact parameters. Pure
-functions over files; `sim/sandbox` imports it for the native viewers, and a
-future GPU/batched backend (e.g. MuJoCo Warp) would consume the same spec.
-
-### core.py — VirtualMars
-
-The layer you use directly in the VirtualMars section above.
-`update_camera()` / `read_rgb()` are split (same for depth) so callers can
-update the scene under a lock but render outside it — that's what keeps
-physics from stalling in the world server.
-
-### world_server.py — the world host
-
-Hosts one VirtualMars behind two localhost interfaces, one per kind of
-consumer (the invariant: robot software sees the world only through the
-robot adapter; humans and tools see it only through the observer stream):
-
-- **driver RPC** (port 8799) — sensing/actuation for node.py, robot-shaped
-  and rate-limited like real hardware. Renders are demand-paced: a camera
-  or depth product renders once per client pull (~8Hz), never free-running.
-- **observer stream** (WebSocket, port 8800; the webapp proxies it at
-  `/worldstate`) — ground truth `{t, wall, pose, joints, objects, challenge}`
-  pushed after every physics slice (~75Hz), latest-wins per client, and stage
-  commands (the viewer's prop chips: `drop_prop_at` releases a prop over a spot
-  you picked and lets physics settle it, `place_prop_at_robot` / `place_group`
-  set props down at rest at their own reach offsets, `remove_prop` /
-  `remove_all_props` send them back off-map, which is where every prop starts;
-  plus `start_challenge` / `abort_challenge`) accepted back on the same socket.
-  Scenery and scoring, never robot control. Rosters that never change while the
-  server runs (the props, the challenges) go out once per connection instead of
-  riding every broadcast. The 3D view and the challenge panel are just two
-  clients of the same stream.
-
-Physics steps against the wall clock in <=25ms slices (a stall replays as
-several smooth slices, never one teleport), with all GL work on the main
-thread — macOS GL is main-thread-sensitive. The world always runs on the
-host, started by the launcher via `uv` (which is why `uv` is a
-prerequisite): native/WSLg GL renders ~7x faster than software GL in
-Docker, and physics never competes with the ROS stack for the container's
-CPU. The container ships no MuJoCo at all — the driver node is a pure RPC
-client. `./innate-sim logs world-server` shows the host server log.
-
-### challenges.py — the judge
-
-Hosted by the world server, which is what makes the verification honest: the
-judge reads the same MuJoCo state the physics runs on, and nothing about a
-challenge is ever published to the robot stack. A run is a `Challenge`
-sidecar (see [Challenges](#challenges)) plus three pieces of engine:
-
-- `tick()` runs on every state broadcast, judges the next unmet goal against
-  the world it was handed, and returns the `challenge` block the stream
-  carries. It never touches the sim itself — the poses and prop centres are
-  gathered under the sim lock by the caller — so any frontend is a renderer,
-  never a grader.
-- `start()`/`abort()` arrive as observer commands. `start()` deactivates,
-  resets the world and drops the scenario's props, and only then publishes
-  the run, so a tick landing mid-setup can never judge a half-built scene.
-- `SkillEventBridge` subscribes to `/brain/skill_status_update` over the
-  stack's rosbridge for `SkillDone`. Entirely best-effort: the sim never
-  waits on it and never fails because of it.
-- `ChallengeChatBridge` listens to normal robot speech on `/brain/chat_out`
-  and publishes runtime-generated environment replies on `/brain/chat_in`.
-  Scenario-private facts stay inside the runtime; the robot receives only its
-  ordinary chat output.
-
-Distances are measured to a prop's visual centre, not its body origin (a
-human scan stands feet-at-origin), which the prop sidecar already knows —
-see `PropRegistry.center_xy`. Results land in `workspace/challenges.json`,
-written atomically. A broken challenge file is skipped at load; a predicate
-that raises fails that run and nothing else.
-
-### node.py — mars_sim_driver (the digital twin's hardware)
-
-The ROS adapter that makes the world *be* the robot: a thin RPC client of
-the world server publishing the exact topic surface of the hardware
-drivers — same topics, types, rates and frame names — so everything above
-(Nav2, AMCL, brain, webapp, Foxglove) runs unmodified. The full
-topic/service surface with rates is in the `node.py` module docstring;
-highlights:
-
-- `/odom` + TF @30Hz, `/scan` @6Hz, cameras @7.5/5Hz JPEG, depth + point
-  cloud @8Hz with the real stereo pipeline's [0.25, 2.0]m clamp
-- arm/head command topics and `goto_js*` services; streamed setpoints
-  replay on the stream's own timeline, so clumped delivery under load
-  still plays back at the commanded rate
-- latched `/robot_info` `{"simulated": true}` — how the webapp knows to
-  render the Three.js view instead of opening WebRTC
-- `/virtual_mars/reset` (sim-only, `std_msgs/Bool` — see node.py)
-
-Camera topics render lazily — no subscribers, no render requests, no GL
-work — which is what makes headless runs cheap.
-
-`sim_driver.launch.py` also starts `robot_state_publisher` (same URDF as the
-real bringup) and `grid_localizer_sim`, the stand-in for the CUDA-only
-grid_localizer: identical lifecycle/service contract, but it seeds AMCL from
-ground truth (republishing until AMCL confirms with `/amcl_pose`).
-
-### Assets
-
-The generated geometry is not in git, and it now reaches you two different ways.
-
-`sim/assets/` (the MuJoCo store the world server reads) is *extracted to disk*:
-`./innate-sim up` — or `./innate-sim assets`, which needs no Docker at all —
-fetches a single layer of the asset image over plain HTTPS (~85 MB, one-time;
-`sim/launcher/oci.py`). The world server runs on the host and writes caches
-beside the geometry, so this one has to be a real, writable directory.
-
-The viewer's assets (per-room apartment glbs, robot meshes, collision hulls) are
-*never staged on the host*: compose mounts them straight out of the same image
-(`type: image`, which needs Compose 2.35+).
-
-The SimSession bundle the webapp loads is mounted the same way, but from a
-**separate** image, `innate-os-sim-viewer`. The two are split because their
-change rates differ by orders of magnitude: the geometry costs hours to
-regenerate and moves a few times a year, the bundle is ~1 MB and moves on every
-viewer commit. While they shared one content-addressed tag, a one-line edit in
-`sim/viewer/src` renamed the asset image too, and `up` then asked GHCR for a tag
-CI had never published. Either way `up` needs no Node.js.
-
-The bundle's tag is `inputs-<hash>` over `sim/viewer` **as it is on disk** —
-membership from `git ls-files --cached --others --exclude-standard`, so an
-edited file and a brand-new untracked one both count, while gitignored cruft
-does not. One hash serves both sides: a clean checkout computes what CI
-computed and pulls the published image, and any edit names an image CI cannot
-have published, so the launcher builds `sim/viewer/Dockerfile` itself as
-`innate-os-sim-viewer-local:inputs-<same hash>`. Same Dockerfile CI uses, so
-**no path here needs Node.js on the host** — only Docker, which running the sim
-already requires. There is no flag to set: editing the files is the signal.
-
-The asset image's tag is `inputs-<hash>` over the tracked files it is built
-from — the pipeline scripts, the Dockerfiles, and the pinned URLs of the raw
-geometry. Nothing about it is recorded anywhere: change any of those and the
-tag moves, CI builds it once, and every later publish of the same tag is
-skipped outright. To change the geometry, edit the pipeline in `sim/tools/`
-(see [`sandbox/README.md`](sandbox/README.md)) and push; CI rebuilds it.
-
-### Credits
-
-The apartment environment is derived from ["Appartement"](https://sketchfab.com/3d-models/appartement-6a7a5fe208344b2e8123a88923dbd5b3) by [SrMonteiro](https://sketchfab.com/crispimrafael), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Changes were made: split per room, convex-decomposed for collision, re-exported for rendering (GLB/MuJoCo meshes), and rasterized into a navigation map.
+The apartment is derived from ["Appartement"](https://sketchfab.com/3d-models/appartement-6a7a5fe208344b2e8123a88923dbd5b3) by [SrMonteiro](https://sketchfab.com/crispimrafael), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Changes were made: split per room, convex-decomposed for collision, re-exported for rendering, and rasterized into a navigation map.


### PR DESCRIPTION
## Summary
- Shorten the root README into an introduction: lead with the live simulator, keep the product visuals and badges, and send setup/Foxglove/ROS detail to the docs.
- Match the public `innate` API from #820 (class refs for skills, agents, and inputs) and point at the workspace hello-world guide.
- Apply the same treatment to `sim/README.md`, and put [Building with the simulator](https://docs.innate.bot/simulator/building-with-the-simulator) first in the docs lists.

## Test plan
- [ ] Check the GitHub render of `README.md` (logo light/dark, badges, GIFs, sim screenshot).
- [ ] Click through live sim (`sim.innate.bot`), docs links, Discord, app downloads, and the workspace guide.
- [ ] Check the GitHub render of `sim/README.md` and that the Foxglove link is not the old `#foxglove` anchor.
- [ ] Confirm the skill/agent/input examples match shipped agents (`from innate import Agent`, class refs).