### PR TITLE
fix(webapp): the stage fills the screen it is given, the camera sits centred in it

### DIFF
--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -2235,19 +2235,16 @@ body:has(.agent-indicator:not([hidden], [data-off-route])) .tgt-hud {
   z-index: 1;
 }
 
-@media (min-width: 1401px) {
+@media (min-width: 641px) {
   /* Inset by the frame's 1px border rather than drawing a second one, so the
      map sits in the frame the same way the feed does and the hairline stays
      whatever the frame says it is. 17px radius is the frame's 18px less that
      border, matching the video. */
   .agent-cockpit.agent-sim .cam-map-host.big {
     top: calc(var(--agent-dock-gutter) + 1px);
-    right: auto;
-    bottom: auto;
+    right: calc(var(--agent-dock-width) + 2 * var(--agent-dock-gutter) + 1px);
+    bottom: calc(var(--agent-dock-gutter) + 1px);
     left: calc(var(--agent-dock-gutter) + 1px);
-    width: calc(var(--agent-frame-width) - 2px);
-    height: auto;
-    aspect-ratio: 4 / 3;
     overflow: hidden;
     border-radius: 17px;
   }
@@ -9648,19 +9645,18 @@ select.skill-input {
 }
 
 @media (min-width: 641px) {
+  /* The scene renders at whatever shape it is given, so it takes the room the chat does
+     not: deriving its height from its width instead ran it off the bottom of any display
+     wider than 4:3 plus the chat. */
   .agent-cockpit.agent-sim .agent-feed-frame {
     position: absolute;
     display: block;
     top: var(--agent-dock-gutter);
-    right: auto;
-    bottom: auto;
+    right: calc(var(--agent-dock-width) + var(--agent-dock-gutter) + var(--agent-dock-gutter));
+    bottom: var(--agent-dock-gutter);
     left: var(--agent-dock-gutter);
-    width: calc(
-      100% - var(--agent-dock-width) - var(--agent-dock-gutter) -
-        var(--agent-dock-gutter) - var(--agent-dock-gutter)
-    );
+    width: auto;
     height: auto;
-    aspect-ratio: 4 / 3;
     overflow: hidden;
     background: #000;
     border: 1px solid color-mix(in srgb, var(--text) 34%, var(--bg));
@@ -9675,7 +9671,6 @@ select.skill-input {
     left: 0;
     width: 100%;
     height: 100%;
-    aspect-ratio: 4 / 3;
     transform: none;
   }
 
@@ -9736,29 +9731,6 @@ select.skill-input {
 
   .agent-cockpit.agent-sim .video-stage > :is(canvas, video) {
     border-radius: 0;
-  }
-}
-
-/* Wide-but-short screens: the 4:3 frame is derived from whatever width the dock
-   leaves over, so past a certain aspect ratio it is taller than the stage and
-   its bottom corners get cropped. Invert the dependency — size the frame from
-   the available height, then define the dock as the width left over. Every rule
-   that already anchors to --agent-dock-width (the panel, the camera strip, the
-   Inspect Brain toggle) then follows the frame's edge for free. Below this the
-   dock's own width still binds, so the two agree at the boundary. */
-@media (min-width: 1401px) {
-  .agent-cockpit.agent-sim {
-    /* Fixed dock width, kept as its own name so --agent-dock-width can be
-       derived below without a circular reference. */
-    --agent-dock-base: 388px;
-    --agent-frame-fit: calc((100dvh - 2 * var(--agent-dock-gutter)) * 4 / 3);
-    --agent-frame-max: calc(
-      100% - var(--agent-dock-base) - 3 * var(--agent-dock-gutter)
-    );
-    --agent-frame-width: min(var(--agent-frame-fit), var(--agent-frame-max));
-    --agent-dock-width: calc(
-      100% - var(--agent-frame-width) - 3 * var(--agent-dock-gutter)
-    );
   }
 }
 

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -11462,7 +11462,10 @@ body.story-active :is(.rail, .rail-ribbon, .rail-scrim, .sim-scene-setup, .agent
 body.story-active { grid-template-columns: minmax(0, 1fr); }
 .agent-cockpit.story-active > :is(.agent-stage-view-toggle, .sim-debug-stack, .agent-challenge-dock) { display: none; }
 .agent-cockpit.story-active .agent-stream > .chat-msg:is(.skill-output, .system):not(.narrator) { display: none; }
-.agent-cockpit.story-active .agent-stream.compact > .chat-thoughts { display: none; }
+/* A first-timer does not need the model's reasoning, and with it never shown the Compact /
+   Detailed switch has nothing to switch: both go until the story is over. */
+.agent-cockpit.story-active .agent-stream > .chat-thoughts { display: none; }
+.agent-cockpit.story-active .agent-stream-mode { display: none; }
 /* In the story a failure is a setback, not an alarm. */
 .agent-cockpit.story-active .agent-stream .chat-skill.failed { border-left-color: #d9a441; }
 .agent-cockpit.story-active .agent-stream .chat-skill.failed .chat-skill-status { color: #d9a441; }

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -2235,7 +2235,8 @@ body:has(.agent-indicator:not([hidden], [data-off-route])) .tgt-hud {
   z-index: 1;
 }
 
-@media (min-width: 641px) {
+/* Only where the frame is a box rather than full bleed (see the 641-1400 override). */
+@media (min-width: 1401px) {
   /* Inset by the frame's 1px border rather than drawing a second one, so the
      map sits in the frame the same way the feed does and the hairline stays
      whatever the frame says it is. 17px radius is the frame's 18px less that
@@ -11281,7 +11282,9 @@ select.skill-input {
   color: inherit; background: transparent; border: 0; border-radius: 14px 0 0 14px;
   font: inherit; cursor: pointer;
 }
-.agent-studio-dock-action { display: flex; padding-right: 8px; }
+/* Clear of the pill's 14px corner: at 8px the button's own corner broke through the curve
+   and read as hanging off the edge. Matches the toggle's leading inset. */
+.agent-studio-dock-action { display: flex; padding-right: 14px; }
 .agent-studio-dock-action .agent-toggle { height: 32px; }
 .agent-studio-dock-icon { grid-row: 1 / 3; width: 22px; height: 22px; }
 .agent-studio-dock-toggle .microlabel { grid-column: 2; color: rgb(255 255 255 / 55%); }

--- a/webapp/css/app.css
+++ b/webapp/css/app.css
@@ -8618,7 +8618,6 @@ select.skill-input {
     max-height: 100%;
     border: 1px solid transparent;
     border-radius: 18px;
-    object-position: left top;
   }
 
   .agent-cockpit .video-stage.video-ready video {
@@ -9711,7 +9710,6 @@ select.skill-input {
     max-height: none;
     border: 0;
     border-radius: 0;
-    object-position: center;
     object-fit: cover;
   }
 


### PR DESCRIPTION
The agent page assumed a 4:3 stage. On a wide display that either pushed the scene off the bottom of the screen or grew the chat to fill the difference, and both look broken on someone else's monitor.

Before
<img width="1728" height="621" alt="image" src="https://github.com/user-attachments/assets/5666989e-f1fa-4dab-8a60-b011db9d9209" />

After
<img width="1728" height="620" alt="image" src="https://github.com/user-attachments/assets/705885b0-ba06-400e-b053-6b500c4cdab2" />

## What was happening

Two rules disagreed about who absorbs a wide aspect ratio.

Below 1401px the stage took its width from what the chat left over and its height from 4:3, so the taller-than-the-screen case simply overflowed:

| Display | Stage height | Off the bottom |
|---|---|---|
| 1512 x 982 | 823 | fits |
| 1920 x 1080 | 1130 | 68 px |
| 2560 x 1080 | 1610 | 548 px |
| 3440 x 1440 | 2270 | 848 px |

Above 1401px a later rule fixed the overflow by inverting the dependency: size the stage from the available height at 4:3, then let the chat take everything left. Nothing fell off the screen, but an ultrawide got a 1114px chat beside a small scene.

## What this does

Nothing on this page has an intrinsic 4:3. The sim renders every view through three.js into one canvas, the robot's own cameras included, and the camera takes its aspect from the element on resize. The ratio was inherited from real camera feeds, which this page never shows as video.

So the chat keeps its 388px column and the stage takes both remaining dimensions. The inversion and the derived `--agent-frame-width` / `--agent-dock-base` variables go with it. A promoted map follows the frame's box instead of its own 4:3 slab, still scoped to the widths where the frame is a box rather than full bleed.

Two smaller things from the same screenshots:

- **Stop button.** At 8px from the pill's edge its corner sat inside the pill's 14px radius, so against a bright scene it read as hanging off. It now matches the inset on the other end.
- **Compact / Detailed.** The two differ only by the model's reasoning, which the story already hid, so during the intro the switch changed nothing. The reasoning is hidden in either mode there and the switch goes with it.

- **Camera picture.** A real feed sat against the left edge of the frame with black to the right. The video element spans the frame and is then capped at its height, so the picture is letterboxed inside a box far wider than itself, and a `left top` pin held it there. Removing the pin centres it; a duplicate of the declaration lower down already said centre.

## Verification

Driven headlessly against a running sim at 430x900, 700x900, 1000x800, 1512x982, 2560x1080 and 3440x1440. From 1512 up the stage ends one gutter above the bottom and one gutter from the chat at every width, the chat stays 388px, and no size scrolls horizontally. Below 1401 the stage stays deliberately full bleed with the chat floating over it, unchanged.

The mode switch was checked in three states: hidden during the story with no reasoning shown; still hidden and still no reasoning after forcing the stream into Detailed, so a returning visitor cannot land in a half-story view; and back after skipping. The pill was compared before and after by screenshotting it.

The camera centring was measured on an isolated page against the real stylesheet, with a 4:3 source and the 388px chat: equal gaps of 271, 363 and 563px either side at 1728x594, 2560x1080 and 3440x1440, and no movement at 1512x982 or below, where the picture already fills the frame.

## Known consequence

A robot camera promoted to the big view now renders wider than the real camera's 4:3, so you see slightly more than the robot does. If that matters for teleop honesty the fix is to pillarbox those views in the viewer, not to shape the page around them.

