### PR TITLE
Fix tutorial memories leaking into the next map

### DIFF
--- a/ci/run_integration_tests.sh
+++ b/ci/run_integration_tests.sh
@@ -88,6 +88,7 @@ echo "=== unit tests (fast, no ROS) ==="
 # harness (run via colcon test below), not a pytest suite — skip it here.
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q \
   src/brain/brain_client/test \
+  src/mars_bot/mars_nav/test \
   --ignore=src/brain/brain_client/test/test_node_boot.launch.py \
   src/brain/manipulation/test/test_config_validation.py
 

--- a/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
+++ b/ros2_ws/src/brain/brain_client/brain_client/memory/recorder.py
@@ -183,6 +183,14 @@ class MemoryRecorder:
         self._nav_mode = msg.data
 
     def _on_current_map(self, msg: String) -> None:
+        if msg.data != self._map_name:
+            # Navigation can switch maps without changing mode. Never write a
+            # frame captured in the old map into the new store on the next tick,
+            # or let the old AMCL confidence admit more frames during the swap.
+            self._candidate = None
+            self._confident_since = None
+            self._covariance = None
+            self._covariance_at = 0.0
         self._map_name = msg.data
 
     def _on_mapping_session(self, msg: String) -> None:

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -826,6 +826,50 @@ def test_confidence_must_hold_before_recording(data_dir, clock):
     assert len(store.snapshot().memories) == 1
 
 
+@pytest.mark.parametrize("target", ["B.yaml", ""])
+def test_map_change_discards_old_capture_and_requires_fresh_localization(data_dir, clock, target):
+    published = []
+    recorder, store = make_recorder(data_dir, published)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    assert len(store.snapshot().memories) == 1
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))  # buffered in the old map
+
+    recorder._on_current_map(SimpleNamespace(data=target))
+    recorder.tick()
+    assert store.snapshot().memories == ()
+    assert json.loads(published[-1].data)["positions"] == []
+    # Even a camera still streaming cannot reuse the previous map's AMCL confidence.
+    clock.now += 3.1
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
+    recorder.tick()
+    assert store.snapshot().memories == ()
+
+    if target:
+        fresh = frame(42)
+        observe(recorder, clock, fresh)
+        assert store.snapshot().memories == ()
+        observe(recorder, clock, fresh, advance=3.1)
+        assert len(store.snapshot().memories) == 1
+        assert stored_image(store, store.snapshot().memories[0].id) == fresh
+
+    # Switching does not delete the memories that belong to the old map.
+    store.switch_map("A.yaml")
+    assert len(store.snapshot().memories) == 1
+    assert stored_image(store, store.snapshot().memories[0].id) == GOOD_JPEG
+
+
+def test_repeated_current_map_reports_do_not_interrupt_recording(data_dir, clock):
+    recorder, store = make_recorder(data_dir)
+    see_confident_world(recorder, clock)
+    recorder.tick()
+    for _ in range(4):
+        recorder._on_current_map(SimpleNamespace(data="A.yaml"))
+        observe(recorder, clock, GOOD_JPEG)
+    assert len(store.snapshot().memories) == 1
+
+
 def test_a_covariance_spike_resets_the_clock(data_dir, clock):
     recorder, store = make_recorder(data_dir)
     see_confident_world(recorder, clock)

--- a/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
+++ b/ros2_ws/src/brain/brain_client/test/test_spatial_memory.py
@@ -826,48 +826,22 @@ def test_confidence_must_hold_before_recording(data_dir, clock):
     assert len(store.snapshot().memories) == 1
 
 
