### PR TITLE
feat(brain): an OpenAI-compatible provider behind the seam — Nemotron, NIM, vLLM, Ollama

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,8 +17,15 @@
 # GEMINI_API_KEY=
 # OPENAI_API_KEY=
 
-# BRAIN_BACKEND picks the provider: gemini (default) or openai.
+# BRAIN_BACKEND picks the provider: gemini (default), openai, or openai_compat.
 # BRAIN_BACKEND=gemini
+#
+# openai_compat is any server speaking /v1/chat/completions — NVIDIA's hosted
+# NIM API, a NIM or vLLM container on your network, Ollama. It never goes
+# through the proxy. Set BRAIN_MODEL to that server's model id, and a thinking
+# level of "off" for models that reason by default (Nemotron 3).
+# OPENAI_COMPAT_BASE_URL=https://integrate.api.nvidia.com/v1
+# OPENAI_COMPAT_API_KEY=
 
 # BRAIN_MODEL overrides the brain's model (default gemini-3.6-flash). It must
 # belong to BRAIN_BACKEND. GEMINI_MODEL is the name this had before the brain

--- a/ros2_ws/src/brain/brain_client/brain_client/README.md
+++ b/ros2_ws/src/brain/brain_client/brain_client/README.md
@@ -6,7 +6,7 @@ code, start from what it *does*:
 | Folder | What lives here |
 |---|---|
 | `nodes/` | The runnable ROS entry points (the only files with `main()`). Thin composition roots — they build collaborators, wire them, and spin. No behaviour. |
-| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `context` (bounded Gemini conversation), `tools` + `transport` (declarations and the wire), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached) + `search_server` (the `/brain/search_memory` action skills call), and the system `prompt`. |
+| `brain/` | The local agent loop: `agent` (look → think → act as one cancellable coroutine), `loop` (the dedicated-thread asyncio runtime it runs on), `llm/` (the model seam: `types` + `tools`, and one package per provider — `gemini`, `openai`, `openai_compat` — each with its `context`, `wire`, `transport`), pure `grounding` (pointed pixel → floor target), `memory_search` (recall over the spatial memory, context-cached) + `search_server` (the `/brain/search_memory` action skills call), and the system `prompt`. |
 | `core/` | The activate/deactivate/reset state machine and directive switching (`lifecycle`), typed `config`, and the shared `state`. |
 | `perception/` | Turning sensors into what the agent sees: `camera`, `pose`/`pose_tracking`, `scan_health`, `gaze`. |
 | `memory/` | Persistent per-map spatial memory: `store` (JSON index + JPEGs on disk), pure `selection` (which viewpoints earn a slot), `recorder` (the always-on ROS adapter that captures them). |

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/__init__.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 Innate Inc
 """Picking the model backend the brain thinks with.
 
-Adding a provider means adding a package beside these two and one line in
+Adding a provider means adding a package beside these and one line in
 :func:`pick_conversation`; nothing above this module knows which one is in use.
 """
 
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from brain_client.brain.llm import gemini, openai
+from brain_client.brain.llm import gemini, openai, openai_compat
 from brain_client.brain.llm.types import Backend, Provider
 
 if TYPE_CHECKING:
@@ -20,7 +20,12 @@ if TYPE_CHECKING:
     from brain_client.core.config import BrainConfig
     from innate_proxy import ProxyClient
 
