### PR TITLE
feat(mars_cam): guided camera calibration, with either board

### DIFF
--- a/ros2_ws/src/mars_bot/mars_cam/CMakeLists.txt
+++ b/ros2_ws/src/mars_bot/mars_cam/CMakeLists.txt
@@ -313,6 +313,12 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  # Unit tests for the pure (ROS-free) checkerboard calibration helpers.
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_checkerboard_calibration test/test_checkerboard_calibration.py
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
   # Unit tests for the pure (GStreamer/ROS-free) streamer helpers in webrtc_internal.hpp.
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_webrtc_internal test/test_webrtc_internal.cpp)

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/calibration_experiment.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/calibration_experiment.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""On-disk artefacts for a checkerboard calibration experiment.
+
+Everything a run produces — capture metadata, the candidate calibration, the
+held-out validation report and the debug renders — lands under one timestamped
+directory that is never the production calibration directory.
+"""
+
+import csv
+import json
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from mars_cam.calibration_validation import ErrorStats, ValidationReport
+from mars_cam.checkerboard import CaptureDiagnostics
+
+# The C++ loader claims any directory whose name contains this substring, so an
+# experiment directory must never include it or it can shadow production.
+_PRODUCTION_DIR_MARKER = "calibration_config"
+
+CANDIDATE_CALIB_NAME = "stereo_calib_candidate.yaml"
+
+
+class ExperimentRecorder:
+    """Owns one experiment run's output directory and writes its artefacts."""
+
+    def __init__(self, root: Path, target_type: str) -> None:
+        if _PRODUCTION_DIR_MARKER in root.name:
+            raise ValueError(f"Experiment root must not contain '{_PRODUCTION_DIR_MARKER}': {root}")
+        self.run_dir = root / f"{target_type}_{time.strftime('%Y%m%d_%H%M%S')}"
+        self.image_dir = self.run_dir / "images"
+        self.debug_dir = self.run_dir / "debug"
+        for directory in (self.image_dir, self.debug_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+    # ---------------------------------------------------------------- images
+
+    def save_pair(self, index: int, left: np.ndarray, right: np.ndarray) -> None:
+        cv2.imwrite(str(self.image_dir / f"left_{index:03d}.png"), left)
+        cv2.imwrite(str(self.image_dir / f"right_{index:03d}.png"), right)
+
+    def save_detection_overlay(
+        self,
+        index: int,
+        left: np.ndarray,
+        right: np.ndarray,
+        corners_left: np.ndarray,
+        corners_right: np.ndarray,
+        pattern: tuple[int, int],
+    ) -> None:
+        panels = []
+        for image, corners in ((left, corners_left), (right, corners_right)):
+            panel = image.copy()
+            cv2.drawChessboardCorners(panel, pattern, corners, True)
+            panels.append(panel)
+        cv2.imwrite(str(self.debug_dir / f"detection_{index:03d}.png"), np.hstack(panels))
+
+    def save_coverage(self, corners_left: list[np.ndarray], corners_right: list[np.ndarray], size: tuple[int, int]):
+        """Dot map of every accepted corner, per camera, as one side-by-side image."""
+        width, height = size
+        panels = []
+        for corner_sets, color in ((corners_left, (80, 80, 255)), (corners_right, (80, 255, 80))):
+            canvas = np.zeros((height, width, 3), dtype=np.uint8)
+            for corners in corner_sets:
+                for point in corners.reshape(-1, 2):
+                    x, y = int(point[0]), int(point[1])
+                    if 0 <= x < width and 0 <= y < height:
+                        cv2.circle(canvas, (x, y), 2, color, -1)
+            panels.append(canvas)
+        cv2.imwrite(str(self.debug_dir / "coverage.png"), np.hstack(panels))
+
+    def save_rectified_samples(
+        self,
+        pairs: list[tuple[int, np.ndarray, np.ndarray]],
+        calib: dict,
+        size: tuple[int, int],
+        line_spacing: int = 32,
+    ) -> None:
+        """Rectified left/right pairs with horizontal guides for eyeballing alignment."""
+        width, height = size
+        map_left = cv2.initUndistortRectifyMap(
+            calib["K1"], calib["D1"], calib["R1"], calib["P1"], (width, height), cv2.CV_32FC1
+        )
+        map_right = cv2.initUndistortRectifyMap(
+            calib["K2"], calib["D2"], calib["R2"], calib["P2"], (width, height), cv2.CV_32FC1
+        )
+        for index, left, right in pairs:
+            rect_left = cv2.remap(left, map_left[0], map_left[1], cv2.INTER_LINEAR)
+            rect_right = cv2.remap(right, map_right[0], map_right[1], cv2.INTER_LINEAR)
+            canvas = np.hstack([rect_left, rect_right])
+            for y in range(0, height, line_spacing):
+                cv2.line(canvas, (0, y), (canvas.shape[1], y), (0, 255, 255), 1)
+            cv2.imwrite(str(self.debug_dir / f"rectified_{index:03d}.png"), canvas)
+
+    # -------------------------------------------------------------- metadata
+
+    def write_captures(self, diagnostics: list[CaptureDiagnostics]) -> tuple[Path, Path]:
+        rows = [d.flat_record() for d in diagnostics]
+        json_path = self.run_dir / "captures.json"
+        csv_path = self.run_dir / "captures.csv"
+        json_path.write_text(json.dumps(rows, indent=2))
+        _write_csv(csv_path, rows)
+        return json_path, csv_path
+
+    def write_validation(self, report: ValidationReport) -> tuple[Path, Path]:
+        payload = report.to_dict()
+        corner_rows = payload.pop("corner_samples", [])
+        json_path = self.run_dir / "validation_report.json"
+        json_path.write_text(json.dumps(payload, indent=2))
+        _write_csv(self.run_dir / "corner_errors.csv", corner_rows)
+        markdown_path = self.run_dir / "validation_report.md"
+        markdown_path.write_text(render_markdown(report))
+        return json_path, markdown_path
+
+    def write_summary(self, summary: dict) -> Path:
+        path = self.run_dir / "run_summary.json"
+        path.write_text(json.dumps(summary, indent=2, default=str))
+        return path
+
+    def save_candidate_calibration(self, calib: dict) -> Path:
+        """Write the solved calibration as a candidate, never as production."""
+        path = self.run_dir / CANDIDATE_CALIB_NAME
+        storage = cv2.FileStorage(str(path), cv2.FileStorage_WRITE)
+        if not storage.isOpened():
+            raise RuntimeError(f"Failed to open candidate calibration for writing: {path}")
+        storage.write("version", 2)
+        storage.write("model", "pinhole")
+        storage.write("image_width", calib["image_width"])
+        storage.write("image_height", calib["image_height"])
+        for key in ("K1", "D1", "K2", "D2", "R", "T", "R1", "R2", "P1", "P2", "Q"):
+            storage.write(key, calib[key])
+        storage.release()
+        return path
+
+
+def skew_summary(diagnostics: list[CaptureDiagnostics]) -> dict[str, float | int]:
+    """Observed left/right timestamp skew, reported before any tolerance change."""
+    skews = np.array([abs(d.stamp_skew_sec) for d in diagnostics if d.left.stamp_sec > 0.0])
+    if skews.size == 0:
+        return {"count": 0}
+    return {
+        "count": int(skews.size),
+        "mean_ms": float(np.mean(skews) * 1000.0),
+        "median_ms": float(np.median(skews) * 1000.0),
+        "p95_ms": float(np.percentile(skews, 95) * 1000.0),
+        "max_ms": float(np.max(skews) * 1000.0),
+        "std_ms": float(np.std(skews) * 1000.0),
+    }
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    if not rows:
+        path.write_text("")
+        return
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _stats_row(label: str, stats: ErrorStats, unit: str) -> str:
+    return (
+        f"| {label} ({unit}) | {stats.count} | {stats.mean:.4f} | {stats.rms:.4f} | "
+        f"{stats.median:.4f} | {stats.p95:.4f} | {stats.maximum:.4f} |"
+    )
+
+
+def render_markdown(report: ValidationReport) -> str:
+    """Human-readable validation summary written beside the machine-readable JSON."""
+    lines = [
+        "# Held-out stereo calibration validation",
+        "",
+        f"Validation pairs (never seen by calibrateCamera / stereoCalibrate): **{report.num_pairs}**",
+        "",
+        "## Overall",
+        "",
+        "| Metric | N | Mean | RMS | Median | p95 | Max |",
+        "|---|---|---|---|---|---|---|",
+        _stats_row("Left reprojection", report.left_reprojection, "px"),
+        _stats_row("Right reprojection", report.right_reprojection, "px"),
+        _stats_row("Rectified epipolar abs(dy)", report.epipolar_dy, "px"),
+        _stats_row("Neighbour spacing error", report.spacing_error_mm, "mm"),
+        _stats_row("Planarity RMS per image", report.planarity_rms_mm, "mm"),
+        _stats_row("Planarity p95 per image", report.planarity_p95_mm, "mm"),
+        "",
+        f"Mean reconstructed neighbour spacing: **{report.mean_spacing_mm:.3f} mm** "
+        f"(nominal {report.nominal_spacing_mm:.3f} mm)",
+        "",
+        f"Median triangulated depth: **{report.median_depth_m:+.4f} m** — "
+        f"Q yields positive Z for points in front of the camera: **{report.q_yields_positive_z}**",
+        "",
+        "## Error versus image location",
+        "",
+        "| Ring | r range | N | Reproj mean (px) | Reproj p95 (px) | abs(dy) mean (px) | abs(dy) p95 (px) |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for ring in report.radial_bins:
+        upper = "1.00+" if ring.r_max == float("inf") else f"{ring.r_max:.2f}"
+        lines.append(
+            f"| {ring.label} | {ring.r_min:.2f}–{upper} | {ring.reprojection.count} | "
+            f"{ring.reprojection.mean:.4f} | {ring.reprojection.p95:.4f} | "
+            f"{ring.epipolar_dy.mean:.4f} | {ring.epipolar_dy.p95:.4f} |"
+        )
+
+    lines += [
+        "",
+        "## Per validation image",
+        "",
+        "| Image | L reproj RMS (px) | R reproj RMS (px) | abs(dy) RMS (px) | Spacing err mean (mm) | "
+        "Planarity RMS (mm) | Median depth (m) |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for image in report.per_image:
+        lines.append(
+            f"| {image.index} | {image.left_reprojection.rms:.4f} | {image.right_reprojection.rms:.4f} | "
+            f"{image.epipolar_dy.rms:.4f} | {image.spacing_error_mm.mean:.4f} | "
+            f"{image.planarity_rms_mm:.4f} | {image.median_depth_m:+.4f} |"
+        )
+    lines.append("")
+    return "\n".join(lines)

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/calibration_experiment.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/calibration_experiment.py
@@ -187,8 +187,12 @@ def render_markdown(report: ValidationReport) -> str:
         _stats_row("Planarity RMS per image", report.planarity_rms_mm, "mm"),
         _stats_row("Planarity p95 per image", report.planarity_p95_mm, "mm"),
         "",
-        f"Mean reconstructed neighbour spacing: **{report.mean_spacing_mm:.3f} mm** "
-        f"(nominal {report.nominal_spacing_mm:.3f} mm)",
+        (
+            f"Mean reconstructed neighbour spacing: **{report.mean_spacing_mm:.3f} mm** "
+            f"(nominal {report.nominal_spacing_mm:.3f} mm)"
+            if report.spacing_error_mm.count
+            else "Neighbour spacing: **n/a** — needs a complete grid; ChArUco returns corner subsets."
+        ),
         "",
         f"Median triangulated depth: **{report.median_depth_m:+.4f} m** — "
         f"Q yields positive Z for points in front of the camera: **{report.q_yields_positive_z}**",

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/calibration_validation.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/calibration_validation.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Held-out validation metrics for a solved stereo calibration.
+
+Pure functions — no ROS, no file I/O. Everything here runs on image pairs that
+were deliberately kept out of ``calibrateCamera``/``stereoCalibrate``, so the
+numbers measure generalisation rather than fit.
+"""
+
+from dataclasses import asdict, dataclass, field
+
+import cv2
+import numpy as np
+
+from mars_cam.checkerboard import PatternSize
+
+# Normalised radius bin edges, in units of half the image diagonal.
+RADIAL_EDGES: tuple[float, float] = (1.0 / 3.0, 2.0 / 3.0)
+RADIAL_LABELS: tuple[str, str, str] = ("center", "middle", "outer")
+
+
+@dataclass(frozen=True)
+class ErrorStats:
+    """The distribution summary reported for every error metric."""
+
+    count: int
+    mean: float
+    rms: float
+    median: float
+    p95: float
+    maximum: float
+
+    @staticmethod
+    def of(values: np.ndarray) -> "ErrorStats":
+        flat = np.asarray(values, dtype=np.float64).ravel()
+        if flat.size == 0:
+            return ErrorStats(0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        return ErrorStats(
+            count=int(flat.size),
+            mean=float(np.mean(flat)),
+            rms=float(np.sqrt(np.mean(flat**2))),
+            median=float(np.median(flat)),
+            p95=float(np.percentile(flat, 95)),
+            maximum=float(np.max(flat)),
+        )
+
+
+@dataclass(frozen=True)
+class StereoCalibrationMatrices:
+    """The solved parameters the validator needs, in OpenCV conventions."""
+
+    K1: np.ndarray
+    D1: np.ndarray
+    K2: np.ndarray
+    D2: np.ndarray
+    R1: np.ndarray
+    R2: np.ndarray
+    P1: np.ndarray
+    P2: np.ndarray
+
+
+@dataclass(frozen=True)
+class ValidationPair:
+    """One held-out stereo observation of the target."""
+
+    index: int
+    object_points: np.ndarray
+    corners_left: np.ndarray
+    corners_right: np.ndarray
+    grid_shape: PatternSize | None = None
+
+
+@dataclass(frozen=True)
+class PerImageMetrics:
+    index: int
+    left_reprojection: ErrorStats
+    right_reprojection: ErrorStats
+    epipolar_dy: ErrorStats
+    spacing_error_mm: ErrorStats
+    planarity_rms_mm: float
+    planarity_p95_mm: float
+    median_depth_m: float
+
+
+@dataclass(frozen=True)
+class RadialBin:
+    label: str
+    r_min: float
+    r_max: float
+    reprojection: ErrorStats
+    epipolar_dy: ErrorStats
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Everything measured on the held-out set, ready to serialise."""
+
+    num_pairs: int
+    left_reprojection: ErrorStats
+    right_reprojection: ErrorStats
+    epipolar_dy: ErrorStats
+    spacing_error_mm: ErrorStats
+    mean_spacing_mm: float
+    nominal_spacing_mm: float
+    planarity_rms_mm: ErrorStats
+    planarity_p95_mm: ErrorStats
+    median_depth_m: float
+    q_yields_positive_z: bool
+    radial_bins: list[RadialBin]
+    per_image: list[PerImageMetrics]
+    corner_samples: list[dict[str, float]] = field(default_factory=list, repr=False)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _reprojection_errors(pair_obj: np.ndarray, corners: np.ndarray, K: np.ndarray, D: np.ndarray) -> np.ndarray:
+    """Per-corner reprojection error after fitting this image's pose alone.
+
+    The board pose is not a calibration output for a held-out image, so it has
+    to be recovered with solvePnP before the intrinsics can be scored.
+    """
+    obj = np.asarray(pair_obj, dtype=np.float64).reshape(-1, 1, 3)
+    img = np.asarray(corners, dtype=np.float64).reshape(-1, 1, 2)
+    ok, rvec, tvec = cv2.solvePnP(obj, img, K, D, flags=cv2.SOLVEPNP_ITERATIVE)
+    if not ok:
+        return np.empty(0)
+    projected, _ = cv2.projectPoints(obj, rvec, tvec, K, D)
+    return np.linalg.norm(projected.reshape(-1, 2) - img.reshape(-1, 2), axis=1)
+
+
+def _rectify(corners: np.ndarray, K: np.ndarray, D: np.ndarray, R: np.ndarray, P: np.ndarray) -> np.ndarray:
+    return cv2.undistortPoints(np.asarray(corners, dtype=np.float64).reshape(-1, 1, 2), K, D, R=R, P=P).reshape(-1, 2)
+
+
+def _triangulate(rect_left: np.ndarray, rect_right: np.ndarray, P1: np.ndarray, P2: np.ndarray) -> np.ndarray:
+    homogeneous = cv2.triangulatePoints(P1, P2, rect_left.T.copy(), rect_right.T.copy())
+    w = homogeneous[3]
+    w[np.abs(w) < 1e-12] = 1e-12
+    return (homogeneous[:3] / w).T
+
+
+def _neighbour_spacings(points: np.ndarray, grid_shape: PatternSize) -> np.ndarray:
+    """Distances between 4-neighbour corners of the reconstructed grid."""
+    cols, rows = grid_shape
+    grid = points.reshape(rows, cols, 3)
+    horizontal = np.linalg.norm(grid[:, 1:] - grid[:, :-1], axis=2).ravel()
+    vertical = np.linalg.norm(grid[1:] - grid[:-1], axis=2).ravel()
+    return np.concatenate([horizontal, vertical])
+
+
+def _plane_residuals(points: np.ndarray) -> np.ndarray:
+    """Point-to-plane distances for the best-fit plane through the corners."""
+    if len(points) < 3:
+        return np.empty(0)
+    centred = points - points.mean(axis=0)
+    _, _, vt = np.linalg.svd(centred, full_matrices=False)
+    return np.abs(centred @ vt[2])
+
+
+def _radial_norm(corners: np.ndarray, image_size: tuple[int, int]) -> np.ndarray:
+    """Distance from the image centre, normalised by half the image diagonal."""
+    width, height = image_size
+    centre = np.array([width / 2.0, height / 2.0])
+    half_diagonal = 0.5 * float(np.hypot(width, height))
+    return np.linalg.norm(corners.reshape(-1, 2) - centre, axis=1) / half_diagonal
+
+
+def evaluate(
+    calib: StereoCalibrationMatrices,
+    pairs: list[ValidationPair],
+    image_size: tuple[int, int],
+    square_size: float,
+) -> ValidationReport:
+    """Score a solved calibration on stereo pairs it never saw."""
+    per_image: list[PerImageMetrics] = []
+    all_left: list[np.ndarray] = []
+    all_right: list[np.ndarray] = []
+    all_dy: list[np.ndarray] = []
+    all_spacing_mm: list[np.ndarray] = []
+    all_spacing_error_mm: list[np.ndarray] = []
+    all_planarity_rms: list[float] = []
+    all_planarity_p95: list[float] = []
+    all_depths: list[np.ndarray] = []
+    radii: list[np.ndarray] = []
+    corner_samples: list[dict[str, float]] = []
+
+    for pair in pairs:
+        left_err = _reprojection_errors(pair.object_points, pair.corners_left, calib.K1, calib.D1)
+        right_err = _reprojection_errors(pair.object_points, pair.corners_right, calib.K2, calib.D2)
+
+        rect_left = _rectify(pair.corners_left, calib.K1, calib.D1, calib.R1, calib.P1)
+        rect_right = _rectify(pair.corners_right, calib.K2, calib.D2, calib.R2, calib.P2)
+        dy = np.abs(rect_left[:, 1] - rect_right[:, 1])
+
+        points3d = _triangulate(rect_left, rect_right, calib.P1, calib.P2)
+        depths = points3d[:, 2]
+
+        # A wrong-signed P2 negates the whole reconstruction, which leaves every
+        # distance intact — so spacing and planarity stay meaningful and only
+        # the depth sign reports the problem.
+        spacing = _neighbour_spacings(points3d, pair.grid_shape) if pair.grid_shape is not None else np.empty(0)
+        spacing_mm = spacing * 1000.0
+        spacing_error_mm = np.abs(spacing - square_size) * 1000.0
+        planarity_mm = _plane_residuals(points3d) * 1000.0
+        planarity_rms = float(np.sqrt(np.mean(planarity_mm**2))) if planarity_mm.size else 0.0
+        planarity_p95 = float(np.percentile(planarity_mm, 95)) if planarity_mm.size else 0.0
+
+        radius = _radial_norm(pair.corners_left, image_size)
+        radii.append(radius)
+        for i in range(len(radius)):
+            corner_samples.append(
+                {
+                    "image_index": float(pair.index),
+                    "corner_index": float(i),
+                    "u_left": float(pair.corners_left.reshape(-1, 2)[i, 0]),
+                    "v_left": float(pair.corners_left.reshape(-1, 2)[i, 1]),
+                    "radius_norm": float(radius[i]),
+                    "reprojection_px": float(left_err[i]) if i < len(left_err) else float("nan"),
+                    "epipolar_dy_px": float(dy[i]),
+                }
+            )
+
+        all_left.append(left_err)
+        all_right.append(right_err)
+        all_dy.append(dy)
+        all_spacing_mm.append(spacing_mm)
+        all_spacing_error_mm.append(spacing_error_mm)
+        all_planarity_rms.append(planarity_rms)
+        all_planarity_p95.append(planarity_p95)
+        all_depths.append(depths)
+
+        per_image.append(
+            PerImageMetrics(
+                index=pair.index,
+                left_reprojection=ErrorStats.of(left_err),
+                right_reprojection=ErrorStats.of(right_err),
+                epipolar_dy=ErrorStats.of(dy),
+                spacing_error_mm=ErrorStats.of(spacing_error_mm),
+                planarity_rms_mm=planarity_rms,
+                planarity_p95_mm=planarity_p95,
+                median_depth_m=float(np.median(depths)),
+            )
+        )
+
+    spacing_mm_all = _concat(all_spacing_mm)
+    depth_all = _concat(all_depths)
+    median_depth = float(np.median(depth_all)) if depth_all.size else 0.0
+
+    return ValidationReport(
+        num_pairs=len(pairs),
+        left_reprojection=ErrorStats.of(_concat(all_left)),
+        right_reprojection=ErrorStats.of(_concat(all_right)),
+        epipolar_dy=ErrorStats.of(_concat(all_dy)),
+        spacing_error_mm=ErrorStats.of(_concat(all_spacing_error_mm)),
+        mean_spacing_mm=float(np.mean(spacing_mm_all)) if spacing_mm_all.size else 0.0,
+        nominal_spacing_mm=square_size * 1000.0,
+        planarity_rms_mm=ErrorStats.of(np.array(all_planarity_rms)),
+        planarity_p95_mm=ErrorStats.of(np.array(all_planarity_p95)),
+        median_depth_m=median_depth,
+        q_yields_positive_z=median_depth > 0.0,
+        radial_bins=_bin_by_radius(_concat(radii), _concat(all_left), _concat(all_dy)),
+        per_image=per_image,
+        corner_samples=corner_samples,
+    )
+
+
+def _concat(arrays: list[np.ndarray]) -> np.ndarray:
+    usable = [a for a in arrays if a.size]
+    return np.concatenate(usable) if usable else np.empty(0)
+
+
+def _bin_by_radius(radii: np.ndarray, reprojection: np.ndarray, dy: np.ndarray) -> list[RadialBin]:
+    """Split corner errors into centre/middle/outer rings of the image."""
+    if radii.size == 0:
+        return []
+
+    def masked(values: np.ndarray, mask: np.ndarray) -> ErrorStats:
+        # solvePnP can drop an image, leaving reprojection shorter than radii.
+        return ErrorStats.of(values[mask]) if values.size == radii.size else ErrorStats.of(np.empty(0))
+
+    edges = (0.0, RADIAL_EDGES[0], RADIAL_EDGES[1], float("inf"))
+    bins: list[RadialBin] = []
+    for label, low, high in zip(RADIAL_LABELS, edges[:-1], edges[1:]):  # noqa: B905 — fixed-length, always aligned
+        mask = (radii >= low) & (radii < high)
+        bins.append(
+            RadialBin(
+                label=label,
+                r_min=low,
+                r_max=high,
+                reprojection=masked(reprojection, mask),
+                epipolar_dy=masked(dy, mask),
+            )
+        )
+    return bins

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/capture_guidance.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/capture_guidance.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Live guidance for an operator moving a calibration board through the frame.
+
+Pure functions — no ROS, no I/O, no OpenCV state. Answers the two questions the
+capture screen asks on every frame: is the board at a useful size, and what is
+still missing before this run will calibrate well.
+
+Everything here is expressed relative to the frame rather than in metres. This
+runs *during* calibration, so there are no intrinsics yet to turn pixels into
+distances, and inventing a focal length to report a confident-looking millimetre
+figure would be worse than reporting the thing actually measured.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# Board extent (its diagonal over the frame diagonal) that reads as usable.
+# Below the floor, corner localisation degrades faster than the extra range is
+# worth; above the ceiling there is no room left to move the board without
+# clipping corners out of frame, and detection fails rather than degrades.
+EXTENT_MIN = 0.25
+EXTENT_MAX = 0.85
+
+TOO_FAR = "TOO_FAR"
+TOO_CLOSE = "TOO_CLOSE"
+IN_RANGE = "IN_RANGE"
+
+# A board this foreshortened counts as tilted. Tilt is normalised by extent (see
+# measure), which makes it ~0.0143 per degree off square regardless of range, so
+# 0.28 is about 20 degrees — enough to separate focal length from distance.
+TILT_MIN = 0.28
+
+ZONE_GRID = 3
+CAPTURES_PER_ZONE = 1
+CAPTURES_PER_SCALE_BAND = 2
+CAPTURES_TILTED = 6
+
+ZONE_LABELS = (
+    ("top-left", "top-centre", "top-right"),
+    ("mid-left", "centre", "mid-right"),
+    ("bottom-left", "bottom-centre", "bottom-right"),
+)
+SCALE_LABELS = ("close", "mid-range", "far")
+
+
+@dataclass(frozen=True)
+class BoardView:
+    """One detected board, reduced to what coverage actually depends on."""
+
+    centroid_norm: tuple[float, float]
+    extent: float
+    tilt: float
+
+    @property
+    def hint(self) -> str:
+        if self.extent < EXTENT_MIN:
+            return TOO_FAR
+        if self.extent > EXTENT_MAX:
+            return TOO_CLOSE
+        return IN_RANGE
+
+    @property
+    def usable(self) -> bool:
+        return self.hint == IN_RANGE
+
+    @property
+    def zone(self) -> tuple[int, int]:
+        """Which cell of the 3x3 grid the board centre falls in."""
+        col = min(ZONE_GRID - 1, max(0, int(self.centroid_norm[0] * ZONE_GRID)))
+        row = min(ZONE_GRID - 1, max(0, int(self.centroid_norm[1] * ZONE_GRID)))
+        return row, col
+
+    @property
+    def scale_band(self) -> int:
+        """0 = filling the frame, 2 = small in frame, across the usable range."""
+        span = (EXTENT_MAX - EXTENT_MIN) / 3.0
+        offset = (EXTENT_MAX - self.extent) / span
+        return min(2, max(0, int(offset)))
+
+
+def measure(image_points: np.ndarray, board_points: np.ndarray, frame_size: tuple[int, int]) -> BoardView | None:
+    """Reduce one detection to a BoardView, or None if the geometry is degenerate.
+
+    ``board_points`` are the same corners in board coordinates, which is what
+    lets a partial ChArUco detection be measured the same way as a complete
+    checkerboard: the homography is fitted from whatever correspondences exist
+    and then asked about the board's own outline.
+    """
+    image_xy = np.asarray(image_points, dtype=np.float64).reshape(-1, 2)
+    board_xy = np.asarray(board_points, dtype=np.float64).reshape(-1, 3)[:, :2]
+    if len(image_xy) < 4 or len(image_xy) != len(board_xy):
+        return None
+
+    width, height = frame_size
+    if width <= 0 or height <= 0:
+        return None
+
+    homography = _fit_homography(board_xy, image_xy)
+    if homography is None:
+        return None
+
+    outline = _project(homography, _board_outline(board_xy))
+    if outline is None:
+        return None
+
+    centroid = image_xy.mean(axis=0)
+    lo, hi = image_xy.min(axis=0), image_xy.max(axis=0)
+    extent = float(np.hypot(*(hi - lo)) / np.hypot(width, height))
+    if extent < 1e-6:
+        return None
+
+    # Raw foreshortening shrinks with range for the same physical tilt, because
+    # it depends on the board's depth spread relative to its distance. Dividing
+    # by extent cancels that: the result is ~0.0143 per degree off square at any
+    # distance, so one threshold works across the whole usable range.
+    return BoardView(
+        centroid_norm=(float(centroid[0] / width), float(centroid[1] / height)),
+        extent=extent,
+        tilt=_foreshortening(outline) / extent,
+    )
+
+
+def _board_outline(board_xy: np.ndarray) -> np.ndarray:
+    """The board's own bounding rectangle, corners ordered TL, TR, BR, BL."""
+    lo, hi = board_xy.min(axis=0), board_xy.max(axis=0)
+    return np.array([[lo[0], lo[1]], [hi[0], lo[1]], [hi[0], hi[1]], [lo[0], hi[1]]], dtype=np.float64)
+
+
+def _foreshortening(quad: np.ndarray) -> float:
+    """How much opposite edges disagree in length — 0 when square to the camera.
+
+    Perspective is the only thing that can shorten one edge relative to the one
+    opposite it, so this isolates tilt from board size, board position and
+    in-plane rotation, none of which change the ratio.
+    """
+    top = np.linalg.norm(quad[1] - quad[0])
+    bottom = np.linalg.norm(quad[2] - quad[3])
+    left = np.linalg.norm(quad[3] - quad[0])
+    right = np.linalg.norm(quad[2] - quad[1])
+    if min(top, bottom, left, right) <= 1e-9:
+        return 0.0
+    return float(max(abs(np.log(top / bottom)), abs(np.log(left / right))))
+
+
+def _fit_homography(source: np.ndarray, target: np.ndarray) -> np.ndarray | None:
+    """Direct linear transform, normalised — no cv2 so this stays unit-testable."""
+    src, t_src = _normalise(source)
+    dst, t_dst = _normalise(target)
+    if src is None or dst is None:
+        return None
+
+    rows = []
+    for (x, y), (u, v) in zip(src, dst):  # noqa: B905 — equal length checked by the caller
+        rows.append([-x, -y, -1.0, 0.0, 0.0, 0.0, u * x, u * y, u])
+        rows.append([0.0, 0.0, 0.0, -x, -y, -1.0, v * x, v * y, v])
+
+    _, _, vt = np.linalg.svd(np.asarray(rows, dtype=np.float64))
+    normalised = vt[-1].reshape(3, 3)
+    homography = np.linalg.inv(t_dst) @ normalised @ t_src
+    if abs(homography[2, 2]) < 1e-12:
+        return None
+    return homography / homography[2, 2]
+
+
+def _normalise(points: np.ndarray) -> tuple[np.ndarray | None, np.ndarray]:
+    """Hartley normalisation: centre on the mean, scale to mean distance sqrt(2)."""
+    centre = points.mean(axis=0)
+    centred = points - centre
+    spread = float(np.mean(np.hypot(centred[:, 0], centred[:, 1])))
+    if spread < 1e-9:
+        return None, np.eye(3)
+    scale = np.sqrt(2.0) / spread
+    transform = np.array([[scale, 0.0, -scale * centre[0]], [0.0, scale, -scale * centre[1]], [0.0, 0.0, 1.0]])
+    return centred * scale, transform
+
+
+def _project(homography: np.ndarray, points: np.ndarray) -> np.ndarray | None:
+    homogeneous = np.column_stack([points, np.ones(len(points))]) @ homography.T
+    w = homogeneous[:, 2]
+    if np.any(np.abs(w) < 1e-9):
+        return None
+    return homogeneous[:, :2] / w[:, None]
+
+
+@dataclass(frozen=True)
+class Progress:
+    """What the capture screen shows: one percentage and what is short."""
+
+    percent: float
+    missing: tuple[str, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing
+
+
+class CoverageTracker:
+    """Accumulates accepted captures and reports what the run still needs.
+
+    Counting captures alone is the failure this exists to prevent: forty images
+    of a board held square in the middle of the frame satisfy any target count
+    and calibrate badly, because nothing in them separates focal length from
+    distance or constrains distortion away from the centre.
+    """
+
+    def __init__(self, target_captures: int) -> None:
+        self._target = max(1, target_captures)
+        self._count = 0
+        self._zones = np.zeros((ZONE_GRID, ZONE_GRID), dtype=int)
+        self._scales = np.zeros(3, dtype=int)
+        self._tilted = 0
+
+    def add(self, view: BoardView) -> None:
+        self._count += 1
+        row, col = view.zone
+        self._zones[row, col] += 1
+        self._scales[view.scale_band] += 1
+        if view.tilt >= TILT_MIN:
+            self._tilted += 1
+
+    @property
+    def captures(self) -> int:
+        return self._count
+
+    def progress(self) -> Progress:
+        met, total, missing = 0, 0, []
+
+        for row in range(ZONE_GRID):
+            for col in range(ZONE_GRID):
+                total += 1
+                if self._zones[row, col] >= CAPTURES_PER_ZONE:
+                    met += 1
+                else:
+                    missing.append(ZONE_LABELS[row][col])
+
+        for band in range(3):
+            total += 1
+            if self._scales[band] >= CAPTURES_PER_SCALE_BAND:
+                met += 1
+            else:
+                missing.append(SCALE_LABELS[band])
+
+        total += 1
+        if self._tilted >= CAPTURES_TILTED:
+            met += 1
+        else:
+            missing.append("tilted views")
+
+        total += 1
+        if self._count >= self._target:
+            met += 1
+        else:
+            missing.append(f"{self._target - self._count} more captures")
+
+        return Progress(percent=100.0 * met / total, missing=tuple(missing))
+
+    def advice(self) -> str:
+        """One sentence naming the most useful next move, or "" when done."""
+        progress = self.progress()
+        if progress.complete:
+            return ""
+        return f"Still needed: {', '.join(progress.missing[:3])}"

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/capture_guidance.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/capture_guidance.py
@@ -6,26 +6,93 @@ Pure functions — no ROS, no I/O, no OpenCV state. Answers the two questions th
 capture screen asks on every frame: is the board at a useful size, and what is
 still missing before this run will calibrate well.
 
-Everything here is expressed relative to the frame rather than in metres. This
-runs *during* calibration, so there are no intrinsics yet to turn pixels into
-distances, and inventing a focal length to report a confident-looking millimetre
-figure would be worse than reporting the thing actually measured.
+Every decision here is made on frame-relative quantities, because this runs
+*during* calibration and there are no intrinsics yet to convert with. Distances
+in metres appear only as display text, derived from the lens's nominal field of
+view — approximate on purpose, and never an input to a threshold.
 """
 
 from dataclasses import dataclass
 
 import numpy as np
 
-# Board extent (its diagonal over the frame diagonal) that reads as usable.
-# Below the floor, corner localisation degrades faster than the extra range is
-# worth; above the ceiling there is no room left to move the board without
-# clipping corners out of frame, and detection fails rather than degrades.
-EXTENT_MIN = 0.25
+# Near limit, as board diagonal over frame diagonal. Board-independent: this is
+# about fitting inside the frame, and past it corners start leaving the image
+# rather than degrading.
 EXTENT_MAX = 0.85
+
+# Far limit, as pixels per square needed to still detect. Plain corners survive
+# on far less than ArUco markers, which have to resolve 6x6 cells of payload
+# well enough to decode — which is why the same paper reaches roughly three
+# times further as a checkerboard than as a ChArUco board.
+CHECKERBOARD_MIN_PIXELS_PER_SQUARE = 10.0
+CHARUCO_MIN_PIXELS_PER_SQUARE = 20.0
+
+# Used only when no board geometry was supplied, so the hint degrades to a
+# generic "very small in frame" rather than being silently disabled.
+DEFAULT_EXTENT_MIN = 0.12
 
 TOO_FAR = "TOO_FAR"
 TOO_CLOSE = "TOO_CLOSE"
 IN_RANGE = "IN_RANGE"
+
+
+@dataclass(frozen=True)
+class BoardGeometry:
+    """The printed target, reduced to what sets the usable range.
+
+    ``squares`` counts the span of the DETECTED corner grid in squares, not the
+    printed square count: a 9x6 inner-corner checkerboard spans 8x5 squares, and
+    a 17x9 ChArUco board yields corners spanning 16x8.
+    """
+
+    squares: tuple[int, int]
+    square_size_m: float
+    min_pixels_per_square: float
+
+    @staticmethod
+    def checkerboard(pattern: tuple[int, int], square_size_m: float) -> "BoardGeometry":
+        return BoardGeometry(
+            squares=(pattern[0] - 1, pattern[1] - 1),
+            square_size_m=square_size_m,
+            min_pixels_per_square=CHECKERBOARD_MIN_PIXELS_PER_SQUARE,
+        )
+
+    @staticmethod
+    def charuco(squares_x: int, squares_y: int, square_size_m: float) -> "BoardGeometry":
+        return BoardGeometry(
+            squares=(squares_x - 1, squares_y - 1),
+            square_size_m=square_size_m,
+            min_pixels_per_square=CHARUCO_MIN_PIXELS_PER_SQUARE,
+        )
+
+    @property
+    def diagonal_squares(self) -> float:
+        return float(np.hypot(*self.squares))
+
+    @property
+    def diagonal_m(self) -> float:
+        return self.diagonal_squares * self.square_size_m
+
+    def extent_min(self, frame_diagonal_px: float) -> float:
+        """Smallest usable board diagonal, as a fraction of the frame diagonal."""
+        if frame_diagonal_px <= 0.0:
+            return 0.0
+        return self.diagonal_squares * self.min_pixels_per_square / frame_diagonal_px
+
+    def range_m(self, focal_px: float, frame_diagonal_px: float) -> tuple[float, float]:
+        """(nearest, furthest) the board can be held, in metres.
+
+        Approximate by construction — ``focal_px`` comes from the lens's nominal
+        field of view, not from a calibration, because the calibration is what
+        this is trying to produce. For telling an operator "hold it around 30cm"
+        that is accurate enough; nothing downstream consumes it.
+        """
+        if focal_px <= 0.0 or frame_diagonal_px <= 0.0:
+            return 0.0, 0.0
+        span = focal_px * self.diagonal_m / frame_diagonal_px
+        return span / EXTENT_MAX, span / self.extent_min(frame_diagonal_px)
+
 
 # A board this foreshortened counts as tilted. Tilt is normalised by extent (see
 # measure), which makes it ~0.0143 per degree off square regardless of range, so
@@ -47,15 +114,23 @@ SCALE_LABELS = ("close", "mid-range", "far")
 
 @dataclass(frozen=True)
 class BoardView:
-    """One detected board, reduced to what coverage actually depends on."""
+    """One detected board, reduced to what coverage actually depends on.
+
+    ``extent_min`` rides along rather than being a module constant because it
+    depends on the target: the same sheet of letter paper reaches much further
+    as a checkerboard than as a ChArUco board.
+    """
 
     centroid_norm: tuple[float, float]
     extent: float
     tilt: float
+    pixels_per_square: float = 0.0
+    extent_min: float = DEFAULT_EXTENT_MIN
+    approx_distance_m: float = 0.0
 
     @property
     def hint(self) -> str:
-        if self.extent < EXTENT_MIN:
+        if self.extent < self.extent_min:
             return TOO_FAR
         if self.extent > EXTENT_MAX:
             return TOO_CLOSE
@@ -75,12 +150,17 @@ class BoardView:
     @property
     def scale_band(self) -> int:
         """0 = filling the frame, 2 = small in frame, across the usable range."""
-        span = (EXTENT_MAX - EXTENT_MIN) / 3.0
-        offset = (EXTENT_MAX - self.extent) / span
-        return min(2, max(0, int(offset)))
+        span = max(1e-6, (EXTENT_MAX - self.extent_min) / 3.0)
+        return min(2, max(0, int((EXTENT_MAX - self.extent) / span)))
 
 
-def measure(image_points: np.ndarray, board_points: np.ndarray, frame_size: tuple[int, int]) -> BoardView | None:
+def measure(
+    image_points: np.ndarray,
+    board_points: np.ndarray,
+    frame_size: tuple[int, int],
+    geometry: BoardGeometry | None = None,
+    focal_px: float = 0.0,
+) -> BoardView | None:
     """Reduce one detection to a BoardView, or None if the geometry is degenerate.
 
     ``board_points`` are the same corners in board coordinates, which is what
@@ -107,9 +187,15 @@ def measure(image_points: np.ndarray, board_points: np.ndarray, frame_size: tupl
 
     centroid = image_xy.mean(axis=0)
     lo, hi = image_xy.min(axis=0), image_xy.max(axis=0)
-    extent = float(np.hypot(*(hi - lo)) / np.hypot(width, height))
+    frame_diagonal = float(np.hypot(width, height))
+    extent = float(np.hypot(*(hi - lo)) / frame_diagonal)
     if extent < 1e-6:
         return None
+
+    diagonal_px = extent * frame_diagonal
+    pixels_per_square = diagonal_px / geometry.diagonal_squares if geometry else 0.0
+    extent_min = geometry.extent_min(frame_diagonal) if geometry else DEFAULT_EXTENT_MIN
+    distance = focal_px * geometry.diagonal_m / diagonal_px if geometry and focal_px > 0.0 else 0.0
 
     # Raw foreshortening shrinks with range for the same physical tilt, because
     # it depends on the board's depth spread relative to its distance. Dividing
@@ -119,6 +205,9 @@ def measure(image_points: np.ndarray, board_points: np.ndarray, frame_size: tupl
         centroid_norm=(float(centroid[0] / width), float(centroid[1] / height)),
         extent=extent,
         tilt=_foreshortening(outline) / extent,
+        pixels_per_square=float(pixels_per_square),
+        extent_min=float(extent_min),
+        approx_distance_m=float(distance),
     )
 
 

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/checkerboard.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/checkerboard.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Plain-checkerboard detection and per-capture quality diagnostics.
+
+Pure helpers — no ROS, no file I/O — so the stereo calibrator's checkerboard
+mode and its offline validation pass share one detector.
+"""
+
+from dataclasses import dataclass, field
+
+import cv2
+import numpy as np
+
+PatternSize = tuple[int, int]
+BBox = tuple[float, float, float, float]
+Point2 = tuple[float, float]
+
+# EXHAUSTIVE trades runtime for recall on tilted/blurred boards; ACCURACY runs
+# the subpixel refinement that makes a second cornerSubPix pass redundant.
+SB_FLAGS = cv2.CALIB_CB_EXHAUSTIVE | cv2.CALIB_CB_ACCURACY
+
+
+@dataclass(frozen=True)
+class CheckerboardTarget:
+    """The printed board: inner-corner counts and the measured square pitch."""
+
+    pattern: PatternSize
+    square_size: float
+
+    @property
+    def num_corners(self) -> int:
+        return self.pattern[0] * self.pattern[1]
+
+    def object_grid(self) -> np.ndarray:
+        """Planar (z=0) object points, row-major to match the detector's order."""
+        cols, rows = self.pattern
+        grid = np.zeros((rows * cols, 3), np.float32)
+        grid[:, :2] = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2) * self.square_size
+        return grid
+
+
+@dataclass(frozen=True)
+class ViewDiagnostics:
+    """Per-image capture quality, recorded whether or not detection succeeded."""
+
+    detected: bool
+    num_corners: int
+    stamp_sec: float
+    brightness: float
+    sharpness: float
+    bbox: BBox
+    coverage_pct: float
+    centroid_norm: Point2
+
+
+@dataclass(frozen=True)
+class CaptureDiagnostics:
+    """One capture attempt, as written to the experiment metadata files."""
+
+    index: int
+    attempt: int
+    accepted: bool
+    reason: str
+    split: str
+    stamp_skew_sec: float
+    left: ViewDiagnostics
+    right: ViewDiagnostics
+    corners_left: np.ndarray | None = field(default=None, repr=False)
+    corners_right: np.ndarray | None = field(default=None, repr=False)
+
+    def flat_record(self) -> dict[str, float | int | str | bool]:
+        """One flat row per capture, shared by the JSON and CSV writers."""
+        record: dict[str, float | int | str | bool] = {
+            "index": self.index,
+            "attempt": self.attempt,
+            "accepted": self.accepted,
+            "reason": self.reason,
+            "split": self.split,
+            "stamp_skew_sec": self.stamp_skew_sec,
+        }
+        for side, view in (("left", self.left), ("right", self.right)):
+            record[f"{side}_detected"] = view.detected
+            record[f"{side}_num_corners"] = view.num_corners
+            record[f"{side}_stamp_sec"] = view.stamp_sec
+            record[f"{side}_brightness"] = view.brightness
+            record[f"{side}_sharpness"] = view.sharpness
+            record[f"{side}_bbox_x0"], record[f"{side}_bbox_y0"] = view.bbox[0], view.bbox[1]
+            record[f"{side}_bbox_x1"], record[f"{side}_bbox_y1"] = view.bbox[2], view.bbox[3]
+            record[f"{side}_coverage_pct"] = view.coverage_pct
+            record[f"{side}_centroid_x_norm"] = view.centroid_norm[0]
+            record[f"{side}_centroid_y_norm"] = view.centroid_norm[1]
+        return record
+
+
+def sharpness(gray: np.ndarray) -> float:
+    """Variance of the Laplacian — low values flag motion blur or defocus."""
+    return float(cv2.Laplacian(gray, cv2.CV_64F).var())
+
+
+def detect(gray: np.ndarray, pattern: PatternSize) -> np.ndarray | None:
+    """Locate the complete inner-corner grid, or None if it is not fully visible.
+
+    findChessboardCornersSB already returns subpixel coordinates, so no
+    cornerSubPix pass follows it.
+    """
+    found, corners = cv2.findChessboardCornersSB(gray, pattern, flags=SB_FLAGS)
+    if not found or corners is None or len(corners) != pattern[0] * pattern[1]:
+        return None
+    # The build returns either (N,2) or (N,1,2); downstream OpenCV calls all
+    # want the channelled form.
+    return _canonical(np.asarray(corners, dtype=np.float32).reshape(-1, 1, 2))
+
+
+def _canonical(corners: np.ndarray) -> np.ndarray:
+    """Resolve the detector's 180-degree origin ambiguity.
+
+    A rectangular grid comes back row-major from one of two opposite origins.
+    Left and right must pick the same one or every correspondence is reversed;
+    anchoring on the top-left-most endpoint agrees across a short baseline.
+    """
+    first, last = corners[0, 0], corners[-1, 0]
+    if (first[0] + first[1]) > (last[0] + last[1]):
+        return corners[::-1].copy()
+    return corners
+
+
+def measure(gray: np.ndarray, corners: np.ndarray | None, stamp_sec: float) -> ViewDiagnostics:
+    """Build the capture-quality record for one image of a stereo pair."""
+    height, width = gray.shape[:2]
+    if corners is None:
+        return ViewDiagnostics(
+            detected=False,
+            num_corners=0,
+            stamp_sec=stamp_sec,
+            brightness=float(np.mean(gray)),
+            sharpness=sharpness(gray),
+            bbox=(0.0, 0.0, 0.0, 0.0),
+            coverage_pct=0.0,
+            centroid_norm=(0.0, 0.0),
+        )
+
+    pts = corners.reshape(-1, 2)
+    x0, y0 = float(pts[:, 0].min()), float(pts[:, 1].min())
+    x1, y1 = float(pts[:, 0].max()), float(pts[:, 1].max())
+    return ViewDiagnostics(
+        detected=True,
+        num_corners=int(len(pts)),
+        stamp_sec=stamp_sec,
+        brightness=float(np.mean(gray)),
+        sharpness=sharpness(gray),
+        bbox=(x0, y0, x1, y1),
+        coverage_pct=100.0 * (x1 - x0) * (y1 - y0) / float(width * height),
+        centroid_norm=(float(pts[:, 0].mean()) / width, float(pts[:, 1].mean()) / height),
+    )

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -256,12 +256,14 @@ class StereoCalibrator(Node):
         self.capture_diagnostics: list[cb.CaptureDiagnostics] = []
         self.validation_indices: set[int] = set()
         self.recorder: ExperimentRecorder | None = None
-        if self.target_type == TARGET_CHECKERBOARD:
+        # A held-out split with nowhere to report it would silently shrink the
+        # training set and produce no metrics, so the recorder follows the split.
+        if self.target_type == TARGET_CHECKERBOARD or self.validate_charuco:
             configured_root = str(self.get_parameter("experiment_directory").value).strip()
             root = Path(configured_root) if configured_root else self.data_directory / "calibration_experiments"
             self.recorder = ExperimentRecorder(root, self.target_type)
             self.tmp_image_dir = self.recorder.image_dir
-            self.get_logger().info(f"Checkerboard experiment output: {self.recorder.run_dir}")
+            self.get_logger().info(f"{self.target_type} experiment output: {self.recorder.run_dir}")
 
         # Enter-event topic: keyboard thread publishes, callback triggers capture
         self._enter_pub = self.create_publisher(Bool, "/mars/main_camera/calib/enter_events", 10)
@@ -837,7 +839,7 @@ class StereoCalibrator(Node):
         """Detect the configured target in a stereo pair and store it if valid."""
         if self.target_type == TARGET_CHECKERBOARD:
             return self._process_checkerboard_pair(left_img, right_img, label, save_images, stamps)
-        return self._process_charuco_pair(left_img, right_img, label, save_images)
+        return self._process_charuco_pair(left_img, right_img, label, save_images, stamps)
 
     def _next_split(self) -> str:
         """Deterministic train/validation assignment for the next accepted pair.
@@ -935,7 +937,14 @@ class StereoCalibrator(Node):
         )
         return result
 
-    def _process_charuco_pair(self, left_img, right_img, label="capture", save_images=False) -> DetectionResult:
+    def _process_charuco_pair(
+        self,
+        left_img,
+        right_img,
+        label: str = "capture",
+        save_images: bool = False,
+        stamps: tuple[float, float] = (0.0, 0.0),
+    ) -> DetectionResult:
         """Detect ChArUco corners in a stereo image pair and store if valid.
 
         This is the shared detection/filtering/storage pipeline used by both
@@ -981,6 +990,25 @@ class StereoCalibrator(Node):
         right_markers = len(marker_ids_right) if marker_ids_right is not None else 0
         left_corners = len(charuco_ids_left) if charuco_ids_left is not None else 0
         right_corners = len(charuco_ids_right) if charuco_ids_right is not None else 0
+
+        view_left = cb.measure(left_gray, charuco_corners_left, stamps[0])
+        view_right = cb.measure(right_gray, charuco_corners_right, stamps[1])
+
+        def record(accepted: bool, reason: str, split: str = "") -> None:
+            self.capture_diagnostics.append(
+                cb.CaptureDiagnostics(
+                    index=self.images_captured if accepted else -1,
+                    attempt=self.capture_attempts,
+                    accepted=accepted,
+                    reason=reason,
+                    split=split,
+                    stamp_skew_sec=stamps[0] - stamps[1],
+                    left=view_left,
+                    right=view_right,
+                    corners_left=charuco_corners_left,
+                    corners_right=charuco_corners_right,
+                )
+            )
 
         self.get_logger().info(
             f"Detection results - Left: {left_markers} markers, {left_corners} corners | "
@@ -1041,11 +1069,13 @@ class StereoCalibrator(Node):
                 self.get_logger().info(f"  Saved diagnostic images to: {debug_dir}")
             except Exception as e:
                 self.get_logger().debug(f"Could not save diagnostic images: {e}")
+            record(False, f"too few corners (L{left_corners}/R{right_corners}, need {self.min_corners})")
             return result
 
         # Find common corner IDs between left and right
         if charuco_ids_left is None or charuco_ids_right is None:
             self.get_logger().warn(f"{label}: ChArUco board not detected in one or both images.")
+            record(False, "board not detected in one or both images")
             return result
 
         left_ids_set = set(charuco_ids_left.flatten())
@@ -1056,6 +1086,7 @@ class StereoCalibrator(Node):
             self.get_logger().warn(
                 f"{label}: Not enough common corners! Common: {len(common_ids)} (need {self.min_corners}+)."
             )
+            record(False, f"too few common corners ({len(common_ids)}, need {self.min_corners})")
             return result
 
         # Filter to keep only common corners, sorted by ID
@@ -1086,15 +1117,19 @@ class StereoCalibrator(Node):
         self.common_corners_right.append(corners_right_filtered)
         self.common_obj_points.append(obj_pts_common.reshape(-1, 1, 3))
 
-        if self._next_split() == "validation":
-            self.validation_indices.add(self.images_captured)
+        index = self.images_captured
+        split = self._next_split()
+        if split == "validation":
+            self.validation_indices.add(index)
+        record(True, "ok", split)
         self.images_captured += 1
 
-        # Optionally save images to disk
+        # Optionally save images to disk. Indexed before the increment so the
+        # filename matches the capture index that validation_indices stores.
         if save_images:
             try:
-                cv2.imwrite(str(self.tmp_image_dir / f"left_{self.images_captured:03d}.png"), left_img)
-                cv2.imwrite(str(self.tmp_image_dir / f"right_{self.images_captured:03d}.png"), right_img)
+                cv2.imwrite(str(self.tmp_image_dir / f"left_{index:03d}.png"), left_img)
+                cv2.imwrite(str(self.tmp_image_dir / f"right_{index:03d}.png"), right_img)
             except Exception as e:
                 self.get_logger().warn(f"Failed to save images: {e}")
 
@@ -1359,7 +1394,11 @@ class StereoCalibrator(Node):
         recorder.write_summary(
             {
                 "target_type": self.target_type,
-                "pattern": list(self.checkerboard.pattern),
+                "pattern": (
+                    list(self.checkerboard.pattern)
+                    if self.target_type == TARGET_CHECKERBOARD
+                    else [self.squares_x, self.squares_y]
+                ),
                 "square_size_m": square_size,
                 "image_size": list(image_size),
                 "pairs_accepted": self.images_captured,
@@ -1389,7 +1428,7 @@ class StereoCalibrator(Node):
                 f"p95 {skew['p95_ms']:.2f}ms, max {skew['max_ms']:.2f}ms (sync slop is 100ms, unchanged)"
             )
         self.get_logger().info("=" * 60)
-        return f"Checkerboard experiment complete: {recorder.run_dir}"
+        return f"{self.target_type} experiment complete: {recorder.run_dir}"
 
     def _save_rectified_samples(self, recorder, calib, image_size, pairs) -> None:
         """Re-read a few saved captures and render them rectified with guide lines."""

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -172,6 +172,10 @@ class StereoCalibrator(Node):
         # adjacent frames can never be paired; loosen it only for a driver that
         # genuinely stamps the eyes separately.
         self.declare_parameter("sync_slop_sec", 0.01)
+        # Lens spec, used ONLY to show the operator an approximate distance in
+        # cm. Never feeds a threshold — the real focal length is the output of
+        # this process, not an input to it.
+        self.declare_parameter("nominal_hfov_deg", 98.0)
 
         # Get parameters
         self.left_topic = self.get_parameter("left_topic").value
@@ -378,6 +382,25 @@ class StereoCalibrator(Node):
             self.get_logger().info(f"Stop service available on '{self.stop_service_name}'")
             self.get_logger().info(f"Delete service available on '{self.delete_service_name}'")
 
+    def _board_geometry(self) -> guidance.BoardGeometry:
+        """The target's usable range follows from its own geometry.
+
+        One threshold cannot serve both: the ArUco markers on a ChArUco board
+        need roughly twice the pixels per square that a plain corner does, so
+        the same sheet of letter paper reaches about three times further as a
+        checkerboard.
+        """
+        if self.target_type == TARGET_CHECKERBOARD:
+            return guidance.BoardGeometry.checkerboard(self.checkerboard.pattern, self.checkerboard.square_size)
+        return guidance.BoardGeometry.charuco(self.squares_x, self.squares_y, self.square_size)
+
+    def _focal_px(self) -> float:
+        """Pixels per radian-ish, from the lens's nominal FOV — display only."""
+        hfov = float(self.get_parameter("nominal_hfov_deg").value)
+        if hfov <= 0.0 or hfov >= 180.0:
+            return 0.0
+        return (self.image_width / 2.0) / np.tan(np.radians(hfov / 2.0))
+
     def _note_view(self, image_points, board_points) -> None:
         """Measure what the operator is holding, for the live distance hint.
 
@@ -391,7 +414,9 @@ class StereoCalibrator(Node):
             return
         shape = self.latest_left_frame.shape if self.latest_left_frame is not None else None
         frame_size = (shape[1], shape[0]) if shape else (self.image_width, self.image_height)
-        self._last_view = guidance.measure(image_points, board_points, frame_size)
+        self._last_view = guidance.measure(
+            image_points, board_points, frame_size, self._board_geometry(), self._focal_px()
+        )
 
     def _count_toward_coverage(self) -> None:
         """Fold the last measured view into coverage, once a capture is kept."""
@@ -409,10 +434,26 @@ class StereoCalibrator(Node):
         if view is None:
             return "No board detected — is the whole board in both cameras?"
         if view.hint == guidance.TOO_FAR:
-            return "Board too far away — move it closer to the cameras"
+            geometry = self._board_geometry()
+            return (
+                f"Board too far — {view.pixels_per_square:.0f} pixels per square, "
+                f"needs {geometry.min_pixels_per_square:.0f}. Move it closer."
+            )
         if view.hint == guidance.TOO_CLOSE:
-            return "Board too close — back it off so the whole board stays in frame"
+            return "Board too close — it fills the frame, so corners fall outside it. Move it back."
         return "Board partly visible — every corner must be in both cameras"
+
+    def _working_range_message(self) -> str:
+        """The distance band this board can actually be used at.
+
+        Worth stating up front: a letter-sized target cannot span the whole
+        depth corridor on a wide lens, so the operator should be told the range
+        the board has rather than left to discover it by being told "too far".
+        """
+        near, far = self._board_geometry().range_m(self._focal_px(), np.hypot(self.image_width, self.image_height))
+        if far <= 0.0:
+            return f"Using the {self.target_type} target"
+        return f"Using the {self.target_type} target — hold it roughly {near * 100:.0f}-{far * 100:.0f} cm from the cameras"
 
     def _reset_calibration_session(self):
         """Reset all capture/calibration buffers for a new run."""
@@ -493,6 +534,8 @@ class StereoCalibrator(Node):
             feedback.distance_hint = view.hint
             feedback.board_extent = float(view.extent)
             feedback.board_tilt = float(view.tilt)
+            feedback.pixels_per_square = float(view.pixels_per_square)
+            feedback.approx_distance_m = float(view.approx_distance_m)
         progress = self._coverage.progress()
         feedback.coverage_percent = float(progress.percent)
         feedback.coverage_missing = list(progress.missing)
@@ -637,7 +680,7 @@ class StereoCalibrator(Node):
             # One-shot "goal started" tick so the frontend can anchor a countdown
             # from goal-acceptance, not just after the first capture — otherwise a
             # slow first capture gets no warning before an unannounced timeout abort.
-            self._publish_action_feedback(goal_handle, "READY", "Waiting for first capture")
+            self._publish_action_feedback(goal_handle, "READY", self._working_range_message())
 
             # Wait for capture_trigger events (handled in _enter_event_callback)
             # until enough images are captured, the goal is cancelled, or the

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -124,9 +124,9 @@ class StereoCalibrator(Node):
         # Target selection: "charuco" (production) or "checkerboard" (A/B experiment)
         self.declare_parameter("target_type", TARGET_CHARUCO)
 
-        # ChArUco board parameters
-        self.declare_parameter("squares_x", 17)  # 8 squares wide
-        self.declare_parameter("squares_y", 9)  # 11 squares tall
+        # ChArUco board parameters (calib.io 17x9 squares -> 16x8 = 128 interpolated corners)
+        self.declare_parameter("squares_x", 17)  # squares across, 272mm at 16mm pitch
+        self.declare_parameter("squares_y", 9)  # squares down, 144mm at 16mm pitch
         self.declare_parameter("square_size", 0.016)  # 16mm in meters
         self.declare_parameter("marker_size", 0.012)  # 12mm in meters
         self.declare_parameter("dictionary_id", cv2.aruco.DICT_4X4_250)

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -51,6 +51,7 @@ from sensor_msgs.msg import CompressedImage, Image
 from std_msgs.msg import Bool
 from std_srvs.srv import Trigger
 
+from mars_cam import capture_guidance as guidance
 from mars_cam import checkerboard as cb
 from mars_cam.calibration_debug_vis import generate_coverage_images, generate_debug_mosaic, generate_visualizations
 from mars_cam.calibration_experiment import ExperimentRecorder, skew_summary
@@ -72,6 +73,13 @@ DEFAULT_DELETE_SERVICE_NAME = "/mars/main_camera/delete_stereo_calibration"
 
 TARGET_CHARUCO = "charuco"
 TARGET_CHECKERBOARD = "checkerboard"
+
+# Goal.board -> target_type. BOARD_DEFAULT leaves the node's configured target
+# alone, so a CLI run and an app run with no explicit choice behave the same.
+BOARD_BY_GOAL = {
+    RunStereoCalibration.Goal.BOARD_CHARUCO: TARGET_CHARUCO,
+    RunStereoCalibration.Goal.BOARD_CHECKERBOARD: TARGET_CHECKERBOARD,
+}
 
 
 def _stamp_sec(msg: Image) -> float:
@@ -234,6 +242,10 @@ class StereoCalibrator(Node):
         self.latest_right_frame = None
         self.latest_stamps: tuple[float, float] = (0.0, 0.0)
         self.frame_lock = threading.Lock()
+        # Live capture guidance. Built here as well as per-run, because CLI mode
+        # detects without ever opening an action goal.
+        self._coverage = guidance.CoverageTracker(self.num_images_required)
+        self._last_view: guidance.BoardView | None = None
         self.images_captured = 0
         self.capture_attempts = 0
         self.calibration_done = False
@@ -366,6 +378,42 @@ class StereoCalibrator(Node):
             self.get_logger().info(f"Stop service available on '{self.stop_service_name}'")
             self.get_logger().info(f"Delete service available on '{self.delete_service_name}'")
 
+    def _note_view(self, image_points, board_points) -> None:
+        """Measure what the operator is holding, for the live distance hint.
+
+        Measured from the LEFT image only. The two eyes see the board at almost
+        the same size and tilt, and a hint that flickered between them would
+        read as noise rather than as advice. Called on rejected attempts too —
+        "too far" is most useful precisely when detection just failed.
+        """
+        if image_points is None or board_points is None:
+            self._last_view = None
+            return
+        shape = self.latest_left_frame.shape if self.latest_left_frame is not None else None
+        frame_size = (shape[1], shape[0]) if shape else (self.image_width, self.image_height)
+        self._last_view = guidance.measure(image_points, board_points, frame_size)
+
+    def _count_toward_coverage(self) -> None:
+        """Fold the last measured view into coverage, once a capture is kept."""
+        if self._last_view is not None:
+            self._coverage.add(self._last_view)
+
+    def _rejection_advice(self) -> str:
+        """Why a capture was dropped, in terms the operator can act on.
+
+        A board that was seen but sits outside the usable size range gets the
+        specific reason; "no board detected" is only the honest answer when
+        nothing was found at all.
+        """
+        view = self._last_view
+        if view is None:
+            return "No board detected — is the whole board in both cameras?"
+        if view.hint == guidance.TOO_FAR:
+            return "Board too far away — move it closer to the cameras"
+        if view.hint == guidance.TOO_CLOSE:
+            return "Board too close — back it off so the whole board stays in frame"
+        return "Board partly visible — every corner must be in both cameras"
+
     def _reset_calibration_session(self):
         """Reset all capture/calibration buffers for a new run."""
         self.indiv_corners_left = []
@@ -383,6 +431,8 @@ class StereoCalibrator(Node):
         self.calibration_data = None
         self._last_rms = {"left": 0.0, "right": 0.0, "stereo": 0.0}
         self._last_quality = ""
+        self._coverage = guidance.CoverageTracker(self.num_images_required)
+        self._last_view = None
         with self.frame_lock:
             self.latest_left_frame = None
             self.latest_right_frame = None
@@ -436,6 +486,17 @@ class StereoCalibrator(Node):
         # Live value (not the cached attribute) so a mid-run `ros2 param set`
         # is reflected immediately, same as the watchdog itself.
         feedback.capture_timeout_sec = float(self.get_parameter("capture_timeout_sec").value)
+
+        feedback.board = self.target_type
+        view = self._last_view
+        if view is not None:
+            feedback.distance_hint = view.hint
+            feedback.board_extent = float(view.extent)
+            feedback.board_tilt = float(view.tilt)
+        progress = self._coverage.progress()
+        feedback.coverage_percent = float(progress.percent)
+        feedback.coverage_missing = list(progress.missing)
+
         for name, img in (images or {}).items():
             ok, buf = cv2.imencode(".jpg", img)
             if not ok:
@@ -541,6 +602,7 @@ class StereoCalibrator(Node):
             result.right_rms = float(self._last_rms["right"])
             result.stereo_rms = float(self._last_rms["stereo"])
             result.quality = self._last_quality
+            result.board = self.target_type
             return result
 
         try:
@@ -559,6 +621,11 @@ class StereoCalibrator(Node):
                 self.num_images_required = int(goal.num_images)
             if goal.min_corners > 0:
                 self.min_corners = int(goal.min_corners)
+            if goal.board in BOARD_BY_GOAL:
+                self.target_type = BOARD_BY_GOAL[goal.board]
+                self.get_logger().info(f"Goal selected the {self.target_type} target")
+            # After the overrides: the tracker's capture target is one of them.
+            self._coverage = guidance.CoverageTracker(self.num_images_required)
 
             setup_head(self)
 
@@ -725,7 +792,7 @@ class StereoCalibrator(Node):
             feedback_message = (
                 f"Captured {self.images_captured}/{self.num_images_required}"
                 if result.success
-                else "No board detected in this capture"
+                else self._rejection_advice()
             )
             self._publish_action_feedback(
                 goal_handle,
@@ -830,8 +897,12 @@ class StereoCalibrator(Node):
         while rclpy.ok() and not self.calibration_done:
             try:
                 # Wait for Enter key
+                progress = self._coverage.progress()
+                advice = self._coverage.advice()
                 input(
-                    f"[{self.images_captured} captured] Move the board and press Enter (Ctrl+C to finish and calibrate)"
+                    f"[{self.images_captured} captured, {progress.percent:.0f}% covered] "
+                    f"{advice or 'Coverage complete'} — move the board and press Enter "
+                    f"(Ctrl+C to finish and calibrate)\n"
                 )
                 if not self.calibration_done:
                     self._enter_pub.publish(Bool(data=True))
@@ -895,6 +966,9 @@ class StereoCalibrator(Node):
 
         split = self._next_split() if accepted else ""
         index = self.images_captured if accepted else -1
+        self._note_view(corners_left, self.checkerboard.object_grid())
+        if accepted:
+            self._count_toward_coverage()
 
         self.capture_diagnostics.append(
             cb.CaptureDiagnostics(
@@ -1003,6 +1077,13 @@ class StereoCalibrator(Node):
 
         view_left = cb.measure(left_gray, charuco_corners_left, stamps[0])
         view_right = cb.measure(right_gray, charuco_corners_right, stamps[1])
+
+        # ChArUco detects a subset of the grid, so the board-space points come
+        # from the corner ids rather than from a full pattern.
+        if charuco_ids_left is not None and left_corners >= 4:
+            self._note_view(charuco_corners_left, self.charuco_board.getChessboardCorners()[charuco_ids_left.flatten()])
+        else:
+            self._note_view(None, None)
 
         def record(accepted: bool, reason: str, split: str = "") -> None:
             self.capture_diagnostics.append(
@@ -1132,6 +1213,7 @@ class StereoCalibrator(Node):
         if split == "validation":
             self.validation_indices.add(index)
         record(True, "ok", split)
+        self._count_toward_coverage()
         self.images_captured += 1
 
         # Optionally save images to disk. Indexed before the increment so the

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -2,24 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Innate Inc
 """
-Stereo Camera Calibration Node using ChArUco Board.
+Stereo Camera Calibration Node — ChArUco (production) or plain checkerboard (experiment).
 
 This launches an interactive calibration tool that:
 1. Subscribes to the stereo camera topic
 2. Allows user to capture images by pressing Enter
-3. Detects ChArUco board corners in both cameras
+3. Detects target corners in both cameras
 4. Performs stereo calibration after collecting enough images
 5. Optionally saves the calibration to replace the existing one
 
+Both target types share one OpenCV pinhole pipeline: independent
+``calibrateCamera`` per eye, then ``stereoCalibrate`` with ``CALIB_FIX_INTRINSIC``.
+Only the detector and the bookkeeping around it differ, so the two arms are
+directly comparable.
 
-This node subscribes to a stereo image topic, allows the user to capture
-calibration images interactively, and performs OpenCV stereo calibration
-using the pinhole camera model.
+``target_type:=checkerboard`` additionally holds out every Nth accepted pair,
+scores the solve on those unseen images, and writes everything to a separate
+experiment directory — it never touches the production ``stereo_calib.yaml``.
 
 Usage:
     ros2 run mars_cam stereo_calibrator
     or
     ros2 run mars_cam stereo_calibrator --ros-args -p squares_y:=8 -p squares_x:=11 -p square_size:=0.016 -p marker_size:=0.012
+    or
+    ros2 run mars_cam stereo_calibrator --ros-args -p target_type:=checkerboard
 
     Then press Enter to capture images. After 30 images, calibration is computed.
     ros2 bag record /mars/main_camera/calib/enter_events
@@ -45,7 +51,9 @@ from sensor_msgs.msg import CompressedImage, Image
 from std_msgs.msg import Bool
 from std_srvs.srv import Trigger
 
+from mars_cam import checkerboard as cb
 from mars_cam.calibration_debug_vis import generate_coverage_images, generate_debug_mosaic, generate_visualizations
+from mars_cam.calibration_experiment import ExperimentRecorder, skew_summary
 from mars_cam.calibration_utils import (
     find_calibration_dir,
     prompt_save,
@@ -53,9 +61,21 @@ from mars_cam.calibration_utils import (
     save_calibration,
     setup_head,
 )
+from mars_cam.calibration_validation import (
+    StereoCalibrationMatrices,
+    ValidationPair,
+    evaluate,
+)
 
 DEFAULT_STOP_SERVICE_NAME = "/mars/main_camera/stop_stereo_calibration"
 DEFAULT_DELETE_SERVICE_NAME = "/mars/main_camera/delete_stereo_calibration"
+
+TARGET_CHARUCO = "charuco"
+TARGET_CHECKERBOARD = "checkerboard"
+
+
+def _stamp_sec(msg: Image) -> float:
+    return float(msg.header.stamp.sec) + float(msg.header.stamp.nanosec) * 1e-9
 
 
 @dataclass
@@ -101,12 +121,27 @@ class StereoCalibrator(Node):
         self.declare_parameter("image_height", 480)
         self.declare_parameter("data_directory", "/home/jetson1/innate-os/data")
 
+        # Target selection: "charuco" (production) or "checkerboard" (A/B experiment)
+        self.declare_parameter("target_type", TARGET_CHARUCO)
+
         # ChArUco board parameters
         self.declare_parameter("squares_x", 17)  # 8 squares wide
         self.declare_parameter("squares_y", 9)  # 11 squares tall
         self.declare_parameter("square_size", 0.016)  # 16mm in meters
         self.declare_parameter("marker_size", 0.012)  # 12mm in meters
         self.declare_parameter("dictionary_id", cv2.aruco.DICT_4X4_250)
+
+        # Plain-checkerboard parameters (US-Letter target: 10x7 squares -> 9x6 inner corners).
+        # Measure the printed pitch and override checkerboard_square_size if the
+        # printer scaled the page — every metric below is reported against it.
+        self.declare_parameter("checkerboard_cols", 9)  # inner corners in X
+        self.declare_parameter("checkerboard_rows", 6)  # inner corners in Y
+        self.declare_parameter("checkerboard_square_size", 0.022)  # 22mm in meters
+        self.declare_parameter("checkerboard_num_images", 40)
+        # Every Nth accepted pair is held out of the solve; 5 -> 20%. 0 disables.
+        self.declare_parameter("validation_stride", 5)
+        self.declare_parameter("validate_charuco", False)
+        self.declare_parameter("experiment_directory", "")
 
         # Calibration parameters
         self.declare_parameter("num_images", 20)
@@ -131,13 +166,31 @@ class StereoCalibrator(Node):
         self.image_height = self.get_parameter("image_height").value
         self.data_directory = Path(self.get_parameter("data_directory").value)
 
+        self.target_type = str(self.get_parameter("target_type").value).strip().lower()
+        if self.target_type not in (TARGET_CHARUCO, TARGET_CHECKERBOARD):
+            raise ValueError(
+                f"target_type must be '{TARGET_CHARUCO}' or '{TARGET_CHECKERBOARD}', got {self.target_type!r}"
+            )
+
         self.squares_x = self.get_parameter("squares_x").value
         self.squares_y = self.get_parameter("squares_y").value
         self.square_size = self.get_parameter("square_size").value
         self.marker_size = self.get_parameter("marker_size").value
         self.dictionary_id = self.get_parameter("dictionary_id").value
 
+        self.checkerboard = cb.CheckerboardTarget(
+            pattern=(
+                int(self.get_parameter("checkerboard_cols").value),
+                int(self.get_parameter("checkerboard_rows").value),
+            ),
+            square_size=float(self.get_parameter("checkerboard_square_size").value),
+        )
+        self.validation_stride = int(self.get_parameter("validation_stride").value)
+        self.validate_charuco = bool(self.get_parameter("validate_charuco").value)
+
         self.num_images_required = self.get_parameter("num_images").value
+        if self.target_type == TARGET_CHECKERBOARD:
+            self.num_images_required = int(self.get_parameter("checkerboard_num_images").value)
         self.min_corners = self.get_parameter("min_corners").value
         self.use_legacy_pattern = self.get_parameter("use_legacy_pattern").value
         self.debug = self.get_parameter("debug").value
@@ -172,6 +225,7 @@ class StereoCalibrator(Node):
         self.bridge = CvBridge()
         self.latest_left_frame = None
         self.latest_right_frame = None
+        self.latest_stamps: tuple[float, float] = (0.0, 0.0)
         self.frame_lock = threading.Lock()
         self.images_captured = 0
         self.capture_attempts = 0
@@ -196,6 +250,18 @@ class StereoCalibrator(Node):
         # Image storage directory - inside data directory so images persist
         self.tmp_image_dir = self.data_directory / "stereo_calibration_images"
         self.tmp_image_dir.mkdir(parents=True, exist_ok=True)
+
+        # Experiment bookkeeping. The recorder owns a run directory that is
+        # deliberately outside the production calibration directory.
+        self.capture_diagnostics: list[cb.CaptureDiagnostics] = []
+        self.validation_indices: set[int] = set()
+        self.recorder: ExperimentRecorder | None = None
+        if self.target_type == TARGET_CHECKERBOARD:
+            configured_root = str(self.get_parameter("experiment_directory").value).strip()
+            root = Path(configured_root) if configured_root else self.data_directory / "calibration_experiments"
+            self.recorder = ExperimentRecorder(root, self.target_type)
+            self.tmp_image_dir = self.recorder.image_dir
+            self.get_logger().info(f"Checkerboard experiment output: {self.recorder.run_dir}")
 
         # Enter-event topic: keyboard thread publishes, callback triggers capture
         self._enter_pub = self.create_publisher(Bool, "/mars/main_camera/calib/enter_events", 10)
@@ -246,9 +312,15 @@ class StereoCalibrator(Node):
             self.check_existing_images()
 
         # Print info (one concise summary line; full detail at debug)
+        if self.target_type == TARGET_CHECKERBOARD:
+            cols, rows = self.checkerboard.pattern
+            target_summary = (
+                f"checkerboard {cols}x{rows} inner corners, {self.checkerboard.square_size * 1000:.1f}mm pitch"
+            )
+        else:
+            target_summary = f"ChArUco {self.squares_x}x{self.squares_y}"
         self.get_logger().info(
-            f"Stereo Camera Calibrator ready (ChArUco {self.squares_x}x{self.squares_y}, "
-            f"{self.num_images_required} images required)"
+            f"Stereo Camera Calibrator ready ({target_summary}, {self.num_images_required} images required)"
         )
         self.get_logger().debug("=" * 60)
         self.get_logger().debug(f"Left topic: {self.left_topic}")
@@ -294,6 +366,8 @@ class StereoCalibrator(Node):
         self.common_corners_left = []
         self.common_corners_right = []
         self.common_obj_points = []
+        self.capture_diagnostics = []
+        self.validation_indices = set()
         self.images_captured = 0
         self.capture_attempts = 0
         self.calibration_done = False
@@ -303,6 +377,7 @@ class StereoCalibrator(Node):
         with self.frame_lock:
             self.latest_left_frame = None
             self.latest_right_frame = None
+            self.latest_stamps = (0.0, 0.0)
 
     def _goal_callback(self, goal_request):
         """Accept a new goal, stopping any currently active run first."""
@@ -593,6 +668,7 @@ class StereoCalibrator(Node):
             with self.frame_lock:
                 self.latest_left_frame = left_frame
                 self.latest_right_frame = right_frame
+                self.latest_stamps = (_stamp_sec(left_msg), _stamp_sec(right_msg))
 
         except Exception as e:
             self.get_logger().error(f"Failed to convert image: {e}")
@@ -617,10 +693,11 @@ class StereoCalibrator(Node):
                 return
             left_img = self.latest_left_frame.copy()
             right_img = self.latest_right_frame.copy()
+            stamps = self.latest_stamps
 
         self.capture_attempts += 1
         self._last_capture_time = time.time()
-        result = self._process_image_pair(left_img, right_img, label="Capture", save_images=True)
+        result = self._process_image_pair(left_img, right_img, label="Capture", save_images=True, stamps=stamps)
 
         if result.success:
             self.get_logger().info(f"[{self.images_captured}] Captured! Detected {result.num_common} common corners.")
@@ -749,7 +826,116 @@ class StereoCalibrator(Node):
             except (EOFError, KeyboardInterrupt):
                 break
 
-    def _process_image_pair(self, left_img, right_img, label="capture", save_images=False) -> DetectionResult:
+    def _process_image_pair(
+        self,
+        left_img,
+        right_img,
+        label="capture",
+        save_images=False,
+        stamps: tuple[float, float] = (0.0, 0.0),
+    ) -> DetectionResult:
+        """Detect the configured target in a stereo pair and store it if valid."""
+        if self.target_type == TARGET_CHECKERBOARD:
+            return self._process_checkerboard_pair(left_img, right_img, label, save_images, stamps)
+        return self._process_charuco_pair(left_img, right_img, label, save_images)
+
+    def _next_split(self) -> str:
+        """Deterministic train/validation assignment for the next accepted pair.
+
+        A fixed stride rather than a random draw so a rerun over the same
+        captures reproduces the split exactly, and so held-out poses stay spread
+        across the whole session instead of clustering at the end.
+        """
+        stride = self.validation_stride
+        if stride <= 0:
+            return "train"
+        if self.target_type == TARGET_CHARUCO and not self.validate_charuco:
+            return "train"
+        return "validation" if (self.images_captured + 1) % stride == 0 else "train"
+
+    def _process_checkerboard_pair(
+        self,
+        left_img,
+        right_img,
+        label: str,
+        save_images: bool,
+        stamps: tuple[float, float],
+    ) -> DetectionResult:
+        """Detect the full inner-corner grid in both images and store if complete."""
+        left_gray = cv2.cvtColor(left_img, cv2.COLOR_BGR2GRAY)
+        right_gray = cv2.cvtColor(right_img, cv2.COLOR_BGR2GRAY)
+
+        pattern = self.checkerboard.pattern
+        corners_left = cb.detect(left_gray, pattern)
+        corners_right = cb.detect(right_gray, pattern)
+
+        diagnostics_left = cb.measure(left_gray, corners_left, stamps[0])
+        diagnostics_right = cb.measure(right_gray, corners_right, stamps[1])
+
+        result = DetectionResult(left_img=left_img, right_img=right_img)
+        accepted = corners_left is not None and corners_right is not None
+        if accepted:
+            reason = "ok"
+        elif corners_left is None and corners_right is None:
+            reason = "pattern incomplete in both images"
+        else:
+            reason = f"pattern incomplete in {'left' if corners_left is None else 'right'} image"
+
+        split = self._next_split() if accepted else ""
+        index = self.images_captured if accepted else -1
+
+        self.capture_diagnostics.append(
+            cb.CaptureDiagnostics(
+                index=index,
+                attempt=self.capture_attempts,
+                accepted=accepted,
+                reason=reason,
+                split=split,
+                stamp_skew_sec=stamps[0] - stamps[1],
+                left=diagnostics_left,
+                right=diagnostics_right,
+                corners_left=corners_left,
+                corners_right=corners_right,
+            )
+        )
+
+        if not accepted:
+            self.get_logger().warn(
+                f"{label}: {reason} (need the complete {pattern[0]}x{pattern[1]} grid in BOTH images). "
+                f"Brightness L/R {diagnostics_left.brightness:.1f}/{diagnostics_right.brightness:.1f}, "
+                f"sharpness L/R {diagnostics_left.sharpness:.0f}/{diagnostics_right.sharpness:.0f}"
+            )
+            return result
+
+        object_points = self.checkerboard.object_grid().reshape(-1, 1, 3)
+        self.indiv_corners_left.append(corners_left)
+        self.indiv_corners_right.append(corners_right)
+        self.indiv_obj_points_left.append(object_points)
+        self.indiv_obj_points_right.append(object_points)
+        self.common_corners_left.append(corners_left)
+        self.common_corners_right.append(corners_right)
+        self.common_obj_points.append(object_points)
+
+        if split == "validation":
+            self.validation_indices.add(index)
+        self.images_captured += 1
+
+        if save_images and self.recorder is not None:
+            self.recorder.save_pair(index, left_img, right_img)
+            self.recorder.save_detection_overlay(index, left_img, right_img, corners_left, corners_right, pattern)
+
+        result.success = True
+        result.num_common = self.checkerboard.num_corners
+        result.corners_left_filtered = corners_left
+        result.corners_right_filtered = corners_right
+        result.obj_pts_common = object_points
+        self.get_logger().info(
+            f"{label}: accepted [{index}] as {split} — skew {abs(stamps[0] - stamps[1]) * 1000.0:.1f}ms, "
+            f"coverage L/R {diagnostics_left.coverage_pct:.0f}%/{diagnostics_right.coverage_pct:.0f}%"
+        )
+        return result
+
+    def _process_charuco_pair(self, left_img, right_img, label="capture", save_images=False) -> DetectionResult:
         """Detect ChArUco corners in a stereo image pair and store if valid.
 
         This is the shared detection/filtering/storage pipeline used by both
@@ -900,6 +1086,8 @@ class StereoCalibrator(Node):
         self.common_corners_right.append(corners_right_filtered)
         self.common_obj_points.append(obj_pts_common.reshape(-1, 1, 3))
 
+        if self._next_split() == "validation":
+            self.validation_indices.add(self.images_captured)
         self.images_captured += 1
 
         # Optionally save images to disk
@@ -940,12 +1128,20 @@ class StereoCalibrator(Node):
         self.calibration_done = True
 
         image_size = (self.image_width, self.image_height)
+        train = [i for i in range(self.images_captured) if i not in self.validation_indices]
+
+        def keep(values: list) -> list:
+            return [values[i] for i in train]
 
         self.get_logger().info("Running individual camera calibrations...")
         self.get_logger().info(
             f"  Individual points: {len(self.indiv_obj_points_left)} images, "
             f"Common points: {len(self.common_obj_points)} images"
         )
+        if self.validation_indices:
+            self.get_logger().info(
+                f"  Held out {len(self.validation_indices)} pairs for validation; calibrating on {len(train)}"
+            )
 
         # # Debug: check shapes
         # for i, (obj_l, corners_l) in enumerate(zip(self.indiv_obj_points_left, self.indiv_corners_left)):
@@ -955,13 +1151,13 @@ class StereoCalibrator(Node):
 
         # Calibrate left camera using ALL left-camera corners (not just common)
         ret_left, K1, D1, rvecs_left, tvecs_left = cv2.calibrateCamera(
-            self.indiv_obj_points_left, self.indiv_corners_left, image_size, None, None, flags=0
+            keep(self.indiv_obj_points_left), keep(self.indiv_corners_left), image_size, None, None, flags=0
         )
         self.get_logger().info(f"Left camera RMS error: {ret_left:.4f}")
 
         # Calibrate right camera using ALL right-camera corners (not just common)
         ret_right, K2, D2, rvecs_right, tvecs_right = cv2.calibrateCamera(
-            self.indiv_obj_points_right, self.indiv_corners_right, image_size, None, None, flags=0
+            keep(self.indiv_obj_points_right), keep(self.indiv_corners_right), image_size, None, None, flags=0
         )
         self.get_logger().info(f"Right camera RMS error: {ret_right:.4f}")
 
@@ -971,9 +1167,9 @@ class StereoCalibrator(Node):
         flags = cv2.CALIB_FIX_INTRINSIC
 
         ret_stereo, K1, D1, K2, D2, R, T, E, F = cv2.stereoCalibrate(
-            self.common_obj_points,
-            self.common_corners_left,
-            self.common_corners_right,
+            keep(self.common_obj_points),
+            keep(self.common_corners_left),
+            keep(self.common_corners_right),
             K1,
             D1,
             K2,
@@ -983,8 +1179,12 @@ class StereoCalibrator(Node):
             criteria=(cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 100, 1e-6),
         )
 
-        # Ensure T[0] is positive (left camera physically left of right camera)
-        # If negative, cameras are physically swapped - negate to fix depth sign
+        # UNDER REVIEW — see docs/stereo_calibration_experiment.md. stereoCalibrate
+        # returns the left camera's origin in the right camera's frame, so a
+        # correctly-wired rig gives T[0] < 0 and this branch always fires. It is
+        # kept for now because every downstream consumer takes |baseline|; the
+        # measured consequence is a sign-flipped Q, recorded in the run summary.
+        t_x_raw = float(T[0, 0])
         if T[0, 0] < 0:
             self.get_logger().warn(f"T[0] = {T[0, 0]:.4f}m is negative - cameras may be physically swapped")
             self.get_logger().warn("Negating T to ensure positive depth output")
@@ -1064,6 +1264,15 @@ class StereoCalibrator(Node):
         self.get_logger().info("Generating visualization images...")
         generate_visualizations(self)
 
+        if self.recorder is not None:
+            experiment_message = self._write_experiment_outputs(
+                self.recorder, image_size, t_x_raw, ret_left, ret_right, ret_stereo
+            )
+            restore_head(self)
+            if shutdown_on_complete and rclpy.ok():
+                rclpy.shutdown()
+            return True, experiment_message
+
         # Interactive CLI mode: ask user and terminate through prompt_save().
         if save_decision is None:
             prompt_save(self)
@@ -1084,6 +1293,135 @@ class StereoCalibrator(Node):
         except Exception as e:
             restore_head(self)
             return False, f"Failed to finalize calibration: {e}"
+
+    def _validation_pairs(self) -> list[ValidationPair]:
+        """Held-out observations, in capture order."""
+        grid_shape = self.checkerboard.pattern if self.target_type == TARGET_CHECKERBOARD else None
+        return [
+            ValidationPair(
+                index=i,
+                object_points=self.common_obj_points[i],
+                corners_left=self.common_corners_left[i],
+                corners_right=self.common_corners_right[i],
+                grid_shape=grid_shape,
+            )
+            for i in sorted(self.validation_indices)
+        ]
+
+    def _write_experiment_outputs(
+        self,
+        recorder: ExperimentRecorder,
+        image_size: tuple[int, int],
+        t_x_raw: float,
+        ret_left: float,
+        ret_right: float,
+        ret_stereo: float,
+    ) -> str:
+        """Write the candidate calibration, capture metadata and validation report.
+
+        Never writes the production stereo_calib.yaml — the whole point of the
+        experiment arm is that the shipped calibration stays untouched.
+        """
+        calib = self.calibration_data
+        candidate_path = recorder.save_candidate_calibration(calib)
+        recorder.write_captures(self.capture_diagnostics)
+        recorder.save_coverage(self.indiv_corners_left, self.indiv_corners_right, image_size)
+
+        square_size = (
+            self.checkerboard.square_size if self.target_type == TARGET_CHECKERBOARD else float(self.square_size)
+        )
+        pairs = self._validation_pairs()
+        report = None
+        if pairs:
+            report = evaluate(
+                StereoCalibrationMatrices(
+                    K1=calib["K1"],
+                    D1=calib["D1"],
+                    K2=calib["K2"],
+                    D2=calib["D2"],
+                    R1=calib["R1"],
+                    R2=calib["R2"],
+                    P1=calib["P1"],
+                    P2=calib["P2"],
+                ),
+                pairs,
+                image_size,
+                square_size,
+            )
+            recorder.write_validation(report)
+            self._log_validation(report)
+        else:
+            self.get_logger().warn("No validation pairs were held out — skipping the held-out report")
+
+        self._save_rectified_samples(recorder, calib, image_size, pairs)
+
+        skew = skew_summary(self.capture_diagnostics)
+        recorder.write_summary(
+            {
+                "target_type": self.target_type,
+                "pattern": list(self.checkerboard.pattern),
+                "square_size_m": square_size,
+                "image_size": list(image_size),
+                "pairs_accepted": self.images_captured,
+                "capture_attempts": self.capture_attempts,
+                "pairs_train": self.images_captured - len(self.validation_indices),
+                "pairs_validation": len(self.validation_indices),
+                "validation_indices": sorted(self.validation_indices),
+                "validation_stride": self.validation_stride,
+                "train_rms": {"left": ret_left, "right": ret_right, "stereo": ret_stereo},
+                "baseline_m": float(np.linalg.norm(calib["T"])),
+                "stereo_calibrate_tx_raw_m": t_x_raw,
+                "tx_was_negated": t_x_raw < 0.0,
+                "sync_slop_sec": 0.1,
+                "timestamp_skew": skew,
+                "validation": report.to_dict() if report is not None else None,
+            }
+        )
+
+        self.get_logger().info("=" * 60)
+        self.get_logger().info(f"Experiment written to: {recorder.run_dir}")
+        self.get_logger().info(
+            f"  Candidate calibration: {candidate_path.name} (production stereo_calib.yaml UNTOUCHED)"
+        )
+        if skew.get("count"):
+            self.get_logger().info(
+                f"  Timestamp skew: mean {skew['mean_ms']:.2f}ms, median {skew['median_ms']:.2f}ms, "
+                f"p95 {skew['p95_ms']:.2f}ms, max {skew['max_ms']:.2f}ms (sync slop is 100ms, unchanged)"
+            )
+        self.get_logger().info("=" * 60)
+        return f"Checkerboard experiment complete: {recorder.run_dir}"
+
+    def _save_rectified_samples(self, recorder, calib, image_size, pairs) -> None:
+        """Re-read a few saved captures and render them rectified with guide lines."""
+        sample_indices = [p.index for p in pairs[:4]] or list(range(min(4, self.images_captured)))
+        samples = []
+        for index in sample_indices:
+            left = cv2.imread(str(recorder.image_dir / f"left_{index:03d}.png"))
+            right = cv2.imread(str(recorder.image_dir / f"right_{index:03d}.png"))
+            if left is not None and right is not None:
+                samples.append((index, left, right))
+        if samples:
+            recorder.save_rectified_samples(samples, calib, image_size)
+
+    def _log_validation(self, report) -> None:
+        self.get_logger().info(f"Held-out validation on {report.num_pairs} pairs:")
+        self.get_logger().info(
+            f"  Reprojection RMS  L {report.left_reprojection.rms:.4f}px  R {report.right_reprojection.rms:.4f}px"
+        )
+        self.get_logger().info(
+            f"  Epipolar |dy|     mean {report.epipolar_dy.mean:.4f}px  p95 {report.epipolar_dy.p95:.4f}px  "
+            f"max {report.epipolar_dy.maximum:.4f}px"
+        )
+        self.get_logger().info(
+            f"  Neighbour spacing mean {report.mean_spacing_mm:.3f}mm vs nominal "
+            f"{report.nominal_spacing_mm:.3f}mm (mean abs error {report.spacing_error_mm.mean:.3f}mm)"
+        )
+        self.get_logger().info(f"  Planarity RMS     {report.planarity_rms_mm.mean:.3f}mm")
+        if not report.q_yields_positive_z:
+            self.get_logger().warn(
+                f"  Q reprojects front-of-camera points to NEGATIVE Z "
+                f"(median {report.median_depth_m:+.3f}m) — see the T-sign finding in the report"
+            )
 
 
 def main(args=None):

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -158,6 +158,12 @@ class StereoCalibrator(Node):
         # How long to wait for a capture_trigger before timing out a managed run
         # (guards against an orphaned goal if the requesting client disconnects).
         self.declare_parameter("capture_timeout_sec", 60.0)
+        # Stereo pair sync tolerance. The driver splits one side-by-side capture,
+        # so both eyes carry the same stamp and 146 measured captures showed a
+        # median and p95 skew of 0.0ms. This sits below the 33ms frame period so
+        # adjacent frames can never be paired; loosen it only for a driver that
+        # genuinely stamps the eyes separately.
+        self.declare_parameter("sync_slop_sec", 0.01)
 
         # Get parameters
         self.left_topic = self.get_parameter("left_topic").value
@@ -185,6 +191,7 @@ class StereoCalibrator(Node):
             ),
             square_size=float(self.get_parameter("checkerboard_square_size").value),
         )
+        self.sync_slop_sec = float(self.get_parameter("sync_slop_sec").value)
         self.validation_stride = int(self.get_parameter("validation_stride").value)
         self.validate_charuco = bool(self.get_parameter("validate_charuco").value)
 
@@ -342,7 +349,7 @@ class StereoCalibrator(Node):
         self.sync = message_filters.ApproximateTimeSynchronizer(
             [self.left_sub, self.right_sub],
             queue_size=10,
-            slop=0.1,  # 100ms tolerance
+            slop=self.sync_slop_sec,
         )
         self.sync.registerCallback(self.image_callback)
 
@@ -691,7 +698,10 @@ class StereoCalibrator(Node):
 
         with self.frame_lock:
             if self.latest_left_frame is None or self.latest_right_frame is None:
-                self.get_logger().warn("No frames available yet. Make sure the camera is running.")
+                self.get_logger().warn(
+                    f"No frames available yet. Check the camera is running, and that the left/right "
+                    f"stamps agree to within sync_slop_sec ({self.sync_slop_sec * 1000:.0f}ms)."
+                )
                 return
             left_img = self.latest_left_frame.copy()
             right_img = self.latest_right_frame.copy()
@@ -1411,7 +1421,7 @@ class StereoCalibrator(Node):
                 "baseline_m": float(np.linalg.norm(calib["T"])),
                 "stereo_calibrate_tx_raw_m": t_x_raw,
                 "tx_was_negated": t_x_raw < 0.0,
-                "sync_slop_sec": 0.1,
+                "sync_slop_sec": self.sync_slop_sec,
                 "timestamp_skew": skew,
                 "validation": report.to_dict() if report is not None else None,
             }
@@ -1425,7 +1435,8 @@ class StereoCalibrator(Node):
         if skew.get("count"):
             self.get_logger().info(
                 f"  Timestamp skew: mean {skew['mean_ms']:.2f}ms, median {skew['median_ms']:.2f}ms, "
-                f"p95 {skew['p95_ms']:.2f}ms, max {skew['max_ms']:.2f}ms (sync slop is 100ms, unchanged)"
+                f"p95 {skew['p95_ms']:.2f}ms, max {skew['max_ms']:.2f}ms "
+                f"(sync slop {self.sync_slop_sec * 1000:.0f}ms)"
             )
         self.get_logger().info("=" * 60)
         return f"{self.target_type} experiment complete: {recorder.run_dir}"

--- a/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
+++ b/ros2_ws/src/mars_bot/mars_cam/mars_cam/stereo_calibrator.py
@@ -1451,10 +1451,13 @@ class StereoCalibrator(Node):
             f"  Epipolar |dy|     mean {report.epipolar_dy.mean:.4f}px  p95 {report.epipolar_dy.p95:.4f}px  "
             f"max {report.epipolar_dy.maximum:.4f}px"
         )
-        self.get_logger().info(
-            f"  Neighbour spacing mean {report.mean_spacing_mm:.3f}mm vs nominal "
-            f"{report.nominal_spacing_mm:.3f}mm (mean abs error {report.spacing_error_mm.mean:.3f}mm)"
-        )
+        if report.spacing_error_mm.count:
+            self.get_logger().info(
+                f"  Neighbour spacing mean {report.mean_spacing_mm:.3f}mm vs nominal "
+                f"{report.nominal_spacing_mm:.3f}mm (mean abs error {report.spacing_error_mm.mean:.3f}mm)"
+            )
+        else:
+            self.get_logger().info("  Neighbour spacing n/a (needs a complete grid; ChArUco returns corner subsets)")
         self.get_logger().info(f"  Planarity RMS     {report.planarity_rms_mm.mean:.3f}mm")
         if not report.q_yields_positive_z:
             self.get_logger().warn(

--- a/ros2_ws/src/mars_bot/mars_cam/package.xml
+++ b/ros2_ws/src/mars_bot/mars_cam/package.xml
@@ -48,6 +48,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2_ws/src/mars_bot/mars_cam/test/test_capture_guidance.py
+++ b/ros2_ws/src/mars_bot/mars_cam/test/test_capture_guidance.py
@@ -12,16 +12,19 @@ import numpy as np
 import pytest
 
 from mars_cam.capture_guidance import (
+    DEFAULT_EXTENT_MIN,
     EXTENT_MAX,
-    EXTENT_MIN,
     IN_RANGE,
     TILT_MIN,
     TOO_CLOSE,
     TOO_FAR,
+    BoardGeometry,
     BoardView,
     CoverageTracker,
     measure,
 )
+
+EXTENT_MIN = DEFAULT_EXTENT_MIN
 
 FRAME = (640, 480)
 FOCAL = 500.0
@@ -136,6 +139,75 @@ def test_distance_hints_bracket_the_usable_range():
 def test_scale_bands_span_the_usable_range():
     bands = {BoardView((0.5, 0.5), e, 0.0).scale_band for e in np.linspace(EXTENT_MIN, EXTENT_MAX, 40)}
     assert bands == {0, 1, 2}
+
+
+# -------------------------------------------------------------- board geometry
+
+CHECKER = BoardGeometry.checkerboard((9, 6), 0.022)
+CHARUCO = BoardGeometry.charuco(17, 9, 0.016)
+FRAME_DIAG = float(np.hypot(*FRAME))
+
+
+def test_charuco_cannot_be_held_as_far_as_a_checkerboard():
+    """The finding this whole design turns on: ArUco markers must resolve enough
+    pixels to decode, so the same sheet of paper reaches much less far."""
+    _, checker_far = CHECKER.range_m(FOCAL, FRAME_DIAG)
+    _, charuco_far = CHARUCO.range_m(FOCAL, FRAME_DIAG)
+    assert charuco_far < checker_far
+    assert CHARUCO.extent_min(FRAME_DIAG) > CHECKER.extent_min(FRAME_DIAG)
+
+
+def test_a_board_needing_more_pixels_must_be_held_closer():
+    fussy = BoardGeometry(squares=(8, 5), square_size_m=0.022, min_pixels_per_square=20.0)
+    assert fussy.extent_min(FRAME_DIAG) == pytest.approx(2 * CHECKER.extent_min(FRAME_DIAG))
+
+
+def test_the_usable_range_brackets_the_extent_limits():
+    near, far = CHECKER.range_m(FOCAL, FRAME_DIAG)
+    assert near < far
+    # Held at the near limit the board spans EXTENT_MAX of the frame; at the far
+    # limit it is down to the detection floor.
+    for distance, expected in ((near, EXTENT_MAX), (far, CHECKER.extent_min(FRAME_DIAG))):
+        view = measure(project(board_points(), distance=distance), board_points(), FRAME, CHECKER, FOCAL)
+        assert view.extent == pytest.approx(expected, rel=1e-6)
+
+
+def test_degenerate_optics_do_not_produce_a_range():
+    assert CHECKER.range_m(0.0, FRAME_DIAG) == (0.0, 0.0)
+    assert CHECKER.range_m(FOCAL, 0.0) == (0.0, 0.0)
+    assert CHECKER.extent_min(0.0) == 0.0
+
+
+# ------------------------------------------------------- distance round-trip
+
+
+@pytest.mark.parametrize("distance", [0.15, 0.3, 0.55])
+def test_the_reported_distance_recovers_the_true_one(distance):
+    grid = board_points()
+    view = measure(project(grid, distance=distance), grid, FRAME, CHECKER, FOCAL)
+    assert view.approx_distance_m == pytest.approx(distance, rel=0.02)
+
+
+def test_pixels_per_square_falls_off_with_range():
+    grid = board_points()
+    near_m, far_m = CHECKER.range_m(FOCAL, FRAME_DIAG)
+    near = measure(project(grid, distance=near_m * 1.2), grid, FRAME, CHECKER, FOCAL)
+    beyond = measure(project(grid, distance=far_m * 1.3), grid, FRAME, CHECKER, FOCAL)
+    assert near.pixels_per_square > beyond.pixels_per_square
+    assert near.hint == IN_RANGE
+    assert beyond.hint == TOO_FAR
+    assert beyond.pixels_per_square < CHECKER.min_pixels_per_square
+
+
+def test_no_geometry_still_measures_but_reports_no_distance():
+    """A caller that has not said which board it is must still get a usable
+    view, not a crash and not a fabricated distance."""
+    grid = board_points()
+    view = measure(project(grid, distance=0.4), grid, FRAME)
+    assert view is not None
+    assert view.approx_distance_m == 0.0
+    assert view.pixels_per_square == 0.0
+    assert view.extent_min == DEFAULT_EXTENT_MIN
 
 
 # ----------------------------------------------------------------------- zones

--- a/ros2_ws/src/mars_bot/mars_cam/test/test_capture_guidance.py
+++ b/ros2_ws/src/mars_bot/mars_cam/test/test_capture_guidance.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Tests for the live capture guidance.
+
+The behaviour under test is the difference between an operator who is told
+"73%, still need the top-left corner and more tilt" and one who is told "27 of
+40" while filling the middle of the frame with square-on views that cannot
+constrain the calibration.
+"""
+
+import numpy as np
+import pytest
+
+from mars_cam.capture_guidance import (
+    EXTENT_MAX,
+    EXTENT_MIN,
+    IN_RANGE,
+    TILT_MIN,
+    TOO_CLOSE,
+    TOO_FAR,
+    BoardView,
+    CoverageTracker,
+    measure,
+)
+
+FRAME = (640, 480)
+FOCAL = 500.0
+
+
+def board_points(cols: int = 9, rows: int = 6, pitch: float = 0.022) -> np.ndarray:
+    """Inner corners of a checkerboard, in board coordinates, z = 0."""
+    grid = np.zeros((rows * cols, 3), dtype=np.float64)
+    grid[:, :2] = np.mgrid[0:cols, 0:rows].T.reshape(-1, 2) * pitch
+    return grid
+
+
+def project(
+    points: np.ndarray,
+    distance: float,
+    pitch_deg: float = 0.0,
+    yaw_deg: float = 0.0,
+    offset: tuple[float, float] = (0.0, 0.0),
+) -> np.ndarray:
+    """Image points for a board centred on the optical axis, then rotated."""
+    centred = points - points.mean(axis=0)
+    p, y = np.radians(pitch_deg), np.radians(yaw_deg)
+    rot_x = np.array([[1, 0, 0], [0, np.cos(p), -np.sin(p)], [0, np.sin(p), np.cos(p)]])
+    rot_y = np.array([[np.cos(y), 0, np.sin(y)], [0, 1, 0], [-np.sin(y), 0, np.cos(y)]])
+    camera = centred @ (rot_y @ rot_x).T + np.array([offset[0], offset[1], distance])
+    u = FOCAL * camera[:, 0] / camera[:, 2] + FRAME[0] / 2.0
+    v = FOCAL * camera[:, 1] / camera[:, 2] + FRAME[1] / 2.0
+    return np.column_stack([u, v])
+
+
+# ------------------------------------------------------------------- geometry
+
+
+def test_square_on_board_reads_as_untilted():
+    grid = board_points()
+    view = measure(project(grid, distance=0.5), grid, FRAME)
+    assert view is not None
+    assert view.tilt == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.parametrize("angle", [25.0, 35.0, -30.0])
+def test_a_tilted_board_is_detected_as_tilted(angle):
+    grid = board_points()
+    view = measure(project(grid, distance=0.5, pitch_deg=angle), grid, FRAME)
+    assert view is not None
+    assert view.tilt >= TILT_MIN
+
+
+def test_tilt_grows_with_angle():
+    grid = board_points()
+    tilts = [measure(project(grid, distance=0.5, pitch_deg=a), grid, FRAME).tilt for a in (5.0, 20.0, 40.0)]
+    assert tilts[0] < tilts[1] < tilts[2]
+
+
+def test_tilt_does_not_change_with_range():
+    """The property one threshold depends on: the same physical tilt must read
+    the same whether the board is held close or far."""
+    grid = board_points()
+    tilts = [measure(project(grid, distance=d, pitch_deg=30.0), grid, FRAME).tilt for d in (0.35, 0.6, 1.0)]
+    assert max(tilts) - min(tilts) < 0.02
+    assert all(t >= TILT_MIN for t in tilts)
+
+
+def test_in_plane_rotation_is_not_tilt():
+    """Rotating the board in its own plane changes no edge-length ratio."""
+    grid = board_points()
+    spun = grid.copy()
+    theta = np.radians(30.0)
+    rot = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
+    spun[:, :2] = grid[:, :2] @ rot.T
+    view = measure(project(spun, distance=0.5), spun, FRAME)
+    assert view is not None
+    assert view.tilt == pytest.approx(0.0, abs=1e-6)
+
+
+def test_a_partial_charuco_style_detection_measures_the_same_tilt():
+    """Half the corners missing must not change the answer — that is the whole
+    reason tilt comes from a fitted homography rather than the outer corners."""
+    grid = board_points()
+    image = project(grid, distance=0.5, pitch_deg=30.0)
+    keep = np.arange(0, len(grid), 2)
+    full = measure(image, grid, FRAME)
+    partial = measure(image[keep], grid[keep], FRAME)
+    assert full is not None and partial is not None
+    assert partial.tilt == pytest.approx(full.tilt, abs=0.02)
+
+
+def test_degenerate_input_returns_none():
+    grid = board_points()
+    assert measure(np.zeros((3, 2)), grid[:3], FRAME) is None
+    assert measure(project(grid, 0.5), grid, (0, 0)) is None
+    assert measure(np.zeros((len(grid), 2)), grid, FRAME) is None
+
+
+# ------------------------------------------------------------------- distance
+
+
+def test_closer_boards_have_a_larger_extent():
+    grid = board_points()
+    near = measure(project(grid, distance=0.3), grid, FRAME)
+    far = measure(project(grid, distance=1.2), grid, FRAME)
+    assert near.extent > far.extent
+
+
+def test_distance_hints_bracket_the_usable_range():
+    assert BoardView((0.5, 0.5), EXTENT_MIN - 0.05, 0.0).hint == TOO_FAR
+    assert BoardView((0.5, 0.5), (EXTENT_MIN + EXTENT_MAX) / 2, 0.0).hint == IN_RANGE
+    assert BoardView((0.5, 0.5), EXTENT_MAX + 0.05, 0.0).hint == TOO_CLOSE
+    assert BoardView((0.5, 0.5), (EXTENT_MIN + EXTENT_MAX) / 2, 0.0).usable
+
+
+def test_scale_bands_span_the_usable_range():
+    bands = {BoardView((0.5, 0.5), e, 0.0).scale_band for e in np.linspace(EXTENT_MIN, EXTENT_MAX, 40)}
+    assert bands == {0, 1, 2}
+
+
+# ----------------------------------------------------------------------- zones
+
+
+def test_board_position_maps_to_the_expected_zone():
+    assert BoardView((0.1, 0.1), 0.5, 0.0).zone == (0, 0)
+    assert BoardView((0.5, 0.5), 0.5, 0.0).zone == (1, 1)
+    assert BoardView((0.95, 0.95), 0.5, 0.0).zone == (2, 2)
+
+
+def test_a_board_at_the_frame_edge_stays_in_range():
+    """Clamping matters: a centroid of exactly 1.0 must not index off the grid."""
+    assert BoardView((1.0, 1.0), 0.5, 0.0).zone == (2, 2)
+    assert BoardView((0.0, 0.0), 0.5, 0.0).zone == (0, 0)
+
+
+def test_the_projected_centroid_lands_in_the_right_zone():
+    grid = board_points()
+    view = measure(project(grid, distance=0.5, offset=(-0.15, -0.1)), grid, FRAME)
+    assert view.zone == (0, 0)
+
+
+# -------------------------------------------------------------------- progress
+
+
+def fill(tracker: CoverageTracker, count: int, zone=(0.5, 0.5), extent=0.55, tilt=0.0) -> None:
+    for _ in range(count):
+        tracker.add(BoardView(zone, extent, tilt))
+
+
+def test_repeating_one_pose_never_completes():
+    tracker = CoverageTracker(target_captures=10)
+    fill(tracker, 40)
+    progress = tracker.progress()
+    assert not progress.complete
+    assert progress.percent < 100.0
+    assert "top-left" in progress.missing
+    assert "tilted views" in progress.missing
+
+
+def test_hitting_the_capture_target_alone_is_not_completion():
+    tracker = CoverageTracker(target_captures=5)
+    fill(tracker, 5)
+    assert tracker.captures == 5
+    assert not any(m.endswith("more captures") for m in tracker.progress().missing)
+    assert not tracker.progress().complete
+
+
+def test_progress_rises_as_zones_are_covered():
+    tracker = CoverageTracker(target_captures=20)
+    seen = [tracker.progress().percent]
+    for x in (0.15, 0.5, 0.85):
+        for y in (0.15, 0.5, 0.85):
+            tracker.add(BoardView((x, y), 0.55, 0.0))
+            seen.append(tracker.progress().percent)
+    assert seen == sorted(seen)
+    assert seen[-1] > seen[0]
+
+
+def test_a_full_sweep_reaches_completion():
+    tracker = CoverageTracker(target_captures=18)
+    extents = [EXTENT_MAX - 0.05, (EXTENT_MIN + EXTENT_MAX) / 2, EXTENT_MIN + 0.05]
+    for x in (0.15, 0.5, 0.85):
+        for y in (0.15, 0.5, 0.85):
+            for i, extent in enumerate(extents):
+                tracker.add(BoardView((x, y), extent, TILT_MIN if i else 0.0))
+    progress = tracker.progress()
+    assert progress.complete, progress.missing
+    assert progress.percent == pytest.approx(100.0)
+    assert tracker.advice() == ""
+
+
+def test_advice_names_what_is_short():
+    tracker = CoverageTracker(target_captures=10)
+    fill(tracker, 3)
+    advice = tracker.advice()
+    assert advice.startswith("Still needed:")
+    assert len(advice.split(", ")) <= 3

--- a/ros2_ws/src/mars_bot/mars_cam/test/test_checkerboard_calibration.py
+++ b/ros2_ws/src/mars_bot/mars_cam/test/test_checkerboard_calibration.py
@@ -405,3 +405,44 @@ def test_markdown_report_renders_all_sections(solved_rig):
     assert "Error versus image location" in text
     assert "Per validation image" in text
     assert "|dy|" not in text  # unescaped pipes would break the tables
+
+
+def test_validation_metrics_work_without_a_full_grid():
+    """The ChArUco arm holds out pairs too, but its captures carry corner subsets.
+
+    Regression guard: a held-out split with no report is worse than no split at
+    all, because it silently shrinks the training set and measures nothing.
+    """
+    rig = solved_rig.__wrapped__() if hasattr(solved_rig, "__wrapped__") else None
+    assert rig is not None
+
+    K1, D1, K2, D2, R, T = rig["matrices"]
+    R1, R2, P1, P2, _, _, _ = cv2.stereoRectify(
+        K1, D1, K2, D2, IMAGE_SIZE, R, T, alpha=0, flags=cv2.CALIB_ZERO_DISPARITY
+    )
+    # Keep an arbitrary subset of corners, the way ChArUco interpolation does.
+    subset = np.array([0, 3, 7, 11, 15, 19, 24, 30, 33, 41, 47, 52])
+    pairs = [
+        ValidationPair(
+            index=i,
+            object_points=rig["object_grid"][subset],
+            corners_left=rig["detections"][i][0][subset],
+            corners_right=rig["detections"][i][1][subset],
+            grid_shape=None,
+        )
+        for i in rig["validation"]
+    ]
+    report = evaluate(
+        StereoCalibrationMatrices(K1=K1, D1=D1, K2=K2, D2=D2, R1=R1, R2=R2, P1=P1, P2=P2),
+        pairs,
+        IMAGE_SIZE,
+        SQUARE,
+    )
+
+    # Spacing needs the grid structure and is correctly skipped; everything else stands.
+    assert report.spacing_error_mm.count == 0
+    assert report.left_reprojection.count == len(subset) * len(pairs)
+    assert report.epipolar_dy.count == len(subset) * len(pairs)
+    assert report.planarity_rms_mm.count == len(pairs)
+    assert report.q_yields_positive_z
+    assert sum(b.epipolar_dy.count for b in report.radial_bins) == report.epipolar_dy.count

--- a/ros2_ws/src/mars_bot/mars_cam/test/test_checkerboard_calibration.py
+++ b/ros2_ws/src/mars_bot/mars_cam/test/test_checkerboard_calibration.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Innate Inc
+"""Tests for the checkerboard calibration arm.
+
+These run against synthetically rendered boards with exactly known geometry, so
+a detector or correspondence regression shows up as a metric blowing out rather
+than as a silently worse calibration on the robot. Nothing here imports ROS.
+"""
+
+import cv2
+import numpy as np
+import pytest
+
+from mars_cam.calibration_experiment import ExperimentRecorder, render_markdown, skew_summary
+from mars_cam.calibration_validation import (
+    ErrorStats,
+    StereoCalibrationMatrices,
+    ValidationPair,
+    evaluate,
+)
+from mars_cam.checkerboard import CaptureDiagnostics, CheckerboardTarget, detect, measure, sharpness
+
+PATTERN = (9, 6)
+SQUARE = 0.022
+IMAGE_SIZE = (640, 480)
+BASELINE = 0.060
+K = np.array([[520.0, 0.0, 320.0], [0.0, 520.0, 240.0], [0.0, 0.0, 1.0]])
+D = np.zeros((5, 1))
+
+# Right camera sits +BASELINE along the left camera's +x, so a point in left
+# coordinates lands at X - [B,0,0] in right coordinates.
+R_LEFT_TO_RIGHT = np.eye(3)
+T_LEFT_TO_RIGHT = np.array([[-BASELINE], [0.0], [0.0]])
+
+
+def board_texture(square_px: int = 48, quiet_zone: int = 60) -> tuple[np.ndarray, float]:
+    """A 10x7-square board (9x6 inner corners) on a white quiet zone.
+
+    Returns the texture and the metres-per-texture-pixel scale.
+    """
+    cols_sq, rows_sq = PATTERN[0] + 1, PATTERN[1] + 1
+    board = np.zeros((rows_sq * square_px, cols_sq * square_px), np.uint8)
+    for r in range(rows_sq):
+        for c in range(cols_sq):
+            if (r + c) % 2 == 0:
+                board[r * square_px : (r + 1) * square_px, c * square_px : (c + 1) * square_px] = 255
+    canvas = np.full((board.shape[0] + 2 * quiet_zone, board.shape[1] + 2 * quiet_zone), 255, np.uint8)
+    canvas[quiet_zone : quiet_zone + board.shape[0], quiet_zone : quiet_zone + board.shape[1]] = board
+    return canvas, SQUARE / square_px
+
+
+def render(texture: np.ndarray, scale: float, quiet_zone: int, rvec: np.ndarray, tvec: np.ndarray, K_: np.ndarray):
+    """Project the planar board texture into a camera view."""
+    rotation, _ = cv2.Rodrigues(rvec)
+    # Board origin (first inner corner) sits one square in from the texture edge.
+    offset = np.array(
+        [[1.0, 0.0, -(quiet_zone * scale + SQUARE)], [0.0, 1.0, -(quiet_zone * scale + SQUARE)], [0, 0, 1]]
+    )
+    texture_to_metres = np.array([[scale, 0.0, 0.0], [0.0, scale, 0.0], [0.0, 0.0, 1.0]])
+    plane_to_camera = np.hstack([rotation[:, :2], tvec])
+    homography = K_ @ plane_to_camera @ np.linalg.inv(offset) @ texture_to_metres
+    return cv2.warpPerspective(
+        texture, homography, IMAGE_SIZE, flags=cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT, borderValue=255
+    )
+
+
+def synthetic_views(rvec: np.ndarray, tvec: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """One stereo pair of the board at the given pose in the left camera frame."""
+    texture, scale = board_texture()
+    left = render(texture, scale, 60, rvec, tvec, K)
+    rotation, _ = cv2.Rodrigues(rvec)
+    right_rotation = R_LEFT_TO_RIGHT @ rotation
+    right_tvec = R_LEFT_TO_RIGHT @ tvec + T_LEFT_TO_RIGHT
+    right = render(texture, scale, 60, cv2.Rodrigues(right_rotation)[0], right_tvec, K)
+    return left, right
+
+
+def board_poses(count: int) -> list[tuple[np.ndarray, np.ndarray]]:
+    rng = np.random.default_rng(7)
+    poses = []
+    for _ in range(count):
+        rvec = rng.uniform(-0.25, 0.25, 3).reshape(3, 1)
+        tvec = (np.array([-0.09, -0.07, 0.55]) + rng.uniform(-0.04, 0.04, 3)).reshape(3, 1)
+        poses.append((rvec, tvec))
+    return poses
+
+
+# --------------------------------------------------------------------- target
+
+
+def test_object_grid_matches_pattern_and_pitch():
+    target = CheckerboardTarget(pattern=PATTERN, square_size=SQUARE)
+    grid = target.object_grid()
+
+    assert grid.shape == (54, 3)
+    assert target.num_corners == 54
+    assert np.allclose(grid[:, 2], 0.0)
+    # Row-major: consecutive points in a row are one pitch apart in x.
+    assert grid[1, 0] - grid[0, 0] == pytest.approx(SQUARE)
+    assert grid[PATTERN[0], 1] - grid[0, 1] == pytest.approx(SQUARE)
+
+
+def test_measured_pitch_override_scales_the_grid():
+    grid = CheckerboardTarget(pattern=PATTERN, square_size=0.0218).object_grid()
+    assert grid[1, 0] == pytest.approx(0.0218)
+
+
+# ------------------------------------------------------------------ detection
+
+
+def test_detects_the_complete_grid():
+    left, _ = synthetic_views(np.zeros((3, 1)), np.array([[-0.09], [-0.07], [0.55]]))
+    corners = detect(left, PATTERN)
+
+    assert corners is not None
+    assert corners.shape == (54, 1, 2)
+
+
+def test_returns_none_when_the_board_is_absent():
+    assert detect(np.full((480, 640), 255, np.uint8), PATTERN) is None
+
+
+def test_canonical_order_always_starts_at_the_top_left_endpoint():
+    """The anchor is what makes two eyes agree, so it must be deterministic."""
+    left, _ = synthetic_views(np.zeros((3, 1)), np.array([[-0.09], [-0.07], [0.55]]))
+
+    for image in (left, cv2.rotate(left, cv2.ROTATE_180)):
+        corners = detect(image, PATTERN)
+        assert corners is not None
+        first, last = corners[0, 0], corners[-1, 0]
+        assert first[0] + first[1] <= last[0] + last[1]
+
+
+def test_rotating_the_board_reverses_the_order_rather_than_scrambling_it():
+    """A 180-degree view is the same grid read from the opposite origin.
+
+    The board pose absorbs that choice during calibration; what must never
+    happen is an arbitrary reordering, which would break correspondence.
+    """
+    left, _ = synthetic_views(np.zeros((3, 1)), np.array([[-0.09], [-0.07], [0.55]]))
+    upright = detect(left, PATTERN)
+    flipped = detect(cv2.rotate(left, cv2.ROTATE_180), PATTERN)
+
+    assert upright is not None and flipped is not None
+    unrotated = np.stack([IMAGE_SIZE[0] - 1 - flipped[:, 0, 0], IMAGE_SIZE[1] - 1 - flipped[:, 0, 1]], axis=1)
+    assert np.allclose(unrotated[::-1], upright.reshape(-1, 2), atol=1.0)
+
+
+def test_left_and_right_corners_correspond():
+    """Index i must name the same physical corner in both cameras."""
+    left, right = synthetic_views(np.array([[0.15], [-0.2], [0.05]]), np.array([[-0.09], [-0.07], [0.55]]))
+    corners_left = detect(left, PATTERN)
+    corners_right = detect(right, PATTERN)
+
+    assert corners_left is not None and corners_right is not None
+    dy = np.abs(corners_left.reshape(-1, 2)[:, 1] - corners_right.reshape(-1, 2)[:, 1])
+    # A pure-x baseline with identical intrinsics keeps matched corners on the
+    # same row; a reversed ordering would scatter dy across the board height.
+    assert dy.max() < 2.0
+
+
+# ---------------------------------------------------------------- diagnostics
+
+
+def test_measure_reports_geometry_for_a_detected_board():
+    left, _ = synthetic_views(np.zeros((3, 1)), np.array([[-0.09], [-0.07], [0.55]]))
+    view = measure(left, detect(left, PATTERN), stamp_sec=12.5)
+
+    assert view.detected
+    assert view.num_corners == 54
+    assert view.stamp_sec == 12.5
+    assert 0.0 < view.coverage_pct <= 100.0
+    assert 0.0 < view.centroid_norm[0] < 1.0
+    assert 0.0 < view.centroid_norm[1] < 1.0
+    assert view.bbox[2] > view.bbox[0] and view.bbox[3] > view.bbox[1]
+
+
+def test_measure_still_reports_quality_when_detection_fails():
+    blank = np.full((480, 640), 128, np.uint8)
+    view = measure(blank, None, stamp_sec=3.0)
+
+    assert not view.detected
+    assert view.num_corners == 0
+    assert view.brightness == pytest.approx(128.0)
+    assert view.coverage_pct == 0.0
+
+
+def test_sharpness_separates_blurred_from_sharp():
+    left, _ = synthetic_views(np.zeros((3, 1)), np.array([[-0.09], [-0.07], [0.55]]))
+    assert sharpness(left) > sharpness(cv2.GaussianBlur(left, (11, 11), 5))
+
+
+def test_skew_summary_reports_the_distribution():
+    def diagnostics(skew: float) -> CaptureDiagnostics:
+        view = measure(np.full((48, 64), 100, np.uint8), None, stamp_sec=1.0)
+        return CaptureDiagnostics(
+            index=0, attempt=0, accepted=True, reason="ok", split="train", stamp_skew_sec=skew, left=view, right=view
+        )
+
+    summary = skew_summary([diagnostics(s) for s in (0.001, -0.003, 0.002)])
+
+    assert summary["count"] == 3
+    assert summary["max_ms"] == pytest.approx(3.0)
+    assert summary["median_ms"] == pytest.approx(2.0)
+
+
+# ----------------------------------------------------------------- statistics
+
+
+def test_error_stats_summarise_a_known_distribution():
+    stats = ErrorStats.of(np.array([1.0, 2.0, 3.0, 4.0]))
+
+    assert stats.count == 4
+    assert stats.mean == pytest.approx(2.5)
+    assert stats.rms == pytest.approx(np.sqrt(7.5))
+    assert stats.median == pytest.approx(2.5)
+    assert stats.maximum == pytest.approx(4.0)
+
+
+def test_error_stats_tolerate_an_empty_sample():
+    assert ErrorStats.of(np.empty(0)).count == 0
+
+
+# ------------------------------------------------------- end-to-end pipeline
+
+
+@pytest.fixture(scope="module")
+def solved_rig():
+    """Detect a synthetic capture set, calibrate on 80%, hold out 20%."""
+    target = CheckerboardTarget(pattern=PATTERN, square_size=SQUARE)
+    object_grid = target.object_grid().reshape(-1, 1, 3)
+
+    detections = []
+    for rvec, tvec in board_poses(15):
+        left, right = synthetic_views(rvec, tvec)
+        corners_left, corners_right = detect(left, PATTERN), detect(right, PATTERN)
+        if corners_left is not None and corners_right is not None:
+            detections.append((corners_left, corners_right))
+
+    assert len(detections) >= 12, f"detector only found {len(detections)} of 15 synthetic boards"
+
+    validation = {i for i in range(len(detections)) if (i + 1) % 5 == 0}
+    train = [i for i in range(len(detections)) if i not in validation]
+
+    objs = [object_grid] * len(train)
+    _, K1, D1, _, _ = cv2.calibrateCamera(objs, [detections[i][0] for i in train], IMAGE_SIZE, None, None, flags=0)
+    _, K2, D2, _, _ = cv2.calibrateCamera(objs, [detections[i][1] for i in train], IMAGE_SIZE, None, None, flags=0)
+    _, K1, D1, K2, D2, R, T, _, _ = cv2.stereoCalibrate(
+        objs,
+        [detections[i][0] for i in train],
+        [detections[i][1] for i in train],
+        K1,
+        D1,
+        K2,
+        D2,
+        IMAGE_SIZE,
+        flags=cv2.CALIB_FIX_INTRINSIC,
+        criteria=(cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 100, 1e-6),
+    )
+    return {
+        "detections": detections,
+        "validation": sorted(validation),
+        "object_grid": object_grid,
+        "matrices": (K1, D1, K2, D2, R, T),
+    }
+
+
+def _rectify_and_evaluate(solved_rig, negate_t: bool):
+    K1, D1, K2, D2, R, T = solved_rig["matrices"]
+    T_used = -T if negate_t else T
+    R1, R2, P1, P2, _, _, _ = cv2.stereoRectify(
+        K1, D1, K2, D2, IMAGE_SIZE, R, T_used, alpha=0, flags=cv2.CALIB_ZERO_DISPARITY
+    )
+    pairs = [
+        ValidationPair(
+            index=i,
+            object_points=solved_rig["object_grid"],
+            corners_left=solved_rig["detections"][i][0],
+            corners_right=solved_rig["detections"][i][1],
+            grid_shape=PATTERN,
+        )
+        for i in solved_rig["validation"]
+    ]
+    calib = StereoCalibrationMatrices(K1=K1, D1=D1, K2=K2, D2=D2, R1=R1, R2=R2, P1=P1, P2=P2)
+    return evaluate(calib, pairs, IMAGE_SIZE, SQUARE)
+
+
+def test_stereocalibrate_returns_negative_tx_for_a_right_mounted_second_camera(solved_rig):
+    """Pins the convention the T-sign finding rests on."""
+    _, _, _, _, _, T = solved_rig["matrices"]
+    assert T[0, 0] < 0
+    assert abs(abs(T[0, 0]) - BASELINE) < 0.002
+
+
+def test_held_out_metrics_are_tight_on_a_synthetic_rig(solved_rig):
+    report = _rectify_and_evaluate(solved_rig, negate_t=False)
+
+    assert report.num_pairs == len(solved_rig["validation"])
+    assert report.left_reprojection.rms < 0.5
+    assert report.right_reprojection.rms < 0.5
+    assert report.epipolar_dy.p95 < 0.5
+    assert report.mean_spacing_mm == pytest.approx(SQUARE * 1000.0, abs=0.5)
+    assert report.spacing_error_mm.mean < 0.5
+    assert report.planarity_rms_mm.mean < 1.0
+
+
+def test_validation_reports_positive_depth_with_the_sign_as_returned(solved_rig):
+    report = _rectify_and_evaluate(solved_rig, negate_t=False)
+
+    assert report.q_yields_positive_z
+    assert report.median_depth_m > 0.0
+
+
+def test_negating_t_flips_reconstructed_depth_but_not_distances(solved_rig):
+    """The T negation is detectable as a depth-sign flip, and only that."""
+    good = _rectify_and_evaluate(solved_rig, negate_t=False)
+    negated = _rectify_and_evaluate(solved_rig, negate_t=True)
+
+    assert not negated.q_yields_positive_z
+    assert negated.median_depth_m == pytest.approx(-good.median_depth_m, rel=1e-6)
+    # A global negation preserves every distance, which is why the bug hides.
+    assert negated.spacing_error_mm.mean == pytest.approx(good.spacing_error_mm.mean, rel=1e-6)
+    assert negated.epipolar_dy.rms == pytest.approx(good.epipolar_dy.rms, rel=1e-6)
+
+
+def test_radial_bins_cover_every_validation_corner(solved_rig):
+    report = _rectify_and_evaluate(solved_rig, negate_t=False)
+
+    assert [b.label for b in report.radial_bins] == ["center", "middle", "outer"]
+    assert sum(b.epipolar_dy.count for b in report.radial_bins) == report.epipolar_dy.count
+
+
+def test_per_image_metrics_exist_for_each_validation_pair(solved_rig):
+    report = _rectify_and_evaluate(solved_rig, negate_t=False)
+    assert [m.index for m in report.per_image] == solved_rig["validation"]
+
+
+# --------------------------------------------------------------- experiment io
+
+
+def test_recorder_refuses_to_write_into_the_production_directory(tmp_path):
+    with pytest.raises(ValueError, match="calibration_config"):
+        ExperimentRecorder(tmp_path / "mars_calibration_config", "checkerboard")
+
+
+def test_recorder_writes_candidate_not_production(tmp_path, solved_rig):
+    K1, D1, K2, D2, R, T = solved_rig["matrices"]
+    R1, R2, P1, P2, Q, _, _ = cv2.stereoRectify(
+        K1, D1, K2, D2, IMAGE_SIZE, R, T, alpha=0, flags=cv2.CALIB_ZERO_DISPARITY
+    )
+    recorder = ExperimentRecorder(tmp_path / "calibration_experiments", "checkerboard")
+    path = recorder.save_candidate_calibration(
+        {
+            "K1": K1,
+            "D1": D1,
+            "K2": K2,
+            "D2": D2,
+            "R": R,
+            "T": T,
+            "R1": R1,
+            "R2": R2,
+            "P1": P1,
+            "P2": P2,
+            "Q": Q,
+            "image_width": IMAGE_SIZE[0],
+            "image_height": IMAGE_SIZE[1],
+        }
+    )
+
+    assert path.name == "stereo_calib_candidate.yaml"
+    assert not (tmp_path / "calibration_experiments" / "stereo_calib.yaml").exists()
+    stored = cv2.FileStorage(str(path), cv2.FileStorage_READ)
+    assert int(stored.getNode("version").real()) == 2
+    assert np.allclose(stored.getNode("K1").mat(), K1)
+    stored.release()
+
+
+def test_recorder_writes_capture_metadata(tmp_path):
+    view = measure(np.full((48, 64), 100, np.uint8), None, stamp_sec=5.0)
+    diagnostics = [
+        CaptureDiagnostics(
+            index=0,
+            attempt=1,
+            accepted=True,
+            reason="ok",
+            split="train",
+            stamp_skew_sec=0.004,
+            left=view,
+            right=view,
+        )
+    ]
+    recorder = ExperimentRecorder(tmp_path / "calibration_experiments", "checkerboard")
+    json_path, csv_path = recorder.write_captures(diagnostics)
+
+    assert "stamp_skew_sec" in json_path.read_text()
+    header = csv_path.read_text().splitlines()[0]
+    for column in ("left_sharpness", "right_brightness", "left_coverage_pct", "left_centroid_x_norm", "split"):
+        assert column in header
+
+
+def test_markdown_report_renders_all_sections(solved_rig):
+    text = render_markdown(_rectify_and_evaluate(solved_rig, negate_t=False))
+
+    assert "Held-out stereo calibration validation" in text
+    assert "Error versus image location" in text
+    assert "Per validation image" in text
+    assert "|dy|" not in text  # unescaped pipes would break the tables

--- a/ros2_ws/src/mars_bot/mars_msgs/action/RunStereoCalibration.action
+++ b/ros2_ws/src/mars_bot/mars_msgs/action/RunStereoCalibration.action
@@ -3,6 +3,11 @@ uint8 MODE_MANUAL=0
 uint8 MODE_AUTONOMOUS=1
 uint8 mode  # only MODE_MANUAL implemented currently
 
+uint8 BOARD_DEFAULT=0      # whatever the node is configured for
+uint8 BOARD_CHARUCO=1
+uint8 BOARD_CHECKERBOARD=2
+uint8 board  # overrides the node's target_type for this run only
+
 int32 num_images
 int32 min_corners
 bool save_calibration
@@ -16,6 +21,7 @@ float32 left_rms
 float32 right_rms
 float32 stereo_rms
 string quality  # EXCELLENT | GOOD | ACCEPTABLE | POOR - consider recalibrating (empty if not computed)
+string board  # which target the run actually used
 ---
 # Feedback
 string phase  # READY (goal accepted, watchdog armed) | CAPTURE | PROCESSING
@@ -26,3 +32,12 @@ string[] image_names
 sensor_msgs/CompressedImage[] images
 string message
 float32 capture_timeout_sec  # live watchdog timeout; client re-anchors its countdown to this on every tick
+
+# Live capture guidance. All relative to the frame, never metres: these are
+# produced DURING calibration, so there are no intrinsics yet to convert with.
+string board  # which target this run is detecting
+string distance_hint  # TOO_CLOSE | IN_RANGE | TOO_FAR (empty when nothing detected)
+float32 board_extent  # board diagonal over frame diagonal
+float32 board_tilt  # ~0.0143 per degree off square, range-independent
+float32 coverage_percent  # 0-100 across position, scale, tilt and count
+string[] coverage_missing  # what is still short, most useful first

--- a/ros2_ws/src/mars_bot/mars_msgs/action/RunStereoCalibration.action
+++ b/ros2_ws/src/mars_bot/mars_msgs/action/RunStereoCalibration.action
@@ -33,11 +33,14 @@ sensor_msgs/CompressedImage[] images
 string message
 float32 capture_timeout_sec  # live watchdog timeout; client re-anchors its countdown to this on every tick
 
-# Live capture guidance. All relative to the frame, never metres: these are
-# produced DURING calibration, so there are no intrinsics yet to convert with.
+# Live capture guidance. Every threshold behind these is frame-relative: they
+# are produced DURING calibration, so there are no intrinsics yet to convert
+# with. approx_distance_m is the one exception, and is display text only.
 string board  # which target this run is detecting
 string distance_hint  # TOO_CLOSE | IN_RANGE | TOO_FAR (empty when nothing detected)
 float32 board_extent  # board diagonal over frame diagonal
 float32 board_tilt  # ~0.0143 per degree off square, range-independent
+float32 pixels_per_square  # detection headroom; the far limit is a floor on this
+float32 approx_distance_m  # from the lens's NOMINAL fov, for display only
 float32 coverage_percent  # 0-100 across position, scale, tilt and count
 string[] coverage_missing  # what is still short, most useful first

--- a/webapp/css/calibration.css
+++ b/webapp/css/calibration.css
@@ -128,6 +128,12 @@
   font: inherit;
 }
 
+select.calib-input {
+  width: auto;
+  min-width: 132px;
+  text-align: left;
+}
+
 .calib-checkbox-row {
   display: flex;
   align-items: flex-start;
@@ -221,6 +227,62 @@
 
 .calib-quality-bad {
   color: var(--danger);
+}
+
+.calib-setup {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.calib-badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.calib-progress {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--hairline);
+  overflow: hidden;
+}
+
+.calib-progress-fill {
+  height: 100%;
+  width: 0;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.25s ease;
+}
+
+.calib-progress-fill.done {
+  background: var(--ok);
+}
+
+.calib-progress-label {
+  margin: 0;
+}
+
+.calib-missing {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.calib-missing li {
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--hairline-strong);
+  font-size: 11px;
+  color: var(--muted);
 }
 
 .calib-badge {

--- a/webapp/js/calibration/main.js
+++ b/webapp/js/calibration/main.js
@@ -44,6 +44,7 @@ export function mount(stage) {
  *   for the server's capture-timeout watchdog, re-anchored from
  *   `capture_timeout_sec` on every feedback tick. Display-only — see render().
  * @property {string} distanceHint TOO_CLOSE | IN_RANGE | TOO_FAR, "" if nothing seen
+ * @property {number} approxDistanceM Approximate, from the lens's nominal FOV — display only
  * @property {number} coveragePercent 0-100 across position, scale, tilt and count
  * @property {string[]} coverageMissing What the run is still short of
  *
@@ -396,6 +397,7 @@ function buildView(root) {
       fb.deadlineMs = Date.now() + values.capture_timeout_sec * 1000;
     }
     if (typeof values?.distance_hint === "string") fb.distanceHint = values.distance_hint;
+    if (typeof values?.approx_distance_m === "number") fb.approxDistanceM = values.approx_distance_m;
     if (typeof values?.coverage_percent === "number") fb.coveragePercent = values.coverage_percent;
     if (Array.isArray(values?.coverage_missing)) fb.coverageMissing = values.coverage_missing;
     applyCoverageImages(values);
@@ -423,6 +425,7 @@ function buildView(root) {
       message: "",
       deadlineMs: null,
       distanceHint: "",
+      approxDistanceM: 0,
       coveragePercent: 0,
       coverageMissing: [],
     };
@@ -620,13 +623,16 @@ function buildView(root) {
       distanceBadge.hidden = !hint;
       distanceBadge.classList.toggle("ok", hint === "IN_RANGE");
       distanceBadge.classList.toggle("bad", hint === "TOO_CLOSE" || hint === "TOO_FAR");
+      // Approximate by construction — the real focal length is what this run
+      // is producing, so the cm figure comes from the lens's nominal FOV.
+      const roughCm = fb.approxDistanceM > 0 ? ` (~${Math.round(fb.approxDistanceM * 100)} cm)` : "";
       distanceBadge.textContent =
         hint === "TOO_CLOSE"
-          ? "Too close — move the board back"
+          ? `Too close — move the board back${roughCm}`
           : hint === "TOO_FAR"
-            ? "Too far — bring the board closer"
+            ? `Too far — bring the board closer${roughCm}`
             : hint === "IN_RANGE"
-              ? "Good distance"
+              ? `Good distance${roughCm}`
               : "";
 
       const pct = Math.max(0, Math.min(100, fb.coveragePercent));

--- a/webapp/js/calibration/main.js
+++ b/webapp/js/calibration/main.js
@@ -43,6 +43,9 @@ export function mount(stage) {
  * @property {number | null} deadlineMs Wall-clock deadline (Date.now()-comparable)
  *   for the server's capture-timeout watchdog, re-anchored from
  *   `capture_timeout_sec` on every feedback tick. Display-only — see render().
+ * @property {string} distanceHint TOO_CLOSE | IN_RANGE | TOO_FAR, "" if nothing seen
+ * @property {number} coveragePercent 0-100 across position, scale, tilt and count
+ * @property {string[]} coverageMissing What the run is still short of
  *
  * @typedef {Object} ResultState
  * @property {boolean} success
@@ -58,6 +61,33 @@ export function mount(stage) {
 
 const CALIBRATION_BOARD_PDF_URL =
   "https://raw.githubusercontent.com/innate-inc/web-docs/main/.gitbook/assets/mars-calibration-board.pdf";
+
+// Goal.board enum values from RunStereoCalibration.action. The geometry in each
+// blurb is the node's default for that target — a board printed to different
+// dimensions needs the matching stereo_calibrator parameters, not just this pick.
+const BOARDS = {
+  charuco: {
+    goal: 1,
+    label: "ChArUco",
+    blurb: "17x9 squares, 16mm / 12mm markers. Partial views are fine — corners are found from the markers.",
+    href: CALIBRATION_BOARD_PDF_URL,
+    linkText: "Calibration board (PDF)",
+  },
+  checkerboard: {
+    goal: 2,
+    label: "Checkerboard",
+    blurb: "9x6 inner corners, 22mm squares. Every corner must stay inside BOTH cameras or the capture is dropped.",
+    href: "https://calib.io/pages/camera-calibration-pattern-generator",
+    linkText: "Pattern generator (calib.io)",
+  },
+};
+
+const SETUP_STEPS = [
+  "Park the robot facing a clear, evenly lit wall. The head moves to its calibration angle on Start.",
+  "Hold the board square-on, about a third of the frame wide, and press Enter or Capture.",
+  "Work through the frame — corners as well as the middle — varying distance and tilting the board each time.",
+  "Follow the prompts below until coverage reads 100%.",
+];
 
 /**
  * @param {HTMLElement} root
@@ -97,6 +127,22 @@ function buildView(root) {
   const controls = document.createElement("div");
   controls.className = "calib-panel";
 
+  const boardRow = document.createElement("div");
+  boardRow.className = "calib-field-row";
+  const boardLabel = document.createElement("label");
+  boardLabel.className = "calib-field-label";
+  boardLabel.textContent = "Target";
+  const boardSelect = document.createElement("select");
+  boardSelect.className = "calib-input";
+  for (const [key, board] of Object.entries(BOARDS)) {
+    const option = document.createElement("option");
+    option.value = key;
+    option.textContent = board.label;
+    boardSelect.append(option);
+  }
+  boardLabel.htmlFor = boardSelect.id = "calib-board-select";
+  boardRow.append(boardLabel, boardSelect);
+
   const numField = fieldRow("Images to capture", String(STEREO_CALIB_DEFAULT_NUM_IMAGES));
   const minField = fieldRow("Min corners per capture", String(STEREO_CALIB_DEFAULT_MIN_CORNERS));
 
@@ -128,7 +174,6 @@ function buildView(root) {
   boardTitle.textContent = "Calibration board (PDF)";
   const boardSub = document.createElement("span");
   boardSub.className = "calib-board-sub";
-  boardSub.textContent = "ChArUco board — print at 100% scale and keep it flat";
   boardText.append(boardTitle, boardSub);
   const boardDl = document.createElement("span");
   boardDl.className = "calib-board-dl";
@@ -160,7 +205,15 @@ function buildView(root) {
   const statusLine = document.createElement("p");
   statusLine.className = "calib-status microlabel";
 
-  controls.append(boardLink, numField.row, minField.row, saveRow, actionRow, statusLine);
+  const setupList = document.createElement("ol");
+  setupList.className = "calib-setup";
+  for (const step of SETUP_STEPS) {
+    const item = document.createElement("li");
+    item.textContent = step;
+    setupList.append(item);
+  }
+
+  controls.append(boardLink, setupList, boardRow, numField.row, minField.row, saveRow, actionRow, statusLine);
 
   // ---- live feedback --------------------------------------------------------
   const feedback = document.createElement("div");
@@ -173,6 +226,23 @@ function buildView(root) {
   const boardBadge = document.createElement("span");
   boardBadge.className = "calib-badge";
 
+  // Distance is reported as board-size-in-frame, not metres: the numbers come
+  // from a run that has no intrinsics yet, so there is nothing to convert with.
+  const distanceBadge = document.createElement("span");
+  distanceBadge.className = "calib-badge";
+  distanceBadge.title = "Board size in frame — the calibrator has no metric scale until it finishes";
+
+  const coverageBar = document.createElement("div");
+  coverageBar.className = "calib-progress";
+  const coverageFill = document.createElement("div");
+  coverageFill.className = "calib-progress-fill";
+  coverageBar.append(coverageFill);
+  const coverageLabel = document.createElement("p");
+  coverageLabel.className = "calib-progress-label microlabel";
+
+  const missingList = document.createElement("ul");
+  missingList.className = "calib-missing";
+
   const feedbackMessage = document.createElement("p");
   feedbackMessage.className = "calib-feedback-message";
 
@@ -182,7 +252,21 @@ function buildView(root) {
   const rightCoverage = coverageTile("Right");
   coverageRow.append(leftCoverage.tile, rightCoverage.tile);
 
-  feedback.append(progressRow.row, attemptsRow.row, countdownRow.row, boardBadge, feedbackMessage, coverageRow);
+  const badgeRow = document.createElement("div");
+  badgeRow.className = "calib-badge-row";
+  badgeRow.append(boardBadge, distanceBadge);
+
+  feedback.append(
+    progressRow.row,
+    attemptsRow.row,
+    countdownRow.row,
+    badgeRow,
+    coverageBar,
+    coverageLabel,
+    missingList,
+    feedbackMessage,
+    coverageRow,
+  );
 
   // ---- result ---------------------------------------------------------------
   const result = document.createElement("div");
@@ -311,6 +395,9 @@ function buildView(root) {
     if (typeof values?.capture_timeout_sec === "number" && values.capture_timeout_sec > 0) {
       fb.deadlineMs = Date.now() + values.capture_timeout_sec * 1000;
     }
+    if (typeof values?.distance_hint === "string") fb.distanceHint = values.distance_hint;
+    if (typeof values?.coverage_percent === "number") fb.coveragePercent = values.coverage_percent;
+    if (Array.isArray(values?.coverage_missing)) fb.coverageMissing = values.coverage_missing;
     applyCoverageImages(values);
     render();
   }
@@ -328,12 +415,28 @@ function buildView(root) {
     const saveCalibration = saveCheckbox.checked;
 
     lastResult = null;
-    fb = { imagesCaptured: 0, target: numImages, captureAttempts: 0, cornersFound: null, message: "", deadlineMs: null };
+    fb = {
+      imagesCaptured: 0,
+      target: numImages,
+      captureAttempts: 0,
+      cornersFound: null,
+      message: "",
+      deadlineMs: null,
+      distanceHint: "",
+      coveragePercent: 0,
+      coverageMissing: [],
+    };
 
     const { promise, cancel } = ros.sendActionGoal(
       RUN_STEREO_CALIBRATION_ACTION,
       RUN_STEREO_CALIBRATION_ACTION_TYPE,
-      { mode: 0, num_images: numImages, min_corners: minCorners, save_calibration: saveCalibration },
+      {
+        mode: 0,
+        board: BOARDS[selectedBoard()].goal,
+        num_images: numImages,
+        min_corners: minCorners,
+        save_calibration: saveCalibration,
+      },
       { onFeedback },
     );
     activeRun = { cancel, canceling: false };
@@ -372,10 +475,39 @@ function buildView(root) {
     );
   }
 
-  captureBtn.addEventListener("click", () => {
+  /** @returns {keyof typeof BOARDS} */
+  function selectedBoard() {
+    return boardSelect.value in BOARDS ? /** @type {keyof typeof BOARDS} */ (boardSelect.value) : "charuco";
+  }
+
+  function capture() {
     if (!activeRun || activeRun.canceling) return;
     ros.publish(STEREO_CALIB_CAPTURE_TOPIC, { data: true });
+  }
+
+  captureBtn.addEventListener("click", capture);
+
+  // Enter is the capture key, matching the CLI flow — the operator has both
+  // hands on the board and cannot aim at a button. Ignored while a field has
+  // focus, so setting the image count doesn't fire a capture.
+  /** @param {KeyboardEvent} e */
+  function onKeyDown(e) {
+    if (e.key !== "Enter" || e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
+    const target = /** @type {HTMLElement | null} */ (e.target);
+    if (target && ["INPUT", "SELECT", "TEXTAREA", "BUTTON", "A"].includes(target.tagName)) return;
+    if (!activeRun) return;
+    e.preventDefault();
+    capture();
+  }
+  document.addEventListener("keydown", onKeyDown);
+
+  boardSelect.addEventListener("change", () => {
+    const board = BOARDS[selectedBoard()];
+    boardLink.href = board.href;
+    boardTitle.textContent = board.linkText;
+    boardSub.textContent = board.blurb;
   });
+  boardSelect.dispatchEvent(new Event("change"));
 
   stopBtn.addEventListener("click", () => {
     if (!activeRun || activeRun.canceling) return;
@@ -451,9 +583,10 @@ function buildView(root) {
     captureBtn.disabled = !activeRun || activeRun.canceling;
     stopBtn.disabled = !activeRun || activeRun.canceling;
     stopBtn.textContent = activeRun?.canceling ? "Stopping…" : "Stop";
+    boardSelect.disabled = running;
 
     statusLine.textContent = activeRun
-      ? "Calibration running — move the board and click Capture"
+      ? "Calibration running — move the board and press Enter"
       : ros.state === "connected"
         ? "Idle"
         : "Not connected";
@@ -482,6 +615,36 @@ function buildView(root) {
           : fb.cornersFound === false
             ? "Board not detected"
             : "Waiting for first capture";
+
+      const hint = fb.distanceHint;
+      distanceBadge.hidden = !hint;
+      distanceBadge.classList.toggle("ok", hint === "IN_RANGE");
+      distanceBadge.classList.toggle("bad", hint === "TOO_CLOSE" || hint === "TOO_FAR");
+      distanceBadge.textContent =
+        hint === "TOO_CLOSE"
+          ? "Too close — move the board back"
+          : hint === "TOO_FAR"
+            ? "Too far — bring the board closer"
+            : hint === "IN_RANGE"
+              ? "Good distance"
+              : "";
+
+      const pct = Math.max(0, Math.min(100, fb.coveragePercent));
+      coverageFill.style.width = `${pct}%`;
+      coverageFill.classList.toggle("done", pct >= 100);
+      coverageLabel.textContent =
+        pct >= 100 ? "Coverage complete — finish to calibrate" : `${Math.round(pct)}% covered — still needed:`;
+      missingList.replaceChildren(
+        // Only the few most useful; the full list is long early on and reads as
+        // a wall of failure rather than as the next thing to do.
+        ...fb.coverageMissing.slice(0, 4).map((item) => {
+          const li = document.createElement("li");
+          li.textContent = item;
+          return li;
+        }),
+      );
+      missingList.hidden = pct >= 100 || fb.coverageMissing.length === 0;
+
       feedbackMessage.textContent = fb.message;
     }
 
@@ -538,6 +701,7 @@ function buildView(root) {
     destroy() {
       unsubState();
       unsubDepthCheck();
+      document.removeEventListener("keydown", onKeyDown);
       clearInterval(countdownTicker);
       if (calibCheckTimer !== null) clearTimeout(calibCheckTimer);
       // A run left going while the operator navigates away must not keep


### PR DESCRIPTION
## What

A guided calibration flow on the robot's `/calibration` page.

The operator picks a board, presses Start, and moves the board around in front of the cameras. They press Enter to take each photo. The page tells them if the board is too close or too far away. It also shows how much of the job is done, and what is still missing.

The page can now use either board: ChArUco or a plain checkerboard. Before this, it could only use ChArUco.

This branch also takes the calibration work out of the depth obstacle branch, so the two can be reviewed on their own.

## Why

The old page said one thing while it ran: "Move the board and press Enter". You could take 40 photos and only find out at the end that the result was poor. Then you had to do it again, with no idea what went wrong.

Two things spoil a calibration run:

1. **The board is at a bad distance.** Too far away and the camera cannot resolve the squares. Too close and part of the board falls outside the picture.
2. **The photos are all too much alike.** 40 photos of a board held flat in the middle of the frame will not calibrate well, however many you take.

The second one is the interesting one, and it is easy to get wrong. Calibration has to work out the lens focal length. Sliding the board closer and further away gives it almost nothing to work with. A small board close up looks the same as a big board far away. **Tilting the board is what tells them apart.**

So the progress number is not a photo count. It tracks where the board was in the frame, how big it was, how much it was tilted, and how many photos were taken. It cannot reach 100% while any of those is missing. A run of 40 flat, centred photos now reads as incomplete, which is the whole point.

## What the boards can and cannot do

All our calibration boards print on letter paper. That puts a hard limit on how far away they can be held. The limit is different for each board:

| Board | Usable range | Limited by |
|---|---|---|
| Checkerboard, 9x6 corners, 22 mm | about 8 to 61 cm | needs 10 pixels per square to find corners |
| ChArUco, 17x9 squares, 16 mm | about 12 to 22 cm | needs 20 pixels per square to read markers |

ChArUco is the weaker of the two here. Its markers hold a pattern the camera has to read. A checkerboard only has corners to find. Reading takes about twice the pixels, so the same sheet of paper gives about a third of the reach.

This matters because the depth obstacle layer measures the floor from 25 cm to 100 cm ahead. Our boards cannot cover that. Reaching 100 cm would need a board about 72 cm across, which is roughly A1. So calibration happens close up and the result is stretched to cover the longer range. That is a real limit of the setup, not something to tune away. The page now states the usable range when a run starts, instead of letting the operator discover it through rejected photos.

## How

Board choice moved into the action goal, so the app can pick per run. It used to be a ROS parameter that the node read once at startup.

The guidance itself is a new module, `capture_guidance.py`, with no ROS or OpenCV state in it. It answers two questions on every photo: is the board at a usable size, and what is the run still short of. Both limits are worked out from the board's own geometry rather than from fixed numbers, which is what lets one rule serve both boards.

Distance is measured as board size in the frame, not in centimetres. There are no camera intrinsics during a calibration run, because producing them is the point of the run. The page does show a rough distance in cm, so the operator has a number to aim for. That figure comes from the lens's stated field of view. No threshold depends on it.

The head already moved to a fixed angle on Start. The page now says so, rather than leaving the operator to guess the setup.

## Needs manual testing

**Nothing here has been run against a real camera.** Please treat this as untested on hardware.

Before testing:

- `mars_msgs` needs a rebuild. `RunStereoCalibration.action` gained fields, so the app cannot send the board choice until that is built.

Worth checking on the robot:

- A full run with each board, start to finish, and whether the saved calibration is good.
- Whether the "too close" and "too far" messages fire at sensible distances. The pixel thresholds behind them (10 and 20 pixels per square) are standard rules of thumb, not measurements from this lens. If detection falls off somewhere else, those two numbers are the ones to change.
- Whether the coverage percentage feels honest. It should be hard to reach 100% without genuinely working the board around the frame.
- That Enter takes a photo, and that it does not fire while you are typing in the image count field.

The two runs already recorded on the robot (68 checkerboard photos, 78 ChArUco) hold per-photo diagnostics in their experiment JSON and CSV. Those files would let us replace the two pixel thresholds with measured values instead of estimates.

## Verified

Everything below is local. None of it involves a camera.

- 53 Python tests pass. 24 are the existing checkerboard and ChArUco comparison tests, which still run and are unchanged. 29 are new, covering the guidance module.
- `ruff check` and `ruff format` clean across `mars_cam`.
- `tsc --noEmit` reports no errors in `webapp/js/calibration/main.js`. The repo has many pre-existing errors in other files.
- The tilt measurement was checked by projecting a synthetic board at known angles and distances. It reads zero when the board is square to the camera, rises with angle, ignores in-plane rotation, and stays within 0.02 across 35 cm to 100 cm. It also gives the same answer when half the corners are missing. That is what lets a partial ChArUco view be scored like a full checkerboard.
- The distance estimate was checked by projecting at a known distance and reading it back, within 2%.

An early version of the distance limits was wrong, and the arithmetic above is what caught it. The first thresholds worked out to 8.5 to 43 cm on this lens, which sits nearer than the range the depth layer serves. They would have pushed the operator away from the useful distances.

## Merge order

This should merge before `nikita/camera-depth-obstacle-avoidance`. That branch imports `ErrorStats` from `calibration_validation.py`, which lives here. Once this lands, rebasing the depth branch on main drops its copies of these commits on its own.

https://claude.ai/code/session_01ShVeyid4YVPthaFuGXrX3m