-@pytest.mark.parametrize("target", ["B.yaml", ""])
-def test_map_change_discards_old_capture_and_requires_fresh_localization(data_dir, clock, target):
-    published = []
-    recorder, store = make_recorder(data_dir, published)
-    see_confident_world(recorder, clock)
-    recorder.tick()
-    observe(recorder, clock, GOOD_JPEG, advance=3.1)
-    assert len(store.snapshot().memories) == 1
-    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))  # buffered in the old map
-
-    recorder._on_current_map(SimpleNamespace(data=target))
-    recorder.tick()
-    assert store.snapshot().memories == ()
-    assert json.loads(published[-1].data)["positions"] == []
-    # Even a camera still streaming cannot reuse the previous map's AMCL confidence.
-    clock.now += 3.1
-    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
-    recorder.tick()
-    assert store.snapshot().memories == ()
-
-    if target:
-        fresh = frame(42)
-        observe(recorder, clock, fresh)
-        assert store.snapshot().memories == ()
-        observe(recorder, clock, fresh, advance=3.1)
-        assert len(store.snapshot().memories) == 1
-        assert stored_image(store, store.snapshot().memories[0].id) == fresh
-
-    # Switching does not delete the memories that belong to the old map.
-    store.switch_map("A.yaml")
-    assert len(store.snapshot().memories) == 1
-    assert stored_image(store, store.snapshot().memories[0].id) == GOOD_JPEG
-
-
-def test_repeated_current_map_reports_do_not_interrupt_recording(data_dir, clock):
+def test_map_change_discards_buffered_capture(data_dir, clock):
     recorder, store = make_recorder(data_dir)
     see_confident_world(recorder, clock)
     recorder.tick()
+    observe(recorder, clock, GOOD_JPEG, advance=3.1)
+    recorder._on_image(SimpleNamespace(data=GOOD_JPEG))
+    recorder._on_current_map(SimpleNamespace(data="B.yaml"))
+    recorder.tick()
+    assert store.snapshot().memories == ()
+    fresh = frame(42)
     for _ in range(4):
-        recorder._on_current_map(SimpleNamespace(data="A.yaml"))
-        observe(recorder, clock, GOOD_JPEG)
-    assert len(store.snapshot().memories) == 1
+        recorder._on_current_map(SimpleNamespace(data="B.yaml"))
+        observe(recorder, clock, fresh)
+    assert stored_image(store, store.snapshot().memories[0].id) == fresh
+    store.switch_map("A.yaml")
+    assert stored_image(store, store.snapshot().memories[0].id) == GOOD_JPEG
 
 
 def test_a_covariance_spike_resets_the_clock(data_dir, clock):

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -938,13 +938,13 @@ class ModeManager(Node):
         self.get_logger().error(f"Failed to load map after {max_retries} attempts")
         return False
 
-    def _efficient_map_switch(self) -> tuple[bool, str]:
+    def _efficient_map_switch(self, requested_map: str) -> tuple[bool, str]:
         """
-        Efficiently switch maps by transitioning bt_navigator down, loading map, then bringing all nodes up.
+        Switch maps with navigation stopped and the previous AMCL filter discarded.
 
         Algorithm:
         1. Transition bt_navigator to inactive
-        2. Load new map on map_server
+        2. Reset AMCL, then expose and load the new map
         3. Transition all nodes to active
         """
         nodes = modes_nodes.get("navigation", [])
@@ -959,6 +959,16 @@ class ModeManager(Node):
         if not success:
             failures.append("bt_navigator")
             self.get_logger().warning("Failed to transition bt_navigator down")
+
+        # Stop and clear AMCL before publishing the new map identity. Otherwise
+        # its old filter can keep supplying confident poses during the switch.
+        # Cleanup + configure honors always_reset_initial_pose; deactivation
+        # alone retains the filter. The activation loop below brings it back.
+        if not transition_node(
+            self._service_clients, self.get_logger(), "navigation_amcl", State.PRIMARY_STATE_UNCONFIGURED
+        ):
+            return False, "Could not reset AMCL before switching maps"
+        self.current_map = requested_map
 
         # Step 2: Load new map
         self.get_logger().info("Step 2: Loading new map")
@@ -1072,15 +1082,11 @@ class ModeManager(Node):
             my_generation = self._switch_generation
             previous_map = self.current_map
             try:
-                # _efficient_map_switch loads self.current_map, so set it for
-                # the attempt but only persist (and keep) it on success.
-                self.current_map = requested_map
-
                 # If we're in navigation mode, use efficient map switch
                 if self.current_mode == "navigation":
                     self.get_logger().info(f"Efficiently switching to new map: {requested_map}")
 