-_BUILDERS = {Provider.GEMINI: gemini.build, Provider.OPENAI: openai.build}
+_BUILDERS = {Provider.GEMINI: gemini.build, Provider.OPENAI: openai.build, Provider.OPENAI_COMPAT: openai_compat.build}
+_KEY_HINTS = {
+    Provider.GEMINI: "GEMINI_API_KEY",
+    Provider.OPENAI: "OPENAI_API_KEY",
+    Provider.OPENAI_COMPAT: "OPENAI_COMPAT_BASE_URL (and OPENAI_COMPAT_API_KEY if the server wants one)",
+}
 
 
 def pick_conversation(
@@ -45,4 +50,7 @@ def provider(name: str, logger: RcutilsLogger) -> Provider:
 
 def key_hint(name: str) -> str:
     """Which vendor key would configure this provider without a service key."""
-    return "OPENAI_API_KEY" if name.strip().lower() == Provider.OPENAI else "GEMINI_API_KEY"
+    try:
+        return _KEY_HINTS[Provider(name.strip().lower())]
+    except ValueError:
+        return _KEY_HINTS[Provider.GEMINI]

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/context.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai/context.py
@@ -19,11 +19,10 @@ Threading contract: see :class:`~brain_client.brain.llm.types.Conversation`.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 from brain_client.brain.llm.openai import wire
-from brain_client.brain.llm.types import Decision, ToolCall, Usage, clean_speech
+from brain_client.brain.llm.types import Decision, ToolCall, Usage, clean_speech, parse_arguments
 from brain_client.brain.utils import FrameLabel
 
 if TYPE_CHECKING:
@@ -249,7 +248,7 @@ def _decision_from(output: list[dict]) -> Decision:
             decision.calls.append(
                 ToolCall(
                     name=str(item.get("name") or ""),
-                    args=_arguments(item.get("arguments")),
+                    args=parse_arguments(item.get("arguments")),
                     id=str(item.get("call_id") or ""),
                 )
             )
@@ -260,14 +259,3 @@ def _decision_from(output: list[dict]) -> Decision:
     decision.speech = clean_speech("".join(speech).strip())
     decision.thoughts = "\n".join(t for t in thoughts if t).strip() or None
     return decision
-
-
-def _arguments(raw: object) -> dict:
-    """Call arguments arrive as a JSON-encoded string, not an object."""
-    if isinstance(raw, dict):
-        return raw
-    try:
-        parsed = json.loads(raw) if isinstance(raw, str) and raw else {}
-    except json.JSONDecodeError:
-        return {}
-    return parsed if isinstance(parsed, dict) else {}

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai_compat/__init__.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai_compat/__init__.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The OpenAI-compatible backend: any ``/v1/chat/completions`` server.
+
+NVIDIA's hosted NIM API, a NIM or vLLM container on the LAN, Ollama — whatever
+answers the Chat Completions wire format at ``OPENAI_COMPAT_BASE_URL``. This is
+the provider for models Innate does not host, so it never goes through the
+proxy: the endpoint and its key are the operator's own.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from brain_client.brain.llm.openai_compat import wire
+from brain_client.brain.llm.openai_compat.context import OpenAICompatConversation
+from brain_client.brain.llm.openai_compat.transport import Endpoint, direct_transport
+from brain_client.brain.llm.types import Backend
+
+if TYPE_CHECKING:
+    from rclpy.impl.rcutils_logger import RcutilsLogger
+
+    from brain_client.brain.llm.types import Conversation
+    from brain_client.core.config import BrainConfig
+    from innate_proxy import ProxyClient
+
+THINKING_LEVELS = ("off", "low", "medium", "high")
+
+
+def build(config: BrainConfig, proxy: ProxyClient | None, logger: RcutilsLogger) -> tuple[Conversation | None, Backend]:
+    endpoint = Endpoint.from_env()
+    if endpoint is None:
+        return None, Backend.UNCONFIGURED
+    conversation = OpenAICompatConversation(
+        direct_transport(endpoint),
+        model=config.brain_model,
+        thinking=_thinking_fields(config.brain_thinking_level, logger),
+        max_history=config.history_max_entries,
+        max_image_turns=config.history_max_image_turns,
+        reference=wire.reference_turns(),
+    )
+    return conversation, Backend.OPENAI_COMPAT
+
+
+def _thinking_fields(level: str, logger: RcutilsLogger) -> dict:
+    """The request fields that set the thinking level on this kind of server.
+
+    Chat Completions has no single knob: ``off`` is the chat-template switch
+    vLLM and NIM expose for models that reason by default (Nemotron 3, Qwen3),
+    and low/medium/high is ``reasoning_effort`` where the server honours it.
+    Anything else (Gemini's "minimal") means the server's default.
+    """
+    if not level:
+        return {}
+    if level == "off":
+        return {"chat_template_kwargs": {"enable_thinking": False}}
+    if level in THINKING_LEVELS:
+        return {"reasoning_effort": level}
+    logger.warn(
+        f"[Brain] Unknown openai_compat thinking level {level!r} — using the server default (one of {THINKING_LEVELS})"
+    )
+    return {}

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai_compat/context.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai_compat/context.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""The brain's bounded conversation over the Chat Completions wire.
+
+Chat Completions is the one request shape every OpenAI-compatible server
+answers — NVIDIA NIM, vLLM, Ollama, llama.cpp — which is exactly why this
+provider uses it rather than the richer Responses API the OpenAI provider is
+built on. The trade is thoughts: a server only reports them when it runs a
+reasoning parser (``delta.reasoning_content`` on vLLM and NIM, ``delta.reasoning``
+elsewhere); without one the model's thinking is invisible or, worse, arrives
+inline as text — so run reasoning models with their parser or with thinking
+off (the ``off`` thinking level).
+
+Threading contract: see :class:`~brain_client.brain.llm.types.Conversation`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from brain_client.brain.llm.openai_compat import wire
+from brain_client.brain.llm.types import Decision, ToolCall, Usage, clean_speech, parse_arguments
+from brain_client.brain.utils import FrameLabel
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from brain_client.brain.llm.openai_compat.transport import Transport
+    from brain_client.brain.llm.types import ToolSpec
+    from brain_client.brain.utils import Frame
+
+
+class OpenAICompatConversation:
+    """Bounded model context for a Chat Completions server: one generate() per agent turn."""
+
+    def __init__(
+        self,
+        transport: Transport,
+        *,
+        model: str,
+        thinking: dict,
+        max_history: int,
+        max_image_turns: int,
+        reference: list[dict] | None = None,
+    ):
+        self._transport = transport
+        self._model = model
+        self._thinking = thinking  # request fields that set the thinking level (see build())
+        self._max_history = max_history
+        self._max_image_turns = max_image_turns
+        # Pinned messages (the robot's self-portrait) prepended to every request
+        # but never stored in history — immune to pruning and clear().
+        self._reference = reference or []
+        self._history: list[dict] = []
+        # The one history turn still carrying latest-only frames (wrist camera),
+        # as (message, content indexes) — committing a newer set prunes these.
+        self._latest_only_turn: tuple[dict, list[int]] | None = None
+        self._pending_wrist: list[int] = []
+        self._last_usage: Usage = {}
+        self.on_request: Callable[[dict], None] | None = None
+
+    def clear(self) -> None:
+        self._history = []
+        self._latest_only_turn = None
+        self._pending_wrist = []
+        self._last_usage = {}
+
+    @property
+    def history_len(self) -> int:
+        return len(self._history)
+
+    @property
+    def last_usage(self) -> Usage:
+        return self._last_usage
+
+    @property
+    def image_turn_count(self) -> int:
+        return sum(1 for message in self._history if any(wire.is_image(p) for p in _content(message)))
+
+    def open_turn(self, text: str, frames: list[Frame]) -> dict:
+        self._pending_wrist = [i for i, (label, _) in enumerate(frames) if label == FrameLabel.WRIST]
+        return wire.user_content(text, [jpeg for _, jpeg in frames])
+
+    def generate(
+        self,
+        turn: dict,
+        tools: list[ToolSpec],
+        system: str,
+        on_speech: Callable[[str], None] | None = None,
+    ) -> dict:
+        """Blocking network call — safe on a worker thread (history is only read).
+
+        When this turn carries wrist frames, the previous turn's copies are
+        masked out of the request here; the masking never mutates history.
+        """
+        messages = [*self._reference, *self._history, turn]
+        if self._pending_wrist and self._latest_only_turn is not None:
+            stale, indexes = self._latest_only_turn
+            masked = {**stale, "content": _masked_content(_content(stale), indexes, wire.WRIST_FRAME_REMOVED)}
+            messages = [masked if message is stale else message for message in messages]
+        body: dict = {
+            "model": self._model,
+            "messages": [{"role": "system", "content": system}, *messages],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            **self._thinking,
+        }
+        if tools:
+            body["tools"] = wire.function_tools(tools)
+        if self.on_request is not None:
+            self.on_request(body)
+        response = self._stream(body, on_speech)
+        if not response["speech"] and not response["calls"]:
+            raise RuntimeError(f"openai_compat returned no content: finish_reason={response['finish_reason']}")
+        # Usage rides the response and is committed by commit(), on the loop
+        # thread: writing self._last_usage here would let an abandoned turn's
+        # orphaned request overwrite the committed turn's counts.
+        return response
+
+    def commit(self, turn: dict, response: dict) -> Decision:
+        """Commit the exchange to history and distil the model's Decision.
+
+        Thoughts are display-only and never stored; the assistant message is
+        stored with its tool calls verbatim, ids included, because the tool
+        results that follow have to quote them on the next request.
+        """
+        usage = response["usage"]
+        self._last_usage = {
+            "prompt": usage.get("prompt_tokens", 0),
+            "cached": (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0),
+            "output": usage.get("completion_tokens", 0),
+        }
+        self._history.append(turn)
+        if self._pending_wrist:
+            if self._latest_only_turn is not None:
+                message, indexes = self._latest_only_turn
+                message["content"] = _masked_content(_content(message), indexes, wire.WRIST_FRAME_REMOVED)
+            images = [i for i, part in enumerate(_content(turn)) if wire.is_image(part)]
+            self._latest_only_turn = (turn, [images[i] for i in self._pending_wrist if i < len(images)])
+        self._history.append(wire.assistant_message(response["speech"], response["calls"]))
+        self._prune()
+        return Decision(
+            speech=clean_speech(response["speech"]),
+            thoughts=response["thoughts"].strip() or None,
+            calls=[
+                ToolCall(call["name"], parse_arguments(call["arguments"]), call["id"]) for call in response["calls"]
+            ],
+        )
+
+    def add_tool_outcomes(self, outcomes: list[tuple[ToolCall, str]]) -> None:
+        """Answer the model's function calls (the API requires one response per call)."""
+        self._history.extend(wire.tool_outcome(call.id, outcome) for call, outcome in outcomes)
+
+    def _stream(self, body: dict, on_speech: Callable[[str], None] | None) -> dict:
+        """Assemble the reply from its deltas, speaking text as it lands.
+
+        Tool calls arrive in fragments keyed by ``index`` — the id and name
+        first, the JSON arguments in pieces — and are only whole at the end.
+        A stream that stops before ``finish_reason`` (a dropped connection)
+        or ends on anything but ``stop``/``tool_calls`` is a failed turn:
+        committing it would consume the queued events and could dispatch a
+        call whose arguments were cut mid-JSON.
+        """
+        speech: list[str] = []
+        thoughts: list[str] = []
+        calls: dict[int, dict] = {}
+        finish_reason: str | None = None
+        usage: dict = {}
+        for chunk in self._transport(body):
+            if chunk.get("usage"):
+                usage = chunk["usage"]
+            for choice in chunk.get("choices") or []:
+                delta = choice.get("delta") or {}
+                if delta.get("content"):
+                    speech.append(str(delta["content"]))
+                    if on_speech:
+                        on_speech(str(delta["content"]))
+                reasoning = delta.get("reasoning_content") or delta.get("reasoning")
+                if reasoning:
+                    thoughts.append(str(reasoning))
+                for piece in delta.get("tool_calls") or []:
+                    _absorb_call_piece(calls, piece)
+                if choice.get("finish_reason"):
+                    finish_reason = str(choice["finish_reason"])
+        if finish_reason is None:
+            raise RuntimeError("openai_compat stream ended without a finish_reason")
+        if finish_reason not in ("stop", "tool_calls"):
+            raise RuntimeError(f"openai_compat response did not complete: finish_reason={finish_reason}")
+        return {
+            "speech": "".join(speech),
+            "thoughts": "".join(thoughts),
+            "calls": [calls[index] for index in sorted(calls)],
+            "finish_reason": finish_reason,
+            "usage": usage,
+        }
+
+    def _prune(self) -> None:
+        """Compact the history in chunks, never one entry per turn.
+
+        A server's prefix cache only hits on a shared prefix, so evicting or
+        masking anything every turn forfeits it on every request. The history
+        grows append-only until a budget trips, and one compaction then evicts
+        down to half the cap and masks old frames in the same step — a single
+        cache miss per window instead of one per turn.
+        """
+        history = self._history
+        keep = max(self._max_image_turns, 0)
+        if len(history) > self._max_history:
+            del history[: len(history) - self._max_history // 2]
+            # Cutting at a user message keeps every retained turn whole: an
+            # assistant message or tool result left without its partner is
+            # rejected on the next request.
+            while history and history[0].get("role") != "user":
+                history.pop(0)
+            # An evicted turn must not stay pinned as the latest-only holder: commit
+            # would "prune" an orphan dict nothing reads, and the reference would
+            # keep its base64 wrist frame alive for as long as the arm feed is stale.
+            if self._latest_only_turn is not None and not any(m is self._latest_only_turn[0] for m in history):
+                self._latest_only_turn = None
+        elif self.image_turn_count <= 2 * keep:
+            return  # under both budgets: stay append-only, the cache is warm
+        image_turns = [message for message in history if any(wire.is_image(p) for p in _content(message))]
+        for message in image_turns[:-keep] if keep else image_turns:
+            message["content"] = [dict(wire.FRAME_REMOVED) if wire.is_image(p) else p for p in _content(message)]
+
+
+def _absorb_call_piece(calls: dict[int, dict], piece: dict) -> None:
+    index = int(piece.get("index") or 0)
+    call = calls.get(index)
+    if call is None:
+        # A server that omits ids still needs one echoed back with the result.
+        call = calls[index] = {
+            "id": str(piece.get("id") or f"call_{uuid.uuid4().hex[:12]}"),
+            "name": "",
+            "arguments": "",
+        }
+    function = piece.get("function") or {}
+    if function.get("name"):
+        call["name"] = str(function["name"])
+    if function.get("arguments"):
+        call["arguments"] += str(function["arguments"])
+
+
+def _content(message: dict) -> list[dict]:
+    """The content parts of a user message; empty for string content (assistant
+    and tool messages, and the reference turn's reply)."""
+    content = message.get("content")
+    return content if isinstance(content, list) else []
+
+
+def _masked_content(content: list[dict], indexes: list[int], placeholder: dict) -> list[dict]:
+    return [dict(placeholder) if i in indexes and wire.is_image(p) else p for i, p in enumerate(content)]

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai_compat/transport.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai_compat/transport.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""How the brain reaches an OpenAI-compatible server: straight at OPENAI_COMPAT_BASE_URL.
+
+There is no proxy path on purpose — the endpoint is the operator's own (a
+NIM on their network, NVIDIA's hosted API with their key), so nothing of
+Innate's stands between the robot and it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass
+
+import httpx
+
+BASE_URL_ENV = "OPENAI_COMPAT_BASE_URL"
+API_KEY_ENV = "OPENAI_COMPAT_API_KEY"
+CHAT_COMPLETIONS_PATH = "/chat/completions"
+
+Transport = Callable[[dict], Iterator[dict]]
+"""request body -> streamed response chunks (the model rides in the body)."""
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    """Where the server is: the ``.../v1`` root, and a bearer key if it wants one."""
+
+    base_url: str
+    api_key: str = ""
+
+    @classmethod
+    def from_env(cls) -> Endpoint | None:
+        base_url = os.environ.get(BASE_URL_ENV, "").strip().rstrip("/")
+        if not base_url:
+            return None
+        return cls(base_url, os.environ.get(API_KEY_ENV, "").strip())
+
+
+def direct_transport(endpoint: Endpoint) -> Transport:
+    # One client for the process: reuses the TLS connection across turns
+    # instead of a fresh handshake per generate call. Single-threaded use by
+    # construction (one turn at a time on the agent's worker thread).
+    headers = {"Authorization": f"Bearer {endpoint.api_key}"} if endpoint.api_key else {}
+    client = httpx.Client(headers=headers, timeout=90.0)
+    url = endpoint.base_url + CHAT_COMPLETIONS_PATH
+
+    def stream(body: dict) -> Iterator[dict]:
+        with client.stream("POST", url, json=body) as resp:
+            if resp.status_code != 200:
+                resp.read()
+                raise RuntimeError(f"{endpoint.base_url}: HTTP {resp.status_code}: {resp.text[:200]}")
+            yield from _sse_chunks(resp.iter_lines())
+
+    return stream
+
+
+def _sse_chunks(lines: Iterable[str]) -> Iterator[dict]:
+    """The JSON frames of a Chat Completions stream; ``data: [DONE]`` ends it."""
+    for line in lines:
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :].strip()
+        if payload == "[DONE]":
+            return
+        chunk = json.loads(payload)
+        if isinstance(chunk, dict):
+            yield chunk

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai_compat/wire.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/openai_compat/wire.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Neutral types -> the Chat Completions shapes."""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING
+
+from brain_client.brain.prompt import PORTRAIT_CAPTION, self_portrait
+
+if TYPE_CHECKING:
+    from brain_client.brain.llm.types import ToolSpec
+
+FRAME_REMOVED = {"type": "text", "text": "[older camera frame removed]"}
+WRIST_FRAME_REMOVED = {"type": "text", "text": "[older wrist camera frame removed]"}
+
+
+def function_tools(specs: list[ToolSpec]) -> list[dict]:
+    return [_function(spec) for spec in specs]
+
+
+def image_part(jpeg: bytes) -> dict:
+    return {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{base64.b64encode(jpeg).decode()}"}}
+
+
+def is_image(part: dict) -> bool:
+    return part.get("type") == "image_url"
+
+
+def user_content(text: str, images: list[bytes]) -> dict:
+    return {"role": "user", "content": [{"type": "text", "text": text}, *(image_part(jpeg) for jpeg in images)]}
+
+
+def reference_turns() -> list[dict]:
+    """A pinned exchange showing the model its own body — the system message
+    is text-only, so the portrait rides at the front of the messages instead."""
+    jpeg = self_portrait()
+    if jpeg is None:
+        return []
+    return [
+        user_content(PORTRAIT_CAPTION, [jpeg]),
+        {"role": "assistant", "content": "Understood — that is what my model of robot looks like."},
+    ]
+
+
+def assistant_message(text: str, calls: list[dict]) -> dict:
+    """The model's turn as it is stored and replayed: text plus its tool calls,
+    each with the id the server minted (the tool result has to quote it)."""
+    message: dict = {"role": "assistant", "content": text}
+    if calls:
+        message["tool_calls"] = [
+            {"id": call["id"], "type": "function", "function": {"name": call["name"], "arguments": call["arguments"]}}
+            for call in calls
+        ]
+    return message
+
+
+def tool_outcome(call_id: str, outcome: str) -> dict:
+    return {"role": "tool", "tool_call_id": call_id, "content": outcome}
+
+
+def _function(spec: ToolSpec) -> dict:
+    # Many servers reject a function with no `parameters` at all, so a
+    # no-argument tool declares an empty object schema.
+    parameters = spec.parameters or {"type": "object", "properties": {}, "required": []}
+    return {
+        "type": "function",
+        "function": {"name": spec.name, "description": spec.description, "parameters": parameters},
+    }

--- a/ros2_ws/src/brain/brain_client/brain_client/brain/llm/types.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/brain/llm/types.py
@@ -14,6 +14,7 @@ verbatim on the next request and cannot be rebuilt from a Decision.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
@@ -35,6 +36,7 @@ class Provider(StrEnum):
 
     GEMINI = "gemini"
     OPENAI = "openai"
+    OPENAI_COMPAT = "openai_compat"  # any /v1/chat/completions server: NIM, vLLM, Ollama
 
 
 class Backend(StrEnum):
@@ -43,6 +45,7 @@ class Backend(StrEnum):
     PROXY = "innate-proxy"
     GEMINI_DIRECT = "gemini-direct"
     OPENAI_DIRECT = "openai-direct"
+    OPENAI_COMPAT = "openai-compat"
     UNCONFIGURED = "unconfigured"
 
 
@@ -129,6 +132,18 @@ class Conversation(Protocol):
         ...
 
     def clear(self) -> None: ...
+
+
+def parse_arguments(raw: object) -> dict:
+    """Tool-call arguments as the OpenAI wire formats carry them: a JSON-encoded
+    string, not an object. Anything unreadable is no arguments at all."""
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(raw) if isinstance(raw, str) and raw else {}
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 _TOOL_NARRATION = re.compile(r"Calling tool\b")

--- a/ros2_ws/src/brain/brain_client/brain_client/core/config.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/core/config.py
@@ -42,7 +42,7 @@ class BrainConfig:
     height_cam: float  # camera height above the floor (m)
 
     # --- Local brain ---
-    brain_backend: str  # which provider it thinks with: "gemini" | "openai"
+    brain_backend: str  # which provider it thinks with: "gemini" | "openai" | "openai_compat"
     brain_model: str
     brain_thinking_level: str  # written in the provider's vocabulary; "" = model default
     memory_model: str  # spatial memory search is Gemini-only, whatever the brain runs on
@@ -107,7 +107,9 @@ _PARAM_DEFAULTS: dict[str, str | bool | int | float] = {
     "brain_model": "gemini-3.6-flash",
     # Each provider names its own levels: gemini takes "minimal" | "low" |
     # "medium" | "high", openai takes "none" | "low" | "medium" | "high" |
-    # "xhigh" | "max". "" = the model's default, and an unknown value falls
+    # "xhigh" | "max", openai_compat takes "off" (the vLLM/NIM chat-template
+    # switch for models that reason by default) | "low" | "medium" | "high"
+    # (reasoning_effort). "" = the model's default, and an unknown value falls
     # back to that with a warning rather than 400ing every request.
     # Measured on gemini-3.6-flash (2026-08): minimal is ~3x faster than the
     # default level (0.96s vs 3.08s median turn) and passed the same

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.launch.py
@@ -58,7 +58,7 @@ def generate_launch_description():
     brain_backend_arg = DeclareLaunchArgument(
         "brain_backend",
         default_value=get_env("BRAIN_BACKEND", "gemini"),
-        description="Which provider the local brain thinks with: gemini or openai",
+        description="Which provider the local brain thinks with: gemini, openai or openai_compat",
     )
     brain_model_arg = DeclareLaunchArgument(
         "brain_model",

--- a/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
+++ b/ros2_ws/src/brain/brain_client/launch/brain_client.sim.launch.py
@@ -49,7 +49,7 @@ def generate_launch_description():
     brain_backend_arg = DeclareLaunchArgument(
         "brain_backend",
         default_value=get_env("BRAIN_BACKEND", "gemini"),
-        description="Which provider the local brain thinks with: gemini or openai",
+        description="Which provider the local brain thinks with: gemini, openai or openai_compat",
     )
     brain_model_arg = DeclareLaunchArgument(
         "brain_model",

--- a/sim/launcher/config.py
+++ b/sim/launcher/config.py
@@ -91,9 +91,12 @@ PUBLISHED_PORT_ENV = {
 INNATE_BACKEND = "innate"
 GEMINI_BACKEND = "gemini"
 OPENAI_BACKEND = "openai"
+OPENAI_COMPAT_BACKEND = "openai_compat"
 NO_BACKEND = "none"
 GEMINI_API_KEY = "GEMINI_API_KEY"
 OPENAI_API_KEY = "OPENAI_API_KEY"
+OPENAI_COMPAT_BASE_URL = "OPENAI_COMPAT_BASE_URL"  # an openai_compat brain needs the URL, not a key
+OPENAI_COMPAT_API_KEY = "OPENAI_COMPAT_API_KEY"
 BRAIN_BACKEND = "BRAIN_BACKEND"  # which provider the robot's brain thinks with
 INNATE_SERVICE_KEY = "INNATE_SERVICE_KEY"
 AUTO_OS_IMAGE = "auto"
@@ -241,7 +244,7 @@ LEGACY_SHARED_CONTAINER = "innate-dev"
 LEGACY_SHARED_PROJECT = "innate-os"
 LEGACY_CLOUD_AGENT_CONTAINER = "innate-cloud-agent"
 OS_CONTAINER_TMUX_CMD = "./scripts/launch_sim_in_tmux.zsh --detach"
-SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY, OPENAI_API_KEY)
+SECRET_ENV_KEYS = (INNATE_SERVICE_KEY, GEMINI_API_KEY, OPENAI_API_KEY, OPENAI_COMPAT_API_KEY)
 LOG_TARGETS = {
     "bootstrap": BOOTSTRAP_LOG_PATH,
     "compose": COMPOSE_LOG_PATH,
@@ -466,18 +469,22 @@ def get_nested_bool(data: dict[str, object], *keys: str) -> bool | None:
 def resolve_brain_backend(env: dict[str, str]) -> str:
     """Which key the in-process brain (brain_client) will use to reach its model.
 
-    The service key wins: it also buys voice, and it covers every provider,
-    which a vendor key does not. Below it, the vendor key that matches
-    BRAIN_BACKEND is the one the brain will actually use — a key for the other
-    vendor leaves it unconfigured, which is what this reports.
+    An openai_compat brain never uses the proxy, so its endpoint URL decides
+    alone. Otherwise the service key wins: it also buys voice, and it covers
+    every hosted provider, which a vendor key does not. Below it, the vendor
+    key that matches BRAIN_BACKEND is the one the brain will actually use — a
+    key for the other vendor leaves it unconfigured, which is what this reports.
 
     brain_client's `pick_conversation` (brain/llm/__init__.py) makes the real
     choice and owns this precedence; the launcher runs on the host and cannot
     import it, so this restates the rule. Change one and change the other.
     """
+    provider = (env.get(BRAIN_BACKEND, "") or GEMINI_BACKEND).strip().lower()
+    if provider == OPENAI_COMPAT_BACKEND:
+        has_url = is_configured_secret_value(OPENAI_COMPAT_BASE_URL, env.get(OPENAI_COMPAT_BASE_URL, ""))
+        return OPENAI_COMPAT_BACKEND if has_url else NO_BACKEND
     if is_configured_secret_value(INNATE_SERVICE_KEY, env.get(INNATE_SERVICE_KEY, "")):
         return INNATE_BACKEND
-    provider = (env.get(BRAIN_BACKEND, "") or GEMINI_BACKEND).strip().lower()
     vendor_key = OPENAI_API_KEY if provider == OPENAI_BACKEND else GEMINI_API_KEY
     if is_configured_secret_value(vendor_key, env.get(vendor_key, "")):
         return OPENAI_BACKEND if provider == OPENAI_BACKEND else GEMINI_BACKEND

--- a/sim/launcher/main.py
+++ b/sim/launcher/main.py
@@ -202,7 +202,8 @@ def cmd_up(
             warn("No cloud LLM key configured — the sim is running WITHOUT an agent.")
             warn(
                 "Add GEMINI_API_KEY or OPENAI_API_KEY (your own vendor key, matching the "
-                "brain_backend setting) or INNATE_SERVICE_KEY (Innate proxy) to "
+                "brain_backend setting), OPENAI_COMPAT_BASE_URL (an OpenAI-compatible server) "
+                "or INNATE_SERVICE_KEY (Innate proxy) to "
                 f"{ENV_PATH}, or run `{CLI_SIM} setup`, then restart."
             )
         success("Innate sim runtime is up.")

--- a/sim/launcher/runtime.py
+++ b/sim/launcher/runtime.py
@@ -40,6 +40,7 @@ from config import (
     LEGACY_SHARED_CONTAINER,
     LEGACY_SHARED_PROJECT,
     NO_BACKEND,
+    OPENAI_COMPAT_BACKEND,
     OS_BUILD_LOG_PATH,
     OS_CONTAINER_NAME,
     OS_CONTAINER_SERVICE,
@@ -2997,6 +2998,8 @@ def collect_status_snapshot(config: dict[str, object]) -> dict[str, object]:
         llm_level, llm_label = "warn", "no key"
     elif config["brain_backend"] == INNATE_BACKEND:
         llm_level, llm_label = "healthy", "innate proxy"
+    elif config["brain_backend"] == OPENAI_COMPAT_BACKEND:
+        llm_level, llm_label = "healthy", "openai-compatible endpoint"
     else:
         llm_level, llm_label = "healthy", f"{config['brain_backend']} key"
 

--- a/sim/launcher/setup_wizard.py
+++ b/sim/launcher/setup_wizard.py
@@ -19,6 +19,8 @@ from config import (
     NO_BACKEND,
     OPENAI_API_KEY,
     OPENAI_BACKEND,
+    OPENAI_COMPAT_BACKEND,
+    OPENAI_COMPAT_BASE_URL,
     SECRET_ENV_KEYS,
     SETTINGS_PATH,
     is_configured_secret_value,
@@ -456,14 +458,23 @@ def configure_brain_backend(config: dict[str, object]) -> None:
     # what keeps this report and the runtime dashboard from disagreeing.
     backend = resolve_brain_backend(user_env)
 
+    if backend == OPENAI_COMPAT_BACKEND:
+        # Configured by hand in .env (a URL, a model, maybe a key): there is
+        # nothing for the menu below to collect, and answering it would
+        # switch the provider away from the endpoint that was just set up.
+        success(
+            f"OpenAI-compatible endpoint selected ({OPENAI_COMPAT_BASE_URL} detected); edit {ENV_PATH.name} to change it."
+        )
+        report_configured_keys(config)
+        return
     if not is_interactive_terminal():
         if backend == INNATE_BACKEND:
             success("Innate proxy selected (INNATE_SERVICE_KEY detected).")
         elif backend == NO_BACKEND:
             warn(
                 f"No brain key configured for {BRAIN_BACKEND}={user_env.get(BRAIN_BACKEND) or GEMINI_BACKEND}. "
-                f"Add GEMINI_API_KEY or OPENAI_API_KEY (your own vendor key) or INNATE_SERVICE_KEY "
-                f"(Innate proxy) to {ENV_PATH}."
+                f"Add GEMINI_API_KEY or OPENAI_API_KEY (your own vendor key), OPENAI_COMPAT_BASE_URL "
+                f"(an OpenAI-compatible server) or INNATE_SERVICE_KEY (Innate proxy) to {ENV_PATH}."
             )
         else:
             success(f"Direct {backend} access selected ({_VENDOR_KEYS[backend]} detected).")

--- a/webapp/js/settings/catalog.js
+++ b/webapp/js/settings/catalog.js
@@ -116,6 +116,7 @@ const TIMEZONE_OPTIONS = [
 const BRAIN_BACKEND_OPTIONS = [
   { value: "gemini", label: "Gemini" },
   { value: "openai", label: "OpenAI" },
+  { value: "openai_compat", label: "OpenAI-compatible endpoint" },
 ];
 
 const VAD_ENGINE_OPTIONS = [
@@ -340,9 +341,9 @@ export const SETTINGS_PAGES = [
         title: "AI models",
         note: "The brain and the speech-to-text path use separate models. The transcribe backend picks which STT model knob applies.",
         knobs: [
-          { path: ["brain_client_node", P, "brain_backend"], label: "Brain provider", default: "gemini", type: "string", options: BRAIN_BACKEND_OPTIONS, doc: "Which provider the local brain thinks with. Without an Innate service key it needs that vendor's own key in .env", subsection: "Brain" },
+          { path: ["brain_client_node", P, "brain_backend"], label: "Brain provider", default: "gemini", type: "string", options: BRAIN_BACKEND_OPTIONS, doc: "Which provider the local brain thinks with. Without an Innate service key it needs that vendor's own key in .env; an OpenAI-compatible endpoint (NVIDIA NIM, vLLM, Ollama) is set by OPENAI_COMPAT_BASE_URL there", subsection: "Brain" },
           { path: ["brain_client_node", P, "brain_model"], label: "Brain model", default: "gemini-3.6-flash", type: "string", doc: "Model powering the local brain. Must belong to the chosen provider", subsection: "Brain" },
-          { path: ["brain_client_node", P, "brain_thinking_level"], label: "Thinking level", default: "minimal", type: "string", doc: "Named in the provider's own vocabulary: gemini takes minimal/low/medium/high, openai none/low/medium/high/xhigh/max. Blank uses the model default", subsection: "Brain" },
+          { path: ["brain_client_node", P, "brain_thinking_level"], label: "Thinking level", default: "minimal", type: "string", doc: "Named in the provider's own vocabulary: gemini takes minimal/low/medium/high, openai none/low/medium/high/xhigh/max, an OpenAI-compatible endpoint off/low/medium/high. Blank uses the model default", subsection: "Brain" },
           { path: ["brain_client_node", P, "memory_model"], label: "Spatial memory model", default: "gemini-3.6-flash", type: "string", doc: "Memory search needs Gemini context caching, so it stays on Gemini whichever provider the brain uses", subsection: "Brain" },
           { path: ["input_manager_node", P, "stt_backend"], label: "Transcribe backend", default: "elevenlabs", type: "string", options: STT_BACKEND_OPTIONS, doc: "Which service transcribes the microphone", subsection: "Speech to text" },
           { path: ["input_manager_node", P, "stt_vad_engine"], label: "VAD engine", default: "silero", type: "string", options: VAD_ENGINE_OPTIONS, doc: "Local voice detector, every backend", subsection: "Speech to text" },


### PR DESCRIPTION
Stacked on #809 (the provider seam). Merge that first; this is one more package under `brain/llm/`.

## Why

NVIDIA wants the robot's brain on their own models. Behind the `Conversation` seam that is a
Chat Completions provider pointed at whatever answers it at `OPENAI_COMPAT_BASE_URL` — NVIDIA's
hosted NIM API (`https://integrate.api.nvidia.com/v1`), a NIM or vLLM container on the LAN,
Ollama. It is the provider for models Innate does not host, so it never goes through the proxy.

**Chat Completions, not Responses, on purpose.** It is the one request shape every
OpenAI-compatible server answers; Responses (what the `openai` provider uses, for reasoning
items) is not. The trade is thoughts: a server only reports them when it runs a reasoning
parser (`reasoning_content` on vLLM/NIM, `reasoning` elsewhere), so reasoning models should run
with their parser or with thinking off.

## What is in it

```
llm/openai_compat/__init__.py   build(): endpoint from env, thinking level -> request fields
llm/openai_compat/transport.py  Endpoint (base URL + optional bearer key), one httpx client, SSE
llm/openai_compat/wire.py       neutral types -> chat.completions messages / tools
llm/openai_compat/context.py    OpenAICompatConversation: stream assembly, history, pruning
```

- Text deltas go to the voice as they land; tool calls arrive fragmented by `index` and are
  assembled at stream end. The server's call ids are stored on the assistant message and quoted
  back on `role: tool` messages (a server that omits ids gets one minted).
- A stream that stops before `finish_reason`, or ends on anything but `stop`/`tool_calls`,
  fails the turn instead of committing a truncated call — the rule #809 applied to
  `response.incomplete`.
- Same append-only history and chunked compaction as the other two providers, so a server's
  prefix cache stays warm; wrist frames are latest-only exactly as before.
- `brain_thinking_level` in this provider's vocabulary: `off` → `chat_template_kwargs.enable_thinking=false`
  (the vLLM/NIM switch for models that reason by default: Nemotron 3, Qwen3), `low|medium|high` →
  `reasoning_effort`, `""` → server default.
- `parse_arguments` moves to `llm/types.py`; the `openai` provider now shares it.
- Sim launcher: `resolve_brain_backend` mirrors the precedence (the URL decides alone), the
  status pane labels it, the wizard leaves a hand-configured endpoint alone. Settings page gets
  the option; `.env.template` documents the three lines.

## Configuration

```
BRAIN_BACKEND=openai_compat
BRAIN_MODEL=nvidia/nemotron-3-nano-omni-30b-a3b-reasoning
OPENAI_COMPAT_BASE_URL=https://integrate.api.nvidia.com/v1
OPENAI_COMPAT_API_KEY=nvapi-…          # omit for an open LAN server
```
plus `brain_thinking_level: "off"` in settings for Nemotron 3 (it reasons by default and the
traces are long).

## Verified

- ruff clean; basedpyright 0 errors on `brain/llm`, `core/config.py`, the launcher files.
- 297 pass in the real-ROS brain_client bucket (sim image); launcher `tests/` pass except one
  intersection-pack test that fails identically on the base commit.
- A two-turn exchange through the real httpx transport against a fake Chat Completions server:
  bearer auth, data-URI frames, a tool call split across three deltas, `tool_call_id` round
  trip on the next request, cached-token usage, wrist-frame masking, `enable_thinking=false`
  on the body.

## Not yet verified — needs someone with an NVIDIA key

- No live run against NIM. The wire is the documented one; server quirks are where this breaks.
- Behavioural, not plumbing: the 0-1000 image-coordinate convention behind
  `go_to_point_in_view` and the same-turn answer+call discipline were measured on Gemini. Run
  the reaction-latency probes on Nemotron before trusting it on a robot.

Development tests (12, pure fake-transport) were written and deleted per the repo rule; say
the word and they go into `test_local_brain.py`.