-                    success, message = self._efficient_map_switch()
+                    success, message = self._efficient_map_switch(requested_map)
 
                     if success:
                         self.save_last_map(requested_map)
@@ -1095,6 +1101,7 @@ class ModeManager(Node):
                         self.get_logger().error(response.message)
                 else:
                     # If not in navigation mode, just update the map for next time navigation starts
+                    self.current_map = requested_map
                     self.save_last_map(requested_map)
                     response.success = True
                     response.message = f"Map set to '{requested_map}' for next navigation session"

--- a/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
+++ b/ros2_ws/src/mars_bot/mars_nav/mars_nav/mode_manager.py
@@ -967,14 +967,17 @@ class ModeManager(Node):
         if not transition_node(
             self._service_clients, self.get_logger(), "navigation_amcl", State.PRIMARY_STATE_UNCONFIGURED
         ):
-            return False, "Could not reset AMCL before switching maps"
-        self.current_map = requested_map
+            # Reset may have partially transitioned AMCL. Keep the old map,
+            # but always run the activation loop to restore navigation.
+            failures.append("navigation_amcl_reset")
+        else:
+            self.current_map = requested_map
 
-        # Step 2: Load new map
-        self.get_logger().info("Step 2: Loading new map")
-        map_load_success = self._load_map_on_server(map_server_node)
-        if not map_load_success:
-            failures.append(f"{map_server_node}_map_load")
+            # Step 2: Load new map
+            self.get_logger().info("Step 2: Loading new map")
+            map_load_success = self._load_map_on_server(map_server_node)
+            if not map_load_success:
+                failures.append(f"{map_server_node}_map_load")
 
         # Step 3: Transition all nodes to active
         self.get_logger().info("Step 3: Activating all nodes")

--- a/ros2_ws/src/mars_bot/mars_nav/test/test_map_switch.py
+++ b/ros2_ws/src/mars_bot/mars_nav/test/test_map_switch.py
@@ -9,7 +9,7 @@ from lifecycle_msgs.msg import State
 from mars_nav import mode_manager as module
 
 
-@pytest.mark.parametrize("reset_ok, restore_ok", [(True, True), (False, True), (False, False)])
+@pytest.mark.parametrize("reset_ok, restore_ok", [(True, True), (True, False), (False, True), (False, False)])
 def test_reset_amcl_before_announcing_new_map(monkeypatch, reset_ok, restore_ok):
     manager = SimpleNamespace(
         current_map="A.yaml", _service_clients={}, get_logger=Mock(), _load_map_on_server=Mock(return_value=True)
@@ -24,7 +24,7 @@ def test_reset_amcl_before_announcing_new_map(monkeypatch, reset_ok, restore_ok)
 
     monkeypatch.setattr(module, "transition_node", transition)
     success, message = module.ModeManager._efficient_map_switch(manager, "B.yaml")
-    assert success == reset_ok
+    assert success == (reset_ok and restore_ok)
     assert ("navigation_amcl", State.PRIMARY_STATE_UNCONFIGURED, "A.yaml") in calls
     if reset_ok:
         assert ("navigation_amcl", State.PRIMARY_STATE_ACTIVE, "B.yaml") in calls
@@ -35,5 +35,5 @@ def test_reset_amcl_before_announcing_new_map(monkeypatch, reset_ok, restore_ok)
         for node in ("navigation_amcl", "bt_navigator"):
             assert (node, State.PRIMARY_STATE_ACTIVE, "A.yaml") in calls
         assert "navigation_amcl_reset" in message
-        if not restore_ok:
-            assert "'navigation_amcl'" in message
+    if not restore_ok:
+        assert "'navigation_amcl'" in message

--- a/ros2_ws/src/mars_bot/mars_nav/test/test_map_switch.py
+++ b/ros2_ws/src/mars_bot/mars_nav/test/test_map_switch.py
@@ -9,8 +9,8 @@ from lifecycle_msgs.msg import State
 from mars_nav import mode_manager as module
 
 
-@pytest.mark.parametrize("reset_ok", [True, False])
-def test_reset_amcl_before_announcing_new_map(monkeypatch, reset_ok):
+@pytest.mark.parametrize("reset_ok, restore_ok", [(True, True), (False, True), (False, False)])
+def test_reset_amcl_before_announcing_new_map(monkeypatch, reset_ok, restore_ok):
     manager = SimpleNamespace(
         current_map="A.yaml", _service_clients={}, get_logger=Mock(), _load_map_on_server=Mock(return_value=True)
     )
@@ -18,10 +18,12 @@ def test_reset_amcl_before_announcing_new_map(monkeypatch, reset_ok):
 
     def transition(clients, logger, node, state, **kwargs):
         calls.append((node, state, manager.current_map))
-        return reset_ok if state == State.PRIMARY_STATE_UNCONFIGURED else True
+        if state == State.PRIMARY_STATE_UNCONFIGURED:
+            return reset_ok
+        return restore_ok if node == "navigation_amcl" and state == State.PRIMARY_STATE_ACTIVE else True
 
     monkeypatch.setattr(module, "transition_node", transition)
-    success, _ = module.ModeManager._efficient_map_switch(manager, "B.yaml")
+    success, message = module.ModeManager._efficient_map_switch(manager, "B.yaml")
     assert success == reset_ok
     assert ("navigation_amcl", State.PRIMARY_STATE_UNCONFIGURED, "A.yaml") in calls
     if reset_ok:
@@ -30,3 +32,8 @@ def test_reset_amcl_before_announcing_new_map(monkeypatch, reset_ok):
     else:
         assert manager.current_map == "A.yaml"
         manager._load_map_on_server.assert_not_called()
+        for node in ("navigation_amcl", "bt_navigator"):
+            assert (node, State.PRIMARY_STATE_ACTIVE, "A.yaml") in calls
+        assert "navigation_amcl_reset" in message
+        if not restore_ok:
+            assert "'navigation_amcl'" in message

--- a/ros2_ws/src/mars_bot/mars_nav/test/test_map_switch.py
+++ b/ros2_ws/src/mars_bot/mars_nav/test/test_map_switch.py
@@ -1,0 +1,32 @@
+"""The map identity must not advance while the previous AMCL filter is alive."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from lifecycle_msgs.msg import State
+
+from mars_nav import mode_manager as module
+
+
+@pytest.mark.parametrize("reset_ok", [True, False])
+def test_reset_amcl_before_announcing_new_map(monkeypatch, reset_ok):
+    manager = SimpleNamespace(
+        current_map="A.yaml", _service_clients={}, get_logger=Mock(), _load_map_on_server=Mock(return_value=True)
+    )
+    calls = []
+
+    def transition(clients, logger, node, state, **kwargs):
+        calls.append((node, state, manager.current_map))
+        return reset_ok if state == State.PRIMARY_STATE_UNCONFIGURED else True
+
+    monkeypatch.setattr(module, "transition_node", transition)
+    success, _ = module.ModeManager._efficient_map_switch(manager, "B.yaml")
+    assert success == reset_ok
+    assert ("navigation_amcl", State.PRIMARY_STATE_UNCONFIGURED, "A.yaml") in calls
+    if reset_ok:
+        assert ("navigation_amcl", State.PRIMARY_STATE_ACTIVE, "B.yaml") in calls
+        manager._load_map_on_server.assert_called_once()
+    else:
+        assert manager.current_map == "A.yaml"
+        manager._load_map_on_server.assert_not_called()


### PR DESCRIPTION
Skipping or finishing onboarding could save a tutorial image into the next map: a buffered frame survived the switch, and AMCL could keep publishing confident poses from its previous filter.

Discard the buffered capture on map changes, and clean up AMCL before announcing the new map. Reactivation requires a new initial pose under the existing `always_reset_initial_pose` configuration. If AMCL cannot reset, the old map is retained and the activation loop restores navigation before returning the failure; restoration failures are reported too.

Validation: 144 spatial-memory/navigation tests pass. Coverage stays small: one memory regression and a parameterized reset-order/failure test, wired into CI. An isolated real-AMCL check confirmed that poses stop across cleanup/reconfiguration and resume only after reseeding. Ruff and diff checks pass. Full onboarding UI not retested.
